### PR TITLE
Animation : additional test case to cover adding inactive key

### DIFF
--- a/include/Gaffer/Animation.h
+++ b/include/Gaffer/Animation.h
@@ -169,12 +169,12 @@ class GAFFER_API Animation : public ComputeNode
 				CurvePlugKeySignal& keyValueChangedSignal();
 				CurvePlugKeySignal& keyInterpolationChangedSignal();
 
-				/// Adds specified key to curve, if key is parented to another curve it is removed
-				/// from the other curve. If the key has already been added to the curve, there is
-				/// no affect. If the curve already has an active key with the same time, then if
-				/// removeActiveClashing is true that key will be removed from the curve and returned
-				/// otherwise that key will remain parented to the curve, become inactive and be returned.
-				/// The new key will be the active key at its time.
+				/// Adds specified key to curve, if key is parented to another curve or already parented
+				/// to the curve and inactive it is removed from its parent curve. If the key has already
+				/// been added to the curve and is active, there is no effect. If the curve already has an
+				/// active key with the same time, then if removeActiveClashing is true that key will be
+				/// removed from the curve and returned otherwise that key will remain parented to the
+				/// curve, become inactive and be returned. The key will be the active key at its time.
 				/// \undoable
 				KeyPtr addKey( const KeyPtr &key, bool removeActiveClashing = true );
 

--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -263,6 +263,122 @@ class AnimationTest( GafferTest.TestCase ) :
 		self.assertTrue( k1.parent().isSame( curve ) )
 		self.assertFalse( k1.isActive() )
 
+	def testAddInactiveKey( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		curve = Gaffer.Animation.acquire( s["n"]["op1"] )
+
+		k1 = Gaffer.Animation.Key( time = 1, value = 1 )
+		k2 = Gaffer.Animation.Key( time = 1, value = 2 )
+
+		curve.addKey( k1 )
+		curve.addKey( k2, removeActiveClashing = False )
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k2 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertFalse( k1.isActive() )
+		self.assertTrue( k2.isActive() )
+
+		# add key (which is already parented but inactive) should promote to active
+		with Gaffer.UndoScope( s ) :
+			ck = curve.addKey( k1 )
+		self.assertTrue( k2.isSame( ck ) )
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k1 ) )
+		self.assertIsNone( k2.parent() )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertTrue( k1.isActive() )
+		self.assertFalse( k2.isActive() )
+		self.assertTrue( s.undoAvailable() )
+
+		s.undo()
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k2 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertFalse( k1.isActive() )
+		self.assertTrue( k2.isActive() )
+
+		s.redo()
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k1 ) )
+		self.assertIsNone( k2.parent() )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertTrue( k1.isActive() )
+		self.assertFalse( k2.isActive() )
+		self.assertTrue( s.undoAvailable() )
+
+	def testAddInactiveKeyRemoveActiveClashingFalse( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = GafferTest.AddNode()
+
+		curve = Gaffer.Animation.acquire( s["n"]["op1"] )
+
+		k1 = Gaffer.Animation.Key( time = 1, value = 1 )
+		k2 = Gaffer.Animation.Key( time = 1, value = 2 )
+
+		curve.addKey( k1 )
+		curve.addKey( k2, removeActiveClashing = False )
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k2 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertFalse( k1.isActive() )
+		self.assertTrue( k2.isActive() )
+
+		# add key (which is already parented but inactive) should promote to active
+		with Gaffer.UndoScope( s ) :
+			ck = curve.addKey( k1, removeActiveClashing = False )
+		self.assertTrue( k2.isSame( ck ) )
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k1 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertTrue( k1.isActive() )
+		self.assertFalse( k2.isActive() )
+		self.assertTrue( s.undoAvailable() )
+
+		s.undo()
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k2 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertFalse( k1.isActive() )
+		self.assertTrue( k2.isActive() )
+
+		s.redo()
+
+		self.assertTrue( curve.hasKey( 1 ) )
+		self.assertTrue( curve.getKey( 1 ).isSame( k1 ) )
+		self.assertIsNotNone( k2.parent() )
+		self.assertTrue( k2.parent().isSame( curve ) )
+		self.assertIsNotNone( k1.parent() )
+		self.assertTrue( k1.parent().isSame( curve ) )
+		self.assertTrue( k1.isActive() )
+		self.assertFalse( k2.isActive() )
+		self.assertTrue( s.undoAvailable() )
+
 	def testAddKeySignals( self ) :
 
 		ps = set()

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -291,6 +291,8 @@ void Animation::Key::setValue( const float value )
 		return;
 	}
 
+	// NOTE : inactive keys remain parented and participate in undo/redo and signalling
+
 	if( m_parent )
 	{
 		KeyPtr key = this;
@@ -328,6 +330,8 @@ void Animation::Key::setInterpolation( const Animation::Interpolation interpolat
 	{
 		return;
 	}
+
+	// NOTE : inactive keys remain parented and participate in undo/redo and signalling
 
 	if( m_parent )
 	{


### PR DESCRIPTION
* improve api comments to clarify behaviour when adding an already
  parented inactive key to its parent curve.
* additional test cases to ensure behaviour is as expected.

ref #4370