### PR TITLE
.gitignore : git ignores vscode workspace and gnome desktop files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.swp
 *.so
 *.tmp
+*.desktop
+*.code-workspace
 .gafferBackups
 .idea
 .sconf_temp


### PR DESCRIPTION
Adds patterns to .gitignore so git will ignore vscode workspace files and gnome desktop files
