### PR TITLE
GafferSceneUI::ContextAlgo::expandDescendants : Don't modify context in-place

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
 Fixes
 -----
 
+- Viewer : Fixed bug which prevented the "Expand Selection Fully" operation from working.
 - Timeline : Fixed errors when the end frame is the same as the start frame (#4294).
 - GafferUI : Fixed edge artifacts when rendering transparent icons.
 - Render : Added workaround for hangs caused by specific chains of Expressions being evaluated after completion of the render.

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -150,13 +150,7 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 
 IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatcher &paths, const ScenePlug *scene, int depth )
 {
-	const IECore::PathMatcher* expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
-	if( !expandedPaths )
-	{
-		context->set( g_expandedPathsName, new IECore::PathMatcherData() );
-		expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
-	}
-	IECore::PathMatcher &expanded = *const_cast<IECore::PathMatcher*>(expandedPaths);
+	IECore::PathMatcher expandedPaths = context->get<PathMatcher>( g_expandedPathsName, IECore::PathMatcher() );
 
 	bool needUpdate = false;
 	IECore::PathMatcher leafPaths;
@@ -164,15 +158,13 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 	// \todo: parallelize the walk
 	for( IECore::PathMatcher::Iterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
 	{
-		needUpdate |= expandWalk( *it, scene, depth + 1, expanded, leafPaths );
+		needUpdate |= expandWalk( *it, scene, depth + 1, expandedPaths, leafPaths );
 	}
 
 	if( needUpdate )
 	{
-		// We modified the expanded paths in place with const_cast to avoid unecessary copying,
-		// so the context doesn't know they've changed. So we must let it know
-		// about the change.
-		context->set( g_expandedPathsName, *expandedPaths );
+		// If we modified the expanded paths, we need to set the value back on the context
+		context->set( g_expandedPathsName, expandedPaths );
 	}
 
 	return leafPaths;

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -1821,10 +1821,10 @@ void SceneView::frame( const PathMatcher &filter, const Imath::V3f &direction )
 
 void SceneView::expandSelection( size_t depth )
 {
-	// Note that we are scoping this context at the same time that expandDescendants is doing a cheeky in-place
-	// modification of the context.  In general this could result in highly inconsistent hash results ... it
-	// is safe only because the selected paths is a "ui:" prefixed context variable, and Context is hardcoded
-	// to ignore variables with this prefix during hashing
+	// Note that we are scoping this context when expandDescendants computes a new value for the expanded paths.
+	// This could result in unnecessary cache misses due to changing the context entry, but it's OK because the
+	// selected paths is a "ui:" prefixed context variable, and Context is hardcoded to ignore variables with
+	// this prefix during hashing
 	Context::Scope scope( getContext() );
 	PathMatcher selection = ContextAlgo::expandDescendants( getContext(), m_sceneGadget->getSelection(), preprocessedInPlug<ScenePlug>(), depth - 1 );
 	ContextAlgo::setSelectedPaths( getContext(), selection );


### PR DESCRIPTION
This was the only place in Gaffer where an in-place modification of a context variable was done, and it added complexity, and a bug ( we were not signalling that the context had changed, because at the point when we called context->set(), the value matched the value we were setting it to, and so omitting the signal was skipped ).

I did a bunch of performance testing, and was unable to detect any scenario where there was a noticeable difference for this simpler code.

When do an expand in the viewport, it's difficult to get PathMatcher processing to account for any noticeable fraction of the time.  Doing a synthetic test with an expandDescendants in the script editor in a heavy scene, PathMatcher stuff only accounted for 0.5  seconds out of 10 seconds, and in none of my tests was any difference in performance between the old and new code visible