### PR TITLE
Instancer : Store prototype root attributes on instance roots

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,11 +22,17 @@ API
 - AnnotationsGadget : Added `setVisibleAnnotations()` and `getVisibleAnnotations()` methods to allow filtering of annotations.
 - MonitorAlgo : Added `removePerformanceAnnotations()` and `removeContextAnnotations()` methods.
 
+Fixes
+-----
+
+- Instancer : Fixed variation of prototype root attributes using context variables.
+
 Breaking Changes
 ----------------
 
 - RendererAlgo : Removed from the API. The render adaptor registry and `applyCameraGlobals()` are still available, but have been moved to SceneAlgo.
 - MonitorAlgo : Removed deprecated `annotate()` overloads. Source compatibility is retained.
+- Instancer : Attributes from the prototype root are now placed at the instance root, rather than on the instance group. This allows context variation to potentially vary these attributes. Usually attribute inheritance will mean that this behaves the same, but scenes which explicitly override attributes at specific locations in the hierarchy after an instancer could see modified behaviour.
 
 0.60.0.0b1
 ==========

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -237,8 +237,10 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{
 			PrototypeScope( const Gaffer::ObjectPlug *enginePlug, const Gaffer::Context *context, const ScenePath *parentPath, const ScenePath *branchPath );
+			PrototypeScope( const EngineData *engine, const Gaffer::Context *context, const ScenePath *parentPath, const ScenePath *branchPath );
 			private :
 				ScenePlug::ScenePath m_prototypePath;
+				void setPrototype( const EngineData *engine, const ScenePath *branchPath );
 		};
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1588,12 +1588,12 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/bar" ] ) )
 
 		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances" ), IECore.CompoundObject() )
-		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo" )["gaffer:deformationBlur"].value, False )
-		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar" )["gaffer:deformationBlur"].value, True )
+		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo" ), IECore.CompoundObject() )
+		self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar" ), IECore.CompoundObject() )
 
 		for i in [ "0", "3" ] :
 
-			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}".format( i=i ) ), IECore.CompoundObject() )
+			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}".format( i=i ) )["gaffer:deformationBlur"].value, False )
 			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/foo/{i}".format( i=i ) )["gaffer:deformationBlur"].value, False )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}/bar".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/foo/{i}/bar/sphere" ), IECore.CompoundObject() )
@@ -1601,7 +1601,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		for i in [ "1", "2" ] :
 
-			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}".format( i=i ) ), IECore.CompoundObject() )
+			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/bar/{i}".format( i=i ) )["gaffer:deformationBlur"].value, True )
 			self.assertEqual( script["instancer"]["out"].attributes( "/object/instances/bar/{i}/baz".format( i=i ) ), IECore.CompoundObject() )
 			self.assertEqual( script["instancer"]["out"].fullAttributes( "/object/instances/bar/{i}/baz".format( i=i ) )["gaffer:deformationBlur"].value, True )


### PR DESCRIPTION
This allows for attributes to be affected by context variation.

The code is quite straightforward, though I haven't updated the tests yet.

The only tricky bit is whether this is enough of a perf cost that it should be enabled only when context variation is on.  I would much prefer this to be always this way, since that makes things simpler, and when talking with John this morning, we hypothesized that the time to generate fullAttributes shouldn't be much different, since all the attributes need to be merged anyway.

Unfortunately, in testing, I am seeing a measurable performance cost to the new code path.  A scene that generates 2 million instances with both a prototype root attribute and a point attribute ( so it requires merging ), takes about 15 seconds, and takes about 0.8 seconds longer with the new code.  This difference persists when I switch GafferSceneTest.traverseScene to call fullAttributes.

The same scene goes from taking 54 seconds to 56 seconds to do an Arnold render.  It is curious that the Scene generation time is so much higher in a render than in `gaffer stats`, and in particular that the slowdown from the new code is greater.

I guess tomorrow I should probably try to understand this performance difference ( since I'd really rather not make the code more complex by adding fast paths unless I really need to ).  I guess the most likely explanation for the slowdown may be more calls to PrototypeScope(), and more calls from there of enginePlug->getValue().  It's the same engine being retreived by every location, so it should certainly be cached, but I guess there may still be measurable cost in retrieving it in an Instancer with a huge number of lightweight instances.  I dunno, these numbers still don't quite make sense, so I'm still hoping there's some way I can justify making the code this simple.
