### PR TITLE
AnimationEditor : preserve gadget key selection

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
   - Fixed bug in `Key.setType()`. Previously it modified the value instead of the type.
   - Fixed crash when dragging multiple keys around in editor.
   - Fixed bug which resulted in preview key being incorrectly drawn at the origin.
+  - Fixed bug that cleared key selection when selecting multiple curves via path listing or gadget.
   - Fixed bug when pressing <kbd>f</kbd> to frame viewport which resulted in a blank background in certain cases (#4410).
   - Inserting a new key in editor (Hold "Ctrl" and left click on curve) is now undone/redone as a distinct step.
   - Fixed bug when selecting curve for first time via gadget, keys appear, then disappear (#4443)

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -258,10 +258,15 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 					editablePlugs.add( child )
 
 		editable = self.__animationGadget.editablePlugs()
+		curves = set( self.__sourceCurvePlug( plug ) for plug in editablePlugs & visiblePlugs )
 		with Gaffer.BlockedConnection( self.__editablePlugsConnections ) :
-			editable.clear()
-			for plug in editablePlugs & visiblePlugs :
-				editable.add( self.__sourceCurvePlug( plug ) )
+			for curve in list( editable ) :
+				if curve in curves :
+					curves.remove( curve )
+				else :
+					editable.remove( curve )
+			for curve in curves :
+				editable.add( curve )
 
 	def __editablePlugAdded( self, standardSet, curvePlug ) :
 


### PR DESCRIPTION
* preserve selection of keys when expanding or collapsing path listing
  and when changing curve selection via path listing

fixes #4444