### PR TITLE
Dispatcher : Fix batchSize when driven by a context variable

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Fixes
 - Widget : Fixed drag handling bug that could cause `dragEnterSignal()` to be emitted again on a widget that had already accepted the drag.
 - FilterResults : Fixed bug handling matches at the root location.
 - NodeEditor : Fixed activator and summary updates which were skipped if the layout was not visible when the node was edited.
+- Dispatcher : Fixed dispatching when `dispatcher.batchSize` or `dispatcher.immediate` are driven by context variables.
 
 API
 ---

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -134,12 +134,21 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"dispatcher" : (
+
+			"layout:activator:doesNotRequireSequenceExecution", lambda plug : not plug.node()["task"].requiresSequenceExecution(),
+
+		),
+
 		"dispatcher.batchSize" : (
 
 			"description",
 			"""
 			Maximum number of frames to batch together when dispatching tasks.
+			If the node requires sequence execution `batchSize` will be ignored.
 			""",
+
+			"layout:activator", "doesNotRequireSequenceExecution",
 
 		),
 

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -286,18 +286,7 @@ Dispatcher::PostDispatchSignal &Dispatcher::postDispatchSignal()
 
 void Dispatcher::setupPlugs( Plug *parentPlug )
 {
-	if ( const TaskNode *node = parentPlug->ancestor<const TaskNode>() )
-	{
-		/// \todo: this will always return true until we sort out issue #915.
-		/// But since requiresSequenceExecution() could feasibly return different
-		/// values in different contexts, perhaps the conditional is bogus
-		/// anyway, and if anything we should just grey out the plug in the UI?
-		if( !node->taskPlug()->requiresSequenceExecution() )
-		{
-			parentPlug->addChild( new IntPlug( g_batchSize, Plug::In, 1 ) );
-		}
-	}
-
+	parentPlug->addChild( new IntPlug( g_batchSize, Plug::In, 1 ) );
 	parentPlug->addChild( new BoolPlug( g_immediatePlugName, Plug::In, false ) );
 
 	const CreatorMap &m = creators();


### PR DESCRIPTION
Note I did not apply the same fix for `immediate` because of the ambiguity described in the current todo.