### PR TITLE
Apply `clang-tidy modernize-use-nullptr`

### DIFF
--- a/src/GafferScene/AttributeQuery.cpp
+++ b/src/GafferScene/AttributeQuery.cpp
@@ -407,13 +407,13 @@ const Gaffer::ObjectPlug* AttributeQuery::internalObjectPlug() const
 
 bool AttributeQuery::isSetup() const
 {
-	return ( defaultPlug() != 0 ) && ( valuePlug() != 0 );
+	return ( defaultPlug() != nullptr ) && ( valuePlug() != nullptr );
 }
 
 bool AttributeQuery::canSetup( const Gaffer::ValuePlug* const plug ) const
 {
 	const bool success =
-		( plug != 0 ) &&
+		( plug != nullptr ) &&
 		( ! isSetup() ) &&
 		( canSetPlugType( static_cast< Gaffer::TypeId >( plug->typeId() ) ) );
 
@@ -464,7 +464,7 @@ void AttributeQuery::affects( const Gaffer::Plug* const input, AffectedPlugsCont
 	{
 		const Gaffer::ValuePlug* const vplug = valuePlug();
 
-		if( vplug != 0 )
+		if( vplug != nullptr )
 		{
 			addChildPlugsToAffectedOutputs( vplug, outputs );
 		}
@@ -492,7 +492,7 @@ void AttributeQuery::affects( const Gaffer::Plug* const input, AffectedPlugsCont
 		{
 			const Gaffer::ValuePlug* const vplug = valuePlug();
 
-			if( vplug != 0 )
+			if( vplug != nullptr )
 			{
 				outputs.push_back( correspondingPlug( dplug, input, vplug ) );
 			}

--- a/src/GafferScene/Constraint.cpp
+++ b/src/GafferScene/Constraint.cpp
@@ -421,7 +421,7 @@ void constructLocalFrame( Imath::M44f& m, const Imath::V3f& p, const Imath::V3f&
 struct UVIndexer
 {
 	UVIndexer( const IECoreScene::MeshPrimitive& primitive, const std::string& uvSet, const bool throwOnError )
-	: m_indices( 0 )
+	: m_indices( nullptr )
 	, m_view()
 	{
 		const IECoreScene::PrimitiveVariableMap::const_iterator it = primitive.variables.find( uvSet );
@@ -477,7 +477,7 @@ struct UVIndexer
 	const Imath::V2f& operator[]( const int i ) const
 	{
 		assert( valid() );
-		const int index = ( m_indices != 0 ) ? ( ( *m_indices )[ i ] ) : i;
+		const int index = ( m_indices != nullptr ) ? ( ( *m_indices )[ i ] ) : i;
 		return ( *m_view )[ index ];
 	}
 
@@ -490,7 +490,7 @@ private:
 void computePrimitiveVertexLocalFrame( const IECoreScene::Primitive& primitive, Imath::M44f& m, const int vertexId, const bool throwOnError )
 {
 	const IECore::V3fVectorData* const pdata = primitive.variableData< IECore::V3fVectorData >( "P" );
-	if( pdata == 0 )
+	if( pdata == nullptr )
 	{
 		if( throwOnError )
 		{
@@ -525,7 +525,7 @@ void computeMeshVertexLocalFrame( const IECoreScene::MeshPrimitive& primitive, I
 {
 	const IECore::V3fVectorData* const pdata = primitive.variableData< IECore::V3fVectorData >( "P" );
 
-	if( pdata == 0 )
+	if( pdata == nullptr )
 	{
 		if( throwOnError )
 		{
@@ -673,7 +673,7 @@ void computeMeshUVLocalFrame( const IECoreScene::MeshPrimitive& primitive, Imath
 {
 	const IECore::V3fVectorData* const pdata = primitive.variableData< IECore::V3fVectorData >( "P" );
 
-	if( pdata == 0 )
+	if( pdata == nullptr )
 	{
 		if( throwOnError )
 		{

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -666,7 +666,7 @@ void StandardLightVisualiser::spotlightParameters( const InternedString &attribu
 	outerAngle = 0;
 
 	ConstStringDataPtr penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
-	const std::string *penumbraType = penumbraTypeData ? &penumbraTypeData->readable() : NULL;
+	const std::string *penumbraType = penumbraTypeData ? &penumbraTypeData->readable() : nullptr;
 
 	if( !penumbraType || *penumbraType == "inset" )
 	{


### PR DESCRIPTION
A few inconsistencies had crept in since we last applied it in a63faf062498744780ec7e421a28fb46af96ede8.

These changes were made with the following command :

`run-clang-tidy.py -header-filter='.*' -checks='-*,modernize-use-nullptr' -fix`