### PR TITLE
Cancellation support for Gaffer::Path class

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ API
 - GafferUITest.TestCase : Unexpected Qt messages are now reported as test failures.
 - Context : Modified `ChangedSignal` to use a `CatchingSignalCombiner`, which prevents exceptions from one slot preventing the execution of another.
 - Menu : callable passed as the "checkBox" parameter of a menu item can now return None.
+- Path : Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
 
 Breaking Changes
 ----------------
@@ -54,6 +55,7 @@ Breaking Changes
 - Animation :
   - Renamed `Type` enum to `Interpolation`.
   - Renamed Key's `set/getType()` accessors to `set/getInterpolation()`.
+- Path : Added `canceller` arguments to virtual methods. Note that Python subclasses can be made compatible with both Gaffer 0.60 and 0.61 simply by adding a `canceller = None` argument.
 
 0.60.7.0 (relative to 0.60.6.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ API
 - Menu : callable passed as the "checkBox" parameter of a menu item can now return None.
 - Path : Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
 - ScenePath : Added support for cancellation of calls to `isValid()` and `children()`.
+- FileSystemPath : Added support for cancellation of calls to `children()` and `property()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -35,7 +35,9 @@ API
 - GafferUITest.TestCase : Unexpected Qt messages are now reported as test failures.
 - Context : Modified `ChangedSignal` to use a `CatchingSignalCombiner`, which prevents exceptions from one slot preventing the execution of another.
 - Menu : callable passed as the "checkBox" parameter of a menu item can now return None.
-- Path : Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
+- Path :
+  - Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
+  - Added `cancellationSubject()` virtual function that must be implemented by any paths which access the node graph.
 - ScenePath : Added support for cancellation of calls to `isValid()` and `children()`.
 - FileSystemPath : Added support for cancellation of calls to `children()` and `property()`.
 - PathFilter : Added support for cancellation of calls to `filter()`.

--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ API
 - Path : Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
 - ScenePath : Added support for cancellation of calls to `isValid()` and `children()`.
 - FileSystemPath : Added support for cancellation of calls to `children()` and `property()`.
+- PathFilter : Added support for cancellation of calls to `filter()`.
 
 Breaking Changes
 ----------------
@@ -58,6 +59,7 @@ Breaking Changes
   - Renamed `Type` enum to `Interpolation`.
   - Renamed Key's `set/getType()` accessors to `set/getInterpolation()`.
 - Path : Added `canceller` arguments to virtual methods. Note that Python subclasses can be made compatible with both Gaffer 0.60 and 0.61 simply by adding a `canceller = None` argument.
+- PathFilter : Added `canceller` argument to `doFilter()` method. Note that Python subclasses can be made compatible with both Gaffer 0.60 and 0.61 simply by adding a `canceller = None` argument.
 
 0.60.7.0 (relative to 0.60.6.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - Context : Modified `ChangedSignal` to use a `CatchingSignalCombiner`, which prevents exceptions from one slot preventing the execution of another.
 - Menu : callable passed as the "checkBox" parameter of a menu item can now return None.
 - Path : Added optional `canceller` argument to `isValid()`, `isLeaf()`, `propertyNames()`, `property()` and `children()` methods.
+- ScenePath : Added support for cancellation of calls to `isValid()` and `children()`.
 
 Breaking Changes
 ----------------

--- a/include/Gaffer/CompoundPathFilter.h
+++ b/include/Gaffer/CompoundPathFilter.h
@@ -64,7 +64,7 @@ class GAFFER_API CompoundPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		void doFilter( std::vector<PathPtr> &paths ) const override;
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -257,6 +257,11 @@ class GAFFER_API Context : public IECore::RefCounted
 				void remove( const IECore::InternedString &name );
 				void removeMatching( const IECore::StringAlgo::MatchPattern &pattern );
 
+				/// Sets the canceller. It is the caller's responsibility to
+				/// ensure that the pointer remains valid for the lifetime
+				/// of the EditableScope.
+				void setCanceller( const IECore::Canceller *canceller );
+
 				const Context *context() const { return m_context.get(); }
 
 			private :

--- a/include/Gaffer/FileSequencePathFilter.h
+++ b/include/Gaffer/FileSequencePathFilter.h
@@ -77,7 +77,7 @@ class GAFFER_API FileSequencePathFilter : public PathFilter
 
 	protected :
 
-		void doFilter( std::vector<PathPtr> &paths ) const override;
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -58,9 +58,9 @@ class GAFFER_API FileSystemPath : public Path
 
 		~FileSystemPath() override;
 
-		bool isValid() const override;
-		bool isLeaf() const override;
-		void propertyNames( std::vector<IECore::InternedString> &names ) const override;
+		bool isValid( const IECore::Canceller *canceller = nullptr ) const override;
+		bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override;
+		void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr ) const override;
 		/// Supported properties :
 		///
 		/// "fileSystem:owner" -> StringData
@@ -68,7 +68,7 @@ class GAFFER_API FileSystemPath : public Path
 		/// "fileSystem:modificationTime" -> DateTimeData, in UTC time
 		/// "fileSystem:size" -> UInt64Data, in bytes
 		/// "fileSystem:frameRange" -> StringData
-		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const override;
+		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override;
 		PathPtr copy() const override;
 
 		// Returns true if this FileSystemPath includes FileSequences
@@ -86,7 +86,7 @@ class GAFFER_API FileSystemPath : public Path
 
 	protected :
 
-		void doChildren( std::vector<PathPtr> &children ) const override;
+		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/Gaffer/LeafPathFilter.h
+++ b/include/Gaffer/LeafPathFilter.h
@@ -59,7 +59,7 @@ class GAFFER_API LeafPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		void doFilter( std::vector<PathPtr> &paths ) const override;
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/Gaffer/MatchPatternPathFilter.h
+++ b/include/Gaffer/MatchPatternPathFilter.h
@@ -74,7 +74,7 @@ class GAFFER_API MatchPatternPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		void doFilter( std::vector<PathPtr> &paths ) const override;
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -95,18 +95,18 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 
 		/// Returns true if this path is valid - ie references something
 		/// which actually exists.
-		virtual bool isValid() const;
+		virtual bool isValid( const IECore::Canceller *canceller = nullptr ) const;
 
 		/// Returns true if this path can never have child Paths.
-		virtual bool isLeaf() const;
+		virtual bool isLeaf( const IECore::Canceller *canceller = nullptr ) const;
 
 		/// Fills the vector with the names of all the properties queryable via property().
 		/// Derived class implementations must call the base class implementation first.
-		virtual void propertyNames( std::vector<IECore::InternedString> &names ) const;
+		virtual void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr ) const;
 		/// Queries a property, whose name must have first been retrieved via propertyNames().
 		/// Derived class implementations should fall back to the base class implementation for
 		/// any unrecognised names. Returns null for unknown properties. May return null for invalid paths.
-		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const;
+		virtual IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const;
 
 		/// Returns the parent of this path, or None if the path
 		/// has no parent (is the root).
@@ -115,7 +115,7 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 		/// Fills the vector with Path instances representing all
 		/// the children of this path. Note that an empty list may
 		/// be returned even if isLeaf() is false.
-		size_t children( std::vector<PathPtr> &children ) const;
+		size_t children( std::vector<PathPtr> &children, const IECore::Canceller *canceller = nullptr ) const;
 
 		void setFilter( PathFilterPtr filter );
 		/// Filter may be null.
@@ -184,7 +184,7 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 		/// seems incredibly wasteful. Perhaps it would be better to have a
 		/// virtual childNames() method, and then implement filtering by manipulating
 		/// a single path and returning copies for the ones that passed?
-		virtual void doChildren( std::vector<PathPtr> &children ) const;
+		virtual void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const;
 
 		/// May be called by subclasses to signify that the path has changed
 		/// and to emit pathChangedSignal() if necessary. Note that it can be

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -63,6 +63,7 @@ namespace Gaffer
 
 IE_CORE_FORWARDDECLARE( Path )
 IE_CORE_FORWARDDECLARE( PathFilter )
+IE_CORE_FORWARDDECLARE( Plug )
 
 /// The Path base class provides an abstraction for traversing a hierarchy
 /// of items by name, and retrieving properties from them. Examples of intended
@@ -174,6 +175,13 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 
 		bool operator == ( const Path &other ) const;
 		bool operator != ( const Path &other ) const;
+
+		/// Must be implemented by Paths which access node graphs. The result
+		/// must be suitable for pasing to `ParallelAlgo::callOnBackgroundThread()` by
+		/// code which will query the Path in the background. This allows the background
+		/// processing to be cancelled before node graph edits that affect the Path are
+		/// made.
+		virtual const Plug *cancellationSubject() const;
 
 	protected :
 

--- a/include/Gaffer/PathFilter.h
+++ b/include/Gaffer/PathFilter.h
@@ -71,7 +71,7 @@ class GAFFER_API PathFilter : public IECore::RunTimeTyped
 		void setEnabled( bool enabled );
 		bool getEnabled() const;
 
-		void filter( std::vector<PathPtr> &paths ) const;
+		void filter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller = nullptr ) const;
 
 		typedef boost::signal<void ( PathFilter * )> ChangedSignal;
 		ChangedSignal &changedSignal();
@@ -80,7 +80,7 @@ class GAFFER_API PathFilter : public IECore::RunTimeTyped
 
 		/// Must be implemented by derived classes to filter the passed
 		/// paths in place.
-		virtual void doFilter( std::vector<PathPtr> &paths ) const = 0;
+		virtual void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const = 0;
 
 	private :
 

--- a/include/GafferBindings/PathBinding.inl
+++ b/include/GafferBindings/PathBinding.inl
@@ -48,26 +48,26 @@ namespace Detail
 {
 
 template<typename T>
-bool isValid( const T &p )
+bool isValid( const T &p, const IECore::Canceller *canceller )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	return p.T::isValid();
+	return p.T::isValid( canceller );
 }
 
 template<typename T>
-bool isLeaf( const T &p )
+bool isLeaf( const T &p, const IECore::Canceller *canceller )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	return p.T::isLeaf();
+	return p.T::isLeaf( canceller );
 }
 
 template<typename T>
-boost::python::list propertyNames( const T &p )
+boost::python::list propertyNames( const T &p, const IECore::Canceller *canceller )
 {
 	std::vector<IECore::InternedString> n;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
-		p.T::propertyNames( n );
+		p.T::propertyNames( n, canceller );
 	}
 
 	boost::python::list result;
@@ -81,12 +81,12 @@ boost::python::list propertyNames( const T &p )
 GAFFERBINDINGS_API boost::python::object propertyToPython( IECore::ConstRunTimeTypedPtr a );
 
 template<typename T>
-boost::python::object property( const T &p, const IECore::InternedString &name )
+boost::python::object property( const T &p, const IECore::InternedString &name, const IECore::Canceller *canceller )
 {
 	IECore::ConstRunTimeTypedPtr property;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
-		property = p.T::property( name );
+		property = p.T::property( name, canceller );
 	}
 	return propertyToPython( property );
 }
@@ -169,10 +169,10 @@ template<typename T, typename TWrapper>
 PathClass<T, TWrapper>::PathClass( const char *docString )
 	:	IECorePython::RunTimeTypedClass<T, TWrapper>( docString )
 {
-	this->def( "isValid", &Detail::isValid<T> );
-	this->def( "isLeaf", &Detail::isLeaf<T> );
-	this->def( "propertyNames", &Detail::propertyNames<T> );
-	this->def( "property", &Detail::property<T> );
+	this->def( "isValid", &Detail::isValid<T>, boost::python::arg( "canceller" ) = boost::python::object() );
+	this->def( "isLeaf", &Detail::isLeaf<T>, boost::python::arg( "canceller" ) = boost::python::object() );
+	this->def( "propertyNames", &Detail::propertyNames<T>, boost::python::arg( "canceller" ) = boost::python::object() );
+	this->def( "property", &Detail::property<T>, ( boost::python::arg( "name" ), boost::python::arg( "canceller" ) = boost::python::object() ) );
 	// Backwards compatibility with deprecated Path.info()
 	// method from original python implementation.
 	/// \todo Remove this in due course.

--- a/include/GafferBindings/PathBinding.inl
+++ b/include/GafferBindings/PathBinding.inl
@@ -40,6 +40,7 @@
 #include "GafferBindings/DataBinding.h"
 
 #include "Gaffer/Path.h"
+#include "Gaffer/Plug.h"
 
 namespace GafferBindings
 {
@@ -163,6 +164,12 @@ Gaffer::PathPtr copy( const T &p )
 	return p.T::copy();
 }
 
+template<typename T>
+Gaffer::PlugPtr cancellationSubject( const T &p )
+{
+	return const_cast<Gaffer::Plug *>( p.T::cancellationSubject() );
+}
+
 } // namespace Detail
 
 template<typename T, typename TWrapper>
@@ -173,6 +180,7 @@ PathClass<T, TWrapper>::PathClass( const char *docString )
 	this->def( "isLeaf", &Detail::isLeaf<T>, boost::python::arg( "canceller" ) = boost::python::object() );
 	this->def( "propertyNames", &Detail::propertyNames<T>, boost::python::arg( "canceller" ) = boost::python::object() );
 	this->def( "property", &Detail::property<T>, ( boost::python::arg( "name" ), boost::python::arg( "canceller" ) = boost::python::object() ) );
+	this->def( "cancellationSubject", &Detail::cancellationSubject<T> );
 	// Backwards compatibility with deprecated Path.info()
 	// method from original python implementation.
 	/// \todo Remove this in due course.

--- a/include/GafferScene/SceneFilterPathFilter.h
+++ b/include/GafferScene/SceneFilterPathFilter.h
@@ -61,7 +61,7 @@ class GAFFERSCENE_API SceneFilterPathFilter : public Gaffer::PathFilter
 
 	protected :
 
-		void doFilter( std::vector<Gaffer::PathPtr> &paths ) const override;
+		void doFilter( std::vector<Gaffer::PathPtr> &paths, const IECore::Canceller *canceller ) const override;
 
 	private :
 

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -78,15 +78,15 @@ class GAFFERSCENE_API ScenePath : public Gaffer::Path
 		Gaffer::Context *getContext();
 		const Gaffer::Context *getContext() const;
 
-		bool isValid() const override;
-		bool isLeaf() const override;
+		bool isValid( const IECore::Canceller *canceller = nullptr ) const override;
+		bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override;
 		Gaffer::PathPtr copy() const override;
 
 		static Gaffer::PathFilterPtr createStandardFilter( const std::vector<std::string> &setNames = std::vector<std::string>(), const std::string &setsLabel = "" );
 
 	protected :
 
-		void doChildren( std::vector<Gaffer::PathPtr> &children ) const override;
+		void doChildren( std::vector<Gaffer::PathPtr> &children, const IECore::Canceller *canceller ) const override;
 		void pathChangedSignalCreated() override;
 
 	private :

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -82,6 +82,8 @@ class GAFFERSCENE_API ScenePath : public Gaffer::Path
 		bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override;
 		Gaffer::PathPtr copy() const override;
 
+		const Gaffer::Plug *cancellationSubject() const override;
+
 		static Gaffer::PathFilterPtr createStandardFilter( const std::vector<std::string> &setNames = std::vector<std::string>(), const std::string &setsLabel = "" );
 
 	protected :

--- a/python/Gaffer/DictPath.py
+++ b/python/Gaffer/DictPath.py
@@ -56,7 +56,7 @@ class DictPath( Gaffer.Path ) :
 
 		return self.__dict
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		try :
 			self.__dictEntry()
@@ -64,7 +64,7 @@ class DictPath( Gaffer.Path ) :
 		except :
 			return False
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		try :
 			e = self.__dictEntry()
@@ -72,12 +72,11 @@ class DictPath( Gaffer.Path ) :
 		except :
 			return False
 
-
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + [ "dict:value" ]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		if name == "dict:value" :
 			with IECore.IgnoredExceptions( Exception ) :
@@ -91,7 +90,7 @@ class DictPath( Gaffer.Path ) :
 
 		return DictPath( self.__dict, self[:], self.root(), self.getFilter(), self.__dictTypes )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		try :
 			e = self.__dictEntry()

--- a/python/Gaffer/FileNamePathFilter.py
+++ b/python/Gaffer/FileNamePathFilter.py
@@ -70,7 +70,7 @@ class FileNamePathFilter( Gaffer.PathFilter ) :
 
 		self.__leafOnly = leafOnly
 
-	def _filter( self, paths ) :
+	def _filter( self, paths, canceller ) :
 
 		result = []
 		for p in paths :

--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -78,6 +78,23 @@ class GraphComponentPath( Gaffer.Path ) :
 		else :
 			return Gaffer.Path.property( self, name )
 
+	def cancellationSubject( self ) :
+
+		if isinstance( self.__rootComponent, Gaffer.ScriptNode ) :
+			script = self.__rootComponent
+		else :
+			script = self.__rootComponent.ancestor( Gaffer.ScriptNode )
+
+		if script is None :
+			return None
+
+		# The BackgroundTask cancellation mechanism is plug-centric, but we deal
+		# with any kind of GraphComponent. Returning a plug on the script is
+		# currently sufficient for any edit to a child of the script to cancel
+		# background tasks.
+		## \todo Perhaps BackgroundTask cancellation shouldn't only be plug-centric?
+		return script["fileName"]
+
 	def _children( self, canceller ) :
 
 		try :

--- a/python/Gaffer/GraphComponentPath.py
+++ b/python/Gaffer/GraphComponentPath.py
@@ -51,7 +51,7 @@ class GraphComponentPath( Gaffer.Path ) :
 
 		self.__rootComponent = rootComponent
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		try :
 			self.__graphComponent()
@@ -59,7 +59,7 @@ class GraphComponentPath( Gaffer.Path ) :
 		except :
 			return False
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		return False
 
@@ -67,18 +67,18 @@ class GraphComponentPath( Gaffer.Path ) :
 
 		return GraphComponentPath( self.__rootComponent, self[:], self.root(), self.getFilter() )
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + [ "graphComponent:graphComponent" ]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		if name == "graphComponent:graphComponent" :
 			return self.__graphComponent()
 		else :
 			return Gaffer.Path.property( self, name )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		try :
 			e = self.__graphComponent()

--- a/python/Gaffer/InfoPathFilter.py
+++ b/python/Gaffer/InfoPathFilter.py
@@ -64,7 +64,7 @@ class InfoPathFilter( Gaffer.PathFilter ) :
 
 		return self.__infoKey, self.__matcher
 
-	def _filter( self, paths ) :
+	def _filter( self, paths, canceller ) :
 
 		if self.__matcher is None :
 			return paths

--- a/python/Gaffer/SequencePath.py
+++ b/python/Gaffer/SequencePath.py
@@ -58,7 +58,7 @@ class SequencePath( Gaffer.Path ) :
 		self.__basePathSeed = path
 		self.__minSequenceSize = minSequenceSize
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		for p in self.__basePaths() :
 			if not p.isValid() :
@@ -66,7 +66,7 @@ class SequencePath( Gaffer.Path ) :
 
 		return True
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		for p in self.__basePaths() :
 			if not p.isLeaf() :
@@ -74,11 +74,11 @@ class SequencePath( Gaffer.Path ) :
 
 		return True
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return self.__basePathSeed.propertyNames()
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		result = Gaffer.Path.property( self, name )
 		if result is not None :
@@ -114,7 +114,7 @@ class SequencePath( Gaffer.Path ) :
 
 		return None
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		p = self.__basePath( self )
 

--- a/python/GafferCortex/ClassLoaderPath.py
+++ b/python/GafferCortex/ClassLoaderPath.py
@@ -46,7 +46,7 @@ class ClassLoaderPath( Gaffer.Path ) :
 
 		self.__classLoader = classLoader
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		if not len( self ) :
 			# root is always valid
@@ -61,15 +61,15 @@ class ClassLoaderPath( Gaffer.Path ) :
 
 		return False
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		return str( self )[1:] in self.__classLoader.classNames()
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + [ "classLoader:versions" ]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		if name == "classLoader:versions" :
 			if not self.isLeaf() :
@@ -90,7 +90,7 @@ class ClassLoaderPath( Gaffer.Path ) :
 
 		return self.__classLoader.load( str( self )[1:], version )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		result = []
 		added = set()

--- a/python/GafferCortex/IndexedIOPath.py
+++ b/python/GafferCortex/IndexedIOPath.py
@@ -51,7 +51,7 @@ class IndexedIOPath( Gaffer.Path ) :
 		else :
 			self.__indexedIO = indexedIO
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		try :
 			self.__entry()
@@ -59,7 +59,7 @@ class IndexedIOPath( Gaffer.Path ) :
 		except :
 			return False
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		try :
 			e = self.__entry()
@@ -68,13 +68,13 @@ class IndexedIOPath( Gaffer.Path ) :
 
 		return e.entryType() == IECore.IndexedIO.EntryType.File
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + [
 			"indexedIO:entryType", "indexedIO:dataType", "indexedIO:arrayLength"
 		]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		result = Gaffer.Path.property( self, name )
 		if result is not None :
@@ -100,7 +100,7 @@ class IndexedIOPath( Gaffer.Path ) :
 		d = self.__indexedIO.directory( self[:-1] )
 		return d.read( self[-1] )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		try :
 			d = self.__indexedIO.directory( self[:] )

--- a/python/GafferCortex/ParameterPath.py
+++ b/python/GafferCortex/ParameterPath.py
@@ -49,7 +49,7 @@ class ParameterPath( Gaffer.Path ) :
 		self.__forcedLeafTypes = forcedLeafTypes
 		self.__rootParameter = rootParameter
 
-	def isValid( self ) :
+	def isValid( self, canceller = None ) :
 
 		try :
 			self.__parameter()
@@ -57,7 +57,7 @@ class ParameterPath( Gaffer.Path ) :
 		except :
 			return False
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		try :
 			p = self.__parameter()
@@ -66,11 +66,11 @@ class ParameterPath( Gaffer.Path ) :
 
 		return isinstance( p, self.__forcedLeafTypes ) or not isinstance( p, IECore.CompoundParameter )
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + [ "parameter:parameter" ]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		if name == "parameter:parameter" :
 			with IECore.IgnoredExceptions( Exception ) :
@@ -83,7 +83,7 @@ class ParameterPath( Gaffer.Path ) :
 
 		return ParameterPath( self.__rootParameter, self[:], self.root(), self.getFilter(), self.__forcedLeafTypes )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		try :
 			p = self.__parameter()

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -128,7 +128,7 @@ class _LocalJobsPath( Gaffer.Path ) :
 
 		return c
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames() + [
 			"localDispatcher:status",
@@ -139,7 +139,7 @@ class _LocalJobsPath( Gaffer.Path ) :
 			"localDispatcher:memory",
 		]
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		result = Gaffer.Path.property( self, name )
 		if result is not None :
@@ -178,11 +178,11 @@ class _LocalJobsPath( Gaffer.Path ) :
 
 		return self.__jobPool
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		return len( self )
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		if self.isLeaf() :
 			return []

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -551,6 +551,10 @@ class _ImagesPath( Gaffer.Path ) :
 				# not in a position to do anything more helpful.
 				return None
 
+	def cancellationSubject( self ) :
+
+		return self.__images
+
 	def _orderedImages( self ) :
 
 		# Avoid repeat lookups for plugs with no ui index by first getting all

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -519,15 +519,15 @@ class _ImagesPath( Gaffer.Path ) :
 
 		return self.__class__( self.__images, self[:], self.root(), self.getFilter() )
 
-	def isLeaf( self ) :
+	def isLeaf( self, canceller = None ) :
 
 		return len( self ) > 0
 
-	def propertyNames( self ) :
+	def propertyNames( self, canceller = None ) :
 
 		return Gaffer.Path.propertyNames( self ) + registeredColumns()
 
-	def property( self, name ) :
+	def property( self, name, canceller = None ) :
 
 		if name not in registeredColumns() :
 			return Gaffer.Path.property( self, name )
@@ -563,7 +563,7 @@ class _ImagesPath( Gaffer.Path ) :
 
 		return [ i[0] for i in sorted( imageAndIndices, key = lambda i : i[1] ) ]
 
-	def _children( self ) :
+	def _children( self, canceller ) :
 
 		if len( self ) != 0 :
 			return []

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -37,6 +37,7 @@
 import os
 import unittest
 import six
+import inspect
 import imath
 
 import IECore
@@ -266,6 +267,20 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 			context["sphereName"] = "sphere{}".format( i )
 			path = GafferScene.ScenePath( script["parent"]["out"], context, "/plane/instances/{}/2410/cube".format( context["sphereName"] ) )
 			self.assertTrue( path.isValid() )
+
+	def testCancellation( self ) :
+
+		plane = GafferScene.Plane()
+		path = GafferScene.ScenePath( plane["out"], Gaffer.Context(), "/" )
+
+		canceller = IECore.Canceller()
+		canceller.cancel()
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.children( canceller )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.isValid( canceller )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -308,6 +308,38 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		c = p.children()
 		self.assertEqual( len( c ), 8 )
 
+	def testCancellation( self ) :
+
+		p = Gaffer.FileSystemPath( os.path.dirname( __file__ ) )
+
+		# Children
+
+		c = IECore.Canceller()
+		c.cancel()
+
+		with self.assertRaises( IECore.Cancelled ) :
+			p.children( c )
+
+		# Sequence properties
+
+		for f in range( 0, 100 ) :
+			with open( os.path.join( self.temporaryDirectory(), "{}.txt".format( f ) ), "w" ) as f :
+				f.write( "x" )
+
+		p = Gaffer.FileSystemPath( os.path.join( self.temporaryDirectory(), "#.txt" ), includeSequences = True )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			p.property( "fileSystem:owner", c )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			p.property( "fileSystem:group", c )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			p.property( "fileSystem:size", c )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			p.property( "fileSystem:modificationTime", c )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -68,7 +68,7 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 		self.__plugInputChangedConnections = [ node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ) ) for node in selection ]
 		self.__nameChangedConnections = []
 
-	def _filter( self, paths ) :
+	def _filter( self, paths, canceller ) :
 
 		def shouldKeep( path ) :
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -548,15 +548,15 @@ class _PlugListing( GafferUI.Widget ) :
 
 			return self.__class__( self.__rootItem, self[:], self.root(), self.getFilter() )
 
-		def isLeaf( self ) :
+		def isLeaf( self, canceller = None ) :
 
 			return not isinstance( self.item(), _SectionLayoutItem )
 
-		def isValid( self ) :
+		def isValid( self, canceller = None ) :
 
 			return self.item() is not None
 
-		def _children( self ) :
+		def _children( self, canceller ) :
 
 			item = self.item()
 			if item is None :

--- a/src/Gaffer/CompoundPathFilter.cpp
+++ b/src/Gaffer/CompoundPathFilter.cpp
@@ -119,7 +119,7 @@ void CompoundPathFilter::getFilters( Filters &filters ) const
 	}
 }
 
-void CompoundPathFilter::doFilter( std::vector<PathPtr> &paths ) const
+void CompoundPathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	for( std::list<Filter>::const_iterator it = m_filters.begin(), eIt = m_filters.end(); it != eIt; ++it )
 	{

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -497,6 +497,11 @@ Context::EditableScope::~EditableScope()
 {
 }
 
+void Context::EditableScope::setCanceller( const IECore::Canceller *canceller )
+{
+	m_context->m_canceller = canceller;
+}
+
 void Context::EditableScope::setAllocated( const IECore::InternedString &name, const IECore::Data *value )
 {
 	m_context->set( name, value );

--- a/src/Gaffer/FileSequencePathFilter.cpp
+++ b/src/Gaffer/FileSequencePathFilter.cpp
@@ -75,7 +75,7 @@ void FileSequencePathFilter::setMode( Keep mode )
 	changedSignal()( this );
 }
 
-void FileSequencePathFilter::doFilter( std::vector<PathPtr> &paths ) const
+void FileSequencePathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	paths.erase(
 		std::remove_if(

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -146,6 +146,7 @@ FileSequencePtr FileSystemPath::fileSequence() const
 	}
 
 	FileSequencePtr sequence = nullptr;
+	/// \todo Add cancellation support to `ls`.
 	IECore::ls( this->string(), sequence, /* minSequenceSize = */ 1 );
 	return sequence;
 }
@@ -171,9 +172,11 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 	{
 		if( m_includeSequences )
 		{
+			IECore::Canceller::check( canceller );
 			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
+				IECore::Canceller::check( canceller );
 				std::vector<std::string> files;
 				sequence->fileNames( files );
 
@@ -182,6 +185,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 				std::map<std::string,size_t> ownerCounter;
 				for( std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it )
 				{
+					IECore::Canceller::check( canceller );
 					struct stat s;
 					stat( it->c_str(), &s );
 					struct passwd *pw = getpwuid( s.st_uid );
@@ -208,9 +212,11 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 	{
 		if( m_includeSequences )
 		{
+			IECore::Canceller::check( canceller );
 			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
+				IECore::Canceller::check( canceller );
 				std::vector<std::string> files;
 				sequence->fileNames( files );
 
@@ -219,6 +225,7 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 				std::map<std::string,size_t> ownerCounter;
 				for( std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it )
 				{
+					IECore::Canceller::check( canceller );
 					struct stat s;
 					stat( it->c_str(), &s );
 					struct group *gr = getgrgid( s.st_gid );
@@ -247,15 +254,18 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 
 		if( m_includeSequences )
 		{
+			IECore::Canceller::check( canceller );
 			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
+				IECore::Canceller::check( canceller );
 				std::vector<std::string> files;
 				sequence->fileNames( files );
 
 				std::time_t newest = 0;
 				for( std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it )
 				{
+					IECore::Canceller::check( canceller );
 					std::time_t t = last_write_time( path( *it ), e );
 					if( t > newest )
 					{
@@ -276,15 +286,18 @@ IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedStr
 
 		if( m_includeSequences )
 		{
+			IECore::Canceller::check( canceller );
 			FileSequencePtr sequence = fileSequence();
 			if( sequence )
 			{
+				IECore::Canceller::check( canceller );
 				std::vector<std::string> files;
 				sequence->fileNames( files );
 
 				uintmax_t total = 0;
 				for( std::vector<std::string>::iterator it = files.begin(); it != files.end(); ++it )
 				{
+					IECore::Canceller::check( canceller );
 					uintmax_t s = file_size( path( *it ), e );
 					if( !e )
 					{
@@ -329,15 +342,18 @@ void FileSystemPath::doChildren( std::vector<PathPtr> &children, const IECore::C
 
 	for( directory_iterator it( p ), eIt; it != eIt; ++it )
 	{
+		IECore::Canceller::check( canceller );
 		children.push_back( new FileSystemPath( it->path().string(), const_cast<PathFilter *>( getFilter() ), m_includeSequences ) );
 	}
 
 	if( m_includeSequences )
 	{
+		IECore::Canceller::check( canceller );
 		std::vector<FileSequencePtr> sequences;
 		IECore::ls( p.string(), sequences, /* minSequenceSize */ 1 );
 		for( std::vector<FileSequencePtr>::iterator it = sequences.begin(); it != sequences.end(); ++it )
 		{
+			IECore::Canceller::check( canceller );
 			std::vector<FrameList::Frame> frames;
 			(*it)->getFrameList()->asList( frames );
 			if ( !is_directory( path( (*it)->fileNameForFrame( frames[0] ) ) ) )

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -89,7 +89,7 @@ FileSystemPath::~FileSystemPath()
 {
 }
 
-bool FileSystemPath::isValid() const
+bool FileSystemPath::isValid( const IECore::Canceller *canceller ) const
 {
 	if( !Path::isValid() )
 	{
@@ -105,7 +105,7 @@ bool FileSystemPath::isValid() const
 	return t != status_error && t != file_not_found;
 }
 
-bool FileSystemPath::isLeaf() const
+bool FileSystemPath::isLeaf( const IECore::Canceller *canceller ) const
 {
 	return isValid() && !is_directory( path( this->string() ) );
 }
@@ -150,7 +150,7 @@ FileSequencePtr FileSystemPath::fileSequence() const
 	return sequence;
 }
 
-void FileSystemPath::propertyNames( std::vector<IECore::InternedString> &names ) const
+void FileSystemPath::propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller ) const
 {
 	Path::propertyNames( names );
 
@@ -165,7 +165,7 @@ void FileSystemPath::propertyNames( std::vector<IECore::InternedString> &names )
 	}
 }
 
-IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedString &name ) const
+IECore::ConstRunTimeTypedPtr FileSystemPath::property( const IECore::InternedString &name, const IECore::Canceller *canceller ) const
 {
 	if( name == g_ownerPropertyName )
 	{
@@ -318,7 +318,7 @@ PathPtr FileSystemPath::copy() const
 	return new FileSystemPath( names(), root(), const_cast<PathFilter *>( getFilter() ), m_includeSequences );
 }
 
-void FileSystemPath::doChildren( std::vector<PathPtr> &children ) const
+void FileSystemPath::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 	path p( this->string() );
 

--- a/src/Gaffer/LeafPathFilter.cpp
+++ b/src/Gaffer/LeafPathFilter.cpp
@@ -53,7 +53,7 @@ LeafPathFilter::~LeafPathFilter()
 {
 }
 
-void LeafPathFilter::doFilter( std::vector<PathPtr> &paths ) const
+void LeafPathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	paths.erase(
 		std::remove_if(

--- a/src/Gaffer/MatchPatternPathFilter.cpp
+++ b/src/Gaffer/MatchPatternPathFilter.cpp
@@ -104,7 +104,7 @@ bool MatchPatternPathFilter::getInverted() const
 	return m_inverted;
 }
 
-void MatchPatternPathFilter::doFilter( std::vector<PathPtr> &paths ) const
+void MatchPatternPathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	paths.erase(
 		std::remove_if(

--- a/src/Gaffer/ParallelAlgo.cpp
+++ b/src/Gaffer/ParallelAlgo.cpp
@@ -106,8 +106,8 @@ GAFFER_API std::unique_ptr<BackgroundTask> ParallelAlgo::callOnBackgroundThread(
 
 		[backgroundContext, backgroundMonitors, function] ( const IECore::Canceller &canceller ) {
 
-			ContextPtr c = new Context( *backgroundContext, canceller );
-			Context::Scope contextScope( c.get() );
+			Context::EditableScope contextScope( backgroundContext.get() );
+			contextScope.setCanceller( &canceller );
 			Monitor::Scope monitorScope( backgroundMonitors );
 
 			function();

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -154,7 +154,7 @@ size_t Path::children( std::vector<PathPtr> &children, const IECore::Canceller *
 	doChildren( children, canceller );
 	if( m_filter )
 	{
-		m_filter->filter( children );
+		m_filter->filter( children, canceller );
 	}
 	return children.size();
 }

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -380,6 +380,11 @@ bool Path::operator != ( const Path &other ) const
 	return !(*this == other );
 }
 
+const Plug *Path::cancellationSubject() const
+{
+	return nullptr;
+}
+
 void Path::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 }

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -100,23 +100,23 @@ bool Path::isEmpty() const
 	return m_names.empty() && m_root.string().empty();
 }
 
-bool Path::isValid() const
+bool Path::isValid( const IECore::Canceller *canceller ) const
 {
 	return !isEmpty();
 }
 
-bool Path::isLeaf() const
+bool Path::isLeaf( const IECore::Canceller *canceller ) const
 {
 	return false;
 }
 
-void Path::propertyNames( std::vector<IECore::InternedString> &names ) const
+void Path::propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller ) const
 {
 	names.push_back( g_namePropertyName );
 	names.push_back( g_fullNamePropertyName );
 }
 
-IECore::ConstRunTimeTypedPtr Path::property( const IECore::InternedString &name ) const
+IECore::ConstRunTimeTypedPtr Path::property( const IECore::InternedString &name, const IECore::Canceller *canceller ) const
 {
 	if( name == g_namePropertyName )
 	{
@@ -149,9 +149,9 @@ PathPtr Path::parent() const
 	return result;
 }
 
-size_t Path::children( std::vector<PathPtr> &children ) const
+size_t Path::children( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
-	doChildren( children );
+	doChildren( children, canceller );
 	if( m_filter )
 	{
 		m_filter->filter( children );
@@ -380,7 +380,7 @@ bool Path::operator != ( const Path &other ) const
 	return !(*this == other );
 }
 
-void Path::doChildren( std::vector<PathPtr> &children ) const
+void Path::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 }
 

--- a/src/Gaffer/PathFilter.cpp
+++ b/src/Gaffer/PathFilter.cpp
@@ -79,13 +79,13 @@ bool PathFilter::getEnabled() const
 	return m_enabled;
 }
 
-void PathFilter::filter( std::vector<PathPtr> &paths ) const
+void PathFilter::filter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	if( !m_enabled )
 	{
 		return;
 	}
-	doFilter( paths );
+	doFilter( paths, canceller );
 }
 
 typedef boost::signal<void ( PathFilter * )> ChangedSignal;
@@ -94,6 +94,6 @@ ChangedSignal &PathFilter::changedSignal()
 	return m_changedSignal;
 }
 
-void PathFilter::doFilter( std::vector<PathPtr> &paths ) const
+void PathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 }

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -246,6 +246,27 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::copy();
 		}
 
+		const Plug *cancellationSubject() const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "cancellationSubject" );
+					if( f )
+					{
+						return extract<Plug *>( f() );
+					}
+				}
+				catch( const error_already_set &e )
+				{
+					ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::cancellationSubject();
+		}
+
 		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -103,8 +103,17 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 		{
 		}
 
+		// Caution : In the overrides below, we pass `canceller` to Python via
+		// `boost::python::ptr()`. This produces a Python object which
+		// references `canceller` directly. We can't guarantee the lifetime of
+		// `canceller` beyond the function call,  but we can't stop a Python
+		// override from storing the Python object outside that scope, after
+		// which any accesses will crash. Our only advice is "don't do that",
+		// which seems fairly reasonable given that the only expected use is
+		// to call `IECore.Canceller.check( canceller )` within the override
+		// itself.
 
-		bool isValid() const override
+		bool isValid( const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -114,7 +123,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					boost::python::object f = this->methodOverride( "isValid" );
 					if( f )
 					{
-						return f();
+						return f( boost::python::ptr( canceller ) );
 					}
 				}
 				catch( const error_already_set &e )
@@ -122,10 +131,10 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					ExceptionAlgo::translatePythonException();
 				}
 			}
-			return WrappedType::isValid();
+			return WrappedType::isValid( canceller );
 		}
 
-		bool isLeaf() const override
+		bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -135,7 +144,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					boost::python::object f = this->methodOverride( "isLeaf" );
 					if( f )
 					{
-						return f();
+						return f( boost::python::ptr( canceller ) );
 					}
 				}
 				catch( const error_already_set &e )
@@ -143,10 +152,10 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					ExceptionAlgo::translatePythonException();
 				}
 			}
-			return WrappedType::isLeaf();
+			return WrappedType::isLeaf( canceller );
 		}
 
-		void propertyNames( std::vector<IECore::InternedString> &names ) const override
+		void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -156,8 +165,8 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					boost::python::object f = this->methodOverride( "propertyNames" );
 					if( f )
 					{
-						WrappedType::propertyNames( names );
-						boost::python::list pythonNames = extract<boost::python::list>( f() );
+						WrappedType::propertyNames( names, canceller  );
+						boost::python::list pythonNames = extract<boost::python::list>( f( boost::python::ptr( canceller ) ) );
 						boost::python::container_utils::extend_container( names, pythonNames );
 						return;
 					}
@@ -176,10 +185,10 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					ExceptionAlgo::translatePythonException();
 				}
 			}
-			WrappedType::propertyNames( names );
+			WrappedType::propertyNames( names, canceller  );
 		}
 
-		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name ) const override
+		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -189,7 +198,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					boost::python::object f = this->methodOverride( "property" );
 					if( f )
 					{
-						return extract<IECore::ConstRunTimeTypedPtr>( f( name.c_str() ) );
+						return extract<IECore::ConstRunTimeTypedPtr>( f( name.c_str(), boost::python::ptr( canceller ) ) );
 					}
 					// fall back to emulating properties using the deprecated python info() method.
 					f = this->methodOverride( "info" );
@@ -209,7 +218,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					ExceptionAlgo::translatePythonException();
 				}
 			}
-			return WrappedType::property( name );
+			return WrappedType::property( name, canceller );
 		}
 
 		PathPtr copy() const override
@@ -237,7 +246,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::copy();
 		}
 
-		void doChildren( std::vector<PathPtr> &children ) const override
+		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
 			{
@@ -247,7 +256,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					boost::python::object f = this->methodOverride( "_children" );
 					if( f )
 					{
-						list l = extract<list>( f() );
+						list l = extract<list>( f( boost::python::ptr( canceller ) ) );
 						boost::python::container_utils::extend_container( children, l );
 						return;
 					}
@@ -257,7 +266,7 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 					ExceptionAlgo::translatePythonException();
 				}
 			}
-			WrappedType::doChildren( children );
+			WrappedType::doChildren( children, canceller );
 		}
 
 		void pathChangedSignalCreated() override
@@ -296,10 +305,10 @@ const char *rootWrapper( Path &p )
 	return p.root().c_str();
 }
 
-list childrenWrapper( Path &p )
+list childrenWrapper( Path &p, const IECore::Canceller *canceller )
 {
 	std::vector<PathPtr> c;
-	p.children( c );
+	p.children( c, canceller );
 	list result;
 	for( std::vector<PathPtr>::const_iterator it = c.begin(), eIt = c.end(); it != eIt; ++it )
 	{
@@ -451,7 +460,7 @@ void GafferModule::bindPath()
 			.def( "root", &rootWrapper )
 			.def( "isEmpty", &Path::isEmpty )
 			.def( "parent", &Path::parent )
-			.def( "children", &childrenWrapper )
+			.def( "children", &childrenWrapper, arg( "canceller" ) = object() )
 			.def( "setFilter", &Path::setFilter )
 			.def( "getFilter", (PathFilter *(Path::*)())&Path::getFilter, return_value_policy<CastToIntrusivePtr>() )
 			.def( "pathChangedSignal", &Path::pathChangedSignal, return_internal_reference<1>() )

--- a/src/GafferScene/SceneFilterPathFilter.cpp
+++ b/src/GafferScene/SceneFilterPathFilter.cpp
@@ -102,7 +102,7 @@ struct SceneFilterPathFilter::Remove
 
 };
 
-void SceneFilterPathFilter::doFilter( std::vector<Gaffer::PathPtr> &paths ) const
+void SceneFilterPathFilter::doFilter( std::vector<Gaffer::PathPtr> &paths, const IECore::Canceller *canceller ) const
 {
 	paths.erase(
 		std::remove_if(

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -171,6 +171,11 @@ PathPtr ScenePath::copy() const
 	return new ScenePath( m_scene, m_context, names(), root(), const_cast<PathFilter *>( getFilter() ) );
 }
 
+const Gaffer::Plug *ScenePath::cancellationSubject() const
+{
+	return m_scene.get();
+}
+
 void ScenePath::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 	Context::EditableScope scopedContext( m_context.get() );

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -145,7 +145,7 @@ const Gaffer::Context *ScenePath::getContext() const
 	return m_context.get();
 }
 
-bool ScenePath::isValid() const
+bool ScenePath::isValid( const IECore::Canceller *canceller ) const
 {
 	if( !Path::isValid() )
 	{
@@ -156,7 +156,7 @@ bool ScenePath::isValid() const
 	return m_scene->exists( names() );
 }
 
-bool ScenePath::isLeaf() const
+bool ScenePath::isLeaf( const IECore::Canceller *canceller ) const
 {
 	// Any part of the scene could get children at any time
 	return false;
@@ -167,7 +167,7 @@ PathPtr ScenePath::copy() const
 	return new ScenePath( m_scene, m_context, names(), root(), const_cast<PathFilter *>( getFilter() ) );
 }
 
-void ScenePath::doChildren( std::vector<PathPtr> &children ) const
+void ScenePath::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 	Context::Scope scopedContext( m_context.get() );
 	ConstInternedStringVectorDataPtr childNamesData = m_scene->childNames( names() );

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -152,7 +152,11 @@ bool ScenePath::isValid( const IECore::Canceller *canceller ) const
 		return false;
 	}
 
-	Context::Scope scopedContext( m_context.get() );
+	Context::EditableScope scopedContext( m_context.get() );
+	if( canceller )
+	{
+		scopedContext.setCanceller( canceller );
+	}
 	return m_scene->exists( names() );
 }
 
@@ -169,7 +173,12 @@ PathPtr ScenePath::copy() const
 
 void ScenePath::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
-	Context::Scope scopedContext( m_context.get() );
+	Context::EditableScope scopedContext( m_context.get() );
+	if( canceller )
+	{
+		scopedContext.setCanceller( canceller );
+	}
+
 	ConstInternedStringVectorDataPtr childNamesData = m_scene->childNames( names() );
 	const std::vector<InternedString> &childNames = childNamesData->readable();
 	ScenePlug::ScenePath childPath( names() );

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -271,7 +271,7 @@ class HierarchyViewSetFilter : public HierarchyViewFilter
 			}
 		}
 
-		void doFilter( vector<Gaffer::PathPtr> &paths ) const override
+		void doFilter( vector<Gaffer::PathPtr> &paths, const IECore::Canceller *canceller ) const override
 		{
 			if( paths.empty() )
 			{
@@ -414,7 +414,7 @@ class HierarchyViewSearchFilter : public HierarchyViewFilter
 			}
 		}
 
-		void doFilter( vector<Gaffer::PathPtr> &paths ) const override
+		void doFilter( vector<Gaffer::PathPtr> &paths, const IECore::Canceller *canceller ) const override
 		{
 			if( m_matchPattern.empty() || paths.empty() )
 			{


### PR DESCRIPTION
This makes it possible to cancel a long-running query to a Path, and will be used as the foundations for cancellation in an upcoming asynchronous PathListingWidget/HierarchyView.