### PR TITLE
ErrorDialogue : Fix Python 3 incompatibility in `displayException()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
 - VectorDataWidget : Added <kbd>Backspace</kbd> shortcut for deleting the selected rows.
 - GraphEditor : Simplified logic for drawing strike-throughs on disabled nodes. The strike-through is now only drawn for nodes which have a constant value for their `enabled` plug. This avoids blocking the UI waiting for computes that drive the `enabled` plug, and avoids erroneously drawing the strike-through when the appropriate context to evaluate the plug in is not known.
 
+Fixes
+-----
+
+- ErrorDialogue : Fixed Python 3 incompatibility in `displayException()`.
+
 0.60.6.1 (relative to 0.60.6.0)
 ========
 

--- a/python/GafferUI/ErrorDialogue.py
+++ b/python/GafferUI/ErrorDialogue.py
@@ -145,8 +145,8 @@ class ErrorDialogue( GafferUI.Dialogue ) :
 			return
 
 		excType, excValue, excTrace = exceptionInfo
-		if excValue and excValue.message:
-			message = excValue.message.strip( "\n" ).split( "\n" )[-1]
+		if excValue :
+			message = str( excValue )
 		else:
 			message = str( excType.__name__ )
 


### PR DESCRIPTION
The `message` attribute was removed in Python 3.
