### PR TITLE
Arnold Renderer : Destroy AOV shaders before universe

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x (relative to 0.61.1.0)
+========
+
+Fixes
+-----
+
+- InteractiveArnoldRender : Fixed Arnold 7 crash when stopping a render with global AOV shaders.
+
 0.61.1.0 (relative to 0.61.0.0)
 ========
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -3106,6 +3106,7 @@ class ArnoldGlobals
 			// Delete nodes we own before universe is destroyed.
 			m_shaderCache.reset();
 			m_outputs.clear();
+			m_aovShaders.clear();
 			m_colorManager.reset();
 			m_atmosphere.reset();
 			m_background.reset();


### PR DESCRIPTION
We had been getting away with this up till now, but Arnold 7 is less forgiving and crashes when a node is destroyed after its universe. Strangely, our existing `RendererTest.testAOVShaders` didn't catch this crash, but it reproduced every time when rendering via the GUI.
