### PR TITLE
SceneAlgo : Fix `matchingPathsHash()` bug handling root matches

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Fixes
 -----
 
 - Widget : Fixed drag handling bug that could cause `dragEnterSignal()` to be emitted again on a widget that had already accepted the drag.
+- FilterResults : Fixed bug handling matches at the root location.
 
 API
 ---

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -240,6 +240,19 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 		)
 		self.assertNotEqual( filterResults["out"].hash(), hash )
 
+	def testRootMatchVsNoMatch( self ) :
+
+		plane = GafferScene.Plane()
+		pathFilter = GafferScene.PathFilter()
+
+		filterResults = GafferScene.FilterResults()
+		filterResults["scene"].setInput( plane["out"] )
+		filterResults["filter"].setInput( pathFilter["out"] )
+		self.assertEqual( filterResults["outStrings"].getValue(), IECore.StringVectorData() )
+
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/" ] ) )
+		self.assertEqual( filterResults["outStrings"].getValue(), IECore.StringVectorData( [ "/" ] ) )
+
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testHashPerf( self ):

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -1415,5 +1415,14 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 			GafferScene.SceneAlgo.matchingPathsHash( filter3["out"], group["out"] )
 		)
 
+		rootFilter = GafferScene.PathFilter()
+		rootFilter["paths"].setValue( IECore.StringVectorData( [ "/" ] ) )
+		emptyFilter = GafferScene.PathFilter()
+
+		self.assertNotEqual(
+			GafferScene.SceneAlgo.matchingPathsHash( rootFilter["out"], group["out"] ),
+			GafferScene.SceneAlgo.matchingPathsHash( emptyFilter["out"], group["out"] )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -145,7 +145,14 @@ struct ThreadablePathHashAccumulator
 		// as good ( the only weakness I can see is that if you summed 2**64 identical hashes, they would
 		// cancel out, but I can't see that arising here ).
 		IECore::MurmurHash h;
-		h.append( &path.front(), path.size() );
+		if( path.size() )
+		{
+			h.append( path.data(), path.size() );
+		}
+		else
+		{
+			h.append( 0 );
+		}
 		m_h1Accum += h.h1();
 		m_h2Accum += h.h2();
 		return true;


### PR DESCRIPTION
Yesterday in #4191 I claimed to have been on a hunt for a bug that didn't exist. Turns out I just wasn't looking hard enough...