### PR TITLE
SCons build: Python 3 subprocess always return str not bytes.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -637,13 +637,13 @@ basePythonEnv = baseLibEnv.Clone()
 
 basePythonEnv["PYTHON_VERSION"] = subprocess.check_output(
 	[ "python", "-c", "import sys; print( '{}.{}'.format( *sys.version_info[:2] ) )" ],
-	env=commandEnv["ENV"]
+	env=commandEnv["ENV"], universal_newlines=True
 ).strip()
 
 basePythonEnv["PYTHON_ABI_VERSION"] = basePythonEnv["PYTHON_VERSION"]
 basePythonEnv["PYTHON_ABI_VERSION"] += subprocess.check_output(
 	[ "python", "-c", "import sysconfig; print( sysconfig.get_config_var( 'abiflags' ) or '' )" ],
-	env=commandEnv["ENV"]
+	env=commandEnv["ENV"], universal_newlines=True
 ).strip()
 
 # if BOOST_PYTHON_LIB_SUFFIX is provided, use it


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- SCons build: Python 3 subprocess always return str not bytes.

### Related issues ###

- https://github.com/ImageEngine/cortex/pull/1184

### Dependencies ###

- N/A

### Breaking changes ###

- N/A

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
