### PR TITLE
Animation : Remove custom Key equality operators

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -106,6 +106,7 @@ Breaking Changes
   - Interpolation of a key now affects span to next instead of previous key.
   - Renamed Key's `set/getType()` accessors to `set/getInterpolation()`.
   - Renamed `Step` interpolation mode to `Constant`.
+  - Removed customised Key equality operators, the default operators compare on object identity.
 - Path : Added `canceller` arguments to virtual methods. Note that Python subclasses can be made compatible with both Gaffer 0.60 and 0.61 simply by adding a `canceller = None` argument.
 - PathFilter : Added `canceller` argument to `doFilter()` method. Note that Python subclasses can be made compatible with both Gaffer 0.60 and 0.61 simply by adding a `canceller = None` argument.
 - CopyAttributes : Removed backwards compatibility for accessing input and source scenes as `in[0]` and `in[1]` respectively. Use `in` and `source` instead.

--- a/include/Gaffer/Animation.h
+++ b/include/Gaffer/Animation.h
@@ -109,9 +109,6 @@ class GAFFER_API Animation : public ComputeNode
 				/// Is the key currently active? The key is considered inactive whilst unparented.
 				bool isActive() const;
 
-				bool operator == ( const Key &rhs ) const;
-				bool operator != ( const Key &rhs ) const;
-
 				CurvePlug *parent();
 				const CurvePlug *parent() const;
 

--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -73,14 +73,20 @@ class AnimationTest( GafferTest.TestCase ) :
 
 	def testKeyRepr( self ) :
 
+		def assertKeysEqual( k0, k1 ) :
+
+			self.assertEqual( k0.getTime(), k1.getTime() )
+			self.assertEqual( k0.getValue(), k1.getValue() )
+			self.assertEqual( k0.getInterpolation(), k1.getInterpolation() )
+
 		k = Gaffer.Animation.Key()
-		self.assertEqual( k, eval( repr( k ) ) )
+		assertKeysEqual( k, eval( repr( k ) ) )
 
 		k = Gaffer.Animation.Key( 0, 1, Gaffer.Animation.Interpolation.Constant )
-		self.assertEqual( k, eval( repr( k ) ) )
+		assertKeysEqual( k, eval( repr( k ) ) )
 
 		k = Gaffer.Animation.Key( 10, 4, Gaffer.Animation.Interpolation.ConstantNext )
-		self.assertEqual( k, eval( repr( k ) ) )
+		assertKeysEqual( k, eval( repr( k ) ) )
 
 	def testCanAnimate( self ) :
 
@@ -1762,11 +1768,17 @@ class AnimationTest( GafferTest.TestCase ) :
 		curve.addKey( Gaffer.Animation.Key( 0, 0, Gaffer.Animation.Interpolation.Linear ) )
 		curve.addKey( Gaffer.Animation.Key( 1, 1, Gaffer.Animation.Interpolation.Linear ) )
 
+		def assertKeysEqual( k0, k1 ) :
+
+			self.assertEqual( k0.getTime(), k1.getTime() )
+			self.assertEqual( k0.getValue(), k1.getValue() )
+			self.assertEqual( k0.getInterpolation(), k1.getInterpolation() )
+
 		def assertAnimation( script ) :
 
 			curve = Gaffer.Animation.acquire( script["n"]["user"]["f"] )
-			self.assertEqual( curve.getKey( 0 ),  Gaffer.Animation.Key( 0, 0, Gaffer.Animation.Interpolation.Linear ) )
-			self.assertEqual( curve.getKey( 1 ),  Gaffer.Animation.Key( 1, 1, Gaffer.Animation.Interpolation.Linear ) )
+			assertKeysEqual( curve.getKey( 0 ),  Gaffer.Animation.Key( 0, 0, Gaffer.Animation.Interpolation.Linear ) )
+			assertKeysEqual( curve.getKey( 1 ),  Gaffer.Animation.Key( 1, 1, Gaffer.Animation.Interpolation.Linear ) )
 			with Gaffer.Context() as c :
 				for i in range( 0, 10 ) :
 					c.setTime( i / 9.0 )
@@ -2168,9 +2180,15 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s2["n"]["user"]["f"] )
 
+		def assertKeysEqual( k0, k1 ) :
+
+			self.assertEqual( k0.getTime(), k1.getTime() )
+			self.assertEqual( k0.getValue(), k1.getValue() )
+			self.assertEqual( k0.getInterpolation(), k1.getInterpolation() )
+
 		for frame in range( 0, 10000 ) :
 			context.setFrame( frame )
-			self.assertEqual(
+			assertKeysEqual(
 				curve.getKey( context.getTime() ),
 				Gaffer.Animation.Key( context.getTime(), context.getTime(), Gaffer.Animation.Interpolation.Linear )
 			)

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -364,19 +364,6 @@ bool Animation::Key::isActive() const
 	return m_active;
 }
 
-bool Animation::Key::operator == ( const Key &rhs ) const
-{
-	return
-		m_time == rhs.m_time &&
-		m_value == rhs.m_value &&
-		m_interpolation == rhs.m_interpolation;
-}
-
-bool Animation::Key::operator != ( const Key &rhs ) const
-{
-	return !(*this == rhs);
-}
-
 Animation::CurvePlug *Animation::Key::parent()
 {
 	return m_parent;

--- a/src/GafferModule/AnimationBinding.cpp
+++ b/src/GafferModule/AnimationBinding.cpp
@@ -192,8 +192,6 @@ void GafferModule::bindAnimation()
 		.def( "setInterpolation", &setInterpolation )
 		.def( "isActive", &Animation::Key::isActive )
 		.def( "__repr__", &keyRepr )
-		.def( self == self )
-		.def( self != self )
 		.def(
 			"parent",
 			(Animation::CurvePlug *(Animation::Key::*)())&Animation::Key::parent,


### PR DESCRIPTION
* now that Key's can be active / inactive the concept of Key equality is
  less clearly defined.
* these were only used by the test code where each test can define an
  appropriate concept of equality based on what its testing.
