### PR TITLE
Set : Add `setVariable` plug 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Features
 Improvements
 ------------
 
+- Set : Added `setVariable` plug to allow the input filter to be varied depending on the set name.
 - TabbedContainer : Added menu button to allow selection of tabs that are not
   visible due to a lack of horizontal space.
 

--- a/Changes.md
+++ b/Changes.md
@@ -32,10 +32,12 @@ Fixes
 API
 ---
 
-- Context : Added forwards compatibility for methods added to provide enhanced
-  performance in Gaffer 0.60. This allows the same code to be compiled for both
-  Gaffer 0.60 and Gaffer 0.59 (but with only the Gaffer 0.60 build benefiting
-  from improved performance).
+- Context :
+  - Added forwards compatibility for methods added to provide enhanced
+    performance in Gaffer 0.60. This allows the same code to be compiled for
+    both Gaffer 0.60 and Gaffer 0.59 (but with only the Gaffer 0.60 build
+    benefiting from improved performance).
+  - Added support for `IECore::InternedString` variables in `substitute()`.
 - MetadataAlgo : Added functions for managing annotations on nodes.
 - MonitorAlgo : Added `persistent` argument to `annotate()` functions.
 

--- a/include/GafferScene/Set.h
+++ b/include/GafferScene/Set.h
@@ -76,6 +76,9 @@ class GAFFERSCENE_API Set : public FilteredSceneProcessor
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
+		Gaffer::StringPlug *setVariablePlug();
+		const Gaffer::StringPlug *setVariablePlug() const;
+
 		/// \deprecated
 		Gaffer::StringVectorDataPlug *pathsPlug();
 		const Gaffer::StringVectorDataPlug *pathsPlug() const;

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -120,6 +120,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"setVariable" : [
+
+			"description",
+			"""
+			A context variable created to pass the name of the set
+			being processed to the nodes connected to the `filter`
+			plug. This can be used to vary the filter for each set.
+			""",
+
+		],
+
 		"paths" : [
 
 			"description",

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -688,5 +688,15 @@ class ContextTest( GafferTest.TestCase ) :
 
 		GafferTest.testNewContextAPIBasics()
 
+	def testSubstituteInternedString( self ) :
+
+		c = Gaffer.Context()
+		c["test"] = IECore.InternedStringData( "value" )
+		self.assertEqual( c.substitute( "${test}" ), "value" )
+
+		c["test1"] = IECore.InternedStringData( "${test2}" )
+		c["test2"] = IECore.InternedStringData( "recursion!" )
+		self.assertEqual( c.substitute( "${test1}" ), "recursion!" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -435,6 +435,9 @@ const std::string &Context::SubstitutionProvider::variable( const boost::string_
 			case IECore::StringDataTypeId :
 				recurse = true;
 				return static_cast<const IECore::StringData *>( d )->readable();
+			case IECore::InternedStringDataTypeId :
+				recurse = true;
+				return static_cast<const IECore::InternedStringData *>( d )->readable().string();
 			case IECore::FloatDataTypeId :
 				m_formattedString = boost::lexical_cast<std::string>(
 					static_cast<const IECore::FloatData *>( d )->readable()


### PR DESCRIPTION
This is similar in concept to `Parent.parentVariable`, in that it allows the inputs to the Set node to be varied depending on which set is being processed. The implementation is careful not to "leak" this variable into the upstream scene : it's just the filter that provides the paths that we give access to the variable. This makes the Set node work very nicely with the Spreadsheet to allow edit to arbitrary numbers of sets with just a couple of nodes.

![image](https://user-images.githubusercontent.com/1133871/118141377-34477f80-b401-11eb-8d01-5490234b9157.png)

<details>

```
import Gaffer
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 59, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 7, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Set"] = GafferScene.Set( "Set" )
parent.addChild( __children["Set"] )
__children["Set"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SceneReader"] = GafferScene.SceneReader( "SceneReader" )
parent.addChild( __children["SceneReader"] )
__children["SceneReader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["PathFilter"] = GafferScene.PathFilter( "PathFilter" )
parent.addChild( __children["PathFilter"] )
__children["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Spreadsheet"] = Gaffer.Spreadsheet( "Spreadsheet" )
parent.addChild( __children["Spreadsheet"] )
__children["Spreadsheet"]["rows"].addColumn( Gaffer.StringVectorDataPlug( "paths", defaultValue = IECore.StringVectorData( [  ] ), ) )
__children["Spreadsheet"]["rows"].addRows( 2 )
__children["Spreadsheet"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"] = Gaffer.Expression( "Expression" )
parent.addChild( __children["Expression"] )
__children["Expression"]["__in"].addChild( Gaffer.StringVectorDataPlug( "p0", defaultValue = IECore.StringVectorData( [  ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"]["__out"].addChild( Gaffer.StringPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = 'set', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Expression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Set"]["in"].setInput( __children["SceneReader"]["out"] )
__children["Set"]["filter"].setInput( __children["PathFilter"]["out"] )
__children["Set"]["name"].setInput( __children["Expression"]["__out"]["p0"] )
__children["Set"]["setVariable"].setValue( 'set' )
__children["Set"]["__uiPosition"].setValue( imath.V2f( -6.25, -7.25000095 ) )
__children["SceneReader"]["fileName"].setValue( '${GAFFER_ROOT}/resources/gafferBot/caches/gafferBot.scc' )
__children["SceneReader"]["__uiPosition"].setValue( imath.V2f( -6.25, 6.3499999 ) )
__children["PathFilter"]["paths"].setInput( __children["Spreadsheet"]["out"]["paths"] )
__children["PathFilter"]["__uiPosition"].setValue( imath.V2f( 12.749999, 2.20000005 ) )
__children["Spreadsheet"]["selector"].setValue( '${set}' )
__children["Spreadsheet"]["rows"][1]["name"].setValue( 'limbs' )
__children["Spreadsheet"]["rows"][1]["cells"]["paths"]["value"].setValue( IECore.StringVectorData( [ '/GAFFERBOT/C_torso_GRP/R_armUpper_GRP', '/GAFFERBOT/C_torso_GRP/R_legUpper_GRP', '/GAFFERBOT/C_torso_GRP/L_armUpper_GRP', '/GAFFERBOT/C_torso_GRP/L_legUpper_GRP' ] ) )
__children["Spreadsheet"]["rows"][2]["name"].setValue( 'features' )
__children["Spreadsheet"]["rows"][2]["cells"]["paths"]["value"].setValue( IECore.StringVectorData( [ '/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_mouthGrill001_REN', '/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_browNose001_REN', '/GAFFERBOT/C_torso_GRP/C_head_GRP/L_eye_GRP', '/GAFFERBOT/C_torso_GRP/C_head_GRP/R_eye_GRP' ] ) )
Gaffer.Metadata.registerValue( __children["Spreadsheet"]["rows"][0]["cells"]["paths"], 'spreadsheet:columnWidth', 326 )
Gaffer.Metadata.registerValue( __children["Spreadsheet"]["rows"][0]["cells"]["paths"]["value"], 'description', 'The list of paths to the locations to be matched by the filter.\nA path is formed by a sequence of names separated by \'/\', and\nspecifies the hierarchical position of a location within the scene.\nPaths may use Gaffer\'s standard wildcard characters to match\nmultiple locations.\n\nThe \'*\' wildcard matches any sequence of characters within\nan individual name, but never matches across names separated\nby a \'/\'.\n\n - /robot/*Arm matches /robot/leftArm, /robot/rightArm and\n   /robot/Arm. But does not match /robot/limbs/leftArm or\n   /robot/arm.\n\nThe "..." wildcard matches any sequence of names, and can be\nused to match locations no matter where they are parented in\nthe hierarchy.\n\n - /.../house matches /house, /street/house and /city/street/house.' )
Gaffer.Metadata.registerValue( __children["Spreadsheet"]["rows"][0]["cells"]["paths"]["value"], 'nodule:type', '' )
Gaffer.Metadata.registerValue( __children["Spreadsheet"]["rows"][0]["cells"]["paths"]["value"], 'ui:scene:acceptsPaths', True )
Gaffer.Metadata.registerValue( __children["Spreadsheet"]["rows"][0]["cells"]["paths"]["value"], 'vectorDataPlugValueWidget:dragPointer', 'objects' )
__children["Spreadsheet"]["__uiPosition"].setValue( imath.V2f( 2.14949727, 2.30089068 ) )
__children["Expression"]["__in"]["p0"].setInput( __children["Spreadsheet"]["activeRowNames"] )
__children["Expression"]["__uiPosition"].setValue( imath.V2f( -2.55000019, -1.64916861 ) )
__children["Expression"]["__engine"].setValue( 'python' )
__children["Expression"]["__expression"].setValue( 'parent["__out"]["p0"] = " ".join( parent["__in"]["p0"] )' )


del __children

```
</details>

I've also added support for wildcards that you can edit whatever sets happen to match. Very strictly speaking, this is a breaking change in that prior to this wildcards would be taken verbatim and turned into sets with questionable names. I'm open to debate on that : there's no problem holding that particular commit back till 0.60 if anyone feels strongly.

The change to support `InternedStringData` in substitutions turned out to be unnecessary for this, but it's harmless so I've included it.