### PR TITLE
ImageView : Add shortcuts for previous and next layer

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x (relative to 0.60.5.0)
+========
+
+Improvements
+------------
+
+- Viewer : Added <kbd>PgDn</kbd> and <kbd>PgUp</kbd> hotkeys for switching to the previous and next image layer respectively.
+
 0.60.5.0 (relative to 0.60.4.0)
 ========
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -335,6 +335,8 @@ Isolate red channel                   :kbd:`R`
 Isolate green channel                 :kbd:`G`
 Isolate blue channel                  :kbd:`B`
 Isolate alpha channel                 :kbd:`A`
+Previous layer                        :kbd:`PgDn`
+Next layer                            :kbd:`PgUp`
 Center image at 1:1 scale             :kbd:`Home`
 Next Catalogue image                  :kbd:`↓`
 Previous Catalogue image              :kbd:`↑`


### PR DESCRIPTION
This necessitated adjusting RGBAChannelsPlugValueWidget for subclassing, exposing the ordered list of labelled options, and allowing the layer menu to be extended. This also incidentally fixes a small bug : previously the checkbox was missing for the current layer when the menu had omitted the `RGBA` suffix (to avoid an unnecessary submenu).
