### PR TITLE
OSLExpressionEngine : Handle upstream exceptions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.59.x.x (relative to 0.59.9.4)
+========
+
+Fixes
+-----
+
+- OSL Expression : Fixed crash due to exception in upstream computation
+
 0.59.9.4 (relative to 0.59.9.3)
 ========
 

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -706,5 +706,23 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().y, 0.2 + 0.3 * i + 10 * i, places = 5 )
 			self.assertAlmostEqual( s["dest%i"%i]["p"].getValue().z, 0.3 + 0.3 * i + 10 * i, places = 5 )
 
+	def testException( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["g"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["f"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["ePython"] = Gaffer.Expression()
+		s["ePython"].setExpression( "raise IECore.Exception( 'test string' ); parent['n']['user']['g'] = 4.0" )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent.n.user.f = parent.n.user.g", "OSL" )
+
+		six.assertRaisesRegex( self,
+			Gaffer.ProcessException, "ePython.__execute : test string",
+			s["n"]["user"]["f"].getValue
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -79,6 +79,7 @@ struct RenderState
 	const vector<ustring> *inParameters;
 	const Gaffer::Context *context;
 	const vector<const Gaffer::ValuePlug *> *inPlugs;
+	mutable std::exception_ptr exception;
 
 };
 
@@ -173,36 +174,46 @@ class RendererServices : public OSL::RendererServices
 
 			if( value )
 			{
-				const size_t index = it - renderState->inParameters->begin();
-				const ValuePlug *plug = (*renderState->inPlugs)[index];
-				switch( (Gaffer::TypeId)plug->typeId() )
+				try
 				{
-					case BoolPlugTypeId :
-						*(int *)value = static_cast<const BoolPlug *>( plug )->getValue();
-						return true;
-					case FloatPlugTypeId :
-						*(float *)value = static_cast<const FloatPlug *>( plug )->getValue();
-						return true;
-					case IntPlugTypeId :
-						*(int *)value = static_cast<const IntPlug *>( plug )->getValue();
-						return true;
-					case Color3fPlugTypeId :
-						*(Color3f *)value = static_cast<const Color3fPlug *>( plug )->getValue();
-						return true;
-					case V3fPlugTypeId :
-						*(V3f *)value = static_cast<const V3fPlug *>( plug )->getValue();
-						return true;
-					case M44fPlugTypeId :
-						*(M44f *)value = static_cast<const M44fPlug *>( plug )->getValue();
-						return true;
-					case StringPlugTypeId :
+					const size_t index = it - renderState->inParameters->begin();
+					const ValuePlug *plug = (*renderState->inPlugs)[index];
+					switch( (Gaffer::TypeId)plug->typeId() )
 					{
-						ustring s( static_cast<const StringPlug *>( plug )->getValue() );
-						*(const char **)value = s.c_str();
-						return true;
+						case BoolPlugTypeId :
+							*(int *)value = static_cast<const BoolPlug *>( plug )->getValue();
+							return true;
+						case FloatPlugTypeId :
+							*(float *)value = static_cast<const FloatPlug *>( plug )->getValue();
+							return true;
+						case IntPlugTypeId :
+							*(int *)value = static_cast<const IntPlug *>( plug )->getValue();
+							return true;
+						case Color3fPlugTypeId :
+							*(Color3f *)value = static_cast<const Color3fPlug *>( plug )->getValue();
+							return true;
+						case V3fPlugTypeId :
+							*(V3f *)value = static_cast<const V3fPlug *>( plug )->getValue();
+							return true;
+						case M44fPlugTypeId :
+							*(M44f *)value = static_cast<const M44fPlug *>( plug )->getValue();
+							return true;
+						case StringPlugTypeId :
+						{
+							ustring s( static_cast<const StringPlug *>( plug )->getValue() );
+							*(const char **)value = s.c_str();
+							return true;
+						}
+						default :
+							return false;
 					}
-					default :
-						return false;
+				}
+				catch( ... )
+				{
+					// We need to catch this exception so that OSL doesn't trigger a termination.
+					// Cache the exception so we can throw it from the expression execute()
+					renderState->exception = std::current_exception();
+					return false;
 				}
 			}
 			return false;
@@ -411,6 +422,13 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			}
 
 			s->release_context( shadingContext );
+
+			if( renderState.exception )
+			{
+				// Rethrow any exception that occurred in the internals like get_userdata
+				std::rethrow_exception( renderState.exception );
+			}
+
 			return result;
 		}
 


### PR DESCRIPTION
Code is pretty simple.  I've stashed the exception in RenderState - which I recall you mentioning is the reasonable place to put it.  There is a conflict there with RenderState being treated as const though ... I've made the exception_ptr mutable for now.  Would hypothetically be a threading concern, but OSL expressions are run single threaded anyway.

Test confirms it's working, and I've also confirmed this fixes my actual scene that crashed while testing the active branches PR.