### PR TITLE
Arnold Renderer : Fix bug in tracking of nodes created by procedurals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,13 @@
+0.58.6.x (relative to 0.58.6.5)
+========
+
+Fixes
+-----
+
+- Arnold : Fixed rendering of encapsulated objects for which automatic instancing
+  is not possible. Examples include curves with non-zero `ai:curves:min_pixel_width`
+  and meshes with non-zero `ai:polymesh:subdiv_adaptive_error`.
+
 0.58.6.5 (relative to 0.58.6.4)
 ========
 

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1737,6 +1737,32 @@ class Instance
 
 	public :
 
+		AtNode *node()
+		{
+			return m_ginstance.get() ? m_ginstance.get() : m_node.get();
+		}
+
+		void nodesCreated( vector<AtNode *> &nodes ) const
+		{
+			if( m_ginstance )
+			{
+				nodes.push_back( m_ginstance.get() );
+			}
+			else
+			{
+				// Technically the node was created in `InstanceCache.get()`
+				// rather than by us directly, but we are the sole owner and
+				// this is the most natural place to report the creation.
+				nodes.push_back( m_node.get() );
+			}
+		}
+
+	private :
+
+		// Constructors are private as they are only intended for use in
+		// `InstanceCache::get()`. See comment in `nodesCreated()`.
+		friend class InstanceCache;
+
 		// Non-instanced
 		Instance( const SharedAtNodePtr &node )
 			:	m_node( node )
@@ -1757,21 +1783,6 @@ class Instance
 				AiNodeSetPtr( m_ginstance.get(), g_nodeArnoldString, m_node.get() );
 			}
 		}
-
-		AtNode *node()
-		{
-			return m_ginstance.get() ? m_ginstance.get() : m_node.get();
-		}
-
-		void nodesCreated( vector<AtNode *> &nodes ) const
-		{
-			if( m_ginstance )
-			{
-				nodes.push_back( m_ginstance.get() );
-			}
-		}
-
-	private :
 
 		SharedAtNodePtr m_node;
 		SharedAtNodePtr m_ginstance;


### PR DESCRIPTION
When expanding a procedural, we need to keep track of all the Arnold nodes we create so that we can report them via `procNumNodes()` and `procGetNode()`. We were doing this correctly when taking the automatic-instancing code path that we typically use, but were completely failing to account for nodes created in the non-instancing code path.
