### PR TITLE
GafferArnold : Do not support ai:ignore_motion_blur

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Breaking Changes
   - Moved `render()` and `renderRequestSignal()` to ViewportGadget.
   - Made `select()` private.
 - ViewportGadget : Deprecated old `gadgetsAt()` signature. Please use the new form instead.
+- ArnoldOptions : Support for option ai:ignore_motion_blur has been removed, since it conflicted with a standard Gaffer option.  Set sampleMotion to False using a StandardOptions node instead
 
 0.60.0.0
 ========

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -153,7 +153,6 @@ def __featuresSummary( plug ) :
 		( "ignoreSubdivision", "Subdivs" ),
 		( "ignoreDisplacement", "Disp" ),
 		( "ignoreBump", "Bump" ),
-		( "ignoreMotionBlur", "MBlur" ),
 		( "ignoreSSS", "SSS" ),
 	) :
 		if plug[childName]["enabled"].getValue() :
@@ -846,20 +845,6 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Ignores all bump mapping.
-			""",
-
-			"layout:section", "Features",
-
-		],
-
-		"options.ignoreMotionBlur" : [
-
-			"description",
-			"""
-			Ignores motion blur. Note that the turn
-			off motion blur completely, it is more
-			efficient to use the motion blur controls
-			in the StandardOptions node.
 			""",
 
 			"layout:section", "Features",

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -111,7 +111,6 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_subdivision", new IECore::BoolData( false ), false, "ignoreSubdivision" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_displacement", new IECore::BoolData( false ), false, "ignoreDisplacement" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_bump", new IECore::BoolData( false ), false, "ignoreBump" ) );
-	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_motion_blur", new IECore::BoolData( false ), false, "ignoreMotionBlur" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_sss", new IECore::BoolData( false ), false, "ignoreSSS" ) );
 
 	// Searchpath parameters

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -3093,6 +3093,11 @@ class ArnoldGlobals
 			}
 			else if( boost::starts_with( name.c_str(), "ai:" ) )
 			{
+				if( name == "ai:ignore_motion_blur" )
+				{
+					IECore::msg( IECore::Msg::Warning, "IECoreArnold::Renderer::option", boost::format( "ai:ignore_motion_blur is not supported directly - set generic Gaffer option sampleMotion to False to control this option." ) );
+					return;
+				}
 				AtString arnoldName( name.c_str() + 3 );
 				const AtParamEntry *parameter = AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( options ), arnoldName );
 				if( parameter )


### PR DESCRIPTION
It conflicts with our standard option "sampleMotion", creating inconsistent results if both are set.  Simplying making sure we don't respond to ai:ignore_motion_blur fixes the problem, and printing out a message if it's set could help reduce confusion if someone is using it.