### PR TITLE
Process : Add warning for slow cancellation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x (relative to 0.60.0.0)
+========
+
+Improvements
+------------
+
+- Process : Added warning messages for processes which don't respond promptly to cancellation.
+
 0.60.0.0
 ========
 

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -561,6 +561,49 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		# is not an error.
 		self.assertEqual( len( cs ), 0 )
 
+	def testSlowCancellationWarnings( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( inspect.cleandoc(
+			"""
+			import time
+			parent['n']['op1'] = 10
+			time.sleep( 1.5 )
+			"""
+		) )
+
+		messageHandler = IECore.CapturingMessageHandler()
+
+		def f( context ) :
+
+			with context, messageHandler :
+				s["n"]["sum"].getValue()
+
+		canceller = IECore.Canceller()
+		thread = threading.Thread(
+			target = f,
+			args = [  Gaffer.Context( s.context(), canceller ) ]
+		)
+		thread.start()
+
+		# Give the background thread time to get into the infinite
+		# loop in the Expression, and then cancel it.
+		time.sleep( 0.1 )
+		canceller.cancel()
+		thread.join()
+
+		# Check that we have been warned about the slow cancellation.
+		# Currently we're not smart enough to omit a message only for
+		# the problematic compute - there is a message for each parent
+		# process too.
+		self.assertEqual( len( messageHandler.messages ), 3 )
+		self.assertEqual( messageHandler.messages[0].level, IECore.Msg.Level.Warning )
+		self.assertEqual( messageHandler.messages[0].context, "Process::~Process" )
+		self.assertTrue( messageHandler.messages[0].message.startswith( "Cancellation for `ScriptNode.e.__execute` (computeNode:compute) took" ) )
+
 	class ThrowingNode( Gaffer.ComputeNode ) :
 
 		def __init__( self, name="ThrowingNode" ) :

--- a/src/Gaffer/Process.cpp
+++ b/src/Gaffer/Process.cpp
@@ -92,6 +92,21 @@ Process::~Process()
 	{
 		m->processFinished( this );
 	}
+
+	if( context()->canceller() )
+	{
+		const auto t = context()->canceller()->elapsedTime();
+		if( t > std::chrono::seconds( 1 ) )
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "Process::~Process",
+				boost::format( "Cancellation for `%1%` (%2%) took %3%s" )
+					% plug()->fullName()
+					% type()
+					% std::chrono::duration<float>( t ).count()
+			);
+		}
+	}
 }
 
 const Process *Process::current()


### PR DESCRIPTION
This highlights nodes such as Seeds, which have potentially long-running computes that don't check for cancellation. By turning slow cancellation into a warning we'll be able to detect problematic examples in production and eliminate them.