### PR TITLE
Avoid deprecated Arnold API : Part 1

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -355,17 +355,17 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"]["transformBlur"]["value"].setValue( False )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			camera = arnold.AiNodeLookUpByName( "gaffer:defaultCamera" )
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			camera = arnold.AiNodeLookUpByName( universe, "gaffer:defaultCamera" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 			sphereMotionStart = arnold.AiNodeGetFlt( sphere, "motion_start" )
 			sphereMotionEnd = arnold.AiNodeGetFlt( sphere, "motion_end" )
 			sphereMatrix = arnold.AiNodeGetMatrix( sphere, "matrix" )
 
-			plane = arnold.AiNodeLookUpByName( "/group/plane" )
+			plane = arnold.AiNodeLookUpByName( universe, "/group/plane" )
 			planeMotionStart = arnold.AiNodeGetFlt( plane, "motion_start" )
 			planeMotionEnd = arnold.AiNodeGetFlt( plane, "motion_end" )
 			planeMatrix = arnold.AiNodeGetMatrix( plane, "matrix" )
@@ -386,24 +386,24 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_start" ), 1 )
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_end" ), 1 )
 
-			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions(), "ignore_motion_blur" ), False )
+			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions( universe ), "ignore_motion_blur" ), False )
 
 		# Motion blur
 
 		s["options"]["options"]["transformBlur"]["value"].setValue( True )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			camera = arnold.AiNodeLookUpByName( "gaffer:defaultCamera" )
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			camera = arnold.AiNodeLookUpByName( universe, "gaffer:defaultCamera" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 			sphereMotionStart = arnold.AiNodeGetFlt( sphere, "motion_start" )
 			sphereMotionEnd = arnold.AiNodeGetFlt( sphere, "motion_end" )
 			sphereMatrices = arnold.AiNodeGetArray( sphere, "matrix" )
 
-			plane = arnold.AiNodeLookUpByName( "/group/plane" )
+			plane = arnold.AiNodeLookUpByName( universe, "/group/plane" )
 			planeMotionStart = arnold.AiNodeGetFlt( plane, "motion_start" )
 			planeMotionEnd = arnold.AiNodeGetFlt( plane, "motion_end" )
 			planeMatrices = arnold.AiNodeGetArray( plane, "matrix" )
@@ -435,7 +435,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_start" ), 0.75 )
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_end" ), 1.25 )
 
-			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions(), "ignore_motion_blur" ), False )
+			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions( universe ), "ignore_motion_blur" ), False )
 
 		# Motion blur on, but sampleMotion off
 
@@ -443,17 +443,17 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"]["sampleMotion"]["value"].setValue( False )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			camera = arnold.AiNodeLookUpByName( "gaffer:defaultCamera" )
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			camera = arnold.AiNodeLookUpByName( universe, "gaffer:defaultCamera" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 			sphereMotionStart = arnold.AiNodeGetFlt( sphere, "motion_start" )
 			sphereMotionEnd = arnold.AiNodeGetFlt( sphere, "motion_end" )
 			sphereMatrices = arnold.AiNodeGetArray( sphere, "matrix" )
 
-			plane = arnold.AiNodeLookUpByName( "/group/plane" )
+			plane = arnold.AiNodeLookUpByName( universe, "/group/plane" )
 			planeMotionStart = arnold.AiNodeGetFlt( plane, "motion_start" )
 			planeMotionEnd = arnold.AiNodeGetFlt( plane, "motion_end" )
 			planeMatrices = arnold.AiNodeGetArray( plane, "matrix" )
@@ -486,7 +486,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_start" ), 0.75 )
 			self.assertEqual( arnold.AiNodeGetFlt( camera, "shutter_end" ), 1.25 )
 
-			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions(), "ignore_motion_blur" ), True )
+			self.assertEqual( arnold.AiNodeGetBool( arnold.AiUniverseGetOptions( universe ), "ignore_motion_blur" ), True )
 
 	def testResolution( self ) :
 
@@ -510,10 +510,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 400 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 200 )
 
@@ -523,10 +523,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"]["renderCamera"]["value"].setValue( "/camera" )
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 400 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 200 )
 
@@ -549,10 +549,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Default region
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 640 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 480 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "region_min_x" ), 0 )
@@ -566,10 +566,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 640 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 480 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "region_min_x" ), 160 )
@@ -582,10 +582,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 640 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 480 )
 
@@ -610,10 +610,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			options = arnold.AiUniverseGetOptions()
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			options = arnold.AiUniverseGetOptions( universe )
 			self.assertEqual( arnold.AiNodeGetInt( options, "xres" ), 640 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "yres" ), 480 )
 			self.assertEqual( arnold.AiNodeGetInt( options, "region_min_x" ), -192 )
@@ -731,12 +731,12 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			firstSphere = arnold.AiNodeLookUpByName( "/group/sphere" )
-			secondSphere = arnold.AiNodeLookUpByName( "/group/sphere1" )
+			firstSphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
+			secondSphere = arnold.AiNodeLookUpByName( universe, "/group/sphere1" )
 
 			self.assertEqual( self.__arrayToSet( arnold.AiNodeGetArray( firstSphere, "trace_sets" ) ), { "firstSphere", "group", "bothSpheres" } )
 			self.assertEqual( self.__arrayToSet( arnold.AiNodeGetArray( secondSphere, "trace_sets" ) ), { "secondSphere", "group", "bothSpheres" } )
@@ -784,12 +784,12 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 					render["task"].execute()
 
-					with IECoreArnold.UniverseBlock( writable = True ) :
+					with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-						arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+						arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
 						self.assertEqual(
-							arnold.AiNodeGetInt( arnold.AiUniverseGetOptions(), "AA_seed" ),
+							arnold.AiNodeGetInt( arnold.AiUniverseGetOptions( universe ), "AA_seed" ),
 							seed or round( frame )
 						)
 
@@ -805,10 +805,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			self.assertTrue( arnold.AiNodeLookUpByName( "/sphereArnold" ) is not None )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			self.assertTrue( arnold.AiNodeLookUpByName( universe, "/sphereArnold" ) is not None )
 
 	def testAdaptors( self ) :
 
@@ -833,10 +833,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			node = arnold.AiNodeLookUpByName( "/sphere" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			node = arnold.AiNodeLookUpByName( universe, "/sphere" )
 
 			self.assertEqual( arnold.AiNodeGetBool( node, "matte" ), True )
 
@@ -879,12 +879,12 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
 			# the first sphere had linked lights
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 
 			# check illumination
 			self.assertTrue( arnold.AiNodeGetBool( sphere, "use_light_group" ) )
@@ -905,7 +905,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 			)
 
 			# the second sphere does not have any light linking enabled
-			sphere1 = arnold.AiNodeLookUpByName( "/group/sphere1" )
+			sphere1 = arnold.AiNodeLookUpByName( universe, "/group/sphere1" )
 
 			# check illumination
 			self.assertFalse( arnold.AiNodeGetBool( sphere1, "use_light_group" ) )
@@ -954,11 +954,11 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 			self.assertIsNotNone( sphere )
 
 			self.assertEqual( arnold.AiArrayGetNumElements( arnold.AiNodeGetArray( sphere, "light_group" ) ), 0 )
@@ -998,11 +998,11 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			light = arnold.AiNodeLookUpByName( "light:/group/light" )
+			light = arnold.AiNodeLookUpByName( universe, "light:/group/light" )
 			linkedFilters = arnold.AiNodeGetArray( light, "filters" )
 			numFilters = arnold.AiArrayGetNumElements( linkedFilters.contents )
 
@@ -1171,11 +1171,11 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		render["fileName"].setValue( self.temporaryDirectory() + "/test.ass" )
 		render["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
 
-			sphere = arnold.AiNodeLookUpByName( "/group/sphere" )
+			sphere = arnold.AiNodeLookUpByName( universe, "/group/sphere" )
 			self.assertIsNotNone( sphere )
 
 			self.assertEqual( arnold.AiArrayGetNumElements( arnold.AiNodeGetArray( sphere, "light_group" ) ), 0 )
@@ -1292,25 +1292,25 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["render"]["task"].execute()
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			arnold.AiASSLoad( self.temporaryDirectory() + "/test.ass" )
-			plane = arnold.AiNodeLookUpByName( "/plane" )
+			arnold.AiASSLoad( universe, self.temporaryDirectory() + "/test.ass" )
+			plane = arnold.AiNodeLookUpByName( universe, "/plane" )
 			shader = arnold.AiNodeGetPtr( plane, "shader" )
 			self.assertEqual( arnold.AiNodeGetStr( shader, "filename" ), "bar/path/foo.tx" )
 
-			cube = arnold.AiNodeLookUpByName( "/plane/cube" )
+			cube = arnold.AiNodeLookUpByName( universe, "/plane/cube" )
 			shader2 = arnold.AiNodeGetPtr( cube, "shader" )
 			self.assertEqual( arnold.AiNodeGetStr( shader2, "filename" ), "bar/path/override.tx" )
 
-			light = arnold.AiNodeLookUpByName( "light:/lightGroup/light" )
+			light = arnold.AiNodeLookUpByName( universe, "light:/lightGroup/light" )
 			self.assertEqual( arnold.AiNodeGetStr( light, "filename" ), "/path/default1.ies" )
 
 			gobo = arnold.AiNodeGetPtr( light, "filters" )
 			goboTex = arnold.AiNodeGetLink( gobo, "slidemap" )
 			self.assertEqual( arnold.AiNodeGetStr( goboTex, "filename" ), "default2/gobo.tx" )
 
-			lightFilter = arnold.AiNodeLookUpByName( "lightFilter:/lightGroup/lightFilter" )
+			lightFilter = arnold.AiNodeLookUpByName( universe, "lightFilter:/lightGroup/lightFilter" )
 			self.assertEqual( arnold.AiNodeGetStr( lightFilter, "geometry_type" ), "cylinder" )
 
 	def testEncapsulateDeformationBlur( self ) :

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -1461,7 +1461,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				if( !velocityScale || velocityScale.get() > 0 )
 				{
 					AtNode *options = AiUniverseGetOptions();
-					const AtNode *arnoldCamera = static_cast<const AtNode *>( AiNodeGetPtr( options, "camera" ) );
+					const AtNode *arnoldCamera = static_cast<const AtNode *>( AiNodeGetPtr( options, g_cameraArnoldString ) );
 
 					if( arnoldCamera )
 					{

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -2868,7 +2868,7 @@ class ArnoldGlobals
 				m_enableProgressiveRender( true ),
 				m_shaderCache( shaderCache ),
 				m_renderBegun( false ),
-				m_assFileName( fileName )
+				m_fileName( fileName )
 		{
 			// This only takes effect if called after the UniverseBlock has been created
 			if( messageHandler )
@@ -3314,12 +3314,16 @@ class ArnoldGlobals
 					}
 					break;
 				}
-				case IECoreScenePreview::Renderer::SceneDescription :
-					// An ASS file can only contain options to render from one camera,
-					// so just use the default camera
+				case IECoreScenePreview::Renderer::SceneDescription : {
+					// A scene file can only contain options to render from one camera,
+					// so just use the default camera.
 					updateCamera( m_cameraName );
-					AiASSWrite( m_assFileName.c_str(), AI_NODE_ALL );
+					unique_ptr<AtParamValueMap, decltype(&AiParamValueMapDestroy)> params(
+						AiParamValueMap(), AiParamValueMapDestroy
+					);
+					AiSceneWrite( m_universeBlock->universe(), m_fileName.c_str(), params.get() );
 					break;
+				}
 				case IECoreScenePreview::Renderer::Interactive :
 					// If we want to use Arnold's progressive refinement, we can't be constantly switching
 					// the camera around, so just use the default camera
@@ -3682,9 +3686,9 @@ class ArnoldGlobals
 
 		bool m_renderBegun;
 
-		// Members used by ass generation "renders"
+		// Members used by SceneDescription "renders"
 
-		std::string m_assFileName;
+		std::string m_fileName;
 
 };
 


### PR DESCRIPTION
This is a follow up to the recent https://github.com/ImageEngine/cortex/pull/1171, with the same end goal of building cleanly with `AI_ENABLE_DEPRECATION_WARNINGS`. My intention is to keep Gaffer building with both Cortex 10.2.x and also the future 10.3. I have a _lot_ of code changes on the Gaffer side, and I'm still in the process of disentangling and rationalising them. This is the first little batch - once this is reviewed and merged I'll follow up with more.