### PR TITLE
GafferUI.FileMenu: Add `dialogueParentWindow` argument to `addScript()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+API
+---
+
+- GafferUI.FileMenu: Added `dialogueParentWindow` argument to `addScript()`
+
 0.59.6.0 (relative to 0.59.5.0)
 ========
 

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -92,9 +92,9 @@ def open( menu ) :
 #
 # :param asNew When true, the scripts file name/dirty state will be reset
 #    upon load. Effectively creating an untitled copy.
-def addScript( application, fileName, asNew = False ) :
+def addScript( application, fileName, asNew = False, dialogueParentWindow = None ) :
 
-	return __addScript( application, fileName, asNew = asNew )
+	return __addScript( application, fileName, dialogueParentWindow = dialogueParentWindow, asNew = asNew )
 
 def __addScript( application, fileName, dialogueParentWindow = None, asNew = False ) :
 


### PR DESCRIPTION
Following up on #4166, and @johnhaddon's suggestion, we are just adding `dialogueParentWindow` to the public `GafferUI.FileMenu.addScript()`.

Note that I've kept `asNew` in the same position, which causes a mismatch in the order of the arguments when comparing the private and public implementations of `addScript()`.

However, I thought that keeping the public implementation fully backward compatible was more important. Let me know if you think that breaking backward compatibility is actually preferable here.
