### PR TITLE
Spreadsheet : Add `spreadsheet:columnsNeedSerialisation` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - Render : In addition to the compute cache, the hash cache is now cleared prior to rendering.
+- Spreadsheet : Added interim support for adding a `Spreadsheet::RowsPlug` to a custom node. The previous doubling up of columns on reload can now be avoided by registering `False` for the new `spreadsheet:columnsNeedSerialisation` metadata item.
 
 Fixes
 -----

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -36,6 +36,7 @@
 
 #include "Gaffer/Spreadsheet.h"
 
+#include "Gaffer/Metadata.h"
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/StringPlug.h"
 
@@ -336,6 +337,16 @@ class RowsMapScope : boost::noncopyable, public Context::SubstitutionProvider
 		RowsMap::Selector m_selector;
 
 };
+
+struct MetadataRegistration
+{
+	MetadataRegistration()
+	{
+		Metadata::registerValue( Spreadsheet::RowsPlug::staticTypeId(), "spreadsheet:columnsNeedSerialisation:promotable", new BoolData( false ) );
+	}
+};
+
+MetadataRegistration g_metadataRegistration;
 
 } // namespace
 


### PR DESCRIPTION
This can be used to avoid the serialisation of `setColumn()` calls on RowsPlugs, allowing them to be populated from a custom node's constructor instead.

This solution is not ideal, and the long term plan is to instead generalise the Serialiser with a generic mechanism for GraphComponents to define the serialisation requirements for any descendant individually (also allowing us to remove the `Plug::Dynamic` flag). There's enough value in the workaround that it's worth using for now though, rather than forcing people into workarounds of their own (see https://github.com/themissingcow/gaffer-astro/blob/master/src/GafferAstroModule/SpreadsheetSerialisation.cpp#L81).
