### PR TITLE
Issues With Exceptions During Parallel Eval

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Viewer : Added <kbd>PgDn</kbd> and <kbd>PgUp</kbd> hotkeys for switching to the previous and next image layer respectively.
 
+Fixes
+-----
+
+- Fix crash that could be triggered by exceptions being thrown during parallel evaluation.  This could potentially happen while rendering Instancers where some locations were invalid.
+
 0.60.5.0 (relative to 0.60.4.0)
 ========
 

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -35,6 +35,7 @@
 #ifndef IECOREPREVIEW_TASKMUTEX_H
 #define IECOREPREVIEW_TASKMUTEX_H
 
+#include "IECore/Canceller.h"
 #include "IECore/RefCounted.h"
 
 #include "boost/container/flat_set.hpp"
@@ -195,7 +196,11 @@ class TaskMutex : boost::noncopyable
 							// `static_assert()` to ensure we never build with a buggy
 							// version.
 							static_assert( TBB_INTERFACE_VERSION >= 10003, "Minumum of TBB 2018 Update 3 required" );
-							m_mutex->m_executionState->taskGroup.run_and_wait( fWrapper );
+							tbb::task_group_status s = m_mutex->m_executionState->taskGroup.run_and_wait( fWrapper );
+							if( s == tbb::task_group_status::canceled )
+							{
+								throw IECore::Cancelled();
+							}
 						}
 					);
 

--- a/include/Gaffer/ValuePlug.inl
+++ b/include/Gaffer/ValuePlug.inl
@@ -46,6 +46,19 @@ boost::intrusive_ptr<const T> ValuePlug::getObjectValue( const IECore::MurmurHas
 	boost::intrusive_ptr<const T> result = IECore::runTimeCast<const T>( value );
 	if( !result )
 	{
+		if( !value )
+		{
+			// This is quite a serious error, and it may occur when a calculation has already been cancelled,
+			// which could result in the exception that first cancelled the calculation being displayed, but
+			// not this error - print the error as a message as well as throwing an exception
+			std::string error = boost::str(
+				boost::format( "%1% : getValueInternal() returned NULL. This should be impossible, something has gone badly wrong internally to Gaffer." )
+				% fullName()
+			);
+			IECore::msg( IECore::Msg::Error, "ValuePlug::getObjectValue", error );
+			throw IECore::Exception( error );
+		}
+
 		throw IECore::Exception( boost::str(
 			boost::format( "%1% : getValueInternal() didn't return expected type (wanted %2% but got %3%). Is the hash being computed correctly?" )
 				% fullName() % T::staticTypeName() % value->typeName()

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -80,5 +80,9 @@ class TaskMutexTest( GafferTest.TestCase ) :
 
 		GafferTest.testTaskMutexWorkerExceptions()
 
+	def testDontSilentlyCancel( self ) :
+
+		GafferTest.testTaskMutexDontSilentlyCancel()
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Turns out it is actually pretty easy to come up with a test that crashes master by throwing exceptions during parallel eval.  This could happen when doing a parallel scene traversal with many location where a minority error ( ie a small number of locations disappear during the shutter ).

ff1ee0b converts this from a crash to descriptive error.

5c82d0e actually appears to "fix" the problem, since in this case, the computation is already getting cancelled by the first exception, so the test doesn't notice that we're getting extra weird errors - but I think we're currently thinking this is still wrong - in theory the computations could be actually independent, so it's wrong that computations that should succeed are getting cancelled by an error on a different thread.  In more recent TBB, we could use an isolated task_group_context, but it's not clear what we can do about it on old tbb versions.  I tried making a custom task_group that overwrites my_context, but task_group_context is no_copy - there doesn't seem to be any way to overwrite it once its been initialized.