### PR TITLE
BoolPlugValueWidget : fix "type" to "interpolation" renaming bug.

### DIFF
--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -136,7 +136,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 						Gaffer.Animation.Key(
 							time = self.getContext().getTime(),
 							value = value,
-							type = Gaffer.Animation.Interpolation.Step
+							interpolation = Gaffer.Animation.Interpolation.Step
 						)
 					)
 				else :


### PR DESCRIPTION
ref #4359
