### PR TITLE
Deformer : Add virtual methods for computing bound

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,12 @@ Breaking Changes
 - RendererAlgo : Removed from the API. The render adaptor registry and `applyCameraGlobals()` are still available, but have been moved to SceneAlgo.
 - MonitorAlgo : Removed deprecated `annotate()` overloads. Source compatibility is retained.
 - Instancer : Attributes from the prototype root are now placed at the instance root, rather than on the instance group. This allows context variation to potentially vary these attributes. Usually attribute inheritance will mean that this behaves the same, but scenes which explicitly override attributes at specific locations in the hierarchy after an instancer could see modified behaviour.
+- PointsGridToPoints : Changed default value of `filter` input, so that a filter must now be connected to specify the objects to modify.
+- GafferVDB : Changed base class of the following nodes :
+  - LevelSetToMesh
+  - MeshToLevelSet
+  - LevelSetOffset
+  - PointsGridToPoints
 
 0.60.0.0b1
 ==========

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - Set : Added wildcard support to the `name` plug.
 - GraphEditor : Added tool menu with options to control visibility of annotations.
 - SceneReader : Added support for cancellation of set loading.
+- LevelSetOffset/MeshToLevelSet : Added cancellation support.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,8 @@ API
   - Added optional `userOnly` argument to `annotationTemplates()`.
 - AnnotationsGadget : Added `setVisibleAnnotations()` and `getVisibleAnnotations()` methods to allow filtering of annotations.
 - MonitorAlgo : Added `removePerformanceAnnotations()` and `removeContextAnnotations()` methods.
+- Deformer : Added `affectsProcessedObjectBound()`, `hashProcessedObjectBound()` and `computeProcessedObjectBound()` virtual
+  methods. These can optionally be overridden by derived classes to compute faster approximate bounds where possible.
 
 Fixes
 -----

--- a/include/GafferScene/Deformer.h
+++ b/include/GafferScene/Deformer.h
@@ -80,6 +80,26 @@ class GAFFERSCENE_API Deformer : public ObjectProcessor
 		/// > accessed by `adjustBounds()`.
 		virtual bool adjustBounds() const;
 
+		/// If `computeProcessedObjectBound()` is overridden, this must be overriden
+		/// to return true for any plugs it uses. Unlike other affects methods, overrides
+		/// should _not_ call the base class implementation.
+		virtual bool affectsProcessedObjectBound( const Gaffer::Plug *input ) const;
+		/// If `computeProcessedObjectBound()` is overridden, this must be
+		/// be overridden to match. Unlike other hash methods, overrides should
+		/// _not_ call the base class implementation.
+		virtual void hashProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		/// May be implemented by derived classes to return a bound for the
+		/// result of `computeProcessedObject()`. This will only be called if
+		/// `adjustBounds()` returns true. The default implementation uses
+		/// the brute force approach of actually processing the object, so
+		/// reimplementing to provide a cheaper approximate bound may improve
+		/// performance considerably.
+		/// > Note : Implementations are currently hampered by the fact that
+		/// > `in.bound` provides the bound for the input object _and_ its
+		/// > children. We could consider having separate `in.objectBound`
+		/// > and `in.childBound` plugs instead.
+		virtual Imath::Box3f computeProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context ) const;
+
 	private :
 
 		void init();

--- a/include/GafferScene/SceneElementProcessor.h
+++ b/include/GafferScene/SceneElementProcessor.h
@@ -43,12 +43,9 @@
 namespace GafferScene
 {
 
-/// The SceneElementProcessor class provides a base class for modifying elements of an input
-/// scene while leaving the scene hierarchy unchanged.
-/// \todo This "all in one" base class for modifying bounds/transforms/attributes/objects
-/// is feeling a bit unwieldy, and it seems that typical derived classes only ever modify
-/// one thing anyway. Perhaps we'd be better off with individual TransformProcessor,
-/// AttributeProcessor, ObjectProcessor and Deformer base classes.
+/// \todo Replace with a range of more specific base classes, deprecate and remove.
+/// We already have AttributeProcessor, ObjectProcessor and Deformer, and it looks
+/// like a TransformProcessor would get us most of the rest of the way.
 class GAFFERSCENE_API SceneElementProcessor : public FilteredSceneProcessor
 {
 

--- a/include/GafferVDB/Interrupter.h
+++ b/include/GafferVDB/Interrupter.h
@@ -47,8 +47,7 @@ class Interrupter {
 	public:
 
 		Interrupter(const IECore::Canceller *canceller)
-		:	m_canceller(canceller),
-			m_interrupted(false)
+			:	m_canceller( canceller )
 		{
 		}
 
@@ -62,27 +61,12 @@ class Interrupter {
 
 		bool wasInterrupted( int percent = -1 )
 		{
-			if ( m_interrupted )
-			{
-				return true;
-			}
-
-			// todo this a a problem installing a exception handler
-			// per a call to this function.
-			try
-			{
-				IECore::Canceller::check( m_canceller );
-			}
-			catch( const IECore::Cancelled& )
-			{
-				m_interrupted = true;
-			}
-
-			return m_interrupted;
+			return m_canceller && m_canceller->cancelled();
 		}
+
 	private:
+
 		const IECore::Canceller* m_canceller;
-		bool m_interrupted;
 
 };
 

--- a/include/GafferVDB/LevelSetOffset.h
+++ b/include/GafferVDB/LevelSetOffset.h
@@ -40,7 +40,7 @@
 #include "GafferVDB/Export.h"
 #include "GafferVDB/TypeIds.h"
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/Deformer.h"
 
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
@@ -48,7 +48,7 @@
 namespace GafferVDB
 {
 
-class GAFFERVDB_API LevelSetOffset : public GafferScene::SceneElementProcessor
+class GAFFERVDB_API LevelSetOffset : public GafferScene::Deformer
 {
 
 	public :
@@ -56,7 +56,7 @@ class GAFFERVDB_API LevelSetOffset : public GafferScene::SceneElementProcessor
 		LevelSetOffset(const std::string &name = defaultName<LevelSetOffset>() );
 		~LevelSetOffset() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetOffset, LevelSetOffsetTypeId, GafferScene::SceneElementProcessor );
+		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetOffset, LevelSetOffsetTypeId, GafferScene::Deformer );
 
 		Gaffer::StringPlug *gridPlug();
 		const Gaffer::StringPlug *gridPlug() const;
@@ -64,17 +64,15 @@ class GAFFERVDB_API LevelSetOffset : public GafferScene::SceneElementProcessor
 		Gaffer::FloatPlug *offsetPlug();
 		const Gaffer::FloatPlug *offsetPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesObject() const override;
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
 
-		bool processesBound() const override;
-		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
+		bool affectsProcessedObjectBound( const Gaffer::Plug *input ) const override;
+		void hashProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context ) const override;
 
 	private:
 

--- a/include/GafferVDB/LevelSetToMesh.h
+++ b/include/GafferVDB/LevelSetToMesh.h
@@ -40,7 +40,7 @@
 #include "GafferVDB/Export.h"
 #include "GafferVDB/TypeIds.h"
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/Deformer.h"
 
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
@@ -48,7 +48,7 @@
 namespace GafferVDB
 {
 
-class GAFFERVDB_API LevelSetToMesh : public GafferScene::SceneElementProcessor
+class GAFFERVDB_API LevelSetToMesh : public GafferScene::Deformer
 {
 
 	public :
@@ -56,7 +56,7 @@ class GAFFERVDB_API LevelSetToMesh : public GafferScene::SceneElementProcessor
 		LevelSetToMesh( const std::string &name=defaultName<LevelSetToMesh>() );
 		~LevelSetToMesh() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetToMesh, LevelSetToMeshTypeId, GafferScene::SceneElementProcessor );
+		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetToMesh, LevelSetToMeshTypeId, GafferScene::Deformer );
 
 		Gaffer::StringPlug *gridPlug();
 		const Gaffer::StringPlug *gridPlug() const;
@@ -67,17 +67,15 @@ class GAFFERVDB_API LevelSetToMesh : public GafferScene::SceneElementProcessor
 		Gaffer::FloatPlug *adaptivityPlug();
 		const Gaffer::FloatPlug *adaptivityPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesObject() const override;
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
 
-		bool processesBound() const override;
-		void hashProcessedBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		Imath::Box3f computeProcessedBound( const ScenePath &path, const Gaffer::Context *context, const Imath::Box3f &inputBound ) const override;
+		bool affectsProcessedObjectBound( const Gaffer::Plug *input ) const override;
+		void hashProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/include/GafferVDB/MeshToLevelSet.h
+++ b/include/GafferVDB/MeshToLevelSet.h
@@ -40,7 +40,7 @@
 #include "GafferVDB/Export.h"
 #include "GafferVDB/TypeIds.h"
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/ObjectProcessor.h"
 
 #include "Gaffer/NumericPlug.h"
 
@@ -52,7 +52,7 @@ class StringPlug;
 namespace GafferVDB
 {
 
-class GAFFERVDB_API MeshToLevelSet : public GafferScene::SceneElementProcessor
+class GAFFERVDB_API MeshToLevelSet : public GafferScene::ObjectProcessor
 {
 
 	public :
@@ -60,7 +60,7 @@ class GAFFERVDB_API MeshToLevelSet : public GafferScene::SceneElementProcessor
 		MeshToLevelSet( const std::string &name=defaultName<MeshToLevelSet>() );
 		~MeshToLevelSet() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferVDB::MeshToLevelSet, MeshToLevelSetTypeId, GafferScene::SceneElementProcessor );
+		GAFFER_NODE_DECLARE_TYPE( GafferVDB::MeshToLevelSet, MeshToLevelSetTypeId, GafferScene::ObjectProcessor );
 
 		Gaffer::StringPlug *gridPlug();
 		const Gaffer::StringPlug *gridPlug() const;
@@ -74,13 +74,11 @@ class GAFFERVDB_API MeshToLevelSet : public GafferScene::SceneElementProcessor
 		Gaffer::FloatPlug *interiorBandwidthPlug();
 		const Gaffer::FloatPlug *interiorBandwidthPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesObject() const override;
+		bool affectsProcessedObject( const Gaffer::Plug *plug ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
 
 	private :
 

--- a/include/GafferVDB/PointsGridToPoints.h
+++ b/include/GafferVDB/PointsGridToPoints.h
@@ -40,7 +40,7 @@
 #include "GafferVDB/Export.h"
 #include "GafferVDB/TypeIds.h"
 
-#include "GafferScene/SceneElementProcessor.h"
+#include "GafferScene/ObjectProcessor.h"
 
 #include "Gaffer/NumericPlug.h"
 
@@ -52,7 +52,7 @@ class StringPlug;
 namespace GafferVDB
 {
 
-class GAFFERVDB_API PointsGridToPoints : public GafferScene::SceneElementProcessor
+class GAFFERVDB_API PointsGridToPoints : public GafferScene::ObjectProcessor
 {
 
 	public :
@@ -60,7 +60,7 @@ class GAFFERVDB_API PointsGridToPoints : public GafferScene::SceneElementProcess
 		PointsGridToPoints( const std::string &name=defaultName<PointsGridToPoints>() );
 		~PointsGridToPoints() override;
 
-		GAFFER_NODE_DECLARE_TYPE( GafferVDB::PointsGridToPoints, PointsGridToPointsId, GafferScene::SceneElementProcessor );
+		GAFFER_NODE_DECLARE_TYPE( GafferVDB::PointsGridToPoints, PointsGridToPointsId, GafferScene::ObjectProcessor );
 
 		Gaffer::StringPlug *gridPlug();
 		const Gaffer::StringPlug *gridPlug() const;
@@ -71,13 +71,11 @@ class GAFFERVDB_API PointsGridToPoints : public GafferScene::SceneElementProcess
 		Gaffer::BoolPlug *invertNamesPlug();
 		const Gaffer::BoolPlug *invertNamesPlug() const;
 
-		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
-
 	protected :
 
-		bool processesObject() const override;
+		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const override;
+		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
 
 	private :
 

--- a/python/GafferVDBTest/PointsGridToPointsTest.py
+++ b/python/GafferVDBTest/PointsGridToPointsTest.py
@@ -58,8 +58,12 @@ class PointsGridToPointsTest( GafferVDBTest.VDBTestCase ) :
 		sceneReader = GafferScene.SceneReader( "SceneReader" )
 		sceneReader["fileName"].setValue( self.sourcePath )
 
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ "/vdb" ] ) )
+
 		pointsGridToPoints = GafferVDB.PointsGridToPoints( "PointsGridToPoints" )
 		pointsGridToPoints["in"].setInput( sceneReader["out"] )
+		pointsGridToPoints["filter"].setInput( pointsFilter["out"] )
 
 		points = pointsGridToPoints["out"].object("/vdb")
 
@@ -73,8 +77,12 @@ class PointsGridToPointsTest( GafferVDBTest.VDBTestCase ) :
 		sceneReader = GafferScene.SceneReader( "SceneReader" )
 		sceneReader["fileName"].setValue( self.sourcePath )
 
+		pointsFilter = GafferScene.PathFilter()
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ "/vdb" ] ) )
+
 		pointsGridToPoints = GafferVDB.PointsGridToPoints( "PointsGridToPoints" )
 		pointsGridToPoints["in"].setInput( sceneReader["out"] )
+		pointsGridToPoints["filter"].setInput( pointsFilter["out"] )
 		pointsGridToPoints["grid"].setValue( "nogridhere" )
 
 		vdb = pointsGridToPoints["out"].object("/vdb")

--- a/src/GafferVDB/LevelSetOffset.cpp
+++ b/src/GafferVDB/LevelSetOffset.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferVDB/LevelSetOffset.h"
 
+#include "GafferVDB/Interrupter.h"
+
 #include "IECoreVDB/VDBObject.h"
 
 #include "Gaffer/StringPlug.h"
@@ -118,19 +120,20 @@ IECore::ConstObjectPtr LevelSetOffset::computeProcessedObject( const ScenePath &
 	}
 
 	openvdb::GridBase::Ptr newGrid;
+	Interrupter interrupter( context->canceller() );
 
 	if ( openvdb::FloatGrid::ConstPtr floatGrid = openvdb::GridBase::constGrid<openvdb::FloatGrid>( gridBase ) )
 	{
 		openvdb::FloatGrid::Ptr newFloatGrid = openvdb::GridBase::grid<openvdb::FloatGrid> ( floatGrid->deepCopyGrid() );
 		newGrid = newFloatGrid;
-		openvdb::tools::LevelSetFilter <openvdb::FloatGrid> filter( *newFloatGrid );
+		openvdb::tools::LevelSetFilter<openvdb::FloatGrid, openvdb::FloatGrid, Interrupter> filter( *newFloatGrid, &interrupter );
 		filter.offset( offsetPlug()->getValue() );
 	}
 	else if ( openvdb::DoubleGrid::ConstPtr doubleGrid = openvdb::GridBase::constGrid<openvdb::DoubleGrid>( newGrid ) )
 	{
 		openvdb::DoubleGrid::Ptr newDoubleGrid = openvdb::GridBase::grid<openvdb::DoubleGrid>( doubleGrid->deepCopyGrid() );
 		newGrid = newDoubleGrid;
-		openvdb::tools::LevelSetFilter <openvdb::DoubleGrid> filter( *newDoubleGrid );
+		openvdb::tools::LevelSetFilter<openvdb::DoubleGrid, openvdb::DoubleGrid, Interrupter> filter( *newDoubleGrid, &interrupter );
 		filter.offset( offsetPlug()->getValue() );
 	}
 	else

--- a/src/GafferVDB/MeshToLevelSet.cpp
+++ b/src/GafferVDB/MeshToLevelSet.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferVDB/MeshToLevelSet.h"
 
+#include "GafferVDB/Interrupter.h"
+
 #include "IECoreVDB/VDBObject.h"
 
 #include "Gaffer/StringPlug.h"
@@ -215,14 +217,15 @@ IECore::ConstObjectPtr MeshToLevelSet::computeProcessedObject( const ScenePath &
 	const float interiorBandwidth = interiorBandwidthPlug()->getValue();
 
 	openvdb::math::Transform::Ptr transform = openvdb::math::Transform::createLinearTransform( voxelSize );
+	Interrupter interrupter( context->canceller() );
 
 	openvdb::FloatGrid::Ptr grid = openvdb::tools::meshToVolume<openvdb::FloatGrid>(
+		interrupter,
 		CortexMeshAdapter( mesh, transform.get() ),
 		*transform,
 		exteriorBandwidth, //in voxel units
 		interiorBandwidth, //in voxel units
-		0 //conversionFlags,
-		//primitiveIndexGrid.get()
+		0 //conversionFlags
 	);
 
 	grid->setName( gridPlug()->getValue() );

--- a/src/GafferVDB/MeshToLevelSet.cpp
+++ b/src/GafferVDB/MeshToLevelSet.cpp
@@ -128,7 +128,7 @@ GAFFER_NODE_DEFINE_TYPE( MeshToLevelSet );
 size_t MeshToLevelSet::g_firstPlugIndex = 0;
 
 MeshToLevelSet::MeshToLevelSet( const std::string &name )
-	:	SceneElementProcessor( name, IECore::PathMatcher::NoMatch )
+	:	ObjectProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -182,29 +182,19 @@ const FloatPlug *MeshToLevelSet::interiorBandwidthPlug() const
 	return getChild<FloatPlug>( g_firstPlugIndex + 3 );
 }
 
-void MeshToLevelSet::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+bool MeshToLevelSet::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
-	SceneElementProcessor::affects( input, outputs );
-
-	if(
+	return
 		input == gridPlug() ||
 		input == voxelSizePlug() ||
 		input == exteriorBandwidthPlug() ||
 		input == interiorBandwidthPlug()
-	)
-	{
-		outputs.push_back( outPlug()->objectPlug() );
-	}
-}
-
-bool MeshToLevelSet::processesObject() const
-{
-	return true;
+	;
 }
 
 void MeshToLevelSet::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	SceneElementProcessor::hashProcessedObject( path, context, h );
+	ObjectProcessor::hashProcessedObject( path, context, h );
 
 	gridPlug()->hash( h );
 	voxelSizePlug()->hash( h );
@@ -212,9 +202,9 @@ void MeshToLevelSet::hashProcessedObject( const ScenePath &path, const Gaffer::C
 	interiorBandwidthPlug()->hash ( h );
 }
 
-IECore::ConstObjectPtr MeshToLevelSet::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
+IECore::ConstObjectPtr MeshToLevelSet::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
 {
-	const MeshPrimitive *mesh = runTimeCast<const MeshPrimitive>( inputObject.get() );
+	const MeshPrimitive *mesh = runTimeCast<const MeshPrimitive>( inputObject );
 	if( !mesh )
 	{
 		return inputObject;

--- a/src/GafferVDB/PointsGridToPoints.cpp
+++ b/src/GafferVDB/PointsGridToPoints.cpp
@@ -451,7 +451,8 @@ GAFFER_NODE_DEFINE_TYPE( PointsGridToPoints );
 
 size_t PointsGridToPoints::g_firstPlugIndex = 0;
 
-PointsGridToPoints::PointsGridToPoints( const std::string &name ) : SceneElementProcessor( name )
+PointsGridToPoints::PointsGridToPoints( const std::string &name )
+	:	ObjectProcessor( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
@@ -496,33 +497,23 @@ const Gaffer::BoolPlug *PointsGridToPoints::invertNamesPlug() const
 	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
 }
 
-void PointsGridToPoints::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+bool PointsGridToPoints::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
-	SceneElementProcessor::affects( input, outputs );
-
-	if( input == gridPlug() || input == namesPlug() || input == invertNamesPlug() )
-	{
-		outputs.push_back( outPlug()->objectPlug() );
-	}
-}
-
-bool PointsGridToPoints::processesObject() const
-{
-	return true;
+	return input == gridPlug() || input == namesPlug() || input == invertNamesPlug();
 }
 
 void PointsGridToPoints::hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	SceneElementProcessor::hashProcessedObject( path, context, h );
+	ObjectProcessor::hashProcessedObject( path, context, h );
 
 	gridPlug()->hash( h );
 	namesPlug()->hash( h );
 	invertNamesPlug()->hash ( h );
 }
 
-IECore::ConstObjectPtr PointsGridToPoints::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::ConstObjectPtr inputObject ) const
+IECore::ConstObjectPtr PointsGridToPoints::computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const
 {
-	const VDBObject *vdbObject = runTimeCast<const VDBObject>( inputObject.get() );
+	const VDBObject *vdbObject = runTimeCast<const VDBObject>( inputObject );
 	if( !vdbObject )
 	{
 		return inputObject;


### PR DESCRIPTION
This allows derived classes to compute cheap approximate bounds instead of the default bounds computation which is based on the processed object. This allows us to remove all use of SceneElementProcessor in GafferVDB, getting us closer to deprecating it entirely. While in GafferVDB, I also took the opportunity to add cancellation support where the VDB library allows it.

@andrewkaufman, I've added you as a reviewer since you're the first customer for the new methods, but if you're too busy to do a broader review then no worries.