### PR TITLE
Widget : Add keyboard hotkey for starting and stopping drags 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.60.x.x (relative to 0.60.2.1)
 ========
 
+Features
+--------
+
+- Drag and drop : Added <key>G</key> hotkey for starting and stopping drags without using buttons on the mouse or stylus. This can be used for any drag and drop operation in Gaffer, including making connections in the GraphEditor. Press <key>G</key> to start a drag, and press <key>G</key> again to drop.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,11 @@ Fixes
 
 - ImageReader/ImageWriter : The `name`, `oiio:subimagename` and `oiio:subimages` metadata items are now ignored because they are ambiguous, and caused ImageWriter to write incorrect images. The same information is available in Gaffer via the image's `channelNames`.
 
+Fixes
+-----
+
+- GraphEditor : Fixed bug in <key>D</key> shortcut.
+
 API
 ---
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -841,6 +841,7 @@ bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
 				}
 			}
 		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Several users have requested the ability to make connections in the GraphEditor without needing to press and hold a mouse/stylus button during the drag operation. Since there's a fair bit of drag and drop elsewhere in Gaffer it seemed a pity to limit the feature to this one spot, so I've implemented it at the lowest level in the Widget event handling, so that it applies to _any_ drag and drop operation. I went with <kbd>G</kbd> as the hotkey based on proximity to the index finger of the left hand and also because "G for Grab" seemed like a reasonable mnemonic device.
