### PR TITLE
Install : Allow updating an existing install tree

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -39,12 +39,9 @@ import os
 import re
 import sys
 import glob
-import shutil
-import fnmatch
-import functools
 import platform
-import py_compile
 import subprocess
+import distutils.dir_util
 
 ###############################################################################################
 # Version
@@ -1584,7 +1581,7 @@ for f in exampleFiles :
 
 def installer( target, source, env ) :
 
-	shutil.copytree( str( source[0] ), str( target[0] ), symlinks=True )
+	distutils.dir_util.copy_tree( str( source[0] ), str( target[0] ), preserve_symlinks=True, update=True )
 
 if env.subst( "$PACKAGE_FILE" ).endswith( ".dmg" ) :
 

--- a/config/ie/postInstall
+++ b/config/ie/postInstall
@@ -42,11 +42,10 @@ def __link( source, target ) :
 	if source == target :
 		return
 
-	if os.path.isdir( target ) :
-		if os.path.islink( target ) :
-			os.unlink( target )
-		else :
-			shutil.rmtree( target )
+	if os.path.islink( target ) :
+		os.unlink( target )
+	elif os.path.isdir( target ) :
+		shutil.rmtree( target )
 
 	os.symlink(
 		os.path.relpath( source, os.path.dirname( target ) ),


### PR DESCRIPTION
At IE we often re-run an installation script and run into failures because the top level directory exists. This has been an annoyance in the past, but now that different Arnold versions install to sub-directories this becomes more problematic.

I didn't notice this while testing because we use `scons build` to for local testing and really only run `scons install` during a deployment to production... Looking into the public deployment I think its doing the same (`scons build` several times) and I'm not sure its ever calling `scons install` actually... is that correct?