### PR TITLE
EditMenu : Don't delete unless focus is in GraphEditor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x (relative to 0.60.6.0)
+========
+
+Fixes
+-----
+
+- Edit menu : Stopped the <kbd>Backspace</kbd> hotkey from deleting nodes when the keyboard focus is not in a GraphEditor.
+
 0.60.6.0 (relative to 0.60.5.0)
 ========
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -44,6 +44,8 @@ import IECore
 import Gaffer
 import GafferUI
 
+from Qt import QtWidgets
+
 def appendDefinitions( menuDefinition, prefix="" ) :
 
 	menuDefinition.append( prefix + "/Undo", { "command" : undo, "shortCut" : "Ctrl+Z", "active" : __undoAvailable } )
@@ -194,6 +196,20 @@ def paste( menu ) :
 ## A function suitable as the command for an Edit/Delete menu item. It must
 # be invoked from a menu that has a ScriptWindow in its ancestry.
 def delete( menu ) :
+
+	focusWidget = QtWidgets.QApplication.focusWidget()
+	if focusWidget is not None :
+		focusWidget = GafferUI.Widget._owner( focusWidget )
+		if isinstance( focusWidget, GafferUI.Editor ) :
+			editor = focusWidget
+		else :
+			editor = focusWidget.ancestor( GafferUI.Editor )
+		if editor is not None and not isinstance( editor, GafferUI.GraphEditor ) :
+			# Don't delete unless invoked directly from the menu, or via the
+			# shortcut when a GraphEditor has focus. This avoids unexpected
+			# deletions when the focus is in other editors that don't handle
+			# <kbd>Delete</kbd> themselves.
+			return
 
 	s = scope( menu )
 	with Gaffer.UndoScope( s.script ) :


### PR DESCRIPTION
It's too easy to accidentally delete nodes while the focus is in an editor other than the GraphEditor, and you might reasonably expect <kbd>Delete</kbd> to mean something else. I'm not sold on this approach to fixing the problem, but it's the best I've been able to come up with so far. The only other possibility I could see was to instead have GraphEditor manage <kbd>Delete</kbd>. But it seems we'd still want to have the menu item and to advertise the hotkey there (for discoverability), so that doesn't work great either. If this approach seems reasonable, then we should perhaps also apply it to the Cut and Paste menu items?