### PR TITLE
Embedded color choosers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - PathListingWidget : Fixed the deprecated `getSelectedPaths()` and `getExpandedPaths()` methods in the case that the PathListingWidget's root isn't `/` (#4510).
+- NodeEditor : Fixed subtle label alignment differences between plugs with default and non-default values.
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - NodeEditor : Added embedded colour choosers for all colour plugs. These can be shown and hidden by clicking on the slider icon.
+- Spreadsheet/SceneViewInspector : Added embedded colour choosers to popup editor windows.
 - Rendering : Added `gaffer:version` metadata to the headers of all rendered images.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 - PathListingWidget : Fixed the deprecated `getSelectedPaths()` and `getExpandedPaths()` methods in the case that the PathListingWidget's root isn't `/` (#4510).
 - NodeEditor : Fixed subtle label alignment differences between plugs with default and non-default values.
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
+- Button : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- NodeEditor : Added embedded colour choosers for all colour plugs. These can be shown and hidden by clicking on the slider icon.
 - Rendering : Added `gaffer:version` metadata to the headers of all rendered images.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ API
 ---
 
 - PlugPopup : Added new class for editing plugs in a popup window.
+- ColorChooserPlugValueWidget : Added a new class to allow colours to be edited directly using a ColorChooser.
 
 0.61.1.1 (relative to 0.61.1.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 
 - PlugPopup : Added new class for editing plugs in a popup window.
 - ColorChooserPlugValueWidget : Added a new class to allow colours to be edited directly using a ColorChooser.
+- ColorChooser : Added `setSwatchesVisible()` and `getSwatchesVisible()` methods.
 
 0.61.1.1 (relative to 0.61.1.0)
 ========

--- a/python/GafferUI/Button.py
+++ b/python/GafferUI/Button.py
@@ -102,7 +102,11 @@ class Button( GafferUI.Widget ) :
 		assert( isinstance( imageOrImageFileName, ( six.string_types, GafferUI.Image, type( None ) ) ) )
 
 		if isinstance( imageOrImageFileName, six.string_types ) :
+			# Avoid our image getting parented to the wrong thing
+			# if our caller is in a `with container` block.
+			GafferUI.Widget._pushParent( None )
 			self.__image = GafferUI.Image( imageOrImageFileName )
+			GafferUI.Widget._popParent()
 		else :
 			self.__image = imageOrImageFileName
 

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -151,7 +151,7 @@ class ColorChooser( GafferUI.Widget ) :
 					)
 
 			# initial and current colour swatches
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) as self.__swatchRow :
 
 				self.__initialColorSwatch = GafferUI.ColorSwatch( color, useDisplayTransform = useDisplayTransform, parenting = { "expand" : True } )
 				self.__initialColorSwatch._qtWidget().setFixedHeight( 40 )
@@ -182,6 +182,14 @@ class ColorChooser( GafferUI.Widget ) :
 	def getColor( self ) :
 
 		return self.__color
+
+	def setSwatchesVisible( self, visible ) :
+
+		self.__swatchRow.setVisible( False )
+
+	def getSwatchesVisible( self ) :
+
+		return self.__swatchRow.getVisible()
 
 	## A signal emitted whenever the color is changed. Slots should
 	# have the signature slot( ColorChooser, reason ). The reason

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -151,14 +151,14 @@ class ColorChooser( GafferUI.Widget ) :
 					)
 
 			# initial and current colour swatches
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, parenting = { "expand" : True } ) :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 
 				self.__initialColorSwatch = GafferUI.ColorSwatch( color, useDisplayTransform = useDisplayTransform, parenting = { "expand" : True } )
+				self.__initialColorSwatch._qtWidget().setFixedHeight( 40 )
 				self.__initialColorSwatch.buttonPressSignal().connect( Gaffer.WeakMethod( self.__initialColorPress ), scoped = False )
 
-				GafferUI.Spacer( imath.V2i( 4, 40 ) )
-
 				self.__colorSwatch = GafferUI.ColorSwatch( color, useDisplayTransform = useDisplayTransform, parenting = { "expand" : True } )
+				self.__colorSwatch._qtWidget().setFixedHeight( 40 )
 
 		self.__colorChangedSignal = Gaffer.Signal2()
 

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -164,7 +164,7 @@ class ColorChooser( GafferUI.Widget ) :
 
 		self.__updateUIFromColor()
 
-	## The default color starts as the value passed when creating the dialogue.
+	## The default color starts as the value passed when creating the widget.
 	# It is represented with a swatch which when clicked will revert the current
 	# selection back to the original.
 	def setInitialColor( self, color ) :

--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -47,6 +47,8 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		GafferUI.PlugValueWidget.__init__( self, self.__colorChooser, plugs, **kw )
 
+		self.__colorChooser.setSwatchesVisible( False )
+
 		self.__colorChangedConnection = self.__colorChooser.colorChangedSignal().connect(
 			Gaffer.WeakMethod( self.__colorChanged ), scoped = False
 		)

--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -1,0 +1,120 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import Gaffer
+import GafferUI
+
+class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		self.__colorChooser = GafferUI.ColorChooser()
+
+		GafferUI.PlugValueWidget.__init__( self, self.__colorChooser, plugs, **kw )
+
+		self.__colorChangedConnection = self.__colorChooser.colorChangedSignal().connect(
+			Gaffer.WeakMethod( self.__colorChanged ), scoped = False
+		)
+
+		self.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = False )
+
+		self.__lastChangedReason = None
+		self.__mergeGroupId = 0
+
+		self._updateFromPlugs()
+
+	def setPlugs( self, plugs ) :
+
+		GafferUI.PlugValueWidget.setPlugs( self, plugs )
+
+		self.__colorChooser.setInitialColor( self.__colorFromPlugs() )
+
+	def _updateFromPlugs( self ) :
+
+		with Gaffer.BlockedConnection( self.__colorChangedConnection ) :
+			self.__colorChooser.setColor( self.__colorFromPlugs() )
+
+		self.__colorChooser.setEnabled( self.__allComponentsEditable() )
+
+	def __colorChanged( self, colorChooser, reason ) :
+
+		if not GafferUI.ColorChooser.changesShouldBeMerged( self.__lastChangedReason, reason ) :
+			self.__mergeGroupId += 1
+		self.__lastChangedReason = reason
+
+		with Gaffer.UndoScope(
+			next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ),
+			mergeGroup = "ColorPlugValueWidget%d%d" % ( id( self, ), self.__mergeGroupId )
+		) :
+
+			with Gaffer.BlockedConnection( self._plugConnections() ) :
+				for plug in self.getPlugs() :
+					plug.setValue( self.__colorChooser.getColor() )
+
+	def __colorFromPlugs( self ) :
+
+		with self.getContext() :
+			values = [ p.getValue() for p in self.getPlugs() ]
+
+		if len( values ) :
+			# ColorChooser only supports one colour, and doesn't have
+			# an "indeterminate" state, so when we have multiple plugs
+			# the best we can do is take an average.
+			return sum( values ) / len( values )
+		else :
+			return imath.Color4f( 0 )
+
+	def __visibilityChanged( self, widget ) :
+
+		if self.visible() :
+			self.__colorChooser.setInitialColor( self.__colorChooser.getColor() )
+
+	def __allComponentsEditable( self ) :
+
+		if not self._editable() :
+			return False
+
+		# The base class `_editable()` call doesn't consider that
+		# child plugs might be read only, so check for that.
+		## \todo Should the base class be doing this for us?
+		for plug in self.getPlugs() :
+			for child in Gaffer.Plug.Range( plug ) :
+				if Gaffer.MetadataAlgo.readOnly( child ) :
+					return False
+
+		return True

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -75,7 +75,6 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def setColorChooserVisible( self, visible ) :
 
 		self.__colorChooser.setVisible( visible )
-		self.__swatch.setVisible( not visible )
 		self.__chooserButton.setImage(
 			"colorPlugValueWidgetSliders{}.png".format( "On" if visible else "Off" )
 		)

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -51,6 +51,7 @@ class ColorSwatchPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		## \todo How do set maximum height with a public API?
 		self.__swatch._qtWidget().setMaximumHeight( 20 )
+		self.__swatch._qtWidget().setFixedWidth( 40 )
 
 		self._addPopupMenu( self.__swatch )
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -47,6 +47,8 @@ from Qt import QtWidgets
 #  - "renameable"
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
+	## \todo Remove alignment arguments. Vertically the only alignment that looks good is `Center`, and
+	# horizontally we have standardised on `Right`.
 	def __init__( self, plug, horizontalAlignment=GafferUI.Label.HorizontalAlignment.Left, verticalAlignment=GafferUI.Label.VerticalAlignment.Center, **kw ) :
 
 		GafferUI.PlugValueWidget.__init__( self, QtWidgets.QWidget(), plug, **kw )
@@ -63,6 +65,11 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			formatter = self.__formatter,
 		)
 		self.__label._qtWidget().setObjectName( "gafferPlugLabel" )
+		# Fix the height to match common PlugValueWidgets, so that our text
+		# aligns nicely with theirs. Ideally this should be done purely in the
+		# stylesheet, but that has proved difficult. See comments in
+		# 764eb379d99ff8418fbf2bb79a8231dafc57d8f1 for more details.
+		self.__label._qtWidget().setFixedHeight( 20 )
 		layout.addWidget( self.__label._qtWidget() )
 
 		self.__editableLabel = None # we'll make this lazily as needed

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -65,15 +65,8 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 			nameWidget = GafferUI.LabelPlugValueWidget(
 				self.getPlugs(),
 				horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
-				verticalAlignment = GafferUI.Label.VerticalAlignment.Center,
 			)
 			nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
-			# cheat to get the height of the label to match the height of a line edit
-			# so the label and plug widgets align nicely. ideally we'd get the stylesheet
-			# sorted for the QLabel so that that happened naturally, but QLabel sizing appears
-			# somewhat unpredictable (and is sensitive to HTML in the text as well), making this
-			# a tricky task.
-			nameWidget.label()._qtWidget().setFixedHeight( 20 )
 		else :
 			nameWidget = GafferUI.StringPlugValueWidget( { plug["name"] for plug in self.getPlugs() } )
 			nameWidget.textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -149,6 +149,11 @@ class PlugPopup( _PopupWindow ) :
 					self.__plugValueWidget = None
 					GafferUI.Label( "Unable to edit plugs with mixed types" )
 
+		# If we have a ColorPlugValueWidget, expand it to show the chooser.
+		colorPlugValueWidget = self.__colorPlugValueWidget( self.__plugValueWidget )
+		if colorPlugValueWidget is not None :
+			colorPlugValueWidget.setColorChooserVisible( True )
+
 		self.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = False )
 
 	def popup( self, center = None ) :
@@ -217,5 +222,23 @@ class PlugPopup( _PopupWindow ) :
 				childTextWidget = cls.__firstTextWidget( childWidget )
 				if childTextWidget is not None :
 					return childTextWidget
+
+		return None
+
+	@classmethod
+	def __colorPlugValueWidget( cls, plugValueWidget ) :
+
+		if plugValueWidget is None :
+			return None
+
+		if isinstance( plugValueWidget, GafferUI.ColorPlugValueWidget ) :
+			return plugValueWidget
+
+		for childPlug in Gaffer.Plug.Range( next( iter( plugValueWidget.getPlugs() ) ) ) :
+			childWidget = cls.__colorPlugValueWidget(
+				plugValueWidget.childPlugValueWidget( childPlug )
+			)
+			if childWidget is not None :
+				return childWidget
 
 		return None

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -469,7 +469,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		for p in self.__plugs :
 			if (
-				p == plug or
+				p == plug or p.isAncestorOf( plug ) or
 				Gaffer.MetadataAlgo.readOnlyAffectedByChange( p, plug, key )
 			) :
 				self._updateFromPlugs()

--- a/python/GafferUI/PlugWidget.py
+++ b/python/GafferUI/PlugWidget.py
@@ -40,6 +40,7 @@ import warnings
 import Gaffer
 import GafferUI
 
+from Qt import QtCore
 from Qt import QtWidgets
 
 ## The PlugWidget combines a LabelPlugValueWidget with a second PlugValueWidget
@@ -71,7 +72,6 @@ class PlugWidget( GafferUI.Widget ) :
 		self.__label = GafferUI.LabelPlugValueWidget(
 			plug,
 			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right,
-			verticalAlignment = GafferUI.Label.VerticalAlignment.Top,
 		)
 
 		## \todo Decide how we allow this sort of tweak using the public
@@ -94,7 +94,7 @@ class PlugWidget( GafferUI.Widget ) :
 			)
 			self.__label.label().setToolTip( description )
 
-		layout.addWidget( self.__label._qtWidget() )
+		layout.addWidget( self.__label._qtWidget(), alignment = QtCore.Qt.AlignTop )
 		layout.addWidget( self.__valueWidget._qtWidget() )
 
 		# The plugValueWidget() may have smarter drop behaviour than the labelPlugValueWidget(),

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -80,14 +80,30 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 
-				self.__positionLabel = GafferUI.LabelPlugValueWidget( plug.pointXPlug( 0 ) )
-				self.__positionField = GafferUI.NumericPlugValueWidget( plug.pointXPlug( 0 ) )
+				self.__positionLabel = GafferUI.LabelPlugValueWidget(
+					plug.pointXPlug( 0 ),
+					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
+				)
+				self.__positionField = GafferUI.NumericPlugValueWidget(
+					plug.pointXPlug( 0 ),
+					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
+				)
 
-				self.__valueLabel = GafferUI.LabelPlugValueWidget( plug.pointYPlug( 0 ) )
+				self.__valueLabel = GafferUI.LabelPlugValueWidget(
+					plug.pointYPlug( 0 ),
+					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
+				)
 				if isinstance( plug.pointYPlug( 0 ), Gaffer.FloatPlug ):
-					self.__valueField = GafferUI.NumericPlugValueWidget( plug.pointYPlug( 0 ) )
+					self.__valueField = GafferUI.NumericPlugValueWidget(
+						plug.pointYPlug( 0 ),
+						parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
+					)
 				else:
-					self.__valueField = GafferUI.ColorPlugValueWidget( plug.pointYPlug( 0 ) )
+					self.__valueField = GafferUI.ColorPlugValueWidget(
+						plug.pointYPlug( 0 ),
+						parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
+					)
+					self.__valueField.setColorChooserVisible( True )
 
 		self.setPlug( plug )
 

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -78,7 +78,10 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__lastPositionChangedReason = None
 			self.__positionsMergeGroupId = 0
 
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+			with GafferUI.ListContainer(
+				orientation = GafferUI.ListContainer.Orientation.Horizontal if isinstance( plug.pointYPlug( 0 ), Gaffer.FloatPlug ) else GafferUI.ListContainer.Orientation.Vertical,
+				spacing = 4
+			) :
 
 				self.__positionLabel = GafferUI.LabelPlugValueWidget(
 					plug.pointXPlug( 0 ),

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -580,7 +580,7 @@ class _Widget( QtWidgets.QWidget ) :
 
 		QtWidgets.QWidget.__init__( self, parent )
 
-		self.setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum ) )
+		self.setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed ) )
 		self.setFocusPolicy( QtCore.Qt.ClickFocus )
 
 	def sizeHint( self ) :

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -223,13 +223,22 @@ _styleSheet = string.Template(
 		color: #b0d8fb;
 	}
 
+	QLabel#gafferPlugLabel {
+		/*
+		QLabel's text layout seems to lurch from one approach
+		to another in the presence of non-zero padding. So we
+		need some padding here so that we get a layout that
+		matches the `gafferValueChanged="true"` styling below.
+		*/
+		padding-left: 1px;
+	}
+
 	QLabel#gafferPlugLabel[gafferValueChanged="true"] {
 		background-image: url($GAFFER_ROOT/graphics/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;
-		padding-left: 20px;
+		padding-left: 16px;
 	}
-
 
 	QLabel[gafferItemName="true"] {
 		font-weight: bold;

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -235,6 +235,7 @@ from .StandardNodeUI import StandardNodeUI
 from .NodeToolbar import NodeToolbar
 from .StandardNodeToolbar import StandardNodeToolbar
 from .Viewer import Viewer
+from .ColorChooserPlugValueWidget import ColorChooserPlugValueWidget
 from .ColorSwatchPlugValueWidget import ColorSwatchPlugValueWidget
 from .ColorPlugValueWidget import ColorPlugValueWidget
 from .AboutWindow import AboutWindow

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -277,6 +277,19 @@
 
 		},
 
+		"plugValueWidgetIcons" : {
+
+			"options" : {
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"colorPlugValueWidgetSlidersOff",
+				"colorPlugValueWidgetSlidersOn",
+			]
+
+		},
+
 	},
 
 	"ids" : [

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -23,6 +23,14 @@
   <defs
      id="defs4">
     <linearGradient
+       id="linearGradient1896"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop1894" />
+    </linearGradient>
+    <linearGradient
        id="nodeBorder"
        osb:paint="solid">
       <stop
@@ -41,7 +49,8 @@
     </linearGradient>
     <linearGradient
        id="boundsTemplate"
-       osb:paint="solid">
+       osb:paint="solid"
+       gradientTransform="matrix(1.4488738,0,0,1.25,24.465856,49.36218)">
       <stop
          style="stop-color:#ff0101;stop-opacity:0.0787037;"
          offset="0"
@@ -236,18 +245,19 @@
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:object-paths="false"
-     inkscape:bbox-paths="true"
+     inkscape:bbox-paths="false"
      inkscape:bbox-nodes="true"
-     showgrid="false"
-     inkscape:zoom="0.45664722"
-     inkscape:cx="1498.9798"
-     inkscape:cy="499.01051"
-     inkscape:window-width="1712"
+     showgrid="true"
+     inkscape:zoom="27.8816"
+     inkscape:cx="56.249013"
+     inkscape:cy="-1503.6269"
+     inkscape:window-width="1711"
      inkscape:window-height="870"
-     inkscape:window-x="203"
+     inkscape:window-x="204"
      inkscape:window-y="123"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1">
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true">
     <inkscape:grid
        type="xygrid"
        id="grid3598"
@@ -1324,7 +1334,29 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1966"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">GraphEditor</flowPara></flowRoot>  </g>
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">GraphEditor</flowPara></flowRoot>    <path
+       id="path1880"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,2485.0003 H 743.99999"
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot1888"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,1.0000138,288.10156,1473.8477)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1884"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"><rect
+           id="rect1882"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara1886"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">PlugValueWidgets</flowPara></flowRoot>  </g>
   <g
      inkscape:groupmode="layer"
      id="layer4"
@@ -6870,5 +6902,39 @@
        x="1331.4436"
        y="476.42526"
        ry="24.088617" />
+    <rect
+       y="2544.3623"
+       x="10"
+       height="20"
+       width="20"
+       id="rect1890"
+       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <path
+       style="display:inline;opacity:1;fill:#787878;fill-opacity:1;stroke:#434343;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:normal"
+       d="M 41 2494.5 A 2.5 2.4998784 0 0 0 39.003906 2495.5 L 35 2495.5 C 34.169 2495.5 33.5 2496.169 33.5 2497 C 33.5 2497.831 34.169 2498.5 35 2498.5 L 39.001953 2498.5 A 2.5 2.4998784 0 0 0 41 2499.5 A 2.5 2.4998784 0 0 0 42.996094 2498.5 L 49 2498.5 C 49.831 2498.5 50.5 2497.831 50.5 2497 C 50.5 2496.169 49.831 2495.5 49 2495.5 L 42.998047 2495.5 A 2.5 2.4998784 0 0 0 41 2494.5 z M 45.5 2499.5 A 2.5 2.4998784 0 0 0 43.503906 2500.5 L 35 2500.5 C 34.169 2500.5 33.5 2501.169 33.5 2502 C 33.5 2502.831 34.169 2503.5 35 2503.5 L 43.501953 2503.5 A 2.5 2.4998784 0 0 0 45.5 2504.5 A 2.5 2.4998784 0 0 0 47.496094 2503.5 L 49 2503.5 C 49.831 2503.5 50.5 2502.831 50.5 2502 C 50.5 2501.169 49.831 2500.5 49 2500.5 L 47.498047 2500.5 A 2.5 2.4998784 0 0 0 45.5 2499.5 z M 39 2504.5 A 2.5 2.4998784 0 0 0 37.003906 2505.5 L 35 2505.5 C 34.169 2505.5 33.5 2506.169 33.5 2507 C 33.5 2507.831 34.169 2508.5 35 2508.5 L 37.001953 2508.5 A 2.5 2.4998784 0 0 0 39 2509.5 A 2.5 2.4998784 0 0 0 40.996094 2508.5 L 49 2508.5 C 49.831 2508.5 50.5 2507.831 50.5 2507 C 50.5 2506.169 49.831 2505.5 49 2505.5 L 40.998047 2505.5 A 2.5 2.4998784 0 0 0 39 2504.5 z "
+       transform="translate(0,52.362183)"
+       id="rect1959" />
+    <rect
+       inkscape:label="sizeGuide"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       id="colorPlugValueWidgetSlidersOff"
+       width="18"
+       height="20"
+       x="33"
+       y="2544.3623" />
+    <path
+       id="path2050"
+       d="m 61,2546.8622 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 4.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -6.001953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z m 4.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 8.501953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -1.501953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z m -6.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 2.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -8.001953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z"
+       style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#434343;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:normal"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="2544.3623"
+       x="53"
+       height="20"
+       width="18"
+       id="colorPlugValueWidgetSlidersOn"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
   </g>
 </svg>


### PR DESCRIPTION
While working on the LightEditor, I've been increasingly irritated by the number of clicks it takes to edit the color of a light - one to get a popup plug editor, another to open the colour chooser dialogue (after navigating to where it has appeared on screen), and then the actual interaction I want with the colour chooser. This PR adds an embedded colour chooser to the PlugPopup, cutting out the middle step :

![popupColorChooser](https://user-images.githubusercontent.com/1133871/145086865-776efb09-5362-4a0b-8043-1fd3d1852a4d.gif)

The same thing applies to popup editors in the Spreadsheet - they now also include an embedded colour chooser.

I implemented this by pinching an idea from @themissingcow's [gaffer-astro project](https://github.com/themissingcow/gaffer-astro) : sliders embedded directly in a PlugValueWidget in the NodeEditor. A new icon on any standard colour widget lets you pop open an embedded colour chooser, from which you can pick a color :

![nodeEditorColorChooser](https://user-images.githubusercontent.com/1133871/145087268-e6627f91-04b7-42e3-bcad-e7e8a33914cc.gif)

By default all the pickers in the NodeEditor are collapsed, and this default is just reversed for the pickers in the LightEditor and Spreadsheet popups.

I think @themissingcow's embedded choosers might be more elaborate than this one (which is just Gaffer's standard picker), and there might be some worry about the amount of screen real estate this one takes when used in the NodeEditor. I think that's a reasonable concern, but since they are collapsed by default I'm hopeful that it might be reasonable to include as-is. We could then take this into consideration when improving the ColorChooserWidget, perhaps by making it easy to switch between a smaller set of sliders/wheels. If folks definitely aren't into this implementation, then I could roll back and only include the popups (but I think that would be a pity).

If you have any chance to canvas opinions, @murrays-ie, that would be valuable.
