### PR TITLE
StandardNodeGadget : Simplify strike-through drawing logic

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Spreadsheet : The popup editor for lists of items (e.g. scene paths) is now at least as wide as the spreadsheet column itself.
 - VectorDataWidget : Added <kbd>Backspace</kbd> shortcut for deleting the selected rows.
+- GraphEditor : Simplified logic for drawing strike-throughs on disabled nodes. The strike-through is now only drawn for nodes which have a constant value for their `enabled` plug. This avoids blocking the UI waiting for computes that drive the `enabled` plug, and avoids erroneously drawing the strike-through when the appropriate context to evaluate the plug in is not known.
 
 0.60.6.1 (relative to 0.60.6.0)
 ========

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -49,6 +49,7 @@
 #include "GafferUI/StandardNodule.h"
 #include "GafferUI/Style.h"
 
+#include "Gaffer/ComputeNode.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
@@ -832,17 +833,17 @@ void StandardNodeGadget::updateNodeEnabled( const Gaffer::Plug *dirtiedPlug )
 		return;
 	}
 
+	const ValuePlug *source = enabledPlug->source<ValuePlug>();
 	bool enabled = true;
-	try
+	if( source->direction() != Plug::Out || !IECore::runTimeCast<const ComputeNode>( source->node() ) )
 	{
+		// Only evaluate `enabledPlug` if it won't trigger a compute.
+		// We don't want to hang the UI waiting, and we don't really
+		// know what context to perform the compute in anyway.
+		/// \todo We could consider doing this in the background, using
+		/// an upstream traversal from the focus node to determine context.
 		enabled = enabledPlug->getValue();
 	}
-	catch( const std::exception &e )
-	{
-		// The error will be reported via Node::errorSignal() anyway.
-		return;
-	}
-
 
 	if( enabled == m_nodeEnabled )
 	{


### PR DESCRIPTION
The main motivation behind this is an important custom node being developed at Cinesite, which would currently always render disabled (inaccurately) due to a context-sensitive expression on the `enabled` plug. @danieldresser-ie agreed that for now it is reasonable to only draw the strike-through if we can be completely certain the node is disabled, but we also think we can do better in future based on taking the context from the focus node. This does mean that for now we will draw some nodes without the strikethrough when previously we could have determined they were disabled (because the driver wasn't context-sensitive). But we think it's better to erroneously show a node without a strike-through than it is to erroneously show a node with a strike-through. You can now safely ignore a node shown as disabled, safe in the knowledge that there is no context in which it is ever enabled. Let us know if this seems problematic!