### PR TITLE
StandardNodeGadget : Draw focus gadget above nodes/connections

### DIFF
--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -294,7 +294,7 @@ class FocusGadget : public Gadget
 
 		unsigned layerMask() const override
 		{
-			return (unsigned)GraphLayer::OverBackdrops;
+			return (int)GraphLayer::Highlighting;
 		}
 
 		Imath::Box3f renderBound() const override


### PR DESCRIPTION
Otherwise, when zoomed out (and the focus gadget has a larger relative size) it can get slightly lost.

@danieldresser-ie, this is something I'd noticed feeling a bit odd, and which @themissingcow mentioned to me independently as well. Hopefully it makes sense?