### PR TITLE
Qt 5.15 fixes

### DIFF
--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -331,12 +331,12 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			labelFont.setBold( True )
 			labelFont.setPixelSize( 10 )
 			labelFontMetrics = QtGui.QFontMetrics( labelFont )
-			self.__indexLabel._qtWidget().setMinimumWidth( labelFontMetrics.width( "99" ) )
+			self.__indexLabel._qtWidget().setMinimumWidth( labelFontMetrics.boundingRect( "99" ).width() )
 
 			self.__modeImage = GafferUI.Image( "sourceCursor.png" )
 
 			self.__positionLabel = GafferUI.Label()
-			self.__positionLabel._qtWidget().setMinimumWidth( labelFontMetrics.width( "9999 9999 -> 9999 9999" ) )
+			self.__positionLabel._qtWidget().setMinimumWidth( labelFontMetrics.boundingRect( "9999 9999 -> 9999 9999" ).width() )
 
 			self.__swatch = GafferUI.ColorSwatch()
 			self.__swatch._qtWidget().setFixedWidth( 12 )
@@ -345,13 +345,13 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__busyWidget = GafferUI.BusyWidget( size = 12 )
 
 			self.__rgbLabel = GafferUI.Label()
-			self.__rgbLabel._qtWidget().setMinimumWidth( labelFontMetrics.width( "RGBA : 99999 99999 99999 99999" ) )
+			self.__rgbLabel._qtWidget().setMinimumWidth( labelFontMetrics.boundingRect( "RGBA : 99999 99999 99999 99999" ).width() )
 
 			self.__hsvLabel = GafferUI.Label()
-			self.__hsvLabel._qtWidget().setMinimumWidth( labelFontMetrics.width( "HSV : 99999 99999 99999" ) )
+			self.__hsvLabel._qtWidget().setMinimumWidth( labelFontMetrics.boundingRect( "HSV : 99999 99999 99999" ).width() )
 
 			self.__exposureLabel = GafferUI.Label()
-			self.__exposureLabel._qtWidget().setMinimumWidth( labelFontMetrics.width( "EV : 19.9" ) )
+			self.__exposureLabel._qtWidget().setMinimumWidth( labelFontMetrics.boundingRect( "EV : 19.9" ).width() )
 
 			l.addChild( GafferUI.Spacer( size = imath.V2i( 0 ) ) )
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -290,9 +290,9 @@ class Window( GafferUI.ContainerWidget ) :
 		# possible. Sadly Qt keeps their implementation of this private.
 		# Qt documents that for a window, move() is really pos and includes frame geometry
 
-		desktop = QtWidgets.QApplication.desktop()
-		screenNumber = desktop.screenNumber( position )
-		screenRect = desktop.availableGeometry( screenNumber )
+		screen = QtWidgets.QApplication.screenAt( position )
+		screen = screen if screen is not None else QtWidgets.QApplication.primaryScreen()
+		screenRect = screen.availableGeometry()
 
 		# Find what our window's rect would be on that screen
 		windowRect = self._qtWidget().frameGeometry()

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -317,9 +317,19 @@ _styleSheet = string.Template(
 	}
 
 	QMenu::indicator {
+		width: 15px;
 		padding: 0px 0px 0px 3px;
+		/*
+		Work around https://bugreports.qt.io/browse/QTBUG-90242. In Qt 5.12,
+		indicators are not accounted for in the text layout, instead they are
+		rendered into the space reserved by the left padding of `QMenu::item`. In
+		Qt 5.15.2, indicators are accounted for in the layout, shunting
+		the text to the right. This _is_ logical, but it causes misalignment
+		between checkable and non-checkable items. This negative margin negates
+		the shunt in Qt 5.15 and has no effect in Qt 5.12.
+		*/
+		margin-right: -18px;
 	}
-
 
 	QMenu::indicator:non-exclusive:checked {
 		image: url($GAFFER_ROOT/graphics/menuChecked.png);

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1423,7 +1423,7 @@ _styleSheet = string.Template(
 		border: 1px solid rgb( 46, 75, 107 );
 		border-top-color: rgb( 75, 113, 155 );
 		border-left-color: rgb( 75, 113, 155 );
-		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgba( 69, 113, 161 ), stop: 0.1 rgb( 48, 99, 153 ), stop: 0.90 rgb( 54, 88, 125 ));
+		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb( 69, 113, 161 ), stop: 0.1 rgb( 48, 99, 153 ), stop: 0.90 rgb( 54, 88, 125 ));
 	}
 
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] QPushButton[gafferWithFrame="true"] {


### PR DESCRIPTION
Fixes for a few things that cropped up when upgrading to Qt 5.15, which is the version planned for Gaffer 0.61. 

@andrewkaufman, I've added you as a reviewer in case you have any concerns about effects on other Qt versions you might deploy with. The commit I'm thinking about is https://github.com/GafferHQ/gaffer/pull/4460/commits/d28ed1cc0b25150ba4a472267a1a8b246974fe87, which I have tested with Qt 5.12.10 and Qt 5.15.2, but might need further testing with :

- Qt versions later than 5.15.2. This is the last open-source release, but there are more recent commercial-only patch releases I don't have access to, but which perhaps are in use in host DCCs at Image Engine. I've taken an approach that I hope will work with any hypothetical fixes in Qt, but can't test.
- Menu items with icons in. We don't have any of these in Gaffer, but I believe Jabuka might?
