### PR TITLE
PrimitiveInspector : Update correctly when there are no variables of a particular interpolation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+0.60.x.x (relative to 0.60.9.0)
+========
+
+Fixes
+-----
+
+- PrimitiveInspector : Now updates correctly when all primitive variables with a particular interpolation are removed.
+
+
 0.60.9.0 (relative to 0.60.8.0)
 ========
 

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -355,14 +355,14 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 				primVars[primvar.interpolation].append( conditionPrimvar( primvar ) )
 				toolTips[primvar.interpolation].append( _getPrimvarToolTip( primvarName, primvar ) )
 
-			for interpolation in primVars.keys() :
+			for interpolation in self.__dataWidgets.keys() :
 
 				pv = primVars.get( interpolation, None )
 				h = headers.get( interpolation, None )
-				t = toolTips.get( interpolation, None )
+				t = toolTips.get( interpolation, [] )
 
 				self.__tabbedContainer.setLabel( self.__tabbedChildWidgets[interpolation],
-					"{0} ({1})".format( str( interpolation ), len( pv ) ) )
+					str( interpolation ) + ( " ({0})".format( len( pv ) ) if pv else "" ) )
 
 				self.__dataWidgets[interpolation].setToolTips( t )
 				self.__dataWidgets[interpolation].setHeader( h )


### PR DESCRIPTION
I'm trying not to get sidetracked, but this totally baffled me while building a test scene, and after figuring out what was happening, it's a simple fix.

Previously, if you put down a Sphere and a DeletePrimitiveVariables, open the Primitive Inspector, and then fill in `N` and `uv` as the variables to delete, the Primitive Inspector would not update.

This is because it was only updating interpolations which were mentioned by one of the variables that currently exist.