### PR TITLE
Render : Clear hash cache prior to rendering

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,11 +6,17 @@ Features
 
 - UVSampler : Added a new node sampling primitive variables from specific UV positions on a source object.
 
+Improvements
+------------
+
+- Render : In addition to the compute cache, the hash cache is now cleared prior to rendering.
+
 Fixes
 -----
 
 - Timeline : Fixed errors when the end frame is the same as the start frame (#4294).
 - GafferUI : Fixed edge artifacts when rendering transparent icons.
+- Render : Added workaround for hangs caused by specific chains of Expressions being evaluated after completion of the render.
 
 0.60.1.0 (relative to 0.60.0.0)
 ========

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -344,6 +344,9 @@ void Render::executeInternal( bool flushCaches ) const
 		/// `gaffer execute`, but it would be good to do better.
 		ObjectPool::defaultObjectPool()->clear();
 		ValuePlug::clearCache();
+		/// \todo This is not as effective as it could be, because it doesn't actually
+		/// clear the per-thread caches until the next operation on each thread.
+		ValuePlug::clearHashCache();
 	}
 
 	renderer->render();


### PR DESCRIPTION
This is not as effective as one might hope. The implementation of `clearHashCache()` does clear the global cache immediately, but can't clear the per-thread caches because they might be in use by the threads. Instead it sets a flag that will cause them to be cleared by the next operation on each thread, which in this case cannot occur until after the render has completed.

There is a less pure motivation for this change though : it works around a nasty hang triggered by 8c98104978faf4540333c1b98ff71b906ec8a21b. That can be reproduced by this test :

```
def testCacheMissHang( self ) :

	s = Gaffer.ScriptNode()

	s["n"] = Gaffer.Node()
	s["n"]["p1"] = Gaffer.StringPlug()
	s["n"]["p2"] = Gaffer.StringPlug()
	s["n"]["p3"] = Gaffer.StringPlug()

	s["n"]["p1"].setValue( "aa" )

	s["e"] = Gaffer.Expression()
	s["e"].setExpression( "t = parent['n']['p1']\nparent['n']['p2'] = t[0] + 'a'", "python" )

	s["e2"] = Gaffer.Expression()
	s["e2"].setExpression( "t = parent['n']['p2']\nparent['n']['p3'] = t[0] + 'a'", "python" )

	s["n"]["p3"].getValue()
	Gaffer.ValuePlug.clearCache()
	s["n"]["p3"].getValue()
```

The issue is that `StringPlug::hash()` is based on the _value_ of the string, so that it can account for substitutions. In the setup above, `p2` and `p3` therefore have the same hash, despite `p3` depending on `p2`. If the compute cache is cleared but the hash cache is not, then calling `p3.getValue()` will launch a compute for `p3` which will recurse to a compute to `p2`. That causes a recursive call to `LRUCache::get()` with the _same key_, and that deadlocks.
Clearing the hash cache too means that the compute cache is repopulated during the hashing phase (because `StringPlug::hash()` uses the value) and deadlock is avoided.
