### PR TITLE
Revert "SceneView : Frame key "F" should require no modifiers"

### DIFF
--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -1789,7 +1789,7 @@ bool SceneView::keyPress( GafferUI::GadgetPtr gadget, const GafferUI::KeyEvent &
 		collapseSelection();
 		return true;
 	}
-	else if( event.key == "F" && event.modifiers == GafferUI::ModifiableEvent::Modifiers::None )
+	else if( event.key == "F" )
 	{
 		Imath::Box3f b = framingBound();
 		if( !b.isEmpty() && viewportGadget()->getCameraEditable() )


### PR DESCRIPTION
This reverts commit 732e33eb2e2ff1d6123688ffff4c731c45e98ca4, which broke the feature whereby Ctrl+F would also adjust the clipping planes. I think the original commit was attempting to free up the hotkey for some other feature, but we didn't end up using it?
