### PR TITLE
TaskMutex : Fix exception handling bug in `execute()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Fixed crash triggered by cancellation of long running computes (bug introduced in Gaffer 0.60.6.0).
 - Window : Fixed errors printed by floating child windows at shutdown (bug introduced in 0.60.3.0).
 
 0.60.6.0 (relative to 0.60.5.0)

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -188,21 +188,20 @@ class TaskMutex : boost::noncopyable
 						}
 					};
 
+					boost::optional<tbb::task_group_status> status;
 					m_mutex->m_executionState->arena.execute(
-						[this, &fWrapper] {
+						[this, &fWrapper, &status] {
 							// Prior to TBB 2018 Update 3, `run_and_wait()` is buggy,
 							// causing calls to `wait()` on other threads to return
 							// immediately rather than do the work we want. Use
 							// `static_assert()` to ensure we never build with a buggy
 							// version.
 							static_assert( TBB_INTERFACE_VERSION >= 10003, "Minumum of TBB 2018 Update 3 required" );
-							tbb::task_group_status s = m_mutex->m_executionState->taskGroup.run_and_wait( fWrapper );
-							if( s == tbb::task_group_status::canceled )
-							{
-								throw IECore::Cancelled();
-							}
+							status = m_mutex->m_executionState->taskGroup.run_and_wait( fWrapper );
 						}
 					);
+
+					assert( (bool)status );
 
 					executionStateLock.acquire( m_mutex->m_executionStateMutex );
 					m_mutex->m_executionState = nullptr;
@@ -210,6 +209,10 @@ class TaskMutex : boost::noncopyable
 					if( exception )
 					{
 						std::rethrow_exception( exception );
+					}
+					else if( status.value() == tbb::task_group_status::canceled )
+					{
+						throw IECore::Cancelled();
 					}
 				}
 

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -84,5 +84,9 @@ class TaskMutexTest( GafferTest.TestCase ) :
 
 		GafferTest.testTaskMutexDontSilentlyCancel()
 
+	def testCancellation( self ) :
+
+		GafferTest.testTaskMutexCancellation()
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
In ddfc0f2e458b6b80e0635fb113a2bd5f34288687 (Gaffer 0.60.6.0) we added a `throw` to avoid silently returning to the caller in the case that TBB silently skips the call to the functor. But we neglected to perform the necessary cleanup of `m_executionState` first, leading to two problems.

Debug assertion
---------------

The next call to `execute()` would trigger a debug assertion as follows :

```
gaffer: include/Gaffer/Private/IECorePreview/TaskMutex.h:172: void IECorePreview::TaskMutex::ScopedLock::execute(F&&) [with F = {anonymous}::testTaskMutexCancellation()::<lambda()>::<lambda()>]: Assertion `!m_mutex->m_executionState' failed.
```

This problem is exposed by the newly added `TaskMutexTest.testCancellation()`.

TBB crash
---------

We also observed repeatable crashes in TBB, with stack traces along these lines :

```
* CRASHED in void tbb::task_group_context::propagate_task_group_state<unsigned long>(unsigned long tbb::task_group_context::*, tbb::task_group_context&, unsigned long) at 00:00:00
* signal caught: SIGSEGV -- Invalid memory reference (address not mapped to object)
*
* backtrace:
>> 0 0x00007eff3e6901e5 [libtbb.so.2    ] void tbb::task_group_context::propagate_task_group_state<unsigned long>(unsigned long tbb::task_group_context::*, tbb::task_group_context&, unsigned long) [task_group_context.cpp:339]
*  1 0x00007eff3e68fd29 [libtbb.so.2    ] bool tbb::internal::market::propagate_task_group_state<unsigned long>(unsigned long tbb::task_group_context::*, tbb::task_group_context&, unsigned long)   [task_group_context.cpp:388]
*  2 0x00007eff3e69967e [libtbb.so.2    ] tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*)                                           [custom_scheduler.h    :640]
*  3 0x00007eff3e692893 [libtbb.so.2    ] tbb::internal::arena::process(tbb::internal::generic_scheduler&)                                                                                           [arena.cpp             :156]
*  4 0x00007eff3e6913b2 [libtbb.so.2    ] tbb::internal::market::process(rml::job&)                                                                                                                  [market.cpp            :702]
*  5 0x00007eff3e68d5f5 [libtbb.so.2    ] tbb::internal::rml::private_worker::run()                                                                                                                  [private_server.cpp    :266]
*  6 0x00007eff3e68d828 [libtbb.so.2    ] tbb::internal::rml::private_worker::thread_routine(void*)                                                                                                  [private_server.cpp    :219]
*  7 0x00007eff4d947dd4 [libpthread.so.0] start_thread                                                                                                                                               [pthread_create.c      :  ?]
*  8 0x00007eff4cf67eac [libc.so.6      ] __clone
```

These occurred when cancelling heavy background tasks interactively, and are exposed by the newly added `SceneNodeTest.testChildBoundsCancellation()` test method.

Ensuring that we clean up our state before returning from `execute()` fixes both crashes. It isn't completely clear how the bogus state was leading to the TBB crash, but the fixed code matches the original Gaffer 0.60.5.0 code paths in terms of when we throw and where exceptions are visible to TBB, so I'm reasonably confident that we're back to a good place.
