### PR TITLE
AnimationGadget : preview key is no longer incorrectly drawn at origin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - Animation :
   - Fixed bug in `Key.setType()`. Previously it modified the value instead of the type.
   - Fixed crash when dragging multiple keys around in editor.
+  - Fixed bug which resulted in preview key being incorrectly drawn at the origin.
   - Inserting a new key in editor (Hold "Ctrl" and left click on curve) is now undone/redone as a distinct step.
 - ParallelAlgo : Fixed deadlock in `callOnUIThread()`.
 

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -1359,6 +1359,7 @@ void AnimationGadget::updateKeyPreviewLocation( const Gaffer::Animation::CurvePl
 	if( !curvePlug )
 	{
 		m_keyPreviewLocation = V3f( 0 );
+		m_keyPreview = false;
 		return;
 	}
 


### PR DESCRIPTION
fixes #4390
