### PR TITLE
TabbedContainer : Add scroll menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,12 @@
 0.59.x.x (relative to 0.59.7.0)
 ========
 
+Improvements
+------------
+
+- TabbedContainer : Added menu button to allow selection of tabs that are not
+  visible due to a lack of horizontal space.
+
 API
 ---
 

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import functools
+
 import IECore
 
 import Gaffer
@@ -53,6 +55,9 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 		GafferUI.ContainerWidget.__init__( self, _TabWidget(), **kw )
 
+		# Tab bar
+		# -------
+
 		self.__tabBar = GafferUI.Widget( QtWidgets.QTabBar() )
 		self.__tabBar._qtWidget().setDrawBase( False )
 		self.__tabBar._qtWidget().tabMoved.connect( Gaffer.WeakMethod( self.__moveWidget ) )
@@ -69,15 +74,50 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 		self.__tabBar._qtWidget().setPalette( TabbedContainer.__palette )
 
 		self._qtWidget().setTabBar( self.__tabBar._qtWidget() )
-
-		self._qtWidget().setUsesScrollButtons( False )
 		self._qtWidget().setElideMode( QtCore.Qt.ElideNone )
 
-		self.__widgets = []
+		# Corner widget and scrolling
+		# ---------------------------
+		#
+		# QTabBar does provide scroll buttons for use when there is not enough
+		# horizontal space to show all tabs. But these are really awkward to use
+		# : you may not know which way to scroll, it may take several clicks to
+		# find the thing you want, and it's hard to track the jumpy movement of
+		# the tabs. Instead we provide a dropdown menu which provides an
+		# overview of all tabs and allows you to jump to the right one with a
+		# single click. This is stored in `self.__cornerContainer[0]`, alongside
+		# an optional user-provided corner widget which is stored in
+		# `self.__cornerContainer[1]`.
 
-		self.__cornerWidget = None
+		self.__cornerContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+		with self.__cornerContainer :
+			GafferUI.MenuButton(
+				image = "tabScrollMenu.png", hasFrame = False,
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__scrollMenuDefinition ) )
+			)
+		self._qtWidget().setCornerWidget( self.__cornerContainer._qtWidget() )
 		self.setCornerWidget( cornerWidget )
 
+		# When there's not enough horizontal space, we need QTabWidget to scroll
+		# to show the current tab. But `QTabBarPrivate::makeVisible()` refuses
+		# to do this unless the scroll buttons are visible. So we have to
+		# pretend to be using them and then use the stylesheet to set their size to
+		# 0. One benefit of this hack is that we can track the show/hide events
+		# for the buttons so that we only show our menu button when scrolling
+		# is necessary. This is a bit more reliable than trying to do it ourselves
+		# using resize events and size queries.
+
+		self._qtWidget().setUsesScrollButtons( True )
+		assert( len( self._qtWidget().tabBar().children() ) == 2 ) # We expect a left and a right button
+		_VisibilityLink(
+			self._qtWidget().tabBar().children()[0],
+			self.__cornerContainer[0]._qtWidget()
+		)
+
+		# Child storage and signals
+		# -------------------------
+
+		self.__widgets = []
 		self.__currentChangedSignal = GafferUI.WidgetEventSignal()
 		self._qtWidget().currentChanged.connect( Gaffer.WeakMethod( self.__currentChanged ) )
 
@@ -167,49 +207,41 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 
 	def removeChild( self, child ) :
 
-		assert( child is self.__cornerWidget or child in self.__widgets )
-
-		if child is self.__cornerWidget :
-			self._qtWidget().setCornerWidget( None )
-			self.__cornerWidget = None
+		if child is self.getCornerWidget() :
+			self.setCornerWidget( None )
 		else :
+			assert( child in self.__widgets )
 			# We must remove the child from __widgets before the tab, otherwise
 			# currentChangedSignal will be emit with the old widget.
 			removalIndex = self.__widgets.index( child )
 			self.__widgets.remove( child )
 			self._qtWidget().removeTab( removalIndex )
 
-		child._qtWidget().setParent( None )
-		child._applyVisibility()
+			child._qtWidget().setParent( None )
+			child._applyVisibility()
 
 	def setCornerWidget( self, cornerWidget ) :
 
-		if self.__cornerWidget is not None :
-			self.removeChild( self.__cornerWidget )
+		if len( self.__cornerContainer ) > 1 :
+			del self.__cornerContainer[1]
 
 		if cornerWidget is not None :
 			oldParent = cornerWidget.parent()
 			if oldParent is not None :
 				oldParent.removeChild( cornerWidget )
-			self._qtWidget().setCornerWidget( cornerWidget._qtWidget() )
-			cornerWidget._applyVisibility()
-			assert( cornerWidget._qtWidget().parent() is self._qtWidget() )
-		else :
-			self._qtWidget().setCornerWidget( None )
-
-		self.__cornerWidget = cornerWidget
+			assert( len( self.__cornerContainer ) == 1 )
+			self.__cornerContainer.append( cornerWidget )
 
 	def getCornerWidget( self ) :
 
-		return self.__cornerWidget
+		return self.__cornerContainer[1] if len( self.__cornerContainer ) > 1 else None
 
 	## If the tabs are hidden, then the corner widget will
 	# also be hidden.
 	def setTabsVisible( self, visible ) :
 
 		self._qtWidget().tabBar().setVisible( visible )
-		if self.__cornerWidget is not None :
-			self.__cornerWidget.setVisible( visible )
+		self.__cornerContainer.setVisible( visible )
 
 	def getTabsVisible( self ) :
 
@@ -270,6 +302,29 @@ class TabbedContainer( GafferUI.ContainerWidget ) :
 		if tab >= 0 :
 			self._qtWidget().setCurrentIndex( tab )
 
+	def __scrollMenuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		current = self.getCurrent()
+		for child in self :
+			result.append(
+				self.getLabel( child ),
+				{
+					"checkBox" : child is current,
+					"command" : functools.partial(
+						Gaffer.WeakMethod( self.__scrollTo ),
+						child
+					)
+				}
+			)
+
+		return result
+
+	def __scrollTo( self, child, *unused ) :
+
+		self.setCurrent( child )
+
 # Private implementation - a QTabWidget with custom size behaviour.
 class _TabWidget( QtWidgets.QTabWidget ) :
 
@@ -303,3 +358,21 @@ class _TabWidget( QtWidgets.QTabWidget ) :
 
 		return result
 
+# Used to synchronise the visibility of our "scroll menu" with the visibility
+# of Qt's scroll buttons.
+class _VisibilityLink( QtCore.QObject ) :
+
+	def __init__( self, sourceWidget, destinationWidget ) :
+
+		# Parent to destination widget
+		QtCore.QObject.__init__( self, destinationWidget )
+
+		sourceWidget.installEventFilter( self )
+
+	def eventFilter( self, qObject, qEvent ) :
+
+		qEventType = qEvent.type()
+		if qEventType == qEvent.Show or qEventType == qEvent.Hide :
+			self.parent().setVisible( qObject.isVisible() )
+
+		return False

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -643,6 +643,15 @@ _styleSheet = string.Template(
 		border-bottom-color: $brightColor;
 	}
 
+	QTabWidget[gafferClasses~="GafferUI.TabbedContainer"] > QTabBar::scroller {
+		/* Hide scroll buttons - see TabbedContainer.__init__ for motivation */
+		width: 0px;
+	}
+
+	QTabBar::tear {
+		image: none;
+	}
+
 	/*
 	TabBars not inside a QTabWidget. Currently these are only used by
 	SpreadsheetUI.
@@ -691,10 +700,6 @@ _styleSheet = string.Template(
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"]::scroller {
 		width: 40px;
-	}
-
-	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"]::tear {
-		image: none;
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"] QToolButton {

--- a/python/GafferUITest/TabbedContainerTest.py
+++ b/python/GafferUITest/TabbedContainerTest.py
@@ -70,12 +70,12 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 		b = GafferUI.Button( "baby" )
 		t.setCornerWidget( b )
 		self.assertTrue( t.getCornerWidget() is b )
-		self.assertTrue( b.parent() is t )
+		self.assertTrue( t.isAncestorOf( b ) )
 
 		b2 = GafferUI.Button( "b" )
 		t.setCornerWidget( b2 )
 		self.assertTrue( t.getCornerWidget() is b2 )
-		self.assertTrue( b2.parent() is t )
+		self.assertTrue( t.isAncestorOf( b2 ) )
 		self.assertIsNone( b.parent() )
 
 	def testIndex( self ) :
@@ -228,7 +228,7 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 
 		t.setCornerWidget( b )
 		self.assertEqual( len( l ), 0 )
-		self.assertEqual( b.parent(), t )
+		self.assertTrue( t.isAncestorOf( b ) )
 
 	def testInsert( self ) :
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -235,7 +235,16 @@
 				'viewPaused'
 			]
 
-		}
+		},
+
+		"tabIcons" : {
+
+			"ids" : [
+				"tabScrollMenu",
+				"deleteSmall",
+			],
+
+		},
 
 	},
 
@@ -249,7 +258,6 @@
 		'debugNotification',
 		'debugSmall',
 		'delete',
-		'deleteSmall',
 		'duplicate',
 		'editScopeNode',
 		'editScopeProcessorNode',

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -15,7 +15,7 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
    sodipodi:docname="graphics.svg"
    enable-background="new">
   <defs
@@ -143,7 +143,7 @@
     <linearGradient
        id="linearGradient1643"
        osb:paint="solid"
-       gradientTransform="translate(0.13258252,471.41431)">
+       gradientTransform="translate(54.13258,7492.5003)">
       <stop
          style="stop-color:#9e9e9e;stop-opacity:1;"
          offset="0"
@@ -1380,15 +1380,15 @@
      borderopacity="1"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:zoom="2"
-     inkscape:cx="285.15627"
-     inkscape:cy="-320.69002"
+     inkscape:zoom="35.532116"
+     inkscape:cx="21.900673"
+     inkscape:cy="-1297.1076"
      inkscape:document-units="px"
-     inkscape:current-layer="g2889"
-     inkscape:window-width="2181"
-     inkscape:window-height="1250"
-     inkscape:window-x="1183"
-     inkscape:window-y="208"
+     inkscape:current-layer="layer4"
+     inkscape:window-width="1920"
+     inkscape:window-height="977"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
      showgrid="true"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
@@ -1398,7 +1398,7 @@
      inkscape:snap-object-midpoints="false"
      inkscape:snap-bbox-midpoints="true"
      inkscape:snap-smooth-nodes="true"
-     showguides="true"
+     showguides="false"
      inkscape:guide-bbox="true"
      inkscape:snap-grids="true"
      inkscape:object-paths="false"
@@ -1644,8 +1644,7 @@
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Annotations"
-     style="display:inline;opacity:1"
-     sodipodi:insensitive="true">
+     style="display:inline;opacity:1">
     <flowRoot
        xml:space="preserve"
        id="flowRoot2508"
@@ -2413,7 +2412,29 @@
        sodipodi:end="6.2821905"
        sodipodi:open="true"
        d="m 329.9325,288.09763 a 1.5,1.5 0 0 1 -1.49963,1.5 1.5,1.5 0 0 1 -1.50037,-1.49926 1.5,1.5 0 0 1 1.49888,-1.50074 1.5,1.5 0 0 1 1.50111,1.4985" />
-  </g>
+    <path
+       id="path1982"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,2277 H 743.99999"
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot1990"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,1.0000138,288.10156,1265.8474)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1986"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"><rect
+           id="rect1984"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara1988"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">Tab icons</flowPara></flowRoot>  </g>
   <g
      inkscape:groupmode="layer"
      id="layer4"
@@ -2546,7 +2567,8 @@
     <g
        id="g2889"
        inkscape:label="pointers-PathFilterUI"
-       transform="translate(0,-54)">
+       transform="translate(0,-54)"
+       style="display:inline">
       <rect
          style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
          id="removeObjects"
@@ -3360,6 +3382,14 @@
        id="path1726"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:none;stroke-width:3.77952766;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="tabScrollMenu"
+       width="17"
+       height="19"
+       x="15"
+       y="2286"
+       inkscape:label="tabScrollMenu" />
   </g>
   <g
      inkscape:label="Artwork"
@@ -3661,7 +3691,7 @@
       <path
          inkscape:label="down"
          sodipodi:type="star"
-         style="opacity:0.33;fill:url(#linearGradient6241);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33000004;fill:url(#linearGradient6241);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path6330"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3690,7 +3720,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6332"
-         style="opacity:0.33;fill:url(#linearGradient6338);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33000004;fill:url(#linearGradient6338);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="left"
@@ -3707,7 +3737,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6334"
-         style="opacity:0.33;fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33000004;fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="right"
@@ -3724,7 +3754,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6336"
-         style="opacity:0.33;fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         style="opacity:0.33000004;fill:url(#linearGradient6241);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
          sodipodi:type="star" />
     </g>
     <rect
@@ -5350,7 +5380,7 @@
     </g>
     <g
        id="g3196"
-       transform="matrix(0.49818887,-0.49818887,0.49818887,0.49818887,-44.252357,207.19317)"
+       transform="matrix(0.49818887,-0.49818887,0.49818887,0.49818887,-304.25236,2447.1932)"
        inkscape:label="deleteSmall">
       <path
          inkscape:connector-curvature="0"
@@ -7822,5 +7852,31 @@
        x="391"
        y="66.362183"
        inkscape:label="#rect9457" />
+    <g
+       id="g2047"
+       inkscape:label="tabScrollMenu"
+       transform="translate(12,-28)">
+      <rect
+         y="2370.8623"
+         x="6.5"
+         height="2"
+         width="11"
+         id="rect3246-9"
+         style="display:inline;fill:#696969;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         style="display:inline;fill:#696969;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3248-8"
+         width="11"
+         height="2"
+         x="6.5"
+         y="2374.8623" />
+      <rect
+         y="2378.8623"
+         x="6.5"
+         height="2"
+         width="11"
+         id="rect3250-0"
+         style="display:inline;fill:#696969;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
This appears when there is not enough room to show all the tabs, allowing any tab to be selected using a simple dropdown menu.

![image](https://user-images.githubusercontent.com/1133871/116236623-34842180-a757-11eb-9b65-4a8ac5b8f8f0.png)

I've been resisting adding this for a while, because I feel fairly strongly that it only becomes necessary when the number of tabs is excessive. In the native UIs, we try pretty hard to limit the number of tabs, and the depth of nesting, with our biggest offender being the Instancer with six tabs. But even that fits reasonably well in a standard layout, so I suspect this feature request was driven more by the needs of custom nodes.

Although the standard Qt way of doing this is to use the built-in scroll buttons, I haven't used that for a few reasons :

- It doesn't give you any overview of all the tabs.
- It can take quite a few clicks to get where you're going, and you may not even know which way to go.
- The jumpy scrolling is a bit disorientating.
- The scroll buttons are placed over the tabs, making it hard to style
  them in a way which looks OK against both our raised-current-tab and
  our blending-in-to-the-background-non-current-tabs.

The implementation for this is a bit ugly, because we have to let Qt think it's using the scroll buttons for it to show the current tab properly, but it seems to work reasonably well in practice. There is a weird jump where the last tab disappears when the tab bar is so small that the height exceeds the width, but that doesn't feel too bad because there's not enough space to read the tab anyway. This appears to be down to a bug in the Qt style implementation, where it assumes that if the width is less than the height, it's dealing with a vertical tab bar.

