### PR TITLE
Gadget Render Hacking

### DIFF
--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -322,6 +322,10 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 			const Gadget *gadget;
 			const Imath::M44f transform;
 		};
+		mutable std::vector<RenderItem> m_renderItems;
+
+		void processLayout() const;
+		
 
 		void getRenderItems( const Imath::M44f &transform, std::vector<RenderItem> &renderItems ) const;
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -315,7 +315,15 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 		// Sets the GL state up with the name attribute and transform for
 		// this Gadget, makes sure the style is bound and then calls doRenderLayer().
-		void renderLayer( Layer layer, const Style *currentStyle = nullptr ) const;
+		//void renderLayer( Layer layer, const Style *currentStyle = nullptr ) const;
+
+		struct RenderItem
+		{
+			const Gadget *gadget;
+			const Imath::M44f transform;
+		};
+
+		void getRenderItems( const Imath::M44f &transform, std::vector<RenderItem> &renderItems ) const;
 
 		void styleChanged();
 		void emitDescendantVisibilityChanged();


### PR DESCRIPTION
I know we shouldn't get into this right now, and Paul's probably going to be the main one taking a swing at this, but for getting the Focus Node stuff merged, one of the main questions we have to answer is "how expensive is it to add a new ( rarely used ) render layer".  It currently does add a 15% overhead - so I tried checking that it would be possible to remove this overhead.  The first commit helps with the extra overhead from Focus Nodes, but doesn't speed things up by default a lot, but the second commit is a decent improvement, and this is without changing anything that isn't private.

My heavy test scene with 4000 scenes at the root level went from 12 fps to 15 fps, which is a nice bump, and the overhead of adding new layers is reduced.

I haven't really cleaned this up, since I'm not expecting it to be merged any time soon - I currently completely ignore the possibility of anything override the Style, since that's not yet used anywhere.  I'm also no longer using hasLayer - what would be a big advantage to this approach would be if hasLayer returned a bit mask that could be stored in the RenderItem - that would probably be a speedup.

Anyway, the only real objective of this was to see if we can say "Having more render layers won't be a problem in the future", and it's probably sufficient for that.

( Oh - one last observation that is worth being aware of:  rendering for selection is substantially slower than regular rendering - after reducing the overhead with these changes, it's twice as slow.  Panning around the graph is a lot faster than moving the mouse cursor and waiting for hovers to update, and dragging a noodle where you have to both is really bad.  I'm guessing when we revisit node drawing selection will need some adjustment. )