### PR TITLE
Build changes to allow variants at IE

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Fixes
 
 - GraphEditor : The Dot created when you <kbd>Ctrl</kbd>+click on a connection is now selected automatically, so it can be repositioned by an immediate drag.
 
+Build
+-----
+
+- Added `BOOST_PYTHON_LIB_SUFFIX` option. This matches the approach used in Cortex.
+
 0.60.3.0 (relative to 0.60.2.1)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -234,6 +234,13 @@ options.Add(
 )
 
 options.Add(
+	"BOOST_PYTHON_LIB_SUFFIX",
+	"The suffix appended to the names of the python boost libraries. "
+	"You can modify this so that the correct python library name is used, "
+	"likely related to the specific python version.",
+)
+
+options.Add(
 	"GLEW_LIB_SUFFIX",
 	"The suffix used when locating the glew libraries.",
 	"",
@@ -639,9 +646,12 @@ basePythonEnv["PYTHON_ABI_VERSION"] += subprocess.check_output(
 	env=commandEnv["ENV"]
 ).strip()
 
-basePythonEnv["BOOST_PYTHON_LIB_SUFFIX"] = ""
-if ( int( basePythonEnv["BOOST_MAJOR_VERSION"] ), int( basePythonEnv["BOOST_MINOR_VERSION"] ) ) >= ( 1, 67 ) :
-	basePythonEnv["BOOST_PYTHON_LIB_SUFFIX"] = basePythonEnv["PYTHON_VERSION"].replace( ".", "" )
+# if BOOST_PYTHON_LIB_SUFFIX is provided, use it
+boostPythonLibSuffix = basePythonEnv.get( "BOOST_PYTHON_LIB_SUFFIX", None )
+if boostPythonLibSuffix is None :
+	basePythonEnv["BOOST_PYTHON_LIB_SUFFIX"] = basePythonEnv["BOOST_LIB_SUFFIX"]
+	if ( int( basePythonEnv["BOOST_MAJOR_VERSION"] ), int( basePythonEnv["BOOST_MINOR_VERSION"] ) ) >= ( 1, 67 ) :
+		basePythonEnv["BOOST_PYTHON_LIB_SUFFIX"] = basePythonEnv["PYTHON_VERSION"].replace( ".", "" ) + basePythonEnv["BOOST_PYTHON_LIB_SUFFIX"]
 
 basePythonEnv.Append(
 
@@ -650,7 +660,7 @@ basePythonEnv.Append(
 	],
 
 	LIBS = [
-		"boost_python$BOOST_PYTHON_LIB_SUFFIX$BOOST_LIB_SUFFIX",
+		"boost_python$BOOST_PYTHON_LIB_SUFFIX",
 		"IECorePython$CORTEX_PYTHON_LIB_SUFFIX",
 		"Gaffer",
 	],

--- a/config/ie/installAll
+++ b/config/ie/installAll
@@ -33,6 +33,8 @@ def gafferRegistryVersion() :
 	return varsFound["gafferMilestoneVersion"] + "." + varsFound["gafferMajorVersion"] + ".0.0"
 
 gafferRegVersion = gafferRegistryVersion()
+gafferReg = IEEnv.registry["apps"]["gaffer"][gafferRegVersion][IEEnv.platform()]
+variantReg = gafferReg.get( "variants", {} )
 
 ##########################################################################
 # Run a single build
@@ -40,7 +42,7 @@ gafferRegVersion = gafferRegistryVersion()
 
 def build( extraArgs = [] ) :
 
-	argsToValidate = [ "GAFFER_VERSION={}".format( gafferRegVersion ) ] + extraArgs
+	argsToValidate = [ "GAFFER_VERSION={}".format( gafferRegVersion ) ] + [ x for x in extraArgs if "_VERSION=" in x or x.startswith( "APP=" ) ]
 	if not IEEnv.Registry.validateVariation( argsToValidate ) :
 		print( "Skipped invalid variation combination: " + str(argsToValidate) + "\n" )
 		return
@@ -88,16 +90,18 @@ if platform in ( "cent7.x86_64" ) :
 
 	for cortexCompatibilityVersion, cortexReg in cortexInfo.items() :
 
-		# standalone build
+		# standalone builds
 		compilerVersion = cortexReg.get( "compilerVersion", defaultCompilerVersion )
 		appleseedVersion = appleseedCompilerMap[compilerVersion][cortexCompatibilityVersion]
-		build( [
+		baseArgs = [
 			"COMPILER_VERSION={}".format( compilerVersion ),
 			"CORTEX_VERSION={}".format( cortexCompatibilityVersion ),
 			"APPLESEED_VERSION={}".format( appleseedVersion ),
 			"ARNOLD_VERSION={}".format( aiVersion ),
 			"DL_VERSION={}".format( dlVersion ),
-		] )
+		]
+		for variant, variantArgs in variantReg.items() :
+			build( baseArgs + [ "GAFFER_BUILD_VARIANT={}".format( variant ) ] + [ "=".join( x ) for x in variantArgs.items() ] )
 
 		# app specific builds
 		for app, minimumVersion in (
@@ -112,10 +116,10 @@ if platform in ( "cent7.x86_64" ) :
 					"APP={}".format( app ),
 					"APP_VERSION={}".format( appVersion ),
 					"CORTEX_VERSION={}".format( cortexCompatibilityVersion ),
-                    "APPLESEED_VERSION={}".format( appleseedVersion ),
-                    "ARNOLD_VERSION={}".format( aiVersion ),
-                    "DL_VERSION={}".format( dlVersion ),
-                ] )
+					"APPLESEED_VERSION={}".format( appleseedVersion ),
+					"ARNOLD_VERSION={}".format( aiVersion ),
+					"DL_VERSION={}".format( dlVersion ),
+				] )
 
 else :
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -89,10 +89,12 @@ cortexCompatibilityVersion = ".".join( cortexVersion.split( "." )[0:2] )
 cortexReg = IEEnv.registry["libraries"]["cortex"][cortexCompatibilityVersion][IEEnv.platform()]
 compiler = getOption( "COMPILER", None )
 compilerVersion = getOption( "COMPILER_VERSION", None )
+pythonVersion = getOption( "PYTHON_VERSION", cortexReg["preferredPythonVersion"] )
 targetApp = getOption( "APP", None )
 targetAppVersion = None
 
 gafferReg = IEEnv.registry["apps"]["gaffer"][gafferRegistryVersion()][IEEnv.platform()]
+gafferBuildVariant = getOption( "GAFFER_BUILD_VARIANT", "py2" )
 qtVersion = gafferReg["qtVersion"]
 pysideVersion = gafferReg.get( "pysideVersion", "2.0.0" )
 qtPyVersion = gafferReg.get( "qtPyVersion", "1.0.0.b3" )
@@ -145,7 +147,6 @@ else :
 
 	targetApp = "gaffer"
 	targetAppReg = gafferReg
-	pythonVersion = cortexReg["preferredPythonVersion"]
 	platformReg = IEEnv.registry["platformDefaults"][IEEnv.platform()]
 	if not compiler :
 		compiler = cortexReg.get( "compiler", platformReg["compiler"] )
@@ -202,11 +203,12 @@ baseInstallDir = os.path.join( installRoot, "apps", "gaffer", versionString, IEE
 
 BUILD_DIR = os.path.join( baseBuildDir, targetApp )
 INSTALL_DIR = os.path.join( baseInstallDir, targetApp )
-
 if targetAppVersion :
-
 	BUILD_DIR = os.path.join( BUILD_DIR, targetAppMajorVersion )
 	INSTALL_DIR = os.path.join( INSTALL_DIR, targetAppMajorVersion )
+else :
+	BUILD_DIR = os.path.join( BUILD_DIR, gafferBuildVariant )
+	INSTALL_DIR = os.path.join( INSTALL_DIR, gafferBuildVariant )
 
 GAFFERCORTEX = True
 
@@ -387,14 +389,15 @@ CXX = os.path.join( compilerReg["location"], compilerReg["bin"] )
 SPHINX = os.path.join( sphinxRoot, "bin", "sphinx-build" )
 
 if "install" in sys.argv :
-	# disable docs for releases (the postInstall command will symlink them from the public build)
-	if getOption( "RELEASE", "0" )=="1" :
-		SPHINX = "disableDocs"
-	# disable docs and graphics for all DCC installs (the postInstall command will symlink them our standalone build)
+	# disable docs for installations (the postInstall command will symlink them from the public build)
+	SPHINX = "disableDocs"
+	# disable graphics for all DCC installs (the postInstall command will symlink them our standalone build)
 	if targetAppVersion :
-		SPHINX = "disableDocs"
 		INKSCAPE = "disableGraphics"
-	INSTALL_POST_COMMAND="scons -i -f config/ie/postInstall BASE_INSTALL_DIR={baseInstallDir} INSTALL_DIR=$INSTALL_DIR".format( baseInstallDir = baseInstallDir )
+	INSTALL_POST_COMMAND="scons -i -f config/ie/postInstall BASE_INSTALL_DIR={baseInstallDir} INSTALL_DIR=$INSTALL_DIR GAFFER_BUILD_VARIANT={gafferBuildVariant}".format(
+		baseInstallDir = baseInstallDir,
+		gafferBuildVariant = gafferBuildVariant,
+	)
 
 ##########################################################################
 # figure out the lib suffixes
@@ -405,6 +408,9 @@ OIIO_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenImageIO", oiioVersion )
 OCIO_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenColorIO", ocioVersion )
 OSL_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenShadingLanguage", oslVersion )
 BOOST_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "boost", boostVersion, { "compiler" : compiler, "compilerVersion" : compilerVersion } )
+BOOST_PYTHON_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix(
+	"boost_python", boostVersion, { "compiler" : compiler, "compilerVersion" : compilerVersion, "pythonVersion" : pythonVersion }
+)
 CORTEX_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "cortex", cortexCompatibilityVersion )
 CORTEX_PYTHON_LIB_SUFFIX = CORTEX_LIB_SUFFIX + "-python" + pythonVersion
 

--- a/config/ie/postInstall
+++ b/config/ie/postInstall
@@ -55,7 +55,7 @@ def __link( source, target ) :
 
 # symlink to standalone install
 for subdir in ( "graphics", ) :
-	__link( os.path.join( ARGUMENTS['BASE_INSTALL_DIR'], "gaffer", subdir ), os.path.join( ARGUMENTS['INSTALL_DIR'], subdir ) )
+	__link( os.path.join( ARGUMENTS['BASE_INSTALL_DIR'], "gaffer", ARGUMENTS['GAFFER_BUILD_VARIANT'], subdir ), os.path.join( ARGUMENTS['INSTALL_DIR'], subdir ) )
 
 # symlink to public install
 for subdir in ( "doc", ) :


### PR DESCRIPTION
This is mainly just IE config changes, but I did add one new SConstruct option to make it all work. This matches the approach in Cortex, where `BOOST_PYTHON_LIB_SUFFIX` is expected to be the full suffix (rather than the python-only "midfix"), and allows custom builds to specify a custom suffix.