### PR TITLE
ArnoldAttributes : Support `ai:polymesh:subdiv_frustum_ignore`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.x.x (relative to 0.60.10.0)
+========
+
+Improvements
+------------
+
+- ArnoldAttributes : Added control over Arnold's `polymesh.subdiv_frustum_ignore` parameter. This is accessible from the Subdivision section in the NodeEditor.
+
 0.60.10.0 (relative to 0.60.9.0)
 =========
 

--- a/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
+++ b/python/GafferArnoldTest/IECoreArnoldPreviewTest/RendererTest.py
@@ -1156,6 +1156,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"ai:polymesh:subdiv_adaptive_error" : IECore.FloatData( 0.25 ),
 					"ai:polymesh:subdiv_adaptive_metric" : IECore.StringData( "edge_length" ),
 					"ai:polymesh:subdiv_adaptive_space" : IECore.StringData( "raster" ),
+					"ai:polymesh:subdiv_frustum_ignore" : IECore.BoolData( True ),
 				} )
 			)
 		)
@@ -1172,6 +1173,7 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeGetFlt( node, "subdiv_adaptive_error" ), 0.25 )
 			self.assertEqual( arnold.AiNodeGetStr( node, "subdiv_adaptive_metric" ), "edge_length" )
 			self.assertEqual( arnold.AiNodeGetStr( node, "subdiv_adaptive_space" ), "raster" )
+			self.assertEqual( arnold.AiNodeGetBool( node, "subdiv_frustum_ignore" ), True )
 
 	def testSSSSetNameAttribute( self ) :
 

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -131,6 +131,8 @@ def __subdivisionSummary( plug ) :
 		)
 	if plug["subdivSmoothDerivs"]["enabled"].getValue() :
 		info.append( "Smooth Derivs " + ( "On" if plug["subdivSmoothDerivs"]["value"].getValue() else "Off" ) )
+	if plug["subdivFrustumIgnore"]["enabled"].getValue() :
+		info.append( "Frustum Ignore " + ( "On" if plug["subdivFrustumIgnore"]["value"].getValue() else "Off" ) )
 	if plug["subdividePolygons"]["enabled"].getValue() :
 		info.append( "Subdivide Polygons " + ( "On" if plug["subdividePolygons"]["value"].getValue() else "Off" ) )
 
@@ -659,6 +661,20 @@ Gaffer.Metadata.registerNode(
 			vertex. This can be needed to remove faceting
 			from anisotropic specular and other shading effects
 			that use the derivatives.
+			""",
+
+		],
+
+		"attributes.subdivFrustumIgnore" : [
+
+			"layout:section", "Subdivision",
+			"label", "Ignore Frustum",
+
+			"description",
+			"""
+			Turns off subdivision culling on a per-object basis. This provides
+			finer control on top of the global `subdivFrustumCulling` setting
+			provided by the ArnoldOptions node.
 			""",
 
 		],

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -93,6 +93,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:polymesh:subdiv_adaptive_space", new StringPlug( "value", Plug::In, "raster" ), false, "subdivAdaptiveSpace" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:polymesh:subdiv_uv_smoothing", new StringPlug( "value", Plug::In, "pin_corners" ), false, "subdivUVSmoothing" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:polymesh:subdiv_smooth_derivs", new BoolPlug( "value" ), false, "subdivSmoothDerivs" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "ai:polymesh:subdiv_frustum_ignore", new BoolPlug( "value" ), false, "subdivFrustumIgnore" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:polymesh:subdivide_polygons", new BoolPlug( "value" ), false, "subdividePolygons" ) );
 
 	// Curves parameters

--- a/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
+++ b/src/GafferArnold/IECoreArnoldPreview/Renderer.cpp
@@ -301,6 +301,7 @@ const AtString g_subdivIterationsArnoldString( "subdiv_iterations" );
 const AtString g_subdivAdaptiveErrorArnoldString( "subdiv_adaptive_error" );
 const AtString g_subdivAdaptiveMetricArnoldString( "subdiv_adaptive_metric" );
 const AtString g_subdivAdaptiveSpaceArnoldString( "subdiv_adaptive_space" );
+const AtString g_subdivFrustumIgnoreArnoldString( "subdiv_frustum_ignore" );
 const AtString g_subdivSmoothDerivsArnoldString( "subdiv_smooth_derivs" );
 const AtString g_subdivTypeArnoldString( "subdiv_type" );
 const AtString g_subdivUVSmoothingArnoldString( "subdiv_uv_smoothing" );
@@ -791,6 +792,7 @@ IECore::InternedString g_polyMeshSubdivAdaptiveErrorAttributeName( "ai:polymesh:
 IECore::InternedString g_polyMeshSubdivAdaptiveMetricAttributeName( "ai:polymesh:subdiv_adaptive_metric" );
 IECore::InternedString g_polyMeshSubdivAdaptiveSpaceAttributeName( "ai:polymesh:subdiv_adaptive_space" );
 IECore::InternedString g_polyMeshSubdivSmoothDerivsAttributeName( "ai:polymesh:subdiv_smooth_derivs" );
+IECore::InternedString g_polyMeshSubdivFrustumIgnoreAttributeName( "ai:polymesh:subdiv_frustum_ignore" );
 IECore::InternedString g_polyMeshSubdividePolygonsAttributeName( "ai:polymesh:subdivide_polygons" );
 IECore::InternedString g_polyMeshSubdivUVSmoothingAttributeName( "ai:polymesh:subdiv_uv_smoothing" );
 
@@ -1277,6 +1279,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 				subdividePolygons = attributeValue<bool>( g_polyMeshSubdividePolygonsAttributeName, attributes, false );
 				subdivSmoothDerivs = attributeValue<bool>( g_polyMeshSubdivSmoothDerivsAttributeName, attributes, false );
+				subdivFrustumIgnore = attributeValue<bool>( g_polyMeshSubdivFrustumIgnoreAttributeName, attributes, false );
 			}
 
 			int subdivIterations;
@@ -1286,6 +1289,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			AtString subdivUVSmoothing;
 			bool subdividePolygons;
 			bool subdivSmoothDerivs;
+			bool subdivFrustumIgnore;
 
 			void hash( bool meshInterpolationIsLinear, IECore::MurmurHash &h ) const
 			{
@@ -1297,6 +1301,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					h.append( subdivAdaptiveSpace.c_str() );
 					h.append( subdivUVSmoothing.c_str() );
 					h.append( subdivSmoothDerivs );
+					h.append( subdivFrustumIgnore );
 				}
 			}
 
@@ -1310,6 +1315,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeSetStr( node, g_subdivAdaptiveSpaceArnoldString, subdivAdaptiveSpace );
 					AiNodeSetStr( node, g_subdivUVSmoothingArnoldString, subdivUVSmoothing );
 					AiNodeSetBool( node, g_subdivSmoothDerivsArnoldString, subdivSmoothDerivs );
+					AiNodeSetBool( node, g_subdivFrustumIgnoreArnoldString, subdivFrustumIgnore );
 					if( mesh->interpolation() == "linear" )
 					{
 						AiNodeSetStr( node, g_subdivTypeArnoldString, g_linearArnoldString );


### PR DESCRIPTION
This ignores the elephant in the room : the pre-existing bug whereby we're not turning off auto-instancing when the `subdiv_frustum_culling` global is enabled (because culling effectively makes _all_ subdivision view dependent). We're choosing not to tackle that in `0.60.x` as it has potential to cause large changes in Arnold memory usage and folks will need to profile their scenes thoroughly to determine whether auto-instancing or subdiv frustum culling is the bigger win. In the meantime, this PR at least means culling can be turned off selectively at the per-object level.