### PR TITLE
SceneAlgo : Fix compilation error

### DIFF
--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -890,7 +890,7 @@ IECore::PathMatcher findAttributes( const ScenePlug *scene, const AttributesPred
 	tbb::spin_mutex resultMutex;
 	IECore::PathMatcher result;
 	AttributesFinder<AttributesPredicate> attributesFinder( predicate, resultMutex, result );
-	parallelProcessLocations( scene, attributesFinder );
+	SceneAlgo::parallelProcessLocations( scene, attributesFinder );
 	return result;
 }
 


### PR DESCRIPTION
Seen with Clang 10 on MacOS :

```
src/GafferScene/SceneAlgo.cpp:893:2: error: use of undeclared identifier 'parallelProcessLocations'
        parallelProcessLocations( scene, attributesFinder );
        ^
```