### PR TITLE
OpenImageIOReader : Don't read subimage-related metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - ImageMetadata : Added `extraMetadata` plug, which is useful for generating arbitrary metadata from an expression, and for using types which are not supported by the standard `metadata` plug (timecodes for instance).
 
+Fixes
+-----
+
+- ImageReader/ImageWriter : The `name`, `oiio:subimagename` and `oiio:subimages` metadata items are no longer loaded because they are ambiguous, and caused ImageWriter to write incorrect images. The same information is available in Gaffer via the image's `channelNames`.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ API
 ---
 
 - PlugLayout : Added a warning for plugs that reference activators that have not been registered.
+- ImageTestCase : Added `ignoreChannelNamesOrder` keyword argument to `assertImagesEqual()`. This defaults to `False`, maintaining the previous behaviour.
 
 0.60.2.1 (relative to 0.60.2.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,7 @@ Improvements
 Fixes
 -----
 
-- ImageReader/ImageWriter : The `name`, `oiio:subimagename` and `oiio:subimages` metadata items are no longer loaded because they are ambiguous, and caused ImageWriter to write incorrect images. The same information is available in Gaffer via the image's `channelNames`.
+- ImageReader/ImageWriter : The `name`, `oiio:subimagename` and `oiio:subimages` metadata items are now ignored because they are ambiguous, and caused ImageWriter to write incorrect images. The same information is available in Gaffer via the image's `channelNames`.
 
 API
 ---

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -80,7 +80,8 @@ class ImageTestCase( GafferTest.TestCase ) :
 				tileOrigin.x += GafferImage.ImagePlug.tileSize()
 			tileOrigin.y += GafferImage.ImagePlug.tileSize()
 
-	def assertImagesEqual( self, imageA, imageB, maxDifference = 0.0, ignoreMetadata = False, ignoreDataWindow = False ) :
+	def assertImagesEqual( self, imageA, imageB, maxDifference = 0.0, ignoreMetadata = False, ignoreDataWindow = False, ignoreChannelNamesOrder = False ) :
+
 		self.longMessage = True
 
 		self.assertEqual( imageA["format"].getValue(), imageB["format"].getValue() )
@@ -88,7 +89,12 @@ class ImageTestCase( GafferTest.TestCase ) :
 			self.assertEqual( imageA["dataWindow"].getValue(), imageB["dataWindow"].getValue() )
 		if not ignoreMetadata :
 			self.assertEqual( imageA["metadata"].getValue(), imageB["metadata"].getValue() )
-		self.assertEqual( imageA["channelNames"].getValue(), imageB["channelNames"].getValue() )
+
+		if not ignoreChannelNamesOrder :
+			self.assertEqual( imageA["channelNames"].getValue(), imageB["channelNames"].getValue() )
+		else :
+			self.assertEqual( set( imageA["channelNames"].getValue() ), set( imageB["channelNames"].getValue() ) )
+
 		deep = imageA["deep"].getValue()
 		self.assertEqual( deep, imageB["deep"].getValue() )
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -100,8 +100,6 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			"fileFormat" : IECore.StringData( "openexr" ),
 			"dataType" : IECore.StringData( "float" ),
 		} )
-		if hasattr( IECoreImage, "OpenImageIOAlgo" ) and IECoreImage.OpenImageIOAlgo.version() >= 20206 :
-			expectedMetadata['oiio:subimages'] = IECore.IntData( 1 )
 
 		self.assertEqual( n["out"]["metadata"].getValue(), expectedMetadata )
 
@@ -640,6 +638,16 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( GafferImage.OpenImageIOReader.getOpenFilesLimit(), l + 1 )
 		finally :
 			GafferImage.OpenImageIOReader.setOpenFilesLimit( l )
+
+	def testSubimageMetadataNotLoaded( self ) :
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/multipart.exr" )
+		metadata = reader["out"].metadata()
+
+		self.assertNotIn( "name", metadata )
+		self.assertNotIn( "oiio:subimagename", metadata )
+		self.assertNotIn( "oiio:subimages", metadata )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1019,11 +1019,27 @@ class DeepScanlineWriter
 // Utility for converting IECore::Data types to OIIO::TypeDesc types.
 //////////////////////////////////////////////////////////////////////////
 
+// See associated blacklist in OpenImageIOReader.
+boost::container::flat_set<InternedString> g_metadataBlacklist = {
+	"name",
+	"oiio:subimagename",
+	"oiio:subimages"
+};
+
 void metadataToImageSpecAttributes( const CompoundData *metadata, ImageSpec &spec )
 {
 	const CompoundData::ValueType &members = metadata->readable();
 	for( CompoundData::ValueType::const_iterator it = members.begin(); it != members.end(); ++it )
 	{
+		if( g_metadataBlacklist.count( it->first ) )
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "ImageWriter",
+				boost::format( "Ignoring metadata \"%1%\" because it conflicts with OpenImageIO." ) % it->first
+			);
+			continue;
+		}
+
 		const IECoreImage::OpenImageIOAlgo::DataView dataView( it->second.get() );
 		if( dataView.data )
 		{


### PR DESCRIPTION
As documented in the comments and tests, it doesn't provide accurate information, and it caused the ImageWriter to write images incorrectly. There's probably some debate to be had about whether or not we should treat this as a breaking change. I've taken a sort of kludgy middle ground, classing it as a bugfix but making the PR for `0.60` rather than `0.59` on the grounds that `0.59` is pretty late in its lifecycle, and `0.60` is only just beginning to be adopted in anger. I'm open to other opinions though. One other possibility is that we save this for `0.61` and take a more conservative approach for now - just deleting the metadata in the ImageWriter.
