### PR TITLE
Wrapper : Put IECoreUSD plugin in `PXR_PLUGINPATH_NAME`

### DIFF
--- a/bin/gaffer
+++ b/bin/gaffer
@@ -122,6 +122,8 @@ prependToPath "$GAFFER_ROOT/glsl" IECOREGL_SHADER_INCLUDE_PATHS
 prependToPath "$GAFFER_ROOT/fonts" IECORE_FONT_PATHS
 prependToPath "$HOME/gaffer/ops:$GAFFER_ROOT/ops" IECORE_OP_PATHS
 
+prependToPath "$GAFFER_ROOT/resources/IECoreUSD" PXR_PLUGINPATH_NAME
+
 prependToPath "$HOME/gaffer/opPresets:$GAFFER_ROOT/opPresets" IECORE_OP_PRESET_PATHS
 prependToPath "$HOME/gaffer/procedurals:$GAFFER_ROOT/procedurals" IECORE_PROCEDURAL_PATHS
 prependToPath "$HOME/gaffer/proceduralPresets:$GAFFER_ROOT/proceduralPresets" IECORE_PROCEDURAL_PRESET_PATHS


### PR DESCRIPTION
This will be necessary to pick up the custom metadata registered by https://github.com/ImageEngine/cortex/pull/1188. And that in turn is needed to allow constant primitive variables to round-trip properly in future.