### PR TITLE
GraphComponent : Inline `children()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.61.x.x
 ========
 
+API
+---
+
+- GraphComponent : Inlined `children()` method, yielding 20-40% improvements in various child iteration benchmarks.
+
 Breaking Changes
 ----------------
 

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -169,7 +169,7 @@ class GAFFER_API Context : public IECore::RefCounted
 
 		/// Return the hash of a particular variable ( or a default MurmurHash() if not present )
 		/// Note that this hash includes the name of the variable
-		inline IECore::MurmurHash variableHash( const IECore::InternedString &name ) const;
+		IECore::MurmurHash variableHash( const IECore::InternedString &name ) const;
 
 		bool operator == ( const Context &other ) const;
 		bool operator != ( const Context &other ) const;
@@ -184,7 +184,7 @@ class GAFFER_API Context : public IECore::RefCounted
 		/// Used to request cancellation of long running background operations.
 		/// May be null. Nodes that perform expensive work should check for
 		/// cancellation periodically by calling `Canceller::check( context->canceller() )`.
-		inline const IECore::Canceller *canceller() const;
+		const IECore::Canceller *canceller() const;
 
 		/// The Scope class is used to push and pop the current context on
 		/// the calling thread.
@@ -304,7 +304,7 @@ class GAFFER_API Context : public IECore::RefCounted
 		struct Value
 		{
 
-			inline Value();
+			Value();
 			template<typename T>
 			Value( const IECore::InternedString &name, const T *value );
 			Value( const IECore::InternedString &name, const IECore::Data *value );
@@ -313,7 +313,7 @@ class GAFFER_API Context : public IECore::RefCounted
 			Value &operator = ( const Value &other ) = default;
 
 			template<typename T>
-			inline const T &value() const;
+			const T &value() const;
 			IECore::TypeId typeId() const { return m_typeId; }
 			const void *rawValue() const { return m_value; }
 			// Note : This includes the hash of the name passed
@@ -362,11 +362,11 @@ class GAFFER_API Context : public IECore::RefCounted
 		// manage ownership in any way. Returns true if the value was assigned,
 		// and false if the value was not (due to it being equal to the
 		// previously stored value).
-		inline bool internalSet( const IECore::InternedString &name, const Value &value );
+		bool internalSet( const IECore::InternedString &name, const Value &value );
 		// Throws if variable doesn't exist.
-		inline const Value &internalGet( const IECore::InternedString &name ) const;
+		const Value &internalGet( const IECore::InternedString &name ) const;
 		// Returns nullptr if variable doesn't exist.
-		inline const Value *internalGetIfExists( const IECore::InternedString &name ) const;
+		const Value *internalGetIfExists( const IECore::InternedString &name ) const;
 
 		typedef boost::container::flat_map<IECore::InternedString, Value> Map;
 

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -85,7 +85,7 @@ struct DataTraits<Imath::Vec3<T> >
 
 } // namespace Detail
 
-Context::Value::Value()
+inline Context::Value::Value()
 	:	m_typeId( IECore::InvalidTypeId ), m_value( nullptr )
 {
 }
@@ -166,7 +166,7 @@ void Context::set( const IECore::InternedString &name, const T &value )
 	}
 }
 
-bool Context::internalSet( const IECore::InternedString &name, const Value &value )
+inline bool Context::internalSet( const IECore::InternedString &name, const Value &value )
 {
 	if( !m_changedSignal )
 	{
@@ -271,7 +271,7 @@ void Context::EditableScope::setAllocated( const IECore::InternedString &name, c
 	m_context->set( name, value );
 }
 
-const IECore::Canceller *Context::canceller() const
+inline const IECore::Canceller *Context::canceller() const
 {
 	return m_canceller;
 }

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -172,7 +172,7 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public boost::sig
 		inline const T *getChild( size_t index ) const;
 		/// Read only access to the internal container of children. This
 		/// is useful for iteration over children.
-		const ChildContainer &children() const;
+		inline const ChildContainer &children() const;
 		/// Reorders the existing children.
 		/// \undoable
 		void reorderChildren( const ChildContainer &newOrder );

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -165,14 +165,14 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public boost::sig
 		/// Get a child by index, performing a runTimeCast to T.
 		/// Note that this function does not perform any bounds checking.
 		template<typename T=GraphComponent>
-		inline T *getChild( size_t index );
+		T *getChild( size_t index );
 		/// Get a child by index, performing a runTimeCast to T.
 		/// Note that this function does not perform any bounds checking.
 		template<typename T=GraphComponent>
-		inline const T *getChild( size_t index ) const;
+		const T *getChild( size_t index ) const;
 		/// Read only access to the internal container of children. This
 		/// is useful for iteration over children.
-		inline const ChildContainer &children() const;
+		const ChildContainer &children() const;
 		/// Reorders the existing children.
 		/// \undoable
 		void reorderChildren( const ChildContainer &newOrder );
@@ -182,11 +182,11 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public boost::sig
 		/// Returns a descendant of this node specified by a "." separated
 		/// relative path, performing a runTimeCast to T.
 		template<typename T=GraphComponent>
-		inline T *descendant( const std::string &relativePath );
+		T *descendant( const std::string &relativePath );
 		/// Returns a descendant of this node specified by a "." separated
 		/// relative path, performing a runTimeCast to T.
 		template<typename T=GraphComponent>
-		inline const T *descendant( const std::string &relativePath ) const;
+		const T *descendant( const std::string &relativePath ) const;
 		/// Returns the parent for this component, performing a runTimeCast to T.
 		template<typename T=GraphComponent>
 		T *parent();

--- a/include/Gaffer/GraphComponent.inl
+++ b/include/Gaffer/GraphComponent.inl
@@ -75,20 +75,20 @@ inline const T *GraphComponent::getChild( size_t index ) const
 	return IECore::runTimeCast<const T>( m_children[index].get() );
 }
 
-const GraphComponent::ChildContainer &GraphComponent::children() const
+inline const GraphComponent::ChildContainer &GraphComponent::children() const
 {
 	return m_children;
 }
 
 template<typename T>
-T *GraphComponent::descendant( const std::string &relativePath )
+inline T *GraphComponent::descendant( const std::string &relativePath )
 {
 	// preferring the nasty casts over maintaining two nearly identical implementations for getChild.
 	return const_cast<T *>( const_cast<const GraphComponent *>( this )->descendant<T>( relativePath ) );
 }
 
 template<typename T>
-const T *GraphComponent::descendant( const std::string &relativePath ) const
+inline const T *GraphComponent::descendant( const std::string &relativePath ) const
 {
 	if( !relativePath.size() )
 	{

--- a/include/Gaffer/GraphComponent.inl
+++ b/include/Gaffer/GraphComponent.inl
@@ -75,6 +75,11 @@ inline const T *GraphComponent::getChild( size_t index ) const
 	return IECore::runTimeCast<const T>( m_children[index].get() );
 }
 
+const GraphComponent::ChildContainer &GraphComponent::children() const
+{
+	return m_children;
+}
+
 template<typename T>
 T *GraphComponent::descendant( const std::string &relativePath )
 {

--- a/include/GafferImage/BufferAlgo.h
+++ b/include/GafferImage/BufferAlgo.h
@@ -56,25 +56,25 @@ namespace BufferAlgo
 ////////////////////////////////////////////////////////////////////////////
 
 /// Returns true if the window contains no pixels, and false otherwise.
-inline bool empty( const Imath::Box2i &window );
+bool empty( const Imath::Box2i &window );
 
 /// Returns true if the image windows intersect.
-inline bool intersects( const Imath::Box2i &window1, const Imath::Box2i &window2 );
+bool intersects( const Imath::Box2i &window1, const Imath::Box2i &window2 );
 
 /// Return the intersection of the two image windows.
-inline Imath::Box2i intersection( const Imath::Box2i &window1, const Imath::Box2i &window2 );
+Imath::Box2i intersection( const Imath::Box2i &window1, const Imath::Box2i &window2 );
 
 /// Returns true if the given point is inside the window.
-inline bool contains( const Imath::Box2i &window, const Imath::V2i &point );
+bool contains( const Imath::Box2i &window, const Imath::V2i &point );
 
 /// Returns true if the given area is inside the window.
-inline bool contains( const Imath::Box2i &window, const Imath::Box2i &area );
+bool contains( const Imath::Box2i &window, const Imath::Box2i &area );
 
 /// Clamps the point so that it is contained inside the window.
-inline Imath::V2i clamp( const Imath::V2i &point, const Imath::Box2i &window );
+Imath::V2i clamp( const Imath::V2i &point, const Imath::Box2i &window );
 
 /// Returns the index of point p within a buffer with bounds b.
-inline size_t index( const Imath::V2i &p, const Imath::Box2i &b );
+size_t index( const Imath::V2i &p, const Imath::Box2i &b );
 
 } // namespace BufferAlgo
 

--- a/include/GafferImage/FilterAlgo.h
+++ b/include/GafferImage/FilterAlgo.h
@@ -60,7 +60,7 @@ GAFFERIMAGE_API const OIIO::Filter2D* acquireFilter( const std::string &name );
 
 // Find the region covered by a filter with a given width, given a position and axis-aligned derivatives
 // to compute the bounding rectangle
-inline Imath::Box2f filterSupport( const Imath::V2f &p, float dx, float dy, float filterWidth );
+Imath::Box2f filterSupport( const Imath::V2f &p, float dx, float dy, float filterWidth );
 
 // Filter over a rectangle shaped region of the image defined by a center point and two axis-aligned derivatives.
 // The sampler must have been initialized to cover all pixels with centers lying with the support of the filter,
@@ -77,7 +77,7 @@ GAFFERIMAGE_API float sampleParallelogram( Sampler &sampler, const Imath::V2f &p
 // If you have a point and derivatives defining a region to filter over, but you want to use sampleBox
 // instead of sampleParallelogram for performance reasons, you can use this function to get axis-aligned
 // derivatives which will approximate the result of sampleParallelogram
-inline Imath::V2f derivativesToAxisAligned( const Imath::V2f &p, const Imath::V2f &dpdx, const Imath::V2f &dpdy );
+Imath::V2f derivativesToAxisAligned( const Imath::V2f &p, const Imath::V2f &dpdx, const Imath::V2f &dpdy );
 
 } // namespace FilterAlgo
 

--- a/include/GafferImage/FilterAlgo.inl
+++ b/include/GafferImage/FilterAlgo.inl
@@ -41,7 +41,7 @@
 namespace GafferImage
 {
 
-Imath::Box2f FilterAlgo::filterSupport( const Imath::V2f &p, float dx, float dy, float filterWidth )
+inline Imath::Box2f FilterAlgo::filterSupport( const Imath::V2f &p, float dx, float dy, float filterWidth )
 {
 	return Imath::Box2f (
 		p - 0.5f * filterWidth * Imath::V2f( dx, dy ),
@@ -49,7 +49,7 @@ Imath::Box2f FilterAlgo::filterSupport( const Imath::V2f &p, float dx, float dy,
 
 }
 
-Imath::V2f FilterAlgo::derivativesToAxisAligned( const Imath::V2f &p, const Imath::V2f &dpdx, const Imath::V2f &dpdy )
+inline Imath::V2f FilterAlgo::derivativesToAxisAligned( const Imath::V2f &p, const Imath::V2f &dpdx, const Imath::V2f &dpdy )
 {
 	float dxLength = dpdx.length();
 	float dyLength = dpdy.length();

--- a/include/GafferImage/Format.h
+++ b/include/GafferImage/Format.h
@@ -59,21 +59,21 @@ class GAFFERIMAGE_API Format
 
 	public :
 
-		inline Format();
-		inline explicit Format( const Imath::Box2i &displayWindow, double pixelAspect = 1., bool fromEXRSpace = false );
-		inline Format( int width, int height, double pixelAspect = 1. );
+		Format();
+		explicit Format( const Imath::Box2i &displayWindow, double pixelAspect = 1., bool fromEXRSpace = false );
+		Format( int width, int height, double pixelAspect = 1. );
 
-		inline const Imath::Box2i &getDisplayWindow() const;
-		inline void setDisplayWindow( const Imath::Box2i &window );
+		const Imath::Box2i &getDisplayWindow() const;
+		void setDisplayWindow( const Imath::Box2i &window );
 
-		inline int width() const;
-		inline int height() const;
+		int width() const;
+		int height() const;
 
-		inline double getPixelAspect() const;
-		inline void setPixelAspect( double pixelAspect );
+		double getPixelAspect() const;
+		void setPixelAspect( double pixelAspect );
 
-		inline bool operator == ( const Format &rhs ) const;
-		inline bool operator != ( const Format &rhs ) const;
+		bool operator == ( const Format &rhs ) const;
+		bool operator != ( const Format &rhs ) const;
 
 		/// @name Coordinate system conversions.
 		/// The image coordinate system used by Gaffer has the origin at the
@@ -90,14 +90,14 @@ class GAFFERIMAGE_API Format
 		//@{
 		/// Converts from the EXR coordinate space to the internal space of
 		/// the Format.
-		inline int fromEXRSpace( int exrSpace ) const;
-		inline Imath::V2i fromEXRSpace( const Imath::V2i &exrSpace ) const;
-		inline Imath::Box2i fromEXRSpace( const Imath::Box2i &exrSpace ) const;
+		int fromEXRSpace( int exrSpace ) const;
+		Imath::V2i fromEXRSpace( const Imath::V2i &exrSpace ) const;
+		Imath::Box2i fromEXRSpace( const Imath::Box2i &exrSpace ) const;
 		/// Converts from the internal space of the format to the EXR
 		/// coordinate space.
-		inline int toEXRSpace( int internalSpace ) const;
-		inline Imath::V2i toEXRSpace( const Imath::V2i &internalSpace ) const;
-		inline Imath::Box2i toEXRSpace( const Imath::Box2i &internalSpace ) const;
+		int toEXRSpace( int internalSpace ) const;
+		Imath::V2i toEXRSpace( const Imath::V2i &internalSpace ) const;
+		Imath::Box2i toEXRSpace( const Imath::Box2i &internalSpace ) const;
 		//@}
 
 		/// @name Format registry
@@ -131,7 +131,7 @@ class GAFFERIMAGE_API Format
 /// where possible. Note that this is unrelated to Format::name().
 GAFFERIMAGE_API std::ostream & operator << ( std::ostream &os, const GafferImage::Format &format );
 
-inline void murmurHashAppend( IECore::MurmurHash &h, const GafferImage::Format &data );
+void murmurHashAppend( IECore::MurmurHash &h, const GafferImage::Format &data );
 
 } // namespace GafferImage
 

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -82,25 +82,25 @@ GAFFERIMAGE_API std::vector<std::string> layerNames( const std::vector<std::stri
 /// Returns the name of the layer the channel belongs to.
 /// This is simply the portion of the channelName up to the
 /// last '.', or "" if no such separator exists.
-inline std::string layerName( const std::string &channelName );
+std::string layerName( const std::string &channelName );
 
 /// Returns the base name for a channel - the portion of
 /// the name following the last '.', or the whole name
 /// if no separator exists.
-inline std::string baseName( const std::string &channelName );
+std::string baseName( const std::string &channelName );
 
 /// Joins a layer name and base name to form a channel name.
-inline std::string channelName( const std::string &layerName, const std::string &baseName );
+std::string channelName( const std::string &layerName, const std::string &baseName );
 
 /// Returns 0, 1, 2 and 3 for base names "R", "G", "B"
 /// and "A" respectively. Returns -1 for all other base names.
-inline int colorIndex( const std::string &channelName );
+int colorIndex( const std::string &channelName );
 
 /// Returns true if the specified channel exists in image
-inline bool channelExists( const ImagePlug *image, const std::string &channelName );
+bool channelExists( const ImagePlug *image, const std::string &channelName );
 
 /// Returns true if the specified channel exists in channelNames
-inline bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName );
+bool channelExists( const std::vector<std::string> &channelNames, const std::string &channelName );
 
 /// Default channel names
 /// ==============================

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -206,30 +206,30 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
 
-		inline static int tileSize() { return 1 << tileSizeLog2(); };
-		inline static int tilePixels() { return tileSize() * tileSize(); };
+		static int tileSize() { return 1 << tileSizeLog2(); };
+		static int tilePixels() { return tileSize() * tileSize(); };
 
 		/// Returns the index of the tile containing a point
 		/// This just means dividing by tile size ( always rounding down )
-		inline static const Imath::V2i tileIndex( const Imath::V2i &point )
+		static const Imath::V2i tileIndex( const Imath::V2i &point )
 		{
 			return Imath::V2i( point.x >> tileSizeLog2(), point.y >> tileSizeLog2() );
 		};
 
 		/// Returns the origin of the tile that contains the point.
-		inline static Imath::V2i tileOrigin( const Imath::V2i &point )
+		static Imath::V2i tileOrigin( const Imath::V2i &point )
 		{
 			return tileIndex( point ) * tileSize();
 		}
 
 		/// Returns the unwrapped index of a point within a tile
-		inline static int pixelIndex( const Imath::V2i &point, const Imath::V2i &tileOrigin )
+		static int pixelIndex( const Imath::V2i &point, const Imath::V2i &tileOrigin )
 		{
 			return ( ( point.y - tileOrigin.y ) << tileSizeLog2() ) + point.x - tileOrigin.x;
 		};
 
 		/// Returns the pixel corresponding to an unwrapped index
-		inline static Imath::V2i indexPixel( int index, const Imath::V2i &tileOrigin )
+		static Imath::V2i indexPixel( int index, const Imath::V2i &tileOrigin )
 		{
 			int y = index >> tileSizeLog2();
 			return Imath::V2i( index - ( y << tileSizeLog2() ) + tileOrigin.x, y + tileOrigin.y );

--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -80,7 +80,7 @@ class GAFFERIMAGE_API Sampler
 		/// responsibility to ensure that this point is
 		/// contained within the sample window passed
 		/// to the constructor.
-		inline float sample( int x, int y );
+		float sample( int x, int y );
 
 		/// Samples the channel value at the specified
 		/// subpixel location using bilinear interpolation.
@@ -93,7 +93,7 @@ class GAFFERIMAGE_API Sampler
 		/// pixel location. For instance, the centre of the
 		/// pixel at the bottom left of the image has coordinate
 		/// 0.5, 0.5.
-		inline float sample( float x, float y );
+		float sample( float x, float y );
 
 		/// Appends a hash that represent all the pixel
 		/// values within the requested sample area.
@@ -108,7 +108,7 @@ class GAFFERIMAGE_API Sampler
 		/// @param p Any point within the cache that we wish to retrieve the data for.
 		/// @param tileData Is set to the tile's channel data.
 		/// @param tilePixelIndex XY indices that can be used to access the colour value of point 'p' from tileData.
-		inline void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex );
+		void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex );
 
 		const ImagePlug *m_plug;
 		const std::string m_channelName;

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -41,7 +41,7 @@
 namespace GafferImage
 {
 
-float Sampler::sample( int x, int y )
+inline float Sampler::sample( int x, int y )
 {
 	Imath::V2i p( x, y );
 
@@ -79,7 +79,7 @@ float Sampler::sample( int x, int y )
 	return *(tileData + tileIndex.y * ImagePlug::tileSize() + tileIndex.x);
 }
 
-float Sampler::sample( float x, float y )
+inline float Sampler::sample( float x, float y )
 {
 	int xi;
 	float xf = OIIO::floorfrac( x - 0.5, &xi );
@@ -94,7 +94,7 @@ float Sampler::sample( float x, float y )
 	return OIIO::bilerp( x0y0, x1y0, x0y1, x1y1, xf, yf );
 }
 
-void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex )
+inline void Sampler::cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex )
 {
 	// Get the smart pointer to the tile we want.
 	Imath::V2i relP = p - m_cacheWindow.min;

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -119,7 +119,7 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 		bool buttonPress( const GafferUI::ButtonEvent &event );
 
 		void setTargetedMode( bool targeted );
-		inline bool getTargetedMode() const { return m_targetedMode; }
+		bool getTargetedMode() const { return m_targetedMode; }
 		bool m_targetedMode;
 
 		std::vector<Rotation> m_drag;

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -117,7 +117,7 @@ class GAFFERSCENEUI_API TranslateTool : public TransformTool
 		bool buttonPress( const GafferUI::ButtonEvent &event );
 
 		void setTargetedMode( bool targeted );
-		inline bool getTargetedMode() const { return m_targetedMode; }
+		bool getTargetedMode() const { return m_targetedMode; }
 		bool m_targetedMode;
 
 		std::vector<Translation> m_drag;

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -468,11 +468,6 @@ size_t GraphComponent::index() const
 	return std::find( c.begin(), c.end(), this ) - c.begin();
 }
 
-const GraphComponent::ChildContainer &GraphComponent::children() const
-{
-	return m_children;
-}
-
 void GraphComponent::reorderChildren( const ChildContainer &newOrder )
 {
 	if( newOrder.size() != m_children.size() )


### PR DESCRIPTION
This knocks between 20% and 40% off the runtime of a variety of child iteration benchmarks.
