### PR TITLE
PathListingWidget : Improve backward compatibility

### DIFF
--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -221,6 +221,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		# Note : This doesn't follow the semantics of `getExpansion()` with
 		# respect to paths that are not currently in the model. It is probably
 		# time it was removed.
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( self._qtWidget().model() ) )
 		return _GafferUI._pathListingWidgetPathsForPathMatcher(
 			GafferUI._qtAddress( self._qtWidget() ),
 			self.getExpansion()
@@ -314,6 +315,7 @@ class PathListingWidget( GafferUI.Widget ) :
 	## \deprecated
 	def getSelectedPaths( self ) :
 
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( self._qtWidget().model() ) )
 		return _GafferUI._pathListingWidgetPathsForPathMatcher(
 			GafferUI._qtAddress( self._qtWidget() ),
 			self.getSelection()
@@ -380,11 +382,6 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		self.__currentPath = str( self.__path )
 
-	@GafferUI.LazyMethod()
-	def __updateLazily( self ) :
-
-		self.__update()
-
 	def __dirPath( self ) :
 
 		p = self.__path.copy()
@@ -428,9 +425,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 	def __pathChanged( self, path ) :
 
-		# Updates can be expensive, so we coalesce and
-		# defer them until the last minute.
-		self.__updateLazily()
+		self.__update()
 
 	def __indexForPath( self, path ) :
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -70,7 +70,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( w.getPathExpanded( p1 ), False )
 		w.setPathExpanded( p1, True )
 		self.assertEqual( w.getPathExpanded( p1 ), True )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( len( w.getExpandedPaths() ), 1 )
 		self.assertEqual( str( list( w.getExpandedPaths() )[0] ), str( p1 ) )
 
@@ -87,7 +86,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( w.getExpandedPaths(), [ p1, p2 ] )
 
 		w.setPath( Gaffer.DictPath( {}, "/" ) )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( len( w.getExpandedPaths() ), 0 )
 
 	def testExpansion( self ) :
@@ -216,7 +214,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setPathExpanded( Gaffer.DictPath( d, "/2" ), True )
 		self.assertEqual( len( c ), 2 )
 
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		e = w.getExpandedPaths()
 		self.assertEqual( len( e ), 2 )
 
@@ -308,7 +305,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( c ), 0 )
 
 		w.setSelectedPaths( [ Gaffer.DictPath( d, "/a" ), Gaffer.DictPath( d, "/b" ) ] )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( set( [ str( p ) for p in w.getSelectedPaths() ] ), set( [ "/a", "/b" ] ) )
 
 		self.assertEqual( len( c ), 1 )
@@ -391,7 +387,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( widget.getSelection(), IECore.PathMatcher( [ "/a" ] ) )
 
 		path.append( "a" )
-		widget._PathListingWidget__updateLazily.flush( widget ) # See comments in `__emitPathChanged`
 		self.assertEqual( widget.getSelection(), IECore.PathMatcher() )
 
 	def testExpandedPathsWhenPathChanges( self ) :
@@ -520,8 +515,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		d["a"] = 10
 		p.pathChangedSignal()( p )
 		w.setSelectedPaths( [ p.copy().setFromString( "/a" ) ] )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
-
 		s = w.getSelectedPaths()
 		self.assertEqual( len( s ), 1 )
 		self.assertEqual( str( s[0] ), "/a" )
@@ -917,12 +910,6 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 	def __emitPathChanged( widget ) :
 
 		widget.getPath().pathChangedSignal()( widget.getPath() )
-		# Currently it is the PathListingWidget that processes `pathChangedSignal()`,
-		# and it does so lazily. Flush the update so that the model is informed of the
-		# change.
-		## \todo It may make sense to move the change handler to the model at some point,
-		# and then we could test the model completely independently of the widget.
-		widget._PathListingWidget__updateLazily.flush( widget )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( widget._qtWidget().model() ) )
 
 	@classmethod


### PR DESCRIPTION
The deprecated `get[Selected|Expanded]Paths()` methods work by querying the model, so we need to wait for the model update to complete. We also need to make sure that the model update has _started_, so we remove the lazy update from `__pathChanged`. This latter change is OK because PathModel itself is now doing lazy updates internally.

This fixes a couple of UIEditor bugs :

- Newly added plugs weren't shown in the plug editor panel.
- Newly added presets weren't shown in the presets editor panel.

It would also have fixed an AnimationEditor bug if we hadn't recently refactored that to avoid the deprecated API.

The deprecated APIs do provide some convenience over the official API, by weeding out selected/expanded paths that don't currently exist in the model. So I haven't yet refactored UIEditor to avoid them - I'll wait for feedback from other users of the deprecated APIs before deciding how to approach that.

