### PR TITLE
Avoid legacy Metadata signals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.59.9.x (relative to 0.59.9.2)
+========
+
+Fixes
+-----
+
+- Shader : Fixed metadata signalling performance issue that could cause very poor load times for scripts containing many Shader nodes.
+
 0.59.9.2 (relative to 0.59.9.1)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Shader : Fixed metadata signalling performance issue that could cause very poor load times for scripts containing many Shader nodes.
+- GraphEditor : Removed unnecessary metadata tracking overhead.
 
 0.59.9.2 (relative to 0.59.9.1)
 ========

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -164,7 +164,7 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 		class NetworkBuilder;
 
 		void nameChanged();
-		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Node *node );
+		void nodeMetadataChanged( IECore::InternedString key );
 
 		// We want to use the node name when computing the shader, so that we
 		// can generate more useful shader handles. It's illegal to use anything

--- a/include/GafferUI/AuxiliaryNodeGadget.h
+++ b/include/GafferUI/AuxiliaryNodeGadget.h
@@ -62,7 +62,7 @@ class GAFFERUI_API AuxiliaryNodeGadget : public NodeGadget
 
 		static NodeGadgetTypeDescription<AuxiliaryNodeGadget> g_nodeGadgetTypeDescription;
 
-		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
+		void nodeMetadataChanged( IECore::InternedString key );
 		bool updateLabel();
 		bool updateUserColor();
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -91,7 +91,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		// means not hovered in that direction.
 		void hoveredEdges( const ButtonEvent &event, int &horizontal, int &vertical ) const;
 
-		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
+		void nodeMetadataChanged( IECore::InternedString key );
 
 		bool updateUserColor();
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -138,7 +138,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 
 		ConnectionCreator *closestDragDestination( const DragDropEvent &event ) const;
 
-		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node );
+		void nodeMetadataChanged( IECore::InternedString key );
 
 		bool updateUserColor();
 		void updatePadding();

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -555,7 +555,7 @@ Shader::Shader( const std::string &name )
 	addChild( new CompoundObjectPlug( "__outAttributes", Plug::Out, new IECore::CompoundObject ) );
 
 	nameChangedSignal().connect( boost::bind( &Shader::nameChanged, this ) );
-	Metadata::nodeValueChangedSignal().connect( boost::bind( &Shader::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
+	Metadata::nodeValueChangedSignal( this ).connect( boost::bind( &Shader::nodeMetadataChanged, this, ::_2 ) );
 }
 
 Shader::~Shader()
@@ -840,14 +840,9 @@ void Shader::nameChanged()
 	nodeNamePlug()->setValue( getName() );
 }
 
-void Shader::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
+void Shader::nodeMetadataChanged( IECore::InternedString key )
 {
-	if( node && node != this )
-	{
-		return;
-	}
-
-	if( key == g_nodeColorMetadataName && this->isInstanceOf( nodeTypeId ) )
+	if( key == g_nodeColorMetadataName )
 	{
 		IECore::ConstColor3fDataPtr d = Metadata::value<const IECore::Color3fData>( this, g_nodeColorMetadataName );
 		nodeColorPlug()->setValue( d ? d->readable() : Color3f( 0.0f ) );

--- a/src/GafferUI/AuxiliaryNodeGadget.cpp
+++ b/src/GafferUI/AuxiliaryNodeGadget.cpp
@@ -56,7 +56,7 @@ static IECore::InternedString g_colorKey( "nodeGadget:color" );
 AuxiliaryNodeGadget::AuxiliaryNodeGadget( Gaffer::NodePtr node )
 	:	NodeGadget( node ), m_label( "" ), m_radius( 1.0 )
 {
-	Gaffer::Metadata::nodeValueChangedSignal().connect( boost::bind( &AuxiliaryNodeGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
+	Gaffer::Metadata::nodeValueChangedSignal( node.get() ).connect( boost::bind( &AuxiliaryNodeGadget::nodeMetadataChanged, this, ::_2 ) );
 
 	updateLabel();
 	updateUserColor();
@@ -91,7 +91,7 @@ void AuxiliaryNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	glPopMatrix();
 }
 
-void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
+void AuxiliaryNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 {
 	if( key == g_labelKey )
 	{

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -123,7 +123,7 @@ BackdropNodeGadget::BackdropNodeGadget( Gaffer::NodePtr node )
 	dragEndSignal().connect( boost::bind( &BackdropNodeGadget::dragEnd, this, ::_1, ::_2 ) );
 	leaveSignal().connect( boost::bind( &BackdropNodeGadget::leave, this, ::_1, ::_2 ) );
 
-	Metadata::nodeValueChangedSignal().connect( boost::bind( &BackdropNodeGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
+	Metadata::nodeValueChangedSignal( node.get() ).connect( boost::bind( &BackdropNodeGadget::nodeMetadataChanged, this, ::_2 ) );
 
 	updateUserColor();
 }
@@ -531,14 +531,9 @@ Gaffer::Box2fPlug *BackdropNodeGadget::acquireBoundPlug( bool createIfMissing )
 	return newPlug.get();
 }
 
-void BackdropNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
+void BackdropNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 {
-	if( node && node != this->node() )
-	{
-		return;
-	}
-
-	if( this->node()->isInstanceOf( nodeTypeId ) && key == g_colorKey )
+	if( key == g_colorKey )
 	{
 		if( updateUserColor() )
 		{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -340,7 +340,7 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node )
 		l->leaveSignal().connect( boost::bind( &StandardNodeGadget::leave, this, ::_1 ) );
 	}
 
-	Metadata::nodeValueChangedSignal().connect( boost::bind( &StandardNodeGadget::nodeMetadataChanged, this, ::_1, ::_2, ::_3 ) );
+	Metadata::nodeValueChangedSignal( node.get() ).connect( boost::bind( &StandardNodeGadget::nodeMetadataChanged, this, ::_2 ) );
 
 	// do our first update
 	////////////////////////////////////////////////////////
@@ -759,18 +759,8 @@ ConnectionCreator *StandardNodeGadget::closestDragDestination( const DragDropEve
 	return result;
 }
 
-void StandardNodeGadget::nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, const Gaffer::Node *node )
+void StandardNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 {
-	if( node && node != this->node() )
-	{
-		return;
-	}
-
-	if( !this->node()->isInstanceOf( nodeTypeId ) )
-	{
-		return;
-	}
-
 	if( key == g_colorKey )
 	{
 		if( updateUserColor() )


### PR DESCRIPTION
This follows on from https://github.com/GafferHQ/gaffer/pull/4106, dealing with some stragglers that somehow escaped attention at the time. Profiling the loading of a large production script with 100,000 shader nodes suggests that https://github.com/GafferHQ/gaffer/commit/162fc80947cb54827dbeef034fe52d3cf79dafa1 in particular might produce a significant performance boost. It's debatable whether this should be classed as a fix for the 0.59 series of a performance improvement for the 0.60 series. For now I've made the PR for 0.59 to allow testing of the PR build on the production example.