### PR TITLE
PathListingWidget : Avoid `QItemSelectionModel`

### DIFF
--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -81,27 +81,6 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 			self.__pathListing.setDragPointer( "objects" )
 			self.__pathListing.setSortable( False )
 
-			# Work around insanely slow selection of a range containing many
-			# objects (using a shift-click). The default selection behaviour
-			# is SelectRows and this triggers some terrible performance problems
-			# in Qt. Since we only have a single column, there is no difference
-			# between SelectItems and SelectRows other than the speed.
-			#
-			# This workaround isn't going to be sufficient when we come to add
-			# additional columns to the HierarchyView. What _might_ work instead
-			# is to override `QTreeView.setSelection()` in PathListingWidget.py,
-			# so that we manually expand the selected region to include full rows,
-			# and then don't have to pass the `QItemSelectionModel::Rows` flag to
-			# the subsequent `QItemSelectionModel::select()` call. This would be
-			# essentially the same method we used to speed up
-			# `PathListingWidget.setSelection()`.
-			#
-			# Alternatively we could avoid QItemSelectionModel entirely by managing
-			# the selection ourself as a persistent PathMatcher.
-			self.__pathListing._qtWidget().setSelectionBehavior(
-				self.__pathListing._qtWidget().SelectionBehavior.SelectItems
-			)
-
 			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
 			self.__expansionChangedConnection = self.__pathListing.expansionChangedSignal().connect( Gaffer.WeakMethod( self.__expansionChanged ) )
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1222,7 +1222,7 @@ _styleSheet = string.Template(
 		border-bottom-color: $backgroundRaisedLowlight;
 		border-right-color: $backgroundRaisedLowlight;
 		padding: 0;
-		alternate-background-color: $backgroundRaisedAlt;
+		alternate-background-color: $tintDarker;
 		paint-alternating-row-colors-for-empty-area: 1;
 	}
 


### PR DESCRIPTION
QItemSelectionModel is full of quadratic performance hazards, which have been exacerbated by the async PathModel changes, because we were making many small edits to the selection as we progressed through the update. I did try a batching approach to limit the number of edits we made, and although this helped, it still had poor performance for certain operations (removing many items in particular, even when reduced to a single batched operation).

We now draw the selection directly based on queries to the PathMatcher, which allows us to also draw ancestors of the selection in a partially highlighted state at low cost. And we do our own event handling to implement editing of the selection. The end result : significantly improved performance.
