### PR TITLE
installDependencies.py : Update to GafferHQ/dependencies 3.0.0

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -47,7 +47,7 @@ else :
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.2.0.0-a2/cortex-10.2.0.0-a2-" + platform + "-python2.tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/3.0.0/gafferDependencies-3.0.0-Python2-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 


### PR DESCRIPTION
The CI builds are already using this, but the default here is used in our build instructions for folks making their own builds.
