### PR TITLE
Update to GafferHQ/dependencies 3.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.1.0/gafferDependencies-3.1.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.2.0/gafferDependencies-3.2.0-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.1.0/gafferDependencies-3.1.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.2.0/gafferDependencies-3.2.0-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: gafferhq/build:1.2.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.1.0/gafferDependencies-3.1.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.2.0/gafferDependencies-3.2.0-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.1.0/gafferDependencies-3.1.0-Python2-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/3.2.0/gafferDependencies-3.2.0-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -47,7 +47,7 @@ else :
 # Determine default archive URL.
 
 platform = "osx" if sys.platform == "darwin" else "linux"
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/3.1.0/gafferDependencies-3.1.0-Python2-" + platform + ".tar.gz"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/3.2.0/gafferDependencies-3.2.0-Python2-" + platform + ".tar.gz"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,20 @@ Improvements
 
 - Animation : Added basic support for loading animation saved from Gaffer 0.61. Caution : `Bezier` and `Cubic` interpolation will be converted to `Linear`, because they are features available in Gaffer 0.61 only.
 
+Fixes
+-----
+
+- SceneReader :
+  - Fixed loading of indexed UVs from Alembic curves.
+  - Fixed loading of custom attributes from USD files.
+- SceneWriter : Fixed writing of indexed primitive variables to Alembic caches.
+
+Build
+-----
+
+- Updated to GafferHQ/dependencies 3.2.0 :
+  - Cortex : Updated to version 10.2.3.0.
+
 0.60.11.0 (relative to 0.60.10.0)
 ========
 


### PR DESCRIPTION
This adds a few worthwhile fixes to the next 0.60.x release, via a small Cortex version update.