### PR TITLE
SceneNode : Fix root transform hashing bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - FilterResults : Fixed bug handling matches at the root location.
 - NodeEditor : Fixed activator and summary updates which were skipped if the layout was not visible when the node was edited.
 - Dispatcher : Fixed dispatching when `dispatcher.batchSize` or `dispatcher.immediate` are driven by context variables.
+- SceneNode : Fixed bug hashing the transform for the root location.
 
 API
 ---

--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -156,10 +156,8 @@ void SceneNode::hash( const ValuePlug *output, const Context *context, IECore::M
 			const ScenePath &scenePath = context->get<ScenePath>( ScenePlug::scenePathContextName );
 			if( scenePath.empty() )
 			{
-				// the result of compute() will actually be different if we're at the root, so
-				// we hash an identity M44fData:
-				h.append( IECore::M44fData::staticTypeId() );
-				h.append( Imath::M44f() );
+				// Scene root must have identity transform
+				h = output->defaultHash();
 			}
 			else
 			{
@@ -288,12 +286,17 @@ void SceneNode::compute( ValuePlug *output, const Context *context ) const
 			else if( output == scenePlug->transformPlug() )
 			{
 				const ScenePath &scenePath = context->get<ScenePath>( ScenePlug::scenePathContextName );
-				M44f transform;
-				if( scenePath.size() ) // scene root must have identity transform
+				if( scenePath.empty() )
 				{
-					transform = computeTransform( scenePath, context, scenePlug );
+					// Scene root must have identity transform
+					output->setToDefault();
 				}
-				static_cast<M44fPlug *>( output )->setValue( transform );
+				else
+				{
+					static_cast<M44fPlug *>( output )->setValue(
+						computeTransform( scenePath, context, scenePlug )
+					);
+				}
 			}
 			else if( output == scenePlug->attributesPlug() )
 			{


### PR DESCRIPTION
I first came across this on GCC 9, where it reproduces fairly reliably, but mucking about on Godbolt shows that it's possible in earlier GCC versions too.
The issue seems to be that the following code aliases pointers, so that `x` is accessed through pointers of various types during construction and hashing :

```
template <class T> class Matrix44
{

	T x[4][4];

	Matrix44()
	{
		memset (x, 0, sizeof (x));
		x[0][0] = 1;
		x[1][1] = 1;
		x[2][2] = 1;
		x[3][3] = 1;
	}

	const T *Matrix44<T>::getValue() const
	{
		return (T *) &x[0][0];
	}

}

template<typename T>
inline void murmurHashAppend( MurmurHash &h, const Imath::Matrix44<T> &data )
{
	// Plus more type aliasing in `MurmurHash::append()` itself.
	h.append( data.getValue(), 16 );
}
```

GCC takes this aliasing as permission to assume that all those pointers can't possibly point to the same thing, enabling optimisations that lead to the wrong result. Clang appears to take a more pragmatic approach, where if the source code clearly proves that the pointers _are_ aliased, it will respect that. With GCC, in all the versions I tested, using `-fno-strict-aliasing` also fixed things.

Here's a [Godbolt session](https://godbolt.org/z/sMocsx93j) demonstrating all this. And here are some links to relevant articles and rants on the topic of aliasing :

- https://blog.regehr.org/archives/1307
- https://developers.redhat.com/blog/2020/06/02/the-joys-and-perils-of-c-and-c-aliasing-part-1/
- https://developers.redhat.com/blog/2020/06/03/the-joys-and-perils-of-aliasing-in-c-and-c-part-2/
- https://www.yodaiken.com/2018/06/07/torvalds-on-aliasing/

I believe the reason this fix works is that the construction of the default M44f value is now in a different compilation unit, so GCC has no opportunity to optimise it out based on aliasing analysis. Arguably we should be looking to fix all this in the lower level code rather than work around it, but that doesn't seem particularly straightforward. Given how much real-world code falls foul of GCC's optimisations (see above) it might even be more pragmatic to adopt `-fno-strict-aliasing`. But in any case, the workaround employed here is more idiomatic anyway, and is the way we should be expressing the default-transform-at-root behaviour regardless of the underlying hashing implementation.
