### PR TITLE
Animation : fix bug in `insertKey()` which gave incorrect interpolation

### DIFF
--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -482,7 +482,9 @@ class AnimationTest( GafferTest.TestCase ) :
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
 		interpolation = Gaffer.Animation.Interpolation.Step
+		k0 = Gaffer.Animation.Key( 0, 3 )
 		k = Gaffer.Animation.Key( 10, 5, interpolation )
+		curve.addKey( k0 )
 		curve.addKey( k )
 
 		time = 15

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -613,7 +613,7 @@ Animation::KeyPtr Animation::CurvePlug::insertKeyInternal( const float time, con
 
 	Interpolation interpolation = Gaffer::Animation::defaultInterpolation();
 
-	if( lo && hi )
+	if( lo )
 	{
 		interpolation = lo->m_interpolation;
 	}


### PR DESCRIPTION
* the interpolation of the inserted key should be the interpolation of
  the previous key, including the case where the inserted key is after
  the final key. the test case for this case only had a single existing
  key in the curve so the first and previous key were the same, which is
  not the case when the curve has more than one existing key.
* modified test case to catch bug

ref 4413
