### PR TITLE
Gaffer.V3fPlug : correct serialisation for non default interpretation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 -----
 
 - Instancer : Fixed variation of prototype root attributes using context variables.
+- CompoundNumericPlug : Fixed serialisation of dynamic plugs with non-default interpretations.
 
 Breaking Changes
 ----------------

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -175,6 +175,21 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 
 		self.assertEqual( s["n"]["p"].getValue(), imath.V3f( 1, 2, 3 ) )
 
+	def testDynamicSerialisationNonDefaultInterpretation( self ):
+
+		s = Gaffer.ScriptNode()
+		n = Gaffer.Node()
+		n["p"] = Gaffer.V3fPlug( flags=Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, interpretation = IECore.GeometricData.Interpretation.Vector )
+		n["p"].setValue( imath.V3f( 1, 2, 3 ) )
+		s["n"] = n
+
+		ss = s.serialise()
+
+		s = Gaffer.ScriptNode()
+		s.execute( ss )
+
+		self.assertEqual( s["n"]["p"].interpretation(), IECore.GeometricData.Interpretation.Vector )
+
 	def testDynamicSerialisationWithConnection( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -70,6 +70,11 @@ std::string serialisationRepr( const T *plug, Serialisation *serialisation = nul
 		boost::python::object interpretationRepr = interpretationAsPythonObject.attr( "__repr__" )();
 		extraArgs = "interpretation = " + std::string( boost::python::extract<std::string>( interpretationRepr ) );
 		boost::replace_first( extraArgs, "_IECore", "GeometricData" );
+
+		if( serialisation )
+		{
+			serialisation->addModule( "IECore" );
+		}
 	}
 
 	return ValuePlugSerialiser::repr( plug, extraArgs, serialisation );


### PR DESCRIPTION
- Serialisation adds the IECore module that is referenced for non default interpretations

Fixes #4247