### PR TITLE
Prerequisite Changes For USDShade Support

### DIFF
--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -162,6 +162,33 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 			],
 		)
 
+	def testParameterValuesWhenConnected( self ) :
+
+		n1 = GafferSceneTest.TestShader( "n1" )
+		n2 = GafferSceneTest.TestShader( "n2" )
+		n3 = GafferSceneTest.TestShader( "n3" )
+		n3["type"].setValue( "test:surface" )
+
+		n3["parameters"]["i"].setInput( n1["out"]["r"] )
+		n3["parameters"]["c"].setValue( imath.Color3f( 2, 3, 4 ) )
+		n3["parameters"]["c"].setInput( n2["out"] )
+
+		network = n3.attributes()["test:surface"]
+		self.assertEqual( len( network ), 3 )
+		self.assertEqual(
+			network.inputConnections( "n3" ), [
+				network.Connection( network.Parameter( "n2", "", ), network.Parameter( "n3", "c" ) ),
+				network.Connection( network.Parameter( "n1", "r", ), network.Parameter( "n3", "i" ) )
+			]
+		)
+
+		# The values set on the parameters don't come through, but we get the default value from the
+		# connected shader's output as the correct type
+		self.assertEqual(
+			network.getShader( "n3" ).parameters,
+			IECore.CompoundData( { "i" : IECore.IntData( 0 ), "c" : IECore.Color3fData( imath.Color3f( 0 ) ) } )
+		)
+
 	def testDetectCyclicConnections( self ) :
 
 		n1 = GafferSceneTest.TestShader()

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -63,6 +63,14 @@ struct LocationWriter
 	{
 	}
 
+	~LocationWriter()
+	{
+		// Some implementations of SceneInterface may perform writing when we release the SceneInterface,
+		// so we need to hold the lock while freeing it
+		tbb::mutex::scoped_lock scopedLock( m_mutex );
+		m_output.reset();
+	}
+
 	/// first half of this function can be lock free reading data from ScenePlug
 	/// once all the data has been read then we take a global lock and write
 	/// into the SceneInterface

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -254,6 +254,15 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 			sourceName = partitionEnd( sourceName, '.' );
 		}
 
+		if( parameterName == "color" && ( shader->getName() == "quad_light" || shader->getName() == "skydome_light" ) )
+		{
+			// In general, Arnold should be able to form a connection onto a parameter even if the
+			// parameter already has a value.  Something weird happens with the "color" parameter
+			// on "quad_light" and "skydome_light" though, where the connection is not evaluated
+			// properly unless the parameter is reset first ( possibly due to some special importance
+			// map building that needs to happen when a connection is made to the color parameter )
+			AiNodeResetParameter( node, "color" );
+		}
 		AiNodeLinkOutput( sourceNode, sourceName.c_str(), node, parameterName.c_str() );
 	}
 


### PR DESCRIPTION
The SceneWriter destructor change is extremely straightforward, and I'm quite confident of it.

Storing values on shader parameters with inputs is also pretty straightforward, but there are more potential knock-on effects ... everything seems to be working fine though.