### PR TITLE
GafferTest.TestCase : assertNodesAreDocumented support multi-inheritance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Arnold Render : Changed warnings for invalid mesh lights to be one descriptive warning per light, instead of repeating an unclear warning for every surface that links to the light.
 
+API
+---
+
+- GafferTest.TestCase : Fixed `assertNodesAreDocumented()` support for Node classes with multi-inheritance.
+
 0.60.8.0 (relative to 0.60.7.1)
 ========
 

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -267,7 +267,7 @@ class TestCase( unittest.TestCase ) :
 			else :
 				baseNode = None
 				try :
-					baseNode = cls.__bases__[0]()
+					baseNode = [x for x in cls.__bases__ if issubclass( x, Gaffer.Node )][0]()
 				except :
 					pass
 				if baseNode is not None :


### PR DESCRIPTION
This test was failing to get the correct base node class for classes
with multiple inheritance where the first base class wasn't the one
derived from `Gaffer.Node`.
