### PR TITLE
Serialisation : Fix `modulePath()` type lifetime bug

### DIFF
--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -223,6 +223,7 @@ std::string Serialisation::modulePath( const boost::python::object &o )
 	auto inserted = g_cache.insert( { o.ptr()->ob_type, std::string() } );
 	if( inserted.second )
 	{
+		Py_INCREF( o.ptr()->ob_type );
 		inserted.first->second = modulePathInternal( o );
 	}
 	return inserted.first->second;


### PR DESCRIPTION
I haven't been able to reproduce this locally, but I think it is the cause of the following test failures seen on GitHub CI :

```
Error: ERROR: testExport (GafferTest.ExtensionAlgoTest.ExtensionAlgoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferTest/ExtensionAlgoTest.py", line 102, in testExport
    script.execute( script.serialise( filter = Gaffer.StandardSet( { script["node"] } ) ) )
IECore.Exception: Line 11 : AttributeError: type object 'BoxIOTest' has no attribute 'AddOne'
```

BoxIOTest defines a couple of new classes that only live for the duration of that test, so I think this is the failure sequence :

- BoxIOTest makes a PyTypeObject for the new class, and it gets registered into the `modulePath()` cache.
- BoxIOTest completes, and the type is destroyed.
- ExtensionAlgoTest generates a new class, and it happens to reuse the address of the type from BoxIOTest.
- `modulePath()` reuses the old path from the cache.

The fix is to follow Python's ownership rules and own a reference to the PyTypeObject so that it won't die while it's still in the cache.

