### PR TITLE
GafferUI : Move render() from Gadget to ViewportGadget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,11 +5,18 @@ API
 ---
 
 - GraphComponent : Inlined `children()` method, yielding 20-40% improvements in various child iteration benchmarks.
+- Gadget :
+  - Added `gadgetsAt()` overload which returns the gadgets rather than taking an output parameter by reference.
+  - Added `gadgetsAt()` overload taking a raster space region (rather than position) and an optional layer filter.
 
 Breaking Changes
 ----------------
 
 - FilteredChildIterator/FilteredRecursiveChildIterator : Removed all namespace-level typedefs, which were deprecated in Gaffer 0.59.0.0. Use the class-level typedefs instead, for example `Plug::Iterator` in place of `PlugIterator`.
+- Gadget :
+  - Moved `render()` and `renderRequestSignal()` to ViewportGadget.
+  - Made `select()` private.
+- ViewportGadget : Deprecated old `gadgetsAt()` signature. Please use the new form instead.
 
 0.60.0.0
 ========

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -97,11 +97,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 			Front = 2,
 		};
 
-		/// Returns the Gadget with the specified name, where name has been retrieved
-		/// from an IECoreGL::HitRecord after rendering some Gadget in GL_SELECT mode.
-		/// \todo Consider better mechanisms.
-		static GadgetPtr select( GLuint id );
-
 		/// @name Parent-child relationships
 		////////////////////////////////////////////////////////////////////
 		//@{
@@ -304,6 +299,11 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		void parentChanged( GraphComponent *oldParent ) override;
 
 	private :
+		/// Returns the Gadget with the specified name, where name has been retrieved
+		/// from an IECoreGL::HitRecord after rendering some Gadget in GL_SELECT mode.
+		/// \todo Consider better mechanisms.
+		static GadgetPtr select( GLuint id );
+
 
 		void styleChanged();
 		void emitDescendantVisibilityChanged();

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -190,8 +190,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		Imath::Box3f transformedBound() const;
 		/// The bounding box transformed by the result of fullTransform( ancestor ).
 		Imath::Box3f transformedBound( const Gadget *ancestor ) const;
-		typedef boost::signal<void ( Gadget * )> RenderRequestSignal;
-		RenderRequestSignal &renderRequestSignal();
 		//@}
 
 		/// @name Tool tips
@@ -302,8 +300,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// The default implementation returns true.
 		virtual bool hasLayer( Layer layer ) const;
 
-		/// \deprecated
-		void requestRender();
 		/// Implemented to dirty the layout for both the old and the new parent.
 		void parentChanged( GraphComponent *oldParent ) override;
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -71,6 +71,7 @@ namespace GafferUI
 
 IE_CORE_FORWARDDECLARE( Gadget );
 IE_CORE_FORWARDDECLARE( Style );
+IE_CORE_FORWARDDECLARE( ViewportGadget );
 
 /// Gadgets are zoomable UI elements. They draw themselves using OpenGL, and provide an interface for
 /// handling events. To present a Gadget in the user interface, it should be placed in the viewport of
@@ -87,6 +88,8 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 		enum class Layer
 		{
+			None = -100,
+
 			Back = -2,
 			MidBack = -1,
 			Main = 0,
@@ -179,13 +182,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// @name Display
 		////////////////////////////////////////////////////////////////////
 		//@{
-		/// Renders the Gadget into the current OpenGL context. If currentStyle
-		/// is passed then it must already have been bound with Style::bind(),
-		/// and will be used if and only if not overridden by a Style applied
-		/// specifically to this Gadget. Typically users will not pass currentStyle -
-		/// but it must be passed by Gadget implementations when rendering child
-		/// Gadgets in doRenderLayer().
-		void render() const;
 		/// The bounding box of the Gadget before transformation. The default
 		/// implementation returns the union of the transformed bounding boxes
 		/// of all the children.
@@ -313,10 +309,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 	private :
 
-		// Sets the GL state up with the name attribute and transform for
-		// this Gadget, makes sure the style is bound and then calls doRenderLayer().
-		void renderLayer( Layer layer, const Style *currentStyle = nullptr ) const;
-
 		void styleChanged();
 		void emitDescendantVisibilityChanged();
 
@@ -343,6 +335,9 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		// when absolutely necessary (when slots are connected).
 		static IdleSignal &idleSignalAccessedSignal();
 		friend void GafferUIModule::bindGadget();
+
+		/// ViewportGadget performs the actual rendering, and needs access to the internals of all the gadgets it renders
+		friend ViewportGadget;
 
 };
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -168,6 +168,10 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// to use V3fs?
 		void gadgetsAt( const Imath::V2f &rasterPosition, std::vector<GadgetPtr> &gadgets ) const;
 
+		/// A more flexible form of the above, this allows specifying a region to test instead of a point,
+		/// and optionally accepts filterLayer - if set, only Gadgets in this layer will be rendered
+		void gadgetsAt( const Imath::Box2f &rasterRegion, std::vector<GadgetPtr> &gadgets, Layer filterLayer = Layer::None ) const;
+
 		IECore::LineSegment3f rasterToGadgetSpace( const Imath::V2f &rasterPosition, const Gadget *gadget ) const;
 		Imath::V2f gadgetToRasterSpace( const Imath::V3f &gadgetPosition, const Gadget *gadget ) const;
 
@@ -203,7 +207,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 			private :
 
 				/// Private constructor for use by ViewportGadget.
-				SelectionScope( const ViewportGadget *viewportGadget, const Imath::V2f &rasterPosition, std::vector<IECoreGL::HitRecord> &selection, IECoreGL::Selector::Mode mode );
+				SelectionScope( const ViewportGadget *viewportGadget, const Imath::Box2f &rasterRegion, std::vector<IECoreGL::HitRecord> &selection, IECoreGL::Selector::Mode mode );
 				friend class ViewportGadget;
 
 				void begin( const ViewportGadget *viewportGadget, const Imath::V2f &rasterPosition, const Imath::M44f &transform, IECoreGL::Selector::Mode mode );
@@ -228,6 +232,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 
 		};
 
+		/// Renders the children of the viewport into the current OpenGL context.
 		void render() const;
 
 		/// A signal emitted just prior to rendering the viewport each time. This
@@ -236,6 +241,12 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		UnarySignal &preRenderSignal();
 
 	private :
+
+		void renderInternal( Layer filterLayer = Layer::None ) const;
+
+		// Sets the GL state up with the name attribute and transform for
+		// the Gadget, makes sure the style is bound and then calls doRenderLayer().
+		static void renderLayer( const Gadget *gadget, Layer layer, const Style *currentStyle = nullptr );
 
 		void childRemoved( GraphComponent *parent, GraphComponent *child );
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -240,6 +240,9 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// the viewport or its children.
 		UnarySignal &preRenderSignal();
 
+		typedef boost::signal<void ( ViewportGadget * )> RenderRequestSignal;
+		RenderRequestSignal &renderRequestSignal();
+
 	private :
 
 		void renderInternal( Layer filterLayer = Layer::None ) const;
@@ -311,6 +314,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		UnarySignal m_viewportChangedSignal;
 		UnarySignal m_cameraChangedSignal;
 		UnarySignal m_preRenderSignal;
+		RenderRequestSignal m_renderRequestSignal;
 
 };
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -166,11 +166,14 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// depth buffer if it exists or the drawing order if it doesn't.
 		/// \todo Would it be more convenient for this and the space conversion functions below
 		/// to use V3fs?
-		void gadgetsAt( const Imath::V2f &rasterPosition, std::vector<GadgetPtr> &gadgets ) const;
+		std::vector<Gadget*> gadgetsAt( const Imath::V2f &rasterPosition ) const;
 
 		/// A more flexible form of the above, this allows specifying a region to test instead of a point,
 		/// and optionally accepts filterLayer - if set, only Gadgets in this layer will be rendered
-		void gadgetsAt( const Imath::Box2f &rasterRegion, std::vector<GadgetPtr> &gadgets, Layer filterLayer = Layer::None ) const;
+		std::vector<Gadget*> gadgetsAt( const Imath::Box2f &rasterRegion, Layer filterLayer = Layer::None ) const;
+
+		[[deprecated("Use above form which returns vector")]]
+		void gadgetsAt( const Imath::V2f &rasterPosition, std::vector<GadgetPtr> &gadgets ) const;
 
 		IECore::LineSegment3f rasterToGadgetSpace( const Imath::V2f &rasterPosition, const Gadget *gadget ) const;
 		Imath::V2f gadgetToRasterSpace( const Imath::V3f &gadgetPosition, const Gadget *gadget ) const;
@@ -278,16 +281,16 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		void updateMotionState( const DragDropEvent &event, bool initialEvent = false );
 		Imath::V2f motionPositionFromEvent( const DragDropEvent &event ) const;
 
-		GadgetPtr updatedDragDestination( std::vector<GadgetPtr> &gadgets, const DragDropEvent &event );
+		Gadget* updatedDragDestination( std::vector<Gadget*> &gadgets, const DragDropEvent &event );
 
 		void trackDrag( const DragDropEvent &event );
 		void trackDragIdle();
 
 		template<typename Event, typename Signal>
-		typename Signal::result_type dispatchEvent( std::vector<GadgetPtr> &gadgets, Signal &(Gadget::*signalGetter)(), const Event &event, GadgetPtr &handler );
+		typename Signal::result_type dispatchEvent( std::vector<Gadget*> &gadgets, Signal &(Gadget::*signalGetter)(), const Event &event, Gadget* &handler );
 
 		template<typename Event, typename Signal>
-		typename Signal::result_type dispatchEvent( GadgetPtr gadget, Signal &(Gadget::*signalGetter)(), const Event &event );
+		typename Signal::result_type dispatchEvent( Gadget* gadget, Signal &(Gadget::*signalGetter)(), const Event &event );
 
 		class CameraController;
 		std::unique_ptr<CameraController> m_cameraController;

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -142,28 +142,33 @@ class GadgetTest( GafferUITest.TestCase ) :
 	def testRenderRequestOnStyleChange( self ) :
 
 		g = GafferUI.Gadget()
+		v = GafferUI.ViewportGadget()
+		v.addChild( g )
 
-		cs = GafferTest.CapturingSlot( g.renderRequestSignal() )
+		cs = GafferTest.CapturingSlot( v.renderRequestSignal() )
 		self.assertEqual( len( cs ), 0 )
 
 		s = GafferUI.StandardStyle()
 
 		g.setStyle( s )
 		self.assertEqual( len( cs ), 1 )
-		self.assertTrue( cs[0][0].isSame( g ) )
+		self.assertTrue( cs[0][0].isSame( v ) )
 
 		s2 = GafferUI.StandardStyle()
 		g.setStyle( s2 )
 		self.assertEqual( len( cs ), 2 )
-		self.assertTrue( cs[1][0].isSame( g ) )
+		self.assertTrue( cs[1][0].isSame( v ) )
 
 		s2.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 1 ) )
 		self.assertEqual( len( cs ), 3 )
-		self.assertTrue( cs[2][0].isSame( g ) )
+		self.assertTrue( cs[2][0].isSame( v ) )
 
 	def testHighlighting( self ) :
 
 		g = GafferUI.Gadget()
+		v = GafferUI.ViewportGadget()
+		v.addChild( g )
+
 		self.assertEqual( g.getHighlighted(), False )
 
 		g.setHighlighted( True )
@@ -172,14 +177,14 @@ class GadgetTest( GafferUITest.TestCase ) :
 		g.setHighlighted( False )
 		self.assertEqual( g.getHighlighted(), False )
 
-		cs = GafferTest.CapturingSlot( g.renderRequestSignal() )
+		cs = GafferTest.CapturingSlot( v.renderRequestSignal() )
 
 		g.setHighlighted( False )
 		self.assertEqual( len( cs ), 0 )
 
 		g.setHighlighted( True )
 		self.assertEqual( len( cs ), 1 )
-		self.assertTrue( cs[0][0].isSame( g ) )
+		self.assertTrue( cs[0][0].isSame( v ) )
 
 	def testVisibility( self ) :
 
@@ -215,7 +220,10 @@ class GadgetTest( GafferUITest.TestCase ) :
 	def testVisibilitySignals( self ) :
 
 		g = GafferUI.Gadget()
-		cs = GafferTest.CapturingSlot( g.renderRequestSignal() )
+		v = GafferUI.ViewportGadget()
+		v.addChild( g )
+
+		cs = GafferTest.CapturingSlot( v.renderRequestSignal() )
 		self.assertEqual( len( cs ), 0 )
 
 		g.setVisible( True )
@@ -223,15 +231,15 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 		g.setVisible( False )
 		self.assertEqual( len( cs ), 1 )
-		self.assertEqual( cs[0][0], g )
+		self.assertEqual( cs[0][0], v )
 
 		g.setVisible( False )
 		self.assertEqual( len( cs ), 1 )
-		self.assertEqual( cs[0][0], g )
+		self.assertEqual( cs[0][0], v )
 
 		g.setVisible( True )
 		self.assertEqual( len( cs ), 2 )
-		self.assertEqual( cs[1][0], g )
+		self.assertEqual( cs[1][0], v )
 
 	def testBoundIgnoresHiddenChildren( self ) :
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -85,7 +85,7 @@ SceneGadget::SceneGadget()
 	setOpenGLOptions( openGLOptions.get() );
 
 	m_controller.updateRequiredSignal().connect(
-		boost::bind( &SceneGadget::requestRender, this )
+		boost::bind( &SceneGadget::dirty, this, DirtyType::Layout )
 	);
 
 	visibilityChangedSignal().connect( boost::bind( &SceneGadget::visibilityChanged, this ) );

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -310,65 +310,6 @@ Imath::M44f Gadget::fullTransform( const Gadget *ancestor ) const
 	return result;
 }
 
-void Gadget::render() const
-{
-	bound(); // Updates layout if necessary
-	for( int layer = (int)Layer::Back; layer <= (int)Layer::Front; ++layer )
-	{
-		renderLayer( (Layer)layer, /* currentStyle = */ nullptr );
-	}
-}
-
-void Gadget::renderLayer( Layer layer, const Style *currentStyle ) const
-{
-	const bool haveTransform = m_transform != M44f();
-	if( haveTransform )
-	{
-		glPushMatrix();
-		glMultMatrixf( m_transform.getValue() );
-	}
-
-		if( !currentStyle )
-		{
-			currentStyle = style();
-			currentStyle->bind();
-		}
-		else
-		{
-			if( m_style )
-			{
-				m_style->bind();
-				currentStyle = m_style.get();
-			}
-		}
-
-		if( IECoreGL::Selector *selector = IECoreGL::Selector::currentSelector() )
-		{
-			selector->loadName( m_glName );
-		}
-
-		doRenderLayer( layer, currentStyle );
-
-		for( ChildContainer::const_iterator it=children().begin(); it!=children().end(); it++ )
-		{
-			// Cast is safe because of the guarantees acceptsChild() gives us
-			const Gadget *c = static_cast<const Gadget *>( it->get() );
-			if( !c->getVisible() )
-			{
-				continue;
-			}
-			if( c->hasLayer( layer ) )
-			{
-				c->renderLayer( layer, currentStyle );
-			}
-		}
-
-	if( haveTransform )
-	{
-		glPopMatrix();
-	}
-}
-
 void Gadget::dirty( DirtyType dirtyType )
 {
 	Gadget *g = this;

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -38,6 +38,7 @@
 #include "GafferUI/Gadget.h"
 
 #include "GafferUI/Style.h"
+#include "GafferUI/ViewportGadget.h"
 
 #include "IECoreGL/GL.h"
 #include "IECoreGL/NameStateComponent.h"
@@ -68,7 +69,6 @@ struct Gadget::Signals : boost::noncopyable
 {
 
 	VisibilityChangedSignal visibilityChangedSignal;
-	RenderRequestSignal renderRequestSignal;
 
 	ButtonSignal buttonPressSignal;
 	ButtonSignal buttonReleaseSignal;
@@ -189,7 +189,6 @@ void Gadget::setVisible( bool visible )
 		emitDescendantVisibilityChanged();
 		Signals::emitLazily( m_signals.get(), &Signals::visibilityChangedSignal, this );
 	}
-	Signals::emitLazily( m_signals.get(), &Signals::renderRequestSignal, this );
 	if( p )
 	{
 		p->dirty( DirtyType::Layout );
@@ -319,26 +318,27 @@ void Gadget::dirty( DirtyType dirtyType )
 		{
 			g->m_layoutDirty = true;
 		}
-		Signals::emitLazily( g->m_signals.get(), &Signals::renderRequestSignal, g );
 		if( dirtyType == DirtyType::Bound )
 		{
 			// Bounds changes in children require layout updates in parents.
 			dirtyType = DirtyType::Layout;
 		}
-		g = g->parent<Gadget>();
+		Gadget *p = g->parent<Gadget>();
+		if( !p )
+		{
+			// Found top level gadget, maybe it's a ViewportGadget
+			ViewportGadget *viewportGadget = IECore::runTimeCast<ViewportGadget>( g );
+			if( viewportGadget )
+			{
+				viewportGadget->renderRequestSignal()( viewportGadget );
+			}
+		}
+		g = p;
 	}
 }
 
 void Gadget::updateLayout() const
 {
-}
-
-void Gadget::requestRender()
-{
-	// `requestRender()` has been deprecated and replaced by `dirty()` because
-	// it didn't provide the fine-grained control we need. Where extension code
-	// is still using it, we must assume the worst and dirty the layout.
-	dirty( DirtyType::Layout );
 }
 
 void Gadget::doRenderLayer( Layer layer, const Style *style ) const
@@ -386,11 +386,6 @@ Imath::Box3f Gadget::transformedBound( const Gadget *ancestor ) const
 {
 	Box3f b = bound();
 	return transform( b, fullTransform( ancestor ) );
-}
-
-Gadget::RenderRequestSignal &Gadget::renderRequestSignal()
-{
-	return signals()->renderRequestSignal;
 }
 
 std::string Gadget::getToolTip( const IECore::LineSegment3f &position ) const

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -682,10 +682,8 @@ NodeGadget *GraphGadget::nodeGadgetAt( const IECore::LineSegment3f &lineInGadget
 {
 	const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
 
-	std::vector<GadgetPtr> gadgetsUnderMouse;
-	viewportGadget->gadgetsAt(
-		viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, this ),
-		gadgetsUnderMouse
+	std::vector<Gadget*> gadgetsUnderMouse = viewportGadget->gadgetsAt(
+		viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, this )
 	);
 
 	if( !gadgetsUnderMouse.size() )
@@ -693,7 +691,7 @@ NodeGadget *GraphGadget::nodeGadgetAt( const IECore::LineSegment3f &lineInGadget
 		return nullptr;
 	}
 
-	NodeGadget *nodeGadget = runTimeCast<NodeGadget>( gadgetsUnderMouse[0].get() );
+	NodeGadget *nodeGadget = runTimeCast<NodeGadget>( gadgetsUnderMouse[0] );
 	if( !nodeGadget )
 	{
 		nodeGadget = gadgetsUnderMouse[0]->ancestor<NodeGadget>();
@@ -706,15 +704,16 @@ ConnectionGadget *GraphGadget::connectionGadgetAt( const IECore::LineSegment3f &
 {
 	const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
 
-	std::vector<GadgetPtr> gadgetsUnderMouse;
-	viewportGadget->gadgetsAt( viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, this ), gadgetsUnderMouse );
+	std::vector<Gadget*> gadgetsUnderMouse = viewportGadget->gadgetsAt(
+		viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, this )
+	);
 
 	if ( !gadgetsUnderMouse.size() )
 	{
 		return nullptr;
 	}
 
-	ConnectionGadget *connectionGadget = runTimeCast<ConnectionGadget>( gadgetsUnderMouse[0].get() );
+	ConnectionGadget *connectionGadget = runTimeCast<ConnectionGadget>( gadgetsUnderMouse[0] );
 	if ( !connectionGadget )
 	{
 		connectionGadget = gadgetsUnderMouse[0]->ancestor<ConnectionGadget>();
@@ -732,11 +731,12 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 	rasterRegion.extendBy( viewportGadget->gadgetToRasterSpace( center - Imath::V3f( 2, 2, 1 ), this ) );
 	rasterRegion.extendBy( viewportGadget->gadgetToRasterSpace( center + Imath::V3f( 2, 2, 1 ), this ) );
 
-	std::vector<GadgetPtr> gadgetsUnderMouse;
-	viewportGadget->gadgetsAt( rasterRegion, gadgetsUnderMouse, GraphLayer::Connections );
-	for( const GadgetPtr &g : gadgetsUnderMouse )
+	std::vector<Gadget*> gadgetsUnderMouse = viewportGadget->gadgetsAt(
+		rasterRegion, GraphLayer::Connections
+	);
+	for( Gadget* g : gadgetsUnderMouse )
 	{
-		if( ConnectionGadget *c = IECore::runTimeCast<ConnectionGadget>( g.get() ) )
+		if( ConnectionGadget *c = IECore::runTimeCast<ConnectionGadget>( g ) )
 		{
 			if(
 				c->srcNodule() &&
@@ -1017,10 +1017,8 @@ bool GraphGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 
 		ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
 
-		std::vector<GadgetPtr> gadgetsUnderMouse;
-		viewportGadget->gadgetsAt(
-			viewportGadget->gadgetToRasterSpace( event.line.p0, this ),
-			gadgetsUnderMouse
+		std::vector<Gadget*> gadgetsUnderMouse = viewportGadget->gadgetsAt(
+			viewportGadget->gadgetToRasterSpace( event.line.p0, this )
 		);
 
 		if( !gadgetsUnderMouse.size() || gadgetsUnderMouse[0] == this )
@@ -1034,7 +1032,7 @@ bool GraphGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 			return true;
 		}
 
-		NodeGadget *nodeGadget = runTimeCast<NodeGadget>( gadgetsUnderMouse[0].get() );
+		NodeGadget *nodeGadget = runTimeCast<NodeGadget>( gadgetsUnderMouse[0] );
 		if( !nodeGadget )
 		{
 			nodeGadget = gadgetsUnderMouse[0]->ancestor<NodeGadget>();

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1087,6 +1087,11 @@ ViewportGadget::UnarySignal &ViewportGadget::preRenderSignal()
 	return m_preRenderSignal;
 }
 
+ViewportGadget::RenderRequestSignal &ViewportGadget::renderRequestSignal()
+{
+	return m_renderRequestSignal;
+}
+
 void ViewportGadget::childRemoved( GraphComponent *parent, GraphComponent *child )
 {
 	const Gadget *childGadget = static_cast<const Gadget *>( child );

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -56,7 +56,7 @@ using namespace GafferUI;
 namespace
 {
 
-struct RenderRequestSlotCaller
+struct VisibilityChangedSlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, GadgetPtr g )
 	{
@@ -195,7 +195,6 @@ void GafferUIModule::bindGadget()
 		.def( "fullTransform", &Gadget::fullTransform, fullTransformOverloads() )
 		.def( "transformedBound", (Imath::Box3f (Gadget::*)() const)&Gadget::transformedBound )
 		.def( "transformedBound", (Imath::Box3f (Gadget::*)( const Gadget * ) const)&Gadget::transformedBound )
-		.def( "renderRequestSignal", &Gadget::renderRequestSignal, return_internal_reference<1>() )
 		.def( "setToolTip", &Gadget::setToolTip )
 		.def( "buttonPressSignal", &Gadget::buttonPressSignal, return_internal_reference<1>() )
 		.def( "buttonReleaseSignal", &Gadget::buttonReleaseSignal, return_internal_reference<1>() )
@@ -217,7 +216,6 @@ void GafferUIModule::bindGadget()
 		.def( "_idleSignalAccessedSignal", &Gadget::idleSignalAccessedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "_idleSignalAccessedSignal" )
 		.def( "_dirty", &Gadget::dirty )
-		.def( "_requestRender", &Gadget::requestRender )
 		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
 
@@ -235,7 +233,7 @@ void GafferUIModule::bindGadget()
 		.value( "Layout", Gadget::DirtyType::Layout )
 	;
 
-	SignalClass<Gadget::RenderRequestSignal, DefaultSignalCaller<Gadget::RenderRequestSignal>, RenderRequestSlotCaller>( "RenderRequestSignal" );
+	SignalClass<Gadget::VisibilityChangedSignal, DefaultSignalCaller<Gadget::VisibilityChangedSignal>, VisibilityChangedSlotCaller>( "VisibilityChangedSignal" );
 	SignalClass<Gadget::ButtonSignal, DefaultSignalCaller<Gadget::ButtonSignal>, ButtonSlotCaller>( "ButtonSignal" );
 	SignalClass<Gadget::KeySignal, DefaultSignalCaller<Gadget::KeySignal>, KeySlotCaller>( "KeySignal" );
 	SignalClass<Gadget::DragBeginSignal, DefaultSignalCaller<Gadget::DragBeginSignal>, DragBeginSlotCaller>( "DragBeginSignal" );

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -168,12 +168,6 @@ void setEnabled( Gadget &g, bool enabled )
 	g.setEnabled( enabled );
 }
 
-void render( const Gadget &g )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	g.render();
-}
-
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( fullTransformOverloads, fullTransform, 0, 1 );
 
 } // namespace
@@ -201,7 +195,6 @@ void GafferUIModule::bindGadget()
 		.def( "fullTransform", &Gadget::fullTransform, fullTransformOverloads() )
 		.def( "transformedBound", (Imath::Box3f (Gadget::*)() const)&Gadget::transformedBound )
 		.def( "transformedBound", (Imath::Box3f (Gadget::*)( const Gadget * ) const)&Gadget::transformedBound )
-		.def( "render", &render )
 		.def( "renderRequestSignal", &Gadget::renderRequestSignal, return_internal_reference<1>() )
 		.def( "setToolTip", &Gadget::setToolTip )
 		.def( "buttonPressSignal", &Gadget::buttonPressSignal, return_internal_reference<1>() )

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -170,6 +170,7 @@ void GafferUIModule::bindViewportGadget()
 		.def( "worldToRasterSpace", &ViewportGadget::worldToRasterSpace, ( arg_( "worldPosition" ) ) )
 		.def( "render", &render )
 		.def( "preRenderSignal", &ViewportGadget::preRenderSignal, return_internal_reference<1>() )
+		.def( "renderRequestSignal", &ViewportGadget::renderRequestSignal, return_internal_reference<1>() )
 	;
 
 	enum_<ViewportGadget::DragTracking>( "DragTracking" )

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -96,13 +96,12 @@ void fitClippingPlanes( ViewportGadget &v, const Imath::Box3f &box )
 
 list gadgetsAt( ViewportGadget &v, const Imath::V2f &position )
 {
-	std::vector<GadgetPtr> gadgets;
-	v.gadgetsAt( position, gadgets );
+	std::vector<Gadget*> gadgets = v.gadgetsAt( position );
 
 	boost::python::list result;
-	for( std::vector<GadgetPtr>::const_iterator it=gadgets.begin(); it!=gadgets.end(); it++ )
+	for( Gadget *gadget : gadgets )
 	{
-		result.append( *it );
+		result.append( GadgetPtr( gadget ) );
 	}
 	return result;
 }

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -106,6 +106,18 @@ list gadgetsAt( ViewportGadget &v, const Imath::V2f &position )
 	return result;
 }
 
+list gadgetsAt2( ViewportGadget &v, const Imath::Box2f &region, Gadget::Layer filterLayer = Gadget::Layer::None )
+{
+	std::vector<Gadget*> gadgets = v.gadgetsAt( region, filterLayer );
+
+	boost::python::list result;
+	for( Gadget *gadget : gadgets )
+	{
+		result.append( GadgetPtr( gadget ) );
+	}
+	return result;
+}
+
 struct UnarySlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, ViewportGadgetPtr g )
@@ -163,6 +175,7 @@ void GafferUIModule::bindViewportGadget()
 		.def( "setVariableAspectZoom", &ViewportGadget::setVariableAspectZoom )
 		.def( "getVariableAspectZoom", &ViewportGadget::getVariableAspectZoom )
 		.def( "gadgetsAt", &gadgetsAt )
+		.def( "gadgetsAt", &gadgetsAt2, ( arg_( "rasterRegion" ), arg_( "filterLayer" ) = Gadget::Layer::None )  )
 		.def( "rasterToGadgetSpace", &ViewportGadget::rasterToGadgetSpace, ( arg_( "rasterPosition" ), arg_( "gadget" ) ) )
 		.def( "gadgetToRasterSpace", &ViewportGadget::gadgetToRasterSpace, ( arg_( "gadgetPosition" ), arg_( "gadget" ) ) )
 		.def( "rasterToWorldSpace", &ViewportGadget::rasterToWorldSpace, ( arg_( "rasterPosition" ) ) )


### PR DESCRIPTION
This is an exploration of an API change that would make it easier for ViewportGadget to cache some extra data that could accelerate calls to render(). This is easier if we don't need to support render() from any Gadget, and it seems to make sense to just support it on ViewportGadget.

There are two potentially troublesome parts here:
* needing ViewportGadget to be a friend of Gadget ( since there are internal bits like m_glName that are needed during rendering )
* filterTypeId is not a good mechanism for selecting a subset of nodes to render ( particularly since I'm currently hardcoding to StandardConnectionGadget, whereas I guess I should be supporting any class derived from ConnectionGadget? ).   Any better ideas?