### PR TITLE
Reference : Added support for Spreadsheet inside another Plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.59.9.x (relative to 0.59.9.3)
+========
+
+Fixes
+-----
+
+- Reference : Add support for Spreadsheet inside another Plug
+
 0.59.9.3 (relative to 0.59.9.2)
 ========
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -1633,6 +1633,13 @@ class ReferenceTest( GafferTest.TestCase ) :
 		script["box"]["node"]["user"]["compoundData"] = Gaffer.CompoundDataPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		Gaffer.PlugAlgo.promoteWithName( script["box"]["node"]["user"]["compoundData"], "compoundData" )
 
+		# also test promotion not directly to the box, but to a plug inside the box
+
+		script["box"]["container"] = Gaffer.Plug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["box"]["spreadsheetInPlug"] = Gaffer.Spreadsheet()
+		script["box"]["spreadsheetInPlug"]["rows"].addColumn( Gaffer.IntPlug( "c1" ) )
+		Gaffer.PlugAlgo.promote( script["box"]["spreadsheetInPlug"]["rows"], parent = script["box"]["container"] )
+
 		fileName = os.path.join( self.temporaryDirectory(), "test.grf" )
 		script["box"].exportForReference( fileName )
 
@@ -1647,6 +1654,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		script["reference"]["compoundData"]["m1"] = Gaffer.NameValuePlug( "test1", 10, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		script["reference"]["compoundData"]["m2"] = Gaffer.NameValuePlug( "test2", 20, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		script["reference"]["container"]["rows"].addRows( 2 )
+		for i, row in enumerate( script["reference"]["container"]["rows"] ) :
+			row["cells"]["c1"]["value"].setValue( i )
 
 		def assertExpectedChildren( reference ) :
 
@@ -1672,6 +1683,14 @@ class ReferenceTest( GafferTest.TestCase ) :
 			self.assertFalse( reference.isChildEdit( reference["rows"] ) )
 			self.assertFalse( reference.isChildEdit( reference["compoundData"] ) )
 			self.assertFalse( reference.isChildEdit( reference["compoundData"]["m1"]["value"] ) )
+
+			self.assertEqual( len( reference["container"]["rows"] ), 3 )
+			for i, row in enumerate( reference["container"]["rows"] ) :
+				self.assertEqual( row["cells"]["c1"]["value"].getValue(), i )
+				self.assertEqual( reference.isChildEdit( row ), i > 0 )
+
+			self.assertEqual( len( reference["spreadsheetInPlug"]["rows"] ), 3 )
+			self.assertEqual( reference["spreadsheetInPlug"]["rows"].getInput(), reference["container"]["rows"] )
 
 		assertExpectedChildren( script["reference"] )
 

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -334,7 +334,7 @@ class Reference::PlugEdits : public boost::signals::trackable
 
 		void loadingFinished()
 		{
-			for( auto &plug : Plug::Range( *m_reference ) )
+			for( auto &plug : Plug::RecursiveRange( *m_reference ) )
 			{
 				if( !m_reference->isReferencePlug( plug.get() ) )
 				{
@@ -392,6 +392,16 @@ class Reference::PlugEdits : public boost::signals::trackable
 			if( newPlug->typeId() != oldPlug->typeId() )
 			{
 				return;
+			}
+
+			// Recurse
+
+			for( PlugIterator it( oldPlug ); !it.done(); ++it )
+			{
+				if( Plug *dstChildPlug = newPlug->getChild<Plug>( (*it)->getName() ) )
+				{
+					transferChildEdits( it->get(), dstChildPlug );
+				}
 			}
 
 			auto *edit = plugEdit( oldPlug );


### PR DESCRIPTION
This is required because, at IE, we have a mechanism to promote all plugs from an internal node as a section, and the way it's implemented is by creating an intermediate plug where all those other plugs are added.

This allows us to have plugs with the same name, but from different nodes, promoted to the Box/Reference without any issues.

This intermediate plug is then displayed using the `GafferUI.LayoutPlugValueWidget`.

However, we ran into issues when promoting Spreadsheet plugs, which are apparently caused by the fact that only top-level plugs were considered when handling those types of plugs.

@johnhaddon, the solution proposed here is the simplest and most generic I could think of, but is likely not the most efficient/fastest. Let me know if you have a better solution in mind.



Fixes
-----

- Reference : Add support for Spreadsheet inside another Plug
