### PR TITLE
FilterQuery : Add new node for querying filter at a location

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.59.x.x (relative to 0.59.7.0)
 ========
 
+Features
+--------
+
+- FilterQuery : Added a new node for querying the results of a filter at a specific location.
+
 Improvements
 ------------
 

--- a/include/GafferScene/FilterQuery.h
+++ b/include/GafferScene/FilterQuery.h
@@ -1,0 +1,110 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_FILTERQUERY_H
+#define GAFFERSCENE_FILTERQUERY_H
+
+#include "GafferScene/Export.h"
+#include "GafferScene/TypeIds.h"
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+namespace GafferScene
+{
+
+IE_CORE_FORWARDDECLARE( ScenePlug )
+IE_CORE_FORWARDDECLARE( FilterPlug )
+
+class GAFFERSCENE_API FilterQuery : public Gaffer::ComputeNode
+{
+
+	public :
+
+		FilterQuery( const std::string &name=defaultName<FilterQuery>() );
+		~FilterQuery() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::FilterQuery, FilterQueryTypeId, ComputeNode );
+
+		ScenePlug *scenePlug();
+		const ScenePlug *scenePlug() const;
+
+		FilterPlug *filterPlug();
+		const FilterPlug *filterPlug() const;
+
+		Gaffer::StringPlug *locationPlug();
+		const Gaffer::StringPlug *locationPlug() const;
+
+		Gaffer::BoolPlug *exactMatchPlug();
+		const Gaffer::BoolPlug *exactMatchPlug() const;
+
+		Gaffer::BoolPlug *descendantMatchPlug();
+		const Gaffer::BoolPlug *descendantMatchPlug() const;
+
+		Gaffer::BoolPlug *ancestorMatchPlug();
+		const Gaffer::BoolPlug *ancestorMatchPlug() const;
+
+		Gaffer::StringPlug *closestAncestorPlug();
+		const Gaffer::StringPlug *closestAncestorPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		Gaffer::IntPlug *matchPlug();
+		const Gaffer::IntPlug *matchPlug() const;
+
+		// Used in the computation of `ancestorMatchPlug()`. This uses
+		// `${scene:path}` rather than `locationPlug()` so can be used in
+		// recursive computes to inherit results from ancestor contexts.
+		Gaffer::StringPlug *closestAncestorInternalPlug();
+		const Gaffer::StringPlug *closestAncestorInternalPlug() const;
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( FilterQuery )
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_FILTERQUERY_H

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -159,6 +159,7 @@ enum TypeId
 	UnencapsulateTypeId = 110614,
 	MotionPathTypeId = 110615,
 	InstancerContextVariablePlugTypeId = 110616,
+	FilterQueryTypeId = 110617,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/python/GafferSceneTest/FilterQueryTest.py
+++ b/python/GafferSceneTest/FilterQueryTest.py
@@ -1,0 +1,171 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class FilterQueryTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		# /group
+		#     /grid
+		#          /gridLines
+		#          /centerLines
+		#          /borderLines
+		#     /plane
+		#     /sphere
+
+		grid = GafferScene.Grid()
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( grid["out"] )
+		group["in"][1].setInput( plane["out"] )
+		group["in"][2].setInput( sphere["out"] )
+
+		pathFilter = GafferScene.PathFilter()
+
+		query = GafferScene.FilterQuery()
+		query["scene"].setInput( group["out"] )
+		query["filter"].setInput( pathFilter["out"] )
+
+		allPaths = IECore.PathMatcher()
+		GafferScene.SceneAlgo.matchingPaths(
+			IECore.PathMatcher( [ "/..." ] ),
+			group["out"],
+			allPaths
+		)
+		self.assertEqual( allPaths.size(), 8 )
+
+		for pattern in [
+			"/",
+			"/group",
+			"/group/grid",
+			"/group/grid/gridLines",
+			"/group/*",
+			"/group/grid/*",
+			"/group/...",
+			"/noMatch"
+		] :
+
+			pathFilter["paths"].setValue( IECore.StringVectorData( [ pattern ] ) )
+			for pathString in allPaths.paths() :
+
+				path = GafferScene.ScenePlug.stringToPath( pathString )
+				with Gaffer.Context() as c :
+					c["scene:path"] = path
+					match = pathFilter["out"].match( group["out"] )
+
+				query["location"].setValue( pathString )
+				self.assertEqual( query["exactMatch"].getValue(), bool( match & IECore.PathMatcher.Result.ExactMatch ) )
+				self.assertEqual( query["descendantMatch"].getValue(), bool( match & IECore.PathMatcher.Result.DescendantMatch ) )
+				self.assertEqual( query["ancestorMatch"].getValue(), bool( match & IECore.PathMatcher.Result.AncestorMatch ) )
+
+				ancestor = query["closestAncestor"].getValue()
+				if ancestor == "" :
+					self.assertFalse( match & IECore.PathMatcher.Result.ExactMatch )
+					self.assertFalse( match & IECore.PathMatcher.Result.AncestorMatch )
+				else :
+					ancestor = GafferScene.ScenePlug.stringToPath( ancestor )
+					with Gaffer.Context() as c :
+						c["scene:path"] = ancestor
+						self.assertTrue( pathFilter["out"].match( group["out"] ) & IECore.PathMatcher.Result.ExactMatch )
+						for i in range( len( ancestor ), len( path ) ) :
+							c["scene:path"] = path[:i+1]
+							self.assertFalse( pathFilter["out"].match( group["out"] ) & IECore.PathMatcher.Result.ExactMatch )
+
+	def testEmptyLocation( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "test" )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["setExpression"].setValue( "test" )
+
+		query = GafferScene.FilterQuery()
+		query["scene"].setInput( plane["out"] )
+		query["filter"].setInput( setFilter["out"] )
+
+		self.assertEqual( query["exactMatch"].getValue(), False )
+		self.assertEqual( query["descendantMatch"].getValue(), False )
+		self.assertEqual( query["ancestorMatch"].getValue(), False )
+		self.assertEqual( query["closestAncestor"].getValue(), "" )
+
+	def testNonExistentLocation( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "test" )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["setExpression"].setValue( "test" )
+
+		query = GafferScene.FilterQuery()
+		query["scene"].setInput( plane["out"] )
+		query["filter"].setInput( setFilter["out"] )
+		query["location"].setValue( "/sphere" )
+
+		self.assertEqual( query["exactMatch"].getValue(), False )
+		self.assertEqual( query["descendantMatch"].getValue(), False )
+		self.assertEqual( query["ancestorMatch"].getValue(), False )
+		self.assertEqual( query["closestAncestor"].getValue(), "" )
+
+	def testNonExistentLocationWithAncestors( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "test" )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["setExpression"].setValue( "test" )
+
+		query = GafferScene.FilterQuery()
+		query["scene"].setInput( plane["out"] )
+		query["filter"].setInput( setFilter["out"] )
+		query["location"].setValue( "/plane/this/does/not/exist" )
+
+		self.assertEqual( query["exactMatch"].getValue(), False )
+		self.assertEqual( query["descendantMatch"].getValue(), False )
+		self.assertEqual( query["ancestorMatch"].getValue(), False )
+		self.assertEqual( query["closestAncestor"].getValue(), "" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -152,6 +152,7 @@ from .CurveSamplerTest import CurveSamplerTest
 from .DeleteSetsTest import DeleteSetsTest
 from .UnencapsulateTest import UnencapsulateTest
 from .MotionPathTest import MotionPathTest
+from .FilterQueryTest import FilterQueryTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/FilterQueryUI.py
+++ b/python/GafferSceneUI/FilterQueryUI.py
@@ -1,0 +1,142 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.FilterQuery,
+
+	"description",
+	"""
+	Queries a filter for a particular location in a scene
+	and outputs the results.
+	""",
+
+	# Work around StandardNodeGadget layout bug that would
+	# place the `filter` nodule inside the frame.
+	"nodeGadget:minWidth", 12.0,
+
+	plugs = {
+
+		"scene" : [
+
+			"description",
+			"""
+			The scene to query the filter for.
+			""",
+
+		],
+
+		"filter" : [
+
+			"description",
+			"""
+			The filter to query.
+			""",
+
+			"plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget",
+			"noduleLayout:section", "right",
+
+		],
+
+		"location" : [
+
+			"description",
+			"""
+			The location within the scene to query the filter at.
+
+			> Note : If the location does not exist then the query will not be
+			> performed and all outputs will be set to their default values.
+			""",
+
+			"plugValueWidget:type", "GafferSceneUI.ScenePathPlugValueWidget",
+			"scenePathPlugValueWidget:scene", "scene",
+			"nodule:type", "",
+
+		],
+
+		"exactMatch" : [
+
+			"description",
+			"""
+			Outputs `True` if the filter matches the location, and `False` otherwise.
+			""",
+
+			"layout:section", "Settings.Outputs"
+
+		],
+
+		"descendantMatch" : [
+
+			"description",
+			"""
+			Outputs `True` if the filter matches a descendant of the location,
+			and `False` otherwise.
+			""",
+
+			"layout:section", "Settings.Outputs"
+
+		],
+
+		"ancestorMatch" : [
+
+			"description",
+			"""
+			Outputs `True` if the filter matches an ancestor of the location,
+			and `False` otherwise.
+			""",
+
+			"layout:section", "Settings.Outputs"
+
+		],
+
+		"closestAncestor" : [
+
+			"description",
+			"""
+			Outputs the location of the first ancestor matched by the filter.
+			In the case of an exact match, this will be the location itself.
+			""",
+
+			"layout:section", "Settings.Outputs"
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -165,6 +165,7 @@ from . import ClosestPointSamplerUI
 from . import CurveSamplerUI
 from . import UnencapsulateUI
 from . import MotionPathUI
+from . import FilterQueryUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/FilterQuery.cpp
+++ b/src/GafferScene/FilterQuery.cpp
@@ -1,0 +1,359 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/FilterQuery.h"
+
+#include "GafferScene/Filter.h"
+#include "GafferScene/ScenePlug.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+size_t FilterQuery::g_firstPlugIndex = 0;
+
+GAFFER_NODE_DEFINE_TYPE( FilterQuery )
+
+FilterQuery::FilterQuery( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ScenePlug( "scene" ) );
+	addChild( new FilterPlug( "filter" ) );
+	addChild( new StringPlug( "location" ) );
+	addChild( new BoolPlug( "exactMatch", Gaffer::Plug::Out ) );
+	addChild( new BoolPlug( "descendantMatch", Gaffer::Plug::Out ) );
+	addChild( new BoolPlug( "ancestorMatch", Gaffer::Plug::Out ) );
+	addChild( new StringPlug( "closestAncestor", Gaffer::Plug::Out ) );
+	addChild( new IntPlug( "__match", Gaffer::Plug::Out ) );
+	addChild( new StringPlug( "__closestAncestorInternal", Gaffer::Plug::Out ) );
+}
+
+FilterQuery::~FilterQuery()
+{
+}
+
+ScenePlug *FilterQuery::scenePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const ScenePlug *FilterQuery::scenePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+FilterPlug *FilterQuery::filterPlug()
+{
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
+}
+
+const FilterPlug *FilterQuery::filterPlug() const
+{
+	return getChild<FilterPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::StringPlug *FilterQuery::locationPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::StringPlug *FilterQuery::locationPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::BoolPlug *FilterQuery::exactMatchPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::BoolPlug *FilterQuery::exactMatchPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::BoolPlug *FilterQuery::descendantMatchPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::BoolPlug *FilterQuery::descendantMatchPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::BoolPlug *FilterQuery::ancestorMatchPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::BoolPlug *FilterQuery::ancestorMatchPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::StringPlug *FilterQuery::closestAncestorPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::StringPlug *FilterQuery::closestAncestorPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+Gaffer::IntPlug *FilterQuery::matchPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 7 );
+}
+
+const Gaffer::IntPlug *FilterQuery::matchPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 7 );
+}
+
+Gaffer::StringPlug *FilterQuery::closestAncestorInternalPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+}
+
+const Gaffer::StringPlug *FilterQuery::closestAncestorInternalPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 8 );
+}
+
+void FilterQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if( input->parent() == scenePlug() )
+	{
+		filterPlug()->sceneAffects( input, outputs );
+	}
+
+	if(
+		input == locationPlug() ||
+		input == scenePlug()->existsPlug() ||
+		input == filterPlug()
+	)
+	{
+		outputs.push_back( matchPlug() );
+	}
+
+	if( input == matchPlug() )
+	{
+		outputs.push_back( exactMatchPlug() );
+		outputs.push_back( descendantMatchPlug() );
+		outputs.push_back( ancestorMatchPlug() );
+	}
+
+	if(
+		input == filterPlug()
+	)
+	{
+		outputs.push_back( closestAncestorInternalPlug() );
+	}
+
+	if(
+		input == locationPlug() ||
+		input == scenePlug()->existsPlug() ||
+		input == closestAncestorInternalPlug()
+	)
+	{
+		outputs.push_back( closestAncestorPlug() );
+	}
+}
+
+void FilterQuery::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == matchPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		const string location = locationPlug()->getValue();
+		if( !location.empty() )
+		{
+			ScenePlug::PathScope scope( context, ScenePlug::stringToPath( location ) );
+			if( scenePlug()->existsPlug()->getValue() )
+			{
+				filterPlug()->hash( h );
+			}
+		}
+	}
+	else if( output == exactMatchPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		matchPlug()->hash( h );
+	}
+	else if( output == descendantMatchPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		matchPlug()->hash( h );
+	}
+	else if( output == ancestorMatchPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		matchPlug()->hash( h );
+	}
+	else if( output == closestAncestorPlug() )
+	{
+		const string location = locationPlug()->getValue();
+		if( !location.empty() )
+		{
+			ScenePlug::PathScope scope( context, ScenePlug::stringToPath( location ) );
+			if( scenePlug()->existsPlug()->getValue() )
+			{
+				h = closestAncestorInternalPlug()->hash();
+				return;
+			}
+		}
+		h = output->defaultHash();
+	}
+	else if( output == closestAncestorInternalPlug() )
+	{
+		const int m = filterPlug()->match( scenePlug() );
+		if( m & PathMatcher::ExactMatch )
+		{
+			ComputeNode::hash( output, context, h );
+			const ScenePlug::ScenePath path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+			h.append( path.data(), path.size() );
+			return;
+		}
+		else if( m & PathMatcher::AncestorMatch )
+		{
+			ScenePlug::ScenePath path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+			if( path.size() )
+			{
+				path.pop_back();
+				ScenePlug::PathScope scope( context, path );
+				h = closestAncestorInternalPlug()->hash();
+				return;
+			}
+		}
+		h = output->defaultHash();
+	}
+}
+
+void FilterQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( output == matchPlug() )
+	{
+		unsigned match = IECore::PathMatcher::NoMatch;
+		const string location = locationPlug()->getValue();
+		if( !location.empty() )
+		{
+			ScenePlug::PathScope scope( context, ScenePlug::stringToPath( location ) );
+			if( scenePlug()->existsPlug()->getValue() )
+			{
+				match = filterPlug()->match( scenePlug() );
+			}
+		}
+		static_cast<IntPlug *>( output )->setValue( match );
+	}
+	else if( output == exactMatchPlug() )
+	{
+		static_cast<BoolPlug *>( output )->setValue(
+			matchPlug()->getValue() & IECore::PathMatcher::ExactMatch
+		);
+	}
+	else if( output == descendantMatchPlug() )
+	{
+		static_cast<BoolPlug *>( output )->setValue(
+			matchPlug()->getValue() & IECore::PathMatcher::DescendantMatch
+		);
+	}
+	else if( output == ancestorMatchPlug() )
+	{
+		static_cast<BoolPlug *>( output )->setValue(
+			matchPlug()->getValue() & IECore::PathMatcher::AncestorMatch
+		);
+	}
+	else if( output == closestAncestorPlug() )
+	{
+		const string location = locationPlug()->getValue();
+		if( !location.empty() )
+		{
+			ScenePlug::PathScope scope( context, ScenePlug::stringToPath( location ) );
+			if( scenePlug()->existsPlug()->getValue() )
+			{
+				output->setFrom( closestAncestorInternalPlug() );
+				return;
+			}
+		}
+		output->setToDefault();
+	}
+	else if( output == closestAncestorInternalPlug() )
+	{
+		string result;
+		const int m = filterPlug()->match( scenePlug() );
+		if( m & PathMatcher::ExactMatch )
+		{
+			const ScenePlug::ScenePath path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+			ScenePlug::pathToString( path, result );
+		}
+		else if( m & PathMatcher::AncestorMatch )
+		{
+			// Ancestor match, but we don't know where exactly. Make recursive
+			// calls using the parent location until we find the ancestor with
+			// an exact match.
+			ScenePlug::ScenePath path = context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+			if( path.size() )
+			{
+				path.pop_back();
+				ScenePlug::PathScope scope( context, path );
+				result = closestAncestorInternalPlug()->getValue();
+			}
+		}
+		static_cast<StringPlug *>( output )->setValue( result );
+	}
+
+	ComputeNode::compute( output, context );
+}
+
+Gaffer::ValuePlug::CachePolicy FilterQuery::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if(
+		output == exactMatchPlug() ||
+		output == descendantMatchPlug() ||
+		output == ancestorMatchPlug()
+	)
+	{
+		// Not much point caching these since they are so trivial.
+		return ValuePlug::CachePolicy::Uncached;
+	}
+	return ComputeNode::computeCachePolicy( output );
+}

--- a/src/GafferSceneModule/FilterBinding.cpp
+++ b/src/GafferSceneModule/FilterBinding.cpp
@@ -41,6 +41,7 @@
 #include "GafferScene/Filter.h"
 #include "GafferScene/FilterPlug.h"
 #include "GafferScene/FilterProcessor.h"
+#include "GafferScene/FilterQuery.h"
 #include "GafferScene/FilterResults.h"
 #include "GafferScene/PathFilter.h"
 #include "GafferScene/ScenePlug.h"
@@ -110,5 +111,6 @@ void GafferSceneModule::bindFilter()
 	GafferBindings::DependencyNodeClass<UnionFilter>();
 	GafferBindings::DependencyNodeClass<SetFilter>();
 	GafferBindings::DependencyNodeClass<FilterResults>();
+	GafferBindings::DependencyNodeClass<FilterQuery>();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -343,7 +343,7 @@ nodeMenu.append( "/Scene/Globals/Set Visualiser", GafferScene.SetVisualiser, sea
 nodeMenu.append( "/Scene/OpenGL/Attributes", GafferScene.OpenGLAttributes, searchText = "OpenGLAttributes" )
 nodeMenu.definition().append( "/Scene/OpenGL/Shader", { "subMenu" : GafferSceneUI.OpenGLShaderUI.shaderSubMenu } )
 nodeMenu.append( "/Scene/OpenGL/Render", GafferScene.OpenGLRender, searchText = "OpenGLRender" )
-
+nodeMenu.append( "/Scene/Utility/Filter Query", GafferScene.FilterQuery, searchText = "FilterQuery" )
 
 # Image nodes
 


### PR DESCRIPTION
The initial motivation is to provide the `closestAncestor` output plug, which can be used to drive `Parent.destination` with a second filter, typically one which matches the roots of assets in the scene. In the example below we're "parenting" lights to the heads of the robots, but placing them just under the root of each asset by driving `Parent.destination` with `FilterQuery.closestAncestor`. This is a bit convoluted compared to a simple `${scene:path}/../..` affair, but it allows you to build graphs that work with any asset structure, without needing to know it in advance.

![image](https://user-images.githubusercontent.com/1133871/115897758-ab1dd800-a454-11eb-8598-5e41f70ddcc9.png)

