### PR TITLE
Avoid Framing Light That You Are Currently Looking Through

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 
 - GafferTest.TestCase : Added `plugsToIgnore` argument to `assertNodesConstructWithDefaultValues()`.
 - OpenGLRenderer : gl:queryBound command now supports "omitted" paramter containing a PathMatcher with paths to skip when computing the bound
+- SceneGadget : Added new `bound( selected, omitted = nullptr )` signature, which allows omitting certain paths from the bound computation, with or without limiting to selection.  The previous `selectionBound()` method is now deprecated.
 
 0.60.8.0 (relative to 0.60.7.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- Viewer : Added settings to control aperture and clipping planes when looking through lights. This can be customised on a per-light basis using the new visualiser settings on the Light node.
+- Viewer 
+  - Added settings to control aperture and clipping planes when looking through lights. This can be customised on a per-light basis using the new visualiser settings on the Light node.
+  - The framing the scene while looking through a light now does not try to frame the light you are looking through.
 - Light : Added visualiser settings to control aperture and clipping planes when looking through the light in the Viewer. These settings override the defaults specified in the Viewer itself.
 - LightToCamera : Added `distantAperture` and `clippingPlanes` plugs.
 - Arnold Render : Changed warnings for invalid mesh lights to be one descriptive warning per light, instead of repeating an unclear warning for every surface that links to the light.

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ API
 ---
 
 - GafferTest.TestCase : Added `plugsToIgnore` argument to `assertNodesConstructWithDefaultValues()`.
+- OpenGLRenderer : gl:queryBound command now supports "omitted" paramter containing a PathMatcher with paths to skip when computing the bound
 
 0.60.8.0 (relative to 0.60.7.1)
 ========

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -48,6 +48,8 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/ParallelAlgo.h"
 
+#include "IECore/PathMatcherData.h"
+
 #include "IECoreGL/State.h"
 
 namespace GafferSceneUI
@@ -162,7 +164,12 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		) const;
 
 		/// Returns the bounding box of all the selected objects.
+		/// Deprecated, prefer using `bound( true )` below
 		Imath::Box3f selectionBound() const;
+
+		/// Queries the bound with additional parameters - if `selected` is true, queries only
+		/// selected objects, and "omitted" is a PathMatcher with paths to specifically omit
+		Imath::Box3f bound( bool selected, const IECore::PathMatcher *omitted = nullptr ) const;
 
 		/// Implemented to return the name of the object under the mouse.
 		std::string getToolTip( const IECore::LineSegment3f &line ) const override;

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -874,9 +874,7 @@ def __fitClippingPlanes( view, toSelection = False ) :
 
 	viewportGadget = view.viewportGadget()
 	sceneGadget = viewportGadget.getPrimaryChild()
-	viewportGadget.fitClippingPlanes(
-		sceneGadget.bound() if not toSelection else sceneGadget.selectionBound()
-	)
+	viewportGadget.fitClippingPlanes( sceneGadget.bound( toSelection ) )
 
 def __appendClippingPlaneMenuItems( menuDefinition, prefix, view, parentWidget ) :
 

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -70,6 +70,27 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		sg.waitForCompletion()
 		self.assertEqual( sg.bound(), s["g"]["out"].bound( "/" ) )
 
+		s["g"]["transform"]["translate"].setValue( imath.V3f( 0 ) )
+		s["s"] = GafferScene.Sphere()
+		s["g"]["in"][1].setInput( s["s"]["out"] )
+		s["p"]["transform"]["translate"]["z"].setValue( 10 )
+		sg.waitForCompletion()
+		self.assertEqual( sg.bound(), s["g"]["out"].bound( "/" ) )
+		# Nothing selected, so selected bound is empty
+		self.assertEqual( sg.bound( True ), imath.Box3f() )
+
+		sg.setExpandedPaths( IECore.PathMatcher( ["/group/"] ) )
+		sg.setSelection( IECore.PathMatcher( ["/group/plane"] ) )
+		sg.waitForCompletion()
+
+		self.assertEqual( sg.bound(), s["g"]["out"].bound( "/" ) )
+		# Only plane is selected
+		self.assertEqual( sg.bound( True ), s["p"]["out"].bound( "/" ) )
+		# Omitting plane takes just sphere
+		self.assertEqual( sg.bound( False, IECore.PathMatcher( ["/group/plane"]) ), s["s"]["out"].bound( "/" ) )
+		# Omitting only selected object while using selected=True leaves empty bound
+		self.assertEqual( sg.bound( True, IECore.PathMatcher( ["/group/plane"]) ), imath.Box3f() )
+
 	def assertObjectAt( self, gadget, ndcPosition, path ) :
 
 		viewportGadget = gadget.ancestor( GafferUI.ViewportGadget )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -429,7 +429,21 @@ void SceneGadget::setSelection( const IECore::PathMatcher &selection )
 
 Imath::Box3f SceneGadget::selectionBound() const
 {
-	DataPtr d = m_renderer->command( "gl:queryBound", { { "selection", new BoolData( true ) } } );
+	return bound( true, nullptr );
+}
+
+Imath::Box3f SceneGadget::bound( bool selected, const PathMatcher *omitted ) const
+{
+	DataPtr d;
+	if( omitted )
+	{
+		d = m_renderer->command( "gl:queryBound", { { "selection", new BoolData( selected ) }, { "omitted", new PathMatcherData( *omitted ) } } );
+	}
+	else
+	{
+		d = m_renderer->command( "gl:queryBound", { { "selection", new BoolData( selected ) } } );
+	}
+
 	return static_cast<Box3fData *>( d.get() )->readable();
 }
 

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -175,6 +175,9 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "setSelection", &SceneGadget::setSelection )
 		.def( "getSelection", &SceneGadget::getSelection, return_value_policy<copy_const_reference>() )
 		.def( "selectionBound", &SceneGadget::selectionBound )
+		.def( "bound", (Imath::Box3f (SceneGadget::*)(bool,const IECore::PathMatcher*) const)&SceneGadget::bound,
+			( arg( "selected" ), arg( "omitted" ) = object() )
+		)
 	;
 
 	enum_<SceneGadget::State>( "State" )


### PR DESCRIPTION
Currently, if you are looking through a light, and have no selection, or the selection includes the light you are looking through, and you press "F", then you will attempt to frame the light you are currently looking through, which will push the light backwards every time you press F.

This PR solves this by adding an "omitted" parameter to the gl:queryBound command supported by IECoreGLPreview::Renderer.

The main question is the SceneGadget API.  If the new `queryBound` signature looks good, then I should label the old `selectionBound` as deprecated, expose queryBound to Python, and switch everything to using queryBound ( part of what makes me think this could be reasonable is that there isn't much use of selectionBound, and one of the main uses in SceneViewUI would actually look cleaner using queryBound, since it wouldn't need a conditional ).
