### PR TITLE
OSLCode : Check for empty `.oso` files

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x (relative to 0.61.0.0)
+========
+
+Improvements
+------------
+
+- OSLCode : Improved error reporting for cases where empty `.oso` files are produced.
+
 0.61.0.0
 ========
 

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -306,9 +306,25 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 		}
 	}
 
+	if( !boost::filesystem::file_size( tempOSLFileName ) )
+	{
+		// Belt and braces. `compiler.compile()` should be reporting all errors,
+		// but on rare occasions we have still seen empty `.oso` files being
+		// produced. Detect this and warn so we can get to the bottom of it.
+		throw IECore::Exception( "Empty file after compilation : \"" + tempOSLFileName + "\"" );
+	}
+
 	// Move temp file where we really want it, and clean up.
 
 	boost::filesystem::rename( tempOSOFileName, osoFileName );
+
+	if( !boost::filesystem::file_size( osoFileName ) )
+	{
+		// Belt and braces. `rename()` should be reporting all errors,
+		// but on rare occasions we have still seen empty `.oso` files being
+		// produced. Detect this and warn so we can get to the bottom of it.
+		throw IECore::Exception( "Empty file after rename : \"" + osoFileName.string() + "\"" );
+	}
 
 	return osoFileName;
 }


### PR DESCRIPTION
Despite https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/1360, we have still seen one example of an empty `.oso` file being produced in production. Adding further checks will hopefully help us get to the bottom of it if it happens again.
