### PR TITLE
ImageGadget : Add missing include

### DIFF
--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -58,6 +58,8 @@
 
 #include "OpenColorIO/OpenColorIO.h"
 
+#include "boost/functional/hash.hpp"
+
 #include "tbb/concurrent_unordered_map.h"
 #include "tbb/spin_mutex.h"
 


### PR DESCRIPTION
This was needed to compile from `master` at IE. I'm not sure why @danieldresser-ie isn't having the same issue to be honest... I did rebuild Cortex from `main` and test against that... In any case, it seems harmless to add the include here.