### PR TITLE
BackgroundTask : Prefer `task_arena::enqueue` to `task::enqueue`

### DIFF
--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -70,7 +70,6 @@
 #include "tbb/enumerable_thread_specific.h"
 #include "tbb/parallel_for.h"
 #include "tbb/spin_mutex.h"
-#include "tbb/task.h"
 
 using namespace std;
 using namespace Imath;


### PR DESCRIPTION
TBB is deprecating the `task` class, and this represents decent progress towards dropping our reliance on it. The one remaining use in Gaffer is now in `RenderController.cpp`, but that's walking a scene and is an ideal candidate for using a slightly more flexible version of `SceneAlgo::parallelProcessLocations()`.