### PR TITLE
TestCase : Add optional `nodesToIgnore` arg

### DIFF
--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -226,7 +226,7 @@ class TestCase( unittest.TestCase ) :
 
 			self.assertEqual( instance.getName(), cls.staticTypeName().rpartition( ":" )[2] )
 
-	def assertNodesAreDocumented( self, module, additionalTerminalPlugTypes = () ) :
+	def assertNodesAreDocumented( self, module, additionalTerminalPlugTypes = (), nodesToIgnore = None ) :
 
 		terminalPlugTypes = (
 			Gaffer.ArrayPlug,
@@ -247,6 +247,9 @@ class TestCase( unittest.TestCase ) :
 
 			cls = getattr( module, name )
 			if not inspect.isclass( cls ) or not issubclass( cls, Gaffer.Node ) :
+				continue
+
+			if nodesToIgnore is not None and cls in nodesToIgnore :
 				continue
 
 			if not cls.__module__.startswith( module.__name__ + "." ) :
@@ -288,8 +291,8 @@ class TestCase( unittest.TestCase ) :
 
 			checkPlugs( node )
 
-		self.assertEqual( undocumentedNodes, [] )
 		self.assertEqual( undocumentedPlugs, [] )
+		self.assertEqual( undocumentedNodes, [] )
 
 	## We don't serialise plug values when they're at their default, so
 	# newly constructed nodes _must_ have all their plugs be at the default value.


### PR DESCRIPTION
This is useful for implementation-detail nodes that do not require user-facing documentation.

I wasn't sure if this merits a Changes.md update or not...

Also asserting plug descriptions before nodes. When going through the process of fixing missing docs, its nicer to get the plug listing even if there is still one or two problem nodes. In my particular case, I had one node missing all docs and it was "masking" 150 plugs on other nodes missing docs.