### PR TITLE
PlugLayout : Fix activity/summary updates

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Fixes
 
 - Widget : Fixed drag handling bug that could cause `dragEnterSignal()` to be emitted again on a widget that had already accepted the drag.
 - FilterResults : Fixed bug handling matches at the root location.
+- NodeEditor : Fixed activator and summary updates which were skipped if the layout was not visible when the node was edited.
 
 API
 ---

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -546,7 +546,7 @@ class PlugLayout( GafferUI.Widget ) :
 
 	def __plugDirtied( self, plug ) :
 
-		if not self.visible() or plug.direction() != plug.Direction.In :
+		if plug.direction() != plug.Direction.In :
 			return
 
 		self.__activationsDirty = True


### PR DESCRIPTION
When this code was first written, we weren't using `__updateLazily()` to defer updates until the UI was visible again, so the shortcut for invisible UIs may have been warranted. But now we do defer things nicely, and we definitely don't want to lose updates for things that happened while we weren't visible.
