### PR TITLE
Bookmarks : Ignore bookmarks from read-only boxes in general

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,9 @@ Fixes
 
 - GraphEditor : The Dot created when you <kbd>Ctrl</kbd>+click on a connection is now selected automatically, so it can be repositioned by an immediate drag.
 - MetadataAlgo : Numeric bookmarks are no longer loaded inside nodes with `childNodesAreReadOnly` metadata, to prevent them "stealing" bookmarks from other nodes. Previously this only applied to nodes inside References.
-- Reference : The `childNodesAreReadOnly` metadata is now specified in the Gaffer module, so it applies even without `GafferUI` being imported.
+- Reference :
+  - Moved the `childNodesAreReadOnly` metadata registration to the Gaffer module, so it applies even without `GafferUI` being imported.
+  - Prevented `childNodesAreReadOnly` metadata baked into a referenced file from overriding the Reference node's own metadata.
 
 0.60.3.0 (relative to 0.60.2.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - GraphEditor : The Dot created when you <kbd>Ctrl</kbd>+click on a connection is now selected automatically, so it can be repositioned by an immediate drag.
+- MetadataAlgo : Numeric bookmarks are no longer loaded inside nodes with `childNodesAreReadOnly` metadata, to prevent them "stealing" bookmarks from other nodes. Previously this only applied to nodes inside References.
 
 0.60.3.0 (relative to 0.60.2.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - GraphEditor : The Dot created when you <kbd>Ctrl</kbd>+click on a connection is now selected automatically, so it can be repositioned by an immediate drag.
 - MetadataAlgo : Numeric bookmarks are no longer loaded inside nodes with `childNodesAreReadOnly` metadata, to prevent them "stealing" bookmarks from other nodes. Previously this only applied to nodes inside References.
+- Reference : The `childNodesAreReadOnly` metadata is now specified in the Gaffer module, so it applies even without `GafferUI` being imported.
 
 0.60.3.0 (relative to 0.60.2.1)
 ========

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -58,3 +58,6 @@ from . import NodeAlgo
 from . import ExtensionAlgo
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )
+
+# Class-level non-UI metadata registration
+Metadata.registerValue( Reference, "childNodesAreReadOnly", True )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1762,6 +1762,16 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		self.assertTrue( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( s["r1"] ) )
 
+		# bake in the metadata into the Box to test if it will be handled by the Reference
+		Gaffer.MetadataAlgo.setChildNodesAreReadOnly( b, False )
+
+		b.exportForReference( self.temporaryDirectory() + "/testWithMetadata.grf" )
+
+		s["r2"] = Gaffer.Reference()
+		s["r2"].load( self.temporaryDirectory() + "/testWithMetadata.grf" )
+
+		self.assertTrue( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( s["r2"] ) )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1747,6 +1747,21 @@ class ReferenceTest( GafferTest.TestCase ) :
 		script2.execute( script.serialise() )
 		assertColumnsMatch( script2["reference"]["rows"], script["box"]["rows"].defaultRow() )
 
+	def testChildNodesAreReadOnlyMetadata( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n1"] = GafferTest.AddNode()
+
+		b = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["n1"] ] ) )
+
+		b.exportForReference( self.temporaryDirectory() + "/test.grf" )
+
+		s["r1"] = Gaffer.Reference()
+		s["r1"].load( self.temporaryDirectory() + "/test.grf" )
+
+		self.assertTrue( Gaffer.MetadataAlgo.getChildNodesAreReadOnly( s["r1"] ) )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -59,7 +59,6 @@ Gaffer.Metadata.registerNode(
 	"icon", "referenceNode.png",
 
 	"graphEditor:childrenViewable", True,
-	"childNodesAreReadOnly", True,
 
 	"layout:customWidget:fileName:widgetType", "GafferUI.ReferenceUI._FileNameWidget"
 

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -118,6 +118,37 @@ const Gaffer::GraphComponent *readOnlyReason( const Gaffer::GraphComponent *grap
 	return reason;
 }
 
+bool ancestorChildNodesAreReadOnly( const Gaffer::GraphComponent *graphComponent )
+{
+
+	bool haveNodeDescendants = false;
+	const Gaffer::Node *node = runTimeCast<const Gaffer::Node>( graphComponent );
+	if ( node )
+	{
+		haveNodeDescendants = true;
+	}
+
+	graphComponent = graphComponent->parent();
+
+	while( graphComponent )
+	{
+		const Gaffer::Node *node = runTimeCast<const Gaffer::Node>( graphComponent );
+
+		if( node && haveNodeDescendants && Gaffer::MetadataAlgo::getChildNodesAreReadOnly( node ) )
+		{
+			return true;
+		}
+
+		if( !haveNodeDescendants && node )
+		{
+			haveNodeDescendants = true;
+		}
+
+		graphComponent = graphComponent->parent();
+	}
+	return false;
+}
+
 } // namespace
 
 namespace Gaffer
@@ -262,7 +293,7 @@ void bookmarks( const Node *node, std::vector<NodePtr> &bookmarks )
 
 void setNumericBookmark( ScriptNode *scriptNode, int bookmark, Node *node )
 {
-	if( scriptNode->isExecuting() && node && node->ancestor<Reference>() )
+	if( scriptNode->isExecuting() && node && ancestorChildNodesAreReadOnly( node ) )
 	{
 		return;
 	}

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -143,6 +143,8 @@ void transferOutputs( Gaffer::Plug *srcPlug, Gaffer::Plug *dstPlug )
 	}
 }
 
+const InternedString g_childNodesAreReadOnlyName( "childNodesAreReadOnly" );
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -541,6 +543,8 @@ void Reference::loadInternal( const std::string &fileName )
 	{
 		PlugEdits::LoadingScope loadingScope( m_plugEdits.get() );
 		errors = script->executeFile( path.string(), this, /* continueOnError = */ true );
+		// deregister "childNodesAreReadOnly" metadata, in case it was baked in the exported file
+		Metadata::deregisterValue( this, g_childNodesAreReadOnlyName );
 	}
 
 	// Do a little bit of post processing on everything that was loaded.


### PR DESCRIPTION
This PR changes the bookmark setting code so that bookmarks are ignored not only if they are inside a `Reference`, but also if they are inside a read-only box (like the `DynamicBoxes` used at IE).
