### PR TITLE
FileMenu : Fix thread-safety bug in file save operation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.59.x.x (relative to 0.59.5.0)
+========
+
+Fixes
+-----
+
+- FileMenu : Fixed thread-safety bug in file save operation.
+
 0.59.5.0 (relative to 0.59.4.0)
 ========
 


### PR DESCRIPTION
Making edits to the `unsavedChanges` plug on the background thread meant that `plugSetSignal()` was emitted on the background thread too. This could cause UI components such as the File->Settings window to attempt UI operations on the wrong thread. One symptom was the following error message if that window was open :

```
Traceback (most recent call last):
  File "/home/john/dev/build/gafferPython3/python/Gaffer/WeakMethod.py", line 65, in __call__
    return self.__method( s, *args, **kwArgs )
  File "/home/john/dev/build/gafferPython3/python/GafferUI/PlugLayout.py", line 554, in __plugDirtied
    self.__updateLazily()
  File "/home/john/dev/build/gafferPython3/python/GafferUI/LazyMethod.py", line 108, in wrapper
    GafferUI.EventLoop.addIdleCallback( functools.partial( self.__idle, weakref.ref( widget ), method ) )
  File "/home/john/dev/build/gafferPython3/python/GafferUI/EventLoop.py", line 200, in addIdleCallback
    cls.__ensureIdleTimer()
  File "/home/john/dev/build/gafferPython3/python/GafferUI/EventLoop.py", line 258, in __ensureIdleTimer
    assert( QtCore.QThread.currentThread() == EventLoop.__qtApplication.thread() )
AssertionError
```

I'm not particularly happy that we're no longer using the standard `Script::save()` method here, but I don't see a better option at this point.