### PR TITLE
RendererAlgo : Support `IECoreScene::CoordinateSystem` in `objectSamples()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 Fixes
 -----
 
+- Viewer : Fixed drawing of CoordinateSystems (bug introduced in 0.60.0.0).
 - ErrorDialogue : Fixed Python 3 incompatibility in `displayException()`.
 
 0.60.6.1 (relative to 0.60.6.0)

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1397,5 +1397,22 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		# 0.5.
 		self.assertImagesEqual( s["deformationOff"]["out"], s["deformationOn"]["out"], maxDifference = 0.27, ignoreMetadata = True )
 
+	def testCoordinateSystem( self ) :
+
+		coordinateSystem = GafferScene.CoordinateSystem()
+		render = GafferArnold.ArnoldRender()
+		render["in"].setInput( coordinateSystem["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.ass" ) )
+		render["task"].execute()
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiASSLoad( universe, render["fileName"].getValue() )
+
+			# Arnold doesn't support coordinate systems, so we don't expect a
+			# node to have been created for ours.
+			self.assertIsNone( arnold.AiNodeLookUpByName( universe, "/coordinateSystem" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -736,5 +736,15 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		controller.update()
 		assertMotionSamples( [ 0.6, 1.4 ], False )
 
+	def testCoordinateSystem( self ) :
+
+		coordinateSystem = GafferScene.CoordinateSystem()
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( coordinateSystem["out"], Gaffer.Context(), renderer )
+		controller.update()
+
+		capturedObject = renderer.capturedObject( "/coordinateSystem" )
+		self.assertEqual( capturedObject.capturedSamples(), [ coordinateSystem["out"].object( "/coordinateSystem" ) ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -138,5 +138,14 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( capturedCamera.capturedSamples(), [ expectedCamera( 0.75 ), expectedCamera( 1.25 ) ] )
 		self.assertEqual( capturedCamera.capturedSampleTimes(), [ 0.75, 1.25 ] )
 
+	def testCoordinateSystemSamples( self ) :
+
+		coordinateSystem = GafferScene.CoordinateSystem()
+		with Gaffer.Context() as c :
+			c["scene:path"] = IECore.InternedStringVectorData( [ "coordinateSystem" ] )
+			samples = GafferScene.Private.RendererAlgo.objectSamples( coordinateSystem["out"]["object"], [ 0.75, 1.25 ] )
+			self.assertEqual( len( samples ), 1 )
+			self.assertEqual( samples[0], coordinateSystem["out"].object( "/coordinateSystem" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -333,7 +333,8 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 
 		if(
 			runTimeCast<const VisibleRenderable>( object.get() ) ||
-			runTimeCast<const Camera>( object.get() )
+			runTimeCast<const Camera>( object.get() ) ||
+			runTimeCast<const CoordinateSystem>( object.get() )
 		)
 		{
 			samples.push_back( object.get() );
@@ -361,7 +362,10 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 		{
 			samples.push_back( object.get() );
 		}
-		else if( runTimeCast<const VisibleRenderable>( object.get() ) )
+		else if(
+			runTimeCast<const VisibleRenderable>( object.get() ) ||
+			runTimeCast<const CoordinateSystem>( object.get() )
+		)
 		{
 			// We can't motion blur these chappies, so just take the one
 			// sample. This must be at the frame time rather than shutter


### PR DESCRIPTION
This is necessary for the drawing of coordinate systems in the Viewer. This got broken in 3e4a513431d4ef85f4ef58d766a05bf77c161dda when adding motion blur support to IPR - because the RenderController now calls `objectSamples()` rather than evaluating `objectPlug()->getValue()` directly.

This fix does expose the renderer backends to an object type they won't have seen previously, but they should be robust to that. I have included basic coverage for this in `ArnoldRenderTest.testCoordinateSystem()`. There is probably an argument for having `objectSamples()` be willing to sample everything except `NullObject`, but I've gone for the more conservative approach of whitelisting just CoordinateSystem for now.
