### PR TITLE
Gaffer 0.61 UI Fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Viewer : Fixed scroll wheel handling for overlay widgets. In particular this means that the mouse wheel can now be used to scroll through the parameters of the scene inspector.
+- GraphEditor : Fixed highlighting of input connections for promoted ArrayPlugs.
 
 API
 ---

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1631,6 +1631,18 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( set( nodes ), set( [ box, s["add2"], box["BoxOut1"]["__switch"], box["BoxOut1"] ] ) )
 
 
+		# Test a box with promoted array plug
+		s["add7"] = GafferTest.AddNode()
+		s["add1"]["op1"].setInput( s["add7"]["sum"] )
+		box2 = Gaffer.Box.create( s, Gaffer.StandardSet( [ s["add7"] ] ) )
+		box2["add7"]["arrayInput"] = Gaffer.ArrayPlug( "arrayInput", Gaffer.Plug.Direction.In, Gaffer.FloatPlug() )
+		box2.promotePlug( box2["add7"]["arrayInput"] )
+		box2["arrayInput"][0].setInput( s["add5"]["sum"] )
+		box2["arrayInput"][1].setInput( s["add6"]["sum"] )
+		plugs, nodes = GafferUI.GraphGadget._activePlugsAndNodes( s["add1"]["sum"], c )
+		self.assertEqual( set( plugs ), set( [ s["add1"]["op1"], box2["sum"], box2["add7"]["arrayInput"], box2["arrayInput"][0], box2["arrayInput"][1] ] ) )
+		self.assertEqual( set( nodes ), set( [ s["add1"], box2, box2["add7"], s["add5"], s["add6"] ] ) )
+
 		# Test Loop
 
 		s["loopSwitch"] = Gaffer.Switch()

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -310,7 +310,9 @@ void activeWalkOutput(
 	{
 		if( connectionStart->direction() != Gaffer::Plug::Direction::Out )
 		{
-			// An input plug with no input connections isn't affected by anything
+			// The only possible connections to an input plug with no input connections is if its
+			// children are connected
+			activeWalkInput( connectionStart, true, context, canceller, activePlugs, activeNodes, plugContextsVisited );
 			return;
 		}
 	}

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -208,6 +208,11 @@ class FocusGadget : public Gadget
 					if( g_pendingHoveredFocus )
 					{
 						StandardNodeGadget* parentNodeGadget = static_cast<StandardNodeGadget*>( g_pendingHoveredFocus->parent() );
+						if( !parentNodeGadget )
+						{
+							IECore::msg( IECore::Msg::Error, "FocusGadget::nodeMouseEntered", "Focus gadget hover timer triggered on unparented FocusGadget" );
+							return;
+						}
 						g_hoveredFocus = g_pendingHoveredFocus;
 						g_hoveredFocusNodePosition = parentNodeGadget->getTransform();
 						g_pendingHoveredFocus->dirty( DirtyType::Render );


### PR DESCRIPTION
Two small UI fixes.  Both of these are a bit naive - they could probably use some more thought.  But I think they're both pretty safe to roll out - we just might want to think more about it afterwards.

One is a possible fix for the non-reproducible crash John saw.  John's idea for how it might be happening seems pretty good, though I was unable to reproduce it by deleting a node with a Focus Gadget that is about to show - maybe the timing is just incredibly tight.

The other is a case where GraphGadget::activePlugsAndNodes fails to find some input connections on promoted array plugs.  The existence of this oversight makes me worry there could be other cases I've missed when it comes to how compound plugs are handled, and maybe this needs some more thought.  But the specific case Murray found is pretty straightforward:  the connection from the node inside the box to the box is on the ArrayPlug itself, so it doesn't follow the individual children, just the parent connection.  When it reaches the outside of the box, it notes that the ArrayPlug is an input plug with no inputs, and terminates the traversal.  It should instead consider that although the ArrayPlug isn't connected, its children may be.

This seems like a reasonable fix for the moment - we could more blindly traverse child plugs in more cases, but that is a potential performance hazard.