### PR TITLE
ComputeNodeTest : Tweak timing

### DIFF
--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -496,9 +496,9 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 
 		s["n"] = GafferTest.AddNode()
 		s["e1"] = Gaffer.Expression()
-		s["e1"].setExpression( "import time; time.sleep( 1 ); parent['n']['op1'] = 10" )
+		s["e1"].setExpression( "import time; time.sleep( 0.9 ); parent['n']['op1'] = 10" )
 		s["e2"] = Gaffer.Expression()
-		s["e2"].setExpression( "import time; time.sleep( 1 ); parent['n']['op2'] = 20" )
+		s["e2"].setExpression( "import time; time.sleep( 0.9 ); parent['n']['op2'] = 20" )
 
 		cs = GafferTest.CapturingSlot( s["n"].errorSignal() )
 


### PR DESCRIPTION
This has been failing periodically since 6ffa9db0d2e40cc47303f8af691f24546d4484ba was merged. That commit added warnings for any compute which took longer than 1s to cancel, and the ComputeNodeTest in question takes 1s to cancel. Reducing the compute length takes the cancellation time under the threshold while still giving the main thread time to request cancellation before the background thread completes the compute.
