### PR TITLE
GraphGadgetTest : Fix hang in testActivePlugsAndNodesCancellation

### DIFF
--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1752,10 +1752,10 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 
 		canceller = IECore.Canceller()
 
-		t = Gaffer.ParallelAlgo.callOnBackgroundThread(
-			s["add"]["sum"], lambda : testThreadFunc( s["add"]["sum"], canceller, self )
-		)
 		with GraphGadgetTest.testActivePlugsAndNodesCancellationCondition:
+			t = Gaffer.ParallelAlgo.callOnBackgroundThread(
+				s["add"]["sum"], lambda : testThreadFunc( s["add"]["sum"], canceller, self )
+			)
 			GraphGadgetTest.testActivePlugsAndNodesCancellationCondition.wait()
 
 		canceller.cancel()


### PR DESCRIPTION
It's not clear whether this is the hang that's been affecting the tests ... it doesn't match up with where the hang shows up in CI, but there is a hang here which could be reproduced locally, and which is fixed by this change.