### PR TITLE
Context Entry Storage Experiments

### DIFF
--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -331,7 +331,7 @@ class GAFFER_API Context : public IECore::RefCounted
 		{
 		public:
 			static IECore::DataPtr makeData( IECore::TypeId typeId, const void *raw );
-			static inline void internalSetData( IECore::TypeId typeId, Context &c, const IECore::InternedString &name, const IECore::Data *value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash = nullptr );
+			static inline void internalSetData( IECore::TypeId typeId, Context &c, const IECore::InternedString &name, const IECore::ConstDataPtr &value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash = nullptr );
 			static inline bool typedEquals( IECore::TypeId typeId, const void *rawA, const void *rawB );
 			static inline IECore::MurmurHash entryHash( IECore::TypeId typeId, Storage &s, const IECore::InternedString &name );
 
@@ -345,7 +345,7 @@ class GAFFER_API Context : public IECore::RefCounted
 			static IECore::DataPtr makeDataTemplate( const void *raw );
 
 			template<typename T>
-			static void internalSetDataTemplate( Context &c, const IECore::InternedString &name, const IECore::Data *value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash );
+			static void internalSetDataTemplate( Context &c, const IECore::InternedString &name, const IECore::ConstDataPtr &value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash );
 
 			template<typename T>
 			static bool typedEqualsTemplate( const void *rawA, const void *rawB );
@@ -357,7 +357,7 @@ class GAFFER_API Context : public IECore::RefCounted
 			struct FunctionTableEntry
 			{
 				IECore::DataPtr (*makeDataFunction)( const void *raw );
-				void (*internalSetDataFunction)( Context &c, const IECore::InternedString &name, const IECore::Data *value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash );
+				void (*internalSetDataFunction)( Context &c, const IECore::InternedString &name, const IECore::ConstDataPtr &value, AllocMap &allocMap, bool copy, const IECore::MurmurHash *knownHash );
 				bool (*typedEqualsFunction)( const void *rawA, const void *rawB );
 				IECore::MurmurHash (*entryHashFunction)( Storage &s, const IECore::InternedString &name );
 			};

--- a/include/Gaffer/Random.h
+++ b/include/Gaffer/Random.h
@@ -96,6 +96,8 @@ class GAFFER_API Random : public ComputeNode
 
 };
 
+IE_CORE_DECLAREPTR( Random )
+
 } // namespace Gaffer
 
 #endif // GAFFER_RANDOM_H

--- a/include/Gaffer/ShufflePlug.inl
+++ b/include/Gaffer/ShufflePlug.inl
@@ -85,7 +85,9 @@ T ShufflesPlug::shuffle( const T &sourceContainer ) const
 
 	for( const auto &sourceData : sourceContainer )
 	{
-		scope.set<std::string>( g_sourceVariable, sourceData.first );
+		// Quick way to get a string from a key that could be std::string or IECore::InternedString
+		const std::string &source = sourceData.first;
+		scope.set<std::string>( g_sourceVariable, &source );
 
 		i = 0;
 		bool deleteSource = false;

--- a/include/GafferImage/Format.h
+++ b/include/GafferImage/Format.h
@@ -40,6 +40,7 @@
 #include "GafferImage/Export.h"
 
 #include "IECore/Export.h"
+#include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathBox.h"
@@ -129,6 +130,8 @@ class GAFFERIMAGE_API Format
 /// Outputs a numeric description of the format, omitting default information
 /// where possible. Note that this is unrelated to Format::name().
 GAFFERIMAGE_API std::ostream & operator << ( std::ostream &os, const GafferImage::Format &format );
+
+inline void murmurHashAppend( IECore::MurmurHash &h, const GafferImage::Format &data );
 
 } // namespace GafferImage
 

--- a/include/GafferImage/Format.inl
+++ b/include/GafferImage/Format.inl
@@ -161,6 +161,13 @@ inline Imath::Box2i Format::toEXRSpace( const Imath::Box2i &internalSpace ) cons
 	);
 }
 
+inline void murmurHashAppend( IECore::MurmurHash &h, const GafferImage::Format &data )
+{
+	h.append( data.getDisplayWindow() );
+	h.append( data.getPixelAspect() );
+}
+
 } // namespace GafferImage
+
 
 #endif // GAFFERIMAGE_FORMAT_INL

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -102,6 +102,18 @@ inline bool channelExists( const ImagePlug *image, const std::string &channelNam
 /// Returns true if the specified channel exists in channelNames
 inline bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName );
 
+/// Default channel names
+/// ==============================
+///
+/// You can just use your own strings, but it can be convenient to use these
+
+GAFFERIMAGE_API extern const std::string channelNameA;
+GAFFERIMAGE_API extern const std::string channelNameR;
+GAFFERIMAGE_API extern const std::string channelNameG;
+GAFFERIMAGE_API extern const std::string channelNameB;
+GAFFERIMAGE_API extern const std::string channelNameZ;
+GAFFERIMAGE_API extern const std::string channelNameZBack;
+
 /// Parallel processing functions
 /// ==============================
 ///

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -283,7 +283,7 @@ void parallelProcessTiles( const ImagePlug *imagePlug, TileFunctor &&functor, co
 			[ imagePlug, &functor, &threadState ] ( const Imath::V2i &tileOrigin ) {
 
 				ImagePlug::ChannelDataScope channelDataScope( threadState );
-				channelDataScope.setTileOrigin( tileOrigin );
+				channelDataScope.setTileOrigin( &tileOrigin );
 				functor( imagePlug, tileOrigin );
 
 			}
@@ -322,7 +322,7 @@ void parallelProcessTiles( const ImagePlug *imagePlug, const std::vector<std::st
 
 		for( const std::string &c : channelNames )
 		{
-			channelDataScope.setChannelName( c );
+			channelDataScope.setChannelName( &c );
 			functor( imagePlug, c, tileOrigin );
 		}
 	};
@@ -364,7 +364,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 			[ imagePlug, &tileFunctor, &threadState ] ( const Imath::V2i &tileOrigin ) {
 
 				ImagePlug::ChannelDataScope channelDataScope( threadState );
-				channelDataScope.setTileOrigin( tileOrigin );
+				channelDataScope.setTileOrigin( &tileOrigin );
 
 				return TileFilterResult(
 					tileOrigin, tileFunctor( imagePlug, tileOrigin )
@@ -380,7 +380,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 			[ imagePlug, &gatherFunctor, &threadState ] ( const TileFilterResult &input ) {
 
 				ImagePlug::ChannelDataScope channelDataScope( threadState );
-				channelDataScope.setTileOrigin( input.first );
+				channelDataScope.setTileOrigin( &input.first );
 
 				gatherFunctor( imagePlug, input.first, input.second );
 
@@ -413,7 +413,7 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::str
 		ImagePlug::ChannelDataScope channelDataScope( Gaffer::Context::current() );
 		for( unsigned int i = 0; i < channelNames.size(); i++ )
 		{
-			channelDataScope.setChannelName( channelNames[i] );
+			channelDataScope.setChannelName( &channelNames[i] );
 			result[i] = tileFunctor( imagePlug, channelNames[i], tileOrigin );
 		}
 

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -143,8 +143,17 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		{
 			ChannelDataScope( const Gaffer::Context *context );
 			ChannelDataScope( const Gaffer::ThreadState &threadState );
+
+			[[deprecated("Use faster pointer version")]]
 			void setTileOrigin( const Imath::V2i &tileOrigin );
+			[[deprecated("Use faster pointer version")]]
 			void setChannelName( const std::string &channelName );
+
+			// These fast calls take pointers, and it is the caller's
+			// responsibility to ensure that the memory pointed to
+			// stays valid for the lifetime of the ChannelDataScope
+			void setTileOrigin( const Imath::V2i *tileOrigin );
+			void setChannelName( const std::string *channelName );
 		};
 		//@}
 

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -100,6 +100,8 @@ class GAFFERSCENE_API FilterPlug : public Gaffer::IntPlug
 		struct SceneScope : public Gaffer::Context::EditableScope
 		{
 			SceneScope( const Gaffer::Context *context, const ScenePlug *scenePlug );
+		private:
+			const ScenePlug *m_scenePlug;
 		};
 
 };

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -236,7 +236,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
-			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &parentPath, const ScenePath &branchPath );
+			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath *parentPath, const ScenePath *branchPath );
+		private:
+			ScenePlug::ScenePath m_prototypePath;
 		};
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -76,7 +76,7 @@ class TraverseTask : public tbb::task
 
 		task *execute() override
 		{
-			ScenePlug::PathScope pathScope( m_threadState, m_path );
+			ScenePlug::PathScope pathScope( m_threadState, &m_path );
 
 			if( m_f( m_scene, m_path ) )
 			{
@@ -140,7 +140,7 @@ class LocationTask : public tbb::task
 
 		task *execute() override
 		{
-			ScenePlug::PathScope pathScope( m_threadState, m_path );
+			ScenePlug::PathScope pathScope( m_threadState, &m_path );
 
 			if( !m_f( m_scene, m_path ) )
 			{

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -155,32 +155,50 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// specifying the scene path.
 		struct PathScope : public Gaffer::Context::EditableScope
 		{
+			/// NOTE : Any of these calls which take a pointer are fast versions which require
+			/// the caller to keep the source memory valid for the lifetime of the PathScope.
+
 			/// Standard constructors, for modifying context on the current thread.
 			PathScope( const Gaffer::Context *context );
+			[[deprecated("Use faster pointer version")]]
 			PathScope( const Gaffer::Context *context, const ScenePath &scenePath );
+			PathScope( const Gaffer::Context *context, const ScenePath *scenePath );
 
 			/// Specialised constructors used to transfer state to TBB tasks. See
 			/// ThreadState documentation for more details.
 			PathScope( const Gaffer::ThreadState &threadState );
+			[[deprecated("Use faster pointer version")]]
 			PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath );
+			PathScope( const Gaffer::ThreadState &threadState, const ScenePath *scenePath );
 
+			[[deprecated("Use faster pointer version")]]
 			void setPath( const ScenePath &scenePath );
+			void setPath( const ScenePath *scenePath );
 		};
 
 		/// Utility class to scope a temporary copy of a context,
 		/// specifying the set name.
 		struct SetScope : public Gaffer::Context::EditableScope
 		{
+			/// NOTE : Any of these calls which take a pointer are fast versions which require
+			/// the caller to keep the source memory valid for the lifetime of the SetScope.
+
 			/// Standard constructors, for modifying context on the current thread.
 			SetScope( const Gaffer::Context *context );
+			[[deprecated("Use faster pointer version")]]
 			SetScope( const Gaffer::Context *context, const IECore::InternedString &setName );
+			SetScope( const Gaffer::Context *context, const IECore::InternedString *setName );
 
 			/// Specialised constructors used to transfer state to TBB tasks. See
 			/// ThreadState documentation for more details.
 			SetScope( const Gaffer::ThreadState &threadState );
+			[[deprecated("Use faster pointer version")]]
 			SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName );
+			SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString *setName );
 
+			[[deprecated("Use faster pointer version")]]
 			void setSetName( const IECore::InternedString &setName );
+			void setSetName( const IECore::InternedString *setName );
 		};
 
 		/// Utility class to scope a temporary copy of a context,

--- a/include/GafferTest/ContextTest.h
+++ b/include/GafferTest/ContextTest.h
@@ -37,12 +37,149 @@
 #ifndef GAFFERTEST_CONTEXTTEST_H
 #define GAFFERTEST_CONTEXTTEST_H
 
+#include "GafferTest/Assert.h"
 #include "GafferTest/Export.h"
+
+#include "Gaffer/Context.h"
 
 #include <tuple>
 
 namespace GafferTest
 {
+
+template < typename T >
+void testEditableScopeTyped( const typename T::ValueType &aVal, const typename T::ValueType &bVal )
+{
+	using V = typename T::ValueType;
+
+	Gaffer::ContextPtr baseContext = new Gaffer::Context();
+	baseContext->set( "a", aVal );
+	baseContext->set( "b", bVal );
+
+	// Test basic context functionality
+	GAFFERTEST_ASSERT( baseContext->get<V>( "a" ) == aVal );
+	GAFFERTEST_ASSERT( *baseContext->getIfExists<V>( "a" ) == aVal );
+	GAFFERTEST_ASSERT( baseContext->get<V>( "b" ) == bVal );
+	GAFFERTEST_ASSERT( *baseContext->getIfExists<V>( "b" ) == bVal );
+	GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "doesntExist" ) == nullptr );
+
+	const typename T::Ptr aData = new T( aVal );
+	const typename T::Ptr bData = new T( bVal );
+
+	// Test setting with a TypedData
+	baseContext->set( "a", bData.get() );
+	baseContext->set( "b", bData.get() );
+	GAFFERTEST_ASSERT( baseContext->get<V>( "a" ) == bVal );
+	GAFFERTEST_ASSERT( baseContext->get<V>( "b" ) == bVal );
+
+	// And set back again with a direct value
+	baseContext->set( "a", aVal );
+	GAFFERTEST_ASSERT( baseContext->get<V>( "a" ) == aVal );
+	GAFFERTEST_ASSERT( baseContext->get<V>( "b" ) == bVal );
+
+	// Test getting as a generic Data - this should work where set as Data, or directly from a value
+	GAFFERTEST_ASSERT( baseContext->getAsData( "a" )->isEqualTo( aData.get() ) );
+	GAFFERTEST_ASSERT( baseContext->getAsData( "b" )->isEqualTo( bData.get() ) );
+
+	const V *aPointer = baseContext->getIfExists<V>( "a" );
+	const V *bPointer = baseContext->getIfExists<V>( "b" );
+
+	{
+		// Scope an editable copy of the context
+		Gaffer::Context::EditableScope scope( baseContext.get() );
+
+		const Gaffer::Context *currentContext = Gaffer::Context::current();
+		GAFFERTEST_ASSERT( currentContext != baseContext );
+
+		// The editable copy should be identical to the original,
+		// and the original should be unchanged.
+		GAFFERTEST_ASSERT( baseContext->get<V>( "a" ) == aVal );
+		GAFFERTEST_ASSERT( baseContext->get<V>( "b" ) == bVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "a" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "b" ) == bVal );
+		GAFFERTEST_ASSERT( currentContext->hash() == baseContext->hash() );
+
+		// The copy should even be referencing the exact same data
+		// as the original.
+		GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "a" ) == aPointer );
+		GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "b" ) == bPointer );
+		GAFFERTEST_ASSERT( currentContext->getIfExists<V>( "a" ) == aPointer );
+		GAFFERTEST_ASSERT( currentContext->getIfExists<V>( "b" ) == bPointer );
+
+		// Editing the copy shouldn't affect the original
+		scope.set( "c", &aVal );
+		GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "c" ) == nullptr );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "c" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->hash() != baseContext->hash() );
+
+		// Even if we're editing a variable that exists in
+		// the original.
+		scope.set( "a", &bVal );
+		GAFFERTEST_ASSERT( baseContext->get<V>( "a" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "a" ) == bVal );
+
+		// And we should be able to remove a variable from the
+		// copy without affecting the original too.
+		scope.remove( "b" );
+		GAFFERTEST_ASSERT( baseContext->get<V>( "b" ) == bVal );
+		GAFFERTEST_ASSERT( currentContext->getIfExists<V>( "b" ) == nullptr );
+
+		// And none of the edits should have affected the original
+		// data at all.
+		GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "a" ) == aPointer );
+		GAFFERTEST_ASSERT( baseContext->getIfExists<V>( "b" ) == bPointer );
+
+		// Test setAllocated with Data
+		scope.setAllocated( "a", aData.get() );
+		scope.setAllocated( "b", aData.get() );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "a" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "b" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->getAsData( "a" )->isEqualTo( aData.get() ) );
+		GAFFERTEST_ASSERT( currentContext->getAsData( "b" )->isEqualTo( aData.get() ) );
+
+		// And setAllocated with a direct data
+		scope.setAllocated( "b", bVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "a" ) == aVal );
+		GAFFERTEST_ASSERT( currentContext->get<V>( "b" ) == bVal );
+
+		// Test getting as a generic Data - this should work where set as Data, or directly from a value
+		GAFFERTEST_ASSERT( currentContext->getAsData( "a" )->isEqualTo( aData.get() ) );
+		GAFFERTEST_ASSERT( currentContext->getAsData( "b" )->isEqualTo( bData.get() ) );
+	}
+
+	// Check that setting with a pointer, or a value, or Data, has the same effect
+	{
+		Gaffer::Context::EditableScope x( baseContext.get() );
+		Gaffer::Context::EditableScope y( baseContext.get() );
+		Gaffer::Context::EditableScope z( baseContext.get() );
+
+		x.set( "c", &aVal );
+		y.setAllocated( "c", aVal );
+		z.setAllocated( "c", aData.get() );
+
+		GAFFERTEST_ASSERT( x.context()->get<V>( "c" ) == aVal );
+		GAFFERTEST_ASSERT( y.context()->get<V>( "c" ) == aVal );
+		GAFFERTEST_ASSERT( z.context()->get<V>( "c" ) == aVal );
+
+		GAFFERTEST_ASSERT( x.context()->hash() == y.context()->hash() );
+		GAFFERTEST_ASSERT( x.context()->hash() == z.context()->hash() );
+		GAFFERTEST_ASSERT( x.context()->variableHash( "c" ) == y.context()->variableHash( "c" ) );
+		GAFFERTEST_ASSERT( x.context()->variableHash( "c" ) == z.context()->variableHash( "c" ) );
+
+		x.set( "c", &bVal );
+		y.setAllocated( "c", bVal );
+		z.setAllocated( "c", bData.get() );
+
+		GAFFERTEST_ASSERT( x.context()->get<V>( "c" ) == bVal );
+		GAFFERTEST_ASSERT( y.context()->get<V>( "c" ) == bVal );
+		GAFFERTEST_ASSERT( z.context()->get<V>( "c" ) == bVal );
+
+		GAFFERTEST_ASSERT( x.context()->hash() == y.context()->hash() );
+		GAFFERTEST_ASSERT( x.context()->hash() == z.context()->hash() );
+		GAFFERTEST_ASSERT( x.context()->variableHash( "c" ) == y.context()->variableHash( "c" ) );
+		GAFFERTEST_ASSERT( x.context()->variableHash( "c" ) == z.context()->variableHash( "c" ) );
+	}
+}
 
 GAFFERTEST_API void testManyContexts();
 GAFFERTEST_API void testManySubstitutions();

--- a/include/GafferTest/ContextTest.h
+++ b/include/GafferTest/ContextTest.h
@@ -51,6 +51,7 @@ GAFFERTEST_API void testScopingNullContext();
 GAFFERTEST_API void testEditableScope();
 GAFFERTEST_API std::tuple<int,int,int,int> countContextHash32Collisions( int contexts, int mode, int seed );
 GAFFERTEST_API void testContextHashPerformance( int numEntries, int entrySize, bool startInitialized );
+GAFFERTEST_API void testContextCopyPerformance( int numEntries, int entrySize );
 
 } // namespace GafferTest
 

--- a/include/GafferTest/RandomTest.h
+++ b/include/GafferTest/RandomTest.h
@@ -1,0 +1,49 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERTEST_RANDOMTEST_H
+#define GAFFERTEST_RANDOMTEST_H
+
+#include "GafferTest/Export.h"
+
+namespace GafferTest
+{
+
+GAFFERTEST_API void testRandomPerf();
+
+} // namespace GafferTest
+
+#endif // GAFFERTEST_RANDOMTEST_H

--- a/python/GafferImageTest/ContextSanitiserTest.py
+++ b/python/GafferImageTest/ContextSanitiserTest.py
@@ -1,0 +1,83 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import six
+
+import IECore
+
+import Gaffer
+import GafferImage
+import GafferImageTest
+
+class ContextSanitiserTest( GafferImageTest.ImageTestCase ) :
+
+	def test( self ) :
+
+		constant = GafferImage.Constant()
+
+		# A ContextSanitiser is automatically hooked up by ImageTestCase.setUp, so
+		# we don't need to explicitly set one up
+		with IECore.CapturingMessageHandler() as mh :
+			with Gaffer.Context() as c :
+
+				c["image:channelName"] = IECore.StringData( "R" )
+				c["image:tileOrigin"] = IECore.V2iData( imath.V2i( 0, 0 ) )
+
+				constant["out"]["metadata"].getValue()
+				constant["out"]["sampleOffsets"].getValue()
+				constant["out"]["channelData"].getValue()
+
+				c["image:channelName"] = IECore.IntData( 5 )
+
+				with six.assertRaisesRegex( self, IECore.Exception, 'Context entry is not of type "StringData"' ) :
+					constant["out"]["metadata"].getValue()
+
+		for message in mh.messages :
+			self.assertEqual( message.level, mh.Level.Warning )
+			self.assertEqual( message.context, "ContextSanitiser" )
+
+		self.assertEqual(
+			[ m.message for m in mh.messages ],
+			[
+				'image:channelName in context for Constant.out.metadata computeNode:hash',
+				'image:tileOrigin in context for Constant.out.metadata computeNode:hash',
+				'image:channelName in context for Constant.out.sampleOffsets computeNode:compute'
+			]
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/FormatDataTest.py
+++ b/python/GafferImageTest/FormatDataTest.py
@@ -99,5 +99,8 @@ class FormatDataTest( GafferImageTest.ImageTestCase ) :
 		c["f"] = d
 		self.assertEqual( c["f"], d )
 
+	def testEditableScopeForFormat( self ) :
+		GafferImageTest.testEditableScopeForFormat()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -102,6 +102,7 @@ from .DeepStateTest import DeepStateTest
 from .EmptyTest import EmptyTest
 from .DeepHoldoutTest import DeepHoldoutTest
 from .DeepRecolorTest import DeepRecolorTest
+from .ContextSanitiserTest import ContextSanitiserTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -848,5 +848,10 @@ class ContextTest( GafferTest.TestCase ) :
 
 		GafferTest.testContextHashPerformance( 10, 10, True )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContextCopyPerformance( self ) :
+
+		GafferTest.testContextCopyPerformance( 10, 10 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -81,9 +81,10 @@ class ContextTest( GafferTest.TestCase ) :
 		hash3 = c.hash()
 		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ), ( "b", 1, hash3 ) ] )
 
-		# Even an assignment that doesn't change anything does still trigger the signal
+		# when an assignment makes no actual change, the signal should not
+		# be triggered again.
 		c["b"] = 1
-		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ), ( "b", 1, hash3 ), ( "b", 1, hash3 ) ] )
+		self.assertEqual( changes, [ ( "a", 2, hash1 ), ( "a", 3, hash2 ), ( "b", 1, hash3 ) ] )
 
 		# Removing variables should also trigger the changed signal.
 

--- a/python/GafferTest/RandomTest.py
+++ b/python/GafferTest/RandomTest.py
@@ -166,5 +166,10 @@ class RandomTest( GafferTest.TestCase ) :
 		self.assertEqual( c3, c4 )
 		self.assertEqual( c3, c2 )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testRandomPerf( self ) :
+
+		GafferTest.testRandomPerf()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ContextMonitor.cpp
+++ b/src/Gaffer/ContextMonitor.cpp
@@ -82,8 +82,7 @@ ContextMonitor::Statistics & ContextMonitor::Statistics::operator += ( const Con
 	context->names( names );
 	for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 	{
-		const Data *d = context->get<Data>( *it );
-		m_variables[*it][d->Object::hash()] += 1;
+		m_variables[*it][context->variableHash( *it )] += 1;
 	}
 	return *this;
 }

--- a/src/Gaffer/ContextVariables.cpp
+++ b/src/Gaffer/ContextVariables.cpp
@@ -91,13 +91,13 @@ void ContextVariables::processContext( Context::EditableScope &context ) const
 		IECore::DataPtr data = variablesPlug()->memberDataAndName( it->get(), name );
 		if( data )
 		{
-			context.set( name, data.get() );
+			context.setAllocated( name, data.get() );
 		}
 	}
 	IECore::ConstCompoundDataPtr extraVariablesData = extraVariablesPlug()->getValue();
 	const IECore::CompoundDataMap &extraVariables = extraVariablesData->readable();
 	for( IECore::CompoundDataMap::const_iterator it = extraVariables.begin(), eIt = extraVariables.end(); it != eIt; ++it )
 	{
-		context.set( it->first, it->second.get() );
+		context.setAllocated( it->first, it->second.get() );
 	}
 }

--- a/src/Gaffer/Expression.cpp
+++ b/src/Gaffer/Expression.cpp
@@ -316,15 +316,7 @@ void Expression::hash( const ValuePlug *output, const Context *context, IECore::
 
 		for( std::vector<IECore::InternedString>::const_iterator it = m_contextNames.begin(); it != m_contextNames.end(); it++ )
 		{
-			const IECore::Data *d = context->get<IECore::Data>( *it, nullptr );
-			if( d )
-			{
-				d->hash( h );
-			}
-			else
-			{
-				h.append( 0 );
-			}
+			h.append( context->variableHash( *it ) );
 		}
 	}
 	else if( outPlug()->isAncestorOf( output ) )

--- a/src/Gaffer/Loop.cpp
+++ b/src/Gaffer/Loop.cpp
@@ -197,7 +197,7 @@ void Loop::hash( const ValuePlug *output, const Context *context, IECore::Murmur
 		Context::EditableScope tmpContext( context );
 		if( index >= 0 )
 		{
-			tmpContext.set<int>( indexVariable, index );
+			tmpContext.set( indexVariable, &index );
 		}
 		else
 		{
@@ -219,7 +219,7 @@ void Loop::compute( ValuePlug *output, const Context *context ) const
 		Context::EditableScope tmpContext( context );
 		if( index >= 0 )
 		{
-			tmpContext.set<int>( indexVariable, index );
+			tmpContext.set( indexVariable, &index );
 		}
 		else
 		{

--- a/src/Gaffer/ProcessMessageHandler.cpp
+++ b/src/Gaffer/ProcessMessageHandler.cpp
@@ -80,15 +80,15 @@ void ProcessMessageHandler::handle( Level level, const string &context, const st
 
 		ss << "[ plug: '" << p->plug()->fullName() << "'";
 
-		if( auto frame = p->context()->get<IECore::FloatData>( g_frame, nullptr ) )
+		if( const float *frame = p->context()->getIfExists<float>( g_frame ) )
 		{
-			ss << ", frame: " << frame->readable();
+			ss << ", frame: " << *frame;
 		}
 
-		if( auto path = p->context()->get<IECore::InternedStringVectorData>( g_scenePath, nullptr ) )
+		if( auto path = p->context()->getIfExists< std::vector<IECore::InternedString> >( g_scenePath ) )
 		{
 			std::string strPath = std::string("/") + join(
-				path->readable() | transformed(
+				*path | transformed(
 					[]( const IECore::InternedString &s )
 					{
 						return s.string();

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -283,9 +283,9 @@ class RowsMapScope : boost::noncopyable, public Context::SubstitutionProvider
 			{
 				// Special case for `scene:path`, which users will expect to use PathMatcher
 				// style matching rather than `StringAlgo::match()`.
-				if( auto path = context->get<InternedStringVectorData>( g_scenePath, nullptr ) )
+				if( auto path = context->getIfExists< std::vector<InternedString> >( g_scenePath ) )
 				{
-					m_selector = &path->readable();
+					m_selector = path;
 				}
 				else
 				{

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -643,8 +643,7 @@ class Dispatcher::Batcher
 					continue;
 				}
 
-				result.append( *it );
-				context->get<const IECore::Data>( *it )->hash( result );
+				result.append( context->variableHash( *it ) );
 			}
 			return result;
 		}

--- a/src/GafferImage/ChannelDataProcessor.cpp
+++ b/src/GafferImage/ChannelDataProcessor.cpp
@@ -141,22 +141,22 @@ void ChannelDataProcessor::hashChannelData( const GafferImage::ImagePlug *output
 	IECore::ConstStringVectorDataPtr channelNamesData;
 	bool unpremult = false;
 	bool repremultByProcessedAlpha = false;
-	if( m_hasUnpremultPlug && channelName != "A" )
+	if( m_hasUnpremultPlug && channelName != ImageAlgo::channelNameA )
 	{
 		ImagePlug::GlobalScope globalScope( context );
 		unpremult = processUnpremultipliedPlug()->getValue();
 		if( unpremult )
 		{
 			channelNamesData = inPlug()->channelNamesPlug()->getValue();
-			repremultByProcessedAlpha = channelEnabled( "A" );
+			repremultByProcessedAlpha = channelEnabled( ImageAlgo::channelNameA );
 		}
 	}
 
 	h.append( unpremult );
-	if( unpremult && ImageAlgo::channelExists( channelNamesData->readable(), "A" ) )
+	if( unpremult && ImageAlgo::channelExists( channelNamesData->readable(), ImageAlgo::channelNameA ) )
 	{
 		ImagePlug::ChannelDataScope s( context );
-		s.setChannelName( "A" );
+		s.setChannelName( &ImageAlgo::channelNameA );
 		inPlug()->channelDataPlug()->hash( h );
 		if( repremultByProcessedAlpha )
 		{
@@ -173,23 +173,23 @@ IECore::ConstFloatVectorDataPtr ChannelDataProcessor::computeChannelData( const 
 	IECore::ConstStringVectorDataPtr channelNamesData;
 	bool unpremult = false;
 	bool repremultByProcessedAlpha = false;
-	if( m_hasUnpremultPlug && channelName != "A" )
+	if( m_hasUnpremultPlug && channelName != ImageAlgo::channelNameA )
 	{
 		ImagePlug::GlobalScope globalScope( context );
 		unpremult = processUnpremultipliedPlug()->getValue();
 		if( unpremult )
 		{
 			channelNamesData = inPlug()->channelNamesPlug()->getValue();
-			repremultByProcessedAlpha = channelEnabled( "A" );
+			repremultByProcessedAlpha = channelEnabled( ImageAlgo::channelNameA );
 		}
 	}
 
 	IECore::ConstFloatVectorDataPtr alphaData;
 	IECore::ConstFloatVectorDataPtr postAlphaData;
-	if( unpremult && ImageAlgo::channelExists( channelNamesData->readable(), "A" ) )
+	if( unpremult && ImageAlgo::channelExists( channelNamesData->readable(), ImageAlgo::channelNameA ) )
 	{
 		ImagePlug::ChannelDataScope s( context );
-		s.setChannelName( "A" );
+		s.setChannelName( &ImageAlgo::channelNameA );
 		alphaData = inPlug()->channelDataPlug()->getValue();
 		if( repremultByProcessedAlpha )
 		{

--- a/src/GafferImage/CollectImages.cpp
+++ b/src/GafferImage/CollectImages.cpp
@@ -205,7 +205,7 @@ void CollectImages::hashFormat( const GafferImage::ImagePlug *parent, const Gaff
 	if( rootLayersData->readable().size() )
 	{
 		Context::EditableScope editScope( context );
-		editScope.set( layerVariablePlug()->getValue(), rootLayersData->readable()[0] );
+		editScope.set( layerVariablePlug()->getValue(), &( rootLayersData->readable()[0] ) );
 		h = inPlug()->formatPlug()->hash();
 	}
 	else
@@ -221,7 +221,7 @@ GafferImage::Format CollectImages::computeFormat( const Gaffer::Context *context
 	if( rootLayersData->readable().size() )
 	{
 		Context::EditableScope editScope( context );
-		editScope.set( layerVariablePlug()->getValue(), rootLayersData->readable()[0] );
+		editScope.set( layerVariablePlug()->getValue(), &( rootLayersData->readable()[0] ) );
 		return inPlug()->formatPlug()->getValue();
 	}
 	else
@@ -241,7 +241,7 @@ void CollectImages::hashDeep( const GafferImage::ImagePlug *parent, const Gaffer
 	Context::EditableScope editScope( context );
 	for( const auto &i : rootLayersData->readable() )
 	{
-		editScope.set( layerVariable, i );
+		editScope.set( layerVariable, &i );
 		inPlug()->deepPlug()->hash( h );
 	}
 }
@@ -256,7 +256,7 @@ bool CollectImages::computeDeep( const Gaffer::Context *context, const ImagePlug
 	Context::EditableScope editScope( context );
 	for( const auto &i : rootLayersData->readable() )
 	{
-		editScope.set( layerVariable, i );
+		editScope.set( layerVariable, &i );
 		bool curDeep = inPlug()->deepPlug()->getValue();
 		if( outDeep == -1 )
 		{
@@ -288,7 +288,7 @@ void CollectImages::hashSampleOffsets( const GafferImage::ImagePlug *parent, con
 	Context::EditableScope editScope( context );
 	for( const auto &i : rootLayersData->readable() )
 	{
-		editScope.set( layerVariable, i );
+		editScope.set( layerVariable, &i );
 		inPlug()->sampleOffsetsPlug()->hash( h );
 	}
 }
@@ -307,7 +307,7 @@ IECore::ConstIntVectorDataPtr CollectImages::computeSampleOffsets( const Imath::
 	Context::EditableScope editScope( context );
 	for( const auto &i : rootLayersData->readable() )
 	{
-		editScope.set( layerVariable, i );
+		editScope.set( layerVariable, &i );
 		IECore::ConstIntVectorDataPtr curSampleOffsetsData = inPlug()->sampleOffsetsPlug()->getValue();
 		if( !outSampleOffsetsData )
 		{
@@ -330,7 +330,7 @@ void CollectImages::hashMetadata( const GafferImage::ImagePlug *parent, const Ga
 	if( rootLayersData->readable().size() )
 	{
 		Context::EditableScope editScope( context );
-		editScope.set( layerVariablePlug()->getValue(), rootLayersData->readable()[0] );
+		editScope.set( layerVariablePlug()->getValue(), &( rootLayersData->readable()[0] ) );
 		h = inPlug()->metadataPlug()->hash();
 	}
 	else
@@ -346,7 +346,7 @@ IECore::ConstCompoundDataPtr CollectImages::computeMetadata( const Gaffer::Conte
 	if( rootLayersData->readable().size() )
 	{
 		Context::EditableScope editScope( context );
-		editScope.set( layerVariablePlug()->getValue(), rootLayersData->readable()[0] );
+		editScope.set( layerVariablePlug()->getValue(), &( rootLayersData->readable()[0] ) );
 		return inPlug()->metadataPlug()->getValue();
 	}
 	else
@@ -372,11 +372,11 @@ void CollectImages::hashDataWindow( const GafferImage::ImagePlug *output, const 
 	}
 
 	Context::EditableScope editScope( context );
-	editScope.set( layerVariable, rootLayers[0] );
+	editScope.set( layerVariable, &( rootLayers[0] ) );
 	inPlug()->deepPlug()->hash( h );
 	for( unsigned int i = 0; i < rootLayers.size(); i++ )
 	{
-		editScope.set( layerVariable, rootLayers[i] );
+		editScope.set( layerVariable, &( rootLayers[i] ) );
 		inPlug()->dataWindowPlug()->hash( h );
 	}
 }
@@ -396,11 +396,11 @@ Imath::Box2i CollectImages::computeDataWindow( const Gaffer::Context *context, c
 	}
 
 	Context::EditableScope editScope( context );
-	editScope.set( layerVariable, rootLayers[0] );
+	editScope.set( layerVariable, &( rootLayers[0] ) );
 	bool deep = inPlug()->deepPlug()->getValue();
 	for( unsigned int i = 0; i < rootLayers.size(); i++ )
 	{
-		editScope.set( layerVariable, rootLayers[i] );
+		editScope.set( layerVariable, &( rootLayers[i] ) );
 		Box2i curDataWindow = inPlug()->dataWindowPlug()->getValue();
 		if( i == 0 || !deep )
 		{
@@ -437,7 +437,7 @@ void CollectImages::hashChannelNames( const GafferImage::ImagePlug *output, cons
 	Context::EditableScope editScope( context );
 	for( unsigned int i = 0; i < rootLayers.size(); i++ )
 	{
-		editScope.set( layerVariable, rootLayers[i] );
+		editScope.set( layerVariable, &( rootLayers[i] ) );
 		inPlug()->channelNamesPlug()->hash( h );
 	}
 }
@@ -455,7 +455,7 @@ IECore::ConstStringVectorDataPtr CollectImages::computeChannelNames( const Gaffe
 	Context::EditableScope editScope( context );
 	for( unsigned int i = 0; i < rootLayers.size(); i++ )
 	{
-		editScope.set( layerVariable, rootLayers[i] );
+		editScope.set( layerVariable, &( rootLayers[i] ) );
 		ConstStringVectorDataPtr layerChannelsData = inPlug()->channelNamesPlug()->getValue();
 		const std::vector<string> &layerChannels = layerChannelsData->readable();
 
@@ -496,8 +496,8 @@ void CollectImages::hashChannelData( const GafferImage::ImagePlug *parent, const
 	sourceLayerAndChannel( channelName, rootLayers, srcLayer, srcChannel );
 
 	Context::EditableScope editScope( context );
-	editScope.set( ImagePlug::channelNameContextName, srcChannel );
-	editScope.set( layerVariable, srcLayer );
+	editScope.set( ImagePlug::channelNameContextName, &srcChannel );
+	editScope.set( layerVariable, &srcLayer );
 
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	const Box2i tileBound( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) );
@@ -543,7 +543,7 @@ IECore::ConstFloatVectorDataPtr CollectImages::computeChannelData( const std::st
 	sourceLayerAndChannel( channelName, rootLayers, srcLayer, srcChannel );
 
 	Context::EditableScope editScope( context );
-	editScope.set( layerVariable, srcLayer );
+	editScope.set( layerVariable, &srcLayer );
 
 	// First use this EditableScope as a global scope
 	editScope.remove( ImagePlug::channelNameContextName );
@@ -559,8 +559,8 @@ IECore::ConstFloatVectorDataPtr CollectImages::computeChannelData( const std::st
 	}
 
 	// Then set up the scope to evaluate the input channel data
-	editScope.set( ImagePlug::channelNameContextName, srcChannel );
-	editScope.set( ImagePlug::tileOriginContextName, tileOrigin );
+	editScope.set( ImagePlug::channelNameContextName, &srcChannel );
+	editScope.set( ImagePlug::tileOriginContextName, &tileOrigin );
 
 	ConstFloatVectorDataPtr inputData = inPlug()->channelDataPlug()->getValue();
 

--- a/src/GafferImage/ColorProcessor.cpp
+++ b/src/GafferImage/ColorProcessor.cpp
@@ -167,9 +167,9 @@ void ColorProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 		{
 			ImagePlug::ChannelDataScope channelDataScope( context );
 
-			if( unpremult && ImageAlgo::channelExists( channelNames, "A" ) )
+			if( unpremult && ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameA ) )
 			{
-				channelDataScope.setChannelName( "A" );
+				channelDataScope.setChannelName( &ImageAlgo::channelNameA );
 				alpha = inPlug()->channelDataPlug()->getValue();
 			}
 
@@ -179,7 +179,7 @@ void ColorProcessor::compute( Gaffer::ValuePlug *output, const Gaffer::Context *
 				string channelName = ImageAlgo::channelName( layerName, baseName );
 				if( ImageAlgo::channelExists( channelNames, channelName ) )
 				{
-					channelDataScope.setChannelName( channelName );
+					channelDataScope.setChannelName( &channelName );
 					rgb[i] = inPlug()->channelDataPlug()->getValue()->copy();
 
 					samples = rgb[i]->readable().size();
@@ -290,7 +290,8 @@ void ColorProcessor::hashChannelData( const GafferImage::ImagePlug *output, cons
 	h.append( baseName );
 	{
 		Context::EditableScope layerScope( context );
-		layerScope.set( g_layerNameKey, ImageAlgo::layerName( channel ) );
+		std::string layerNameStr = ImageAlgo::layerName( channel );
+		layerScope.set( g_layerNameKey, &layerNameStr );
 		colorDataPlug()->hash( h );
 	}
 }
@@ -313,7 +314,8 @@ IECore::ConstFloatVectorDataPtr ColorProcessor::computeChannelData( const std::s
 	ConstObjectVectorPtr colorData;
 	{
 		Context::EditableScope layerScope( context );
-		layerScope.set( g_layerNameKey, ImageAlgo::layerName( channel ) );
+		std::string layerNameStr = ImageAlgo::layerName( channel );
+		layerScope.set( g_layerNameKey, &layerNameStr );
 		colorData = boost::static_pointer_cast<const ObjectVector>( colorDataPlug()->getValue() );
 	}
 	return boost::static_pointer_cast<const FloatVectorData>( colorData->members()[ImageAlgo::colorIndex( baseName)] );
@@ -343,7 +345,7 @@ void ColorProcessor::hashColorData( const Gaffer::Context *context, IECore::Murm
 		string channelName = ImageAlgo::channelName( layerName, baseName );
 		if( ImageAlgo::channelExists( channelNames, channelName ) )
 		{
-			channelDataScope.setChannelName( channelName );
+			channelDataScope.setChannelName( &channelName );
 			inPlug()->channelDataPlug()->hash( h );
 		}
 		else
@@ -352,9 +354,9 @@ void ColorProcessor::hashColorData( const Gaffer::Context *context, IECore::Murm
 		}
 	}
 
-	if( unpremult && ImageAlgo::channelExists( channelNames, "A" ) )
+	if( unpremult && ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameA ) )
 	{
-		channelDataScope.setChannelName( "A" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameA );
 		inPlug()->channelDataPlug()->hash( h );
 	}
 }

--- a/src/GafferImage/DeepMerge.cpp
+++ b/src/GafferImage/DeepMerge.cpp
@@ -393,8 +393,8 @@ IECore::ConstFloatVectorDataPtr DeepMerge::computeChannelData( const std::string
 	}
 
 	// In a per-tile and per-channel context, get a ptr to the channel data of each input
-	reusedScope.setTileOrigin( tileOrigin );
-	reusedScope.setChannelName( channelName );
+	reusedScope.setTileOrigin( &tileOrigin );
+	reusedScope.setChannelName( &channelName );
 	std::vector< ConstFloatVectorDataPtr > channelDatas( numInputs );
 	std::vector< const float* > channelPtrs( numInputs, nullptr );
 	for( int j = 0; j < numInputs; j++ )
@@ -410,9 +410,9 @@ IECore::ConstFloatVectorDataPtr DeepMerge::computeChannelData( const std::string
 		{
 			// Special case to copy Z to ZBack when combining images where some have ZBack
 			// and some don't
-			reusedScope.setChannelName( "Z" );
+			reusedScope.setChannelName( &ImageAlgo::channelNameZ );
 			channelDatas[j] = inP->channelDataPlug()->getValue();
-			reusedScope.setChannelName( channelName );
+			reusedScope.setChannelName( &channelName );
 		}
 		else
 		{

--- a/src/GafferImage/DeepRecolor.cpp
+++ b/src/GafferImage/DeepRecolor.cpp
@@ -128,8 +128,8 @@ void DeepRecolor::hashChannelData( const GafferImage::ImagePlug *output, const G
 		!ImageAlgo::channelExists( colorSourceChannelNames->readable(), channelName )
 	)
 	{
-		reusedScope.setTileOrigin( tileOrigin );
-		reusedScope.setChannelName( channelName );
+		reusedScope.setTileOrigin( &tileOrigin );
+		reusedScope.setChannelName( &channelName );
 		h = inPlug()->channelDataPlug()->hash();
 		return;
 	}
@@ -142,11 +142,11 @@ void DeepRecolor::hashChannelData( const GafferImage::ImagePlug *output, const G
 	const Imath::Box2i colorSourceDataWindow = colorSourcePlug()->dataWindowPlug()->getValue();
 	ConstStringVectorDataPtr inChannelNames = inPlug()->channelNamesPlug()->getValue();
 
-	reusedScope.setTileOrigin( tileOrigin );
+	reusedScope.setTileOrigin( &tileOrigin );
 	inPlug()->sampleOffsetsPlug()->hash( h );
 
-	reusedScope.setChannelName( "A" );
-	if( ImageAlgo::channelExists( inChannelNames->readable(), "A" ) )
+	reusedScope.setChannelName( &ImageAlgo::channelNameA );
+	if( ImageAlgo::channelExists( inChannelNames->readable(), ImageAlgo::channelNameA ) )
 	{
 		inPlug()->channelDataPlug()->hash( h );
 	}
@@ -155,7 +155,7 @@ void DeepRecolor::hashChannelData( const GafferImage::ImagePlug *output, const G
 		h.append( true );
 	}
 
-	if( ImageAlgo::channelExists( colorSourceChannelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( colorSourceChannelNames->readable(), ImageAlgo::channelNameA ) )
 	{
 		colorSourcePlug()->channelDataPlug()->hash( h );
 	}
@@ -164,7 +164,7 @@ void DeepRecolor::hashChannelData( const GafferImage::ImagePlug *output, const G
 		h.append( true );
 	}
 
-	reusedScope.setChannelName( channelName );
+	reusedScope.setChannelName( &channelName );
 
 	colorSourcePlug()->channelDataPlug()->hash( h );
 
@@ -189,8 +189,8 @@ IECore::ConstFloatVectorDataPtr DeepRecolor::computeChannelData( const std::stri
 		!ImageAlgo::channelExists( colorSourceChannelNames->readable(), channelName )
 	)
 	{
-		reusedScope.setTileOrigin( tileOrigin );
-		reusedScope.setChannelName( channelName );
+		reusedScope.setTileOrigin( &tileOrigin );
+		reusedScope.setChannelName( &channelName );
 		return inPlug()->channelDataPlug()->getValue();
 	}
 
@@ -202,7 +202,7 @@ IECore::ConstFloatVectorDataPtr DeepRecolor::computeChannelData( const std::stri
 	const Imath::Box2i colorSourceDataWindow = colorSourcePlug()->dataWindowPlug()->getValue();
 	ConstStringVectorDataPtr inChannelNames = inPlug()->channelNamesPlug()->getValue();
 
-	reusedScope.setTileOrigin( tileOrigin );
+	reusedScope.setTileOrigin( &tileOrigin );
 	ConstIntVectorDataPtr sampleOffsetsData = inPlug()->sampleOffsetsPlug()->getValue();
 	const std::vector<int> &sampleOffsets = sampleOffsetsData->readable();
 
@@ -220,11 +220,11 @@ IECore::ConstFloatVectorDataPtr DeepRecolor::computeChannelData( const std::stri
 		return resultData;
 	}
 
-	reusedScope.setChannelName( "A" );
+	reusedScope.setChannelName( &ImageAlgo::channelNameA );
 	ConstFloatVectorDataPtr deepAlphaData;
-	if( ImageAlgo::channelExists( inChannelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( inChannelNames->readable(), ImageAlgo::channelNameA ) )
 	{
-		if( useColorSourceAlpha && channelName != "A" )
+		if( useColorSourceAlpha && channelName != ImageAlgo::channelNameA )
 		{
 			deepAlphaData = outPlug()->channelDataPlug()->getValue();
 		}
@@ -239,7 +239,7 @@ IECore::ConstFloatVectorDataPtr DeepRecolor::computeChannelData( const std::stri
 	}
 
 	ConstFloatVectorDataPtr colorSourceAlphaData;
-	if( ImageAlgo::channelExists( colorSourceChannelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( colorSourceChannelNames->readable(), ImageAlgo::channelNameA ) )
 	{
 		colorSourceAlphaData = colorSourcePlug()->channelDataPlug()->getValue();
 	}
@@ -332,7 +332,7 @@ IECore::ConstFloatVectorDataPtr DeepRecolor::computeChannelData( const std::stri
 	}
 	else
 	{
-		reusedScope.setChannelName( channelName );
+		reusedScope.setChannelName( &channelName );
 
 		ConstFloatVectorDataPtr colorSourceChannelData = colorSourcePlug()->channelDataPlug()->getValue();
 		const std::vector<float> &colorSourceChannel = colorSourceChannelData->readable();

--- a/src/GafferImage/DeepSampleCounts.cpp
+++ b/src/GafferImage/DeepSampleCounts.cpp
@@ -117,7 +117,7 @@ IECore::ConstFloatVectorDataPtr DeepSampleCounts::computeChannelData( const std:
 		return ImagePlug::whiteTile();
 	}
 
-	scope.setTileOrigin( tileOrigin );
+	scope.setTileOrigin( &tileOrigin );
 	ConstIntVectorDataPtr sampleOffsetsData = inPlug()->sampleOffsetsPlug()->getValue();
 
 	FloatVectorDataPtr resultData = new FloatVectorData();

--- a/src/GafferImage/DeepSampler.cpp
+++ b/src/GafferImage/DeepSampler.cpp
@@ -125,13 +125,13 @@ void DeepSampler::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *
 			V2i tileOrigin = ImagePlug::tileOrigin( pixel );
 
 			ImagePlug::ChannelDataScope channelScope( context );
-			channelScope.setTileOrigin( tileOrigin );
+			channelScope.setTileOrigin( &tileOrigin );
 
 			imagePlug()->sampleOffsetsPlug()->hash( h );
 
 			for( const auto &i : channelNames->readable() )
 			{
-				channelScope.setChannelName( i );
+				channelScope.setChannelName( &i );
 				imagePlug()->channelDataPlug()->hash( h );
 			}
 		}
@@ -154,7 +154,7 @@ void DeepSampler::compute( Gaffer::ValuePlug *output, const Gaffer::Context *con
 
 
 			ImagePlug::ChannelDataScope channelScope( context );
-			channelScope.setTileOrigin( tileOrigin );
+			channelScope.setTileOrigin( &tileOrigin );
 			ConstIntVectorDataPtr sampleOffsetsData = imagePlug()->sampleOffsetsPlug()->getValue();
 
 			int pixelIndex = ImagePlug::pixelIndex( pixel, tileOrigin );
@@ -166,7 +166,7 @@ void DeepSampler::compute( Gaffer::ValuePlug *output, const Gaffer::Context *con
 			{
 				for( const auto &i : channelNames->readable() )
 				{
-					channelScope.setChannelName( i );
+					channelScope.setChannelName( &i );
 					ConstFloatVectorDataPtr channelData = imagePlug()->channelDataPlug()->getValue();
 
 					FloatVectorDataPtr pixelChannelData = new FloatVectorData();

--- a/src/GafferImage/DeepState.cpp
+++ b/src/GafferImage/DeepState.cpp
@@ -948,27 +948,27 @@ void DeepState::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	const std::vector<std::string> &channelNames = channelNamesData->readable();
 
 	ImagePlug::ChannelDataScope channelScope( context );
-	if( ImageAlgo::channelExists( channelNames, "Z" ) )
+	if( ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameZ ) )
 	{
-		channelScope.setChannelName( "Z" );
+		channelScope.setChannelName( &ImageAlgo::channelNameZ );
 		inPlug()->channelDataPlug()->hash( h );
 	}
 	else
 	{
 		h.append( false );
 	}
-	if( ImageAlgo::channelExists( channelNames, "ZBack" ) )
+	if( ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameZBack ) )
 	{
-		channelScope.setChannelName( "ZBack" );
+		channelScope.setChannelName( &ImageAlgo::channelNameZBack );
 		inPlug()->channelDataPlug()->hash( h );
 	}
 	else
 	{
 		h.append( false );
 	}
-	if( ImageAlgo::channelExists( channelNames, "A" ) )
+	if( ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameA ) )
 	{
-		channelScope.setChannelName( "A" );
+		channelScope.setChannelName( &ImageAlgo::channelNameA );
 		inPlug()->channelDataPlug()->hash( h );
 	}
 	else
@@ -1008,20 +1008,20 @@ void DeepState::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	CompoundObjectPtr result = new CompoundObject;
 
 	ImagePlug::ChannelDataScope channelScope( Context::current() );
-	bool hasZ = ImageAlgo::channelExists( channelNames, "Z" );
+	bool hasZ = ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameZ );
 
 	ConstFloatVectorDataPtr zData;
 	if( hasZ )
 	{
-		channelScope.setChannelName( "Z" );
+		channelScope.setChannelName( &ImageAlgo::channelNameZ );
 		zData = inPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr zBackData;
-	bool hasZBack = ImageAlgo::channelExists( channelNames, "ZBack" );
+	bool hasZBack = ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameZBack );
 	if( hasZBack )
 	{
-		channelScope.setChannelName( "ZBack" );
+		channelScope.setChannelName( &ImageAlgo::channelNameZBack );
 		zBackData = inPlug()->channelDataPlug()->getValue();
 	}
 	else
@@ -1052,10 +1052,10 @@ void DeepState::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			FloatVectorDataPtr sampleWeightsData = new FloatVectorData();
 			std::vector<float> &sampleWeights = sampleWeightsData->writable();
 
-			if( ImageAlgo::channelExists( channelNames, "A" ) )
+			if( ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameA ) )
 			{
 				ImagePlug::ChannelDataScope channelScope( Context::current() );
-				channelScope.setChannelName( "A" );
+				channelScope.setChannelName( &ImageAlgo::channelNameA );
 				ConstFloatVectorDataPtr alphaData = inPlug()->channelDataPlug()->getValue();
 
 				sampleWeights.resize( sampleOffsetsData->readable().back() );
@@ -1134,9 +1134,9 @@ void DeepState::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 		}
 
 		ConstFloatVectorDataPtr alphaData;
-		if( ImageAlgo::channelExists( channelNames, "A" ) )
+		if( ImageAlgo::channelExists( channelNames, ImageAlgo::channelNameA ) )
 		{
-			channelScope.setChannelName( "A" );
+			channelScope.setChannelName( &ImageAlgo::channelNameA );
 			alphaData = inPlug()->channelDataPlug()->getValue();
 		}
 		else

--- a/src/GafferImage/FlatToDeep.cpp
+++ b/src/GafferImage/FlatToDeep.cpp
@@ -228,8 +228,8 @@ void FlatToDeep::hashChannelData( const GafferImage::ImagePlug *output, const Ga
 				) );
 			}
 
-			reusedScope.setTileOrigin( tileOrigin );
-			reusedScope.setChannelName( zChannel );
+			reusedScope.setTileOrigin( &tileOrigin );
+			reusedScope.setChannelName( &zChannel );
 			h = inPlug()->channelDataPlug()->hash();
 		}
 	}
@@ -256,16 +256,16 @@ void FlatToDeep::hashChannelData( const GafferImage::ImagePlug *output, const Ga
 						+ zBackChannel + "\" found."
 					) );
 				}
-				reusedScope.setTileOrigin( tileOrigin );
-				reusedScope.setChannelName( zBackChannel );
+				reusedScope.setTileOrigin( &tileOrigin );
+				reusedScope.setChannelName( &zBackChannel );
 				h = inPlug()->channelDataPlug()->hash();
 			}
 			else
 			{
 				thicknessPlug()->hash( h );
 
-				reusedScope.setTileOrigin( tileOrigin );
-				reusedScope.setChannelName( zChannel );
+				reusedScope.setTileOrigin( &tileOrigin );
+				reusedScope.setChannelName( &zChannel );
 				outPlug()->channelDataPlug()->hash(h);
 			}
 		}
@@ -311,8 +311,8 @@ IECore::ConstFloatVectorDataPtr FlatToDeep::computeChannelData( const std::strin
 				) );
 			}
 
-			reusedScope.setTileOrigin( tileOrigin );
-			reusedScope.setChannelName( zChannel );
+			reusedScope.setTileOrigin( &tileOrigin );
+			reusedScope.setChannelName( &zChannel );
 			return inPlug()->channelDataPlug()->getValue();
 		}
 	}
@@ -346,8 +346,8 @@ IECore::ConstFloatVectorDataPtr FlatToDeep::computeChannelData( const std::strin
 					) );
 				}
 
-				reusedScope.setTileOrigin( tileOrigin );
-				reusedScope.setChannelName( zBackChannel );
+				reusedScope.setTileOrigin( &tileOrigin );
+				reusedScope.setChannelName( &zBackChannel );
 				return inPlug()->channelDataPlug()->getValue();
 			}
 			else
@@ -355,8 +355,8 @@ IECore::ConstFloatVectorDataPtr FlatToDeep::computeChannelData( const std::strin
 				// Compute ZBack by combining incoming Z with thickness
 				float thickness = thicknessPlug()->getValue();
 
-				reusedScope.setTileOrigin( tileOrigin );
-				reusedScope.setChannelName( zChannel );
+				reusedScope.setTileOrigin( &tileOrigin );
+				reusedScope.setChannelName( &zChannel );
 				FloatVectorDataPtr resultData = outPlug()->channelDataPlug()->getValue()->copy();
 				vector<float> &result = resultData->writable();
 				for( float &i : result )

--- a/src/GafferImage/FormatData.cpp
+++ b/src/GafferImage/FormatData.cpp
@@ -38,10 +38,14 @@
 
 #include "GafferImage/TypeIds.h"
 
+#include "Gaffer/Context.h"
+
 #include "IECore/TypedData.h"
 #include "IECore/TypedData.inl"
 
 using namespace Imath;
+
+Gaffer::Context::ContextTypeDescription<GafferImage::FormatData> formatDataTypeDescription;
 
 namespace IECore
 {

--- a/src/GafferImage/ImageAlgo.cpp
+++ b/src/GafferImage/ImageAlgo.cpp
@@ -137,6 +137,13 @@ std::vector<std::string> GafferImage::ImageAlgo::layerNames( const std::vector<s
 	return result;
 }
 
+const std::string GafferImage::ImageAlgo::channelNameA( "A" );
+const std::string GafferImage::ImageAlgo::channelNameR( "R" );
+const std::string GafferImage::ImageAlgo::channelNameG( "G" );
+const std::string GafferImage::ImageAlgo::channelNameB( "B" );
+const std::string GafferImage::ImageAlgo::channelNameZ( "Z" );
+const std::string GafferImage::ImageAlgo::channelNameZBack( "ZBack" );
+
 IECoreImage::ImagePrimitivePtr GafferImage::ImageAlgo::image( const ImagePlug *imagePlug )
 {
 	if( imagePlug->deepPlug()->getValue() )
@@ -292,7 +299,7 @@ IECore::ConstCompoundObjectPtr GafferImage::ImageAlgo::tiles( const ImagePlug *i
 			ImagePlug::ChannelDataScope channelDataScope( Gaffer::Context::current() );
 			for( unsigned int i = 0; i < channelNames.size(); i++ )
 			{
-				channelDataScope.setChannelName( channelNames[i] );
+				channelDataScope.setChannelName( &channelNames[i] );
 				channelDataResults[i]->members()[tileI] = const_cast<IECore::FloatVectorData*>(
 					imageP->channelDataPlug()->getValue().get()
 				);

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -307,12 +307,24 @@ ImagePlug::ChannelDataScope::ChannelDataScope( const Gaffer::ThreadState &thread
 {
 }
 
+// DEPRECATED
 void ImagePlug::ChannelDataScope::setTileOrigin( const V2i &tileOrigin )
+{
+	setAllocated( tileOriginContextName, tileOrigin );
+}
+
+// DEPRECATED
+void ImagePlug::ChannelDataScope::setChannelName( const std::string &channelName )
+{
+	setAllocated( channelNameContextName, channelName );
+}
+
+void ImagePlug::ChannelDataScope::setTileOrigin( const V2i *tileOrigin )
 {
 	set( tileOriginContextName, tileOrigin );
 }
 
-void ImagePlug::ChannelDataScope::setChannelName( const std::string &channelName )
+void ImagePlug::ChannelDataScope::setChannelName( const std::string *channelName )
 {
 	set( channelNameContextName, channelName );
 }
@@ -320,8 +332,8 @@ void ImagePlug::ChannelDataScope::setChannelName( const std::string &channelName
 IECore::ConstFloatVectorDataPtr ImagePlug::channelData( const std::string &channelName, const Imath::V2i &tile ) const
 {
 	ChannelDataScope channelDataScope( Context::current() );
-	channelDataScope.setChannelName( channelName );
-	channelDataScope.setTileOrigin( tile );
+	channelDataScope.setChannelName( &channelName );
+	channelDataScope.setTileOrigin( &tile );
 
 	return channelDataPlug()->getValue();
 }
@@ -329,8 +341,8 @@ IECore::ConstFloatVectorDataPtr ImagePlug::channelData( const std::string &chann
 IECore::MurmurHash ImagePlug::channelDataHash( const std::string &channelName, const Imath::V2i &tile ) const
 {
 	ChannelDataScope channelDataScope( Context::current() );
-	channelDataScope.setChannelName( channelName );
-	channelDataScope.setTileOrigin( tile );
+	channelDataScope.setChannelName( &channelName );
+	channelDataScope.setTileOrigin( &tile );
 	return channelDataPlug()->hash();
 }
 
@@ -397,13 +409,13 @@ IECore::MurmurHash ImagePlug::deepHash() const
 IECore::ConstIntVectorDataPtr ImagePlug::sampleOffsets( const Imath::V2i &tile ) const
 {
 	ChannelDataScope channelDataScope( Context::current() );
-	channelDataScope.setTileOrigin( tile );
+	channelDataScope.setTileOrigin( &tile );
 	return sampleOffsetsPlug()->getValue();
 }
 
 IECore::MurmurHash ImagePlug::sampleOffsetsHash( const Imath::V2i &tile ) const
 {
 	ChannelDataScope channelDataScope( Context::current() );
-	channelDataScope.setTileOrigin( tile );
+	channelDataScope.setTileOrigin( &tile );
 	return sampleOffsetsPlug()->hash();
 }

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -290,7 +290,7 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 		h.append( statIndex );
 
 		ImagePlug::ChannelDataScope s( context );
-		s.setChannelName( channelName );
+		s.setChannelName( &channelName );
 		allStatsPlug()->hash( h );
 		return;
 	}
@@ -366,7 +366,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 		int statIndex = ( parent == averagePlug() ) ? 2 : ( parent == maxPlug() );
 
 		ImagePlug::ChannelDataScope s( context );
-		s.setChannelName( channelName );
+		s.setChannelName( &channelName );
 		Imath::V3d stats = boost::static_pointer_cast<const IECore::V3dData>( allStatsPlug()->getValue() )->readable();
 		static_cast<FloatPlug *>( output )->setValue( stats[ statIndex ] );
 		return;

--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -108,7 +108,7 @@ class ImageTransform::ChainingScope : boost::noncopyable
 	public :
 
 		ChainingScope( const Gaffer::Context *context, const ImageTransform *imageTransform )
-			:	m_chained( context->get<bool>( chainedContextName, false ) )
+			:	m_chained( context->get<bool>( chainedContextName, false ) ), m_true( true )
 		{
 			if( !m_chained )
 			{
@@ -117,7 +117,7 @@ class ImageTransform::ChainingScope : boost::noncopyable
 					// We're the bottom of a chain. Tell the upstream
 					// nodes they've been chained.
 					m_scope.emplace( context );
-					m_scope->set( chainedContextName, true );
+					m_scope->set( chainedContextName, &m_true );
 				}
 			}
 			else
@@ -156,6 +156,7 @@ class ImageTransform::ChainingScope : boost::noncopyable
 		// an EditableScope when we don't need one.
 		boost::optional<Context::EditableScope> m_scope;
 		bool m_chained;
+		bool m_true;
 
 };
 

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1535,7 +1535,8 @@ void ImageWriter::execute() const
 	// `colorSpaceNode()`.
 
 	Context::EditableScope colorSpaceScope( Context::current() );
-	colorSpaceScope.set( "__imageWriter:colorSpace", colorSpace() );
+	std::string colorSpaceStr = colorSpace();
+	colorSpaceScope.set( "__imageWriter:colorSpace", &colorSpaceStr );
 
 	// Create an OIIO::ImageOutput
 

--- a/src/GafferImage/Mix.cpp
+++ b/src/GafferImage/Mix.cpp
@@ -307,7 +307,7 @@ void Mix::hashChannelData( const GafferImage::ImagePlug *output, const Gaffer::C
 		maskPlug()->deepPlug()->hash( h );
 
 		// The sample offsets need to be accessed in a context with tileOrigin, but without the channel name
-		c.setTileOrigin( tileOrigin );
+		c.setTileOrigin( &tileOrigin );
 		outPlug()->sampleOffsetsPlug()->hash( h );
 		maskPlug()->sampleOffsetsPlug()->hash( h );
 	}
@@ -388,7 +388,7 @@ IECore::ConstFloatVectorDataPtr Mix::computeChannelData( const std::string &chan
 		}
 
 		// The sample offsets need to be accessed in a context with tileOrigin, but without the channel name
-		c.setTileOrigin( tileOrigin );
+		c.setTileOrigin( &tileOrigin );
 
 		if( deep )
 		{

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -149,7 +149,8 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
 	{
-		offsetScope.setTileOrigin( tileOrigin - offset );
+		V2i offsetOrigin = tileOrigin - offset;
+		offsetScope.setTileOrigin( &offsetOrigin );
 		h = inPlug()->channelDataPlug()->hash();
 	}
 	else
@@ -173,7 +174,7 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 		{
 			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 			{
-				offsetScope.setTileOrigin( inTileOrigin );
+				offsetScope.setTileOrigin( &inTileOrigin );
 				inPlug()->channelDataPlug()->hash( h );
 			}
 		}
@@ -183,7 +184,7 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 		// For performance reasons, instead of including hashing sampleOffsets for every input tile, we
 		// just include the output sample offsets, which already depends on the input sample offsets and
 		// the deep plug
-		offsetScope.setTileOrigin( tileOrigin );
+		offsetScope.setTileOrigin( &tileOrigin );
 		offsetScope.remove( ImagePlug::channelNameContextName );
 		outPlug()->sampleOffsetsPlug()->hash( h );
 	}
@@ -196,7 +197,8 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 	const V2i offset = offsetPlug()->getValue();
 	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
 	{
-		offsetScope.setTileOrigin( tileOrigin - offset );
+		V2i offsetOrigin = tileOrigin - offset;
+		offsetScope.setTileOrigin( &offsetOrigin );
 		return inPlug()->channelDataPlug()->getValue();
 	}
 
@@ -219,7 +221,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 	{
 		offsetScope.remove( ImagePlug::channelNameContextName );
 		outSampleOffsetsData = outPlug()->sampleOffsetsPlug()->getValue();
-		offsetScope.setChannelName( channelName );
+		offsetScope.setChannelName( &channelName );
 		outData->writable().resize( outSampleOffsetsData->readable().back() );
 	}
 
@@ -230,7 +232,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 	{
 		for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 		{
-			offsetScope.setTileOrigin( inTileOrigin );
+			offsetScope.setTileOrigin( &inTileOrigin );
 			ConstFloatVectorDataPtr inData = inPlug()->channelDataPlug()->getValue();
 			const float *in = &inData->readable().front();
 
@@ -260,7 +262,7 @@ IECore::ConstFloatVectorDataPtr Offset::computeChannelData( const std::string &c
 			{
 				offsetScope.remove( ImagePlug::channelNameContextName );
 				ConstIntVectorDataPtr inSampleOffsetsData = inPlug()->sampleOffsetsPlug()->getValue();
-				offsetScope.setChannelName( channelName );
+				offsetScope.setChannelName( &channelName );
 				const std::vector<int> &inSampleOffsets = inSampleOffsetsData->readable();
 				const std::vector<int> &outSampleOffsets = outSampleOffsetsData->readable();
 				for( V2i inScanlineOrigin = inRegion.min; inScanlineOrigin.y < inRegion.max.y; inScanlineOrigin.y++ )
@@ -302,7 +304,8 @@ void Offset::hashSampleOffsets( const GafferImage::ImagePlug *parent, const Gaff
 	const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 	if( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 )
 	{
-		offsetScope.setTileOrigin( tileOrigin - offset );
+		V2i offsetOrigin = tileOrigin - offset;
+		offsetScope.setTileOrigin( &offsetOrigin );
 		h = inPlug()->sampleOffsetsPlug()->hash();
 	}
 	else
@@ -328,7 +331,7 @@ void Offset::hashSampleOffsets( const GafferImage::ImagePlug *parent, const Gaff
 		{
 			for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 			{
-				offsetScope.setTileOrigin( inTileOrigin );
+				offsetScope.setTileOrigin( &inTileOrigin );
 				inPlug()->sampleOffsetsPlug()->hash( h );
 			}
 		}
@@ -349,7 +352,8 @@ IECore::ConstIntVectorDataPtr Offset::computeSampleOffsets( const Imath::V2i &ti
 	const V2i offset = offsetPlug()->getValue();
 	if( ( offset.x % ImagePlug::tileSize() == 0 && offset.y % ImagePlug::tileSize() == 0 ) )
 	{
-		offsetScope.setTileOrigin( tileOrigin - offset );
+		V2i offsetOrigin = tileOrigin - offset;
+		offsetScope.setTileOrigin( &offsetOrigin );
 		return inPlug()->sampleOffsetsPlug()->getValue();
 	}
 
@@ -370,7 +374,7 @@ IECore::ConstIntVectorDataPtr Offset::computeSampleOffsets( const Imath::V2i &ti
 	{
 		for( inTileOrigin.x = ImagePlug::tileOrigin( inBound.min ).x; inTileOrigin.x < inBound.max.x; inTileOrigin.x += ImagePlug::tileSize() )
 		{
-			offsetScope.setTileOrigin( inTileOrigin );
+			offsetScope.setTileOrigin( &inTileOrigin );
 			ConstIntVectorDataPtr inData = inPlug()->sampleOffsetsPlug()->getValue();
 			const std::vector<int> &in = inData->readable();
 

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -728,10 +728,10 @@ FilePtr retrieveFile( std::string &fileName, OpenImageIOReader::MissingFrameMode
 				}
 
 				// setup a context with the new frame
-				ContextPtr holdContext = new Context( *context, Context::Shared );
-				holdContext->setFrame( *fIt );
+				Context::EditableScope holdScope( context );
+				holdScope.setFrame( *fIt );
 
-				return retrieveFile( fileName, OpenImageIOReader::Error, node, holdContext.get() );
+				return retrieveFile( fileName, OpenImageIOReader::Error, node, holdScope.context() );
 			}
 
 			// if we got here, there was no suitable file sequence

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -1180,7 +1180,7 @@ IECore::ConstIntVectorDataPtr OpenImageIOReader::computeSampleOffsets( const Ima
 		std::string channelName(""); // TODO - should have better interface for selecting sampleOffsets
 		file->findTile( channelName, tileOrigin, tileBatchIndex, subIndex );
 
-		c.set( g_tileBatchIndexContextName, tileBatchIndex );
+		c.set( g_tileBatchIndexContextName, &tileBatchIndex );
 
 		ConstObjectVectorPtr tileBatch = tileBatchPlug()->getValue();
 
@@ -1229,7 +1229,7 @@ IECore::ConstFloatVectorDataPtr OpenImageIOReader::computeChannelData( const std
 	int subIndex;
 	file->findTile( channelName, tileOrigin, tileBatchIndex, subIndex );
 
-	c.set( g_tileBatchIndexContextName, tileBatchIndex );
+	c.set( g_tileBatchIndexContextName, &tileBatchIndex );
 
 	ConstObjectVectorPtr tileBatch = tileBatchPlug()->getValue();
 	ConstObjectPtr curTileChannel;

--- a/src/GafferImage/Premultiply.cpp
+++ b/src/GafferImage/Premultiply.cpp
@@ -90,7 +90,7 @@ void Premultiply::hashChannelData( const GafferImage::ImagePlug *output, const G
 	inPlug()->channelDataPlug()->hash( h );
 
 	ImagePlug::ChannelDataScope channelDataScope( context );
-	channelDataScope.setChannelName( alphaChannel );
+	channelDataScope.setChannelName( &alphaChannel );
 
 	inPlug()->channelDataPlug()->hash( h );
 }
@@ -119,7 +119,7 @@ void Premultiply::processChannelData( const Gaffer::Context *context, const Imag
 	}
 
 	ImagePlug::ChannelDataScope channelDataScope( context );
-	channelDataScope.setChannelName( alphaChannel );
+	channelDataScope.setChannelName( &alphaChannel );
 
 	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
 	const std::vector<float> &a = aData->readable();

--- a/src/GafferImage/RankFilter.cpp
+++ b/src/GafferImage/RankFilter.cpp
@@ -342,7 +342,7 @@ void RankFilter::hashChannelData( const GafferImage::ImagePlug *parent, const Ga
 	if( masterChannel != "" )
 	{
 		ImagePlug::ChannelDataScope pixelOffsetsScope( context );
-		pixelOffsetsScope.setChannelName( masterChannel );
+		pixelOffsetsScope.setChannelName( &masterChannel );
 
 		pixelOffsetsPlug()->hash( h );
 	}
@@ -377,7 +377,7 @@ IECore::ConstFloatVectorDataPtr RankFilter::computeChannelData( const std::strin
 		ConstV2iVectorDataPtr pixelOffsets;
 		{
 			ImagePlug::ChannelDataScope pixelOffsetsScope( context );
-			pixelOffsetsScope.setChannelName( masterChannel );
+			pixelOffsetsScope.setChannelName( &masterChannel );
 
 			pixelOffsets = pixelOffsetsPlug()->getValue();
 		}

--- a/src/GafferImage/Shuffle.cpp
+++ b/src/GafferImage/Shuffle.cpp
@@ -197,7 +197,7 @@ void Shuffle::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffe
 		}
 		else
 		{
-			channelDataScope.setTileOrigin( tileOrigin );
+			channelDataScope.setTileOrigin( &tileOrigin );
 			inPlug()->sampleOffsetsPlug()->hash( h );
 			h.append( c == "__white" );
 		}
@@ -205,7 +205,7 @@ void Shuffle::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffe
 	else
 	{
 		ImagePlug::ChannelDataScope channelDataScope( context );
-		channelDataScope.setChannelName( c );
+		channelDataScope.setChannelName( &c );
 		h = inPlug()->channelDataPlug()->hash();
 	}
 }
@@ -227,7 +227,7 @@ IECore::ConstFloatVectorDataPtr Shuffle::computeChannelData( const std::string &
 		}
 		else
 		{
-			channelDataScope.setTileOrigin( tileOrigin );
+			channelDataScope.setTileOrigin( &tileOrigin );
 			ConstIntVectorDataPtr sampleOffsets = inPlug()->sampleOffsetsPlug()->getValue();
 
 			FloatVectorDataPtr result = new FloatVectorData();
@@ -242,7 +242,7 @@ IECore::ConstFloatVectorDataPtr Shuffle::computeChannelData( const std::string &
 	else
 	{
 		ImagePlug::ChannelDataScope channelDataScope( context );
-		channelDataScope.setChannelName( c );
+		channelDataScope.setChannelName( &c );
 		return inPlug()->channelDataPlug()->getValue();
 	}
 }

--- a/src/GafferImage/Unpremultiply.cpp
+++ b/src/GafferImage/Unpremultiply.cpp
@@ -90,7 +90,7 @@ void Unpremultiply::hashChannelData( const GafferImage::ImagePlug *output, const
 	inPlug()->channelDataPlug()->hash( h );
 
 	ImagePlug::ChannelDataScope channelDataScope( context );
-	channelDataScope.setChannelName( alphaChannel );
+	channelDataScope.setChannelName( &alphaChannel );
 
 	inPlug()->channelDataPlug()->hash( h );
 }
@@ -119,7 +119,7 @@ void Unpremultiply::processChannelData( const Gaffer::Context *context, const Im
 	}
 
 	ImagePlug::ChannelDataScope channelDataScope( context );
-	channelDataScope.setChannelName( alphaChannel );
+	channelDataScope.setChannelName( &alphaChannel );
 
 	ConstFloatVectorDataPtr aData = inPlug()->channelDataPlug()->getValue();
 	const std::vector<float> &a = aData->readable();

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -215,21 +215,21 @@ void VectorWarp::hashEngine( const Imath::V2i &tileOrigin, const Gaffer::Context
 
 	ImagePlug::ChannelDataScope channelDataScope( context );
 
-	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameR ) )
 	{
-		channelDataScope.setChannelName( "R" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameR );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
-	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameG ) )
 	{
-		channelDataScope.setChannelName( "G" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameG );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
-	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameA ) )
 	{
-		channelDataScope.setChannelName( "A" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameA );
 		vectorPlug()->channelDataPlug()->hash( h );
 	}
 
@@ -256,23 +256,23 @@ const Warp::Engine *VectorWarp::computeEngine( const Imath::V2i &tileOrigin, con
 	ImagePlug::ChannelDataScope channelDataScope( context );
 
 	ConstFloatVectorDataPtr xData = ImagePlug::blackTile();
-	if( ImageAlgo::channelExists( channelNames->readable(), "R" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameR ) )
 	{
-		channelDataScope.setChannelName( "R" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameR );
 		xData = vectorPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr yData = ImagePlug::blackTile();
-	if( ImageAlgo::channelExists( channelNames->readable(), "G" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameG ) )
 	{
-		channelDataScope.setChannelName( "G" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameG );
 		yData = vectorPlug()->channelDataPlug()->getValue();
 	}
 
 	ConstFloatVectorDataPtr aData = ImagePlug::whiteTile();
-	if( ImageAlgo::channelExists( channelNames->readable(), "A" ) )
+	if( ImageAlgo::channelExists( channelNames->readable(), ImageAlgo::channelNameA ) )
 	{
-		channelDataScope.setChannelName( "A" );
+		channelDataScope.setChannelName( &ImageAlgo::channelNameA );
 		aData = vectorPlug()->channelDataPlug()->getValue();
 	}
 

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -67,7 +67,7 @@ namespace
 	{
 		if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
 		{
-			tileScope.setTileOrigin( tileOrigin );
+			tileScope.setTileOrigin( &tileOrigin );
 			plug->hash( h );
 		}
 	}
@@ -76,7 +76,7 @@ namespace
 	{
 		if( BufferAlgo::intersects( dataWindow, Box2i( tileOrigin, tileOrigin + V2i( ImagePlug::tileSize() ) ) ) )
 		{
-			tileScope.setTileOrigin( tileOrigin );
+			tileScope.setTileOrigin( &tileOrigin );
 			return plug->getValue();
 		}
 		else

--- a/src/GafferImageTest/ContextSanitiser.cpp
+++ b/src/GafferImageTest/ContextSanitiser.cpp
@@ -73,18 +73,18 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 	{
 		if( process->plug() == image->sampleOffsetsPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ImagePlug::channelNameContextName, nullptr ) )
+			if( process->context()->getIfExists<std::string>( ImagePlug::channelNameContextName ) )
 			{
 				warn( *process, ImagePlug::channelNameContextName );
 			}
 		}
 		else if( process->plug() != image->channelDataPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ImagePlug::channelNameContextName, nullptr ) )
+			if( process->context()->getIfExists<std::string>( ImagePlug::channelNameContextName ) )
 			{
 				warn( *process, ImagePlug::channelNameContextName );
 			}
-			if( process->context()->get<IECore::Data>( ImagePlug::tileOriginContextName, nullptr ) )
+			if( process->context()->getIfExists<Imath::V2i>( ImagePlug::tileOriginContextName ) )
 			{
 				warn( *process, ImagePlug::tileOriginContextName );
 			}

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -38,8 +38,11 @@
 
 #include "GafferImageTest/ContextSanitiser.h"
 
+#include "GafferTest/ContextTest.h"
+
 #include "GafferImage/ImageAlgo.h"
 #include "GafferImage/ImagePlug.h"
+#include "GafferImage/Format.h"
 
 #include "Gaffer/Node.h"
 
@@ -99,6 +102,14 @@ boost::signals::connection connectProcessTilesToPlugDirtiedSignal( GafferImage::
 	return const_cast<Node *>( node )->plugDirtiedSignal().connect( boost::bind( &processTilesOnDirty, ::_1, image ) );
 }
 
+void testEditableScopeForFormat()
+{
+	GafferTest::testEditableScopeTyped<FormatData>(
+		Format( Imath::Box2i( Imath::V2i( 1, 2 ), Imath::V2i( 1, 2 ) ), 1 ),
+		Format( Imath::Box2i( Imath::V2i( 3, 5 ), Imath::V2i( 1920, 1080 ) ), 1.6 )
+	);
+}
+
 } // namespace
 
 BOOST_PYTHON_MODULE( _GafferImageTest )
@@ -109,4 +120,5 @@ BOOST_PYTHON_MODULE( _GafferImageTest )
 
 	def( "processTiles", &processTilesWrapper );
 	def( "connectProcessTilesToPlugDirtiedSignal", &connectProcessTilesToPlugDirtiedSignal );
+	def( "testEditableScopeForFormat", &testEditableScopeForFormat );
 }

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -1073,7 +1073,7 @@ void ImageGadget::updateTiles()
 		ImagePlug::ChannelDataScope channelScope( Context::current() );
 		for( auto &channelName : channelsToCompute )
 		{
-			channelScope.setChannelName( channelName );
+			channelScope.setChannelName( &channelName );
 			Tile &tile = m_tiles[TileIndex(tileOrigin, channelName)];
 			updates.push_back( tile.computeUpdate( image ) );
 		}

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -126,16 +126,18 @@ class RendererServices : public OSL::RendererServices
 				return false;
 			}
 
-			const Data *data = renderState->context->get<Data>( name.c_str(), nullptr );
+			// TODO - might be nice if there was some way to speed this up by directly querying the type matching
+			// the TypeDesc, instead of getting as a generic Data?
+			const DataPtr data = renderState->context->getAsData( name.c_str(), nullptr );
 			if( !data )
 			{
 				return false;
 			}
 
-			IECoreImage::OpenImageIOAlgo::DataView dataView( data, /* createUStrings = */ true );
+			IECoreImage::OpenImageIOAlgo::DataView dataView( data.get(), /* createUStrings = */ true );
 			if( !dataView.data )
 			{
-				if( auto b = runTimeCast<const BoolData>( data ) )
+				if( auto b = runTimeCast<BoolData>( data.get() ) )
 				{
 					// BoolData isn't supported by `DataView` because `OIIO::TypeDesc` doesn't
 					// have a boolean type. We could work around this in `DataView` by casting to

--- a/src/GafferOSL/OSLImage.cpp
+++ b/src/GafferOSL/OSLImage.cpp
@@ -290,7 +290,8 @@ void OSLImage::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *con
 			if( !dataWindow.isEmpty() )
 			{
 				ImagePlug::ChannelDataScope channelDataScope( context );
-				channelDataScope.setTileOrigin( ImagePlug::tileOrigin( dataWindow.min ) );
+				Imath::V2i dataTileOrigin = ImagePlug::tileOrigin( dataWindow.min );
+				channelDataScope.setTileOrigin( &dataTileOrigin );
 				shadingPlug()->hash( h );
 			}
 		}
@@ -347,7 +348,8 @@ void OSLImage::compute( Gaffer::ValuePlug *output, const Gaffer::Context *contex
 			if( !dataWindow.isEmpty() )
 			{
 				ImagePlug::ChannelDataScope channelDataScope( context );
-				channelDataScope.setTileOrigin( ImagePlug::tileOrigin( dataWindow.min ) );
+				Imath::V2i dataTileOrigin = ImagePlug::tileOrigin( dataWindow.min );
+				channelDataScope.setTileOrigin( &dataTileOrigin );
 
 				ConstCompoundDataPtr shading = runTimeCast<const CompoundData>( shadingPlug()->getValue() );
 				for( CompoundDataMap::const_iterator it = shading->readable().begin(), eIt = shading->readable().end(); it != eIt; ++it )
@@ -426,7 +428,7 @@ void OSLImage::hashChannelData( const GafferImage::ImagePlug *output, const Gaff
 		if( std::binary_search( affectedChannels->readable().begin(), affectedChannels->readable().end(), channelName ) )
 		{
 			// Channel is affected, include shading hash
-			c.set( ImagePlug::tileOriginContextName, tileOrigin );
+			c.set( ImagePlug::tileOriginContextName, &tileOrigin );
 			shadingPlug()->hash( h );
 			h.append( channelName );
 			return;
@@ -449,7 +451,7 @@ IECore::ConstFloatVectorDataPtr OSLImage::computeChannelData( const std::string 
 		if( std::binary_search( affectedChannels->readable().begin(), affectedChannels->readable().end(), channelName ) )
 		{
 			// Channel is affected, evaluate shading
-			c.set( ImagePlug::tileOriginContextName, tileOrigin );
+			c.set( ImagePlug::tileOriginContextName, &tileOrigin );
 
 			ConstCompoundDataPtr shadedPoints = runTimeCast<const CompoundData>( shadingPlug()->getValue() );
 			ConstFloatVectorDataPtr result = shadedPoints->member<FloatVectorData>( channelName );
@@ -521,7 +523,7 @@ void OSLImage::hashShading( const Gaffer::Context *context, IECore::MurmurHash &
 		{
 			if( shadingEngine->needsAttribute( channelName ) )
 			{
-				c.setChannelName( channelName );
+				c.setChannelName( &channelName );
 				defaultedInPlug()->channelDataPlug()->hash( h );
 			}
 		}
@@ -570,7 +572,7 @@ IECore::ConstCompoundDataPtr OSLImage::computeShading( const Gaffer::Context *co
 		{
 			if( shadingEngine->needsAttribute( channelName ) )
 			{
-				c.setChannelName( channelName );
+				c.setChannelName( &channelName );
 				shadingPoints->writable()[channelName] = boost::const_pointer_cast<FloatVectorData>(
 					defaultedInPlug()->channelDataPlug()->getValue()
 				);

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -307,13 +307,14 @@ class RenderState
 
 			for( const auto &name : contextVariablesNeeded )
 			{
+				DataPtr contextEntryData = context->getAsData( name.string(), nullptr );
 				m_contextVariables.insert(
 					make_pair(
 						ustring( name.c_str() ),
-						IECoreImage::OpenImageIOAlgo::DataView(
-							context->get<Data>( name.string(), nullptr ),
-							/* createUStrings = */ true
-						)
+						ContextData{
+							IECoreImage::OpenImageIOAlgo::DataView( contextEntryData.get(), /* createUStrings = */ true ),
+							contextEntryData
+						}
 					)
 				);
 			}
@@ -327,7 +328,7 @@ class RenderState
 				return false;
 			}
 
-			return ShadingSystem::convert_value( value, type, it->second.data, it->second.type );
+			return ShadingSystem::convert_value( value, type, it->second.dataView.data, it->second.dataView.type );
 		}
 
 		bool userData( size_t pointIndex, ustring name, TypeDesc type, void *value ) const
@@ -393,8 +394,14 @@ class RenderState
 			size_t numValues;
 		};
 
+		struct ContextData
+		{
+			IECoreImage::OpenImageIOAlgo::DataView dataView;
+			ConstDataPtr dataStorage;
+		};
+
 		container::flat_map<ustring, UserData, OIIO::ustringPtrIsLess> m_userData;
-		container::flat_map<ustring, IECoreImage::OpenImageIOAlgo::DataView, OIIO::ustringPtrIsLess> m_contextVariables;
+		container::flat_map<ustring, ContextData, OIIO::ustringPtrIsLess> m_contextVariables;
 
 };
 

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -1121,15 +1121,7 @@ void ShadingEngine::hash( IECore::MurmurHash &h ) const
 		}
 		for( const auto &name : m_contextVariablesNeeded )
 		{
-			const IECore::Data *d = context->get<IECore::Data>( name, nullptr );
-			if( d )
-			{
-				d->hash( h );
-			}
-			else
-			{
-				h.append( 0 );
-			}
+			h.append( context->variableHash( name ) );
 		}
 	}
 }

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -580,8 +580,7 @@ void BranchCreator::hashSet( const IECore::InternedString &setName, const Gaffer
 	{
 		const ScenePlug::ScenePath &parentPath = *it;
 		{
-			ScenePlug::PathScope pathScope( context, parentPath );
-			pathScope.setPath( parentPath );
+			ScenePlug::PathScope pathScope( context, &parentPath );
 			mappingPlug()->hash( h );
 		}
 		MurmurHash branchSetHash;
@@ -617,7 +616,7 @@ IECore::ConstPathMatcherDataPtr BranchCreator::computeSet( const IECore::Interne
 
 		Private::ConstChildNamesMapPtr mapping;
 		{
-			ScenePlug::PathScope pathScope( context, parentPath );
+			ScenePlug::PathScope pathScope( context, &parentPath );
 			mapping = boost::static_pointer_cast<const Private::ChildNamesMap>( mappingPlug()->getValue() );
 		}
 
@@ -802,7 +801,7 @@ IECore::PathMatcher::Result BranchCreator::parentAndBranchPaths( const ScenePath
 
 		Private::ConstChildNamesMapPtr mapping;
 		{
-			ScenePlug::PathScope pathScope( Context::current(), parentPath );
+			ScenePlug::PathScope pathScope( Context::current(), &parentPath );
 			mapping = boost::static_pointer_cast<const Private::ChildNamesMap>( mappingPlug()->getValue() );
 		}
 

--- a/src/GafferScene/CollectPrimitiveVariables.cpp
+++ b/src/GafferScene/CollectPrimitiveVariables.cpp
@@ -141,7 +141,7 @@ void CollectPrimitiveVariables::hashProcessedObject( const ScenePath &path, cons
 	InternedString suffixContextVariableName( suffixContextVariablePlug()->getValue() );
 	for( const std::string & suffix : suffixesData->readable() )
 	{
-		scope.set( suffixContextVariableName, suffix );
+		scope.set( suffixContextVariableName, &suffix );
 		IECore::MurmurHash curHash = inPlug()->objectPlug()->hash();
 		if( curHash != inputHash )
 		{
@@ -180,7 +180,7 @@ IECore::ConstObjectPtr CollectPrimitiveVariables::computeProcessedObject( const 
 	InternedString suffixContextVariableName( suffixContextVariablePlug()->getValue() );
 	for( unsigned int i = 0; i < suffixes.size(); i++ )
 	{
-		scope.set( suffixContextVariableName, suffixes[i] );
+		scope.set( suffixContextVariableName, &suffixes[i] );
 		IECore::MurmurHash collectObjectHash = inPlug()->objectPlug()->hash();
 		if( collectObjectHash == inputHash )
 		{

--- a/src/GafferScene/CollectTransforms.cpp
+++ b/src/GafferScene/CollectTransforms.cpp
@@ -183,7 +183,7 @@ void CollectTransforms::hash( const Gaffer::ValuePlug *output, const Gaffer::Con
 		InternedString attributeContextVariableName( attributeContextVariablePlug()->getValue() );
 		for( const std::string &name : names )
 		{
-			scope.set( attributeContextVariableName, name );
+			scope.set( attributeContextVariableName, &name );
 			IECore::MurmurHash collectedHash;
 			if( worldMatrix )
 			{
@@ -254,7 +254,7 @@ void CollectTransforms::compute( Gaffer::ValuePlug *output, const Gaffer::Contex
 		InternedString attributeContextVariableName( attributeContextVariablePlug()->getValue() );
 		for( const std::string &name : names )
 		{
-			scope.set( attributeContextVariableName, name );
+			scope.set( attributeContextVariableName, &name );
 			if( worldMatrix )
 			{
 				IECore::MurmurHash collectedTransformHash = inPlug()->fullTransformHash( scenePath );

--- a/src/GafferScene/CopyAttributes.cpp
+++ b/src/GafferScene/CopyAttributes.cpp
@@ -153,7 +153,7 @@ void CopyAttributes::hashAttributes( const ScenePath &path, const Gaffer::Contex
 	{
 		ScenePlug::ScenePath sourceLocationPath;
 		ScenePlug::stringToPath( sourceLocation, sourceLocationPath );
-		ScenePlug::PathScope pathScope( context, sourceLocationPath );
+		ScenePlug::PathScope pathScope( context, &sourceLocationPath );
 		if( sourcePlug()->exists() )
 		{
 			sourcePlug()->attributesPlug()->hash( h );
@@ -190,7 +190,7 @@ IECore::ConstCompoundObjectPtr CopyAttributes::computeAttributes( const ScenePat
 	{
 		ScenePlug::ScenePath sourceLocationPath;
 		ScenePlug::stringToPath( sourceLocation, sourceLocationPath );
-		ScenePlug::PathScope pathScope( context, sourceLocationPath );
+		ScenePlug::PathScope pathScope( context, &sourceLocationPath );
 		if( sourcePlug()->exists() )
 		{
 			sourceAttributes = sourcePlug()->attributesPlug()->getValue();

--- a/src/GafferScene/Encapsulate.cpp
+++ b/src/GafferScene/Encapsulate.cpp
@@ -217,7 +217,7 @@ IECore::ConstPathMatcherDataPtr Encapsulate::computeSet( const IECore::InternedS
 
 	for( PathMatcher::RawIterator pIt = inputSet.begin(), peIt = inputSet.end(); pIt != peIt; )
 	{
-		sceneScope.set( ScenePlug::scenePathContextName, *pIt );
+		sceneScope.set( ScenePlug::scenePathContextName, &(*pIt) );
 		const int m = filterPlug()->getValue();
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::AncestorMatch ) )
 		{

--- a/src/GafferScene/FilterPlug.cpp
+++ b/src/GafferScene/FilterPlug.cpp
@@ -164,5 +164,7 @@ unsigned FilterPlug::match( const ScenePlug *scene ) const
 FilterPlug::SceneScope::SceneScope( const Gaffer::Context *context, const ScenePlug *scenePlug )
 	:	EditableScope( context )
 {
-	set( inputSceneContextName, (uint64_t)scenePlug );
+	m_scenePlug = scenePlug;
+	set<uint64_t>( inputSceneContextName, (uint64_t*)&m_scenePlug );
 }
+

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -54,6 +54,12 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
+namespace
+{
+	const ScenePlug::ScenePath g_root;
+
+}
+
 GAFFER_NODE_DEFINE_TYPE( Group );
 
 size_t Group::g_firstPlugIndex = 0;
@@ -161,7 +167,7 @@ void Group::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *contex
 
 	if( output == mappingPlug() )
 	{
-		ScenePlug::PathScope scope( context, ScenePath() );
+		ScenePlug::PathScope scope( context, &g_root );
 		for( const auto &p : ScenePlug::Range( *inPlugs() ) )
 		{
 			p->childNamesPlug()->hash( h );
@@ -174,7 +180,7 @@ void Group::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context )
 	if( output == mappingPlug() )
 	{
 		vector<ConstInternedStringVectorDataPtr> inputChildNames; inputChildNames.reserve( inPlugs()->children().size() );
-		ScenePlug::PathScope scope( context, ScenePath() );
+		ScenePlug::PathScope scope( context, &g_root );
 		for( const auto &p : ScenePlug::Range( *inPlugs() ) )
 		{
 			inputChildNames.push_back( p->childNamesPlug()->getValue() );
@@ -200,7 +206,7 @@ void Group::hashBound( const ScenePath &path, const Gaffer::Context *context, co
 	else if( path.size() == 1 ) // "/group"
 	{
 		SceneProcessor::hashBound( path, context, parent, h );
-		ScenePlug::PathScope scope( context, ScenePath() );
+		ScenePlug::PathScope scope( context, &g_root );
 		for( ScenePlugIterator it( inPlugs() ); !it.done(); ++it )
 		{
 			(*it)->boundPlug()->hash( h );

--- a/src/GafferScene/Isolate.cpp
+++ b/src/GafferScene/Isolate.cpp
@@ -266,7 +266,7 @@ void Isolate::hashChildNames( const ScenePath &path, const Gaffer::Context *cont
 			const unsigned m = setsToKeep.match( childPath );
 			if( m == IECore::PathMatcher::NoMatch )
 			{
-				sceneScope.set( ScenePlug::scenePathContextName, childPath );
+				sceneScope.set( ScenePlug::scenePathContextName, &childPath );
 				filterPlug()->hash( h );
 			}
 			else
@@ -305,7 +305,7 @@ IECore::ConstInternedStringVectorDataPtr Isolate::computeChildNames( const Scene
 			unsigned m = setsToKeep.match( childPath );
 			if( m == IECore::PathMatcher::NoMatch )
 			{
-				sceneScope.set( ScenePlug::scenePathContextName, childPath );
+				sceneScope.set( ScenePlug::scenePathContextName, &childPath );
 				m |= filterPlug()->getValue();
 			}
 			if( m != IECore::PathMatcher::NoMatch )
@@ -396,7 +396,7 @@ IECore::ConstPathMatcherDataPtr Isolate::computeSet( const IECore::InternedStrin
 
 	for( PathMatcher::RawIterator pIt = inputSet.begin(), peIt = inputSet.end(); pIt != peIt; )
 	{
-		sceneScope.set( ScenePlug::scenePathContextName, *pIt );
+		sceneScope.set( ScenePlug::scenePathContextName, &(*pIt) );
 		const int m = filterPlug()->getValue() | setsToKeep.match( *pIt );
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::AncestorMatch ) )
 		{

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -460,7 +460,7 @@ IECore::ConstPathMatcherDataPtr LightToCamera::computeSet( const IECore::Interne
 	/// work for us.
 	for( PathMatcher::Iterator pIt = lightSet.begin(), peIt = lightSet.end(); pIt != peIt; ++pIt )
 	{
-		sceneScope.set( ScenePlug::scenePathContextName, *pIt );
+		sceneScope.set( ScenePlug::scenePathContextName, &(*pIt) );
 		const int m = filterPlug()->getValue();
 		if( m & IECore::PathMatcher::ExactMatch )
 		{

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -313,7 +313,7 @@ void MergeScenes::hashActiveInputs( const Gaffer::Context *context, IECore::Murm
 		InputMask parentActiveInputs;
 		{
 			ScenePath parentPath = scenePath; parentPath.pop_back();
-			ScenePlug::PathScope parentScope( context, parentPath );
+			ScenePlug::PathScope parentScope( context, &parentPath );
 			parentActiveInputs = activeInputsPlug()->getValue();
 		}
 
@@ -355,7 +355,7 @@ int MergeScenes::computeActiveInputs( const Gaffer::Context *context ) const
 		InputMask parentActiveInputs;
 		{
 			ScenePath parentPath = scenePath; parentPath.pop_back();
-			ScenePlug::PathScope parentScope( context, parentPath );
+			ScenePlug::PathScope parentScope( context, &parentPath );
 			parentActiveInputs = activeInputsPlug()->getValue();
 		}
 
@@ -413,7 +413,7 @@ void MergeScenes::hashMergedDescendantsBound( const Gaffer::Context *context, IE
 	for( const auto &childName : childNamesData->readable() )
 	{
 		childPath.back() = childName;
-		childScope.setPath( childPath );
+		childScope.setPath( &childPath );
 		const InputMask childActiveInputs( activeInputsPlug()->getValue() );
 		if( childActiveInputs.count() == 1 && childActiveInputs[firstActiveIndex] )
 		{
@@ -461,7 +461,7 @@ const Imath::Box3f MergeScenes::computeMergedDescendantsBound( const Gaffer::Con
 	for( const auto &childName : childNamesData->readable() )
 	{
 		childPath.back() = childName;
-		childScope.setPath( childPath );
+		childScope.setPath( &childPath );
 		const InputMask childActiveInputs( activeInputsPlug()->getValue() );
 		if( childActiveInputs.count() == 1 && childActiveInputs[firstActiveIndex] )
 		{

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -201,10 +201,9 @@ void PathFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 
 void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
+	const ScenePlug::ScenePath *path = context->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 
-	if( !pathData )
+	if( !path )
 	{
 		// This is a special case used by the Prune and Isolate nodes
 		// to request a hash representing the effects of the filter
@@ -229,8 +228,7 @@ void PathFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *conte
 
 	// Standard case
 
-	const ScenePlug::ScenePath &path = pathData->readable();
-	h.append( path.data(), path.size() );
+	h.append( path->data(), path->size() );
 
 	if( m_pathMatcher )
 	{

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -283,7 +283,8 @@ void PathFilter::hashRootSizes( const Gaffer::Context *context, IECore::MurmurHa
 	const ScenePlug::ScenePath &path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
 	if( path.size() )
 	{
-		ScenePlug::PathScope parentScope( context, ScenePlug::ScenePath( path.begin(), path.begin() + path.size() - 1 ) );
+		ScenePlug::ScenePath parentPath( path.begin(), path.begin() + path.size() - 1 );
+		ScenePlug::PathScope parentScope( context, &parentPath );
 		rootSizesPlug()->hash( h );
 	}
 	rootsPlug()->hash( h );
@@ -299,7 +300,8 @@ ConstIntVectorDataPtr PathFilter::computeRootSizes( const Gaffer::Context *conte
 	ConstIntVectorDataPtr parentRootSizes;
 	if( path.size() )
 	{
-		ScenePlug::PathScope parentScope( context, ScenePlug::ScenePath( path.begin(), path.begin() + path.size() - 1 ) );
+		ScenePlug::ScenePath parentPath( path.begin(), path.begin() + path.size() - 1 );
+		ScenePlug::PathScope parentScope( context, &parentPath );
 		parentRootSizes = rootSizesPlug()->getValue();
 		// If the parent has no descendant roots, then we already have
 		// all the roots we need.

--- a/src/GafferScene/PrimitiveVariableExists.cpp
+++ b/src/GafferScene/PrimitiveVariableExists.cpp
@@ -108,7 +108,7 @@ void PrimitiveVariableExists::hash( const ValuePlug *output, const Context *cont
 	ComputeNode::hash( output, context, h );
 	if( output == outPlug() )
 	{
-		if( context->get<InternedStringVectorData>( ScenePlug::scenePathContextName, nullptr ) )
+		if( context->getIfExists< ScenePlug::ScenePath >( ScenePlug::scenePathContextName ) )
 		{
 			h.append( primitiveVariablePlug()->hash() );
 			h.append( inPlug()->objectPlug()->hash() );
@@ -125,7 +125,7 @@ void PrimitiveVariableExists::compute( ValuePlug *output, const Context *context
 	if( output == outPlug() )
 	{
 		bool exists = false;
-		if( context->get<InternedStringVectorData>( ScenePlug::scenePathContextName, nullptr ) )
+		if( context->getIfExists< ScenePlug::ScenePath >( ScenePlug::scenePathContextName ) )
 		{
 			ConstObjectPtr inObject = inPlug()->objectPlug()->getValue();
 

--- a/src/GafferScene/Prune.cpp
+++ b/src/GafferScene/Prune.cpp
@@ -178,7 +178,7 @@ void Prune::hashChildNames( const ScenePath &path, const Gaffer::Context *contex
 		for( vector<InternedString>::const_iterator it = inputChildNames.begin(), eIt = inputChildNames.end(); it != eIt; ++it )
 		{
 			childPath[path.size()] = *it;
-			sceneScope.set( ScenePlug::scenePathContextName, childPath );
+			sceneScope.set( ScenePlug::scenePathContextName, &childPath );
 			filterPlug()->hash( h );
 		}
 	}
@@ -213,7 +213,7 @@ IECore::ConstInternedStringVectorDataPtr Prune::computeChildNames( const ScenePa
 		for( vector<InternedString>::const_iterator it = inputChildNames.begin(), eIt = inputChildNames.end(); it != eIt; ++it )
 		{
 			childPath[path.size()] = *it;
-			sceneScope.set( ScenePlug::scenePathContextName, childPath );
+			sceneScope.set( ScenePlug::scenePathContextName, &childPath );
 			if( !(filterPlug()->getValue() & IECore::PathMatcher::ExactMatch) )
 			{
 				outputChildNames.push_back( *it );
@@ -268,7 +268,7 @@ IECore::ConstPathMatcherDataPtr Prune::computeSet( const IECore::InternedString 
 
 	for( PathMatcher::RawIterator pIt = inputSet.begin(), peIt = inputSet.end(); pIt != peIt; )
 	{
-		sceneScope.set( ScenePlug::scenePathContextName, *pIt );
+		sceneScope.set( ScenePlug::scenePathContextName, &(*pIt) );
 		const int m = filterPlug()->getValue();
 		if( m & ( IECore::PathMatcher::ExactMatch | IECore::PathMatcher::AncestorMatch ) )
 		{

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -244,7 +244,7 @@ void Render::execute() const
 		return;
 	}
 
-	renderScope.set( g_rendererContextName, rendererType );
+	renderScope.set( g_rendererContextName, &rendererType );
 
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
 	const std::string fileName = fileNamePlug()->getValue();

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -69,9 +69,9 @@ struct RenderScope : public Context::EditableScope
 	RenderScope( const Context *context )
 		:	EditableScope( context ), m_sceneTranslationOnly( false )
 	{
-		if( auto d = context->get<BoolData>( g_sceneTranslationOnlyContextName, nullptr ) )
+		if( const bool *d = context->getIfExists<bool>( g_sceneTranslationOnlyContextName ) )
 		{
-			m_sceneTranslationOnly = d->readable();
+			m_sceneTranslationOnly = *d;
 			// Don't leak variable upstream.
 			remove( g_sceneTranslationOnlyContextName );
 		}

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -921,7 +921,7 @@ class RenderController::SceneGraphUpdateTask : public tbb::task
 			// Set up a context to compute the scene at the right
 			// location.
 
-			ScenePlug::PathScope pathScope( m_threadState, m_scenePath );
+			ScenePlug::PathScope pathScope( m_threadState, &m_scenePath );
 
 			// Update the scene graph at this location.
 
@@ -1252,7 +1252,7 @@ void RenderController::update( const ProgressCallback &callback )
 	m_updateRequested = false;
 
 	Context::EditableScope scopedContext( m_context.get() );
-	scopedContext.set( "scene:renderer", m_renderer->name().string() );
+	scopedContext.set( "scene:renderer", &m_renderer->name().string() );
 
 	updateInternal( callback );
 }
@@ -1268,7 +1268,7 @@ std::shared_ptr<Gaffer::BackgroundTask> RenderController::updateInBackground( co
 	cancelBackgroundTask();
 
 	Context::EditableScope scopedContext( m_context.get() );
-	scopedContext.set( "scene:renderer", m_renderer->name().string() );
+	scopedContext.set( "scene:renderer", &m_renderer->name().string() );
 
 	m_backgroundTask = ParallelAlgo::callOnBackgroundThread(
 		// Subject
@@ -1293,7 +1293,7 @@ void RenderController::updateMatchingPaths( const IECore::PathMatcher &pathsToUp
 	}
 
 	Context::EditableScope scopedContext( m_context.get() );
-	scopedContext.set( "scene:renderer", m_renderer->name().string() );
+	scopedContext.set( "scene:renderer", &m_renderer->name().string() );
 
 	updateInternal( callback, &pathsToUpdate );
 }

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1386,8 +1386,8 @@ ConstOutputPtr addGafferOutputHeaders( const Output *output, const ScenePlug *sc
 	context->names( names );
 	for( const auto &name : names )
 	{
-		// Output params are never mutated, so this is 'safe'...
-		DataPtr data = const_cast<Data*>( context->get<Data>( name ) );
+		DataPtr data = context->getAsData( name );
+
 		// The requires a round-trip through the renderer's native type system, as such, it requires
 		// bi-directional conversion in Cortex. Unsupported types result in a slew of warning messages
 		// in render output. As many facilities employ un-supported types in their contexts as standard,

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -397,7 +397,7 @@ struct RenderSets::Updater
 				potentialChange = LightsSetChanged;
 			}
 
-			setScope.setSetName( n );
+			setScope.setSetName( &n );
 			const IECore::MurmurHash &hash = m_scene->setPlug()->hash();
 			if( s->hash != hash )
 			{

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -319,7 +319,7 @@ IECore::ConstCompoundDataPtr GafferScene::SceneAlgo::sets( const ScenePlug *scen
 			ScenePlug::SetScope setScope( threadState );
 			for( size_t i=r.begin(); i!=r.end(); ++i )
 			{
-				setScope.setSetName( setNames[i] );
+				setScope.setSetName( &setNames[i] );
 				setsVector[i] = scene->setPlug()->getValue();
 			}
 
@@ -431,7 +431,7 @@ class CapturingMonitor : public Monitor
 
 IE_CORE_DECLAREPTR( CapturingMonitor )
 
-uint64_t g_historyID = 0;
+std::atomic<uint64_t> g_historyID( 0 );
 
 SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedString scenePlugChildName, SceneAlgo::History *parent )
 {
@@ -669,9 +669,10 @@ SceneAlgo::History::Ptr SceneAlgo::history( const Gaffer::ValuePlug *scenePlugCh
 
 	CapturingMonitorPtr monitor = new CapturingMonitor;
 	{
-		ScenePlug::PathScope pathScope( Context::current(), path );
+		ScenePlug::PathScope pathScope( Context::current(), &path );
+		uint64_t historyID = g_historyID++;
 		// Trick to bypass the hash cache and get a full upstream evaluation.
-		pathScope.set( historyIDContextName(), g_historyID++ );
+		pathScope.set( historyIDContextName(), &historyID );
 		Monitor::Scope monitorScope( monitor );
 		scenePlugChild->hash();
 	}
@@ -1007,7 +1008,7 @@ bool GafferScene::SceneAlgo::visible( const ScenePlug *scene, const ScenePlug::S
 	for( ScenePlug::ScenePath::const_iterator it = path.begin(), eIt = path.end(); it != eIt; ++it )
 	{
 		p.push_back( *it );
-		pathScope.setPath( p );
+		pathScope.setPath( &p );
 
 		ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
 		const BoolData *visibilityData = attributes->member<BoolData>( "scene:visible" );

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -446,7 +446,7 @@ SceneAlgo::History::Ptr historyWalk( const CapturedProcess *process, InternedStr
 		ScenePlug *scene = plug->parent<ScenePlug>();
 		if( scene && plug == scene->getChild( scenePlugChildName ) )
 		{
-			ContextPtr cleanContext = new Context( *process->context, Context::Copied );
+			ContextPtr cleanContext = new Context( *process->context );
 			cleanContext->remove( SceneAlgo::historyIDContextName() );
 			SceneAlgo::History::Ptr history = new SceneAlgo::History( scene, cleanContext );
 			if( !result )

--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -436,13 +436,13 @@ Gaffer::ValuePlug::CachePolicy SceneNode::computeCachePolicy( const Gaffer::Valu
 
 IECore::MurmurHash SceneNode::hashOfTransformedChildBounds( const ScenePath &path, const ScenePlug *out, const IECore::InternedStringVectorData *childNamesData ) const
 {
-	ScenePlug::PathScope pathScope( Context::current(), path );
+	ScenePlug::PathScope pathScope( Context::current(), &path );
 	return out->childBoundsPlug()->hash();
 }
 
 Imath::Box3f SceneNode::unionOfTransformedChildBounds( const ScenePath &path, const ScenePlug *out, const IECore::InternedStringVectorData *childNamesData ) const
 {
-	ScenePlug::PathScope pathScope( Context::current(), path );
+	ScenePlug::PathScope pathScope( Context::current(), &path );
 	return out->childBoundsPlug()->getValue();
 }
 
@@ -517,8 +517,9 @@ void SceneNode::hashExists( const Gaffer::Context *context, const ScenePlug *par
 		return;
 	}
 
-	ScenePath parentPath( scenePath ); parentPath.pop_back();
-	ScenePlug::PathScope parentScope( context, parentPath );
+	ScenePath parentPath( scenePath );
+	parentPath.pop_back();
+	ScenePlug::PathScope parentScope( context, &parentPath );
 	if( !parent->existsPlug()->getValue() )
 	{
 		h.append( false );
@@ -538,8 +539,9 @@ bool SceneNode::computeExists( const Gaffer::Context *context, const ScenePlug *
 		return true;
 	}
 
-	ScenePath parentPath( scenePath ); parentPath.pop_back();
-	ScenePlug::PathScope parentScope( context, parentPath );
+	ScenePath parentPath( scenePath );
+	parentPath.pop_back();
+	ScenePlug::PathScope parentScope( context, &parentPath );
 	if( !parent->existsPlug()->getValue() )
 	{
 		// If `parentPath` doesn't exist, then neither can `scenePath`
@@ -601,7 +603,7 @@ void SceneNode::hashChildBounds( const Gaffer::Context *context, const ScenePlug
 			for( size_t i = range.begin(); i != range.end(); ++i )
 			{
 				childPath.back() = childNames[i];
-				pathScope.setPath( childPath );
+				pathScope.setPath( &childPath );
 				parent->boundPlug()->hash( result );
 				parent->transformPlug()->hash( result );
 			}
@@ -647,7 +649,7 @@ Imath::Box3f SceneNode::computeChildBounds( const Gaffer::Context *context, cons
 			for( size_t i = range.begin(); i != range.end(); ++i )
 			{
 				childPath.back() = childNames[i];
-				pathScope.setPath( childPath );
+				pathScope.setPath( &childPath );
 				Box3f childBound = parent->boundPlug()->getValue();
 				childBound = transform( childBound, parent->transformPlug()->getValue() );
 				result.extendBy( childBound );

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -316,7 +316,14 @@ ScenePlug::PathScope::PathScope( const Gaffer::Context *context )
 	remove( ScenePlug::setNameContextName );
 }
 
+// DEPRECATED
 ScenePlug::PathScope::PathScope( const Gaffer::Context *context, const ScenePath &scenePath )
+	:	PathScope( context )
+{
+	setAllocated( scenePathContextName, scenePath );
+}
+
+ScenePlug::PathScope::PathScope( const Gaffer::Context *context, const ScenePath *scenePath )
 	:	PathScope( context )
 {
 	setPath( scenePath );
@@ -327,13 +334,26 @@ ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState )
 {
 }
 
+// DEPRECATED
 ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath )
+	:	EditableScope( threadState )
+{
+	setAllocated( scenePathContextName, scenePath );
+}
+
+ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState, const ScenePath *scenePath )
 	:	EditableScope( threadState )
 {
 	setPath( scenePath );
 }
 
+// DEPRECATED
 void ScenePlug::PathScope::setPath( const ScenePath &scenePath )
+{
+	setAllocated( scenePathContextName, scenePath );
+}
+
+void ScenePlug::PathScope::setPath( const ScenePath *scenePath )
 {
 	set( scenePathContextName, scenePath );
 }
@@ -345,7 +365,16 @@ ScenePlug::SetScope::SetScope( const Gaffer::Context *context )
 	remove( ScenePlug::scenePathContextName );
 }
 
+// DEPRECATED
 ScenePlug::SetScope::SetScope( const Gaffer::Context *context, const IECore::InternedString &setName )
+	:	EditableScope( context )
+{
+	remove( Filter::inputSceneContextName );
+	remove( ScenePlug::scenePathContextName );
+	setAllocated( setNameContextName, setName );
+}
+
+ScenePlug::SetScope::SetScope( const Gaffer::Context *context, const IECore::InternedString *setName )
 	:	EditableScope( context )
 {
 	remove( Filter::inputSceneContextName );
@@ -360,7 +389,16 @@ ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState )
 	remove( ScenePlug::scenePathContextName );
 }
 
+// DEPRECATED
 ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName )
+	:	EditableScope( threadState )
+{
+	remove( Filter::inputSceneContextName );
+	remove( ScenePlug::scenePathContextName );
+	setAllocated( setNameContextName, setName );
+}
+
+ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString *setName )
 	:	EditableScope( threadState )
 {
 	remove( Filter::inputSceneContextName );
@@ -368,7 +406,13 @@ ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IEC
 	setSetName( setName );
 }
 
+// DEPRECATED
 void ScenePlug::SetScope::setSetName( const IECore::InternedString &setName )
+{
+	setAllocated( setNameContextName, setName );
+}
+
+void ScenePlug::SetScope::setSetName( const IECore::InternedString *setName )
 {
 	set( setNameContextName, setName );
 }
@@ -396,19 +440,19 @@ bool ScenePlug::exists() const
 
 bool ScenePlug::exists( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return existsPlug()->getValue();
 }
 
 Imath::Box3f ScenePlug::bound( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return boundPlug()->getValue();
 }
 
 Imath::M44f ScenePlug::transform( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return transformPlug()->getValue();
 }
 
@@ -420,7 +464,7 @@ Imath::M44f ScenePlug::fullTransform( const ScenePath &scenePath ) const
 	ScenePath path( scenePath );
 	while( path.size() )
 	{
-		pathScope.setPath( path );
+		pathScope.setPath( &path );
 		result = result * transformPlug()->getValue();
 		path.pop_back();
 	}
@@ -430,7 +474,7 @@ Imath::M44f ScenePlug::fullTransform( const ScenePath &scenePath ) const
 
 IECore::ConstCompoundObjectPtr ScenePlug::attributes( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return attributesPlug()->getValue();
 }
 
@@ -443,7 +487,7 @@ IECore::CompoundObjectPtr ScenePlug::fullAttributes( const ScenePath &scenePath 
 	ScenePath path( scenePath );
 	while( path.size() )
 	{
-		pathScope.setPath( path );
+		pathScope.setPath( &path );
 		IECore::ConstCompoundObjectPtr a = attributesPlug()->getValue();
 		const IECore::CompoundObject::ObjectMap &aMembers = a->members();
 		for( IECore::CompoundObject::ObjectMap::const_iterator it = aMembers.begin(), eIt = aMembers.end(); it != eIt; it++ )
@@ -461,13 +505,13 @@ IECore::CompoundObjectPtr ScenePlug::fullAttributes( const ScenePath &scenePath 
 
 IECore::ConstObjectPtr ScenePlug::object( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return objectPlug()->getValue();
 }
 
 IECore::ConstInternedStringVectorDataPtr ScenePlug::childNames( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return childNamesPlug()->getValue();
 }
 
@@ -485,19 +529,19 @@ IECore::ConstInternedStringVectorDataPtr ScenePlug::setNames() const
 
 IECore::ConstPathMatcherDataPtr ScenePlug::set( const IECore::InternedString &setName ) const
 {
-	SetScope scope( Context::current(), setName );
+	SetScope scope( Context::current(), &setName );
 	return setPlug()->getValue();
 }
 
 IECore::MurmurHash ScenePlug::boundHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return boundPlug()->hash();
 }
 
 IECore::MurmurHash ScenePlug::transformHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return transformPlug()->hash();
 }
 
@@ -509,7 +553,7 @@ IECore::MurmurHash ScenePlug::fullTransformHash( const ScenePath &scenePath ) co
 	ScenePath path( scenePath );
 	while( path.size() )
 	{
-		pathScope.setPath( path );
+		pathScope.setPath( &path );
 		transformPlug()->hash( result );
 		path.pop_back();
 	}
@@ -519,7 +563,7 @@ IECore::MurmurHash ScenePlug::fullTransformHash( const ScenePath &scenePath ) co
 
 IECore::MurmurHash ScenePlug::attributesHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return attributesPlug()->hash();
 }
 
@@ -531,7 +575,7 @@ IECore::MurmurHash ScenePlug::fullAttributesHash( const ScenePath &scenePath ) c
 	ScenePath path( scenePath );
 	while( path.size() )
 	{
-		pathScope.setPath( path );
+		pathScope.setPath( &path );
 		attributesPlug()->hash( result );
 		path.pop_back();
 	}
@@ -541,13 +585,13 @@ IECore::MurmurHash ScenePlug::fullAttributesHash( const ScenePath &scenePath ) c
 
 IECore::MurmurHash ScenePlug::objectHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return objectPlug()->hash();
 }
 
 IECore::MurmurHash ScenePlug::childNamesHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return childNamesPlug()->hash();
 }
 
@@ -565,19 +609,19 @@ IECore::MurmurHash ScenePlug::setNamesHash() const
 
 IECore::MurmurHash ScenePlug::setHash( const IECore::InternedString &setName ) const
 {
-	SetScope scope( Context::current(), setName );
+	SetScope scope( Context::current(), &setName );
 	return setPlug()->hash();
 }
 
 Imath::Box3f ScenePlug::childBounds( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return childBoundsPlug()->getValue();
 }
 
 IECore::MurmurHash ScenePlug::childBoundsHash( const ScenePath &scenePath ) const
 {
-	PathScope scope( Context::current(), scenePath );
+	PathScope scope( Context::current(), &scenePath );
 	return childBoundsPlug()->hash();
 }
 

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -239,7 +239,7 @@ struct AstEvaluator
 					continue;
 				}
 
-				setScope.setSetName( setName );
+				setScope.setSetName( &setName );
 				ConstPathMatcherDataPtr setData = m_scene->setPlug()->getValue();
 				result.addPaths( setData->readable() );
 			}
@@ -358,7 +358,7 @@ struct AstHasher
 					continue;
 				}
 
-				setScope.setSetName( setName );
+				setScope.setSetName( &setName );
 				m_hash.append( m_scene->setPlug()->hash() );
 			}
 		}

--- a/src/GafferScene/SetFilter.cpp
+++ b/src/GafferScene/SetFilter.cpp
@@ -145,13 +145,7 @@ void SetFilter::hashMatch( const ScenePlug *scene, const Gaffer::Context *contex
 	/// the scene then we would be able to use that in these situations and have a broader range
 	/// of filters. If we manage that, then we should go back to throwing an exception here if
 	/// the context doesn't contain a path. We should then do the same in the PathFilter.
-	typedef IECore::TypedData<ScenePlug::ScenePath> ScenePathData;
-	const ScenePathData *pathData = context->get<ScenePathData>( ScenePlug::scenePathContextName, nullptr );
-	if( pathData )
-	{
-		const ScenePlug::ScenePath &path = pathData->readable();
-		h.append( &(path[0]), path.size() );
-	}
+	h.append( context->variableHash( ScenePlug::scenePathContextName ) );
 
 	Gaffer::Context::EditableScope expressionResultScope( context );
 	expressionResultScope.remove( ScenePlug::scenePathContextName );

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -767,9 +767,9 @@ void Shader::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	{
 		ComputeNode::hash( output, context, h );
 		const Plug *outputParameter = outPlug();
-		if( auto *name = context->get<IECore::StringData>( g_outputParameterContextName, nullptr ) )
+		if( const std::string *name = context->getIfExists< std::string >( g_outputParameterContextName ) )
 		{
-			outputParameter = outputParameter->descendant<Plug>( name->readable() );
+			outputParameter = outputParameter->descendant<Plug>( *name );
 		}
 		attributesHash( outputParameter, h );
 		return;
@@ -793,9 +793,9 @@ void Shader::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context 
 	if( output == outAttributesPlug() )
 	{
 		const Plug *outputParameter = outPlug();
-		if( auto *name = context->get<IECore::StringData>( g_outputParameterContextName, nullptr ) )
+		if( const std::string *name = context->getIfExists< std::string >( g_outputParameterContextName ) )
 		{
-			outputParameter = outputParameter->descendant<Plug>( name->readable() );
+			outputParameter = outputParameter->descendant<Plug>( *name );
 		}
 		static_cast<CompoundObjectPlug *>( output )->setValue( attributes( outputParameter ) );
 		return;

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -217,9 +217,11 @@ IECore::MurmurHash ShaderPlug::attributesHash() const
 		if( auto s = runTimeCast<const GafferScene::Shader>( p->node() ) )
 		{
 			Context::EditableScope scope( Context::current() );
+			std::string outputParameter;
 			if( p != s->outPlug() )
 			{
-				scope.set( Shader::g_outputParameterContextName, p->relativeName( s->outPlug() ) );
+				outputParameter = p->relativeName( s->outPlug() );
+				scope.set( Shader::g_outputParameterContextName, &outputParameter );
 			}
 			h = s->outAttributesPlug()->hash();
 		}
@@ -235,9 +237,11 @@ IECore::ConstCompoundObjectPtr ShaderPlug::attributes() const
 		if( auto s = runTimeCast<const GafferScene::Shader>( p->node() ) )
 		{
 			Context::EditableScope scope( Context::current() );
+			std::string outputParameter;
 			if( p != s->outPlug() )
 			{
-				scope.set( Shader::g_outputParameterContextName, p->relativeName( s->outPlug() ) );
+				outputParameter = p->relativeName( s->outPlug() );
+				scope.set( Shader::g_outputParameterContextName, &outputParameter );
 			}
 			return s->outAttributesPlug()->getValue();
 		}

--- a/src/GafferScene/Transform.cpp
+++ b/src/GafferScene/Transform.cpp
@@ -206,7 +206,7 @@ Imath::M44f Transform::relativeParentTransform( const ScenePath &path, const Gaf
 	while( ancestorPath.size() ) // Root transform is always identity so can be ignored
 	{
 		ancestorPath.pop_back();
-		pathScope.setPath( ancestorPath );
+		pathScope.setPath( &ancestorPath );
 		if( filterValue( pathScope.context() ) & IECore::PathMatcher::ExactMatch )
 		{
 			matchingAncestorFound = true;
@@ -228,7 +228,7 @@ IECore::MurmurHash Transform::relativeParentTransformHash( const ScenePath &path
 	while( ancestorPath.size() ) // Root transform is always identity so can be ignored
 	{
 		ancestorPath.pop_back();
-		pathScope.setPath( ancestorPath );
+		pathScope.setPath( &ancestorPath );
 		if( filterValue( pathScope.context() ) & IECore::PathMatcher::ExactMatch )
 		{
 			result.append( true );

--- a/src/GafferScene/Unencapsulate.cpp
+++ b/src/GafferScene/Unencapsulate.cpp
@@ -80,13 +80,14 @@ class CapsuleScope : boost::noncopyable
 			if( m_capsule )
 			{
 				m_scope.emplace( m_capsule->context() );
-				m_scope->set( ScenePlug::scenePathContextName, concatScenePath( m_capsule->root(), branchPath ) );
+				m_capsulePath = concatScenePath( m_capsule->root(), branchPath );
+				m_scope->set( ScenePlug::scenePathContextName, &m_capsulePath );
 			}
 		}
 
 		CapsuleScope(
 			const Gaffer::Context *context, const ScenePlug *inPlug,
-			const ScenePlug::ScenePath &parentPath, const InternedString &setName
+			const ScenePlug::ScenePath &parentPath, const InternedString *setName
 		) : CapsuleScope( context, inPlug, parentPath )
 		{
 			if( m_capsule )
@@ -131,6 +132,7 @@ class CapsuleScope : boost::noncopyable
 		boost::optional<Context::EditableScope> m_scope;
 		IECore::ConstObjectPtr m_object;
 		const Capsule* m_capsule;
+		ScenePlug::ScenePath m_capsulePath;
 
 };
 
@@ -290,7 +292,7 @@ bool Unencapsulate::affectsBranchSet( const Gaffer::Plug *input ) const
 
 void Unencapsulate::hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, setName );
+	CapsuleScope cs( context, inPlug(), parentPath, &setName );
 	if( !cs.scene( false ) )
 	{
 		h = outPlug()->setPlug()->defaultValue()->Object::hash();
@@ -304,7 +306,7 @@ void Unencapsulate::hashBranchSet( const ScenePath &parentPath, const IECore::In
 
 IECore::ConstPathMatcherDataPtr Unencapsulate::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, setName );
+	CapsuleScope cs( context, inPlug(), parentPath, &setName );
 	if( !cs.scene( false ) )
 	{
 		return outPlug()->setPlug()->defaultValue();

--- a/src/GafferSceneTest/ContextSanitiser.cpp
+++ b/src/GafferSceneTest/ContextSanitiser.cpp
@@ -81,14 +81,14 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 {
 	if( const ScenePlug *scene = process->plug()->parent<ScenePlug>() )
 	{
-		if( process->context()->get<IECore::Data>( FilterPlug::inputSceneContextName, nullptr ) )
+		if( process->context()->getIfExists<uint64_t>( FilterPlug::inputSceneContextName ) )
 		{
 			warn( *process, FilterPlug::inputSceneContextName );
 		}
 
 		if( process->plug() != scene->setPlug() )
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::setNameContextName, nullptr ) )
+			if( process->context()->getIfExists<InternedString>( ScenePlug::setNameContextName ) )
 			{
 				warn( *process, ScenePlug::setNameContextName );
 			}
@@ -107,7 +107,7 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 			process->plug()->getName() != g_sortedChildNames
 		)
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )
+			if( process->context()->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 			{
 				warn( *process, ScenePlug::scenePathContextName );
 			}
@@ -118,11 +118,11 @@ void ContextSanitiser::processStarted( const Gaffer::Process *process )
 	{
 		if( process->plug()->getName() == g_internalOut )
 		{
-			if( process->context()->get<IECore::Data>( ScenePlug::scenePathContextName, nullptr ) )
+			if( process->context()->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )
 			{
 				warn( *process, ScenePlug::scenePathContextName );
 			}
-			if( process->context()->get<IECore::Data>( ScenePlug::setNameContextName, nullptr ) )
+			if( process->context()->getIfExists<InternedString>( ScenePlug::setNameContextName ) )
 			{
 				warn( *process, ScenePlug::setNameContextName );
 			}

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -105,12 +105,7 @@ void setExpandedPaths( Context *context, const IECore::PathMatcher &paths )
 
 IECore::PathMatcher getExpandedPaths( const Gaffer::Context *context )
 {
-	if( const IECore::PathMatcherData *expandedPaths = context->get<IECore::PathMatcherData>( g_expandedPathsName, nullptr ) )
-	{
-		return expandedPaths->readable();
-	}
-
-	return IECore::PathMatcher();
+	return context->get<PathMatcher>( g_expandedPathsName, IECore::PathMatcher() );
 }
 
 bool affectsExpandedPaths( const IECore::InternedString &name )
@@ -120,14 +115,13 @@ bool affectsExpandedPaths( const IECore::InternedString &name )
 
 void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 {
-	IECore::PathMatcherData *expandedPaths = const_cast<IECore::PathMatcherData *>( context->get<IECore::PathMatcherData>( g_expandedPathsName, nullptr ) );
+	const IECore::PathMatcher *expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
 	if( !expandedPaths )
 	{
-		expandedPaths = new IECore::PathMatcherData();
-		context->set( g_expandedPathsName, expandedPaths );
+		context->set( g_expandedPathsName, new IECore::PathMatcherData() );
+		expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
 	}
-
-	IECore::PathMatcher &expanded = expandedPaths->writable();
+	IECore::PathMatcher &expanded = *const_cast<IECore::PathMatcher*>(expandedPaths);
 
 	bool needUpdate = false;
 	if( expandAncestors )
@@ -147,7 +141,7 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 
 	if( needUpdate )
 	{
-		// We modified the expanded paths in place to avoid unecessary copying,
+		// We modified the expanded paths in place with const_cast to avoid unecessary copying,
 		// so the context doesn't know they've changed. So we must let it know
 		// about the change.
 		context->set( g_expandedPathsName, *expandedPaths );
@@ -156,14 +150,13 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 
 IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatcher &paths, const ScenePlug *scene, int depth )
 {
-	IECore::PathMatcherData *expandedPaths = const_cast<IECore::PathMatcherData *>( context->get<IECore::PathMatcherData>( g_expandedPathsName, nullptr ) );
+	const IECore::PathMatcher* expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
 	if( !expandedPaths )
 	{
-		expandedPaths = new IECore::PathMatcherData();
-		context->set( g_expandedPathsName, expandedPaths );
+		context->set( g_expandedPathsName, new IECore::PathMatcherData() );
+		expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
 	}
-
-	IECore::PathMatcher &expanded = expandedPaths->writable();
+	IECore::PathMatcher &expanded = *const_cast<IECore::PathMatcher*>(expandedPaths);
 
 	bool needUpdate = false;
 	IECore::PathMatcher leafPaths;
@@ -176,7 +169,7 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 
 	if( needUpdate )
 	{
-		// We modified the expanded paths in place to avoid unecessary copying,
+		// We modified the expanded paths in place with const_cast to avoid unecessary copying,
 		// so the context doesn't know they've changed. So we must let it know
 		// about the change.
 		context->set( g_expandedPathsName, *expandedPaths );

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -149,8 +149,8 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 	{
 		// We modified the expanded paths in place to avoid unecessary copying,
 		// so the context doesn't know they've changed. So we must let it know
-		// about the change
-		context->changed( g_expandedPathsName );
+		// about the change.
+		context->set( g_expandedPathsName, *expandedPaths );
 	}
 }
 
@@ -178,8 +178,8 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 	{
 		// We modified the expanded paths in place to avoid unecessary copying,
 		// so the context doesn't know they've changed. So we must let it know
-		// about the change
-		context->changed( g_expandedPathsName );
+		// about the change.
+		context->set( g_expandedPathsName, *expandedPaths );
 	}
 
 	return leafPaths;

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -146,9 +146,9 @@ class HierarchyViewFilter : public Gaffer::PathFilter
 			m_context->names( names );
 			for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 			{
-				const Data *newValue = m_context->get<Data>( *it );
-				const Data *oldValue = oldContext->get<Data>( *it, nullptr );
-				if( !oldValue || !newValue->isEqualTo( oldValue ) )
+				IECore::DataPtr newValue = m_context->getAsData( *it );
+				IECore::DataPtr oldValue = oldContext->getAsData( *it, nullptr );
+				if( !oldValue || !newValue->isEqualTo( oldValue.get() ) )
 				{
 					contextChanged( *it );
 				}
@@ -159,7 +159,7 @@ class HierarchyViewFilter : public Gaffer::PathFilter
 			oldContext->names( names );
 			for( vector<InternedString>::const_iterator it = names.begin(), eIt = names.end(); it != eIt; ++it )
 			{
-				if( !m_context->get<Data>( *it, nullptr ) )
+				if( !m_context->getAsData( *it, nullptr ) )
 				{
 					contextChanged( *it );
 				}

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -298,12 +298,12 @@ void GafferTest::testContextHashPerformance( int numEntries, int entrySize, bool
 
 	const ThreadState &threadState = ThreadState::current();
 
-	tbb::parallel_for( tbb::blocked_range<size_t>( 0, 10000000 ), [&threadState, &varyingVarName]( const tbb::blocked_range<size_t> &r )
+	tbb::parallel_for( tbb::blocked_range<int>( 0, 10000000 ), [&threadState, &varyingVarName]( const tbb::blocked_range<int> &r )
 		{
-			for( size_t i = r.begin(); i != r.end(); ++i )
+			for( int i = r.begin(); i != r.end(); ++i )
 			{
 				Context::EditableScope scope( threadState );
-				scope.set( varyingVarName, (int)i );
+				scope.set( varyingVarName, &i );
 
 				// This call is relied on by ValuePlug's HashCacheKey, so it is crucial that it be fast
 				scope.context()->hash();

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -320,3 +320,26 @@ void GafferTest::testContextHashPerformance( int numEntries, int entrySize, bool
 	);
 
 }
+
+void GafferTest::testContextCopyPerformance( int numEntries, int entrySize )
+{
+	// We usually deal with contexts that already have some stuff in them, so adding some entries
+	// to the context makes this test more realistic
+	ContextPtr baseContext = new Context();
+	for( int i = 0; i < numEntries; i++ )
+	{
+		baseContext->set( InternedString( i ), std::string( entrySize, 'x') );
+	}
+
+	const InternedString varyingVarName = "varyVar";
+
+	tbb::parallel_for( tbb::blocked_range<int>( 0, 1000000 ), [&baseContext, &varyingVarName]( const tbb::blocked_range<int> &r )
+		{
+			for( int i = r.begin(); i != r.end(); ++i )
+			{
+				ContextPtr copy = new Context( *baseContext );
+			}
+		}
+	);
+
+}

--- a/src/GafferTest/RandomTest.cpp
+++ b/src/GafferTest/RandomTest.cpp
@@ -1,0 +1,64 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferTest/RandomTest.h"
+
+#include "GafferTest/Assert.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/Random.h"
+#include "Gaffer/StringPlug.h"
+
+using namespace std;
+using namespace boost;
+using namespace IECore;
+using namespace Gaffer;
+
+void GafferTest::testRandomPerf()
+{
+	ContextPtr base = new Context();
+	InternedString varName = "varName";
+
+	Gaffer::RandomPtr random = new Gaffer::Random();
+	random->contextEntryPlug()->setValue( varName.string() );
+
+	Context::EditableScope scope( base.get() );
+	for( int i = 0; i < 100000; ++i )
+	{
+		scope.set( varName, &i );
+		random->outColorPlug()->getValue();
+	}
+}

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -43,6 +43,7 @@
 #include "GafferTest/FilteredRecursiveChildIteratorTest.h"
 #include "GafferTest/MetadataTest.h"
 #include "GafferTest/MultiplyNode.h"
+#include "GafferTest/RandomTest.h"
 #include "GafferTest/RecursiveChildIteratorTest.h"
 
 #include "LRUCacheTest.h"
@@ -95,6 +96,7 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	def( "testContextCopyPerformance", &testContextCopyPerformance );
 	def( "testComputeNodeThreading", &testComputeNodeThreading );
 	def( "testDownstreamIterator", &testDownstreamIterator );
+	def( "testRandomPerf", &testRandomPerf );
 
 	bindTaskMutexTest();
 	bindLRUCacheTest();

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -92,6 +92,7 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	def( "testEditableScope", &testEditableScope );
 	def( "countContextHash32Collisions", &countContextHash32CollisionsWrapper );
 	def( "testContextHashPerformance", &testContextHashPerformance );
+	def( "testContextCopyPerformance", &testContextCopyPerformance );
 	def( "testComputeNodeThreading", &testComputeNodeThreading );
 	def( "testDownstreamIterator", &testDownstreamIterator );
 

--- a/src/GafferTestModule/ValuePlugTest.cpp
+++ b/src/GafferTestModule/ValuePlugTest.cpp
@@ -85,7 +85,7 @@ void parallelGetValueWithVar( const IntPlug *plug, int iterations, const IECore:
 			Context::EditableScope scope( threadState );
 			for( int i = r.begin(); i < r.end(); ++i )
 			{
-				scope.set( iterationVar, i );
+				scope.set( iterationVar, &i );
 				plug->getValue();
 			}
 		}


### PR DESCRIPTION
I'm still expecting lots of feedback on this, but I think it is now theoretically ready to consider merging, and hopefully this incorporates everything I've talked about with John.

For anyone other than John and I who is following this, the point of this is that EditScopes now store pointers to the context variable values, rather than allocating TypedData.  This means that EditScope::set never does an allocation, and has the potential to speed up some cases a fair bit ( ~30% on testContextHashPerformance, and also a significant improvement in testManyContexts after switching it to use EditScopes - it doesn't really make sense otherwise, since there is now no way to create a Borrowed context outside an EditScope ).

Not that the ￼final commit "DELETE THIS COMMIT: Context : Weird hack ..." I'm planning to remove, as it makes things much messier, and doesn't actually improve performance noticeably.  I've included it just for reference because we'd discussed it.