### PR TITLE
PathListingWidget : Fix hang in Shift+click range selection

### DIFF
--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -1842,9 +1842,9 @@ IECore::PathMatcher pathsForIndexRange( uint64_t treeViewAddress, uint64_t index
 	IECore::PathMatcher result;
 	// Range is inclusive, so always includes index0 and index1, even
 	// if they are equal.
-	while( true ) {
+	while( index0.isValid() ) {
 		result.addPath( model->namesForIndex( index0 ) );
-		if( index0 == index1 )
+		if( index0.internalPointer() == index1.internalPointer() )
 		{
 			break;
 		}


### PR DESCRIPTION
This was only apparent in PathListingWidgets with more than one column, and occurred when we tried to build a range of paths between an index in one column and an index in another. In this case `QModelIndex::operator==` would never succeed because it includes the column in the comparison, and we would never exit the loop. We now compare just the internal pointers to the `PathModel::Items`, giving a column-insensitive comparison.

The change to `while( index0.isValid() )` is not necessary for this bugfix, but is a precaution against any similar hangs in the future. I'd rather get a "range selection not selecting the right things" bug report than a "range selection hangs" bug report.
