### PR TITLE
Render : Don't flush caches when rendering batched frames

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -46,6 +46,9 @@ Improvements
 - SceneAlgo : Reduced threading overhead for `parallelProcessLocations()`, `parallelTraverse()` and `filteredParallelTraverse()`. This is particularly noticeable when visiting locations with many children.
 - Set : Added wildcard support to the `name` plug.
 - GraphEditor : Added tool menu with options to control visibility of annotations.
+- Render : Improved scene generation times for renders that use `dispatcher.batchSize` to
+  render multiple frames at once. Previously Gaffer's cache was cleared after scene generation
+  on each frame, but this is now only done for single-frame batches.
 
 Fixes
 -----

--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -93,8 +93,11 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		void postTasks( const Gaffer::Context *context, Tasks &tasks ) const override;
 		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 		void execute() const override;
+		void executeSequence( const std::vector<float> &frames ) const override;
 
 	private :
+
+		void executeInternal( bool flushCaches ) const;
 
 		ScenePlug *adaptedInPlug();
 		const ScenePlug *adaptedInPlug() const;


### PR DESCRIPTION
We'll be generating the scene again on another frame, so want to keep everything we can in Gaffer's cache.
