### PR TITLE
Parent : Add `parentVariable` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,17 @@
+0.59.x.x (relative to 0.59.6.0)
+========
+
+Improvements
+------------
+
+- Parent : Added `parentVariable` plug, to create a context variable that passes the
+  parent location to nodes upstream of the `children` plug. This allows the children
+  to be varied procedurally according to what they are parented to.
+
 API
 ---
 
-- GafferUI.FileMenu: Added `dialogueParentWindow` argument to `addScript()`
+- GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)
 ========

--- a/include/GafferScene/Parent.h
+++ b/include/GafferScene/Parent.h
@@ -57,6 +57,9 @@ class GAFFERSCENE_API Parent : public BranchCreator
 		Gaffer::ArrayPlug *childrenPlug();
 		const Gaffer::ArrayPlug *childrenPlug() const;
 
+		Gaffer::StringPlug *parentVariablePlug();
+		const Gaffer::StringPlug *parentVariablePlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -87,6 +90,7 @@ class GAFFERSCENE_API Parent : public BranchCreator
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
 		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+		bool constantBranchSetNames() const override;
 
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
 		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
@@ -94,11 +98,15 @@ class GAFFERSCENE_API Parent : public BranchCreator
 
 	private :
 
+		class ParentScope;
+		class SourceScope;
+
 		Gaffer::ObjectPlug *mappingPlug();
 		const Gaffer::ObjectPlug *mappingPlug() const;
 
+		bool affectsParentScope( const Gaffer::Plug *input ) const;
+		bool affectsSourceScope( const Gaffer::Plug *input ) const;
 		bool isChildrenPlug( const Gaffer::Plug *input, const IECore::InternedString &scenePlugChildName ) const;
-		ScenePath sourcePath( const ScenePath &branchPath, const ScenePlug **source ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -229,16 +229,14 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 		if "sets" in checks :
 			self.assertEqual( scenePlug1.setNames(), scenePlug2.setNames() )
 			for setName in scenePlug1.setNames() :
-				if not pathsToPrune:
-					self.assertEqual( scenePlug1.set( setName ), scenePlug2.set( setName ) )
-				else:
-					if scenePlug1.set( setName ) != scenePlug2.set( setName ):
-						pruned1 = scenePlug1.set( setName )
-						pruned2 = scenePlug2.set( setName )
-						for p in pathsToPrune:
-							pruned1.value.prune( p )
-							pruned2.value.prune( p )
-						self.assertEqual( pruned1, pruned2 )
+				set1 = scenePlug1.set( setName ).value
+				set2 = scenePlug2.set( setName ).value
+				for p in pathsToPrune :
+					set1.prune( p )
+					set2.prune( p )
+				if scenePlug2PathPrefix :
+					set2 = set2.subTree( scenePlug2PathPrefix )
+				self.assertEqual( set1, set2 )
 
 	def assertPathHashesEqual( self, scenePlug1, scenePath1, scenePlug2, scenePath2, checks = allPathChecks ) :
 

--- a/python/GafferSceneUI/ParentUI.py
+++ b/python/GafferSceneUI/ParentUI.py
@@ -84,6 +84,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"parentVariable" : [
+
+			"description",
+			"""
+			A context variable used to pass the location of the parent to the
+			upstream nodes connected into the `children` plug. This can be used
+			to procedurally vary the children at each different parent location.
+			""",
+
+		],
+
 	}
 
 )


### PR DESCRIPTION
This can be used to do procedural variation of the children according to which location they are being parented to. This also has the nice side effect of halving the number of contexts created for a typical evaluation. Before, we were creating a GlobalScope in `sourcePath()` and then a second scope to evaluate the `sourcePlug` at the right scene location. This is now done with a single context allocation via the SourceScope class.