### PR TITLE
OSLShader : Cache OSLQueries

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - TransformQuery : Added a new node to query the transform for a scene location.
 
+Improvements
+------------
+
+- OSLShader : Reduced loading times where many nodes reference the same shader.
+
 Documentation
 -------------
 

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -38,6 +38,7 @@ import os
 import unittest
 import imath
 import random
+import shutil
 
 import IECore
 import IECoreScene
@@ -552,8 +553,9 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n = GafferOSL.OSLShader()
 		n.loadShader( s1 )
 
+		s1Parameters = n["parameters"].keys()
 		self.assertEqual(
-			n["parameters"].keys(),
+			s1Parameters,
 			[
 				"commonI",
 				"commonF",
@@ -678,6 +680,13 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		for plug in n["parameters"] :
 			if isinstance( plug, Gaffer.ValuePlug ) :
 				self.assertTrue( plug.isSetToDefault() )
+
+		shutil.copyfile( s1 + ".oso", s2 + ".oso" )
+		n.reloadShader()
+		self.assertEqual(
+			n["parameters"].keys(),
+			s1Parameters
+		)
 
 	def testSplineParameters( self ) :
 

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -60,7 +60,6 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/container/flat_set.hpp"
 
-
 #include "tbb/mutex.h"
 
 using namespace std;
@@ -138,6 +137,36 @@ ShaderTypeSet &compatibleShaders()
 {
 	static ShaderTypeSet g_compatibleShaders;
 	return g_compatibleShaders;
+}
+
+} // namespace
+
+/////////////////////////////////////////////////////////////////////////
+// LRUCache of OSLQueries
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using OSLQueryPtr = shared_ptr<OSLQuery>;
+using QueryCache = IECorePreview::LRUCache<string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel>;
+
+QueryCache &queryCache()
+{
+	static QueryCache g_cache(
+		[] ( const std::string &shaderName, size_t &cost ) {
+			const char *searchPath = getenv( "OSL_SHADER_PATHS" );
+			OSLQueryPtr query = make_shared<OSLQuery>();
+			if( !query->open( shaderName, searchPath ? searchPath : "" ) )
+			{
+				throw Exception( query->geterror() );
+			}
+			cost = 1;
+			return query;
+		},
+		10000
+	);
+	return g_cache;
 }
 
 } // namespace
@@ -1006,13 +1035,7 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		return;
 	}
 
-	const char *searchPath = getenv( "OSL_SHADER_PATHS" );
-
-	OSLQuery query;
-	if( !query.open( shaderName, searchPath ? searchPath : "" ) )
-	{
-		throw Exception( query.geterror() );
-	}
+	OSLQueryPtr query = queryCache().get( shaderName );
 
 	const bool outPlugHadChildren = existingOut ? existingOut->children().size() : false;
 	if( !keepExistingValues )
@@ -1029,7 +1052,7 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 
 	m_metadata = nullptr;
 	namePlug->source<StringPlug>()->setValue( shaderName );
-	typePlug->source<StringPlug>()->setValue( std::string( "osl:" ) + query.shadertype().c_str() );
+	typePlug->source<StringPlug>()->setValue( std::string( "osl:" ) + query->shadertype().c_str() );
 
 	const IECore::CompoundData *metadata = OSLShader::metadata();
 	const IECore::CompoundData *parameterMetadata = nullptr;
@@ -1038,7 +1061,7 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		parameterMetadata = metadata->member<IECore::CompoundData>( "parameter" );
 	}
 
-	loadShaderParameters( query, parametersPlug, parameterMetadata );
+	loadShaderParameters( *query, parametersPlug, parameterMetadata );
 
 	if( existingOut )
 	{
@@ -1063,9 +1086,9 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		setChild( "out", outPlug );
 	}
 
-	if( query.shadertype() == "shader" )
+	if( query->shadertype() == "shader" )
 	{
-		loadShaderParameters( query, outPlug(), parameterMetadata );
+		loadShaderParameters( *query, outPlug(), parameterMetadata );
 	}
 	else
 	{
@@ -1270,8 +1293,9 @@ const IECore::Data *OSLShader::parameterMetadata( const Gaffer::Plug *plug, cons
 
 void OSLShader::reloadShader()
 {
-	// Remove any metadata cache entry for the given shader name, allowing
-	// it to be reloaded fresh if it has changed
+	// Remove any cache entries for the given shader name, allowing
+	// them to be reloaded fresh if the shader has changed.
+	queryCache().erase( namePlug()->getValue() );
 	g_metadataCache.erase( namePlug()->getValue() );
 	Shader::reloadShader();
 }


### PR DESCRIPTION
This reduces the time to load 5000 `ubersurface` shaders by 60%. This was testing with the shaders on a fast local drive. We suspect the benefits may be greater when loading from a server under load.
