### PR TITLE
Fixed `assertNodesConstructWithDefaultValues()` to recurse through all plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ Fixes
   - Inserting a new key in editor (Hold "Ctrl" and left click on curve) is now undone/redone as a distinct step.
 - ParallelAlgo : Fixed deadlock in `callOnUIThread()`.
 - NameSwitch : Fixed context management bug that allowed variables such as `scene:path` to leak into the context used to evaluate the `selector` plug.
+- GafferTest.TestCase : Fixed `assertNodesConstructWithDefaultValues()` to recurse through all plugs
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Fixes
 - ParallelAlgo : Fixed deadlock in `callOnUIThread()`.
 - NameSwitch : Fixed context management bug that allowed variables such as `scene:path` to leak into the context used to evaluate the `selector` plug.
 - GafferTest.TestCase : Fixed `assertNodesConstructWithDefaultValues()` to recurse through all plugs
+- CopyAttributes : Relaxed compatibility shim to avoid infinite recursion when using `Gaffer.Plug.RecursiveRange`
 
 API
 ---

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -517,8 +517,8 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		tweaks2["shader"].setValue( "test:surface" )
 
 		copyAttributes = GafferScene.CopyAttributes()
-		copyAttributes["in"][0].setInput( tweaks1["out"] )
-		copyAttributes["in"][1].setInput( tweaks2["out"] )
+		copyAttributes["in"].setInput( tweaks1["out"] )
+		copyAttributes["source"].setInput( tweaks2["out"] )
 
 		# No filter
 

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -301,6 +301,8 @@ class TestCase( unittest.TestCase ) :
 	# ones.
 	def assertNodesConstructWithDefaultValues( self, module, nodesToIgnore = None ) :
 
+		nonDefaultPlugs = []
+
 		for name in dir( module ) :
 
 			cls = getattr( module, name )
@@ -315,7 +317,7 @@ class TestCase( unittest.TestCase ) :
 			except :
 				continue
 
-			for plug in node.children( Gaffer.Plug ) :
+			for plug in Gaffer.Plug.RecursiveRange( node ) :
 
 				if plug.source().direction() != plug.Direction.In or not isinstance( plug, Gaffer.ValuePlug ) :
 					continue
@@ -323,7 +325,10 @@ class TestCase( unittest.TestCase ) :
 				if not plug.getFlags( plug.Flags.Serialisable ) :
 					continue
 
-				self.assertTrue( plug.isSetToDefault(), plug.fullName() + " not at default value following construction" )
+				if not plug.isSetToDefault() :
+					nonDefaultPlugs.append( plug.fullName() + " not at default value following construction" )
+
+		self.assertEqual( nonDefaultPlugs, [] )
 
 	def assertModuleDoesNotImportUI( self, moduleName ) :
 

--- a/startup/GafferScene/copyAttributesCompatibility.py
+++ b/startup/GafferScene/copyAttributesCompatibility.py
@@ -60,10 +60,10 @@ def __copyAttributesInGetItem( originalGetItem ) :
 
 		# We're getting a child of CopyAttributes.in.
 
-		if key in ( "in0", 0 ) :
+		if key in ( "in0", ) :
 			# First element of old ArrayPlug - redirect to self.
 			return self
-		elif key in ( "in1", 1 ) :
+		elif key in ( "in1", ) :
 			# Second element of old ArrayPlug - redirect to source.
 			return self.parent()["source"]
 		else:


### PR DESCRIPTION
Unfortunately this required another fix in a compatibility shim, so needs to target the next major version rather than 0.60_maintenance