### PR TITLE
BackdropNodeGadget : Add dedicated title bar for selection/movement

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- Backdrop : Added a dedicated title bar for selection and moving Backdrops. This is smaller but more obvious than the previous region, reducing the likelihood of accidental movement.
 - Animation : Added compatibility for loading animation from Gaffer 0.61 where Step has been renamed to Constant.
 
 Fixes

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -89,6 +89,8 @@ void titleAndDescriptionFromPlugs( const StringPlug *titlePlug, const StringPlug
 }
 
 const float g_margin = 3.0f;
+const float g_titleBarHeight = 1.0f;
+const float g_titleBarMargin = 1.0f;
 IECore::InternedString g_boundPlugName( "__uiBound" );
 IECore::InternedString g_colorKey( "nodeGadget:color" );
 Box2f g_defaultBound( V2f( -10 ), V2f( 10 ) );
@@ -279,6 +281,13 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 	const Box3f titleCharacterBound = style->characterBound( Style::HeadingText );
 	const float titleBaseline = bound.max.y - g_margin - titleCharacterBound.max.y;
 
+	const float titleBarHeight = g_titleBarHeight / scale;
+	const float titleBarMargin = g_titleBarMargin / scale;
+	const Box2f titleBar(
+		V2f( bound.min.x + titleBarMargin, bound.max.y - ( titleBarHeight + titleBarMargin ) ),
+		V2f( bound.max.x - titleBarMargin, bound.max.y - titleBarMargin )
+	);
+
 	if( IECoreGL::Selector::currentSelector() )
 	{
 		// when selecting we render in a simplified form.
@@ -295,7 +304,7 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 		style->renderSolidRectangle( Box2f( V2f( bound.max.x - width, bound.min.y ), bound.max ) ); // right
 		style->renderSolidRectangle( Box2f( bound.min, V2f( bound.max.x, bound.min.y + width ) ) ); // bottom
 		style->renderSolidRectangle( Box2f( V2f( bound.min.x, bound.max.y - width ), bound.max ) ); // top
-		style->renderSolidRectangle( Box2f( V2f( bound.min.x, titleBaseline - g_margin ), bound.max ) ); // heading
+		style->renderSolidRectangle( titleBar ); // title bar for movement
 	}
 	else
 	{
@@ -315,14 +324,19 @@ void BackdropNodeGadget::doRenderLayer( Layer layer, const Style *style ) const
 			glPopMatrix();
 		}
 
-		if( m_hovered )
-		{
-			style->renderHorizontalRule(
-				V2f( bound.center().x, titleBaseline - g_margin / 2.0f ),
-				bound.size().x - g_margin * 2.0f,
-				Style::HighlightedState
-			);
-		}
+		/// \todo Add `Style::renderBackdropTitleBar()` method so that
+		/// we don't have to hardcode the drawing here.
+		glPushAttrib( GL_CURRENT_BIT );
+			if( m_hovered )
+			{
+				glColor4f( 0.466, 0.612, 0.741, 1.0f );
+			}
+			else
+			{
+				glColor4f( 1.0, 1.0, 1.0, 0.15f );
+			}
+			style->renderSolidRectangle( titleBar );
+		glPopAttrib();
 
 		Box2f textBound = bound;
 		textBound.min += V2f( g_margin );


### PR DESCRIPTION
The larger size and less obvious highlighting of the previous region was causing user frustration due to unwanted hits.
![image](https://user-images.githubusercontent.com/1133871/138872603-be6cb826-d34a-4398-9ad3-91406f2a1369.png)
