### PR TITLE
BranchCreator : Fix unnecessary input bounds evaluation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.60.12.x (relative to 0.60.12.0)
+=========
+
+Fixes
+-----
+
+- BranchCreator : Fixed bug in bounding box computation which could cause excessive evaluation of the input scene.
+
 0.60.12.0 (relative to 0.60.11.0)
 =========
 

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -1218,13 +1218,13 @@ BranchCreator::LocationType BranchCreator::sourceAndBranchPaths( const ScenePath
 		}
 	}
 
-	if( location->children.empty() )
+	if( path.size() == location->depth && !location->children.empty() )
 	{
-		return PassThrough;
+		return location->exists ? Ancestor : NewAncestor;
 	}
 	else
 	{
-		return location->exists ? Ancestor : NewAncestor;
+		return PassThrough;
 	}
 }
 


### PR DESCRIPTION
We were doing a complete (and completely unnecessary) recursive bounds evaluation of `/GAFFERBOT` when creating a branch at `/children`. In this case, `branchesData->locationOrAncestor( "/GAFFERBOT" )` correctly returned the root location, but we incorrectly interpreted that as meaning that `/GAFFERBOT` was an ancestor of the branch. If `path` is deeper than `location`, then path _cannot_ be the ancestor of a branch.
