### PR TITLE
CI : Update host OS to Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         include:
 
           - name: linux
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: RELEASE
             variant: linux-python2
             publish: true
@@ -52,7 +52,7 @@ jobs:
             sconsCacheMegabytes: 400
 
           - name: linux-debug
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: DEBUG
             variant: linux-python2
             publish: false
@@ -64,7 +64,7 @@ jobs:
             sconsCacheMegabytes: 2500
 
           - name: linux-python3
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: RELEASE
             variant: linux-python3
             publish: true

--- a/.github/workflows/whitespaceCheck.yml
+++ b/.github/workflows/whitespaceCheck.yml
@@ -2,7 +2,7 @@ name: Whitespace check
 on: [ pull_request ]
 jobs:
   check:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
As described at https://github.com/actions/virtual-environments/issues/3287, support for Ubuntu 16.04 was dropped by GitHub on September 20th. Our CI workflows are now failing to start because they can't find a worker.

We could update to either 18.04 or 20.04, and I don't know enough to make a truly informed decision between the two. Plumping for 20.04 since if it works, it will give us the longest period before we have to switch up again.

In practice this shouldn't affect us much at all, because we only use the host OS to launch a Docker container with our preferred CentOS7 build environment, and all the real work happens in there.
