### PR TITLE
Explicit LRUCache cancellation support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - GraphEditor :
   - Improved drawing performance for large node graphs. Gains of about 40% are typical, with much greater gains when looking at a small region of a large graph or performing selection tests (for example when hovering over something or dragging a connection).
   - Added support for middle-drag panning while dragging nodes and connections using <kbd>G</kbd>.
+- Cancellation : Improved responsiveness of cancellation of tasks waiting on results from another thread.
 
 Fixes
 -----

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -221,7 +221,7 @@ class Serial
 		// handle is writable or not is determined by the AcquireMode.
 		// Returns true on success and false if no entry was
 		// found.
-		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode, const IECore::Canceller *canceller )
 		{
 			if( mode == Insert || mode == InsertWritable )
 			{
@@ -415,7 +415,7 @@ class Parallel
 
 			private :
 
-				bool acquire( Bin &bin, const Key &key, AcquireMode mode )
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode, const IECore::Canceller *canceller )
 				{
 					assert( !m_item );
 
@@ -487,6 +487,10 @@ class Parallel
 							// access another item in the same Bin.
 							binLock.release();
 						}
+						// Check for cancellation before trying again. We could
+						// be waiting a while, and our caller may have lost interest
+						// in the meantime.
+						IECore::Canceller::check( canceller );
 					}
 				}
 
@@ -498,9 +502,9 @@ class Parallel
 
 		};
 
-		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode, const IECore::Canceller *canceller )
 		{
-			return handle.acquire( bin( key ), key, mode );
+			return handle.acquire( bin( key ), key, mode, canceller );
 		}
 
 		void push( Handle &handle )
@@ -773,7 +777,7 @@ class TaskParallel
 
 			private :
 
-				bool acquire( Bin &bin, const Key &key, AcquireMode mode, bool spawnsTasks )
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode, bool spawnsTasks, const IECore::Canceller *canceller )
 				{
 					assert( !m_item );
 
@@ -823,12 +827,30 @@ class TaskParallel
 						const bool acquired = m_itemLock.acquireOr(
 							it->mutex, lockType,
 							// Work accepter
-							[&binLock] ( bool workAvailable ) {
+							[&binLock, canceller] ( bool workAvailable ) {
 								// Release the bin lock prior to accepting work, because
 								// the work might involve recursion back into the cache,
 								// thus requiring the bin lock.
 								binLock.release();
-								return true;
+								// Only accept work if our caller still wants
+								// the result. Note : Once we've accepted the
+								// work, the caller has no ability to recall us.
+								// The only canceller being checked at that
+								// point will be the one passed to the
+								// `LRUCache::get()` call that we work in
+								// service of. This isn't ideal, as it can cause
+								// UI stalls if one UI element is waiting to
+								// cancel an operation, but it's tasks have been
+								// "captured" by collaboration on a compute
+								// started by another UI element (which hasn't
+								// requested cancellation).  One alternative is
+								// that we would only accept work if our
+								// canceller matches the one in use by the
+								// original caller. This would rule out
+								// collaboration between UI elements, but would
+								// still allow diamond dependencies in graph
+								// evaluation to use collaboration.
+								return (!canceller || !canceller->cancelled());
 							}
 						);
 
@@ -858,6 +880,8 @@ class TaskParallel
 							m_spawnsTasks = spawnsTasks;
 							return true;
 						}
+
+						IECore::Canceller::check( canceller );
 					}
 				}
 
@@ -872,7 +896,7 @@ class TaskParallel
 		/// Templated so that we can be called with the GetterKey as
 		/// well as the regular Key.
 		template<typename K>
-		bool acquire( const K &key, Handle &handle, AcquireMode mode )
+		bool acquire( const K &key, Handle &handle, AcquireMode mode, const IECore::Canceller *canceller )
 		{
 			return handle.acquire(
 				bin( key ), key, mode,
@@ -882,7 +906,8 @@ class TaskParallel
 				/// to do. `TaskMutex::ScopedLock::execute()` has significant
 				/// overhead, so we also want to avoid it if tasks won't
 				/// be spawned for a particular key.
-				mode == AcquireMode::Insert && spawnsTasks( key )
+				mode == AcquireMode::Insert && spawnsTasks( key ),
+				canceller
 			);
 		}
 
@@ -1076,10 +1101,10 @@ typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Poli
 }
 
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
-Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
+Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key, const IECore::Canceller *canceller )
 {
 	typename Policy<LRUCache>::Handle handle;
-	m_policy.acquire( key, handle, LRUCachePolicy::Insert );
+	m_policy.acquire( key, handle, LRUCachePolicy::Insert, canceller );
 	const CacheEntry &cacheEntry = handle.readable();
 	const Status status = cacheEntry.status();
 
@@ -1089,7 +1114,7 @@ Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 		Cost cost = 0;
 		try
 		{
-			handle.execute( [this, &value, &key, &cost] { value = m_getter( key, cost ); } );
+			handle.execute( [this, &value, &key, &cost, canceller] { value = m_getter( key, cost, canceller ); } );
 		}
 		catch( IECore::Cancelled const &c )
 		{
@@ -1133,7 +1158,7 @@ template<typename Key, typename Value, template <typename> class Policy, typenam
 boost::optional<Value> LRUCache<Key, Value, Policy, GetterKey>::getIfCached( const Key &key )
 {
 	typename Policy<LRUCache>::Handle handle;
-	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindReadable ) )
+	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindReadable, /* canceller = */ nullptr ) )
 	{
 		return boost::none;
 	}
@@ -1160,7 +1185,7 @@ template<typename Key, typename Value, template <typename> class Policy, typenam
 bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &value, Cost cost )
 {
 	typename Policy<LRUCache>::Handle handle;
-	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
+	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable, /* canceller = */ nullptr );
 	assert( handle.isWritable() );
 	bool result = setInternal( key, handle.writable(), value, cost );
 	m_policy.push( handle );
@@ -1193,7 +1218,7 @@ bool LRUCache<Key, Value, Policy, GetterKey>::cached( const Key &key ) const
 	typename Policy<LRUCache>::Handle handle;
 	// Preferring const_cast over forcing all policies to implement
 	// a ConstHandle and const acquire() variant.
-	if( !const_cast<Policy<LRUCache> &>( m_policy ).acquire( key, handle, LRUCachePolicy::FindReadable ) )
+	if( !const_cast<Policy<LRUCache> &>( m_policy ).acquire( key, handle, LRUCachePolicy::FindReadable, /* canceller = */ nullptr ) )
 	{
 		return false;
 	}
@@ -1205,7 +1230,7 @@ template<typename Key, typename Value, template <typename> class Policy, typenam
 bool LRUCache<Key, Value, Policy, GetterKey>::erase( const Key &key )
 {
 	typename Policy<LRUCache>::Handle handle;
-	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindWritable ) )
+	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindWritable, /* canceller = */ nullptr ) )
 	{
 		return false;
 	}

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -106,14 +106,29 @@ class LRUCacheTest( GafferTest.TestCase ) :
 		GafferTest.testLRUCacheContentionForOneItem( "serial" )
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemSerialWithCanceller( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "serial", withCanceller = True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContentionForOneItemParallel( self ) :
 
 		GafferTest.testLRUCacheContentionForOneItem( "parallel" )
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemParallelWithCanceller( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "parallel", withCanceller = True )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContentionForOneItemTaskParallel( self ) :
 
 		GafferTest.testLRUCacheContentionForOneItem( "taskParallel" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testContentionForOneItemTaskParallelWithCanceller( self ) :
+
+		GafferTest.testLRUCacheContentionForOneItem( "taskParallel", withCanceller = True )
 
 	def testRecursionSerial( self ) :
 
@@ -182,6 +197,14 @@ class LRUCacheTest( GafferTest.TestCase ) :
 	def testCancellationTaskParallel( self ) :
 
 		GafferTest.testLRUCacheCancellation( "taskParallel" )
+
+	def testCancellationOfSecondGetParallel( self ) :
+
+		GafferTest.testLRUCacheCancellationOfSecondGet( "parallel" )
+
+	def testCancellationOfSecondGetTaskParallel( self ) :
+
+		GafferTest.testLRUCacheCancellationOfSecondGet( "taskParallel" )
 
 	def testUncacheableItemSerial( self ) :
 

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -37,6 +37,8 @@
 
 import gc
 import inspect
+import os
+import subprocess
 import threading
 import time
 import imath
@@ -872,6 +874,36 @@ class ValuePlugTest( GafferTest.TestCase ) :
 			GafferTest.parallelGetValue( m["product"], 10000, "testVar" )
 
 	def testCancellationOfSecondGetValueCall( self ) :
+
+		## \todo Should just be checking `tbb.global_control.active_value( max_allowed_parallelism )`
+		# to get the true limit set by `-threads` argument. But IECore's Python
+		# binding of `global_control` doesn't expose that yet.
+		if IECore.hardwareConcurrency() < 3 and "VALUEPLUGTEST_SUBPROCESS" not in os.environ :
+
+			# This test requires at least 3 TBB threads (including the main
+			# thread), because we need the second enqueued BackgroundTask to
+			# start execution before the first one has completed. If we have
+			# insufficient threads then we end up in deadlock, so to avoid this
+			# we relaunch in a subprocess with sufficient threads.
+			#
+			# Note : deadlock only ensues because the first task will never
+			# return without cancellation. This is an artificial situation, not
+			# one that would occur in practical usage of Gaffer itself.
+
+			print( "Running in subprocess due to insufficient TBB threads" )
+
+			try :
+				env = os.environ.copy()
+				env["VALUEPLUGTEST_SUBPROCESS"] = "1"
+				subprocess.check_output(
+					[ "gaffer", "test", "-threads", "3", "GafferTest.ValuePlugTest.testCancellationOfSecondGetValueCall" ],
+					stderr = subprocess.STDOUT,
+					env = env
+				)
+			except subprocess.CalledProcessError as e :
+				self.fail( e.output )
+
+			return
 
 		class InfiniteLoop( Gaffer.ComputeNode ) :
 

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -235,7 +235,8 @@ class ValuePlug::HashProcess : public Process
 			// using a HashProcess instance.
 
 			const ComputeNode *computeNode = IECore::runTimeCast<const ComputeNode>( p->node() );
-			const HashProcessKey processKey( p, plug, Context::current(), p->m_dirtyCount, computeNode, computeNode ? computeNode->hashCachePolicy( p ) : CachePolicy::Uncached );
+			const Context *currentContext = Context::current();
+			const HashProcessKey processKey( p, plug, currentContext, p->m_dirtyCount, computeNode, computeNode ? computeNode->hashCachePolicy( p ) : CachePolicy::Uncached );
 
 			if( processKey.cachePolicy == CachePolicy::Uncached )
 			{
@@ -261,15 +262,15 @@ class ValuePlug::HashProcess : public Process
 				// And then look up the result in our cache.
 				if( g_hashCacheMode == HashCacheMode::Standard )
 				{
-					return threadData.cache.get( processKey );
+					return threadData.cache.get( processKey, currentContext->canceller() );
 				}
 				else if( g_hashCacheMode == HashCacheMode::Checked )
 				{
 					HashProcessKey legacyProcessKey( processKey );
 					legacyProcessKey.dirtyCount = g_legacyGlobalDirtyCount + DIRTY_COUNT_RANGE_MAX + 1;
 
-					const IECore::MurmurHash check = threadData.cache.get( legacyProcessKey );
-					const IECore::MurmurHash result = threadData.cache.get( processKey );
+					const IECore::MurmurHash check = threadData.cache.get( legacyProcessKey, currentContext->canceller() );
+					const IECore::MurmurHash result = threadData.cache.get( processKey, currentContext->canceller() );
 
 					if( result != check )
 					{
@@ -282,7 +283,7 @@ class ValuePlug::HashProcess : public Process
 						}
 						catch( ... )
 						{
-							ProcessException::wrapCurrentException( processKey.plug, Context::current(), staticType );
+							ProcessException::wrapCurrentException( processKey.plug, currentContext, staticType );
 						}
 					}
 					return result;
@@ -293,7 +294,7 @@ class ValuePlug::HashProcess : public Process
 					HashProcessKey legacyProcessKey( processKey );
 					legacyProcessKey.dirtyCount = g_legacyGlobalDirtyCount + DIRTY_COUNT_RANGE_MAX + 1;
 
-					return threadData.cache.get( legacyProcessKey );
+					return threadData.cache.get( legacyProcessKey, currentContext->canceller() );
 				}
 			}
 		}
@@ -392,6 +393,9 @@ class ValuePlug::HashProcess : public Process
 
 		static IECore::MurmurHash globalCacheGetter( const HashProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
+			// Canceller will be passed to `ComputeNode::hash()` implicitly
+			// via the context.
+			assert( canceller == Context::current()->canceller() );
 			cost = 1;
 			IECore::MurmurHash result;
 			switch( key.cachePolicy )
@@ -423,12 +427,13 @@ class ValuePlug::HashProcess : public Process
 
 		static IECore::MurmurHash localCacheGetter( const HashProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
+			assert( canceller == Context::current()->canceller() );
 			cost = 1;
 			switch( key.cachePolicy )
 			{
 				case CachePolicy::TaskCollaboration :
 				case CachePolicy::TaskIsolation :
-					return g_globalCache.get( key );
+					return g_globalCache.get( key, canceller );
 				default :
 				{
 					assert( key.cachePolicy != CachePolicy::Uncached );
@@ -611,7 +616,7 @@ class ValuePlug::ComputeProcess : public Process
 			}
 			else
 			{
-				return g_cache.get( processKey );
+				return g_cache.get( processKey, Context::current()->canceller() );
 			}
 		}
 
@@ -673,6 +678,9 @@ class ValuePlug::ComputeProcess : public Process
 
 		static IECore::ConstObjectPtr cacheGetter( const ComputeProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
+			// Canceller will be passed to `ComputeNode::hash()` implicitly
+			// via the context.
+			assert( canceller == Context::current()->canceller() );
 			IECore::ConstObjectPtr result;
 			switch( key.cachePolicy )
 			{

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -390,7 +390,7 @@ class ValuePlug::HashProcess : public Process
 			}
 		}
 
-		static IECore::MurmurHash globalCacheGetter( const HashProcessKey &key, size_t &cost )
+		static IECore::MurmurHash globalCacheGetter( const HashProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
 			cost = 1;
 			IECore::MurmurHash result;
@@ -421,7 +421,7 @@ class ValuePlug::HashProcess : public Process
 			return result;
 		}
 
-		static IECore::MurmurHash localCacheGetter( const HashProcessKey &key, size_t &cost )
+		static IECore::MurmurHash localCacheGetter( const HashProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
 			cost = 1;
 			switch( key.cachePolicy )
@@ -671,7 +671,7 @@ class ValuePlug::ComputeProcess : public Process
 			}
 		}
 
-		static IECore::ConstObjectPtr cacheGetter( const ComputeProcessKey &key, size_t &cost )
+		static IECore::ConstObjectPtr cacheGetter( const ComputeProcessKey &key, size_t &cost, const IECore::Canceller *canceller )
 		{
 			IECore::ConstObjectPtr result;
 			switch( key.cachePolicy )

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -184,7 +184,7 @@ namespace {
 	const AtString g_shaderTypeArnoldString( "shaderType" );
 }
 
-static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size_t &cost )
+static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	IECoreArnold::UniverseBlock arnoldUniverse( /* writable = */ false );
 

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -101,7 +101,7 @@ struct SurfaceTextureCacheGetterKey
 	MurmurHash hash;
 };
 
-CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, size_t &cost )
+CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = key.resolution.x * key.resolution.y * 3 * 4; // 3 x 32bit float channels;
 

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -140,7 +140,7 @@ struct OSLTextureCacheGetterKey
 
 };
 
-CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost )
+CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	// make the cost be image data in bytes
 	cost = key.resolution * key.resolution * 3 * 4;

--- a/src/GafferArnoldUI/VisualiserAlgo.cpp
+++ b/src/GafferArnoldUI/VisualiserAlgo.cpp
@@ -66,7 +66,7 @@ const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
 
 typedef std::shared_ptr<OSLQuery> OSLQueryPtr;
 
-OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost )
+OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = 1;
 

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -105,7 +105,7 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 	}
 }
 
-std::string shaderCacheGetter( const std::string &shaderName, size_t &cost )
+std::string shaderCacheGetter( const std::string &shaderName, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = 1;
 	const char *oslShaderPaths = getenv( "OSL_SHADER_PATHS" );

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -651,7 +651,7 @@ struct CacheEntry
 };
 
 
-CacheEntry fileCacheGetter( const std::string &fileName, size_t &cost )
+CacheEntry fileCacheGetter( const std::string &fileName, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = 1;
 

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -91,7 +91,7 @@ FT_Library library()
 // is fairly costly. But since FT_Faces belong to FT_Libraries
 // the cache must be maintained per-thread.
 typedef std::shared_ptr<FT_FaceRec_> FacePtr;
-FacePtr faceLoader( const std::string &font, size_t &cost )
+FacePtr faceLoader( const std::string &font, size_t &cost, const IECore::Canceller *canceller )
 {
 	const char *e = getenv( "IECORE_FONT_PATHS" );
 	IECore::SearchPath sp( e ? e : "" );

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -99,7 +99,7 @@ struct ShadingEngineCacheGetterKey
 
 };
 
-ConstShadingEnginePtr getter( const ShadingEngineCacheGetterKey &key, size_t &cost )
+ConstShadingEnginePtr getter( const ShadingEngineCacheGetterKey &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = 1;
 
@@ -152,7 +152,7 @@ using QueryCache = IECorePreview::LRUCache<string, OSLQueryPtr, IECorePreview::L
 QueryCache &queryCache()
 {
 	static QueryCache g_cache(
-		[] ( const std::string &shaderName, size_t &cost ) {
+		[] ( const std::string &shaderName, size_t &cost, const IECore::Canceller *canceller ) {
 			const char *searchPath = getenv( "OSL_SHADER_PATHS" );
 			OSLQueryPtr query = make_shared<OSLQuery>();
 			if( !query->open( shaderName, searchPath ? searchPath : "" ) )
@@ -1189,7 +1189,7 @@ static IECore::CompoundDataPtr convertMetadata( const std::vector<OSLQuery::Para
 	return result;
 }
 
-static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size_t &cost )
+static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	cost = 1;
 	if( !key.size() )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -942,7 +942,7 @@ GAFFERSCENE_API IECore::PathMatcher GafferScene::SceneAlgo::linkedObjects( const
 	using QueryCache = IECorePreview::LRUCache<std::string, bool, IECorePreview::LRUCachePolicy::TaskParallel>;
 	const Context *context = Context::current();
 	QueryCache queryCache(
-		[&lights, scene, context]( const std::string &setExpression, size_t &cost )
+		[&lights, scene, context]( const std::string &setExpression, size_t &cost, const IECore::Canceller *canceller )
 		{
 			cost = 1;
 			Context::Scope scopedContext( context );

--- a/src/GafferScene/Text.cpp
+++ b/src/GafferScene/Text.cpp
@@ -60,7 +60,7 @@ namespace GafferScene
 namespace Detail
 {
 
-FontPtr fontGetter( const std::string &fileName, size_t &cost )
+FontPtr fontGetter( const std::string &fileName, size_t &cost, const IECore::Canceller *canceller )
 {
 	const char *e = getenv( "IECORE_FONT_PATHS" );
 	IECore::SearchPath sp( e ? e : "" );

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -100,7 +100,7 @@ struct TestLRUCache
 	{
 		typedef LRUCache<int, int, Policy> Cache;
 		Cache cache(
-			[]( int key, size_t &cost ) { cost = 1; return key; },
+			[]( int key, size_t &cost, const IECore::Canceller *canceller ) { cost = 1; return key; },
 			m_maxCost
 		);
 
@@ -147,7 +147,7 @@ struct TestLRUCacheRemovalCallback
 		typedef LRUCache<int, int, Policy> Cache;
 		Cache cache(
 			// Getter
-			[]( int key, size_t &cost ) {
+			[]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				cost = 1; return key * 2;
 			},
 			/* maxCost = */ 5,
@@ -207,31 +207,42 @@ template<template<typename> class Policy>
 struct TestLRUCacheContentionForOneItem
 {
 
+	TestLRUCacheContentionForOneItem( bool withCanceller )
+		:	m_withCanceller( withCanceller )
+	{
+	}
+
 	void operator()()
 	{
 		typedef LRUCache<int, int, Policy> Cache;
 		Cache cache(
-			[]( int key, size_t &cost ) { cost = 1; return key; },
+			[]( int key, size_t &cost, const IECore::Canceller *canceller ) { cost = 1; return key; },
 			100
 		);
+
+		IECore::Canceller canceller;
+		const IECore::Canceller *cancellerOrNull = m_withCanceller ? &canceller : nullptr;
 
 		tbb::parallel_for(
 			tbb::blocked_range<size_t>( 0, 10000000 ),
 			[&]( const tbb::blocked_range<size_t> &r ) {
 				for( size_t i = r.begin(); i < r.end(); ++i )
 				{
-					GAFFERTEST_ASSERTEQUAL( cache.get( 1 ), 1 );
+					GAFFERTEST_ASSERTEQUAL( cache.get( 1, cancellerOrNull ), 1 );
 				}
 			}
 		);
 	}
 
+	private :
+
+		bool m_withCanceller;
 
 };
 
-void testLRUCacheContentionForOneItem( const std::string &policy )
+void testLRUCacheContentionForOneItem( const std::string &policy, bool withCanceller )
 {
-	DispatchTest<TestLRUCacheContentionForOneItem>()( policy );
+	DispatchTest<TestLRUCacheContentionForOneItem>()( policy, withCanceller );
 }
 
 template<template<typename> class Policy>
@@ -252,7 +263,7 @@ struct TestLRUCacheRecursion
 		cache.reset(
 			new Cache(
 				// Getter that calls back into the cache with a different key.
-				[&cache]( int key, size_t &cost ) {
+				[&cache]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 					cost = 1;
 					switch( key )
 					{
@@ -314,7 +325,7 @@ struct TestLRUCacheRecursionOnOneItem
 				// key, up to a certain limit, and then actually returns
 				// a value. This is basically insane, but it models
 				// situations that can occur in Gaffer.
-				[&cache, &recursionDepth]( int key, size_t &cost ) {
+				[&cache, &recursionDepth]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 					cost = 1;
 					if( ++recursionDepth == 100 )
 					{
@@ -360,7 +371,7 @@ struct TestLRUCacheClearFromGet
 				// in Gaffer, because `get()` might trigger arbitrary python, arbitrary python
 				// might trigger garbage collection, garbage collection might destroy a plug,
 				// and destroying a plug clears the cache.
-				[&cache]( int key, size_t &cost ) { cache->clear(); cost = 1; return key; },
+				[&cache]( int key, size_t &cost, const IECore::Canceller *canceller ) { cache->clear(); cost = 1; return key; },
 				100
 			)
 		);
@@ -385,7 +396,7 @@ struct TestLRUCacheExceptions
 
 		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
 		Cache cache(
-			[&calls]( int key, size_t &cost ) {
+			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
 				throw IECore::Exception( boost::str(
 					boost::format( "Get failed for %1%" ) % key
@@ -481,7 +492,7 @@ struct TestLRUCacheExceptions
 		// Check that if we don't cache errors, then it gets called twice
 		calls.clear();
 		Cache noErrorsCache(
-			[&calls]( int key, size_t &cost ) {
+			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
 				throw IECore::Exception( boost::str(
 					boost::format( "Get failed for %1%" ) % key
@@ -543,15 +554,13 @@ struct TestLRUCacheCancellation
 	{
 		std::vector<int> calls;
 
-		typedef std::unique_ptr<IECore::Canceller> CancellerPtr;
-		CancellerPtr canceller;
-		canceller.reset( new IECore::Canceller() );
+		IECore::Canceller canceller;
 
 		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
 		Cache cache(
-			[&calls, &canceller]( int key, size_t &cost ) {
+			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
-				IECore::Canceller::check( canceller.get() );
+				IECore::Canceller::check( canceller );
 				return key;
 			},
 			1000
@@ -559,8 +568,8 @@ struct TestLRUCacheCancellation
 
 		// Check normal operation
 
-		GAFFERTEST_ASSERTEQUAL( cache.get( 1 ), 1 );
-		GAFFERTEST_ASSERTEQUAL( cache.get( 2 ), 2 );
+		GAFFERTEST_ASSERTEQUAL( cache.get( 1, &canceller ), 1 );
+		GAFFERTEST_ASSERTEQUAL( cache.get( 2, &canceller ), 2 );
 
 		GAFFERTEST_ASSERTEQUAL( calls.size(), 2 );
 		GAFFERTEST_ASSERTEQUAL( calls[0], 1 );
@@ -570,13 +579,13 @@ struct TestLRUCacheCancellation
 		// exception, and will simply get the value again for subsequent
 		// lookups.
 
-		canceller->cancel();
+		canceller.cancel();
 
 		bool caughtCancel = false;
 		int val = -1;
 		try
 		{
-			val = cache.get( 3 );
+			val = cache.get( 3, &canceller );
 		}
 		catch( IECore::Cancelled const &c )
 		{
@@ -589,11 +598,11 @@ struct TestLRUCacheCancellation
 		GAFFERTEST_ASSERTEQUAL( calls.size(), 3 );
 		GAFFERTEST_ASSERTEQUAL( calls.back(), 3 );
 
-		// reset and check that we get called again
+		// Use a fresh canceller and check that we get called again.
 
-		canceller.reset( new IECore::Canceller() );
+		IECore::Canceller canceller2;
 
-		val = cache.get( 3 );
+		val = cache.get( 3, &canceller2 );
 
 		GAFFERTEST_ASSERTEQUAL( val, 3 );
 		GAFFERTEST_ASSERTEQUAL( calls.size(), 4 );
@@ -606,6 +615,92 @@ struct TestLRUCacheCancellation
 void testLRUCacheCancellation( const std::string &policy )
 {
 	DispatchTest<TestLRUCacheCancellation>()( policy );
+}
+
+template<template<typename> class Policy>
+struct TestLRUCacheCancellationOfSecondGet
+{
+
+	void operator()()
+	{
+
+		// Make a cache with a getter that will never return unless cancelled.
+
+		std::atomic_int getterCount; getterCount = 0;
+
+		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		Cache cache(
+			[&getterCount]( int key, size_t &cost, const IECore::Canceller *canceller ) {
+				getterCount++;
+				while( true )
+				{
+					IECore::Canceller::check( canceller );
+				}
+				cost = 1;
+				return key;
+			},
+			10
+		);
+
+		// Run an async task that will make a first call to `get()`.
+		// This will never return unless we can cancel it via
+		// `firstCanceller`.
+
+		IECore::Canceller firstCanceller;
+		tbb::task_group taskGroup;
+
+		taskGroup.run(
+			[&cache, &firstCanceller] {
+				cache.get( 1, &firstCanceller );
+			}
+		);
+
+		// Wait for it to get stuck inside the getter.
+
+		while( !getterCount )
+		{
+		}
+
+		// Now make a second call to `get()`. We want to be
+		// able to cancel this even though it would otherwise
+		// have to wait for the first call to complete.
+
+		IECore::Canceller secondCanceller;
+		secondCanceller.cancel();
+		try
+		{
+			cache.get( 1, &secondCanceller );
+		}
+		catch( const IECore::Cancelled &e )
+		{
+			firstCanceller.cancel();
+		}
+
+		GAFFERTEST_ASSERT( firstCanceller.cancelled() );
+
+		// Now wait for the first task and check that it
+		// was the only one to actually run the getter.
+
+		bool firstCancelled = false;
+		try
+		{
+			taskGroup.wait();
+		}
+		catch( IECore::Cancelled &e )
+		{
+			firstCancelled = true;
+		}
+
+		GAFFERTEST_ASSERT( firstCancelled );
+		GAFFERTEST_ASSERTEQUAL( getterCount.load(), 1 );
+	}
+
+};
+
+void testLRUCacheCancellationOfSecondGet( const std::string &policy )
+{
+	GAFFERTEST_ASSERT( policy != "serial" ); // Test requires parallel calls to `get()`.
+	DispatchTest<TestLRUCacheCancellationOfSecondGet>()( policy );
 }
 
 // This test exposes a potential source of bugs when some items
@@ -627,7 +722,7 @@ struct TestLRUCacheUncacheableItem
 		CachePtr cache;
 		cache.reset(
 			new Cache(
-				[&cache]( int key, size_t &cost ) {
+				[&cache]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 					if( key == 0 )
 					{
 						// Too big to cache
@@ -677,7 +772,7 @@ struct TestLRUCacheGetIfCached
 		using Cache = IECorePreview::LRUCache<int, int, Policy>;
 
 		Cache cache(
-			[]( int key, size_t &cost ) {
+			[]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				cost = 1;
 				return key;
 			},
@@ -713,12 +808,13 @@ void GafferTestModule::bindLRUCacheTest()
 {
 	def( "testLRUCache", &testLRUCache, ( arg( "numIterations" ), arg( "numValues" ), arg( "maxCost" ), arg( "clearFrequency" ) = 0 ) );
 	def( "testLRUCacheRemovalCallback", &testLRUCacheRemovalCallback );
-	def( "testLRUCacheContentionForOneItem", &testLRUCacheContentionForOneItem );
+	def( "testLRUCacheContentionForOneItem", &testLRUCacheContentionForOneItem, arg( "withCanceller" ) = false );
 	def( "testLRUCacheRecursion", &testLRUCacheRecursion, ( arg( "numIterations" ), arg( "numValues" ), arg( "maxCost" ) ) );
 	def( "testLRUCacheRecursionOnOneItem", &testLRUCacheRecursionOnOneItem );
 	def( "testLRUCacheClearFromGet", &testLRUCacheClearFromGet );
 	def( "testLRUCacheExceptions", &testLRUCacheExceptions );
 	def( "testLRUCacheCancellation", &testLRUCacheCancellation );
+	def( "testLRUCacheCancellationOfSecondGet", &testLRUCacheCancellationOfSecondGet );
 	def( "testLRUCacheUncacheableItem", &testLRUCacheUncacheableItem );
 	def( "testLRUCacheGetIfCached", &testLRUCacheGetIfCached );
 }

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -61,7 +61,7 @@ using namespace GafferUI;
 namespace
 {
 
-Box3f boundGetter( const std::string &fileName, size_t &cost )
+Box3f boundGetter( const std::string &fileName, size_t &cost, const IECore::Canceller *canceller )
 {
 	const char *s = getenv( "GAFFERUI_IMAGE_PATHS" );
 	IECore::SearchPath sp( s ? s : "" );

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -256,7 +256,7 @@ class IconColumn : public Column
 		std::string m_prefix;
 		IECore::InternedString m_propertyName;
 
-		static QVariant iconGetter( const std::string &fileName, size_t &cost )
+		static QVariant iconGetter( const std::string &fileName, size_t &cost, const IECore::Canceller *canceller )
 		{
 			const char *s = getenv( "GAFFERUI_IMAGE_PATHS" );
 			IECore::SearchPath sp( s ? s : "" );


### PR DESCRIPTION
While working on an asynchronous version of the HierarchyView, I ran into an interesting UI hang when the HierarchyView was waiting to cancel its background task. The problem turned out to be that the Viewer also had a background task, and it was computing the same thing that the HierarchyView wanted. So the HierarchyView task was stuck waiting for this to finish in `LRUCachePolicy::Handle::acquire()`, which was immune to cancellation.

This PR adds an `IECore::Canceller` argument to `LRUCache::get()`, so that cancellation can be performed not only in the GetterFunction, but also in the internal cache mechanism (`Handle::acquire` in this case). Using this in ValuePlug's cache allows immediate cancellation in the case above. As noted in the comments, the TaskCollaboration task policy is somewhat immune to this new form of cancellation, and this is something we'd like to improve in the future - but at least we know about it now.