### PR TITLE
StandardStyle : Don't draw empty annotations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Window : Fixed errors printed by floating child windows at shutdown (bug introduced in 0.60.3.0).
+- GraphEditor : Fixed annotation drawing glitch triggered by annotations with empty text. Empty annotations are now ignored.
 
 0.60.6.0 (relative to 0.60.5.0)
 ========

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -822,6 +822,12 @@ Imath::V3f StandardStyle::closestPointOnConnection( const Imath::V3f &p, const I
 
 Imath::V2f StandardStyle::renderAnnotation( const Imath::V2f &origin, const std::string &text, State state, const Imath::Color3f *userColor ) const
 {
+	const Box3f textBounds = textBound( BodyText, text );
+	if( textBounds.isEmpty() )
+	{
+		return origin;
+	}
+
 	const float padding = 0.5;
 	const float borderWidth = 0.1;
 	const float spacing = 0.25;
@@ -834,8 +840,6 @@ Imath::V2f StandardStyle::renderAnnotation( const Imath::V2f &origin, const std:
 
 		const Color4f darkGrey( 0.1, 0.1, 0.1, 1.0 );
 		const Color4f midGrey( 0.65, 0.65, 0.65, 1.0 );
-
-		Box3f textBounds = textBound( BodyText, text );
 
 		renderFrameInternal(
 			Box2f( V2f( 0, textBounds.min.y ), V2f( textBounds.max.x, characterBound.max.y ) ),


### PR DESCRIPTION
Empty bounds were causing us to draw huge frames with inverted min/max. We now simply skip the drawing of annotations with empty text. I did consider not returning them from `MetadataAlgo::annotations()` at all, but have held off on that for now - it means making the `annotations()` query slightly more expensive, and I'm not sure if someone might be expecting the current behaviour or not.