### PR TITLE
Set : Support wildcards in `name` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -137,7 +137,9 @@ Features
 Improvements
 ------------
 
-- Set : Added `setVariable` plug to allow the input filter to be varied depending on the set name.
+- Set :
+  - Added `setVariable` plug to allow the input filter to be varied depending on the set name.
+  - Added wildcard support to the `name` plug.
 - TabbedContainer : Added menu button to allow selection of tabs that are not
   visible due to a lack of horizontal space.
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -112,8 +112,10 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The name of the set that will be created or edited.
-			You can create multiple set names at once by separating them with spaces.
+			The name of the set that will be created or edited. Multiple sets
+			may be created or modified by entering their names separated by
+			spaces. Wildcards may also be used to match multiple input sets to
+			be modified.
 			""",
 
 			"ui:scene:acceptsSetName", True,


### PR DESCRIPTION
This is the commit carried over from #4223 because we wanted to hold it back till 0.60 and have more time for discussion. There are two topics :

1. Are we OK with the breaking change whereby you can't make sets containing wildcard characters in their name? I presume we are fine with this now we're moving it to a new major version.
2. What is the right behaviour when `mode == Create` and there are wildcards in the name? Current behaviour is to match against existing sets, and replace their contents. Alternative behaviour would be to error if wildcards exist at all in this mode, regardless of whether they match anything. I'm going to start the discussion by backing the current behaviour. My thinking is that `Create` mode has never actually been `Create`, since it has always been perfectly happy to replace the contents of a pre-existing set. When you look at it that way, it is perfectly reasonable to replace the contents of pre-existing sets that match a wildcard. I would be happy to rename `Create` to `Replace` if that helps clarify things.