### PR TITLE
SignalBinding : Reduce boilerplate by using variadic templates

### DIFF
--- a/include/GafferBindings/SignalBinding.inl
+++ b/include/GafferBindings/SignalBinding.inl
@@ -51,305 +51,42 @@ namespace GafferBindings
 namespace Detail
 {
 
-template<int Arity, typename Signal>
-struct DefaultSignalCallerBase;
-
-template<typename Signal>
-struct DefaultSignalCallerBase<0, Signal>
-{
-	static typename Signal::result_type call( Signal &s )
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		return s();
-	}
-};
-
-template<typename Signal>
-struct DefaultSignalCallerBase<1, Signal>
-{
-#if BOOST_VERSION < 103900
-	static typename Signal::result_type call( Signal &s, typename Signal::arg2_type a1 )
-#else
-	static typename Signal::result_type call( Signal &s, typename Signal::arg1_type a1 )
-#endif
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		return s( a1 );
-	}
-};
-
-template<typename Signal>
-struct DefaultSignalCallerBase<2, Signal>
-{
-#if BOOST_VERSION < 103900
-	static typename Signal::result_type call( Signal &s, typename Signal::arg2_type a1, typename Signal::arg3_type a2 )
-#else
-	static typename Signal::result_type call( Signal &s, typename Signal::arg1_type a1, typename Signal::arg2_type a2 )
-#endif
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		return s( a1, a2 );
-	}
-};
-
-template<typename Signal>
-struct DefaultSignalCallerBase<3, Signal>
-{
-#if BOOST_VERSION < 103900
-	static typename Signal::result_type call( Signal &s, typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3 )
-#else
-	static typename Signal::result_type call( Signal &s, typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3 )
-#endif
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		return s( a1, a2, a3 );
-	}
-};
-
-template<typename Signal>
-struct DefaultSignalCallerBase<4, Signal>
-{
-#if BOOST_VERSION < 103900
-	static typename Signal::result_type call( Signal &s, typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3, typename Signal::arg5_type a4 )
-#else
-	static typename Signal::result_type call( Signal &s, typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3, typename Signal::arg4_type a4 )
-#endif
-	{
-		IECorePython::ScopedGILRelease gilRelease;
-		return s( a1, a2, a3, a4 );
-	}
-};
-
-template<int Arity, typename Signal>
-struct DefaultSlotCallerBase;
-
-template<typename Signal>
-struct DefaultSlotCallerBase<0, Signal>
-{
-	typename Signal::slot_result_type operator()( boost::python::object slot )
-	{
-		return boost::python::extract<typename Signal::slot_result_type>( slot() )();
-	}
-};
-
-template<typename Signal>
-struct DefaultSlotCallerBase<1, Signal>
-{
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg2_type a1 )
-#else
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg1_type a1 )
-#endif
-	{
-		return boost::python::extract<typename Signal::slot_result_type>( slot( a1 ) )();
-	}
-};
-
-template<typename Signal>
-struct DefaultSlotCallerBase<2, Signal>
-{
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg2_type a1, typename Signal::arg3_type a2 )
-#else
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg1_type a1, typename Signal::arg2_type a2 )
-#endif
-	{
-		return boost::python::extract<typename Signal::slot_result_type>( slot( a1, a2 ) )();
-	}
-};
-
-template<typename Signal>
-struct DefaultSlotCallerBase<3, Signal>
-{
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3 )
-#else
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3 )
-#endif
-	{
-		return boost::python::extract<typename Signal::slot_result_type>( slot( a1, a2, a3 ) )();
-	}
-};
-
-template<typename Signal>
-struct DefaultSlotCallerBase<4, Signal>
-{
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3, typename Signal::arg5_type a4 )
-#else
-	typename Signal::slot_result_type operator()( boost::python::object slot, typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3, typename Signal::arg4_type a4 )
-#endif
-	{
-		return boost::python::extract<typename Signal::slot_result_type>( slot( a1, a2, a3, a4 ) )();
-	}
-};
-
-template<int Arity, typename Signal, typename Caller>
-struct SlotBase;
-
 template<typename Signal, typename Caller>
-struct SlotBase<0, Signal, Caller>
-{
-	SlotBase( boost::python::object slot )
-		:	m_slot( boost::python::borrowed( slot.ptr() ) )
-	{
-	}
-	~SlotBase()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		m_slot.reset();
-	}
-	typename Signal::slot_result_type operator()()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		try
-		{
-			return Caller()( boost::python::object( m_slot ) );
-		}
-		catch( const boost::python::error_already_set& e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return typename Signal::slot_result_type();
-	}
-	boost::python::handle<PyObject> m_slot;
-};
+struct Slot;
 
-template<typename Signal, typename Caller>
-struct SlotBase<1, Signal, Caller>
+template<typename Result, typename... Args, typename Combiner, typename Caller>
+struct Slot<boost::signal<Result( Args... ), Combiner>, Caller>
 {
-	SlotBase( boost::python::object slot )
-		:	m_slot( boost::python::borrowed( slot.ptr() ) )
-	{
-	}
-	~SlotBase()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		m_slot.reset();
-	}
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( typename Signal::arg2_type a1 )
-#else
-	typename Signal::slot_result_type operator()( typename Signal::arg1_type a1 )
-#endif
-	{
-		IECorePython::ScopedGILLock gilLock;
-		try
-		{
-			return Caller()( boost::python::object( m_slot ), a1 );
-		}
-		catch( const boost::python::error_already_set& e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return typename Signal::slot_result_type();
-	}
-	boost::python::handle<PyObject> m_slot;
-};
 
-template<typename Signal, typename Caller>
-struct SlotBase<2, Signal, Caller>
-{
-	SlotBase( boost::python::object slot )
-		:	m_slot( boost::python::borrowed( slot.ptr() ) )
-	{
-	}
-	~SlotBase()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		m_slot.reset();
-	}
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( typename Signal::arg2_type a1, typename Signal::arg3_type a2 )
-#else
-	typename Signal::slot_result_type operator()( typename Signal::arg1_type a1, typename Signal::arg2_type a2 )
-#endif
-	{
-		IECorePython::ScopedGILLock gilLock;
-		try
-		{
-			return Caller()( boost::python::object( m_slot ), a1, a2 );
-		}
-		catch( const boost::python::error_already_set& e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return typename Signal::slot_result_type();
-	}
-	boost::python::handle<PyObject> m_slot;
-};
-
-template<typename Signal, typename Caller>
-struct SlotBase<3, Signal, Caller>
-{
-	SlotBase( boost::python::object slot )
-		:	m_slot( boost::python::borrowed( slot.ptr() ) )
-	{
-	}
-	~SlotBase()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		m_slot.reset();
-	}
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3 )
-#else
-	typename Signal::slot_result_type operator()( typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3 )
-#endif
-	{
-		IECorePython::ScopedGILLock gilLock;
-		try
-		{
-			return Caller()( boost::python::object( m_slot ), a1, a2, a3 );
-		}
-		catch( const boost::python::error_already_set& e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return typename Signal::slot_result_type();
-	}
-	boost::python::handle<PyObject> m_slot;
-};
-
-template<typename Signal, typename Caller>
-struct SlotBase<4, Signal, Caller>
-{
-	SlotBase( boost::python::object slot )
-		:	m_slot( boost::python::borrowed( slot.ptr() ) )
-	{
-	}
-	~SlotBase()
-	{
-		IECorePython::ScopedGILLock gilLock;
-		m_slot.reset();
-	}
-#if BOOST_VERSION < 103900
-	typename Signal::slot_result_type operator()( typename Signal::arg2_type a1, typename Signal::arg3_type a2, typename Signal::arg4_type a3, typename Signal::arg5_type a4 )
-#else
-	typename Signal::slot_result_type operator()( typename Signal::arg1_type a1, typename Signal::arg2_type a2, typename Signal::arg3_type a3, typename Signal::arg4_type a4 )
-#endif
-	{
-		IECorePython::ScopedGILLock gilLock;
-		try
-		{
-			return Caller()( boost::python::object( m_slot ), a1, a2, a3, a4 );
-		}
-		catch( const boost::python::error_already_set& e )
-		{
-			IECorePython::ExceptionAlgo::translatePythonException();
-		}
-		return typename Signal::slot_result_type();
-	}
-	boost::python::handle<PyObject> m_slot;
-};
-
-template<typename Signal, typename Caller>
-struct Slot : public SlotBase<Signal::slot_function_type::arity, Signal, Caller>
-{
 	Slot( boost::python::object slot )
-		:	SlotBase<Signal::slot_function_type::arity, Signal, Caller>( slot )
+		:	m_slot( boost::python::borrowed( slot.ptr() ) )
 	{
+
 	}
+
+	~Slot()
+	{
+		IECorePython::ScopedGILLock gilLock;
+		m_slot.reset();
+	}
+
+	using Signal = boost::signal<Result( Args... ), Combiner>;
+
+	typename Signal::slot_result_type operator()( Args&&... args )
+	{
+		IECorePython::ScopedGILLock gilLock;
+		try
+		{
+			return Caller()( boost::python::object( m_slot ), std::forward<Args>( args )... );
+		}
+		catch( const boost::python::error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
+	}
+
+	boost::python::handle<PyObject> m_slot;
+
 };
 
 // Ideally we would bind `boost::signals::trackable` to Python
@@ -400,14 +137,36 @@ boost::python::object connectInGroup( Signal &s, int group, boost::python::objec
 } // namespace Detail
 
 template<typename Signal>
-struct DefaultSignalCaller : public Detail::DefaultSignalCallerBase<Signal::slot_function_type::arity, Signal>
+struct DefaultSignalCaller;
+
+template<typename Result, typename... Args, typename Combiner>
+struct DefaultSignalCaller<boost::signal<Result( Args... ), Combiner>>
 {
+
+	using Signal = boost::signal<Result( Args... ), Combiner>;
+
+	static Result call( Signal &s, Args... args )
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		return s( args... );
+	}
 
 };
 
 template<typename Signal>
-struct DefaultSlotCaller : public Detail::DefaultSlotCallerBase<Signal::slot_function_type::arity, Signal>
+struct DefaultSlotCaller;
+
+template<typename Result, typename... Args, typename Combiner>
+struct DefaultSlotCaller<boost::signal<Result( Args... ), Combiner>>
 {
+
+	using Signal = boost::signal<Result ( Args... )>;
+
+	typename Signal::slot_result_type operator()( boost::python::object slot, Args&&... args )
+	{
+		return boost::python::extract<typename Signal::slot_result_type>( slot( std::forward<Args>( args )... ) )();
+	}
+
 };
 
 template<typename Signal, typename SignalCaller, typename SlotCaller>


### PR DESCRIPTION
I've been noodling about with ideas for replacing `boost::signals`, which has been removed and replaced by the reputedly even more bloated `boost::signals2`. `boost::signals` uses a trick to define a whole load of template base classes `template0..16` and then derive from the right one depending on how many arguments there are in the signal signature. We were using the same technique in our python bindings for the signals, and it involves lots and lots of boilerplate repetition. So I've been experimenting with using a single variadic template instead.

This is a little offshoot of all that. We're still using `boost::signals`, but this replaces all the repetition in the bindings with variadic templates. It seems like a decent improvement so far...