### PR TITLE
Menu : callable passed as menu item "checkBox" parameter can return None

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ API
   - Add support for Gadget's double click signal.
 - GafferUITest.TestCase : Unexpected Qt messages are now reported as test failures.
 - Context : Modified `ChangedSignal` to use a `CatchingSignalCombiner`, which prevents exceptions from one slot preventing the execution of another.
+- Menu : callable passed as the "checkBox" parameter of a menu item can now return None.
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -371,7 +371,9 @@ class Menu( GafferUI.Widget ) :
 		if item.checkBox is not None :
 			qtAction.setCheckable( True )
 			checked = self.__evaluateItemValue( item.checkBox )
-			qtAction.setChecked( checked )
+			# if a callable was passed as the "checkBox" parameter it may return None
+			if checked is not None :
+				qtAction.setChecked( checked )
 
 		if item.command :
 


### PR DESCRIPTION
Passing None as the "checkBox" parameter of a menu item and returning
None from the callable passed as the "checkBox" parameter of a menu item
now gives the same behaviour.

fixes #4353