### PR TITLE
StandardStyle : Handle alpha correctly when converting LinToSRGB

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x
+======== (relative to 0.60.1.0)
+
+Improvements
+------------
+
+- GafferUI : Fix edge artifacts when rendering transparent icons ( Requires Cortex 10.2.1.0 to get perfect results, but is an improvement even without it )
+
 0.60.1.0 (relative to 0.60.0.0)
 ========
 

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1389,7 +1389,7 @@ static const std::string &fragmentSource()
 		"	if( textureType==1 )"
 		"	{"
 		"		OUTCOLOR = texture2D( texture, gl_TexCoord[0].xy );"
-		"		OUTCOLOR = vec4( ieLinToSRGB( OUTCOLOR.r ), ieLinToSRGB( OUTCOLOR.g ), ieLinToSRGB( OUTCOLOR.b ), ieLinToSRGB( OUTCOLOR.a ) );"
+		"		OUTCOLOR = vec4( OUTCOLOR.a * ieLinToSRGB( OUTCOLOR.r / OUTCOLOR.a ), OUTCOLOR.a * ieLinToSRGB( OUTCOLOR.g / OUTCOLOR.a ), OUTCOLOR.a * ieLinToSRGB( OUTCOLOR.b / OUTCOLOR.a ), OUTCOLOR.a );"
 		"	}"
 		"	else if( textureType==2 )"
 		"	{"


### PR DESCRIPTION
The previous code was creating matte edges on transparent images because it was applying a color space transform to premultiplied channels, and was also incorrectly applying a color space gamma to the alpha channel.

Note that to get perfectly correct results, we also need to handle unpremulting properly when we apply a colorspace on load ( see https://github.com/ImageEngine/cortex/pull/1169 ).  But even without that, this appears to yield a result that is slightly less wrong.
