### PR TITLE
FilterResults : Add `root` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,7 +28,7 @@ Fixes
 API
 ---
 
-- SceneAlgo : Added overloads with `root` argument for `parallelTraverse()` and `filteredParallelTraverse()`.
+- SceneAlgo : Added overloads with `root` argument for `parallelTraverse()`, `filteredParallelTraverse()`, `matchingPaths()` and `matchingPathsHash()`.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
 API
 ---
 
+- SceneAlgo : Added overloads with `root` argument for `parallelTraverse()` and `filteredParallelTraverse()`.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
   - Added the full path to nodes so that nodes nested in Boxes can be identified.
   - Added edit button to open a NodeEditor for nodes in the history.
   - Fixed gap in between sections.
+- FilterResults : Added `root` plug. This can be used to limit the results to `root` and its descendants.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -29,7 +29,9 @@ Fixes
 API
 ---
 
-- SceneAlgo : Added overloads with `root` argument for `parallelTraverse()`, `filteredParallelTraverse()`, `matchingPaths()` and `matchingPathsHash()`.
+- SceneAlgo :
+  - Added overloads with `root` argument for `parallelTraverse()`, `filteredParallelTraverse()`, `matchingPaths()` and `matchingPathsHash()`.
+  - Deprecated `matchingPaths()` overloads taking `Filter *`. Pass a `Filter.out` plug instead.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)

--- a/include/GafferScene/FilterResults.h
+++ b/include/GafferScene/FilterResults.h
@@ -41,6 +41,7 @@
 #include "GafferScene/TypeIds.h"
 
 #include "Gaffer/ComputeNode.h"
+#include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedObjectPlug.h"
 
 namespace GafferScene
@@ -64,6 +65,9 @@ class GAFFERSCENE_API FilterResults : public Gaffer::ComputeNode
 
 		FilterPlug *filterPlug();
 		const FilterPlug *filterPlug() const;
+
+		Gaffer::StringPlug *rootPlug();
+		const Gaffer::StringPlug *rootPlug() const;
 
 		Gaffer::PathMatcherDataPlug *outPlug();
 		const Gaffer::PathMatcherDataPlug *outPlug() const;

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -81,12 +81,14 @@ GAFFERSCENE_API void matchingPaths( const Filter *filter, const ScenePlug *scene
 /// As above, but specifying the filter as a plug - typically Filter::outPlug() or
 /// FilteredSceneProcessor::filterPlug() would be passed.
 GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, IECore::PathMatcher &paths );
+GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root, IECore::PathMatcher &paths );
 /// As above, but specifying the filter as a PathMatcher.
 GAFFERSCENE_API void matchingPaths( const IECore::PathMatcher &filter, const ScenePlug *scene, IECore::PathMatcher &paths );
 
 /// Matching above, but doing a fast hash of the matching paths instead of storing all paths
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const Filter *filter, const ScenePlug *scene );
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene );
+GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root );
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher &filter, const ScenePlug *scene );
 
 /// Parallel scene traversal

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -126,6 +126,9 @@ void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFu
 /// The functor must take ( const ScenePlug*, const ScenePlug::ScenePath& ), and can return false to prune traversal
 template <class ThreadableFunctor>
 void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f );
+/// As above, but starting the traversal at `root`.
+template <class ThreadableFunctor>
+void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
 
 /// Calls a functor on all paths in the scene that are matched by the filter.
 /// The functor must take ( const ScenePlug*, const ScenePlug::ScenePath& ), and can return false to prune traversal
@@ -135,6 +138,9 @@ void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::Filter
 /// FilteredSceneProcessor::filterPlug() would be passed.
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f );
+/// As above, but starting the traversal at `root`.
+template <class ThreadableFunctor>
+void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
 /// As above, but using a PathMatcher as a filter.
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f );

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -76,18 +76,20 @@ namespace SceneAlgo
 /// whether directly or indirectly via an intermediate filter.
 GAFFERSCENE_API std::unordered_set<FilteredSceneProcessor *> filteredNodes( Filter *filter );
 
-/// Finds all the paths in the scene that are matched by the filter, and adds them into the PathMatcher.
+/// \deprecated
 GAFFERSCENE_API void matchingPaths( const Filter *filter, const ScenePlug *scene, IECore::PathMatcher &paths );
-/// As above, but specifying the filter as a plug - typically Filter::outPlug() or
-/// FilteredSceneProcessor::filterPlug() would be passed.
+/// Finds all the paths in the scene that are matched by the filter, and adds them into the PathMatcher.
 GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, IECore::PathMatcher &paths );
+/// \todo Add default value for `root` and remove overload above.
 GAFFERSCENE_API void matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root, IECore::PathMatcher &paths );
 /// As above, but specifying the filter as a PathMatcher.
 GAFFERSCENE_API void matchingPaths( const IECore::PathMatcher &filter, const ScenePlug *scene, IECore::PathMatcher &paths );
 
-/// Matching above, but doing a fast hash of the matching paths instead of storing all paths
+/// \deprecated
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const Filter *filter, const ScenePlug *scene );
+/// As for `matchingPaths()`, but doing a fast hash of the matching paths instead of storing them.
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene );
+/// \todo Add default value for `root` and remove overload above.
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root );
 GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher &filter, const ScenePlug *scene );
 
@@ -121,6 +123,7 @@ GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher 
 template <class ThreadableFunctor>
 void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f );
 /// As above, but starting the traversal at the specified root.
+/// \todo Add default value for `root` and remove overload above.
 template <class ThreadableFunctor>
 void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
 
@@ -129,6 +132,7 @@ void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFu
 template <class ThreadableFunctor>
 void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f );
 /// As above, but starting the traversal at `root`.
+/// \todo Add default value for `root` and remove overload above.
 template <class ThreadableFunctor>
 void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
 
@@ -141,6 +145,7 @@ void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::Filter
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f );
 /// As above, but starting the traversal at `root`.
+/// \todo Add default value for `root` and remove overload above.
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
 /// As above, but using a PathMatcher as a filter.

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -59,6 +59,17 @@ class TraverseTask : public tbb::task
 		{
 		}
 
+		TraverseTask(
+			const GafferScene::ScenePlug *scene,
+			const Gaffer::ThreadState &threadState,
+			const ScenePlug::ScenePath &path,
+			ThreadableFunctor &f
+		)
+			:	m_scene( scene ), m_threadState( threadState ), m_f( f ), m_path( path )
+		{
+		}
+
+
 		~TraverseTask() override
 		{
 		}
@@ -256,6 +267,14 @@ void parallelTraverse( const GafferScene::ScenePlug *scene, ThreadableFunctor &f
 }
 
 template <class ThreadableFunctor>
+void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root )
+{
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated ); // Prevents outer tasks silently cancelling our tasks
+	Detail::TraverseTask<ThreadableFunctor> *task = new( tbb::task::allocate_root( taskGroupContext ) ) Detail::TraverseTask<ThreadableFunctor>( scene, Gaffer::ThreadState::current(), root, f );
+	tbb::task::spawn_root_and_wait( *task );
+}
+
+template <class ThreadableFunctor>
 void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const GafferScene::Filter *filter, ThreadableFunctor &f )
 {
 	filteredParallelTraverse( scene, filter->outPlug(), f );
@@ -266,6 +285,13 @@ void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const Gaffer
 {
 	Detail::ThreadableFilteredFunctor<ThreadableFunctor> ff( f, filterPlug );
 	parallelTraverse( scene, ff );
+}
+
+template <class ThreadableFunctor>
+void filteredParallelTraverse( const ScenePlug *scene, const Gaffer::IntPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root )
+{
+	Detail::ThreadableFilteredFunctor<ThreadableFunctor> ff( f, filterPlug );
+	parallelTraverse( scene, ff, root );
 }
 
 template <class ThreadableFunctor>

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -75,6 +75,11 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( matchingPaths.match( "/plane/instances/group/1121/plane" ), IECore.PathMatcher.Result.ExactMatch )
 		self.assertEqual( matchingPaths.match( "/plane/instances/group/1121/sphere" ), IECore.PathMatcher.Result.NoMatch )
 
+		# Test root argument
+		matchingPaths = IECore.PathMatcher()
+		GafferScene.SceneAlgo.matchingPaths( filter["out"], instancer["out"], "/plane/instances/group/1121", matchingPaths )
+		self.assertEqual( matchingPaths.paths(), [ "/plane/instances/group/1121/plane" ] )
+
 	def testExists( self ) :
 
 		sphere = GafferScene.Sphere()

--- a/python/GafferSceneUI/FilterResultsUI.py
+++ b/python/GafferSceneUI/FilterResultsUI.py
@@ -77,6 +77,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"root" : [
+
+			"description",
+			"""
+			Isolates the search to this location and its descendants.
+			""",
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:scene", "scene",
+			"nodule:type", "",
+
+		],
+
 		"out" : [
 
 			"description",

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -54,6 +54,7 @@ FilterResults::FilterResults( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ScenePlug( "scene" ) );
 	addChild( new FilterPlug( "filter" ) );
+	addChild( new StringPlug( "root" ) );
 	addChild( new PathMatcherDataPlug( "__internalOut", Gaffer::Plug::Out, new PathMatcherData ) );
 	addChild( new PathMatcherDataPlug( "out", Gaffer::Plug::Out, new PathMatcherData ) );
 	addChild( new StringVectorDataPlug( "outStrings", Gaffer::Plug::Out, new StringVectorData ) );
@@ -83,34 +84,44 @@ const FilterPlug *FilterResults::filterPlug() const
 	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
 }
 
+Gaffer::StringPlug *FilterResults::rootPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *FilterResults::rootPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
 Gaffer::PathMatcherDataPlug *FilterResults::internalOutPlug()
 {
-	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 2 );
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 3 );
 }
 
 const Gaffer::PathMatcherDataPlug *FilterResults::internalOutPlug() const
 {
-	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 2 );
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 3 );
 }
 
 Gaffer::PathMatcherDataPlug *FilterResults::outPlug()
 {
-	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 3 );
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 4 );
 }
 
 const Gaffer::PathMatcherDataPlug *FilterResults::outPlug() const
 {
-	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 3 );
+	return getChild<PathMatcherDataPlug>( g_firstPlugIndex + 4 );
 }
 
 Gaffer::StringVectorDataPlug *FilterResults::outStringsPlug()
 {
-	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::StringVectorDataPlug *FilterResults::outStringsPlug() const
 {
-	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 5 );
 }
 
 void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -124,6 +135,7 @@ void FilterResults::affects( const Gaffer::Plug *input, AffectedPlugsContainer &
 
 	if(
 		input == filterPlug() ||
+		input == rootPlug() ||
 		input == scenePlug()->childNamesPlug()
 	)
 	{
@@ -147,7 +159,9 @@ void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context
 
 	if( output == internalOutPlug() )
 	{
-		h.append( SceneAlgo::matchingPathsHash( filterPlug(), scenePlug() ) );
+		ScenePlug::ScenePath rootPath;
+		ScenePlug::stringToPath( rootPlug()->getValue(), rootPath );
+		h.append( SceneAlgo::matchingPathsHash( filterPlug(), scenePlug(), rootPath ) );
 	}
 	else if( output == outPlug() )
 	{
@@ -165,8 +179,10 @@ void FilterResults::compute( Gaffer::ValuePlug *output, const Gaffer::Context *c
 {
 	if( output == internalOutPlug() )
 	{
+		ScenePlug::ScenePath rootPath;
+		ScenePlug::stringToPath( rootPlug()->getValue(), rootPath );
 		PathMatcherDataPtr data = new PathMatcherData;
-		SceneAlgo::matchingPaths( filterPlug(), scenePlug(), data->writable() );
+		SceneAlgo::matchingPaths( filterPlug(), scenePlug(), rootPath, data->writable() );
 		static_cast<PathMatcherDataPlug *>( output )->setValue( data );
 		return;
 	}

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -174,6 +174,12 @@ void GafferScene::SceneAlgo::matchingPaths( const Gaffer::IntPlug *filterPlug, c
 	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f );
 }
 
+void GafferScene::SceneAlgo::matchingPaths( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root, IECore::PathMatcher &paths )
+{
+	ThreadablePathAccumulator f( paths );
+	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f, root );
+}
+
 void GafferScene::SceneAlgo::matchingPaths( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	ThreadablePathAccumulator f( paths );
@@ -189,6 +195,13 @@ IECore::MurmurHash GafferScene::SceneAlgo::matchingPathsHash( const GafferScene:
 {
 	ThreadablePathHashAccumulator f;
 	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f );
+	return IECore::MurmurHash( f.m_h1Accum, f.m_h2Accum );
+}
+
+IECore::MurmurHash GafferScene::SceneAlgo::matchingPathsHash( const GafferScene::FilterPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root )
+{
+	ThreadablePathHashAccumulator f;
+	GafferScene::SceneAlgo::filteredParallelTraverse( scene, filterPlug, f, root );
 	return IECore::MurmurHash( f.m_h1Accum, f.m_h2Accum );
 }
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -101,7 +101,14 @@ void matchingPathsWrapper2( const Gaffer::IntPlug *filterPlug, const ScenePlug *
 	SceneAlgo::matchingPaths( filterPlug, scene, paths );
 }
 
-void matchingPathsWrapper3( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
+void matchingPathsWrapper3( const Gaffer::IntPlug *filterPlug, const ScenePlug *scene, const ScenePlug::ScenePath &root, PathMatcher &paths )
+{
+	// gil release in case the scene traversal dips back into python:
+	IECorePython::ScopedGILRelease r;
+	SceneAlgo::matchingPaths( filterPlug, scene, root, paths );
+}
+
+void matchingPathsWrapper4( const PathMatcher &filter, const ScenePlug *scene, PathMatcher &paths )
 {
 	// gil release in case the scene traversal dips back into python:
 	IECorePython::ScopedGILRelease r;
@@ -268,6 +275,7 @@ void bindSceneAlgo()
 	def( "matchingPaths", &matchingPathsWrapper1 );
 	def( "matchingPaths", &matchingPathsWrapper2 );
 	def( "matchingPaths", &matchingPathsWrapper3 );
+	def( "matchingPaths", &matchingPathsWrapper4 );
 	def( "shutter", &shutterWrapper );
 	def( "setExists", &setExistsWrapper );
 	def(


### PR DESCRIPTION
This isolates the search to `root` and its descendants. It could be used for optimisation, but I'm actually aiming to use it in conjunction with the new `Parent.parentVariable` feature from #4178 to faciliate some new patterns for processing subtrees and placing the result at the subtree root.