### PR TITLE
Wrapper : Set `IECORE_RTLD_GLOBAL=0`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -51,6 +51,7 @@ API
 - TypedObjectPlug : Added default value for `direction` and `defaultValue` constructor arguments.
 - VectorDataWidget : Added `setErrored()` and `getErrored()` methods to control an error state. Errors are reflected by a red background colour.
 - PlugLayout : Added support for `layout:minimumWidth` metadata.
+- Removed use of `RTLD_GLOBAL` for loading Python modules.
 
 Breaking Changes
 ----------------

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -169,6 +169,9 @@ fi
 
 prependToPath "$GAFFER_ROOT/python" PYTHONPATH
 
+# Stop Cortex from making all Python modules load with RTLD_GLOBAL.
+export IECORE_RTLD_GLOBAL=0
+
 # Get library paths set up
 ##########################################################################
 

--- a/python/GafferArnold/__init__.py
+++ b/python/GafferArnold/__init__.py
@@ -40,28 +40,7 @@ __import__( "GafferScene" )
 # are always loaded for these, even if people only import GafferArnold
 __import__( "GafferOSL" )
 
-try :
-
-	# Make sure we import _GafferArnold _without_ RTLD_GLOBAL. This prevents
-	# clashes between the LLVM symbols in libai.so and the Mesa OpenGL driver.
-	# Ideally we wouldn't use RTLD_GLOBAL anywhere - see
-	# https://github.com/ImageEngine/cortex/pull/810.
-
-	import sys
-	import ctypes
-
-	if hasattr( sys, "getdlopenflags" ):
-		originalDLOpenFlags = sys.getdlopenflags()
-		sys.setdlopenflags( originalDLOpenFlags & ~ctypes.RTLD_GLOBAL )
-
-	from ._GafferArnold import *
-
-finally :
-
-	if hasattr( sys, "getdlopenflags" ):
-		sys.setdlopenflags( originalDLOpenFlags )
-		del originalDLOpenFlags
-	del sys, ctypes
+from ._GafferArnold import *
 
 from .ArnoldShaderBall import ArnoldShaderBall
 from .ArnoldTextureBake import ArnoldTextureBake

--- a/python/IECoreArnold/__init__.py
+++ b/python/IECoreArnold/__init__.py
@@ -34,21 +34,6 @@
 #
 ##########################################################################
 
-try :
-
-	# See comments in `GafferArnold/__init__.py`
-	import sys
-	import ctypes
-	if hasattr( sys, "getdlopenflags" ):
-		originalDLOpenFlags = sys.getdlopenflags()
-		sys.setdlopenflags( originalDLOpenFlags & ~ctypes.RTLD_GLOBAL )
-
-	from ._IECoreArnold import *
-
-finally :
-	if hasattr( sys, "getdlopenflags" ):
-		sys.setdlopenflags( originalDLOpenFlags )
-		del originalDLOpenFlags
-	del sys, ctypes
+from ._IECoreArnold import *
 
 from .UniverseBlock import UniverseBlock

--- a/startup/GafferScene/usd.py
+++ b/startup/GafferScene/usd.py
@@ -35,35 +35,11 @@
 ##########################################################################
 
 import os
-import sys
-import ctypes
 
 import IECore
 
 moduleSearchPath = IECore.SearchPath( os.environ["PYTHONPATH"] )
 if moduleSearchPath.find( "IECoreUSD" ) and moduleSearchPath.find( "pxr/Usd" ) :
-
-	# Import the USD Python module _without_ RTLD_GLOBAL, otherwise
-	# we get errors like the following spewed to the shell when we first
-	# open a USD file :
-	#
-	# ```
-	# Coding Error: in DefinePythonClass at line 932 of /disk1/john/dev/gafferDependencies/USD/working/USD-18.09/pxr/base/lib/tf/type.cpp
-	# -- TfType 'TfNotice' already has a defined Python type; cannot redefine
-	# ```
-	#
-	# > Note : RTLD_GLOBAL is turned on in the first place by IECore/__init__.py.
-	# > Ideally we'd stop doing that and wouldn't need this workaround. See
-	# > https://github.com/ImageEngine/cortex/pull/810.
-
-	try :
-		if hasattr( sys, "getdlopenflags" ):
-			originalDLOpenFlags = sys.getdlopenflags()
-			sys.setdlopenflags( originalDLOpenFlags & ~ctypes.RTLD_GLOBAL )
-		from pxr import Usd
-	finally :
-		if hasattr( sys, "getdlopenflags" ):
-			sys.setdlopenflags( originalDLOpenFlags )
 
 	# Import IECoreUSD so that we get the USD SceneInterface registered,
 	# providing USD functionality to both the SceneReader and SceneWriter.


### PR DESCRIPTION
This builds on https://github.com/ImageEngine/cortex/pull/1127, disabling the use of `RTLD_GLOBAL` in Gaffer.