### PR TITLE
Gadget render optimization

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,18 @@
 0.61.x.x
 ========
 
+Improvements
+------------
+
+- GraphEditor : Improved drawing performance for large node graphs, about 40% in general, with much greater gains when looking at a small region of a large graph, and even more gains for selection tests ( for example when hovering over something or dragging a noodle )
+
 API
 ---
 
 - GraphComponent : Inlined `children()` method, yielding 20-40% improvements in various child iteration benchmarks.
 - Gadget :
+  - Added `layerMask()` and `renderBound()` virtual functions.
+- ViewportGadget :
   - Added `gadgetsAt()` overload which returns the gadgets rather than taking an output parameter by reference.
   - Added `gadgetsAt()` overload taking a raster space region (rather than position) and an optional layer filter.
 
@@ -15,7 +22,9 @@ Breaking Changes
 - FilteredChildIterator/FilteredRecursiveChildIterator : Removed all namespace-level typedefs, which were deprecated in Gaffer 0.59.0.0. Use the class-level typedefs instead, for example `Plug::Iterator` in place of `PlugIterator`.
 - Gadget :
   - Moved `render()` and `renderRequestSignal()` to ViewportGadget.
-  - Made `select()` private.
+  - Removed `select()` method.
+  - Replaced `hasLayer()` virtual function with `layerMask()`.
+  - Added `renderBound()` virtual function.
 - ViewportGadget : Deprecated old `gadgetsAt()` signature. Please use the new form instead.
 - ArnoldOptions : Removed support for the `ai:ignore_motion_blur` option. Turn off the `sampleMotion` option using a StandardOptions node instead.
 

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -165,6 +165,7 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 
 		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -164,6 +164,7 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -171,6 +171,7 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 
 		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -170,6 +170,7 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const GafferUI::Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -80,6 +80,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -79,6 +79,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -86,6 +86,7 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -87,6 +87,7 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -93,6 +93,7 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -94,6 +94,7 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/AuxiliaryNodeGadget.h
+++ b/include/GafferUI/AuxiliaryNodeGadget.h
@@ -57,6 +57,7 @@ class GAFFERUI_API AuxiliaryNodeGadget : public NodeGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/AuxiliaryNodeGadget.h
+++ b/include/GafferUI/AuxiliaryNodeGadget.h
@@ -58,6 +58,7 @@ class GAFFERUI_API AuxiliaryNodeGadget : public NodeGadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -72,6 +72,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -71,6 +71,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/CompoundNumericNodule.h
+++ b/include/GafferUI/CompoundNumericNodule.h
@@ -69,6 +69,7 @@ class GAFFERUI_API CompoundNumericNodule : public StandardNodule
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/CompoundNumericNodule.h
+++ b/include/GafferUI/CompoundNumericNodule.h
@@ -68,6 +68,7 @@ class GAFFERUI_API CompoundNumericNodule : public StandardNodule
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/DotNodeGadget.h
+++ b/include/GafferUI/DotNodeGadget.h
@@ -64,6 +64,7 @@ class GAFFERUI_API DotNodeGadget : public StandardNodeGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/Frame.h
+++ b/include/GafferUI/Frame.h
@@ -60,6 +60,7 @@ class GAFFERUI_API Frame : public IndividualContainer
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/Frame.h
+++ b/include/GafferUI/Frame.h
@@ -59,6 +59,7 @@ class GAFFERUI_API Frame : public IndividualContainer
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -287,7 +287,8 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 		/// Should be implemented by subclasses to draw themselves as appropriate
 		/// for the specified layer. Child gadgets will be drawn automatically
-		/// _after_ the parent gadget has been drawn.
+		/// _after_ the parent gadget has been drawn.  Whenever overriding this,
+		/// you must override layerMask and renderBound() as well.
 		virtual void doRenderLayer( Layer layer, const Style *style ) const;
 
 		/// Returns a bitmask built from the flags in the Layer enum.
@@ -296,6 +297,9 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// layerMask must currently return a constant value.  In the future, we
 		/// may implement a new DirtyType to allow dirtying the layerMask
 		virtual unsigned layerMask() const;
+
+		/// The bound of everything drawn by doRenderLayer
+		virtual Imath::Box3f renderBound() const;
 
 		/// Implemented to dirty the layout for both the old and the new parent.
 		void parentChanged( GraphComponent *oldParent ) override;

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -88,13 +88,12 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 		enum class Layer
 		{
-			None = -100,
-
-			Back = -2,
-			MidBack = -1,
-			Main = 0,
-			MidFront = 1,
-			Front = 2,
+			None = 0,
+			Back = 1,
+			MidBack = 2,
+			Main = 4,
+			MidFront = 8,
+			Front = 16,
 		};
 
 		/// @name Parent-child relationships
@@ -290,10 +289,13 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// for the specified layer. Child gadgets will be drawn automatically
 		/// _after_ the parent gadget has been drawn.
 		virtual void doRenderLayer( Layer layer, const Style *style ) const;
-		/// May return false to indicate that neither this gadget nor any
-		/// of its children will render anything for the specified layer.
-		/// The default implementation returns true.
-		virtual bool hasLayer( Layer layer ) const;
+
+		/// Returns a bitmask built from the flags in the Layer enum.
+		/// Any subclass which implements doRenderLayer must also implement layerMask
+		/// to indicate which layers doRenderLayer should be called for.
+		/// layerMask must currently return a constant value.  In the future, we
+		/// may implement a new DirtyType to allow dirtying the layerMask
+		virtual unsigned layerMask() const;
 
 		/// Implemented to dirty the layout for both the old and the new parent.
 		void parentChanged( GraphComponent *oldParent ) override;
@@ -335,6 +337,20 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		friend ViewportGadget;
 
 };
+
+
+/// Allow for clients to succinctly write bitmasks as Back | Main | Front
+inline unsigned operator| ( Gadget::Layer a, Gadget::Layer b )
+{
+	return (unsigned)a | (unsigned)b;
+}
+
+inline unsigned operator| ( unsigned a, Gadget::Layer b )
+{
+	return a | (unsigned)b;
+}
+
+
 
 } // namespace GafferUI
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -301,17 +301,11 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		void parentChanged( GraphComponent *oldParent ) override;
 
 	private :
-		/// Returns the Gadget with the specified name, where name has been retrieved
-		/// from an IECoreGL::HitRecord after rendering some Gadget in GL_SELECT mode.
-		/// \todo Consider better mechanisms.
-		static GadgetPtr select( GLuint id );
-
 		void styleChanged();
 		void emitDescendantVisibilityChanged();
 
 		ConstStylePtr m_style;
 
-		GLuint m_glName;
 		bool m_visible;
 		bool m_enabled;
 		bool m_highlighted;

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -304,7 +304,6 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// \todo Consider better mechanisms.
 		static GadgetPtr select( GLuint id );
 
-
 		void styleChanged();
 		void emitDescendantVisibilityChanged();
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -270,10 +270,14 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 			/// A re-render is needed, but the bounding box
 			/// and layout remain the same.
 			Render,
-			/// The bounding box has changed. Implies Render.
+			/// The result of renderBound() has changed, but the layout bounds have not.
+			/// Internal render caches which depend on the render bounds need to be rebuilt,
+			/// but we don't need to re-layout
+			RenderBound,
+			/// The layout bounding box has changed. Implies RenderBound and Render.
 			Bound,
 			/// Parameters used by `updateLayout()` have changed.
-			/// Implies Bound and Render.
+			/// Implies Bound, RenderBound and Render.
 			Layout,
 		};
 

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -133,7 +133,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// unless the same is true for all its ancestors.
 		void setVisible( bool visible );
 		/// Returns the visibility status for this Gadget.
-		bool getVisible() const;
+		bool getVisible() const { return m_visible; }
 		/// Returns true if this Gadget and all its parents up to the specified
 		/// ancestor are visible.
 		bool visible( Gadget *relativeTo = nullptr ) const;

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -191,6 +191,7 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -190,6 +190,7 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -71,6 +71,7 @@ class GAFFERUI_API Handle : public Gadget
 		// the raster scale.
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 		// Must be implemented by derived classes to draw their
 		// handle.

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -70,7 +70,7 @@ class GAFFERUI_API Handle : public Gadget
 		// Implemented to call renderHandle() after applying
 		// the raster scale.
 		void doRenderLayer( Layer layer, const Style *style ) const override;
-		bool hasLayer( Layer layer ) const override;
+		unsigned layerMask() const override;
 
 		// Must be implemented by derived classes to draw their
 		// handle.

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -84,6 +84,7 @@ class GAFFERUI_API ImageGadget : public Gadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -83,6 +83,7 @@ class GAFFERUI_API ImageGadget : public Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -98,11 +98,6 @@ class GAFFERUI_API NoduleLayout : public Gadget
 		/// "noduleLayout:customGadget:*"" metadata entries.
 		static void registerCustomGadget( const std::string &gadgetType, CustomGadgetCreator creator );
 
-
-	protected :
-
-		bool hasLayer( Layer layer ) const override;
-
 	private :
 
 		LinearContainer *noduleContainer();

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -71,6 +71,7 @@ class GAFFERUI_API PlugAdder : public ConnectionCreator
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 		void applyEdgeMetadata( Gaffer::Plug *plug, bool opposite = false ) const;
 

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -72,6 +72,7 @@ class GAFFERUI_API PlugAdder : public ConnectionCreator
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 		void applyEdgeMetadata( Gaffer::Plug *plug, bool opposite = false ) const;
 

--- a/include/GafferUI/SpacerGadget.h
+++ b/include/GafferUI/SpacerGadget.h
@@ -60,10 +60,6 @@ class GAFFERUI_API SpacerGadget : public Gadget
 		/// Rejects all children.
 		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 
-	protected :
-
-		void doRenderLayer( Layer layer, const Style *style ) const override;
-
 	private :
 
 		Imath::Box3f m_bound;

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -77,6 +77,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -76,7 +76,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
-		bool hasLayer( Layer layer ) const override;
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -104,7 +104,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
-		bool hasLayer( Layer layer ) const override;
+		unsigned layerMask() const override;
 
 		const Imath::Color3f *userColor() const;
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -105,6 +105,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 		const Imath::Color3f *userColor() const;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -75,6 +75,7 @@ class GAFFERUI_API StandardNodule : public Nodule
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 		void renderLabel( const Style *style ) const;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -73,8 +73,8 @@ class GAFFERUI_API StandardNodule : public Nodule
 
 	protected :
 
-		bool hasLayer( Layer layer ) const override;
 		void doRenderLayer( Layer layer, const Style *style ) const override;
+		unsigned layerMask() const override;
 
 		void renderLabel( const Style *style ) const;
 

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -64,6 +64,7 @@ class GAFFERUI_API TextGadget : public Gadget
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
 		unsigned layerMask() const override;
+		Imath::Box3f renderBound() const override;
 
 	private :
 

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -63,7 +63,7 @@ class GAFFERUI_API TextGadget : public Gadget
 	protected :
 
 		void doRenderLayer( Layer layer, const Style *style ) const override;
-		bool hasLayer( Layer layer ) const override { return layer == Layer::Main; };
+		unsigned layerMask() const override;
 
 	private :
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -260,6 +260,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 			const Style *style;
 			const Imath::M44f transform;
 			const Imath::Box3f bound;
+			const unsigned layerMask;
 		};
 		mutable std::vector<RenderItem> m_renderItems;
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -248,6 +248,23 @@ class GAFFERUI_API ViewportGadget : public Gadget
 
 	private :
 
+		// Called by `Gadget::dirty()` to notify ViewportGadget of changes
+		// that may affect the rendering it is responsible for.
+		void childDirtied( DirtyType dirtyType );
+
+		friend class Gadget;
+
+		struct RenderItem
+		{
+			const Gadget *gadget;
+			const Style *style;
+			const Imath::M44f transform;
+			const Imath::Box3f bound;
+		};
+		mutable std::vector<RenderItem> m_renderItems;
+
+		static void getRenderItems( const Gadget *gadget,  Imath::M44f transform, const Style *parentStyle, std::vector<RenderItem> &renderItems );
+
 		void renderInternal( Layer filterLayer = Layer::None ) const;
 
 		// Sets the GL state up with the name attribute and transform for

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -197,6 +197,27 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			return WrappedType::layerMask();
 		}
 
+		Imath::Box3f renderBound() const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "renderBound" );
+					if( f )
+					{
+						return boost::python::extract<Imath::Box3f>( f() );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::bound();
+		}
+
 };
 
 } // namespace GafferUIBindings

--- a/include/GafferUIBindings/GadgetBinding.h
+++ b/include/GafferUIBindings/GadgetBinding.h
@@ -176,6 +176,27 @@ class GadgetWrapper : public GafferBindings::GraphComponentWrapper<WrappedType>
 			WrappedType::doRenderLayer( layer, style );
 		}
 
+		unsigned layerMask() const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "layerMask" );
+					if( f )
+					{
+						return boost::python::extract<unsigned>( f() );
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::layerMask();
+		}
+
 };
 
 } // namespace GafferUIBindings

--- a/python/GafferSceneUITest/CropWindowToolTest.py
+++ b/python/GafferSceneUITest/CropWindowToolTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import IECore
 import Gaffer
 import GafferImage
 import GafferScene
@@ -139,7 +140,15 @@ class CropWindowToolTest( GafferUITest.TestCase ) :
 
 		script["image"]["fileName"].setValue( "${GAFFER_ROOT}/resources/images/macaw.exr" )
 
-		self.waitForIdle( 1000 )
+		with IECore.CapturingMessageHandler() as mh :
+			self.waitForIdle( 1000 )
+
+		# Don't fail due to running on computer that can't do GPU color transforms well
+		if len( mh.messages ):
+			self.assertEqual( len( mh.messages ), 1 )
+			self.assertEqual( mh.messages[0].context, "ImageGadget" )
+			self.assertTrue( mh.messages[0].message.startswith( "Could not find supported floating point texture format in OpenGL" ) )
+
 		self.assertEqual( tool.status(), "Error: No <b>gaffer:sourceScene</b> metadata in image" )
 
 		script["meta"] = GafferImage.ImageMetadata()
@@ -153,8 +162,9 @@ class CropWindowToolTest( GafferUITest.TestCase ) :
 		# Valid options path
 
 		self.waitForIdle( 1000 )
-		self.assertEqual( tool.status(), "Info: Editing <b>options.options.renderCropWindow.value</b>" )
 
+
+		self.assertEqual( tool.status(), "Info: Editing <b>options.options.renderCropWindow.value</b>" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -101,6 +101,10 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 				return functools.reduce( operator.or_, layers )
 
+			def renderBound( self ) :
+
+				return b
+
 		mg = MyGadget()
 
 		# we can't call the methods of the gadget directly in python to test the

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -344,10 +344,6 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 				self.setTransform( imath.M44f().translate( imath.V3f( t[0], t[1], 0 ) ) )
 				self.layer = layer
 
-			def bound( self ) :
-
-				return imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) )
-
 			def doRenderLayer( self, layer, style ) :
 
 				style.renderSolidRectangle( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
@@ -355,6 +351,11 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 			def layerMask( self ) :
 
 				return self.layer
+
+			def renderBound( self ) :
+
+				return imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) )
+
 
 
 		a = TestGadget( "A", ( 0.5, 0.5 ), GafferUI.Gadget.Layer.Main )

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -328,5 +328,68 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 		m.removeScalingAndShear()
 		self.assertEqual( v.getCameraTransform(), m )
 
+	def testGadgetsAt( self ) :
+
+		with GafferUI.Window() as w :
+			gw = GafferUI.GadgetWidget()
+
+		v = gw.getViewportGadget()
+
+		class TestGadget( GafferUI.Gadget ) :
+
+			def __init__( self, name, t, layer ) :
+
+				GafferUI.Gadget.__init__( self )
+				self.setName( name )
+				self.setTransform( imath.M44f().translate( imath.V3f( t[0], t[1], 0 ) ) )
+				self.layer = layer
+
+			def bound( self ) :
+
+				return imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) )
+
+			def doRenderLayer( self, layer, style ) :
+
+				style.renderSolidRectangle( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+
+			def layerMask( self ) :
+
+				return self.layer
+
+
+		a = TestGadget( "A", ( 0.5, 0.5 ), GafferUI.Gadget.Layer.Main )
+		b = TestGadget( "B", ( 2.5, 0.5 ), GafferUI.Gadget.Layer.Back )
+		c = TestGadget( "C", ( 0.5, 2.5 ), GafferUI.Gadget.Layer.MidFront )
+		d = TestGadget( "D", ( 2.5, 2.5 ), GafferUI.Gadget.Layer.MidFront )
+		v.addChild( a )
+		v.addChild( b )
+		v.addChild( c )
+		v.addChild( d )
+
+		w.setVisible( True )
+		self.waitForIdle( 1000 )
+
+		v.setViewport( imath.V2i( 100 ) )
+		v.frame( imath.Box3f( imath.V3f( 0 ), imath.V3f( 4 ) ) )
+
+		# Single point form
+		self.assertEqual( v.gadgetsAt( imath.V2f( 2, 2 ) ), [] )
+		self.assertEqual( v.gadgetsAt( imath.V2f( 25, 75 ) ), [a] )
+		self.assertEqual( v.gadgetsAt( imath.V2f( 75, 75 ) ), [b] )
+		self.assertEqual( v.gadgetsAt( imath.V2f( 25, 25 ) ), [c] )
+		self.assertEqual( v.gadgetsAt( imath.V2f( 75, 25 ) ), [d] )
+
+		# Region form
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 100, 100 ) ) ) ), set( [a,b,c,d ] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 0, 50 ), imath.V2f( 100, 100 ) ) ) ), set( [a,b] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 50, 0 ), imath.V2f( 100, 100 ) ) ) ), set( [b,d] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 50, 50 ), imath.V2f( 100, 100 ) ) ) ), set( [b] ) )
+
+		# Using filterLayer
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 100, 100 ) ), GafferUI.Gadget.Layer.Main ) ), set( [a] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 100, 100 ) ), GafferUI.Gadget.Layer.Back ) ), set( [b] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 100, 100 ) ), GafferUI.Gadget.Layer.MidFront ) ), set( [c,d] ) )
+		self.assertEqual( set( v.gadgetsAt( imath.Box2f( imath.V2f( 50, 0 ), imath.V2f( 100, 100 ) ), GafferUI.Gadget.Layer.MidFront ) ), set( [d] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -1372,3 +1372,8 @@ void ImageGadget::doRenderLayer( Layer layer, const GafferUI::Style *style ) con
 		}
 	}
 }
+
+unsigned ImageGadget::layerMask() const
+{
+	return (unsigned)Layer::Main;
+}

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -1377,3 +1377,8 @@ unsigned ImageGadget::layerMask() const
 {
 	return (unsigned)Layer::Main;
 }
+
+Imath::Box3f ImageGadget::renderBound() const
+{
+	return bound();
+}

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -559,6 +559,16 @@ class Box2iGadget : public GafferUI::Gadget
 			return (unsigned)Layer::Main;
 		}
 
+		Imath::Box3f renderBound() const override
+		{
+			// We draw handles outside the box, so we need to extend outside box - since we
+			// don't usually have many Box2iGadgets at once, we return infinite rather than
+			// finessing the overrender
+			Box3f b;
+			b.makeInfinite();
+			return b;
+		}
+
 	private :
 
 		void plugDirtied( Plug *plug )
@@ -941,6 +951,16 @@ class V2iGadget : public GafferUI::Gadget
 		unsigned layerMask() const override
 		{
 			return (unsigned)Layer::Main;
+		}
+
+		Imath::Box3f renderBound() const override
+		{
+			// We draw handles outside the box, so we need to extend outside box - since we
+			// don't usually have many Box2iGadgets at once, we return infinite rather than
+			// finessing the overrender
+			Box3f b;
+			b.makeInfinite();
+			return b;
 		}
 
 	private :

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -554,6 +554,11 @@ class Box2iGadget : public GafferUI::Gadget
 			glPopMatrix();
 		}
 
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
+		}
+
 	private :
 
 		void plugDirtied( Plug *plug )
@@ -931,6 +936,11 @@ class V2iGadget : public GafferUI::Gadget
 			glPopAttrib();
 
 			glPopMatrix();
+		}
+
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
 		}
 
 	private :

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -270,6 +270,11 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 
 		}
 
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
+		}
+
 	private :
 
 		void setRectangleInternal( const Imath::Box2f &rectangle, RectangleChangedReason reason )

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -275,6 +275,21 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 			return (unsigned)Layer::Main;
 		}
 
+		Imath::Box3f renderBound() const override
+		{
+			if( m_rasterSpace )
+			{
+				// We draw in raster space so don't have a sensible bound
+				Box3f b;
+				b.makeInfinite();
+				return b;
+			}
+			else
+			{
+				return bound();
+			}
+		}
+
 	private :
 
 		void setRectangleInternal( const Imath::Box2f &rectangle, RectangleChangedReason reason )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -476,6 +476,11 @@ void SceneGadget::doRenderLayer( Layer layer, const GafferUI::Style *style ) con
 	renderScene();
 }
 
+unsigned SceneGadget::layerMask() const
+{
+	return (unsigned)Layer::Main;
+}
+
 void SceneGadget::updateRenderer()
 {
 	if( m_paused )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -481,6 +481,15 @@ unsigned SceneGadget::layerMask() const
 	return (unsigned)Layer::Main;
 }
 
+Imath::Box3f SceneGadget::renderBound() const
+{
+	// The SceneGadget can render things outside it's layout, such as a Camera frustum, so it
+	// needs an infinite render bound
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 void SceneGadget::updateRenderer()
 {
 	if( m_paused )

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -997,6 +997,14 @@ class CameraOverlay : public GafferUI::Gadget
 			return (unsigned)Layer::Main;
 		}
 
+		Imath::Box3f renderBound() const override
+		{
+			// we draw in raster space so don't have a sensible bound
+			Box3f b;
+			b.makeInfinite();
+			return b;
+		}
+
 	private :
 
 		Box2f m_resolutionGate;

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -576,6 +576,11 @@ class GnomonGadget : public GafferUI::Gadget
 
 		}
 
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
+		}
+
 		virtual void renderGnomon( const Style *style ) const = 0;
 
 };
@@ -870,7 +875,7 @@ class CameraOverlay : public GafferUI::Gadget
 		{
 			if( layer != Layer::Main )
 			{
-				return Gadget::doRenderLayer( layer, style );
+				return;
 			}
 
 			if( IECoreGL::Selector::currentSelector() || ( m_resolutionGate.isEmpty() && m_apertureGate.isEmpty() ) )
@@ -985,6 +990,11 @@ class CameraOverlay : public GafferUI::Gadget
 			}
 
 			glPopAttrib();
+		}
+
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
 		}
 
 	private :

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -132,6 +132,14 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 			return (unsigned)Layer::Main;
 		}
 
+		Imath::Box3f renderBound() const override
+		{
+			// we draw in raster space so don't have a sensible bound
+			Box3f b;
+			b.makeInfinite();
+			return b;
+		}
+
 	private :
 
 		Imath::V3f m_startPosition;

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -109,7 +109,7 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 		{
 			if( layer != Layer::Main )
 			{
-				return Gadget::doRenderLayer( layer, style );
+				return;
 			}
 
 			if( IECoreGL::Selector::currentSelector() )
@@ -125,6 +125,11 @@ class SelectionTool::DragOverlay : public GafferUI::Gadget
 			b.extendBy( viewportGadget->gadgetToRasterSpace( m_endPosition, this ) );
 
 			style->renderSelectionBox( b );
+		}
+
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::Main;
 		}
 
 	private :

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -175,6 +175,11 @@ class HandlesGadget : public Gadget
 
 		}
 
+		unsigned layerMask() const override
+		{
+			return (unsigned)Layer::MidFront;
+		}
+
 };
 
 } // namespace

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -474,6 +474,11 @@ class GridGadget : public GafferUI::Gadget
 			}
 		}
 
+		unsigned layerMask() const override
+		{
+			return Layer::Main | Layer::MidBack | Layer::Front;
+		}
+
 };
 
 } // namespace

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -271,8 +271,6 @@ AnimationGadget::~AnimationGadget()
 
 void AnimationGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-	Gadget::doRenderLayer( layer, style );
-
 	glDisable( GL_DEPTH_TEST );
 
 	const ViewportGadget *viewportGadget = ancestor<ViewportGadget>();
@@ -437,6 +435,16 @@ void AnimationGadget::doRenderLayer( Layer layer, const Style *style ) const
 		break;
 
 	}
+}
+
+unsigned AnimationGadget::layerMask() const
+{
+	return
+		AnimationLayer::Grid |
+		AnimationLayer::Curves |
+		AnimationLayer::Keys |
+		AnimationLayer::Axes |
+		AnimationLayer::Overlay;
 }
 
 Gaffer::StandardSet *AnimationGadget::visiblePlugs()

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -447,6 +447,14 @@ unsigned AnimationGadget::layerMask() const
 		AnimationLayer::Overlay;
 }
 
+Imath::Box3f AnimationGadget::renderBound() const
+{
+	// We render an infinite grid
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 Gaffer::StandardSet *AnimationGadget::visiblePlugs()
 {
 	return m_visiblePlugs.get();

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -254,6 +254,14 @@ unsigned AnnotationsGadget::layerMask() const
 	return (unsigned)GraphLayer::Overlay;
 }
 
+Imath::Box3f AnnotationsGadget::renderBound() const
+{
+	// This Gadget renders annotations for many nodes, so we can't give it a tight render bound
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 GraphGadget *AnnotationsGadget::graphGadget()
 {
 	return parent<GraphGadget>();

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -249,6 +249,11 @@ void AnnotationsGadget::doRenderLayer( Layer layer, const Style *style ) const
 	}
 }
 
+unsigned AnnotationsGadget::layerMask() const
+{
+	return (unsigned)GraphLayer::Overlay;
+}
+
 GraphGadget *AnnotationsGadget::graphGadget()
 {
 	return parent<GraphGadget>();

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -318,6 +318,13 @@ unsigned AuxiliaryConnectionsGadget::layerMask() const
 	return (unsigned)GraphLayer::Connections;
 }
 
+Box3f AuxiliaryConnectionsGadget::renderBound() const
+{
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 void AuxiliaryConnectionsGadget::renderConnection( const AuxiliaryConnection &c, const Style *style ) const
 {
 	const Style::State state = c.srcNodeGadget->getHighlighted() || c.dstNodeGadget->getHighlighted() ? Style::HighlightedState : Style::NormalState;

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -313,6 +313,11 @@ void AuxiliaryConnectionsGadget::doRenderLayer( Layer layer, const Style *style 
 	}
 }
 
+unsigned AuxiliaryConnectionsGadget::layerMask() const
+{
+	return (unsigned)GraphLayer::Connections;
+}
+
 void AuxiliaryConnectionsGadget::renderConnection( const AuxiliaryConnection &c, const Style *style ) const
 {
 	const Style::State state = c.srcNodeGadget->getHighlighted() || c.dstNodeGadget->getHighlighted() ? Style::HighlightedState : Style::NormalState;

--- a/src/GafferUI/AuxiliaryNodeGadget.cpp
+++ b/src/GafferUI/AuxiliaryNodeGadget.cpp
@@ -73,7 +73,6 @@ Imath::Box3f AuxiliaryNodeGadget::bound() const
 
 void AuxiliaryNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-
 	if( layer != GraphLayer::Nodes )
 	{
 		return NodeGadget::doRenderLayer( layer, style );
@@ -94,6 +93,12 @@ void AuxiliaryNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 unsigned AuxiliaryNodeGadget::layerMask() const
 {
 	return NodeGadget::layerMask() | (unsigned)GraphLayer::Nodes;
+}
+
+Imath::Box3f AuxiliaryNodeGadget::renderBound() const
+{
+	// If we expect to support labels longer than 2 characters, we should add the text bound in here
+	return bound();
 }
 
 void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )

--- a/src/GafferUI/AuxiliaryNodeGadget.cpp
+++ b/src/GafferUI/AuxiliaryNodeGadget.cpp
@@ -91,6 +91,11 @@ void AuxiliaryNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	glPopMatrix();
 }
 
+unsigned AuxiliaryNodeGadget::layerMask() const
+{
+	return NodeGadget::layerMask() | (unsigned)GraphLayer::Nodes;
+}
+
 void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
 {
 	if( key == g_labelKey )

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -341,6 +341,18 @@ unsigned BackdropNodeGadget::layerMask() const
 	return (unsigned)GraphLayer::Backdrops;
 }
 
+Imath::Box3f BackdropNodeGadget::renderBound() const
+{
+	// This doesn't take into account the possibility that the title sticks out beyond the backdrop,
+	// meaning that you could see the part of the title sticking out of a Backdrop disappear when the Backdrop
+	// goes off-screen.
+	//
+	// To fix this, we could either take into account style()->textBound, scaling, and the title text here,
+	// or we could just limit the title to only rendering inside the Backdrop
+
+	return bound();
+}
+
 void BackdropNodeGadget::contextChanged()
 {
 	// Title and description may depend on the context

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -336,6 +336,11 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	glPopMatrix();
 }
 
+unsigned BackdropNodeGadget::layerMask() const
+{
+	return (unsigned)GraphLayer::Backdrops;
+}
+
 void BackdropNodeGadget::contextChanged()
 {
 	// Title and description may depend on the context

--- a/src/GafferUI/CompoundNumericNodule.cpp
+++ b/src/GafferUI/CompoundNumericNodule.cpp
@@ -295,6 +295,18 @@ void CompoundNumericNodule::doRenderLayer( Layer layer, const Style *style ) con
 	}
 }
 
+unsigned CompoundNumericNodule::layerMask() const
+{
+	if( !noduleLayout() )
+	{
+		return StandardNodule::layerMask();
+	}
+	else
+	{
+		return 0;
+	}
+}
+
 NoduleLayout *CompoundNumericNodule::noduleLayout()
 {
 	return children().size() ? getChild<NoduleLayout>( 0 ) : nullptr;

--- a/src/GafferUI/CompoundNumericNodule.cpp
+++ b/src/GafferUI/CompoundNumericNodule.cpp
@@ -307,6 +307,18 @@ unsigned CompoundNumericNodule::layerMask() const
 	}
 }
 
+Imath::Box3f CompoundNumericNodule::renderBound() const
+{
+	if( !noduleLayout() )
+	{
+		return StandardNodule::renderBound();
+	}
+	else
+	{
+		return Box3f();
+	}
+}
+
 NoduleLayout *CompoundNumericNodule::noduleLayout()
 {
 	return children().size() ? getChild<NoduleLayout>( 0 ) : nullptr;

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -112,6 +112,11 @@ void DotNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	NodeGadget::doRenderLayer( layer, style );
 }
 
+unsigned DotNodeGadget::layerMask() const
+{
+	return NodeGadget::layerMask() | (unsigned)GraphLayer::Nodes;
+}
+
 Gaffer::Dot *DotNodeGadget::dotNode()
 {
 	return static_cast<Dot *>( node() );

--- a/src/GafferUI/Frame.cpp
+++ b/src/GafferUI/Frame.cpp
@@ -76,7 +76,6 @@ Imath::Box3f Frame::bound() const
 
 void Frame::doRenderLayer( Layer layer, const Style *style ) const
 {
-	IndividualContainer::doRenderLayer( layer, style );
 	if( layer != Layer::Main )
 	{
 		return;
@@ -84,4 +83,9 @@ void Frame::doRenderLayer( Layer layer, const Style *style ) const
 
 	Imath::Box3f b = IndividualContainer::bound();
 	style->renderFrame( Box2f( V2f( b.min.x, b.min.y ), V2f( b.max.x, b.max.y ) ), m_border );
+}
+
+unsigned Frame::layerMask() const
+{
+	return (unsigned)Layer::Main;
 }

--- a/src/GafferUI/Frame.cpp
+++ b/src/GafferUI/Frame.cpp
@@ -89,3 +89,8 @@ unsigned Frame::layerMask() const
 {
 	return (unsigned)Layer::Main;
 }
+
+Imath::Box3f Frame::renderBound() const
+{
+	return bound();
+}

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -322,10 +322,9 @@ void Gadget::dirty( DirtyType dirtyType )
 		if( !p )
 		{
 			// Found top level gadget, maybe it's a ViewportGadget
-			ViewportGadget *viewportGadget = IECore::runTimeCast<ViewportGadget>( g );
-			if( viewportGadget )
+			if( auto viewportGadget = IECore::runTimeCast<ViewportGadget>( g ) )
 			{
-				viewportGadget->renderRequestSignal()( viewportGadget );
+				viewportGadget->childDirtied( dirtyType );
 			}
 		}
 		g = p;

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -339,9 +339,9 @@ void Gadget::doRenderLayer( Layer layer, const Style *style ) const
 {
 }
 
-bool Gadget::hasLayer( Layer layer ) const
+unsigned Gadget::layerMask() const
 {
-	return true;
+	return 0;
 }
 
 Imath::Box3f Gadget::bound() const

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -41,7 +41,6 @@
 #include "GafferUI/ViewportGadget.h"
 
 #include "IECoreGL/GL.h"
-#include "IECoreGL/NameStateComponent.h"
 #include "IECoreGL/Selector.h"
 
 #include "IECore/SimpleTypedData.h"
@@ -107,20 +106,6 @@ struct Gadget::Signals : boost::noncopyable
 Gadget::Gadget( const std::string &name )
 	:	GraphComponent( name ), m_style( nullptr ), m_visible( true ), m_enabled( true ), m_highlighted( false ), m_layoutDirty( false ), m_toolTip( "" )
 {
-	std::string n = "__Gaffer::Gadget::" + boost::lexical_cast<std::string>( (size_t)this );
-	m_glName = IECoreGL::NameStateComponent::glNameFromName( n, true );
-}
-
-GadgetPtr Gadget::select( GLuint id )
-{
-	const std::string &name = IECoreGL::NameStateComponent::nameFromGLName( id );
-	if( name.compare( 0, 18, "__Gaffer::Gadget::" ) )
-	{
-		return nullptr;
-	}
-	std::string address = name.c_str() + 18;
-	size_t a = boost::lexical_cast<size_t>( address );
-	return reinterpret_cast<Gadget *>( a );
 }
 
 Gadget::~Gadget()

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -210,11 +210,6 @@ void Gadget::emitDescendantVisibilityChanged()
 	}
 }
 
-bool Gadget::getVisible() const
-{
-	return m_visible;
-}
-
 bool Gadget::visible( Gadget *relativeTo ) const
 {
 	const Gadget *g = this;

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -329,6 +329,12 @@ unsigned Gadget::layerMask() const
 	return 0;
 }
 
+Imath::Box3f Gadget::renderBound() const
+{
+	return Box3f();
+}
+
+
 Imath::Box3f Gadget::bound() const
 {
 	if( !m_layoutDirty )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -814,6 +814,14 @@ unsigned GraphGadget::layerMask() const
 	return GraphLayer::Connections | GraphLayer::Overlay;
 }
 
+Box3f GraphGadget::renderBound() const
+{
+	// We only have one graph gadget, so we don't need to worry about the exact extents for render culling
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
 {
 	if( event.key == "D" )

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -754,8 +754,6 @@ ConnectionGadget *GraphGadget::reconnectionGadgetAt( const NodeGadget *gadget, c
 
 void GraphGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-	Gadget::doRenderLayer( layer, style );
-
 	glDisable( GL_DEPTH_TEST );
 
 	switch( layer )
@@ -809,6 +807,11 @@ void GraphGadget::doRenderLayer( Layer layer, const Style *style ) const
 		break;
 	}
 
+}
+
+unsigned GraphGadget::layerMask() const
+{
+	return GraphLayer::Connections | GraphLayer::Overlay;
 }
 
 bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -122,11 +122,6 @@ Imath::Box3f Handle::bound() const
 	return Box3f( V3f( -1 ), V3f( 1 ) );
 }
 
-bool Handle::hasLayer( Layer layer ) const
-{
-	return layer == Layer::MidFront;
-}
-
 void Handle::doRenderLayer( Layer layer, const Style *style ) const
 {
 	if( m_visibleOnHover )
@@ -147,6 +142,11 @@ void Handle::doRenderLayer( Layer layer, const Style *style ) const
 	renderHandle( style, state );
 
 	glPopMatrix();
+}
+
+unsigned Handle::layerMask() const
+{
+	return (unsigned)Layer::MidFront;
 }
 
 Imath::V3f Handle::rasterScaleFactor() const

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -149,6 +149,14 @@ unsigned Handle::layerMask() const
 	return (unsigned)Layer::MidFront;
 }
 
+Imath::Box3f Handle::renderBound() const
+{
+	// Having a raster scale makes our bound somewhat meaningless
+	Box3f b;
+	b.makeInfinite();
+	return b;
+}
+
 Imath::V3f Handle::rasterScaleFactor() const
 {
 	if( m_rasterScale <= 0.0f )

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -205,6 +205,10 @@ unsigned ImageGadget::layerMask() const
 	return (unsigned)Layer::Main;
 }
 
+Imath::Box3f ImageGadget::renderBound() const
+{
+	return bound();
+}
 
 Imath::Box3f ImageGadget::bound() const
 {

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -188,7 +188,6 @@ IECoreGL::ConstTexturePtr ImageGadget::loadTexture( const std::string &fileName 
 
 void ImageGadget::doRenderLayer( Layer layer, const Style *style ) const
 {
-	Gadget::doRenderLayer( layer, style );
 	if( layer != Layer::Main )
 	{
 		return;
@@ -199,9 +198,13 @@ void ImageGadget::doRenderLayer( Layer layer, const Style *style ) const
 		Box2f b( V2f( m_bound.min.x, m_bound.min.y ), V2f( m_bound.max.x, m_bound.max.y ) );
 		style->renderImage( b, texture );
 	}
-
-	Gadget::doRenderLayer( layer, style );
 }
+
+unsigned ImageGadget::layerMask() const
+{
+	return (unsigned)Layer::Main;
+}
+
 
 Imath::Box3f ImageGadget::bound() const
 {

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -463,11 +463,6 @@ void NoduleLayout::registerCustomGadget( const std::string &gadgetType, CustomGa
 	customGadgetCreators()[gadgetType] = creator;
 }
 
-bool NoduleLayout::hasLayer( Layer layer ) const
-{
-	return layer != GraphLayer::Backdrops;
-}
-
 LinearContainer *NoduleLayout::noduleContainer()
 {
 	return getChild<LinearContainer>( 0 );

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -251,6 +251,11 @@ void PlugAdder::doRenderLayer( Layer layer, const Style *style ) const
 	}
 }
 
+unsigned PlugAdder::layerMask() const
+{
+	return GraphLayer::Connections | GraphLayer::Nodes | GraphLayer::Highlighting;
+}
+
 void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const
 {
 	const StandardNodeGadget::Edge edge = tangentEdge( tangent( this ) );

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -256,6 +256,11 @@ unsigned PlugAdder::layerMask() const
 	return GraphLayer::Connections | GraphLayer::Nodes | GraphLayer::Highlighting;
 }
 
+Imath::Box3f PlugAdder::renderBound() const
+{
+	return bound();
+}
+
 void PlugAdder::applyEdgeMetadata( Gaffer::Plug *plug, bool opposite ) const
 {
 	const StandardNodeGadget::Edge edge = tangentEdge( tangent( this ) );

--- a/src/GafferUI/SpacerGadget.cpp
+++ b/src/GafferUI/SpacerGadget.cpp
@@ -49,10 +49,6 @@ SpacerGadget::~SpacerGadget()
 {
 }
 
-void SpacerGadget::doRenderLayer( Layer layer, const Style *style ) const
-{
-}
-
 Imath::Box3f SpacerGadget::bound() const
 {
 	return m_bound;

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -353,9 +353,9 @@ void StandardConnectionGadget::doRenderLayer( Layer layer, const Style *style ) 
 	}
 }
 
-bool StandardConnectionGadget::hasLayer( Layer layer ) const
+unsigned StandardConnectionGadget::layerMask() const
 {
-	return layer == GraphLayer::Connections;
+	return (unsigned)GraphLayer::Connections;
 }
 
 Imath::V3f StandardConnectionGadget::closestPoint( const Imath::V3f& p ) const

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -358,6 +358,17 @@ unsigned StandardConnectionGadget::layerMask() const
 	return (unsigned)GraphLayer::Connections;
 }
 
+Imath::Box3f StandardConnectionGadget::renderBound() const
+{
+	Box3f r = bound();
+
+	// Extend render bound to account for how the initial curve of the connection can stick out
+	// beyond the source point, plus the thickness of the connection line
+	r.min -= V3f( 2.5 );
+	r.max += V3f( 2.5 );
+	return r;
+}
+
 Imath::V3f StandardConnectionGadget::closestPoint( const Imath::V3f& p ) const
 {
 	const_cast<StandardConnectionGadget *>( this )->updateConnectionGeometry();

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -415,9 +415,9 @@ void StandardNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	}
 }
 
-bool StandardNodeGadget::hasLayer( Layer layer ) const
+unsigned StandardNodeGadget::layerMask() const
 {
-	return layer != GraphLayer::Backdrops;
+	return GraphLayer::Nodes | GraphLayer::Overlay;
 }
 
 const Imath::Color3f *StandardNodeGadget::userColor() const

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -420,6 +420,11 @@ unsigned StandardNodeGadget::layerMask() const
 	return GraphLayer::Nodes | GraphLayer::Overlay;
 }
 
+Imath::Box3f StandardNodeGadget::renderBound() const
+{
+	return bound();
+}
+
 const Imath::Color3f *StandardNodeGadget::userColor() const
 {
 	return m_userColor.get_ptr();

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -209,6 +209,22 @@ unsigned StandardNodule::layerMask() const
 	return GraphLayer::Connections | GraphLayer::Nodes | GraphLayer::Highlighting | GraphLayer::Overlay;
 }
 
+Imath::Box3f StandardNodule::renderBound() const
+{
+	if( m_draggingConnection )
+	{
+		// When dragging a connection, we could drag it anywhere, and need to render it
+		Box3f b;
+		b.makeInfinite();
+		return b;
+	}
+	else
+	{
+		// Usual max size we render at ( when highlighted )
+		return Box3f( V3f( -1, -1, 0 ), V3f( 1, 1, 0 ) );
+	}
+}
+
 void StandardNodule::renderLabel( const Style *style ) const
 {
 	const NodeGadget *nodeGadget = ancestor<NodeGadget>();

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -136,7 +136,7 @@ void StandardNodule::updateDragEndPoint( const Imath::V3f position, const Imath:
 	m_dragPosition = position;
 	m_dragTangent = tangent;
 	m_draggingConnection = true;
-	dirty( DirtyType::Render );
+	dirty( DirtyType::RenderBound );
 }
 
 void StandardNodule::createConnection( Gaffer::Plug *endpoint )
@@ -412,13 +412,14 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 		{
 			setCompatibleLabelsVisible( event, false );
 		}
+		dirty( DirtyType::Render );
 	}
 	else if( !event.destinationGadget )
 	{
 		m_draggingConnection = false;
+		dirty( DirtyType::RenderBound );
 	}
 
-	dirty( DirtyType::Render );
 	return true;
 }
 
@@ -426,6 +427,7 @@ bool StandardNodule::dragEnd( GadgetPtr gadget, const DragDropEvent &event )
 {
 	GafferUI::Pointer::setCurrent( "" );
 	m_draggingConnection = false;
+	dirty( DirtyType::RenderBound );
 	setHighlighted( false );
 	return true;
 }

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -153,28 +153,6 @@ void StandardNodule::createConnection( Gaffer::Plug *endpoint )
 	}
 }
 
-bool StandardNodule::hasLayer( Layer layer ) const
-{
-	if( children().size() )
-	{
-		return true;
-	}
-
-	switch( layer )
-	{
-		case GraphLayer::Connections :
-			return m_draggingConnection;
-		case GraphLayer::Nodes :
-			return !getHighlighted();
-		case GraphLayer::Highlighting :
-			return getHighlighted();
-		case GraphLayer::Overlay :
-			return m_labelVisible && !IECoreGL::Selector::currentSelector();
-		default :
-			return false;
-	}
-}
-
 void StandardNodule::doRenderLayer( Layer layer, const Style *style ) const
 {
 	switch( layer )
@@ -224,6 +202,11 @@ void StandardNodule::doRenderLayer( Layer layer, const Style *style ) const
 	}
 
 	// if the nodule isn't highlighted it will be drawn in the normal, non-overlayed manner
+}
+
+unsigned StandardNodule::layerMask() const
+{
+	return GraphLayer::Connections | GraphLayer::Nodes | GraphLayer::Highlighting | GraphLayer::Overlay;
 }
 
 void StandardNodule::renderLabel( const Style *style ) const

--- a/src/GafferUI/TextGadget.cpp
+++ b/src/GafferUI/TextGadget.cpp
@@ -97,3 +97,8 @@ unsigned TextGadget::layerMask() const
 {
 	return (unsigned)Layer::Main;
 }
+
+Imath::Box3f TextGadget::renderBound() const
+{
+	return m_bound;
+}

--- a/src/GafferUI/TextGadget.cpp
+++ b/src/GafferUI/TextGadget.cpp
@@ -92,3 +92,8 @@ void TextGadget::doRenderLayer( Layer layer, const Style *style ) const
 
 	style->renderText( Style::LabelText, m_text );
 }
+
+unsigned TextGadget::layerMask() const
+{
+	return (unsigned)Layer::Main;
+}

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1111,8 +1111,8 @@ void ViewportGadget::renderInternal( Gadget::Layer filterLayer ) const
 
 void ViewportGadget::getRenderItems( const Gadget *gadget, M44f transform, const Style *style, std::vector<RenderItem> &renderItems )
 {
-	const Box3f bound = gadget->bound();
-	bool boundDefault = bound == Box3f();
+	const Box3f bound = gadget->renderBound();
+	bool boundSpecial = bound.isEmpty() || bound == g_infiniteBox;
 
 	if( gadget->getStyle() )
 	{
@@ -1129,7 +1129,7 @@ void ViewportGadget::getRenderItems( const Gadget *gadget, M44f transform, const
 	{
 		renderItems.push_back( {
 			gadget, style, transform,
-			boundDefault ? g_infiniteBox : Imath::transform( bound, transform ),
+			boundSpecial ? bound : Imath::transform( bound, transform ),
 			layerMask
 		} );
 	}

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1038,7 +1038,7 @@ void ViewportGadget::render() const
 
 void ViewportGadget::childDirtied( DirtyType dirtyType )
 {
-	if( dirtyType == DirtyType::Layout )
+	if( dirtyType == DirtyType::Layout || dirtyType == DirtyType::RenderBound )
 	{
 		// We need to rebuild the render items list
 		m_renderItems.clear();

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -216,7 +216,6 @@ void GafferUIModule::bindGadget()
 		.def( "_idleSignalAccessedSignal", &Gadget::idleSignalAccessedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "_idleSignalAccessedSignal" )
 		.def( "_dirty", &Gadget::dirty )
-		.def( "select", &Gadget::select ).staticmethod( "select" )
 	;
 
 	enum_<Gadget::Layer>( "Layer" )


### PR DESCRIPTION
Here's the stuff I've been working for improving Gadget render performance.  Definitely look through it carefully, but the overall approach is looking quite good - it's doing a lot more than reducing the overhead from the Focus PR.

Oh, I should throw out the first commit that dumps the frametime before we merge, but it is pretty useful when evaluating this.

Here are the main metrics I've been considering, measured by eyeballing average milliseconds per frame from the console output, testing in a scene with 4000 group nodes connected in a chain.  The places where "16 milliseconds" shows up indicate that we're actually idling wait for the next refresh, the actual time spent rendering is actually a bit lower.

|      |      Original      |  This PR |
|----------|:-------------:|------:|
| Panning ( Zoomed out ) | 81 | 49 |
|  Panning ( Zoomed in ) | 81 | 16 |
| Moving Node ( Zoomed out ) | 120 | 85  |
| Moving Node ( Zoomed in ) | 120 | 51 |
| Dragging Noodle ( Zoomed out ) | 180 | 66 |
| Dragging Noodle ( Zoomed in ) | 180 | 16 |
| Just Moving Cursor ( running gadgetsAt ) | 107 | 7 |