### PR TITLE
SceneAlgo/FilterResults improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ API
   - Added `setHoverPositionVisible()` and `getHoverPositionVisible()` accessors to control an optional position indicator drawn under the pointer.
 - Expression : Added `Engine::executeCachePolicy()` method which must be implemented by subclasses.
 - ImageAlgo : Added constants for the default channel names - `channelNameR` etc.
+- SceneAlgo : Added optional `root` argument to `filteredParallelTraverse( scene, pathMatcher )`.
 
 Breaking Changes
 ----------------
@@ -71,7 +72,9 @@ Breaking Changes
   - Removed `setPositionIncrement()/getPositionIncrement()` from `Slider`. Use `setIncrement()/getIncrement()` instead.
   - Replaced `_drawPosition()` method with `_drawValue()`.
 - StandardOptions : Removed `cameraBlur` plug. This never functioned as advertised, as the regular `transformBlur` and `deformationBlur` blur settings were applied to cameras instead. As before, a StandardAttributes node may be used to customise blur for individual cameras.
-- SceneAlgo : Changed signature of the following methods to use `GafferScene::FilterPlug` : `matchingPaths`, `filteredParallelTraverse`, `Detail::ThreadableFilteredFunctor`.
+- SceneAlgo :
+  - Changed signature of the following methods to use `GafferScene::FilterPlug` : `matchingPaths`, `filteredParallelTraverse`, `Detail::ThreadableFilteredFunctor`.
+  - Removed `filteredParallelTraverse()` overload which accepted a `Filter *`. Pass `filter->outPlug()` instead.
 - DeleteFaces / DeletePoints / DeleteCurves : The PrimitiveVariable name is now taken verbatim, rather than stripping whitespace.
 - Serialisation :
   - Disabled copy construction.

--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Improvements
 - Context : Optimized `hash()` method, and reduced overhead in `EditableScope`.
 - NameSwitch/Spreadsheet : Rows with an empty name are now treated as if they were disabled. See Breaking Changes for further details.
 - ContextVariables : Improved performance by around 50%.
+- SceneAlgo : Reduced threading overhead for `parallelProcessLocations()`, `parallelTraverse()` and `filteredParallelTraverse()`. This is particularly noticeable when visiting locations with many children.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Improvements
 - Context : Optimized `hash()` method, and reduced overhead in `EditableScope`.
 - NameSwitch/Spreadsheet : Rows with an empty name are now treated as if they were disabled. See Breaking Changes for further details.
 - ContextVariables : Improved performance by around 50%.
+- FilterResults : Improved performance.
 - SceneAlgo : Reduced threading overhead for `parallelProcessLocations()`, `parallelTraverse()` and `filteredParallelTraverse()`. This is particularly noticeable when visiting locations with many children.
 
 Fixes

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -123,12 +123,13 @@ GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher 
 template <class ThreadableFunctor>
 void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
-/// Calls a functor on all paths in the scene
-/// The functor must take ( const ScenePlug*, const ScenePlug::ScenePath& ), and can return false to prune traversal
+/// Calls a functor on all locations in the scene. This differs from `parallelProcessLocations()` in that a single instance
+/// of the functor is used for all locations.
+/// The functor must take `( const ScenePlug *, const ScenePlug::ScenePath & )`, and can return false to prune traversal.
 template <class ThreadableFunctor>
 void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
-/// Calls a functor on all paths in the scene that are matched by the filter.
+/// As for `parallelTraverse()`, but only calling the functor for locations matched by the filter.
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 /// As above, but using a PathMatcher as a filter.

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -121,36 +121,19 @@ GAFFERSCENE_API IECore::MurmurHash matchingPathsHash( const IECore::PathMatcher 
 /// };
 /// ```
 template <class ThreadableFunctor>
-void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f );
-/// As above, but starting the traversal at the specified root.
-/// \todo Add default value for `root` and remove overload above.
-template <class ThreadableFunctor>
-void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
+void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
 /// Calls a functor on all paths in the scene
 /// The functor must take ( const ScenePlug*, const ScenePlug::ScenePath& ), and can return false to prune traversal
 template <class ThreadableFunctor>
-void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f );
-/// As above, but starting the traversal at `root`.
-/// \todo Add default value for `root` and remove overload above.
-template <class ThreadableFunctor>
-void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
+void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
 /// Calls a functor on all paths in the scene that are matched by the filter.
-/// The functor must take ( const ScenePlug*, const ScenePlug::ScenePath& ), and can return false to prune traversal
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::Filter *filter, ThreadableFunctor &f );
-/// As above, but specifying the filter as a plug - typically Filter::outPlug() or
-/// FilteredSceneProcessor::filterPlug() would be passed.
-template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterPlug, ThreadableFunctor &f );
-/// As above, but starting the traversal at `root`.
-/// \todo Add default value for `root` and remove overload above.
-template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root );
+void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 /// As above, but using a PathMatcher as a filter.
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f );
+void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
 /// Globals
 /// =======

--- a/include/GafferScene/SceneAlgo.inl
+++ b/include/GafferScene/SceneAlgo.inl
@@ -241,24 +241,10 @@ namespace SceneAlgo
 {
 
 template <class ThreadableFunctor>
-void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f )
-{
-	return parallelProcessLocations( scene, f, ScenePlug::ScenePath() );
-}
-
-template <class ThreadableFunctor>
 void parallelProcessLocations( const GafferScene::ScenePlug *scene, ThreadableFunctor &f, const ScenePlug::ScenePath &root )
 {
 	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated ); // Prevents outer tasks silently cancelling our tasks
 	Detail::LocationTask<ThreadableFunctor> *task = new( tbb::task::allocate_root( taskGroupContext ) ) Detail::LocationTask<ThreadableFunctor>( scene, Gaffer::ThreadState::current(), root, f );
-	tbb::task::spawn_root_and_wait( *task );
-}
-
-template <class ThreadableFunctor>
-void parallelTraverse( const GafferScene::ScenePlug *scene, ThreadableFunctor &f )
-{
-	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated ); // Prevents outer tasks silently cancelling our tasks
-	Detail::TraverseTask<ThreadableFunctor> *task = new( tbb::task::allocate_root( taskGroupContext ) ) Detail::TraverseTask<ThreadableFunctor>( scene, Gaffer::ThreadState::current(), f );
 	tbb::task::spawn_root_and_wait( *task );
 }
 
@@ -271,19 +257,6 @@ void parallelTraverse( const ScenePlug *scene, ThreadableFunctor &f, const Scene
 }
 
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const GafferScene::Filter *filter, ThreadableFunctor &f )
-{
-	filteredParallelTraverse( scene, filter->outPlug(), f );
-}
-
-template <class ThreadableFunctor>
-void filteredParallelTraverse( const GafferScene::ScenePlug *scene, const GafferScene::FilterPlug *filterPlug, ThreadableFunctor &f )
-{
-	Detail::ThreadableFilteredFunctor<ThreadableFunctor> ff( f, filterPlug );
-	parallelTraverse( scene, ff );
-}
-
-template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::FilterPlug *filterPlug, ThreadableFunctor &f, const ScenePlug::ScenePath &root )
 {
 	Detail::ThreadableFilteredFunctor<ThreadableFunctor> ff( f, filterPlug );
@@ -291,10 +264,10 @@ void filteredParallelTraverse( const ScenePlug *scene, const GafferScene::Filter
 }
 
 template <class ThreadableFunctor>
-void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f )
+void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f, const ScenePlug::ScenePath &root )
 {
 	Detail::PathMatcherFunctor<ThreadableFunctor> ff( f, filter );
-	parallelTraverse( scene, ff );
+	parallelTraverse( scene, ff, root );
 }
 
 } // namespace SceneAlgo

--- a/python/GafferSceneTest/FilterResultsTest.py
+++ b/python/GafferSceneTest/FilterResultsTest.py
@@ -255,7 +255,7 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
 	@GafferTest.TestRunner.PerformanceTestMethod()
-	def testHashPerf( self ):
+	def testHashPerformance( self ):
 
 		sphere = GafferScene.Sphere()
 
@@ -276,6 +276,30 @@ class FilterResultsTest( GafferSceneTest.SceneTestCase ) :
 
 		with GafferTest.TestRunner.PerformanceScope():
 			filterResults["out"].hash()
+
+	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testComputePerformance( self ):
+
+		sphere = GafferScene.Sphere()
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( sphere["out"] )
+		duplicate["target"].setValue( '/sphere' )
+		duplicate["copies"].setValue( 1000000 )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ '...' ] ) )
+
+		filterResults = GafferScene.FilterResults()
+		filterResults["scene"].setInput( duplicate["out"] )
+		filterResults["filter"].setInput( pathFilter["out"] )
+
+		# Evaluate the root childNames beforehand to focus our timing on the compute
+		duplicate["out"].childNames( "/" )
+
+		with GafferTest.TestRunner.PerformanceScope():
+			filterResults["out"].getValue()
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This improves FilterResults performance by replacing a custom task tree with a recursive `parallel_for` in `SceneAlgo`, and removing a lock from `matchingPaths()`. The results are pretty compelling for several of the tests, as documented in the commits , with a 95% reduction in runtime for one in particular.

The results are inconclusive for the new `SceneAlgoTest.testMatchingPathsHashPerformance` though. This test is fairly noisy, and it's not clear if performance is unchanged or slightly worse. I added it deliberately to provide a counterpoint to the existing tests where huge levels of parallelism are available at the children of a single location, making `parallel_for` a clear win. In `testMatchingPathsHashPerformance` the opportunities for parallelism _are_ there if the scene hierarchy is taken as a whole, but each location only has two children. This is tricky because we _do_ need to use `parallel_for` to exploit the overall parallelism, but there's overhead in using it redundantly once each core is busy with work. I did experiment with only splitting via `parallel_for` up to a certain depth and then using a serial path, but was surprised to find this gave no benefit. I feel like VTune is lying to me, or I'm missing something obvious.

One other possibility might be to use a single `parallel_for` with a custom `Range` class that performs the recursive traversal of the scene. I'm not sure how this will maintain the constraint that parent locations must be visited before children though. Putting this version up to see if you can reproduce my results, as assuming you don't see any regressions on the marginal stuff I think it's worth merging for the definite improvements on the rest.
