### PR TITLE
UVView : Fix grid rendering

### DIFF
--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -474,6 +474,13 @@ class GridGadget : public GafferUI::Gadget
 			}
 		}
 
+		Box3f renderBound() const override
+		{
+			Box3f b;
+			b.makeInfinite();
+			return b;
+		}
+
 		unsigned layerMask() const override
 		{
 			return Layer::Main | Layer::MidBack | Layer::Front;


### PR DESCRIPTION
I missed adding a render bound to UV grid which is now required to render after #4277