### PR TITLE
NodeBinding : Fix `isInstanceOf()` to allow wrapping of NameSwitch

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ Fixes
 - ParallelAlgo : Fixed deadlock in `callOnUIThread()`.
 - NameSwitch : Fixed context management bug that allowed variables such as `scene:path` to leak into the context used to evaluate the `selector` plug.
 - GafferTest.TestCase : Fixed `assertNodesConstructWithDefaultValues()` to recurse through all plugs.
+- NodeBinding : Fixed bug that could cause type queries to fail if types derived from Switch or ContextProcessor were wrapped for subclassing in Python.
 
 API
 ---

--- a/include/GafferBindings/DependencyNodeBinding.h
+++ b/include/GafferBindings/DependencyNodeBinding.h
@@ -93,17 +93,6 @@ class DependencyNodeWrapper : public NodeWrapper<WrappedType>, public Dependency
 		{
 		}
 
-		bool isInstanceOf( IECore::TypeId typeId ) const override
-		{
-			if( typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId )
-			{
-				// Correct for the slightly overzealous (but hugely beneficial)
-				// optimisation in NodeWrapper::isInstanceOf().
-				return true;
-			}
-			return NodeWrapper<WrappedType>::isInstanceOf( typeId );
-		}
-
 		void affects( const Gaffer::Plug *input, Gaffer::DependencyNode::AffectedPlugsContainer &outputs ) const override
 		{
 			if( this->isSubclassed() && this->initialised() )

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -392,17 +392,6 @@ class ScriptNodeWrapper : public NodeWrapper<ScriptNode>
 		{
 		}
 
-		bool isInstanceOf( IECore::TypeId typeId ) const override
-		{
-			if( typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId )
-			{
-				// Correct for the slightly overzealous (but hugely beneficial)
-				// optimisation in NodeWrapper::isInstanceOf().
-				return true;
-			}
-			return NodeWrapper<ScriptNode>::isInstanceOf( typeId );
-		}
-
 };
 
 ContextPtr context( ScriptNode &s )


### PR DESCRIPTION
The approach we had taken to optimising `isInstanceOf( SwitchTypeId )` assumed that Switch would never be wrapped for derivation in Python, and we had a `static_assert()` to protect against this case. But it didn't protect against the wrapping of _NameSwitch_ for derivation in Python, and unfortunately there is  such an extension class in a facility-specific module in the wild. This caused `customNameSwitch->isInstanceOf( SwitchTypeId )` to fail, resulting in an exception being thrown when creating a `SwitchPlugAdder` for the UI.

The solution is to avoid assumptions related to wrapping. Since we know the types we want to optimise are implemented in C++, we can still avoid entering Python, but by calling the base class implementation rather than returning `false` directly.

This bug was introduced in `0.59.4.0`, but I'm making the PR for `master` because I _think_ that removing the overrides in `DependencyNodeWrapper` and `ScriptNodeWrapper` breaks ABI. Pending discussion with the owners of wrapped NameSwitches, I may make a more limited PR for `0.60_maintenance`, containing only the changes to `NodeWrapper`.