### PR TITLE
GraphEditor : Fix bug in drop-to-frame

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,8 @@ Fixes
 -----
 
 - PlugValueWidget : Fixed bug that tried to update the widget before all graph edits were complete.
+- GraphEditor : Fixed framing of nodes dropped into the editor. This was incorrect when the editor was
+  not at the default zoom.
 
 API
 ---

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -429,13 +429,20 @@ class GraphEditor( GafferUI.Editor ) :
 			bound.setMin( boundCenter - newBoundSize / 2.0 )
 			bound.setMax( boundCenter + newBoundSize / 2.0 )
 
+		self.__gadgetWidget.getViewportGadget().frame( bound )
+
 		if at is not None :
+			# Offset the bound and reframe so that the centre of the bound moves
+			# to `at`, which is specified in raster space. We have to do this
+			# _after_ the initial call to `frame()` because
+			# `rasterToGadgetSpace()` is affected by the zoom calculated by
+			# `frame()`. Because we are not changing the size of the bound, the
+			# second call to `frame()` will use the same zoom.
 			viewport = self.graphGadgetWidget().getViewportGadget()
 			offset = viewport.rasterToGadgetSpace( imath.V2f( self.bound().size() / 2 ), graphGadget ).p0 - viewport.rasterToGadgetSpace( at, graphGadget ).p0
 			bound.setMin( bound.min() + offset )
 			bound.setMax( bound.max() + offset )
-
-		self.__gadgetWidget.getViewportGadget().frame( bound )
+			self.__gadgetWidget.getViewportGadget().frame( bound )
 
 	def __buttonDoubleClick( self, widget, event ) :
 


### PR DESCRIPTION
This isn't pretty, but I don't see a way of doing it in a single step without either modifying the ViewportGadget API, or copying its internal logic in GraphEditor.
