### PR TITLE
Annotations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ API
   performance in Gaffer 0.60. This allows the same code to be compiled for both
   Gaffer 0.60 and Gaffer 0.59 (but with only the Gaffer 0.60 build benefiting
   from improved performance).
+- MetadataAlgo : Added functions for managing annotations on nodes.
 
 0.59.7.0 (relative to 0.59.6.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ API
   Gaffer 0.60 and Gaffer 0.59 (but with only the Gaffer 0.60 build benefiting
   from improved performance).
 - MetadataAlgo : Added functions for managing annotations on nodes.
+- MonitorAlgo : Added `persistent` argument to `annotate()` functions.
 
 0.59.7.0 (relative to 0.59.6.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ Features
 --------
 
 - FilterQuery : Added a new node for querying the results of a filter at a specific location.
+- GraphEditor : Added "Annotate..." item to the node context menu. This can be configured with
+  multiple annotation templates using the `MetadataAlgo` API.
 
 Improvements
 ------------

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -145,6 +145,10 @@ GAFFER_API bool numericBookmarkAffectedByChange( const IECore::InternedString &c
 /// next to a node. Each node can have arbitrary numbers of annotations,
 /// with different annotations being distinguished by their `name`.
 /// Templates can be used to define defaults for standard annotation types.
+/// The text from the template is used as a default when first creating
+/// an annotation via the UI, and the colour from the template provides
+/// the default colour if one is not specified explicitly by an annotation
+/// itself.
 
 struct GAFFER_API Annotation
 {

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -40,8 +40,11 @@
 #include "Gaffer/Export.h"
 #include "Gaffer/Node.h"
 
+#include "IECore/SimpleTypedData.h"
 #include "IECore/StringAlgo.h"
 #include "IECore/TypeIds.h"
+
+#include "OpenEXR/ImathColor.h"
 
 #include <vector>
 
@@ -134,6 +137,54 @@ GAFFER_API Node *getNumericBookmark( ScriptNode *script, int bookmark );
 /// Returns 0 if the node isn't assigned, the bookmark otherwise.
 GAFFER_API int numericBookmark( const Node *node );
 GAFFER_API bool numericBookmarkAffectedByChange( const IECore::InternedString &changedKey );
+
+/// Annotations
+/// ===========
+///
+/// Annotations define arbitrary text to be displayed in a coloured area
+/// next to a node. Each node can have arbitrary numbers of annotations,
+/// with different annotations being distinguished by their `name`.
+/// Templates can be used to define defaults for standard annotation types.
+
+struct GAFFER_API Annotation
+{
+
+	Annotation() = default;
+	Annotation( const std::string &text );
+	Annotation( const std::string &text, const Imath::Color3f &color );
+	Annotation( const IECore::ConstStringDataPtr &text, const IECore::ConstColor3fDataPtr &color = nullptr );
+	Annotation( const Annotation &other ) = default;
+	Annotation( Annotation &&other ) = default;
+
+	operator bool() const { return textData.get(); }
+
+	bool operator == ( const Annotation &rhs );
+	bool operator != ( const Annotation &rhs ) { return !(*this == rhs); };
+
+	IECore::ConstStringDataPtr textData;
+	IECore::ConstColor3fDataPtr colorData;
+
+	const std::string &text() const { return textData ? textData->readable() : g_defaultText; }
+	const Imath::Color3f &color() const { return colorData ? colorData->readable() : g_defaultColor; }
+
+	private :
+
+		static std::string g_defaultText;
+		static Imath::Color3f g_defaultColor;
+
+};
+
+GAFFER_API void addAnnotation( Node *node, const std::string &name, const Annotation &annotation, bool persistent = true );
+GAFFER_API Annotation getAnnotation( const Node *node, const std::string &name, bool inheritTemplate = false );
+GAFFER_API void removeAnnotation( Node *node, const std::string &name );
+GAFFER_API void annotations( const Node *node, std::vector<std::string> &names );
+
+GAFFER_API void addAnnotationTemplate( const std::string &name, const Annotation &annotation );
+GAFFER_API Annotation getAnnotationTemplate( const std::string &name );
+GAFFER_API void removeAnnotationTemplate( const std::string &name );
+GAFFER_API void annotationTemplates( std::vector<std::string> &names );
+
+GAFFER_API bool annotationsAffectedByChange( const IECore::InternedString &changedKey );
 
 /// Change queries
 /// ==============

--- a/include/Gaffer/MonitorAlgo.h
+++ b/include/Gaffer/MonitorAlgo.h
@@ -70,8 +70,16 @@ enum PerformanceMetric
 GAFFER_API std::string formatStatistics( const PerformanceMonitor &monitor, size_t maxLinesPerMetric = 50 );
 GAFFER_API std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetric metric, size_t maxLines = 50 );
 
+GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor, bool persistent );
+/// \todo Remove, and default `persistent = true` above.
 GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor );
+
+GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric, bool persistent );
+/// \todo Remove, and default `persistent = true` above.
 GAFFER_API void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric );
+
+GAFFER_API void annotate( Node &root, const ContextMonitor &monitor, bool persistent );
+/// \todo Remove, and default `persistent = true` above.
 GAFFER_API void annotate( Node &root, const ContextMonitor &monitor );
 
 } // namespace MonitorAlgo

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -37,9 +37,9 @@
 #ifndef GAFFERUI_ANNOTATIONSGADGET_H
 #define GAFFERUI_ANNOTATIONSGADGET_H
 
-#include "GafferUI/Gadget.h"
+#include "Gaffer/MetadataAlgo.h"
 
-#include "IECore/SimpleTypedData.h"
+#include "GafferUI/Gadget.h"
 
 #include <unordered_map>
 
@@ -87,16 +87,10 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 		void graphGadgetChildRemoved( const GraphComponent *child );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
 
-		struct StandardAnnotation
-		{
-			IECore::ConstStringDataPtr text;
-			IECore::ConstColor3fDataPtr color;
-		};
-
 		struct Annotations
 		{
 			bool dirty = true;
-			std::vector<StandardAnnotation> standardAnnotations;
+			std::vector<Gaffer::MetadataAlgo::Annotation> standardAnnotations;
 			bool bookmarked = false;
 			IECore::InternedString numericBookmark;
 			bool renderable = false;

--- a/python/GafferTest/MonitorAlgoTest.py
+++ b/python/GafferTest/MonitorAlgoTest.py
@@ -64,30 +64,30 @@ class MonitorAlgoTest( GafferTest.TestCase ) :
 		Gaffer.MonitorAlgo.annotate( s, m, Gaffer.MonitorAlgo.PerformanceMetric.ComputeCount )
 
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"]["n1"], "annotation:performanceMonitor:computeCount:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"]["n1"], "performanceMonitor:computeCount" ).text(),
 			"Compute count : 1"
 		)
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"]["n2"], "annotation:performanceMonitor:computeCount:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"]["n2"], "performanceMonitor:computeCount" ).text(),
 			"Compute count : 1"
 		)
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"], "annotation:performanceMonitor:computeCount:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"], "performanceMonitor:computeCount" ).text(),
 			"Compute count : 2"
 		)
 
 		Gaffer.MonitorAlgo.annotate( s, m, Gaffer.MonitorAlgo.PerformanceMetric.HashesPerCompute )
 
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"]["n1"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"]["n1"], "performanceMonitor:hashesPerCompute" ).text(),
 			"Hashes per compute : 2"
 		)
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"]["n2"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"]["n2"], "performanceMonitor:hashesPerCompute" ).text(),
 			"Hashes per compute : 1"
 		)
 		self.assertEqual(
-			Gaffer.Metadata.value( s["b"], "annotation:performanceMonitor:hashesPerCompute:text" ),
+			Gaffer.MetadataAlgo.getAnnotation( s["b"], "performanceMonitor:hashesPerCompute" ).text(),
 			"Hashes per compute : 1.5"
 		)
 

--- a/python/GafferUI/AnnotationsUI.py
+++ b/python/GafferUI/AnnotationsUI.py
@@ -1,0 +1,149 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
+
+	def append( menuPath, name ) :
+
+		menuDefinition.append(
+			menuPath,
+			{
+				"command" : functools.partial( __annotate, node, name ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( node ),
+			}
+		)
+
+	names = Gaffer.MetadataAlgo.annotationTemplates()
+	if not names :
+		append( "/Annotate...", "user" )
+	else :
+		for name in names :
+			append(
+				"/Annotate/{}...".format( IECore.CamelCase.toSpaced( name ) ),
+				name
+			)
+		menuDefinition.append( "/Annotate/Divider", { "divider" : True } )
+		append( "/Annotate/User...", "user" )
+
+def __annotate( node, name, menu ) :
+
+	dialogue = __AnnotationsDialogue( node, name )
+	dialogue.wait( parentWindow = menu.ancestor( GafferUI.Window ) )
+
+class __AnnotationsDialogue( GafferUI.Dialogue ) :
+
+	def __init__( self, node, name ) :
+
+		GafferUI.Dialogue.__init__( self, "Annotate" )
+
+		self.__node = node
+		self.__name = name
+
+		template = Gaffer.MetadataAlgo.getAnnotationTemplate( name )
+		annotation = Gaffer.MetadataAlgo.getAnnotation( node, name ) or template
+
+		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) as layout :
+
+			self.__textWidget = GafferUI.MultiLineTextWidget(
+				text = annotation.text() if annotation else "",
+			)
+			self.__textWidget.textChangedSignal().connect(
+				Gaffer.WeakMethod( self.__updateButtonStatus ), scoped = False
+			)
+
+			if not template :
+				self.__colorChooser = GafferUI.ColorChooser(
+					annotation.color() if annotation else imath.Color3f( 0.15, 0.26, 0.26 ),
+					useDisplayTransform = False
+				)
+				self.__colorChooser.colorChangedSignal().connect(
+					Gaffer.WeakMethod( self.__updateButtonStatus ), scoped = False
+				)
+			else :
+				self.__colorChooser = None
+
+		self._setWidget( layout )
+
+		self.__cancelButton = self._addButton( "Cancel" )
+		self.__removeButton = self._addButton( "Remove" )
+		self.__annotateButton = self._addButton( "Annotate" )
+
+		self.__updateButtonStatus()
+
+	def wait( self, **kw ) :
+
+		button = self.waitForButton( **kw )
+		if button is self.__cancelButton or button is None :
+			return
+
+		with Gaffer.UndoScope( self.__node.scriptNode() ) :
+			if button is self.__removeButton :
+				Gaffer.MetadataAlgo.removeAnnotation( self.__node, self.__name )
+			else :
+				Gaffer.MetadataAlgo.addAnnotation(
+					self.__node, self.__name,
+					self.__makeAnnotation()
+				)
+
+	def __updateButtonStatus( self, *unused ) :
+
+		existingAnnotation = Gaffer.MetadataAlgo.getAnnotation( self.__node, self.__name )
+		newAnnotation = self.__makeAnnotation()
+
+		self.__cancelButton.setEnabled( newAnnotation != existingAnnotation )
+		self.__removeButton.setEnabled( bool( existingAnnotation ) )
+		self.__annotateButton.setEnabled( bool( newAnnotation ) and newAnnotation != existingAnnotation )
+
+	def __makeAnnotation( self ) :
+
+		if not self.__textWidget.getText() :
+			return Gaffer.MetadataAlgo.Annotation()
+
+		if self.__colorChooser is not None :
+			return Gaffer.MetadataAlgo.Annotation(
+				self.__textWidget.getText(),
+				self.__colorChooser.getColor()
+			)
+		else :
+			return Gaffer.MetadataAlgo.Annotation( self.__textWidget.getText() )

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -271,6 +271,7 @@ from .NameValuePlugValueWidget import NameValuePlugValueWidget
 from .ShufflePlugValueWidget import ShufflePlugValueWidget
 from .ShufflePlugValueWidget import ShufflesPlugValueWidget
 from .BackgroundTaskDialogue import BackgroundTaskDialogue
+from . import AnnotationsUI
 
 # and then specific node uis
 

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -37,7 +37,7 @@
 #include "Gaffer/MonitorAlgo.h"
 
 #include "Gaffer/ContextMonitor.h"
-#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/PerformanceMonitor.h"
 #include "Gaffer/Plug.h"
@@ -87,7 +87,7 @@ struct HashCountMetric
 	}
 
 	const std::string description = "number of hash processes";
-	const std::string annotation = "hashCount";
+	const std::string annotation = "performanceMonitor:hashCount";
 	const std::string annotationPrefix = "Hash count : ";
 
 };
@@ -103,7 +103,7 @@ struct ComputeCountMetric
 	}
 
 	const std::string description = "number of compute processes";
-	const std::string annotation = "computeCount";
+	const std::string annotation = "performanceMonitor:computeCount";
 	const std::string annotationPrefix = "Compute count : ";
 
 };
@@ -119,7 +119,7 @@ struct HashDurationMetric
 	}
 
 	const std::string description = "time spent in hash processes";
-	const std::string annotation = "hashDuration";
+	const std::string annotation = "performanceMonitor:hashDuration";
 	const std::string annotationPrefix = "Hash time : ";
 
 };
@@ -135,7 +135,7 @@ struct ComputeDurationMetric
 	}
 
 	const std::string description = "time spent in compute processes";
-	const std::string annotation = "computeDuration";
+	const std::string annotation = "performanceMonitor:computeDuration";
 	const std::string annotationPrefix = "Compute time : ";
 
 };
@@ -151,7 +151,7 @@ struct TotalDurationMetric
 	}
 
 	const std::string description = "sum of time spent in hash and compute processes";
-	const std::string annotation = "totalDuration";
+	const std::string annotation = "performanceMonitor:totalDuration";
 	const std::string annotationPrefix = "Time : ";
 
 };
@@ -167,7 +167,7 @@ struct PerHashDurationMetric
 	}
 
 	const std::string description = "time spent per hash process";
-	const std::string annotation = "perHashDuration";
+	const std::string annotation = "performanceMonitor:perHashDuration";
 	const std::string annotationPrefix = "Time per hash : ";
 
 };
@@ -183,7 +183,7 @@ struct PerComputeDurationMetric
 	}
 
 	const std::string description = "time spent per compute process";
-	const std::string annotation = "perComputeDuration";
+	const std::string annotation = "performanceMonitor:perComputeDuration";
 	const std::string annotationPrefix = "Time per compute : ";
 
 };
@@ -199,7 +199,7 @@ struct HashesPerComputeMetric
 	}
 
 	const std::string description = "number of hash processes per compute process";
-	const std::string annotation = "hashesPerCompute";
+	const std::string annotation = "performanceMonitor:hashesPerCompute";
 	const std::string annotationPrefix = "Hashes per compute : ";
 
 };
@@ -376,18 +376,17 @@ double toDouble( const boost::chrono::duration<double> &v )
 }
 
 template<typename T>
-ConstColor3fDataPtr heat( const T &v, const T &m )
+Color3f heat( const T &v, const T &m )
 {
 	const double heatFactor = toDouble( v ) / toDouble( m );
-	const Color3f heat = lerp( Color3f( 0 ), Color3f( 0.5, 0, 0 ), heatFactor );
-	return new Color3fData( heat );
+	return lerp( Color3f( 0 ), Color3f( 0.5, 0, 0 ), heatFactor );
 }
 
 struct Annotate
 {
 
-	Annotate( Node &root, const PerformanceMonitor::StatisticsMap &statistics )
-		:	m_root( root ), m_statistics( statistics )
+	Annotate( Node &root, const PerformanceMonitor::StatisticsMap &statistics, bool persistent )
+		:	m_root( root ), m_statistics( statistics ), m_persistent( persistent )
 	{
 	}
 
@@ -396,20 +395,17 @@ struct Annotate
 	template<typename Metric>
 	ResultType operator() ( const Metric &metric ) const
 	{
-		walk<Metric>(
-			m_root, metric,
-			"annotation:performanceMonitor:" + metric.annotation + ":text",
-			"annotation:performanceMonitor:" + metric.annotation + ":color"
-		);
+		walk<Metric>( m_root, metric );
 	}
 
 	private :
 
 		Node &m_root;
 		const PerformanceMonitor::StatisticsMap &m_statistics;
+		const bool m_persistent;
 
 		template<typename Metric>
-		PerformanceMonitor::Statistics walk( Node &node, const Metric &metric, const InternedString &textKey, const InternedString &colorKey ) const
+		PerformanceMonitor::Statistics walk( Node &node, const Metric &metric ) const
 		{
 			using Value = typename Metric::ResultType;
 			using ChildStatistics = std::pair<Node &, PerformanceMonitor::Statistics>;
@@ -434,7 +430,7 @@ struct Annotate
 			for( NodeIterator childNodeIt( &node ); !childNodeIt.done(); ++childNodeIt )
 			{
 				Node &childNode = **childNodeIt;
-				const auto cs = walk( childNode, metric, textKey, colorKey );
+				const auto cs = walk( childNode, metric );
 				childStatistics.push_back( ChildStatistics( childNode, cs ) );
 				maxChildValue = std::max( maxChildValue, metric( cs ) );
 			}
@@ -451,13 +447,15 @@ struct Annotate
 					continue;
 				}
 
-				Metadata::registerValue(
-					&cs.first, textKey,
-					new StringData(
-						metric.annotationPrefix + boost::lexical_cast<std::string>( value )
-					)
+				MetadataAlgo::addAnnotation(
+					&cs.first,
+					metric.annotation,
+					MetadataAlgo::Annotation(
+						metric.annotationPrefix + boost::lexical_cast<std::string>( value ),
+						heat( value, maxChildValue )
+					),
+					m_persistent
 				);
-				Metadata::registerValue( &cs.first, colorKey, heat( value, maxChildValue ) );
 
 				result += cs.second;
 			}
@@ -467,10 +465,9 @@ struct Annotate
 
 };
 
-InternedString g_contextAnnotationTextKey = "annotation:contextMonitor:text";
-InternedString g_contextAnnotationColorKey = "annotation:contextMonitor:color";
+const std::string g_contextAnnotationName = "annotation:contextMonitor";
 
-ContextMonitor::Statistics annotateContextWalk( Node &node, const ContextMonitor::StatisticsMap &statistics )
+ContextMonitor::Statistics annotateContextWalk( Node &node, const ContextMonitor::StatisticsMap &statistics, bool persistent )
 {
 
 	using ChildStatistics = std::pair<Node &, ContextMonitor::Statistics>;
@@ -495,7 +492,7 @@ ContextMonitor::Statistics annotateContextWalk( Node &node, const ContextMonitor
 	for( NodeIterator childNodeIt( &node ); !childNodeIt.done(); ++childNodeIt )
 	{
 		Node &childNode = **childNodeIt;
-		const auto cs = annotateContextWalk( childNode, statistics );
+		const auto cs = annotateContextWalk( childNode, statistics, persistent );
 		childStatistics.push_back( ChildStatistics( childNode, cs ) );
 		maxUniqueContexts = std::max( maxUniqueContexts, cs.numUniqueContexts() );
 	}
@@ -523,11 +520,12 @@ ContextMonitor::Statistics annotateContextWalk( Node &node, const ContextMonitor
 			}
 		}
 
-		Metadata::registerValue(
-			&cs.first, g_contextAnnotationTextKey,
-			new StringData( text )
+		MetadataAlgo::addAnnotation(
+			&cs.first,
+			g_contextAnnotationName,
+			MetadataAlgo::Annotation( text, heat( cs.second.numUniqueContexts(), maxUniqueContexts ) ),
+			persistent
 		);
-		Metadata::registerValue( &cs.first, g_contextAnnotationColorKey, heat( cs.second.numUniqueContexts(), maxUniqueContexts ) );
 
 		result += cs.second;
 	}
@@ -586,22 +584,37 @@ std::string formatStatistics( const PerformanceMonitor &monitor, PerformanceMetr
 	return dispatchMetric<FormatStatistics>( FormatStatistics( monitor.allStatistics(), maxLines ), metric );
 }
 
-void annotate( Node &root, const PerformanceMonitor &monitor )
+void annotate( Node &root, const PerformanceMonitor &monitor, bool persistent )
 {
 	for( int m = First; m <= Last; ++m )
 	{
-		annotate( root, monitor, static_cast<PerformanceMetric>( m ) );
+		annotate( root, monitor, static_cast<PerformanceMetric>( m ), persistent );
 	}
+}
+
+void annotate( Node &root, const PerformanceMonitor &monitor )
+{
+	annotate( root, monitor, /* persistent = */ true );
+}
+
+void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric, bool persistent )
+{
+	dispatchMetric<Annotate>( Annotate( root, monitor.allStatistics(), persistent ), metric );
 }
 
 void annotate( Node &root, const PerformanceMonitor &monitor, PerformanceMetric metric )
 {
-	dispatchMetric<Annotate>( Annotate( root, monitor.allStatistics() ), metric );
+	annotate( root, monitor, metric, /* persistent = */ true );
+}
+
+void annotate( Node &root, const ContextMonitor &monitor, bool persistent )
+{
+	annotateContextWalk( root, monitor.allStatistics(), persistent );
 }
 
 void annotate( Node &root, const ContextMonitor &monitor )
 {
-	annotateContextWalk( root, monitor.allStatistics() );
+	annotate( root, monitor, /* persistent = */ true );
 }
 
 } // namespace MonitorAlgo

--- a/src/GafferModule/MonitorBinding.cpp
+++ b/src/GafferModule/MonitorBinding.cpp
@@ -122,22 +122,22 @@ list contextMonitorVariableNames( const ContextMonitor::Statistics &s )
 	return result;
 }
 
-void annotateWrapper1( Node &root, const PerformanceMonitor &monitor )
+void annotateWrapper1( Node &root, const PerformanceMonitor &monitor, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	MonitorAlgo::annotate( root, monitor );
+	MonitorAlgo::annotate( root, monitor, persistent );
 }
 
-void annotateWrapper2( Node &root, const PerformanceMonitor &monitor, MonitorAlgo::PerformanceMetric metric )
+void annotateWrapper2( Node &root, const PerformanceMonitor &monitor, MonitorAlgo::PerformanceMetric metric, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	MonitorAlgo::annotate( root, monitor, metric );
+	MonitorAlgo::annotate( root, monitor, metric, persistent );
 }
 
-void annotateWrapper3( Node &root, const ContextMonitor &monitor )
+void annotateWrapper3( Node &root, const ContextMonitor &monitor, bool persistent )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	MonitorAlgo::annotate( root, monitor );
+	MonitorAlgo::annotate( root, monitor, persistent );
 }
 
 } // namespace
@@ -184,19 +184,19 @@ void GafferModule::bindMonitor()
 		def(
 			"annotate",
 			&annotateWrapper1,
-			( arg( "node" ), arg( "monitor" ) )
+			( arg( "node" ), arg( "monitor" ), arg( "persistent" ) = true )
 		);
 
 		def(
 			"annotate",
 			&annotateWrapper2,
-			( arg( "node" ), arg( "monitor" ), arg( "metric" ) )
+			( arg( "node" ), arg( "monitor" ), arg( "metric" ), arg( "persistent" ) = true )
 		);
 
 		def(
 			"annotate",
 			&annotateWrapper3,
-			( arg( "node" ), arg( "monitor" ) )
+			( arg( "node" ), arg( "monitor" ), arg( "persistent" ) = true )
 		);
 	}
 

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -110,6 +110,37 @@ float luminance( const Color3f &c )
 	return c.dot( V3f( 0.2126, 0.7152, 0.0722 ) );
 }
 
+string wrap( const std::string &text, size_t maxLineLength )
+{
+	string result;
+
+	using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+	boost::char_separator<char> separator( "", " \n" );
+	Tokenizer tokenizer( text, separator );
+
+	size_t lineLength = 0;
+	for( const auto &s : tokenizer )
+	{
+		if( s == "\n" )
+		{
+			result += s;
+			lineLength = 0;
+		}
+		else if( lineLength == 0 || lineLength + s.size() < maxLineLength )
+		{
+			result += s;
+			lineLength += s.size();
+		}
+		else
+		{
+			result += "\n" + s;
+			lineLength = s.size();
+		}
+	}
+
+	return result;
+}
+
 float g_offset = 0.5;
 float g_borderWidth = 0.5;
 float g_spacing = 0.25;
@@ -192,6 +223,12 @@ void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
 			{
 				annotations.standardAnnotations.push_back(
 					MetadataAlgo::getAnnotation( node, name, /* inheritTemplate = */ true )
+				);
+				// Word wrap. It might be preferable to do this during
+				// rendering, but we have no way of querying the extent of
+				// `Style::renderWrappedText()`.
+				annotations.standardAnnotations.back().textData = new StringData(
+					wrap( annotations.standardAnnotations.back().text(), 60 )
 				);
 			}
 			annotations.renderable |= (bool)annotations.standardAnnotations.size();

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -105,6 +105,11 @@ IECoreGL::Texture *numericBookmarkTexture()
 	return numericBookmarkTexture.get();
 }
 
+float luminance( const Color3f &c )
+{
+	return c.dot( V3f( 0.2126, 0.7152, 0.0722 ) );
+}
+
 float g_offset = 0.5;
 float g_borderWidth = 0.5;
 float g_spacing = 0.25;
@@ -226,6 +231,7 @@ void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
 			glPushMatrix();
 			IECoreGL::glTranslate( V2f( b.max.x + g_offset + g_borderWidth, b.max.y - g_borderWidth ) );
 
+			const Color4f darkGrey( 0.1, 0.1, 0.1, 1.0 );
 			const Color4f midGrey( 0.65, 0.65, 0.65, 1.0 );
 			float previousHeight = 0;
 			for( const auto &a : annotations.standardAnnotations )
@@ -251,7 +257,10 @@ void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
 					g_borderWidth, Style::NormalState,
 					&a.color()
 				);
-				style->renderText( Style::BodyText, a.text(), Style::NormalState, &midGrey );
+				style->renderText(
+					Style::BodyText, a.text(), Style::NormalState,
+					luminance( a.color() ) > 0.4 ? &darkGrey : &midGrey
+				);
 				previousHeight = textBounds.size().y + g_borderWidth * 2;
 			}
 			glPopMatrix();

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -100,6 +100,7 @@ def __nodeContextMenu( graphEditor, node, menuDefinition ) :
 	GafferDispatchUI.DispatcherUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphEditor.appendContentsMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.UIEditor.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
+	GafferUI.AnnotationsUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferSceneUI.FilteredSceneProcessorUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 	GafferUI.GraphBookmarksUI.appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition )
 


### PR DESCRIPTION
This adds a little MetadataAlgo API on top of the convention we were already using for annotating nodes, and exposes it to the user via a "Annotate..." menu item in the GraphEditor.

![image](https://user-images.githubusercontent.com/1133871/117459115-f2bb5e00-af42-11eb-882f-57801834c7a9.png)

Multiple categories of annotations can be configured during starting using the new `MetadataAlgo.addAnnotationTemplate()` method.