### PR TITLE
Widget : Fix shutdown errors caused by child windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x (relative to 0.60.6.0)
+========
+
+Fixes
+-----
+
+- Window : Fixed errors printed by floating child windows at shutdown (bug introduced in 0.60.3.0).
+
 0.60.6.0 (relative to 0.60.5.0)
 ========
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -928,7 +928,7 @@ class _EventFilter( QtCore.QObject ) :
 
 		elif qEventType==qEvent.Show or qEventType==qEvent.Hide :
 
-			self.__showHide( qObject, qEvent )
+			return self.__showHide( qObject, qEvent )
 
 		# but for anything else we ignore disabled widgets
 		if not qObject.isEnabled() :


### PR DESCRIPTION
These  were emitted for any child window I tested (floating NodeEditors, Preferences window, Settings window, About window), and looked like this :

```
Traceback (most recent call last):
  File "/home/john/Downloads/gaffer-0.60.3.0-linux-python3/python/GafferUI/Widget.py", line 934, in eventFilter
    if not qObject.isEnabled() :
RuntimeError: Internal C++ object (PySide2.QtWidgets.QWidget) already deleted.
```

This was introduced by 0fcdd51f2dfe32eeb7f1832c61e39f0a2b8c7977, which added event filters to all windows.

I don't understand why, but during `self.__showHide()`, PySide would flag our `qObject` as deleted. This occurred inside the call to `_owner()` and appeared to be triggered by querying the `parentWidget()` of its parent. On return to `eventFilter()` we then queried `qObject.isEnabled()` on a newly invalidated object, triggering the exception.

Fortunately, we should have been returning immediately after calling `__showHide()` anyway (the code below deals only with other event types). By adding in the return, we avoid accessing the invalid object and can exit cleanly. It would be good to understand the underlying PySide problem more thoroughly, but since this code is evidently more correct, and fortunately fixes the problem, it'll have to do for now.
