### PR TITLE
Improve Performance of ContextVariables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a1/cortex-10.2.0.0-a1-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a1/cortex-10.2.0.0-a1-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a1/cortex-10.2.0.0-a1-linux-python3.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a1/cortex-10.2.0.0-a1-macos-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-macos-python2.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -47,7 +47,7 @@ else :
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a1/cortex-10.2.0.0-a1-" + platform + "-python2.tar.gz"
+defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-" + platform + "-python2.tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Improvements
 - OSLImage : Avoided some unnecessary computes and hashing when calculating channel names or passing through channel data unaltered.
 - Context : Optimized `hash()` method, and reduced overhead in `EditableScope`.
 - NameSwitch/Spreadsheet : Rows with an empty name are now treated as if they were disabled. See Breaking Changes for further details.
+- ContextVariables : Improved performance by around 50%.
 
 Fixes
 -----
@@ -98,6 +99,7 @@ Breaking Changes
 - ScriptNode : Added private member data.
 - Expression : Changed the Python expression cache policy to `Standard`. This executes expressions behind a lock, and can cause hangs if buggy upstream nodes perform TBB tasks without an appropriate `TaskIsolation` or `TaskCollaboration` policy. In this case, the `GAFFER_PYTHONEXPRESSION_CACHEPOLICY` environment variable may be set to `Legacy` or `TaskIsolation` while the bugs are fixed.
 - Node : Removed `plugFlagsChangedSignal()`. We aim to phase flags out completely in future, and none of the current flags are expected to be changed after construction.
+- ContextProcessor : Added `storage` argument to `processContext()` method.
 
 Build
 -----

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -88,7 +88,7 @@ class IECORE_EXPORT ContextProcessor : public ComputeNode
 		/// Must be implemented to return true if the input is used in `processContext()`.
 		virtual bool affectsContext( const Plug *input ) const = 0;
 		/// Must be implemented to modify context in place.
-		virtual void processContext( Context::EditableScope &context ) const = 0;
+		virtual void processContext( Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const = 0;
 
 	private :
 

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -60,12 +60,21 @@ class IECORE_EXPORT ContextVariables : public ContextProcessor
 		AtomicCompoundDataPlug *extraVariablesPlug();
 		const AtomicCompoundDataPlug *extraVariablesPlug() const;
 
+		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
+
 	protected :
 
+		/// Implemented to compute combinedVariablesPlug
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
 		bool affectsContext( const Plug *input ) const override;
-		void processContext( Context::EditableScope &context ) const override;
+		void processContext( Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const override;
 
 	private :
+
+		AtomicCompoundDataPlug *combinedVariablesPlug();
+		const AtomicCompoundDataPlug *combinedVariablesPlug() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -59,7 +59,7 @@ class IECORE_EXPORT DeleteContextVariables : public ContextProcessor
 	protected :
 
 		bool affectsContext( const Plug *input ) const override;
-		void processContext( Context::EditableScope &context ) const override;
+		void processContext( Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const override;
 
 	private :
 

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -62,7 +62,7 @@ class IECORE_EXPORT TimeWarp : public ContextProcessor
 	protected :
 
 		bool affectsContext( const Plug *input ) const override;
-		void processContext( Context::EditableScope &context ) const override;
+		void processContext( Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const override;
 
 	private :
 

--- a/python/GafferTest/ContextVariablesTest.py
+++ b/python/GafferTest/ContextVariablesTest.py
@@ -200,5 +200,21 @@ class ContextVariablesTest( GafferTest.TestCase ) :
 		self.assertIsInstance( s2["c"]["in"], Gaffer.IntPlug )
 		self.assertIsInstance( s2["c"]["out"], Gaffer.IntPlug )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ):
+		c = Gaffer.ContextVariables()
+		c.setup( Gaffer.IntPlug() )
+		for i in range( 10 ):
+			c["variables"].addChild( Gaffer.NameValuePlug( "a%i"%i, IECore.StringData( "A" * 100 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		c["variables"].addChild( Gaffer.NameValuePlug( "intName", IECore.IntData( 100 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		# This would be a bit more representative if our source node was actually affected by the context variables,
+		# but without access to OSL in this test we don't have any efficient way to read context variables handy,
+		# and we're mostly just interested in the amount of overhead anyway
+		n = GafferTest.MultiplyNode()
+		c["in"].setInput( n["product"] )
+
+		GafferTest.parallelGetValue( c["out"], 1000000, "iter" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ContextProcessor.cpp
+++ b/src/Gaffer/ContextProcessor.cpp
@@ -57,9 +57,13 @@ class ContextProcessor::ProcessedScope : public Context::EditableScope
 			ContextAlgo::GlobalScope globalScope( context, processor->inPlug() );
 			if( processor->enabledPlug()->getValue() )
 			{
-				processor->processContext( *this );
+				processor->processContext( *this, m_storage );
 			}
 		}
+
+	private :
+
+		IECore::ConstRefCountedPtr m_storage;
 
 };
 

--- a/src/Gaffer/DeleteContextVariables.cpp
+++ b/src/Gaffer/DeleteContextVariables.cpp
@@ -72,7 +72,7 @@ bool DeleteContextVariables::affectsContext( const Plug *input ) const
 	return input == variablesPlug();
 }
 
-void DeleteContextVariables::processContext( Context::EditableScope &context ) const
+void DeleteContextVariables::processContext( Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const
 {
 	context.removeMatching( variablesPlug()->getValue() );
 }

--- a/src/Gaffer/TimeWarp.cpp
+++ b/src/Gaffer/TimeWarp.cpp
@@ -82,7 +82,7 @@ bool TimeWarp::affectsContext( const Plug *input ) const
 	return input == speedPlug() || input == offsetPlug();
 }
 
-void TimeWarp::processContext( Context::EditableScope &scope ) const
+void TimeWarp::processContext( Context::EditableScope &scope, IECore::ConstRefCountedPtr &storage ) const
 {
 	scope.setFrame(
 		scope.context()->getFrame() * speedPlug()->getValue() + offsetPlug()->getValue()


### PR DESCRIPTION
This goes on top of #4174

#4174 reduces the performance of ContextVariables slightly, so this looks at ways to speed that back up.

The "Cache variable values for performance" commit is purely internal, and is quite a nice speedup when the ContextVariables is used in many contexts, and the context variables being set don't vary with the context - it saves repeated Data allocs in memberDataAndName, and also repeated string->InternedString conversions.

The last commit is a bit more troublesome, because it requires an API change to processContext, but it is also a noticeable speedup, by avoiding the allocations within Context::setAllocated.  I think that adding the "allocations" parameter kinda makes sense with the new EditableScope API, but see what you think.

Timing results are:
Pre-#4174:  1.48 s
Post-#4174:  1.52 s
Cache Variable Values:  1.10 s
API Change:  0.82 s