### PR TITLE
Switch : Improve usage of `ContextAlgo::GlobalScope`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
 - Cancellation : Improved responsiveness of cancellation of tasks waiting on results from another thread.
 - ImageReader : Channels from EXR subimages named `rgb`, `rgba` or `depth` (either uppercase or lowercase) are now loaded into Gaffer's primary image layer.
 - PathFilter : Removed `scene:filter:inputScene` and `scene:path` variables from the context used to evaluate the `paths` plug. This improves performance in some scenarios, and prevents the creation of invalid filters where the paths themselves depend on the current scene location.
+- Switch : Removed variables such as `scene:path` and `image:channelName` from the context used to evaluate the `enabled` plug. This improves performance in some scenarios, and prevents the creation of invalid switches.
 - NodeEditor : Added option in node editor context menu to set interpolation of an animated value.
 
 Fixes
@@ -35,6 +36,7 @@ Fixes
   - Fixed bug when pressing <kbd>f</kbd> to frame viewport which resulted in a blank background in certain cases (#4410).
   - Inserting a new key in editor (Hold "Ctrl" and left click on curve) is now undone/redone as a distinct step.
 - ParallelAlgo : Fixed deadlock in `callOnUIThread()`.
+- NameSwitch : Fixed context management bug that allowed variables such as `scene:path` to leak into the context used to evaluate the `selector` plug.
 
 API
 ---

--- a/python/GafferSceneTest/NameSwitchTest.py
+++ b/python/GafferSceneTest/NameSwitchTest.py
@@ -1,0 +1,118 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import inspect
+import unittest
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class NameSwitchTest( GafferSceneTest.SceneTestCase ) :
+
+	def testSelectorFromGlobals( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["options"] = GafferScene.CustomOptions()
+		script["options"]["options"]["selector"] = Gaffer.NameValuePlug( "selector", "sphere" )
+
+		script["plane"] = GafferScene.Plane()
+		script["sphere"] = GafferScene.Sphere()
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"].setup( GafferScene.ScenePlug() )
+		script["switch"]["in"][0]["name"].setValue( "plane" )
+		script["switch"]["in"][0]["value"].setInput( script["plane"]["out"] )
+		script["switch"]["in"][1]["name"].setValue( "sphere" )
+		script["switch"]["in"][1]["value"].setInput( script["sphere"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			g = parent["options"]["out"]["globals"]
+			parent["switch"]["selector"] = g["option:selector"]
+			"""
+		) )
+
+		# As well as asserting that the scene is as expected here, we're also
+		# indirectly testing that `scene:path` isn't leaked into the context
+		# used to evaluate the globals (because SceneTestCase installs a
+		# ContextSanitiser for the duration of the test).
+
+		self.assertEqual(
+			script["switch"]["out"]["value"].object( "/sphere" ),
+			script["sphere"]["out"].object( "/sphere" )
+		)
+
+	def testEnabledFromGlobals( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["options"] = GafferScene.CustomOptions()
+		script["options"]["options"]["enabled"] = Gaffer.NameValuePlug( "enabled", True )
+
+		script["plane"] = GafferScene.Plane()
+		script["sphere"] = GafferScene.Sphere()
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"].setup( GafferScene.ScenePlug() )
+		script["switch"]["selector"].setValue( "sphere" )
+		script["switch"]["in"][0]["name"].setValue( "plane" )
+		script["switch"]["in"][0]["value"].setInput( script["plane"]["out"] )
+		script["switch"]["in"][1]["name"].setValue( "sphere" )
+		script["switch"]["in"][1]["value"].setInput( script["sphere"]["out"] )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			g = parent["options"]["out"]["globals"]
+			parent["switch"]["enabled"] = g["option:enabled"]
+			"""
+		) )
+
+		# As well as asserting that the scene is as expected here, we're also
+		# indirectly testing that `scene:path` isn't leaked into the context
+		# used to evaluate the globals (because SceneTestCase installs a
+		# ContextSanitiser for the duration of the test).
+
+		self.assertEqual(
+			script["switch"]["out"]["value"].object( "/sphere" ),
+			script["sphere"]["out"].object( "/sphere" )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -157,6 +157,7 @@ from .TransformQueryTest import TransformQueryTest
 from .BoundQueryTest import BoundQueryTest
 from .ExistenceQueryTest import ExistenceQueryTest
 from .AttributeQueryTest import AttributeQueryTest
+from .NameSwitchTest import NameSwitchTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -40,6 +40,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextAlgo.h"
 #include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/NameValuePlug.h"
 
 #include "boost/bind.hpp"
 #include "boost/bind/placeholders.hpp"
@@ -299,33 +300,46 @@ void Switch::plugInputChanged( Plug *plug )
 size_t Switch::inputIndex( const Context *context ) const
 {
 	const ArrayPlug *inPlugs = this->inPlugs();
-	if( enabledPlug()->getValue() && inPlugs && inPlugs->children().size() > 1 )
+	const size_t numInputs = inPlugs ? inPlugs->children().size() : 0;
+	if( numInputs <= 1 )
 	{
-		size_t index = 0;
-		const IntPlug *indexPlug = this->indexPlug();
-		if( variesWithContext( indexPlug ) )
-		{
-			ContextAlgo::GlobalScope indexScope( context, inPlugs->getChild<Plug>( 0 ) );
-			index = indexPlug->getValue();
-		}
-		else
-		{
-			index = indexPlug->getValue();
-		}
+		return 0;
+	}
 
-		if( inPlugs->resizeWhenInputsChange() )
-		{
-			// Last input is always unconnected, so should be ignored.
-			return index % (inPlugs->children().size() - 1);
-		}
-		else
-		{
-			return index % inPlugs->children().size();
-		}
+	// Find a plug we can use to create a GlobalScope, accounting for the
+	// NameValuePlugs created by NameSwitch.
+	const Plug *globalScopePlug = inPlugs->getChild<Plug>( 0 );
+	if( auto nameValuePlug = IECore::runTimeCast<const NameValuePlug>( globalScopePlug ) )
+	{
+		globalScopePlug = nameValuePlug->valuePlug();
+	}
+
+	const BoolPlug *enabledPlug = this->enabledPlug();
+	const IntPlug *indexPlug = this->indexPlug();
+
+	// Create a GlobalScope if either the `index` or `enabled` plugs will launch
+	// an upstream compute. This avoids leakage of context variables such as
+	// `scene:path`.
+	boost::optional<ContextAlgo::GlobalScope> globalScope;
+	if( variesWithContext( enabledPlug ) || variesWithContext( indexPlug ) )
+	{
+		globalScope.emplace( context, globalScopePlug );
+	}
+
+	if( !enabledPlug->getValue() )
+	{
+		return 0;
+	}
+
+	const size_t index = indexPlug->getValue();
+	if( inPlugs->resizeWhenInputsChange() )
+	{
+		// Last input is always unconnected, so should be ignored.
+		return index % (numInputs - 1);
 	}
 	else
 	{
-		return 0;
+		return index % numInputs;
 	}
 }
 


### PR DESCRIPTION
- Protect `enabled` plug in addition to `index` plug.
- Handle NameValuePlug by considering `value` child plug, so that NameSwitch benefits from the GlobalScope treatment too.

The latter fixes a performance problem found in production by @murrays-ie.

The back story here is that Gaffer's hash cache is indexed by Context, and we can reduce pressure on the cache significantly by "sanitising" the context that plugs are hashed in. The `Switch.out` plug will be evaluated in contexts with `scene:path` for scenes and `image:tileOrigin` etc for images, but the `index` and `selector` plugs do not need these variables. In fact, the `index` cannot be varied by location or tile without breaking the consistency of the scene or image. And for large scenes and images, the number of different contexts produced by `scene:path` and `image:tileOrigin` can be huge. The GlobalScope removes these context variables for the upstream computes driving `index` and `enabled`, leading to much greater efficiency in the caching of the results.

