### PR TITLE
Use New Cortex Cancellation Features

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,10 @@ Improvements
 ------------
 
 - Serialisation : Reduced script save times by around 50%.
+- Cancellation : Improved responsiveness by supporting cancellation of long computes in the following nodes :
+  - SceneReader
+  - LevelSetOffset
+  - MeshToLevelSet
 - Expression :
   - Improved performance of Python expression evaluation when the same result is required in multiple threads. Specific expression benchmarks have shown a 10x speedup and some production scenes show an overall 15-30% improvement. Caution : This can expose pre-existing bugs in other nodes - see Breaking Changes for details.
   - Improved error message when Python expression assigns an invalid value.
@@ -32,8 +36,6 @@ Improvements
 - SceneAlgo : Reduced threading overhead for `parallelProcessLocations()`, `parallelTraverse()` and `filteredParallelTraverse()`. This is particularly noticeable when visiting locations with many children.
 - Set : Added wildcard support to the `name` plug.
 - GraphEditor : Added tool menu with options to control visibility of annotations.
-- SceneReader : Added support for cancellation of set loading.
-- LevelSetOffset/MeshToLevelSet : Added cancellation support.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,14 @@ Improvements
   - MeshToLevelSet
   - Plane
   - Sphere
+  - DeleteFaces
+  - MeshDistortion
+  - MeshTangents
+  - MeshType
+  - PrimitiveSampler
+  - ResamplePrimitiveVariables
+  - ReverseWinding
+  - Seeds
 - Expression :
   - Improved performance of Python expression evaluation when the same result is required in multiple threads. Specific expression benchmarks have shown a 10x speedup and some production scenes show an overall 15-30% improvement. Caution : This can expose pre-existing bugs in other nodes - see Breaking Changes for details.
   - Improved error message when Python expression assigns an invalid value.

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,8 @@ Improvements
   - SceneReader
   - LevelSetOffset
   - MeshToLevelSet
+  - Plane
+  - Sphere
 - Expression :
   - Improved performance of Python expression evaluation when the same result is required in multiple threads. Specific expression benchmarks have shown a 10x speedup and some production scenes show an overall 15-30% improvement. Caution : This can expose pre-existing bugs in other nodes - see Breaking Changes for details.
   - Improved error message when Python expression assigns an invalid value.

--- a/src/GafferScene/DeleteFaces.cpp
+++ b/src/GafferScene/DeleteFaces.cpp
@@ -141,5 +141,5 @@ IECore::ConstObjectPtr DeleteFaces::computeProcessedObject( const ScenePath &pat
 		throw InvalidArgumentException( boost::str( boost::format( "DeleteFaces : No primitive variable \"%s\" found" ) % deletePrimVarName ) );
 	}
 
-	return MeshAlgo::deleteFaces( mesh, it->second, invertPlug()->getValue() );
+	return MeshAlgo::deleteFaces( mesh, it->second, invertPlug()->getValue(), context->canceller() );
 }

--- a/src/GafferScene/MeshDistortion.cpp
+++ b/src/GafferScene/MeshDistortion.cpp
@@ -164,7 +164,8 @@ IECore::ConstObjectPtr MeshDistortion::computeProcessedObject( const ScenePath &
 		mesh,
 		uvSet,
 		referencePosition,
-		position
+		position,
+		context->canceller()
 	);
 
 	MeshPrimitivePtr result = mesh->copy();

--- a/src/GafferScene/MeshTangents.cpp
+++ b/src/GafferScene/MeshTangents.cpp
@@ -222,7 +222,7 @@ IECore::ConstObjectPtr MeshTangents::computeProcessedObject( const ScenePath &pa
 		std::string uTangent = uTangentPlug()->getValue();
 		std::string vTangent = vTangentPlug()->getValue();
 
-		tangentPrimvars = MeshAlgo::calculateTangentsFromUV( mesh, uvSet, position, ortho, leftHanded );
+		tangentPrimvars = MeshAlgo::calculateTangentsFromUV( mesh, uvSet, position, ortho, leftHanded, context->canceller() );
 
 		meshWithTangents->variables[uTangent] = tangentPrimvars.first;
 		meshWithTangents->variables[vTangent] = tangentPrimvars.second;
@@ -235,15 +235,15 @@ IECore::ConstObjectPtr MeshTangents::computeProcessedObject( const ScenePath &pa
 
 		if ( mode == Mode::FirstEdge )
 		{
-			tangentPrimvars = MeshAlgo::calculateTangentsFromFirstEdge( mesh, position, normal, ortho, leftHanded  );
+			tangentPrimvars = MeshAlgo::calculateTangentsFromFirstEdge( mesh, position, normal, ortho, leftHanded, context->canceller() );
 		}
 		else if ( mode == Mode::TwoEdges )
 		{
-			tangentPrimvars = MeshAlgo::calculateTangentsFromTwoEdges( mesh, position, normal, ortho, leftHanded  );
+			tangentPrimvars = MeshAlgo::calculateTangentsFromTwoEdges( mesh, position, normal, ortho, leftHanded, context->canceller() );
 		}
 		else
 		{
-			tangentPrimvars = MeshAlgo::calculateTangentsFromPrimitiveCentroid( mesh, position, normal, ortho, leftHanded  );
+			tangentPrimvars = MeshAlgo::calculateTangentsFromPrimitiveCentroid( mesh, position, normal, ortho, leftHanded, context->canceller() );
 		}
 
 		meshWithTangents->variables[tangent] = tangentPrimvars.first;

--- a/src/GafferScene/MeshType.cpp
+++ b/src/GafferScene/MeshType.cpp
@@ -153,7 +153,7 @@ IECore::ConstObjectPtr MeshType::computeProcessedObject( const ScenePath &path, 
 
 	if( doNormals )
 	{
-		result->variables[ "N" ] = MeshAlgo::calculateNormals( result.get(), PrimitiveVariable::Interpolation::Vertex, "P" );
+		result->variables[ "N" ] = MeshAlgo::calculateNormals( result.get(), PrimitiveVariable::Interpolation::Vertex, "P", context->canceller() );
 	}
 
 	return result;

--- a/src/GafferScene/MeshType.cpp
+++ b/src/GafferScene/MeshType.cpp
@@ -38,7 +38,7 @@
 
 #include "Gaffer/StringPlug.h"
 
-#include "IECoreScene/MeshNormalsOp.h"
+#include "IECoreScene/MeshAlgo.h"
 #include "IECoreScene/MeshPrimitive.h"
 
 using namespace IECore;
@@ -153,10 +153,7 @@ IECore::ConstObjectPtr MeshType::computeProcessedObject( const ScenePath &path, 
 
 	if( doNormals )
 	{
-		IECoreScene::MeshNormalsOpPtr normalOp = new IECoreScene::MeshNormalsOp();
-		normalOp->inputParameter()->setValue( result );
-		normalOp->copyParameter()->setTypedValue( false );
-		normalOp->operate();
+		result->variables[ "N" ] = MeshAlgo::calculateNormals( result.get(), PrimitiveVariable::Interpolation::Vertex, "P" );
 	}
 
 	return result;

--- a/src/GafferScene/Plane.cpp
+++ b/src/GafferScene/Plane.cpp
@@ -100,5 +100,5 @@ void Plane::hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) 
 IECore::ConstObjectPtr Plane::computeSource( const Context *context ) const
 {
 	V2f dimensions = dimensionsPlug()->getValue();
-	return MeshPrimitive::createPlane( Box2f( -dimensions / 2.0f, dimensions / 2.0f ), divisionsPlug()->getValue() );
+	return MeshPrimitive::createPlane( Box2f( -dimensions / 2.0f, dimensions / 2.0f ), divisionsPlug()->getValue(), context->canceller() );
 }

--- a/src/GafferScene/PrimitiveSampler.cpp
+++ b/src/GafferScene/PrimitiveSampler.cpp
@@ -309,7 +309,7 @@ IECore::ConstObjectPtr PrimitiveSampler::computeProcessedObject( const ScenePath
 	ConstPrimitivePtr preprocessedSourcePrimitive = sourcePrimitive;
 	if( auto mesh = runTimeCast<const MeshPrimitive>( preprocessedSourcePrimitive.get() ) )
 	{
-		preprocessedSourcePrimitive = MeshAlgo::triangulate( mesh );
+		preprocessedSourcePrimitive = MeshAlgo::triangulate( mesh, context->canceller() );
 	}
 	PrimitiveEvaluatorPtr evaluator = PrimitiveEvaluator::create( preprocessedSourcePrimitive );
 	if( !evaluator )

--- a/src/GafferScene/ResamplePrimitiveVariables.cpp
+++ b/src/GafferScene/ResamplePrimitiveVariables.cpp
@@ -98,7 +98,7 @@ void ResamplePrimitiveVariables::processPrimitiveVariable( const ScenePath &path
 
 	if( const MeshPrimitive *meshPrimitive = IECore::runTimeCast<const MeshPrimitive>( inputGeometry.get() ) )
 	{
-		MeshAlgo::resamplePrimitiveVariable( meshPrimitive, variable, interpolation );
+		MeshAlgo::resamplePrimitiveVariable( meshPrimitive, variable, interpolation, context->canceller() );
 	}
 	else if( const CurvesPrimitive *curvesPrimitive = IECore::runTimeCast<const CurvesPrimitive>( inputGeometry.get() ) )
 	{

--- a/src/GafferScene/ReverseWinding.cpp
+++ b/src/GafferScene/ReverseWinding.cpp
@@ -73,6 +73,6 @@ IECore::ConstObjectPtr ReverseWinding::computeProcessedObject( const ScenePath &
 	}
 
 	MeshPrimitivePtr meshCopy = mesh->copy();
-	MeshAlgo::reverseWinding( meshCopy.get() );
+	MeshAlgo::reverseWinding( meshCopy.get(), context->canceller() );
 	return meshCopy;
 }

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -342,7 +342,7 @@ IECore::ConstObjectPtr SceneReader::computeObject( const ScenePath &path, const 
 		return parent->objectPlug()->defaultValue();
 	}
 
-	return s->readObject( context->getTime() );
+	return s->readObject( context->getTime(), context->canceller() );
 }
 
 void SceneReader::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const

--- a/src/GafferScene/Seeds.cpp
+++ b/src/GafferScene/Seeds.cpp
@@ -200,7 +200,10 @@ IECore::ConstObjectPtr Seeds::computeBranchObject( const ScenePath &sourcePath, 
 			mesh.get(),
 			densityPlug()->getValue(),
 			V2f( 0 ),
-			densityPrimitiveVariablePlug()->getValue()
+			densityPrimitiveVariablePlug()->getValue(),
+			"uv",
+			"P",
+			context->canceller()
 		);
 		result->variables["type"] = PrimitiveVariable( PrimitiveVariable::Constant, new StringData( pointTypePlug()->getValue() ) );
 

--- a/src/GafferScene/Sphere.cpp
+++ b/src/GafferScene/Sphere.cpp
@@ -165,6 +165,6 @@ IECore::ConstObjectPtr Sphere::computeSource( const Context *context ) const
 	}
 	else
 	{
-		return MeshPrimitive::createSphere( radius, zMin, zMax, thetaMax, divisionsPlug()->getValue() );
+		return MeshPrimitive::createSphere( radius, zMin, zMax, thetaMax, divisionsPlug()->getValue(), context->canceller() );
 	}
 }


### PR DESCRIPTION
These changes are pretty straightforward: wherever Cortex accepts a Canceller, pass one in.  ( Depends on https://github.com/ImageEngine/cortex/pull/1161 )

Despite being straightfoward, it probably should have some testing.  When trying to confirm that things were working interactively, I didn't find it too easy ... the slow cancellation warning doesn't appear to track the troublesome plug very accurately, and there are still some more other places that need cancellers ( when I tried making large geo to test with, I just started getting cancellation warning triggered by IECoreScene::MeshPrimitive::createPlane/createSphere which don't take a Canceller yet ).