### PR TITLE
Animation : keys are now stored in an intrusive container

### DIFF
--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -323,6 +323,9 @@ class GAFFER_API ScriptNode : public Node
 		void addAction( ActionPtr action );
 		void popUndoState();
 
+		// Called by undo/redo to cleanup after action stage
+		void postActionStageCleanup();
+
 		typedef std::stack<UndoScope::State> UndoStateStack;
 		typedef std::list<CompoundActionPtr> UndoList;
 		typedef UndoList::iterator UndoIterator;


### PR DESCRIPTION
* also addresses undo/redo bug where key time is changed after key has been removed from curve. Such changes are not
  recorded in the undo/redo system so key does not have expected time when its added back to curve. In this case undo/redo will now throw an exception indicating that changes were made to the key's time outside the undo system.

fixes #4363
