### PR TITLE
Shuffles UI : Improve descriptions

### DIFF
--- a/python/GafferSceneUI/ShuffleAttributesUI.py
+++ b/python/GafferSceneUI/ShuffleAttributesUI.py
@@ -49,9 +49,9 @@ Gaffer.Metadata.registerNode(
 	the filtered locations. The deleteSource plugs may be used to remove the original
 	source attribute(s) after the shuffling has been completed.
 
-	An additional context variable \"${source}\" can be used on the destination plugs
+	An additional context variable `${source}` can be used on the destination plugs
 	to insert the name of each source attribute. For example, to prefix all attributes
-	with \"user:\" set the source to \"*\" and the destination to \"user:${source}\").
+	with `user:` set the source to `*` and the destination to `user:${source}`.
 	""",
 
 	plugs = {

--- a/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
@@ -47,9 +47,9 @@ Gaffer.Metadata.registerNode(
 	at the filtered locations. The deleteSource plugs may be used to remove the original source
 	primitive variable(s) after the shuffling has been completed.
 
-	An additional context variable \"${source}\" can be used on the destination plugs to insert
-	the name of each source primitive variable. For example, to prefix all primitive variables
-	with \"user:\" set the source to \"*\" and the destination to \"user:${source}\").
+	An additional context variable `${source}` can be used on the destination plugs to insert
+	the name of each source primitive variable. For example, to append `ref` to all primitive variables
+	set the source to `*` and the destination to `${source}ref`.
 	""",
 
 	plugs = {

--- a/python/GafferUI/ShufflePlugValueWidget.py
+++ b/python/GafferUI/ShufflePlugValueWidget.py
@@ -124,8 +124,9 @@ Gaffer.Metadata.registerValue( Gaffer.ShufflePlug,
 	"destination",
 	"description",
 	"""
-	The name(s) of the destination data to be created. Use \"${source}\" to insert the name of the source data.\n
-	For example, to prefix all data with \"user:\" set the destination to \"user:${source}\").
+	The name of the destination data to be created. Use `${source}` to insert
+	the name of the source data. For example, to prepend `prefix:` set the
+	destination to `prefix:${source}`.
 	"""
 )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "deleteSource", "description", "Enable to delete the source data after shuffling to the destination(s)." )


### PR DESCRIPTION
- Use backticks for prettier formatting of string values.
- Use `prefix:` in preference to `user:` in ShufflePlugValueWidget example, as `user:` doesn't have specific meaning in this context.
- Use `ref` suffix in preference to `user:` prefix in ShufflePrimitiveVariablesUI, as `user:` prefix is unconventional for primitive variables, and `ref` suffix represents a relatively common `P->Pref, N->Nref` transformation.
