### PR TITLE
ShaderView : Added deregisterRenderer()

### DIFF
--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -78,6 +78,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 		typedef std::function<GafferScene::InteractiveRenderPtr ()> RendererCreator;
 		static void registerRenderer( const std::string &shaderPrefix, RendererCreator rendererCreator );
+		static void deregisterRenderer( const std::string &shaderPrefix );
 
 		typedef std::function<Gaffer::NodePtr ()> SceneCreator;
 		static void registerScene( const std::string &shaderPrefix, const std::string &name, SceneCreator sceneCreator );
@@ -97,6 +98,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 		void plugSet( Gaffer::Plug *plug );
 		void plugDirtied( Gaffer::Plug *plug );
 		void sceneRegistrationChanged( const PrefixAndName &prefixAndName );
+		void rendererRegistrationChanged();
 
 		void idleUpdate();
 		void updateRenderer();
@@ -120,6 +122,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 		Gaffer::NodePtr m_scene;
 		PrefixAndName m_scenePrefixAndName;
 		SceneChangedSignal m_sceneChangedSignal;
+		bool m_registryUpdated;
 
 		static ViewDescription<ShaderView> g_viewDescription;
 

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -122,7 +122,6 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 		Gaffer::NodePtr m_scene;
 		PrefixAndName m_scenePrefixAndName;
 		SceneChangedSignal m_sceneChangedSignal;
-		bool m_registryUpdated;
 
 		static ViewDescription<ShaderView> g_viewDescription;
 

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -125,7 +125,7 @@ GAFFER_NODE_DEFINE_TYPE( ShaderView );
 ShaderView::ViewDescription<ShaderView> ShaderView::g_viewDescription( GafferScene::Shader::staticTypeId(), "out" );
 
 ShaderView::ShaderView( const std::string &name )
-	:	ImageView( name ), m_framed( false ), m_registryUpdated( false )
+	:	ImageView( name ), m_framed( false )
 {
 	// Create a converter to generate an image
 	// from the input shader.
@@ -285,7 +285,7 @@ void ShaderView::sceneRegistrationChanged( const PrefixAndName &prefixAndName )
 
 void ShaderView::rendererRegistrationChanged()
 {
-	m_registryUpdated = true;
+	m_rendererShaderPrefix = "";
 	plugDirtied( inPlug() );
 }
 
@@ -309,13 +309,12 @@ void ShaderView::idleUpdate()
 void ShaderView::updateRenderer()
 {
 	const std::string shaderPrefix = this->shaderPrefix();
-	if( !m_registryUpdated && m_renderer && shaderPrefix == m_rendererShaderPrefix )
+	if( m_renderer && shaderPrefix == m_rendererShaderPrefix )
 	{
 		return;
 	}
 
 	m_renderer = nullptr;
-	m_registryUpdated = false;
 	m_rendererShaderPrefix = shaderPrefix;
 	if( !inPlug()->getInput() )
 	{

--- a/src/GafferSceneUIModule/ViewBinding.cpp
+++ b/src/GafferSceneUIModule/ViewBinding.cpp
@@ -201,6 +201,11 @@ void registerRenderer( const std::string &shaderPrefix, object creator )
 	ShaderView::registerRenderer( shaderPrefix, CreatorWrapper<InteractiveRender>( creator ) );
 }
 
+void deregisterRenderer( const std::string &shaderPrefix)
+{
+	ShaderView::deregisterRenderer( shaderPrefix );
+}
+
 void registerScene( const std::string &shaderPrefix, const std::string &name, object creator )
 {
 	ShaderView::registerScene( shaderPrefix, name, CreatorWrapper<Node>( creator ) );
@@ -297,6 +302,8 @@ void GafferSceneUIModule::bindViews()
 		.def( "sceneChangedSignal", &ShaderView::sceneChangedSignal, return_internal_reference<1>() )
 		.def( "registerRenderer", &registerRenderer )
 		.staticmethod( "registerRenderer" )
+		.def( "deregisterRenderer", &deregisterRenderer )
+		.staticmethod( "deregisterRenderer" )
 		.def( "registerScene", &registerScene )
 		.def( "registerScene", &registerReferenceScene )
 		.staticmethod( "registerScene" )


### PR DESCRIPTION
This PR adds a static `deregisterRenderer()` function to ShaderView. The adding of `m_registryUpdated` variable is necessary to update on the next idle moment.

### Related issues ###

- Shaderball preview can be unnecessary and can cause license conflicts

### Breaking changes ###

- Added `ShaderView::m_registryUpdated` bool (TODO apply the pr-majorVersion label)

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
