### PR TITLE
Arnold tests : Skip problematic 7.0.0.0 tests on Linux too

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -69,15 +69,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.__scriptFileName = self.temporaryDirectory() + "/test.gfr"
 
-		if (
-			GafferTest.inCI() and
-			[ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] and
-			sys.platform == "darwin"
-		) :
+		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
 			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
 			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release. It sounds as if the problem exists on Linux too,
-			# but we have only encountered it on Mac so far.
+			# upcoming 7.0.0.1 release.
 			self.skipTest( "Exposes Arnold bug" )
 
 	def tearDown( self ) :

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -58,15 +58,10 @@ class RendererTest( GafferTest.TestCase ) :
 
 		GafferTest.TestCase.setUp( self )
 
-		if (
-			GafferTest.inCI() and
-			[ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] and
-			sys.platform == "darwin"
-		) :
+		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
 			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
 			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release. It sounds as if the problem exists on Linux too,
-			# but we have only encountered it on Mac so far.
+			# upcoming 7.0.0.1 release.
 			self.skipTest( "Exposes Arnold bug" )
 
 	def assertReferSameNode( self, a, b ):


### PR DESCRIPTION
We had only seen failures on Mac, although we were informed that the bug wasn't Mac-specific. Now we have seen the failures on Linux too, that gets the same treatment. Roll on 7.0.0.1.
