### PR TITLE
ShaderAssignment : Add `label` plug to relabel shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@ Improvements
 ------------
 
 - Viewer : Added <kbd>PgDn</kbd> and <kbd>PgUp</kbd> hotkeys for switching to the previous and next image layer respectively.
+- Shader : Added "label" blindData which should be used in preference to "gaffer:nodeName" blindData.
+- ShaderAssignment : Added `label` plug to optionally override the shader's "label" blindData.
 
 0.60.5.0 (relative to 0.60.4.0)
 ========

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -41,6 +41,8 @@
 #include "GafferScene/AttributeProcessor.h"
 #include "GafferScene/ShaderPlug.h"
 
+#include "Gaffer/StringPlug.h"
+
 namespace GafferScene
 {
 
@@ -56,6 +58,9 @@ class GAFFERSCENE_API ShaderAssignment : public AttributeProcessor
 
 		GafferScene::ShaderPlug *shaderPlug();
 		const GafferScene::ShaderPlug *shaderPlug() const;
+
+		Gaffer::StringPlug *labelPlug();
+		const Gaffer::StringPlug *labelPlug() const;
 
 	protected :
 

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -629,5 +629,33 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		# were being removed between nodes during script destruction.
 		del script
 
+	def testLabelOverride( self ) :
+
+		shader = GafferSceneTest.TestShader()
+		shader["type"].setValue( "test:surface" )
+		shader["name"].setValue( "shader1" )
+
+		shader2 = GafferSceneTest.TestShader()
+		shader2["type"].setValue( "test:surface" )
+		shader2["name"].setValue( "shader2" )
+
+		plane = GafferScene.Plane()
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		assignment = GafferScene.ShaderAssignment()
+		assignment["in"].setInput( plane["out"] )
+		assignment["filter"].setInput( planeFilter["out"] )
+		assignment["shader"].setInput( shader["out"] )
+
+		output = assignment["out"].attributes( "/plane" )["test:surface"].outputShader()
+		self.assertEqual( output.name, "shader1" )
+		self.assertEqual( output.blindData()["label"], IECore.StringData( "TestShader" ) )
+
+		assignment["label"].setValue( "glass" )
+		output = assignment["out"].attributes( "/plane" )["test:surface"].outputShader()
+		self.assertEqual( output.name, "shader1" )
+		self.assertEqual( output.blindData()["label"], IECore.StringData( "glass" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -95,8 +95,8 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		s2 = s.attributes()["test:surface"]
 		self.assertNotEqual( s2, s1 )
 
-		self.assertEqual( s1.getShader( "node1" ).blindData()["gaffer:nodeName"], IECore.StringData( "node1" ) )
-		self.assertEqual( s2.getShader( "node2" ).blindData()["gaffer:nodeName"], IECore.StringData( "node2" ) )
+		self.assertEqual( s1.getShader( "node1" ).blindData()["label"], IECore.StringData( "node1" ) )
+		self.assertEqual( s2.getShader( "node2" ).blindData()["label"], IECore.StringData( "node2" ) )
 
 	def testNodeColorBlindData( self ) :
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -564,7 +564,7 @@ class TextDiff( SideBySideDiff ) :
 				formattedValues.append( "Missing output shader" )
 				continue
 			shaderName = shader.name
-			nodeName = shader.blindData().get( "gaffer:nodeName", None )
+			nodeName = shader.blindData().get( "label", shader.blindData().get( "gaffer:nodeName", None ) )
 
 			formattedValue = "<table cellspacing=2><tr>"
 			if nodeName is not None :

--- a/python/GafferSceneUI/ShaderAssignmentUI.py
+++ b/python/GafferSceneUI/ShaderAssignmentUI.py
@@ -49,6 +49,8 @@ Gaffer.Metadata.registerNode(
 	Assigns shaders to objects.
 	""",
 
+	"layout:activator:labelOverride", lambda node : not node["label"].isSetToDefault(),
+
 	plugs = {
 
 		"shader" : [
@@ -60,6 +62,19 @@ Gaffer.Metadata.registerNode(
 
 			"noduleLayout:section", "left",
 			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"label" : [
+
+			"description",
+			"""
+			A label for the shader to be assigned. If this is empty, the node
+			connected to the `shader` plug will be used instead.
+			""",
+
+			"nodule:type", "",
+			"layout:visibilityActivator", "labelOverride",
 
 		]
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -333,6 +333,8 @@ class Shader::NetworkBuilder
 			IECoreScene::ShaderPtr shader = new IECoreScene::Shader( shaderNode->namePlug()->getValue(), type );
 
 			const std::string nodeName = shaderNode->nodeNamePlug()->getValue();
+			shader->blindData()->writable()["label"] = new IECore::StringData( nodeName );
+			// \todo: deprecated, stop storing gaffer:nodeName after a grace period
 			shader->blindData()->writable()["gaffer:nodeName"] = new IECore::StringData( nodeName );
 			shader->blindData()->writable()["gaffer:nodeColor"] = new IECore::Color3fData( shaderNode->nodeColorPlug()->getValue() );
 


### PR DESCRIPTION
This affects the label presented to users in the _SceneInspector_ as well as the shader user data output to Arnold or other renderers. The intention is to enable studios to more easily enforce conventions on shaders where they are assigned to the scene (as opposed to within the shading network). It also feels more intuitive to ask users to set a plug (rather than a node name) to alter the scene.

We discussed some other approaches in a few meetings (eg a new `MaterialAssignment` node, a new `Material` shader, exposing the existing mechanism for shader naming to users). The feeling was the new nodes would require a bit more engineering and workflow redesign than this problem alone merits, and the existing mechanism has been non-effective in production for long enough that its worth trying something new.

As requested, I've hidden the plug by default, though I used an activator to make sure its visible if/when its set non-empty.