### PR TITLE
SConstruct : Move to C++17

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.62.x.x
+========
+
+Build
+-----
+
+- Moved minimum required C++ standard to C++17.
+
 0.61.0.0
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -100,8 +100,8 @@ options.Add(
 
 options.Add(
 	"CXXSTD",
-	"The C++ standard to build against. A minimum of C++14 is required.",
-	"c++14",
+	"The C++ standard to build against. A minimum of C++17 is required.",
+	"c++17",
 )
 
 options.Add(

--- a/config/jh/options
+++ b/config/jh/options
@@ -56,4 +56,3 @@ DELIGHT_ROOT = os.environ["DELIGHT"]
 ARNOLD_ROOT = os.environ["ARNOLD_ROOT"]
 VTUNE_ROOT = "/disk1/apps/intel/system_studio_2018/vtune_amplifier_2018.1.0.535340"
 GAFFERCORTEX=1
-CXXSTD="c++14"


### PR DESCRIPTION
This is mandated by VFXPlatform for both 2021 and 2022.
