### PR TITLE
StandardNodeGadget : Draw focus gadget in overlay layer

### DIFF
--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -294,7 +294,7 @@ class FocusGadget : public Gadget
 
 		unsigned layerMask() const override
 		{
-			return (int)GraphLayer::Highlighting;
+			return (int)GraphLayer::Overlay;
 		}
 
 		Imath::Box3f renderBound() const override


### PR DESCRIPTION
So that it is above the strike-through applied to disabled nodes.
