### PR TITLE
StringPlugValueWidget : Test error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.1.0/cortex-10.2.1.0-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.2.0/cortex-10.2.2.0-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.1.0/cortex-10.2.1.0-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.2.0/cortex-10.2.2.0-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.1.0/cortex-10.2.1.0-linux-python3.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.2.0/cortex-10.2.2.0-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.1.0/cortex-10.2.1.0-macos-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.2.2.0/cortex-10.2.2.0-macos-python2.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -47,7 +47,7 @@ else :
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.2.1.0/cortex-10.2.1.0-" + platform + "-python2.tar.gz"
+defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.2.2.0/cortex-10.2.2.0-" + platform + "-python2.tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,12 @@ Fixes
 - Timeline : Fixed errors when the end frame is the same as the start frame (#4294).
 - GafferUI : Fixed edge artifacts when rendering transparent icons.
 - Render : Added workaround for hangs caused by specific chains of Expressions being evaluated after completion of the render.
+- NodeEditor : Fixed `Internal C++ object already deleted` errors in Python 3 builds.
+
+Build
+-----
+
+- Cortex : Updated to version 10.2.2.0.
 
 0.60.1.0 (relative to 0.60.0.0)
 ========

--- a/python/GafferUITest/StringPlugValueWidgetTest.py
+++ b/python/GafferUITest/StringPlugValueWidgetTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import weakref
 
 import Gaffer
 import GafferUI
@@ -128,6 +129,26 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( n["user"]["p1"].getValue(), "" )
 		self.assertEqual( n["user"]["p2"].getValue(), "" )
+
+	def testExceptionHandling( self ) :
+
+		# Compute for `n["p"]` will error because it's an output plug
+		# that ComputeNode knows nothing about.
+
+		n = Gaffer.ComputeNode()
+		n["p"] = Gaffer.StringPlug( direction = Gaffer.Plug.Direction.Out )
+
+		# We want that to be reflected in the UI.
+
+		w = GafferUI.StringPlugValueWidget( n["p"] )
+		self.assertEqual( w.textWidget().getText(), "" )
+		self.assertTrue( w.textWidget().getErrored() )
+
+		# And we don't want the widget to live beyond its natural life
+		# due to reference cycles introduced by exception handling.
+
+		w = weakref.ref( w )
+		self.assertIsNone( w() )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This exposes a bug that was causing various PlugValueWidgets to live beyond their natural lifetime in Python 3, leading to the dreaded `Internal C++ object already deleted` error. The fix will actually be in Cortex, but I'm opening this PR so that we have some coverage in Gaffer's tests too.