### PR TITLE
RendererAlgo::outputOutputs : Fix typo and clarify wording of warning

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Process : Added warning messages for processes which don't respond promptly to cancellation.
 
+Fixes
+-----
+
+- RendererAlgo::outputOutputs : Fix typo and clarify wording of warning
+
 0.60.0.0
 ========
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1473,8 +1473,8 @@ ConstOutputPtr addGafferOutputHeaders( const Output *output, const ScenePlug *sc
 			default :
 				IECore::msg(
 					IECore::Msg::Debug,
-					"GafferScene::RendereAlgo",
-					boost::format(  "Unsupported data type for Context variable \"%s\" (%s), unable to add header" ) % name % data->typeName()
+					"GafferScene::RendererAlgo",
+					boost::format(  "Unsupported data type for Context variable \"%s\" (%s), unable to add this variable to output image header" ) % name % data->typeName()
 				);
 		};
 	}


### PR DESCRIPTION
The type "RendereAlgo" bothered Andrew, and while I was in there, I thought it was worth clarifying both that this is specific to outputting the image header ( which wasn't totally obvious in the log ), and that only this variable failed - it didn't abort the whole header.