### PR TITLE
AnimationUI : ensure key set on BoolPlug uses Constant Interpolation

### DIFF
--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -82,7 +82,10 @@ def __setKey( plug, context ) :
 
 	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		curve = Gaffer.Animation.acquire( plug )
-		curve.insertKey( context.getTime(), value )
+		if isinstance( plug, Gaffer.BoolPlug ) :
+			curve.addKey( Gaffer.Animation.Key( context.getTime(), value, Gaffer.Animation.Interpolation.Constant ) )
+		else :
+			curve.insertKey( context.getTime(), value )
 
 def __removeKey( plug, key ) :
 


### PR DESCRIPTION
* This bug seems to have crept in with the switch to the insertKey api,
  setting a key on a BoolPlug from the NodeEditor context menu now
  ensures that BoolPlugs uses Constant interpolation mode.
* The behaviour now matches the BoolPlugValueWidget