### PR TITLE
Improved PathListingWidget testing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ API
   - Added `gadgetsAt()` overload which returns the gadgets rather than taking an output parameter by reference.
   - Added `gadgetsAt()` overload taking a raster space region (rather than position) and an optional layer filter.
   - Add support for Gadget's double click signal.
+- GafferUITest.TestCase : Unexpected Qt messages are now reported as test failures.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,11 @@ Improvements
 
 - GraphEditor : Improved drawing performance for large node graphs. Gains of about 40% are typical, with much greater gains when looking at a small region of a large graph or performing selection tests (for example when hovering over something or dragging a connection).
 
+Fixes
+-----
+
+- PathListingWidget : Fixed subtle bugs in the underlying Qt model, although they haven't been observed to cause problems in practice.
+
 API
 ---
 

--- a/SConstruct
+++ b/SConstruct
@@ -1035,6 +1035,7 @@ for library in ( "GafferUI", ) :
 	addQtLibrary( library, "Core", False )
 	addQtLibrary( library, "Gui" )
 	addQtLibrary( library, "OpenGL" )
+	addQtLibrary( library, "Test" )
 	if int( env["QT_VERSION"] ) > 4 :
 		addQtLibrary( library, "Widgets" )
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -43,6 +43,7 @@ import Gaffer
 import GafferTest
 
 import GafferUI
+from GafferUI import _GafferUI
 import GafferUITest
 
 class PathListingWidgetTest( GafferUITest.TestCase ) :
@@ -59,6 +60,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		p = Gaffer.DictPath( d, "/" )
 
 		w = GafferUI.PathListingWidget( p )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 		self.assertEqual( len( w.getExpandedPaths() ), 0 )
 
 		p1 = Gaffer.DictPath( d, "/1" )
@@ -95,6 +97,8 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		p = Gaffer.DictPath( d, "/" )
 
 		w = GafferUI.PathListingWidget( p )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
+
 		self.assertTrue( w.getExpansion().isEmpty() )
 
 		cs = GafferTest.CapturingSlot( w.expansionChangedSignal() )
@@ -118,6 +122,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		p = Gaffer.DictPath( d, "/" )
 		w = GafferUI.PathListingWidget( p )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		c = GafferTest.CapturingSlot( w.expansionChangedSignal() )
 		self.assertEqual( len( c ), 0 )
@@ -151,6 +156,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		p = Gaffer.DictPath( d, "/" )
 
 		w = GafferUI.PathListingWidget( p, allowMultipleSelection = True )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 		self.assertTrue( w.getSelection().isEmpty() )
 
 		cs = GafferTest.CapturingSlot( w.selectionChangedSignal() )
@@ -176,6 +182,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		p = Gaffer.DictPath( d, "/" )
 		w = GafferUI.PathListingWidget( p, allowMultipleSelection=True )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		c = GafferTest.CapturingSlot( w.selectionChangedSignal() )
 		self.assertEqual( len( c ), 0 )
@@ -199,6 +206,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		p = Gaffer.DictPath( d, "/" )
 		p1 = Gaffer.DictPath( d, "/a" )
 		w = GafferUI.PathListingWidget( p, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertEqual( w.getPathExpanded( p1 ), False )
 		w.setPathExpanded( p1, True )
@@ -229,6 +237,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		pa = Gaffer.DictPath( d, "/a" )
 		pae = Gaffer.DictPath( d, "/a/e" )
 		w = GafferUI.PathListingWidget( p, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertEqual( w.getPathExpanded( pa ), False )
 		self.assertEqual( w.getPathExpanded( pae ), False )
@@ -252,6 +261,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		with GafferUI.ListContainer() as c :
 			w = GafferUI.PathListingWidget( Gaffer.DictPath( {}, "/" ) )
+			_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertTrue( w.getHeaderVisible() )
 
@@ -272,6 +282,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		p = Gaffer.DictPath( { "a" : { "b" : { "c" : { "d" : 10 } } } }, "/" )
 
 		w = GafferUI.PathListingWidget( p )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 		w.setPathExpanded( p.copy().setFromString( "/a/b/c" ), True )
 
 		self.assertTrue( w.getPathExpanded( p.copy().setFromString( "/a/b/c" ) ) )
@@ -279,6 +290,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 	def testColumns( self ) :
 
 		w = GafferUI.PathListingWidget( Gaffer.DictPath( {}, "/" ) )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertEqual( w.getColumns(), list( w.defaultFileSystemColumns ) )
 

--- a/python/GafferUITest/TestCase.py
+++ b/python/GafferUITest/TestCase.py
@@ -36,9 +36,15 @@
 
 import os
 import sys
+import functools
 import unittest
 import inspect
 import weakref
+
+from Qt import QtCore
+from Qt import QtCompat
+
+import IECore
 
 import Gaffer
 import GafferTest
@@ -46,6 +52,28 @@ import GafferUI
 
 ## A useful base class for creating test cases for the ui.
 class TestCase( GafferTest.TestCase ) :
+
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+
+		# Forward Qt messages to the IECore message handler.
+		# This causes them to be reported as errors by our
+		# base class.
+
+		def messageHandler( type, context, message ) :
+
+			IECore.msg(
+				{
+					QtCore.QtMsgType.QtInfoMsg : IECore.Msg.Level.Info,
+					QtCore.QtMsgType.QtDebugMsg : IECore.Msg.Level.Debug,
+				}.get( type, IECore.Msg.Level.Error ),
+				"Qt",
+				message
+			)
+
+		QtCompat.qInstallMessageHandler( messageHandler )
+		self.addCleanup( functools.partial( QtCompat.qInstallMessageHandler, None ) )
 
 	def tearDown( self ) :
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -396,7 +396,7 @@ class WindowTest( GafferUITest.TestCase ) :
 	def testRemoveOnCloseCrash( self ) :
 
 		parent = GafferUI.Window()
-		parent.setChild( GafferUI.Label( "Hello" ) )
+		parent.setChild( GafferUI.Label( "\n".join( [ "Hello" * 10 ] * 10 ) ) )
 		parent.setVisible( True )
 
 		for i in range( 0, 50 ) :


### PR DESCRIPTION
This beefs up our testing of PathListingWidget by applying a QAbstractItemModelTester which constantly monitors our underlying QAbstractItemModel for consistency while the tests run. This exposed a couple of small bugs which seem to have gone unnoticed the entire time, and which are fixed here. This is a precursor to refactoring our PathModel to support asynchronous updates.

@proberts-cinesite, just to help you get your bearings while reviewing, the PathListingWidget is what we use in things like the file open dialogue and the HierarchyView.

