### PR TITLE
NameSwitch/Spreadsheet : Ignore unnamed rows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Improvements
 - Increased image processing tile size from 64 pixels to 128 pixels. This reduces per-tile overhead on large images, dramatically increasing effective image performance in many cases.
 - OSLImage : Avoided some unnecessary computes and hashing when calculating channel names or passing through channel data unaltered.
 - Context : Optimized `hash()` method.
+- NameSwitch/Spreadsheet : Rows with an empty name are now treated as if they were disabled. See Breaking Changes for further details.
 
 Fixes
 -----
@@ -45,6 +46,7 @@ API
 Breaking Changes
 ----------------
 
+- NameSwitch/Spreadsheet : Rows with an empty name are now treated as if they were disabled. Previously they would cause confusion by being matched against empty selectors. Use the default row for empty selectors instead, or alternatively use a catch-all `*` row.
 - Slider/NumericSlider :
   - Refactored Slider to provide all the functionality of NumericSlider, and removed NumericSlider.
   - Renamed initial constructor argument from `value` to `values`.

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -963,6 +963,49 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 		self.assertEqual( spreadsheet["out"]["c1"].getValue(), 30 )
 		self.assertEqual( spreadsheet["rows"].row( "test" ), spreadsheet["rows"][1] )
 
+	def testUnnamedRowsNeverMatch( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug( "i" ) )
+		row = s["rows"].addRow()
+
+		row["name"].setValue( "" )
+		row["cells"]["i"]["value"].setValue( 1 )
+
+		# Selector is "", but we shouldn't match it to the unnamed row because
+		# that is unintuitive. As a general rule in Gaffer, if something
+		# hasn't been given a name then it is treated as if it was disabled.
+		self.assertEqual( s["out"]["i"].getValue(), 0 )
+		# That should be reinforced by excluding the row from the `activeRows`
+		# and `resolvedRows` outputs.
+		self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData() )
+		self.assertNotIn( "", s["resolvedRows"].getValue() )
+
+		# The same should apply even when the selector receives the empty value
+		# via a substitution.
+		s["selector"].setValue( "${selector}" )
+		with Gaffer.Context() as c :
+			self.assertEqual( s["out"]["i"].getValue(), 0 )
+			# If the variable exists but is empty, we _still_ don't want to
+			# match the empty row. The existence of the variable is not what we
+			# care about : the existence of the row is, and we treat unnamed
+			# rows as non-existent.
+			c["selector"] = ""
+			self.assertEqual( s["out"]["i"].getValue(), 0 )
+			self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData() )
+			self.assertNotIn( "", s["resolvedRows"].getValue() )
+			# But by that logic, a row named '*' _should_ match the empty
+			# variable.
+			row["name"].setValue( "*" )
+			self.assertEqual( s["out"]["i"].getValue(), 1 )
+			self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "*" ] ) )
+			self.assertIn( "*", s["resolvedRows"].getValue() )
+			# Even if the variable doesnt exist at all.
+			del c["selector"]
+			self.assertEqual( s["out"]["i"].getValue(), 1 )
+			self.assertEqual( s["activeRowNames"].getValue(), IECore.StringVectorData( [ "*" ] ) )
+			self.assertIn( "*", s["resolvedRows"].getValue() )
+
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testAddRowPerformance( self ) :
 

--- a/src/Gaffer/NameSwitch.cpp
+++ b/src/Gaffer/NameSwitch.cpp
@@ -161,7 +161,8 @@ void NameSwitch::compute( ValuePlug *output, const Context *context ) const
 			{
 				continue;
 			}
-			if( StringAlgo::matchMultiple( selector, p->namePlug()->getValue() ) )
+			const string name = p->namePlug()->getValue();
+			if( !name.empty() && StringAlgo::matchMultiple( selector, name ) )
 			{
 				outIndex = i;
 				break;

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -103,6 +103,10 @@ class RowsMap : public IECore::Data
 				}
 
 				const std::string name = row->namePlug()->getValue();
+				if( name.empty() )
+				{
+					continue;
+				}
 				activeRowNames.push_back( name );
 
 				const bool hasWildcards = StringAlgo::hasWildcards( name );
@@ -1081,7 +1085,7 @@ void Spreadsheet::compute( ValuePlug *output, const Context *context ) const
 			}
 
 			const string name = rowPlug->namePlug()->getValue();
-			if( result->members().count( name ) )
+			if( name.empty() || result->members().count( name ) )
 			{
 				continue;
 			}


### PR DESCRIPTION
Previously these would be matched whenever the selector was empty, and this was proving confusing for users. Particularly so in the case of the NameSwitch, where it's all too easy to end up with an additional input that you're not using.

The new behaviour is consistent with similar behaviour such as ignoring unnamed attributes in CustomAttributes, unnamed variables in ContextVariables and unnamed tweaks in CameraTweaks etc.

This _is_ a breaking change, so we should maybe consider adding an environment variable to opt-out of the new behaviour to aid in the transition. Speak now if you think we should...