### PR TITLE
BranchCreator : Add `destination` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,11 @@ Improvements
     when parenting lights to geometry.
 - Seeds : Added `destination` plug, to control where the points are placed in the scene
   relative to the meshes they are generated from.
+- Duplicate :
+  - Added `filter` input, allowing multiple objects to be duplicated at once.
+  - Added `destination` plug, to control where the copies are placed relative to the
+    original.
+  - Improved performance for large numbers of copies.
 - Outputs : Reduced the time taken to show the NodeEditor by around 90%.
 - NodeEditor : The "Node Name" label is now draggable. For instance, it can be dragged to the PythonEditor to get a reference to the node or to the GraphEditor to find the node in the graph.
 - GraphEditor : Improved framing of nodes dragged and dropped onto the GraphEditor :

--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ API
   - Added support for `..` in `stringToPath()`.
   - Added `stringToPath()` and `pathToString()` overloads that return a result rather than passing it by reference.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
+- Spreadsheet : Added support for per-plug `ui:spreadsheet:selectorValue` metadata. This defines the initial value for `selector` when the UI is used to create a spreadsheet for the plug.
 
 0.59.6.0 (relative to 0.59.5.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -41,7 +41,9 @@ API
   - Added overloads with `root` argument for `parallelTraverse()`, `filteredParallelTraverse()`, `matchingPaths()` and `matchingPathsHash()`.
   - Deprecated `matchingPaths()` overloads taking `Filter *`. Pass a `Filter.out` plug instead.
   - Added Python bindings for `matchingPathsHash()`.
-- ScenePlug : Added support for `..` in `stringToPath()`.
+- ScenePlug :
+  - Added support for `..` in `stringToPath()`.
+  - Added `stringToPath()` and `pathToString()` overloads that return a result rather than passing it by reference.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)

--- a/Changes.md
+++ b/Changes.md
@@ -4,9 +4,15 @@
 Improvements
 ------------
 
-- Parent : Added `parentVariable` plug, to create a context variable that passes the
-  parent location to nodes upstream of the `children` plug. This allows the children
-  to be varied procedurally according to what they are parented to.
+- Parent :
+  - Added `parentVariable` plug, to create a context variable that passes the
+    parent location to nodes upstream of the `children` plug. This allows the children
+    to be varied procedurally according to what they are parented to.
+  - Added `destination` plug, to allow children to be placed elsewhere in the scene
+    while still inheriting the transform of the "parent". This is particularly useful
+    when parenting lights to geometry.
+- Seeds : Added `destination` plug, to control where the points are placed in the scene
+  relative to the meshes they are generated from.
 - Outputs : Reduced the time taken to show the NodeEditor by around 90%.
 - NodeEditor : The "Node Name" label is now draggable. For instance, it can be dragged to the PythonEditor to get a reference to the node or to the GraphEditor to find the node in the graph.
 - GraphEditor : Improved framing of nodes dragged and dropped onto the GraphEditor :

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,7 @@ API
   - Added overloads with `root` argument for `parallelTraverse()`, `filteredParallelTraverse()`, `matchingPaths()` and `matchingPathsHash()`.
   - Deprecated `matchingPaths()` overloads taking `Filter *`. Pass a `Filter.out` plug instead.
   - Added Python bindings for `matchingPathsHash()`.
+- ScenePlug : Added support for `..` in `stringToPath()`.
 - GafferUI.FileMenu : Added `dialogueParentWindow` argument to `addScript()`.
 
 0.59.6.0 (relative to 0.59.5.0)

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
   - Added `destination` plug, to control where the copies are placed relative to the
     original.
   - Improved performance for large numbers of copies.
+  - Deprecated the `target` plug. Please use filters instead.
 - Outputs : Reduced the time taken to show the NodeEditor by around 90%.
 - NodeEditor : The "Node Name" label is now draggable. For instance, it can be dragged to the PythonEditor to get a reference to the node or to the GraphEditor to find the node in the graph.
 - GraphEditor : Improved framing of nodes dragged and dropped onto the GraphEditor :

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -139,39 +139,39 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		/// \todo Make all these methods pure virtual.
 		//@{
 		virtual bool affectsBranchBound( const Gaffer::Plug *input ) const;
-		virtual void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
+		virtual void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchTransform( const Gaffer::Plug *input ) const;
-		virtual void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
+		virtual void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchAttributes( const Gaffer::Plug *input ) const;
-		virtual void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
+		virtual void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchObject( const Gaffer::Plug *input ) const;
 		/// \deprecated
 		virtual bool processesRootObject() const;
-		virtual void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
+		virtual void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchChildNames( const Gaffer::Plug *input ) const;
-		virtual void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
+		virtual void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const = 0;
+		virtual IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const = 0;
 
 		virtual bool affectsBranchSetNames( const Gaffer::Plug *input ) const;
-		virtual void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
+		virtual void hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		/// Called to determine if all branches have the same set names. If it returns true,
-		/// `computeSetNames()` calls `computeBranchSetNames()` just once, with an empty `parentPath`,
+		/// `computeSetNames()` calls `computeBranchSetNames()` just once, with an empty `sourcePath`,
 		/// rather than having to accumulate all names from all branches. The default implementation
 		/// returns true.
 		virtual bool constantBranchSetNames() const;
 
 		virtual bool affectsBranchSet( const Gaffer::Plug *input ) const;
-		virtual void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-		virtual IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
+		virtual void hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		virtual IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
 		//@}
 
 		// Computes the relevant source and branch paths for computing the result

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -174,30 +174,6 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		virtual IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const;
 		//@}
 
-		// Computes the relevant source and branch paths for computing the result
-		// at the specified path. Returns a PathMatcher::Result to describe where path is
-		// relative to the branch destination, as follows :
-		//
-		// AncestorMatch
-		//
-		// The path is on a branch below the destination, `sourcePath` and `branchPath`
-		// are filled in appropriately, and `branchPath` will not be empty.
-		//
-		// ExactMatch
-		//
-		// The path is at the branch destination exactly. Neither `sourcePath` nor `branchPath`
-		// will be filled in.
-		//
-		// DescendantMatch
-		//
-		// The path is above one or more branch destinations. Neither `sourcePath` nor `branchPath`
-		// will be filled in.
-		//
-		// NoMatch
-		//
-		// The path is a direct pass through from the input - neither
-		// `sourcePath` nor `branchPath` will be filled in.
-		IECore::PathMatcher::Result sourceAndBranchPaths( const ScenePath &path, ScenePath &sourcePath, ScenePath &branchPath ) const;
 		/// \deprecated
 		IECore::PathMatcher::Result parentAndBranchPaths( const ScenePath &path, ScenePath &parentPath, ScenePath &branchPath ) const;
 
@@ -231,6 +207,31 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		// Returns `branches()` if it should be used to compute a set, otherwise `nullptr`.
 		ConstBranchesDataPtr branchesForSet( const IECore::InternedString &setName, const Gaffer::Context *context ) const;
 		bool affectsBranchesForSet( const Gaffer::Plug *input ) const;
+
+		// Classification that determines how locations are
+		// processed.
+		enum LocationType
+		{
+			// On a branch, delegated to the `computeBranch*()` methods.
+			Branch,
+			// Destination which forms the root for a branch. Several
+			// source locations may map to the same destination.
+			Destination,
+			// As above, but the location does not exist in the input scene.
+			NewDestination,
+			// Ancestor of a Destination location.
+			Ancestor,
+			// As above, but the location does not exist in the input scene.
+			NewAncestor,
+			// Location is unrelated to any branches, and is a direct pass
+			// through of the input scene.
+			PassThrough
+		};
+
+		// Returns the classification for `path`. If `Branch`, fills in `sourcePath`
+		// and `branchPath`. If `newChildNames` is passed, then it will be assigned
+		// the names of any `NewDestination/NewAncestor` children at this location.
+		LocationType sourceAndBranchPaths( const ScenePath &path, ScenePath &sourcePath, ScenePath &branchPath, IECore::ConstInternedStringVectorDataPtr *newChildNames = nullptr ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -99,6 +99,7 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 		IECore::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
 		/// @name Branch evaluation methods
 		/// These must be implemented by derived classes. The hashBranch*() methods must either :
@@ -178,17 +179,19 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 
 	private :
 
+		IE_CORE_FORWARDDECLARE( BranchesData );
+
 		/// Returns the path specified by `parentPlug()`, only if it is non-empty
 		/// and is valid within the input scene.
 		boost::optional<ScenePlug::ScenePath> parentPlugPath() const;
 
-		/// All the results from `filterPlug()`.
-		Gaffer::PathMatcherDataPlug *filteredPathsPlug();
-		const Gaffer::PathMatcherDataPlug *filteredPathsPlug() const;
-
-		/// All the parent locations at which we need to create a branch.
-		Gaffer::PathMatcherDataPlug *parentPathsPlug();
-		const Gaffer::PathMatcherDataPlug *parentPathsPlug() const;
+		/// BranchesData telling us what branches we need to make.
+		Gaffer::ObjectPlug *branchesPlug();
+		const Gaffer::ObjectPlug *branchesPlug() const;
+		/// Calls `branchesPlug()->getValue()` in a clean context and
+		/// returns the result. This must be used for all access to
+		/// `branchesPlug()`.
+		ConstBranchesDataPtr branches( const Gaffer::Context *context ) const;
 
 		/// Used to calculate the name remapping needed to prevent name clashes with
 		/// the existing scene. Must be evaluated in a context where "scene:path" is

--- a/include/GafferScene/Duplicate.h
+++ b/include/GafferScene/Duplicate.h
@@ -74,32 +74,32 @@ class GAFFERSCENE_API Duplicate : public BranchCreator
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
-		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
-		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
-		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
-		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
-		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
-		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+		void hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
-		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+		void hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 	private :
 
@@ -117,7 +117,7 @@ class GAFFERSCENE_API Duplicate : public BranchCreator
 		Gaffer::InternedStringVectorDataPlug *childNamesPlug();
 		const Gaffer::InternedStringVectorDataPlug *childNamesPlug() const;
 
-		void sourcePath( const ScenePath &branchPath, ScenePath &source ) const;
+		void branchSource( const ScenePath &branchPath, ScenePath &source ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/Duplicate.h
+++ b/include/GafferScene/Duplicate.h
@@ -103,21 +103,15 @@ class GAFFERSCENE_API Duplicate : public BranchCreator
 
 	private :
 
-		// The BranchCreator::parentPlug() must be used to define the place where the duplicates
-		// are to be parented, but it's much more natural for the user to simply specify which object
-		// they want to duplicate, and expect that the duplicates will appear alongside the original.
-		// This output plug is used to compute the appropriate parent from the target, and is connected
-		// into BranchCreator::parentPlug() so that the user doesn't need to worry about it.
-		Gaffer::StringPlug *outParentPlug();
-		const Gaffer::StringPlug *outParentPlug() const;
+		IE_CORE_FORWARDDECLARE( DuplicatesData );
 
-		// We need the list of names of the duplicates in both computeBranchChildNames()
-		// and computeBranchTransform(), so we compute it on this intermediate plug so that
-		// the list is cached and the work is shared between the two methods.
-		Gaffer::InternedStringVectorDataPlug *childNamesPlug();
-		const Gaffer::InternedStringVectorDataPlug *childNamesPlug() const;
+		// Used to store the names and transforms for each copy. Must be
+		// evaluated in a context where `scene:path` is one of the source
+		// locations.
+		Gaffer::ObjectPlug *duplicatesPlug();
+		const Gaffer::ObjectPlug *duplicatesPlug() const;
 
-		void branchSource( const ScenePath &branchPath, ScenePath &source ) const;
+		void branchSource( const ScenePath &sourcePath, const ScenePath &branchPath, ScenePath &source ) const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/Duplicate.h
+++ b/include/GafferScene/Duplicate.h
@@ -54,6 +54,7 @@ class GAFFERSCENE_API Duplicate : public BranchCreator
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Duplicate, DuplicateTypeId, BranchCreator );
 
+		/// \deprecated Use a filter instead.
 		Gaffer::StringPlug *targetPlug();
 		const Gaffer::StringPlug *targetPlug() const;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -171,40 +171,40 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
-		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
-		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
-		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
 		// Implemented to remove the parent object, because we "convert" the points into a hierarchy
 		bool processesRootObject() const override;
-		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		void hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
-		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		void hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstInternedStringVectorDataPtr computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
-		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+		void hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
-		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+		void hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 		void hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstPathMatcherDataPtr computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const override;
@@ -228,15 +228,15 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::PathMatcherDataPlug *setCollaboratePlug();
 		const Gaffer::PathMatcherDataPlug *setCollaboratePlug() const;
 
-		ConstEngineDataPtr engine( const ScenePath &parentPath, const Gaffer::Context *context ) const;
-		void engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
+		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
-		IECore::ConstCompoundDataPtr prototypeChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const;
-		void prototypeChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		IECore::ConstCompoundDataPtr prototypeChildNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
+		void prototypeChildNamesHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
-			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &parentPath, const ScenePath &branchPath );
+			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &sourcePath, const ScenePath &branchPath );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Parent.h
+++ b/include/GafferScene/Parent.h
@@ -68,33 +68,33 @@ class GAFFERSCENE_API Parent : public BranchCreator
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
-		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
-		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
-		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
-		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
-		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
-		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+		void hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const override;
 		bool constantBranchSetNames() const override;
 
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
-		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+		void hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -261,7 +261,9 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// \todo Many of the places we use this, it would be preferable if the source data was already
 		/// a path. Perhaps a ScenePathPlug could take care of this for us?
 		static void stringToPath( const std::string &s, ScenePlug::ScenePath &path );
+		static ScenePath stringToPath( const std::string &s );
 		static void pathToString( const ScenePlug::ScenePath &path, std::string &s );
+		static std::string pathToString( const ScenePlug::ScenePath &path );
 
 		/// Deprecated methods
 		/// ==================

--- a/include/GafferScene/Seeds.h
+++ b/include/GafferScene/Seeds.h
@@ -68,24 +68,24 @@ class GAFFERSCENE_API Seeds : public BranchCreator
 	protected :
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
-		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
-		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
-		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
-		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
-		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferScene/Unencapsulate.h
+++ b/include/GafferScene/Unencapsulate.h
@@ -57,33 +57,33 @@ class GAFFERSCENE_API Unencapsulate : public BranchCreator
 	protected :
 
 		bool affectsBranchBound( const Gaffer::Plug *input ) const override;
-		void hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchTransform( const Gaffer::Plug *input ) const override;
-		void hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::M44f computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::M44f computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchAttributes( const Gaffer::Plug *input ) const override;
-		void hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool processesRootObject() const override;
 		bool affectsBranchObject( const Gaffer::Plug *input ) const override;
-		void hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchChildNames( const Gaffer::Plug *input ) const override;
-		void hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
+		void hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSetNames( const Gaffer::Plug *input ) const override;
-		void hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const override;
+		void hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const override;
 
 		bool affectsBranchSet( const Gaffer::Plug *input ) const override;
-		void hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
+		void hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstPathMatcherDataPtr computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/python/GafferSceneTest/ParentTest.py
+++ b/python/GafferSceneTest/ParentTest.py
@@ -156,6 +156,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 	def testEmptyParent( self ) :
 
 		c = GafferScene.Cube()
+		c["sets"].setValue( "A" )
 
 		g = GafferScene.Group()
 		g["in"][0].setInput( c["out"] )

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -201,6 +201,10 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( GafferScene.ScenePlug.stringToPath( "//a//b//" ), IECore.InternedStringVectorData( [ "a", "b" ] ) )
 		self.assertEqual( GafferScene.ScenePlug.stringToPath( "/foo/bar/" ), IECore.InternedStringVectorData( [ "foo", "bar" ] ) )
 		self.assertEqual( GafferScene.ScenePlug.stringToPath( "foo/bar/" ), IECore.InternedStringVectorData( [ "foo", "bar" ] ) )
+		self.assertEqual( GafferScene.ScenePlug.stringToPath( "foo/bar/.." ), IECore.InternedStringVectorData( [ "foo" ] ) )
+		self.assertEqual( GafferScene.ScenePlug.stringToPath( "foo/bar/../.." ), IECore.InternedStringVectorData( [] ) )
+		self.assertEqual( GafferScene.ScenePlug.stringToPath( "foo/bar/../../.." ), IECore.InternedStringVectorData( [] ) )
+		self.assertEqual( GafferScene.ScenePlug.stringToPath( "foo/bar/../toto" ), IECore.InternedStringVectorData( [ "foo", "toto" ] ) )
 
 	def testPathToString( self ) :
 

--- a/python/GafferSceneUI/BranchCreatorUI.py
+++ b/python/GafferSceneUI/BranchCreatorUI.py
@@ -72,5 +72,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"destination" : [
+
+			# Deliberately not documenting destination plug, so that
+			# it is given documentation more specific to each
+			# derived class.
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"ui:spreadsheet:selectorValue", "${scene:path}",
+			"layout:index", -1,
+
+		],
+
 	}
 )

--- a/python/GafferSceneUI/DuplicateUI.py
+++ b/python/GafferSceneUI/DuplicateUI.py
@@ -117,5 +117,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"destination" : [
+
+			"description",
+			"""
+			The location where the copies will be placed in the output scene.
+			The default value places them alongside the original.
+			""",
+
+		],
+
 	}
 )

--- a/python/GafferSceneUI/DuplicateUI.py
+++ b/python/GafferSceneUI/DuplicateUI.py
@@ -55,6 +55,8 @@ Gaffer.Metadata.registerNode(
 	a transform applied to them.
 	""",
 
+	"layout:activator:targetInUse", lambda node : not node["target"].isSetToDefault(),
+
 	plugs = {
 
 		"parent" : [
@@ -75,9 +77,14 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The part of the scene to be duplicated.
+
+			> Caution : Deprecated. Please connect a filter instead.
 			""",
 
 			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			# We want people to use filters rather than the `target` plug. So
+			# hide it unless it is already being used.
+			"layout:visibilityActivator", "targetInUse",
 
 		],
 

--- a/python/GafferSceneUI/ParentUI.py
+++ b/python/GafferSceneUI/ParentUI.py
@@ -95,6 +95,24 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"destination" : [
+
+			"description",
+			"""
+			The location where the children will be placed in the output scene.
+			The default is to place the children under the parent, but they may
+			be relocated anywhere while still inheriting the parent's transform.
+			This is particularly useful when parenting lights to geometry but
+			wanting to group them and control their visibility separately.
+
+			When the destination is evaluated, the `${scene:path}` variable holds
+			the source location matched by the filter. This allows the children
+			to be placed relative to the "parent". For example, `${scene:path}/..`
+			will place the children alongside the "parent" rather than under it.
+			""",
+
+		],
+
 	}
 
 )

--- a/python/GafferSceneUI/SeedsUI.py
+++ b/python/GafferSceneUI/SeedsUI.py
@@ -117,7 +117,22 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
-		]
+		],
+
+		"destination" : [
+
+			"description",
+			"""
+			The location where the points primitives will be placed in the output scene.
+			When the destination is evaluated, the `${scene:path}` variable holds
+			the location of the source mesh, so the default value parents the points
+			under the mesh.
+
+			> Tip : `${scene:path}/..` may be used to place the points alongside the
+			> source mesh.
+			""",
+
+		],
 
 	}
 

--- a/python/GafferUI/SpreadsheetUI/_Algo.py
+++ b/python/GafferUI/SpreadsheetUI/_Algo.py
@@ -51,6 +51,8 @@ from ._SectionChooser import _SectionChooser
 def createSpreadsheet( plug ) :
 
 	spreadsheet = Gaffer.Spreadsheet()
+	spreadsheet["selector"].setValue( Gaffer.Metadata.value( plug,"ui:spreadsheet:selectorValue" ) or "" )
+
 	addColumn( spreadsheet, plug )
 	spreadsheet["rows"].addRow()
 

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -84,13 +84,9 @@ void mergeSetNames( const InternedStringVectorData *toAdd, vector<InternedString
 // BranchCreator
 //////////////////////////////////////////////////////////////////////////
 
-
 GAFFER_NODE_DEFINE_TYPE( BranchCreator );
 
 size_t BranchCreator::g_firstPlugIndex = 0;
-
-static InternedString g_childNamesKey( "__BranchCreatorChildNames" );
-static InternedString g_forwardMappingKey( "__BranchCreatorForwardMappings" );
 
 BranchCreator::BranchCreator( const std::string &name )
 	:	FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -299,15 +299,15 @@ class BranchCreator::BranchesData : public IECore::Data
 		static void hashBranch( const BranchCreator *branchCreator, const ScenePlug::ScenePath &path, IECore::MurmurHash &h )
 		{
 			h.append( path.data(), path.size() );
-			h.append( path.size() );
+			h.append( (uint64_t)path.size() );
 
 			ScenePlug::ScenePath destination = ScenePlug::stringToPath( branchCreator->destinationPlug()->getValue() );
 			h.append( destination.data(), destination.size() );
-			h.append( destination.size() );
+			h.append( (uint64_t)destination.size() );
 
 			const ScenePlug::ScenePath existing = closestExistingPath( branchCreator->inPlug(), destination );
 			h.append( existing.data(), existing.size() );
-			h.append( existing.size() );
+			h.append( (uint64_t)existing.size() );
 		}
 
 		void addBranch( const BranchCreator *branchCreator, const ScenePlug::ScenePath &path )

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -410,14 +410,14 @@ void BranchCreator::compute( Gaffer::ValuePlug *output, const Gaffer::Context *c
 
 void BranchCreator::hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		hashBranchBound( parentPath, branchPath, context, h );
+		hashBranchBound( sourcePath, branchPath, context, h );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch || parentMatch == IECore::PathMatcher::DescendantMatch )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch || destinationMatch == IECore::PathMatcher::DescendantMatch )
 	{
 		FilteredSceneProcessor::hashBound( path, context, parent, h );
 		inPlug()->boundPlug()->hash( h );
@@ -431,14 +431,14 @@ void BranchCreator::hashBound( const ScenePath &path, const Gaffer::Context *con
 
 Imath::Box3f BranchCreator::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		return computeBranchBound( parentPath, branchPath, context );
+		return computeBranchBound( sourcePath, branchPath, context );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch || parentMatch == IECore::PathMatcher::DescendantMatch )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch || destinationMatch == IECore::PathMatcher::DescendantMatch )
 	{
 		Box3f result = inPlug()->boundPlug()->getValue();
 		result.extendBy( outPlug()->childBoundsPlug()->getValue() );
@@ -452,18 +452,18 @@ Imath::Box3f BranchCreator::computeBound( const ScenePath &path, const Gaffer::C
 
 void BranchCreator::hashTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		hashBranchTransform( parentPath, branchPath, context, h );
+		hashBranchTransform( sourcePath, branchPath, context, h );
 		if( branchPath.size() == 1 )
 		{
 			ScenePath destinationPath = path; destinationPath.pop_back();
-			if( parentPath != destinationPath )
+			if( sourcePath != destinationPath )
 			{
-				h.append( inPlug()->fullTransformHash( parentPath ) );
+				h.append( inPlug()->fullTransformHash( sourcePath ) );
 				h.append( inPlug()->fullTransform( destinationPath ) );
 			}
 		}
@@ -476,20 +476,20 @@ void BranchCreator::hashTransform( const ScenePath &path, const Gaffer::Context 
 
 Imath::M44f BranchCreator::computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		M44f result = computeBranchTransform( parentPath, branchPath, context );
+		M44f result = computeBranchTransform( sourcePath, branchPath, context );
 		if( branchPath.size() == 1 )
 		{
 			ScenePath destinationPath = path; destinationPath.pop_back();
-			if( parentPath != destinationPath )
+			if( sourcePath != destinationPath )
 			{
 				// Account for the difference between source and destination transforms so that
 				// branches are positioned as if they were parented below the source.
-				M44f relativeTransform = inPlug()->fullTransform( parentPath ) * inPlug()->fullTransform( destinationPath ).inverse();
+				M44f relativeTransform = inPlug()->fullTransform( sourcePath ) * inPlug()->fullTransform( destinationPath ).inverse();
 				result *= relativeTransform;
 			}
 		}
@@ -503,12 +503,12 @@ Imath::M44f BranchCreator::computeTransform( const ScenePath &path, const Gaffer
 
 void BranchCreator::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		hashBranchAttributes( parentPath, branchPath, context, h );
+		hashBranchAttributes( sourcePath, branchPath, context, h );
 	}
 	else
 	{
@@ -518,12 +518,12 @@ void BranchCreator::hashAttributes( const ScenePath &path, const Gaffer::Context
 
 IECore::ConstCompoundObjectPtr BranchCreator::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		return computeBranchAttributes( parentPath, branchPath, context );
+		return computeBranchAttributes( sourcePath, branchPath, context );
 	}
 	else
 	{
@@ -538,14 +538,14 @@ bool BranchCreator::processesRootObject() const
 
 void BranchCreator::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		hashBranchObject( parentPath, branchPath, context, h );
+		hashBranchObject( sourcePath, branchPath, context, h );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
 	{
 		// See notes in `hashObject()`.
 		if( !destinationPlug()->isSetToDefault() )
@@ -562,14 +562,14 @@ void BranchCreator::hashObject( const ScenePath &path, const Gaffer::Context *co
 
 IECore::ConstObjectPtr BranchCreator::computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		return computeBranchObject( parentPath, branchPath, context );
+		return computeBranchObject( sourcePath, branchPath, context );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch && processesRootObject() )
 	{
 		/// \todo The `processesRootObject()` mechanism was intended to allow derived
 		/// classes to modify the object at `sourcePath`, but it is not compatible
@@ -591,14 +591,14 @@ IECore::ConstObjectPtr BranchCreator::computeObject( const ScenePath &path, cons
 
 void BranchCreator::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		hashBranchChildNames( parentPath, branchPath, context, h );
+		hashBranchChildNames( sourcePath, branchPath, context, h );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch )
 	{
 		Private::ConstChildNamesMapPtr mapping = boost::static_pointer_cast<const Private::ChildNamesMap>( mappingPlug()->getValue() );
 		h = mapping->outputChildNames()->Object::hash();
@@ -611,14 +611,14 @@ void BranchCreator::hashChildNames( const ScenePath &path, const Gaffer::Context
 
 IECore::ConstInternedStringVectorDataPtr BranchCreator::computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ScenePath parentPath, branchPath;
-	const IECore::PathMatcher::Result parentMatch = parentAndBranchPaths( path, parentPath, branchPath );
+	ScenePath sourcePath, branchPath;
+	const IECore::PathMatcher::Result destinationMatch = sourceAndBranchPaths( path, sourcePath, branchPath );
 
-	if( parentMatch == IECore::PathMatcher::AncestorMatch )
+	if( destinationMatch == IECore::PathMatcher::AncestorMatch )
 	{
-		return computeBranchChildNames( parentPath, branchPath, context );
+		return computeBranchChildNames( sourcePath, branchPath, context );
 	}
-	else if( parentMatch == IECore::PathMatcher::ExactMatch )
+	else if( destinationMatch == IECore::PathMatcher::ExactMatch )
 	{
 		Private::ConstChildNamesMapPtr mapping = boost::static_pointer_cast<const Private::ChildNamesMap>( mappingPlug()->getValue() );
 		return mapping->outputChildNames();
@@ -850,36 +850,36 @@ bool BranchCreator::affectsBranchSet( const Gaffer::Plug *input ) const
 	return false;
 }
 
-void BranchCreator::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	FilteredSceneProcessor::hashBound( context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ), context, inPlug(), h );
 }
 
-void BranchCreator::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	FilteredSceneProcessor::hashTransform( context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ), context, inPlug(), h );
 }
 
-void BranchCreator::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	FilteredSceneProcessor::hashAttributes( context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ), context, inPlug(), h );
 }
 
-void BranchCreator::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	FilteredSceneProcessor::hashObject( context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ), context, inPlug(), h );
 }
 
-void BranchCreator::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	FilteredSceneProcessor::hashChildNames( context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ), context, inPlug(), h );
 }
 
-void BranchCreator::hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 }
 
-IECore::ConstInternedStringVectorDataPtr BranchCreator::computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr BranchCreator::computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
 	// It's OK to return nullptr, because the value returned from this method
 	// isn't used as the result of a compute(), and won't be stored on a plug.
@@ -892,11 +892,11 @@ bool BranchCreator::constantBranchSetNames() const
 	return true;
 }
 
-void BranchCreator::hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void BranchCreator::hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 }
 
-IECore::ConstPathMatcherDataPtr BranchCreator::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
+IECore::ConstPathMatcherDataPtr BranchCreator::computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
 	// See comments in computeBranchSetNames.
 	return nullptr;

--- a/src/GafferScene/Duplicate.cpp
+++ b/src/GafferScene/Duplicate.cpp
@@ -269,17 +269,17 @@ bool Duplicate::affectsBranchBound( const Gaffer::Plug *input ) const
 	return input == inPlug()->boundPlug();
 }
 
-void Duplicate::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	h = inPlug()->boundHash( source );
 }
 
-Imath::Box3f Duplicate::computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::Box3f Duplicate::computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	return inPlug()->bound( source );
 }
 
@@ -292,13 +292,13 @@ bool Duplicate::affectsBranchTransform( const Gaffer::Plug *input ) const
 	;
 }
 
-void Duplicate::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	if( branchPath.size() == 1 )
 	{
-		BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchTransform( sourcePath, branchPath, context, h );
 		h.append( inPlug()->transformHash( source ) );
 		transformPlug()->hash( h );
 		childNamesPlug()->hash( h );
@@ -310,10 +310,10 @@ void Duplicate::hashBranchTransform( const ScenePath &parentPath, const ScenePat
 	}
 }
 
-Imath::M44f Duplicate::computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::M44f Duplicate::computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	Imath::M44f result = inPlug()->transform( source );
 	if( branchPath.size() == 1 )
 	{
@@ -335,17 +335,17 @@ bool Duplicate::affectsBranchAttributes( const Gaffer::Plug *input ) const
 	return input == inPlug()->attributesPlug();
 }
 
-void Duplicate::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	h = inPlug()->attributesHash( source );
 }
 
-IECore::ConstCompoundObjectPtr Duplicate::computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstCompoundObjectPtr Duplicate::computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	return inPlug()->attributes( source );
 }
 
@@ -354,17 +354,17 @@ bool Duplicate::affectsBranchObject( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Duplicate::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	h = inPlug()->objectHash( source );
 }
 
-IECore::ConstObjectPtr Duplicate::computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstObjectPtr Duplicate::computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	ScenePath source;
-	sourcePath( branchPath, source );
+	branchSource( branchPath, source );
 	return inPlug()->object( source );
 }
 
@@ -373,7 +373,7 @@ bool Duplicate::affectsBranchChildNames( const Gaffer::Plug *input ) const
 	return input == inPlug()->childNamesPlug() || input == childNamesPlug();
 }
 
-void Duplicate::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() == 0 )
 	{
@@ -382,12 +382,12 @@ void Duplicate::hashBranchChildNames( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		ScenePath source;
-		sourcePath( branchPath, source );
+		branchSource( branchPath, source );
 		h = inPlug()->childNamesHash( source );
 	}
 }
 
-IECore::ConstInternedStringVectorDataPtr Duplicate::computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Duplicate::computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() == 0 )
 	{
@@ -396,7 +396,7 @@ IECore::ConstInternedStringVectorDataPtr Duplicate::computeBranchChildNames( con
 	else
 	{
 		ScenePath source;
-		sourcePath( branchPath, source );
+		branchSource( branchPath, source );
 		return inPlug()->childNames( source );
 	}
 }
@@ -406,15 +406,15 @@ bool Duplicate::affectsBranchSetNames( const Gaffer::Plug *input ) const
 	return input == inPlug()->setNamesPlug();
 }
 
-void Duplicate::hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	assert( parentPath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
 	h = inPlug()->setNamesPlug()->hash();
 }
 
-IECore::ConstInternedStringVectorDataPtr Duplicate::computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Duplicate::computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
-	assert( parentPath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
 	return inPlug()->setNamesPlug()->getValue();
 }
 
@@ -427,14 +427,14 @@ bool Duplicate::affectsBranchSet( const Gaffer::Plug *input ) const
 	;
 }
 
-void Duplicate::hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Duplicate::hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	h.append( inPlug()->setHash( setName ) );
 	targetPlug()->hash( h );
 	childNamesPlug()->hash( h );
 }
 
-IECore::ConstPathMatcherDataPtr Duplicate::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
+IECore::ConstPathMatcherDataPtr Duplicate::computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
 	ConstPathMatcherDataPtr inputSetData = inPlug()->set( setName );
 	const PathMatcher &inputSet = inputSetData->readable();
@@ -464,7 +464,7 @@ IECore::ConstPathMatcherDataPtr Duplicate::computeBranchSet( const ScenePath &pa
 	return resultData;
 }
 
-void Duplicate::sourcePath( const ScenePath &branchPath, ScenePath &source ) const
+void Duplicate::branchSource( const ScenePath &branchPath, ScenePath &source ) const
 {
 	assert( branchPath.size() );
 	ScenePlug::stringToPath( targetPlug()->getValue(), source );

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -922,6 +922,10 @@ Instancer::Instancer( const std::string &name )
 	addChild( new ScenePlug( "__capsuleScene", Plug::Out ) );
 	addChild( new PathMatcherDataPlug( "__setCollaborate", Plug::Out, new IECore::PathMatcherData() ) );
 
+	// Hide `destination` plug until we resolve issues surrounding `processesRootObject()`.
+	// See `BranchCreator::computeObject()`.
+	destinationPlug()->setName( "__destination" );
+
 	capsuleScenePlug()->boundPlug()->setInput( outPlug()->boundPlug() );
 	capsuleScenePlug()->transformPlug()->setInput( outPlug()->transformPlug() );
 	capsuleScenePlug()->attributesPlug()->setInput( outPlug()->attributesPlug() );

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -2020,7 +2020,7 @@ void Instancer::hashObject( const ScenePath &path, const Gaffer::Context *contex
 		// when branchPath.size() != 2, we are able to just use all the logic from
 		// BranchCreator, without exposing any new API surface
 		ScenePath sourcePath, branchPath;
-		sourceAndBranchPaths( path, sourcePath, branchPath );
+		parentAndBranchPaths( path, sourcePath, branchPath );
 		if( branchPath.size() == 2 )
 		{
 			BranchCreator::hashBranchObject( sourcePath, branchPath, context, h );

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -1334,9 +1334,9 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	}
 	else if( output == setCollaboratePlug() )
 	{
-		const ScenePath &parentPath = context->get<ScenePath>( ScenePlug::scenePathContextName );
+		const ScenePath &sourcePath = context->get<ScenePath>( ScenePlug::scenePathContextName );
 
-		ConstEngineDataPtr engine = this->engine( parentPath, context );
+		ConstEngineDataPtr engine = this->engine( sourcePath, context );
 		if( !engine->hasContextVariables() )
 		{
 			// We use a slightly approximate version of hasContextVariables in hashBranchSet, to
@@ -1351,14 +1351,14 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 			// We could always hash this stuff in hashBranchSet, but we would lose out a benefit of a more
 			// accurate hash when we do actually have context variables:  the slower hash won't change
 			// if point locations change, unlike the engineHash which includes all changes
-			engineHash( parentPath, context, h );
-			prototypeChildNamesHash( parentPath, context, h );
+			engineHash( sourcePath, context, h );
+			prototypeChildNamesHash( sourcePath, context, h );
 			prototypesPlug()->setPlug()->hash( h );
 			namePlug()->hash( h );
 			return;
 		}
 
-		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
+		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( sourcePath, context );
 
 		tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
 
@@ -1371,7 +1371,7 @@ void Instancer::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 			tbb::parallel_for( tbb::blocked_range<size_t>( 0, childNames.size() ), [&]( const tbb::blocked_range<size_t> &r )
 				{
 					Context::EditableScope scope( threadState );
-					// As part of the setCollaborate plug machinery, we put the parentPath in the context.
+					// As part of the setCollaborate plug machinery, we put the sourcePath in the context.
 					// Need to remove it before evaluating the prototype sets
 					scope.remove( ScenePlug::scenePathContextName );
 					for( size_t i = r.begin(); i != r.end(); ++i )
@@ -1633,11 +1633,11 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 	}
 	else if( output == setCollaboratePlug() )
 	{
-		const ScenePath &parentPath = context->get<ScenePath>( ScenePlug::scenePathContextName );
+		const ScenePath &sourcePath = context->get<ScenePath>( ScenePlug::scenePathContextName );
 
-		ConstEngineDataPtr engine = this->engine( parentPath, context );
+		ConstEngineDataPtr engine = this->engine( sourcePath, context );
 
-		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
+		IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( sourcePath, context );
 
 		PathMatcherDataPtr outputSetData = new PathMatcherData;
 		PathMatcher &outputSet = outputSetData->writable();
@@ -1660,7 +1660,7 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 			tbb::parallel_for( tbb::blocked_range<size_t>( 0, childNames.size() ), [&]( const tbb::blocked_range<size_t> &r )
 				{
 					Context::EditableScope scope( threadState );
-					// As part of the setCollaborate plug machinery, we put the parentPath in the context.
+					// As part of the setCollaborate plug machinery, we put the sourcePath in the context.
 					// Need to remove it before evaluating the prototype sets
 					scope.remove( ScenePlug::scenePathContextName );
 
@@ -1725,12 +1725,12 @@ bool Instancer::affectsBranchBound( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() < 2 )
 	{
 		// "/" or "/instances"
-		ScenePath path = parentPath;
+		ScenePath path = sourcePath;
 		path.insert( path.end(), branchPath.begin(), branchPath.end() );
 		if( branchPath.size() == 0 )
 		{
@@ -1741,14 +1741,14 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		BranchCreator::hashBranchBound( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchBound( sourcePath, branchPath, context, h );
 
-		engineHash( parentPath, context, h );
-		prototypeChildNamesHash( parentPath, context, h );
+		engineHash( sourcePath, context, h );
+		prototypeChildNamesHash( sourcePath, context, h );
 		h.append( branchPath.back() );
 
 		{
-			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+			PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 			prototypesPlug()->boundPlug()->hash( h );
 		}
@@ -1756,17 +1756,17 @@ void Instancer::hashBranchBound( const ScenePath &parentPath, const ScenePath &b
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->boundPlug()->hash();
 	}
 }
 
-Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::Box3f Instancer::computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() < 2 )
 	{
 		// "/" or "/instances"
-		ScenePath path = parentPath;
+		ScenePath path = sourcePath;
 		path.insert( path.end(), branchPath.begin(), branchPath.end() );
 		if( branchPath.size() == 0 )
 		{
@@ -1782,14 +1782,14 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 		// because we have direct access to the engine, we can implement this
 		// more efficiently than `ScenePlug::childBounds()`.
 
-		ConstEngineDataPtr e = engine( parentPath, context );
-		ConstCompoundDataPtr ic = prototypeChildNames( parentPath, context );
+		ConstEngineDataPtr e = engine( sourcePath, context );
+		ConstCompoundDataPtr ic = prototypeChildNames( sourcePath, context );
 		const vector<InternedString> &childNames = ic->member<InternedStringVectorData>( branchPath.back() )->readable();
 
 		M44f childTransform;
 		Box3f childBound;
 		{
-			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+			PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 			childTransform = prototypesPlug()->transformPlug()->getValue();
 			childBound = prototypesPlug()->boundPlug()->getValue();
 		}
@@ -1825,7 +1825,7 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &parentPath, const S
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->boundPlug()->getValue();
 	}
 }
@@ -1838,33 +1838,33 @@ bool Instancer::affectsBranchTransform( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() <= 2 )
 	{
 		// "/" or "/instances" or "/instances/<prototypeName>"
-		BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchTransform( sourcePath, branchPath, context, h );
 	}
 	else if( branchPath.size() == 3 )
 	{
 		// "/instances/<prototypeName>/<id>"
-		BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchTransform( sourcePath, branchPath, context, h );
 		{
-			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+			PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 			prototypesPlug()->transformPlug()->hash( h );
 		}
-		engineHash( parentPath, context, h );
+		engineHash( sourcePath, context, h );
 		h.append( branchPath[2] );
 	}
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->transformPlug()->hash();
 	}
 }
 
-Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::M44f Instancer::computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() <= 2 )
 	{
@@ -1876,10 +1876,10 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 		// "/instances/<prototypeName>/<id>"
 		M44f result;
 		{
-			PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+			PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 			result = prototypesPlug()->transformPlug()->getValue();
 		}
-		ConstEngineDataPtr e = engine( parentPath, context );
+		ConstEngineDataPtr e = engine( sourcePath, context );
 		const size_t pointIndex = e->pointIndex( branchPath[2] );
 		result = result * e->instanceTransform( pointIndex );
 		return result;
@@ -1887,7 +1887,7 @@ Imath::M44f Instancer::computeBranchTransform( const ScenePath &parentPath, cons
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->transformPlug()->getValue();
 	}
 }
@@ -1900,7 +1900,7 @@ bool Instancer::affectsBranchAttributes( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() <= 1 )
 	{
@@ -1910,15 +1910,15 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->attributesPlug()->hash();
 	}
 	else if( branchPath.size() == 3 )
 	{
 		// "/instances/<prototypeName>/<id>"
-		BranchCreator::hashBranchAttributes( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchAttributes( sourcePath, branchPath, context, h );
 		{
-			ConstEngineDataPtr e = engine( parentPath, context );
+			ConstEngineDataPtr e = engine( sourcePath, context );
 			if( e->numInstanceAttributes() )
 			{
 				e->instanceAttributesHash( e->pointIndex( branchPath[2] ), h );
@@ -1928,12 +1928,12 @@ void Instancer::hashBranchAttributes( const ScenePath &parentPath, const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->attributesPlug()->hash();
 	}
 }
 
-IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() <= 1 )
 	{
@@ -1943,13 +1943,13 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->attributesPlug()->getValue();
 	}
 	else if( branchPath.size() == 3 )
 	{
 		// "/instances/<prototypeName>/<id>"
-		ConstEngineDataPtr e = engine( parentPath, context );
+		ConstEngineDataPtr e = engine( sourcePath, context );
 		if( e->numInstanceAttributes() )
 		{
 			return e->instanceAttributes( e->pointIndex( branchPath[2] ) );
@@ -1962,7 +1962,7 @@ IECore::ConstCompoundObjectPtr Instancer::computeBranchAttributes( const ScenePa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->attributesPlug()->getValue();
 	}
 }
@@ -1980,7 +1980,7 @@ bool Instancer::affectsBranchObject( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() <= 2 )
 	{
@@ -1990,12 +1990,12 @@ void Instancer::hashBranchObject( const ScenePath &parentPath, const ScenePath &
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->objectPlug()->hash();
 	}
 }
 
-IECore::ConstObjectPtr Instancer::computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstObjectPtr Instancer::computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() <= 2 )
 	{
@@ -2005,7 +2005,7 @@ IECore::ConstObjectPtr Instancer::computeBranchObject( const ScenePath &parentPa
 	else
 	{
 		// "/instances/<prototypeName>/<id>/...
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->objectPlug()->getValue();
 	}
 }
@@ -2014,16 +2014,16 @@ void Instancer::hashObject( const ScenePath &path, const Gaffer::Context *contex
 {
 	if( parent != capsuleScenePlug() && encapsulateInstanceGroupsPlug()->getValue() )
 	{
-		// Handling this special case here means an extra call to parentAndBranchPaths
+		// Handling this special case here means an extra call to sourceAndBranchPaths
 		// when we're encapsulating and we're not inside a branch - this is a small
 		// unnecessary cost, but by falling back to just using BranchCreator hashObject
 		// when branchPath.size() != 2, we are able to just use all the logic from
 		// BranchCreator, without exposing any new API surface
-		ScenePath parentPath, branchPath;
-		parentAndBranchPaths( path, parentPath, branchPath );
+		ScenePath sourcePath, branchPath;
+		sourceAndBranchPaths( path, sourcePath, branchPath );
 		if( branchPath.size() == 2 )
 		{
-			BranchCreator::hashBranchObject( parentPath, branchPath, context, h );
+			BranchCreator::hashBranchObject( sourcePath, branchPath, context, h );
 			h.append( reinterpret_cast<uint64_t>( this ) );
 			/// We need to include anything that will affect how the capsule will expand.
 			/// \todo Once we fix motion blur behaviour so that Capsules don't
@@ -2031,7 +2031,7 @@ void Instancer::hashObject( const ScenePath &path, const Gaffer::Context *contex
 			/// the `dirtyCount` for `prototypesPlug()->globalsPlug()`, by summing the
 			/// count for its siblings instead.
 			h.append( prototypesPlug()->dirtyCount() );
-			engineHash( parentPath, context, h );
+			engineHash( sourcePath, context, h );
 			h.append( context->hash() );
 			outPlug()->boundPlug()->hash( h );
 			return;
@@ -2045,8 +2045,8 @@ IECore::ConstObjectPtr Instancer::computeObject( const ScenePath &path, const Ga
 {
 	if( parent != capsuleScenePlug() && encapsulateInstanceGroupsPlug()->getValue() )
 	{
-		ScenePath parentPath, branchPath;
-		parentAndBranchPaths( path, parentPath, branchPath );
+		ScenePath sourcePath, branchPath;
+		parentAndBranchPaths( path, sourcePath, branchPath );
 		if( branchPath.size() == 2 )
 		{
 			return new Capsule(
@@ -2073,36 +2073,36 @@ bool Instancer::affectsBranchChildNames( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() == 0 )
 	{
 		// "/"
-		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
 		namePlug()->hash( h );
 	}
 	else if( branchPath.size() == 1 )
 	{
 		// "/instances"
-		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
-		engineHash( parentPath, context, h );
+		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
+		engineHash( sourcePath, context, h );
 	}
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
-		prototypeChildNamesHash( parentPath, context, h );
+		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
+		prototypeChildNamesHash( sourcePath, context, h );
 		h.append( branchPath.back() );
 	}
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		h = prototypesPlug()->childNamesPlug()->hash();
 	}
 }
 
-IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() == 0 )
 	{
@@ -2119,18 +2119,18 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 	else if( branchPath.size() == 1 )
 	{
 		// "/instances"
-		return engine( parentPath, context )->prototypeNames();
+		return engine( sourcePath, context )->prototypeNames();
 	}
 	else if( branchPath.size() == 2 )
 	{
 		// "/instances/<prototypeName>"
-		IECore::ConstCompoundDataPtr ic = prototypeChildNames( parentPath, context );
+		IECore::ConstCompoundDataPtr ic = prototypeChildNames( sourcePath, context );
 		return ic->member<InternedStringVectorData>( branchPath.back() );
 	}
 	else
 	{
 		// "/instances/<prototypeName>/<id>/..."
-		PrototypeScope scope( enginePlug(), context, parentPath, branchPath );
+		PrototypeScope scope( enginePlug(), context, sourcePath, branchPath );
 		return prototypesPlug()->childNamesPlug()->getValue();
 	}
 }
@@ -2139,8 +2139,8 @@ void Instancer::hashChildNames( const ScenePath &path, const Gaffer::Context *co
 {
 	if( parent != capsuleScenePlug() && encapsulateInstanceGroupsPlug()->getValue() )
 	{
-		ScenePath parentPath, branchPath;
-		parentAndBranchPaths( path, parentPath, branchPath );
+		ScenePath sourcePath, branchPath;
+		parentAndBranchPaths( path, sourcePath, branchPath );
 		if( branchPath.size() == 2 )
 		{
 			h = outPlug()->childNamesPlug()->defaultValue()->Object::hash();
@@ -2155,8 +2155,8 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeChildNames( const Sce
 {
 	if( parent != capsuleScenePlug() && encapsulateInstanceGroupsPlug()->getValue() )
 	{
-		ScenePath parentPath, branchPath;
-		parentAndBranchPaths( path, parentPath, branchPath );
+		ScenePath sourcePath, branchPath;
+		parentAndBranchPaths( path, sourcePath, branchPath );
 		if( branchPath.size() == 2 )
 		{
 			return outPlug()->childNamesPlug()->defaultValue();
@@ -2171,15 +2171,15 @@ bool Instancer::affectsBranchSetNames( const Gaffer::Plug *input ) const
 	return input == prototypesPlug()->setNamesPlug();
 }
 
-void Instancer::hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	assert( parentPath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
 	h = prototypesPlug()->setNamesPlug()->hash();
 }
 
-IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
-	assert( parentPath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
 	return prototypesPlug()->setNamesPlug()->getValue();
 }
 
@@ -2194,9 +2194,9 @@ bool Instancer::affectsBranchSet( const Gaffer::Plug *input ) const
 	;
 }
 
-void Instancer::hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	BranchCreator::hashBranchSet( parentPath, setName, context, h );
+	BranchCreator::hashBranchSet( sourcePath, setName, context, h );
 
 	// If we have context variables, we need to do a much more expensive evaluation of the prototype set
 	// plug in every instance context.  We allow task collaboration on this expensive evaluation by redirecting
@@ -2219,34 +2219,34 @@ void Instancer::hashBranchSet( const ScenePath &parentPath, const IECore::Intern
 	if( hasContextVariables )
 	{
 		Context::EditableScope scope( context );
-		scope.set( ScenePlug::scenePathContextName, parentPath );
+		scope.set( ScenePlug::scenePathContextName, sourcePath );
 		setCollaboratePlug()->hash( h );
 	}
 	else
 	{
-		engineHash( parentPath, context, h );
-		prototypeChildNamesHash( parentPath, context, h );
+		engineHash( sourcePath, context, h );
+		prototypeChildNamesHash( sourcePath, context, h );
 		prototypesPlug()->setPlug()->hash( h );
 		namePlug()->hash( h );
 	}
 }
 
-IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
+IECore::ConstPathMatcherDataPtr Instancer::computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
-	ConstEngineDataPtr engine = this->engine( parentPath, context );
+	ConstEngineDataPtr engine = this->engine( sourcePath, context );
 
 	if( engine->hasContextVariables() )
 	{
 		// When doing the much expensive work required when we have context variables, we try to share the
 		// work between multiple threads using an internal PathMatcher plug with a TaskCollaborate policy.
-		// The setCollaborate plug does all the heavy work.  It is evaluated with the parentPath in the
+		// The setCollaborate plug does all the heavy work.  It is evaluated with the sourcePath in the
 		// context's scenePath, and it returns a PathMatcher for the set contents of one branch.
 		Context::EditableScope scope( context );
-		scope.set( ScenePlug::scenePathContextName, parentPath );
+		scope.set( ScenePlug::scenePathContextName, sourcePath );
 		return setCollaboratePlug()->getValue();
 	}
 
-	IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( parentPath, context );
+	IECore::ConstCompoundDataPtr prototypeChildNames = this->prototypeChildNames( sourcePath, context );
 	ConstPathMatcherDataPtr inputSet = prototypesPlug()->setPlug()->getValue();
 
 	PathMatcherDataPtr outputSetData = new PathMatcherData;
@@ -2295,36 +2295,36 @@ IECore::ConstPathMatcherDataPtr Instancer::computeSet( const IECore::InternedStr
 	return BranchCreator::computeSet( setName, context, parent );
 }
 
-Instancer::ConstEngineDataPtr Instancer::engine( const ScenePath &parentPath, const Gaffer::Context *context ) const
+Instancer::ConstEngineDataPtr Instancer::engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
-	ScenePlug::PathScope scope( context, parentPath );
+	ScenePlug::PathScope scope( context, sourcePath );
 	return boost::static_pointer_cast<const EngineData>( enginePlug()->getValue() );
 }
 
-void Instancer::engineHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	ScenePlug::PathScope scope( context, parentPath );
+	ScenePlug::PathScope scope( context, sourcePath );
 	enginePlug()->hash( h );
 }
 
-IECore::ConstCompoundDataPtr Instancer::prototypeChildNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
+IECore::ConstCompoundDataPtr Instancer::prototypeChildNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
-	ScenePlug::PathScope scope( context, parentPath );
+	ScenePlug::PathScope scope( context, sourcePath );
 	return prototypeChildNamesPlug()->getValue();
 }
 
-void Instancer::prototypeChildNamesHash( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Instancer::prototypeChildNamesHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	ScenePlug::PathScope scope( context, parentPath );
+	ScenePlug::PathScope scope( context, sourcePath );
 	prototypeChildNamesPlug()->hash( h );
 }
 
-Instancer::PrototypeScope::PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &parentPath, const ScenePath &branchPath )
+Instancer::PrototypeScope::PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath &sourcePath, const ScenePath &branchPath )
 	:	Gaffer::Context::EditableScope( context )
 {
 	assert( branchPath.size() >= 2 );
 
-	set( ScenePlug::scenePathContextName, parentPath );
+	set( ScenePlug::scenePathContextName, sourcePath );
 	ConstEngineDataPtr engine = boost::static_pointer_cast<const EngineData>( enginePlug->getValue() );
 	const ScenePlug::ScenePath &prototypeRoot = engine->prototypeRoot( branchPath[1] );
 

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -584,7 +584,31 @@ IECore::MurmurHash ScenePlug::childBoundsHash( const ScenePath &scenePath ) cons
 void ScenePlug::stringToPath( const std::string &s, ScenePlug::ScenePath &path )
 {
 	path.clear();
-	IECore::StringAlgo::tokenize( s, '/', path );
+
+	size_t index = 0, size = s.size();
+	while( index < size )
+	{
+		const size_t prevIndex = index;
+		index = s.find( '/', index );
+		index = index == std::string::npos ? size : index;
+		if( index > prevIndex )
+		{
+			if( index == prevIndex + 2 && s[prevIndex] == '.' && s[prevIndex+1] == '.' )
+			{
+				// ".."
+				if( path.size() )
+				{
+					path.pop_back();
+				}
+			}
+			else
+			{
+				const IECore::InternedString name( s.c_str() + prevIndex, index - prevIndex );
+				path.push_back( name );
+			}
+		}
+		index++;
+	}
 }
 
 void ScenePlug::pathToString( const ScenePlug::ScenePath &path, std::string &s )

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -611,6 +611,13 @@ void ScenePlug::stringToPath( const std::string &s, ScenePlug::ScenePath &path )
 	}
 }
 
+ScenePlug::ScenePath ScenePlug::stringToPath( const std::string &s )
+{
+	ScenePath result;
+	stringToPath( s, result );
+	return result;
+}
+
 void ScenePlug::pathToString( const ScenePlug::ScenePath &path, std::string &s )
 {
 	if( !path.size() )
@@ -625,6 +632,13 @@ void ScenePlug::pathToString( const ScenePlug::ScenePath &path, std::string &s )
 			s += "/" + it->string();
 		}
 	}
+}
+
+std::string ScenePlug::pathToString( const ScenePlug::ScenePath &path )
+{
+	std::string result;
+	pathToString( path, result );
+	return result;
 }
 
 std::ostream &operator << ( std::ostream &o, const ScenePlug::ScenePath &path )

--- a/src/GafferScene/Seeds.cpp
+++ b/src/GafferScene/Seeds.cpp
@@ -111,15 +111,15 @@ bool Seeds::affectsBranchBound( const Gaffer::Plug *input ) const
 	return input == inPlug()->boundPlug();
 }
 
-void Seeds::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Seeds::hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	BranchCreator::hashBranchBound( parentPath, branchPath, context, h );
-	h.append( inPlug()->boundHash( parentPath ) );
+	BranchCreator::hashBranchBound( sourcePath, branchPath, context, h );
+	h.append( inPlug()->boundHash( sourcePath ) );
 }
 
-Imath::Box3f Seeds::computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::Box3f Seeds::computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	Box3f b =  inPlug()->bound( parentPath );
+	Box3f b = inPlug()->bound( sourcePath );
 	if( !b.isEmpty() )
 	{
 		// The PointsPrimitive we make has a default point width of 1,
@@ -135,12 +135,12 @@ bool Seeds::affectsBranchTransform( const Gaffer::Plug *input ) const
 	return false;
 }
 
-void Seeds::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Seeds::hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	BranchCreator::hashBranchTransform( parentPath, branchPath, context, h );
+	BranchCreator::hashBranchTransform( sourcePath, branchPath, context, h );
 }
 
-Imath::M44f Seeds::computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::M44f Seeds::computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	return M44f();
 }
@@ -150,12 +150,12 @@ bool Seeds::affectsBranchAttributes( const Gaffer::Plug *input ) const
 	return false;
 }
 
-void Seeds::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Seeds::hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	BranchCreator::hashBranchAttributes( parentPath, branchPath, context, h );
+	BranchCreator::hashBranchAttributes( sourcePath, branchPath, context, h );
 }
 
-IECore::ConstCompoundObjectPtr Seeds::computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstCompoundObjectPtr Seeds::computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	return outPlug()->attributesPlug()->defaultValue();
 }
@@ -170,12 +170,12 @@ bool Seeds::affectsBranchObject( const Gaffer::Plug *input ) const
 	;
 }
 
-void Seeds::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Seeds::hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() == 1 )
 	{
-		BranchCreator::hashBranchObject( parentPath, branchPath, context, h );
-		h.append( inPlug()->objectHash( parentPath ) );
+		BranchCreator::hashBranchObject( sourcePath, branchPath, context, h );
+		h.append( inPlug()->objectHash( sourcePath ) );
 		densityPlug()->hash( h );
 		densityPrimitiveVariablePlug()->hash( h );
 		pointTypePlug()->hash( h );
@@ -185,12 +185,12 @@ void Seeds::hashBranchObject( const ScenePath &parentPath, const ScenePath &bran
 	h = outPlug()->objectPlug()->defaultValue()->Object::hash();
 }
 
-IECore::ConstObjectPtr Seeds::computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstObjectPtr Seeds::computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() == 1 )
 	{
 		// do what we came for
-		ConstMeshPrimitivePtr mesh = runTimeCast<const MeshPrimitive>( inPlug()->object( parentPath ) );
+		ConstMeshPrimitivePtr mesh = runTimeCast<const MeshPrimitive>( inPlug()->object( sourcePath ) );
 		if( !mesh )
 		{
 			return outPlug()->objectPlug()->defaultValue();
@@ -214,11 +214,11 @@ bool Seeds::affectsBranchChildNames( const Gaffer::Plug *input ) const
 	return input == namePlug();
 }
 
-void Seeds::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Seeds::hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	if( branchPath.size() == 0 )
 	{
-		BranchCreator::hashBranchChildNames( parentPath, branchPath, context, h );
+		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
 		namePlug()->hash( h );
 	}
 	else
@@ -227,7 +227,7 @@ void Seeds::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &
 	}
 }
 
-IECore::ConstInternedStringVectorDataPtr Seeds::computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Seeds::computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
 	if( branchPath.size() == 0 )
 	{

--- a/src/GafferScene/Unencapsulate.cpp
+++ b/src/GafferScene/Unencapsulate.cpp
@@ -38,6 +38,8 @@
 
 #include "GafferScene/Capsule.h"
 
+#include "Gaffer/StringPlug.h"
+
 #include "IECore/NullObject.h"
 
 using namespace std;
@@ -143,6 +145,10 @@ size_t Unencapsulate::g_firstPlugIndex = 0;
 Unencapsulate::Unencapsulate( const std::string &name )
 	:	BranchCreator( name )
 {
+	// Hide `destination` plug until we resolve issues surrounding `processesRootObject()`.
+	// See `BranchCreator::computeObject()`. Or perhaps we would never want to allow a
+	// different destination anyway?
+	destinationPlug()->setName( "__destination" );
 	storeIndexOfNextChild( g_firstPlugIndex );
 }
 

--- a/src/GafferScene/Unencapsulate.cpp
+++ b/src/GafferScene/Unencapsulate.cpp
@@ -65,10 +65,10 @@ class CapsuleScope : boost::noncopyable
 	private :
 		// Base constructor used by the two public constructors
 		CapsuleScope(
-			const Gaffer::Context *context, const ScenePlug *inPlug, const ScenePlug::ScenePath &parentPath
+			const Gaffer::Context *context, const ScenePlug *inPlug, const ScenePlug::ScenePath &sourcePath
 		)
 		{
-			m_object = inPlug->object( parentPath );
+			m_object = inPlug->object( sourcePath );
 			m_capsule = IECore::runTimeCast< const Capsule >( m_object.get() );
 		}
 
@@ -76,8 +76,8 @@ class CapsuleScope : boost::noncopyable
 
 		CapsuleScope(
 			const Gaffer::Context *context, const ScenePlug *inPlug,
-			const ScenePlug::ScenePath &parentPath, const ScenePlug::ScenePath &branchPath
-		) : CapsuleScope( context, inPlug, parentPath )
+			const ScenePlug::ScenePath &sourcePath, const ScenePlug::ScenePath &branchPath
+		) : CapsuleScope( context, inPlug, sourcePath )
 		{
 			if( m_capsule )
 			{
@@ -88,8 +88,8 @@ class CapsuleScope : boost::noncopyable
 
 		CapsuleScope(
 			const Gaffer::Context *context, const ScenePlug *inPlug,
-			const ScenePlug::ScenePath &parentPath, const InternedString &setName
-		) : CapsuleScope( context, inPlug, parentPath )
+			const ScenePlug::ScenePath &sourcePath, const InternedString &setName
+		) : CapsuleScope( context, inPlug, sourcePath )
 		{
 			if( m_capsule )
 			{
@@ -161,15 +161,15 @@ bool Unencapsulate::affectsBranchBound( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	h = cs.scene( true )->boundPlug()->hash();
 }
 
-Imath::Box3f Unencapsulate::computeBranchBound( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::Box3f Unencapsulate::computeBranchBound( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	return cs.scene( true )->boundPlug()->getValue();
 }
 
@@ -178,15 +178,15 @@ bool Unencapsulate::affectsBranchTransform( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	h = cs.scene( true )->transformPlug()->hash();
 }
 
-Imath::M44f Unencapsulate::computeBranchTransform( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+Imath::M44f Unencapsulate::computeBranchTransform( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	return cs.scene( true )->transformPlug()->getValue();
 }
 
@@ -195,15 +195,15 @@ bool Unencapsulate::affectsBranchAttributes( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	h = cs.scene( true )->attributesPlug()->hash();
 }
 
-IECore::ConstCompoundObjectPtr Unencapsulate::computeBranchAttributes( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstCompoundObjectPtr Unencapsulate::computeBranchAttributes( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	return cs.scene( true )->attributesPlug()->getValue();
 }
 
@@ -217,9 +217,9 @@ bool Unencapsulate::processesRootObject() const
 	return true;
 }
 
-void Unencapsulate::hashBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	if( branchPath.size() == 0 && !cs.scene( false ) )
 	{
 		h = inPlug()->objectPlug()->hash();
@@ -230,9 +230,9 @@ void Unencapsulate::hashBranchObject( const ScenePath &parentPath, const ScenePa
 	}
 }
 
-IECore::ConstObjectPtr Unencapsulate::computeBranchObject( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstObjectPtr Unencapsulate::computeBranchObject( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	if( branchPath.size() == 0 && !cs.scene( false ) )
 	{
 		// Not inside capsule, just pass through input scene object
@@ -246,9 +246,9 @@ bool Unencapsulate::affectsBranchChildNames( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	if( !cs.scene( false ) )
 	{
 		h = outPlug()->childNamesPlug()->defaultValue()->Object::hash();
@@ -259,9 +259,9 @@ void Unencapsulate::hashBranchChildNames( const ScenePath &parentPath, const Sce
 	}
 }
 
-IECore::ConstInternedStringVectorDataPtr Unencapsulate::computeBranchChildNames( const ScenePath &parentPath, const ScenePath &branchPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Unencapsulate::computeBranchChildNames( const ScenePath &sourcePath, const ScenePath &branchPath, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, branchPath );
+	CapsuleScope cs( context, inPlug(), sourcePath, branchPath );
 	if( !cs.scene( false ) )
 	{
 		return outPlug()->childNamesPlug()->defaultValue();
@@ -277,12 +277,12 @@ bool Unencapsulate::affectsBranchSetNames( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	h = inPlug()->setNamesPlug()->hash();
 }
 
-IECore::ConstInternedStringVectorDataPtr Unencapsulate::computeBranchSetNames( const ScenePath &parentPath, const Gaffer::Context *context ) const
+IECore::ConstInternedStringVectorDataPtr Unencapsulate::computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
 	// We have a standard that any scene containing capsules must contain all the sets used in the capsules
 	// in their list of set names, even if those sets are empty until the capsules are expanded
@@ -294,23 +294,23 @@ bool Unencapsulate::affectsBranchSet( const Gaffer::Plug *input ) const
 	return input == inPlug()->objectPlug();
 }
 
-void Unencapsulate::hashBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+void Unencapsulate::hashBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, setName );
+	CapsuleScope cs( context, inPlug(), sourcePath, setName );
 	if( !cs.scene( false ) )
 	{
 		h = outPlug()->setPlug()->defaultValue()->Object::hash();
 		return;
 	}
 
-	BranchCreator::hashBranchSet( parentPath, setName, context, h );
+	BranchCreator::hashBranchSet( sourcePath, setName, context, h );
 	h.append( cs.scene( false )->setPlug()->hash() );
 	h.append( cs.root().data(), cs.root().size() );
 }
 
-IECore::ConstPathMatcherDataPtr Unencapsulate::computeBranchSet( const ScenePath &parentPath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
+IECore::ConstPathMatcherDataPtr Unencapsulate::computeBranchSet( const ScenePath &sourcePath, const IECore::InternedString &setName, const Gaffer::Context *context ) const
 {
-	CapsuleScope cs( context, inPlug(), parentPath, setName );
+	CapsuleScope cs( context, inPlug(), sourcePath, setName );
 	if( !cs.scene( false ) )
 	{
 		return outPlug()->setPlug()->defaultValue();

--- a/startup/GafferScene/branchCreatorCompatibility.py
+++ b/startup/GafferScene/branchCreatorCompatibility.py
@@ -1,0 +1,61 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferScene
+
+_filterResults = GafferScene.FilterResults()
+_filteredPaths = Gaffer.PathMatcherDataPlug( "__filteredPaths", defaultValue = IECore.PathMatcherData() )
+
+def __branchCreatorGetItem( originalGetItem ) :
+
+	def getItem( self, key ) :
+
+		# In Gaffer 0.54, a connection between these internal implementation details was accidentally
+		# serialised into scripts. The implementation has since been replaced, but we need to provide
+		# proxies to keep the bogus serialisations loading quietly.
+		if key == "__filteredPaths" :
+			return _filteredPaths
+		elif key == "__filterResults" :
+			return _filterResults
+
+		return originalGetItem( self, key )
+
+	return getItem
+
+GafferScene.BranchCreator.__getitem__ = __branchCreatorGetItem( GafferScene.BranchCreator.__getitem__ )


### PR DESCRIPTION
A common requirement in lookdev/lighting is to parent lights to geometry received from modelling, for instance to add a pointlight to every candle in a candelabra. The Parent node makes this relatively easy already, allowing parenting to any number of locations chosen by a filter, and allowing child variation via the recently added `parentVariable` mechanism. But it's not always desirable for the lights to actually live under the geometry in the scene hierarchy. You might want to manage their visibility and other attributes separately, and it's easier to find them again if you can group them together in a single place, perhaps with the rest of the light rig.

This PR provides for this situation, by adding a `destination` plug to the Parent node, so that the children can be placed anywhere in the scene, while still being constrained to the transform of their "parent". The destination can be varied procedurally per child, providing a `..` syntax for relative parenting and compatibility with spreadsheets and expressions for more complex control. In the example below, the point light is "parented" to locations deep within the robot hierarchy and the `destination` plug is used to bring them back to a nice grouping under the root.

![image](https://user-images.githubusercontent.com/1133871/115010112-f3615700-9ea4-11eb-8447-911792761d40.png)

The implementation for all of this is actually in the BranchCreator base class, so the Seeds and Duplicate nodes benefit from the same treatment, and the Duplicate node finally gets to expose the `filter` input. Instancer and Unencapsulate are left as future work, as documented in the code. I'm pretty pleased to have managed to achieve this in a way fully ABI compatible with 0.59, but I think those two could benefit from an ABI break. And I could benefit from a bit of time to think that side of things through separately.

I tried to structure the commits so that you can digest the changes bit by bit, but c0150f5 still represents a bit of a lurch from the commits that came before. Sorry about that...