### PR TITLE
SceneReader : Handle null return from `SceneInterface::readAttribute()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 Fixes
 -----
 
+- SceneReader : Fixed bug attempting to read unsupported custom attribute types from USD files. This caused an obscure `Cannot compute hash from a CompoundObject will NULL data pointers!` error, but now prints a warning instead.
 - GafferTest.TestCase :
   - Fixed `assertNodesAreDocumented()` to work for Nodes with multiple base classes.
   - Fixed `assertTypeNamesArePrefixed()` to work for Nodes in Python submodules.

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -578,5 +578,23 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 				setHash
 			)
 
+	def testNullAttributes( self ) :
+
+		s = GafferScene.SceneReader()
+		s["fileName"].setValue( "${GAFFER_ROOT}/python/GafferSceneTest/usdFiles/unsupportedAttribute.usda" )
+
+		# At the time of writing, `IECoreUSD` advertises custom attributes via
+		# `USDScene::attributeNames()` even if it can't load them, and then it
+		# returns `nullptr` from `USDScene::readAttribute()`. Make sure we are
+		# robust to this.
+
+		with IECore.CapturingMessageHandler() as mh :
+			attributes = s["out"].attributes( "/sphere" )
+
+		self.assertEqual( len( attributes ), 0 )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+		self.assertEqual( mh.messages[0].message, 'Failed to load attribute "test:double4" at location "/sphere"' )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/usdFiles/unsupportedAttribute.usda
+++ b/python/GafferSceneTest/usdFiles/unsupportedAttribute.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def Sphere "sphere"
+{
+	custom double4 test:double4 = ( 1, 2, 3, 4 )
+}

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -309,9 +309,21 @@ IECore::ConstCompoundObjectPtr SceneReader::computeAttributes( const ScenePath &
 			continue;
 		}
 
-		// the const cast is ok, because we're only using it to put the object into a CompoundObject that will
-		// be treated as forever const after being returned from this function.
-		result->members()[ std::string( *it ) ] = boost::const_pointer_cast<Object>( s->readAttribute( *it, context->getTime() ) );
+		ConstObjectPtr attribute = s->readAttribute( *it, context->getTime() );
+		if( attribute )
+		{
+			// The const cast is ok, because we're only using it to put the object into a CompoundObject that will
+			// be treated as forever const after being returned from this function.
+			result->members()[ std::string( *it ) ] = boost::const_pointer_cast<Object>( attribute );
+		}
+		else
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "SceneReader::computeAttributes",
+				boost::format( "Failed to load attribute \"%1%\" at location \"%2%\"" )
+					% *it % ScenePlug::pathToString( path )
+			);
+		}
 	}
 
 	return result;


### PR DESCRIPTION
This deals with a bug whereby USDScene advertises attributes that it can't actually load. We'll need to update Cortex to fix this at the root, but in the meantime we can at least make the SceneReader robust (the expectation throughout Gaffer and in CompoundObject itself is that there will be no null members).
