### PR TITLE
ParameterHandler::setupPlug: Added M44fPlug support and unit test

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.59.x.x (relative to 0.59.9.0)
+========
+
+Fixes
+-----
+
+- ArnoldShader : Fixed loading of shaders with matrix outputs.
+
 0.59.9.0 (relative to 0.59.8.0)
 ========
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -620,6 +620,11 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "switch_rgba", keepExistingValues = False )
 		assertParametersEqual( shader, switch )
 
+	def testLoadTransformMatrixShader( self ):
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "matrix_transform" )
+		self.assertEqual(type(shader["out"]), Gaffer.M44fPlug)
+
 	def testLoadShaderInSerialisation( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -336,6 +336,10 @@ Gaffer::Plug *ParameterHandler::setupPlug( const IECore::InternedString &paramet
 
 			return setupTypedPlug<BoolPlug>( parameterName, plugParent, direction, false );
 
+		case AI_TYPE_MATRIX :
+
+			return setupTypedPlug<M44fPlug>( parameterName, plugParent, direction, false );
+
 		default :
 
 			msg(


### PR DESCRIPTION
`ParameterHandler::setupPlug`: Added `M44fPlug` support and unit test.

### Related issues ###

- Gaffer wasn't supporting the load of the ArnoldShader matrix_transform because its output is a matrix.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
