### PR TITLE
GafferTest.TestCase : assertTypeNamesArePrefixed() submodule support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - GafferTest.TestCase : Fixed `assertNodesAreDocumented()` to work for Nodes with multiple base classes.
+- GafferTest.TestCase : Better support for python submodules on `assertTypeNamesArePrefixed()`.
 
 0.60.8.0 (relative to 0.60.7.1)
 ========

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -203,7 +203,7 @@ class TestCase( unittest.TestCase ) :
 			if issubclass( cls, IECore.RunTimeTyped ) :
 				if cls.staticTypeName() in namesToIgnore :
 					continue
-				if cls.staticTypeName() != module.__name__ + "::" + cls.__name__ :
+				if cls.staticTypeName() != module.__name__.replace( ".", "::" ) + "::" + cls.__name__ :
 					incorrectTypeNames.append( cls.staticTypeName() )
 
 		self.assertEqual( incorrectTypeNames, [] )


### PR DESCRIPTION
For python submodules, the native separator is ".", and not "::", which
results in a mix between both, which is not desirable.

So we replace the "." with "::", so the full name is consistent.

Ex: `GafferJabuka.Nodes.Scene.SceneBuilder` expects the type name `GafferJabuka::Nodes::Scene::SceneBuilder` (instead of `GafferJabuka.Nodes.Scene::SceneBuilder`)
