### PR TITLE
Arnold Renderer : Support render:* custom attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Improvements
 - Switch : Removed variables such as `scene:path` and `image:channelName` from the context used to evaluate the `enabled` plug. This improves performance in some scenarios, and prevents the creation of invalid switches.
 - NodeEditor : Added option in node editor context menu to set interpolation of an animated value.
 - Animation : Added new `ConstantNext` interpolation mode, evaluates to the value of the next key for all times greater than the time of the key.
+- Arnold : Added support for `render:` prefixed attributes. For example, a Color3f attribute called `render:displayColor` will be readable as `displayColor` from a `user_data_rgb` shader.
 
 Fixes
 -----
@@ -48,6 +49,7 @@ Fixes
 - NameSwitch : Fixed context management bug that allowed variables such as `scene:path` to leak into the context used to evaluate the `selector` plug.
 - GafferTest.TestCase : Fixed `assertNodesConstructWithDefaultValues()` to recurse through all plugs.
 - NodeBinding : Fixed bug that could cause type queries to fail if types derived from Switch or ContextProcessor were wrapped for subclassing in Python.
+- Arnold : Fixed bug that prevented the type of a `user:` attribute from being changed during an interactive render.
 
 API
 ---

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1226,7 +1226,7 @@ class RendererTest( GafferTest.TestCase ) :
 			node = arnold.AiNodeLookUpByName( universe, "plane" )
 			self.assertEqual( arnold.AiNodeGetStr( node, "sss_setname" ), "testSet" )
 
-	def testUserAttributes( self ) :
+	def testCustomAttributes( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
 			"Arnold",
@@ -1234,8 +1234,10 @@ class RendererTest( GafferTest.TestCase ) :
 			self.temporaryDirectory() + "/test.ass"
 		)
 
+		# Current convention : attributes prefixed with "user:"
+
 		r.object(
-			"plane1",
+			"userPlane1",
 			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
@@ -1249,7 +1251,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		r.object(
-			"plane2",
+			"userPlane2",
 			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
@@ -1262,6 +1264,36 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
+		# Convention we are transitioning to : attributes prefixed with "render:"
+
+		r.object(
+			"renderPlane1",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes(
+				IECore.CompoundObject( {
+					"render:testInt" : IECore.IntData( 1 ),
+					"render:testFloat" : IECore.FloatData( 2.5 ),
+					"render:testV3f" : IECore.V3fData( imath.V3f( 1, 2, 3 ) ),
+					"render:testColor3f" : IECore.Color3fData( imath.Color3f( 4, 5, 6 ) ),
+					"render:testString" : IECore.StringData( "we're all doomed" ),
+				} )
+			)
+		)
+
+		r.object(
+			"renderPlane2",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes(
+				IECore.CompoundObject( {
+					"render:testInt" : IECore.IntData( 2 ),
+					"render:testFloat" : IECore.FloatData( 25 ),
+					"render:testV3f" : IECore.V3fData( imath.V3f( 0, 1, 0 ) ),
+					"render:testColor3f" : IECore.Color3fData( imath.Color3f( 1, 0.5, 0 ) ),
+					"render:testString" : IECore.StringData( "indeed" ),
+				} )
+			)
+		)
+
 		r.render()
 		del r
 
@@ -1269,19 +1301,215 @@ class RendererTest( GafferTest.TestCase ) :
 
 			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
 
-			plane1 = arnold.AiNodeLookUpByName( universe, "plane1" )
-			self.assertEqual( arnold.AiNodeGetInt( plane1, "user:testInt" ), 1 )
-			self.assertEqual( arnold.AiNodeGetFlt( plane1, "user:testFloat" ), 2.5 )
-			self.assertEqual( arnold.AiNodeGetVec( plane1, "user:testV3f" ), arnold.AtVector( 1, 2, 3 ) )
-			self.assertEqual( arnold.AiNodeGetRGB( plane1, "user:testColor3f" ), arnold.AtRGB( 4, 5, 6 ) )
-			self.assertEqual( arnold.AiNodeGetStr( plane1, "user:testString" ), "we're all doomed" )
+			# Test "user:". We expect the prefix to be included in the Arnold
+			# parameter name.
 
-			plane2 = arnold.AiNodeLookUpByName( universe, "plane2" )
-			self.assertEqual( arnold.AiNodeGetInt( plane2, "user:testInt" ), 2 )
-			self.assertEqual( arnold.AiNodeGetFlt( plane2, "user:testFloat" ), 25 )
-			self.assertEqual( arnold.AiNodeGetVec( plane2, "user:testV3f" ), arnold.AtVector( 0, 1, 0 ) )
-			self.assertEqual( arnold.AiNodeGetRGB( plane2, "user:testColor3f" ), arnold.AtRGB( 1, 0.5, 0 ) )
-			self.assertEqual( arnold.AiNodeGetStr( plane2, "user:testString" ), "indeed" )
+			userPlane1 = arnold.AiNodeLookUpByName( universe, "userPlane1" )
+			self.assertEqual( arnold.AiNodeGetInt( userPlane1, "user:testInt" ), 1 )
+			self.assertEqual( arnold.AiNodeGetFlt( userPlane1, "user:testFloat" ), 2.5 )
+			self.assertEqual( arnold.AiNodeGetVec( userPlane1, "user:testV3f" ), arnold.AtVector( 1, 2, 3 ) )
+			self.assertEqual( arnold.AiNodeGetRGB( userPlane1, "user:testColor3f" ), arnold.AtRGB( 4, 5, 6 ) )
+			self.assertEqual( arnold.AiNodeGetStr( userPlane1, "user:testString" ), "we're all doomed" )
+
+			userPlane2 = arnold.AiNodeLookUpByName( universe, "userPlane2" )
+			self.assertEqual( arnold.AiNodeGetInt( userPlane2, "user:testInt" ), 2 )
+			self.assertEqual( arnold.AiNodeGetFlt( userPlane2, "user:testFloat" ), 25 )
+			self.assertEqual( arnold.AiNodeGetVec( userPlane2, "user:testV3f" ), arnold.AtVector( 0, 1, 0 ) )
+			self.assertEqual( arnold.AiNodeGetRGB( userPlane2, "user:testColor3f" ), arnold.AtRGB( 1, 0.5, 0 ) )
+			self.assertEqual( arnold.AiNodeGetStr( userPlane2, "user:testString" ), "indeed" )
+
+			# Test "render:". We expect the prefix to have been stripped from
+			# the Arnold parameter name.
+
+			renderPlane1 = arnold.AiNodeLookUpByName( universe, "renderPlane1" )
+			self.assertEqual( arnold.AiNodeGetInt( renderPlane1, "testInt" ), 1 )
+			self.assertEqual( arnold.AiNodeGetFlt( renderPlane1, "testFloat" ), 2.5 )
+			self.assertEqual( arnold.AiNodeGetVec( renderPlane1, "testV3f" ), arnold.AtVector( 1, 2, 3 ) )
+			self.assertEqual( arnold.AiNodeGetRGB( renderPlane1, "testColor3f" ), arnold.AtRGB( 4, 5, 6 ) )
+			self.assertEqual( arnold.AiNodeGetStr( renderPlane1, "testString" ), "we're all doomed" )
+
+			renderPlane2 = arnold.AiNodeLookUpByName( universe, "renderPlane2" )
+			self.assertEqual( arnold.AiNodeGetInt( renderPlane2, "testInt" ), 2 )
+			self.assertEqual( arnold.AiNodeGetFlt( renderPlane2, "testFloat" ), 25 )
+			self.assertEqual( arnold.AiNodeGetVec( renderPlane2, "testV3f" ), arnold.AtVector( 0, 1, 0 ) )
+			self.assertEqual( arnold.AiNodeGetRGB( renderPlane2, "testColor3f" ), arnold.AtRGB( 1, 0.5, 0 ) )
+			self.assertEqual( arnold.AiNodeGetStr( renderPlane2, "testString" ), "indeed" )
+
+	def testCustomAttributePrecedence( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		# Mix of attributes where `render:` clashes with `user:`
+
+		r.object(
+			"plane",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes(
+				IECore.CompoundObject( {
+					"user:test" : IECore.StringData( "user" ),
+					"render:user:test" : IECore.StringData( "render" ),
+				} )
+			)
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
+
+			# We expect the `render:` attribute to have taken precedence over
+			# the `user:` one.
+
+			plane = arnold.AiNodeLookUpByName( universe, "plane" )
+			self.assertEqual( arnold.AiNodeGetStr( plane, "user:test" ), "render" )
+
+	def testAddAndRemoveCustomAttributes( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		# Start with one set of attributes.
+
+		o = r.object(
+			"plane",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes(
+				IECore.CompoundObject( {
+					"render:toReplace" : IECore.StringData( "original" ),
+					"render:toRemove" : IECore.StringData( "original" ),
+					"render:toChangeType" : IECore.StringData( "original" ),
+				} )
+			)
+		)
+
+		# Replace with another set.
+
+		o.attributes(
+			r.attributes(
+				IECore.CompoundObject( {
+					"render:toReplace" : IECore.StringData( "new" ),
+					"render:new" : IECore.StringData( "new" ),
+					"render:toChangeType" : IECore.IntData( 101 ),
+				} )
+			)
+		)
+
+		r.render()
+		del o
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
+
+			plane = arnold.AiNodeLookUpByName( universe, "plane" )
+
+			self.assertEqual( arnold.AiNodeGetStr( plane, "toReplace" ), "new" )
+			self.assertEqual( arnold.AiNodeGetStr( plane, "new" ), "new" )
+			self.assertEqual( arnold.AiNodeGetInt( plane, "toChangeType" ), 101 )
+			self.assertIsNone( arnold.AiNodeLookUpUserParameter( plane, "toRemove" ) )
+
+	def testCustomAttributesCantSetStandardParameters( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		# Try to set `motion_start` on the sly, via a `render:` attribute.
+		# We don't want to allow this because we need to manage Arnold's
+		# built in parameters via the official renderer API.
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			r.object(
+				"plane",
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+				r.attributes(
+					IECore.CompoundObject( {
+						"render:motion_start" : IECore.FloatData( -1 ),
+					} )
+				)
+			)
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual(
+			mh.messages[0].message,
+			"Custom attribute \"motion_start\" will be ignored because it clashes with Arnold's built-in parameters"
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
+
+			plane = arnold.AiNodeLookUpByName( universe, "plane" )
+			self.assertEqual( arnold.AiNodeGetFlt( plane, "motion_start" ), 0 )
+
+	def testRemovingCustomAttributesCantResetStandardParameters( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		# Try to set `matrix` on the sly, via a `render:` attribute.
+		# We don't want to allow this because we need to manage it
+		# via `ObjectInterface:transform()`.
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			o = r.object(
+				"plane",
+				IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+				r.attributes(
+					IECore.CompoundObject( {
+						"render:matrix" : IECore.M44fData(
+							imath.M44f().translate( imath.V3f( 1, 2, 3 ) ),
+						)
+					} )
+				)
+			)
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual(
+			mh.messages[0].message,
+			"Custom attribute \"matrix\" will be ignored because it clashes with Arnold's built-in parameters"
+		)
+
+		# Now set `matrix` via the official route.
+		o.transform( imath.M44f().translate( imath.V3f( 4, 5, 6 ) ) )
+		# And remove the dodgy custom attribute. If it's not implemented
+		# carefuly, the code for removing attributes could reset the
+		# matrix, which is definitely not what we want.
+		o.attributes( r.attributes( IECore.CompoundObject( {} ) ) )
+
+		r.render()
+		del o
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
+
+			plane = arnold.AiNodeLookUpByName( universe, "plane" )
+			self.assertEqual(
+				self.__m44f( arnold.AiNodeGetMatrix( plane, "matrix" ) ),
+				imath.M44f().translate( imath.V3f( 4, 5, 6 ) )
+			)
 
 	def testDisplacementAttributes( self ) :
 

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -629,6 +629,10 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 						params.add( m.first.c_str() + 3, d );
 					}
 				}
+				else if( boost::starts_with( m.first.string(), "render:" ) )
+				{
+					msg( Msg::Warning, "DelightRenderer", boost::format( "Render attribute \"%s\" not supported" ) % m.first.string() );
+				}
 				else if( boost::starts_with( m.first.string(), "user:" ) )
 				{
 					msg( Msg::Warning, "DelightRenderer", boost::format( "User attribute \"%s\" not supported" ) % m.first.string() );


### PR DESCRIPTION
This caters for the "primvars" that are loaded as attributes by ImageEngine/cortex#1188. This PR replaces https://github.com/GafferHQ/gaffer/pull/4463, reimplementing the Arnold attribute support to strip the `render:` prefix, and dealing with all the corner cases this introduces. I haven't included the general `user: -> render:` "search and replace" commits, as I'm not confident now is the time to make this new scheme the default (and some of the search/replace wasn't relevant to attributes). Instead I'm going to open an issue where I describe the current state of play and the long term intent, so we can capture the outcome of all our recent discussions in one spot.