### PR TITLE
ArnoldRenderTest : Increase `maxDifference` for image comparison

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1395,7 +1395,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		# The `maxDifference` is huge to account for noise and watermarks, but is still low enough to check what
 		# we want, since if the Encapsulate was sampled at shutter open and not the frame, the difference would be
 		# 0.5.
-		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.25, ignoreMetadata = True )
+		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.27, ignoreMetadata = True )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This should fix sporadic CI failures we've been seeing, and despite being huge is still low enough to guard against the problem the test was intended for.
