### PR TITLE
PathListingWidgetTest : Call indicesForPathsWalk() with correct root

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 Fixes
 -----
 
+- PathListingWidget : Fixed the deprecated `getSelectedPaths()` and `getExpandedPaths()` methods in the case that the PathListingWidget's root isn't `/` (#4510).
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 
 API

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -869,6 +869,21 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( path2.visitedPaths, path1.visitedPaths )
 
+	def testLegacySelectionWithNonEmptyRootPath( self ) :
+
+		d = { "a" : { "b" : 10 } }
+		p = Gaffer.DictPath( d, "/a" )
+
+		w = GafferUI.PathListingWidget( p )
+		w.setSelectedPaths( [ p.copy().setFromString( "/a/b" ) ] )
+		self.assertEqual( { str( s ) for s in w.getSelectedPaths() }, { "/a/b" } )
+
+		d["a"]["c"] = 20
+		p.pathChangedSignal()( p )
+
+		w.setSelectedPaths( [ p.copy().setFromString( "/a/c" ) ] )
+		self.assertEqual( { str( s ) for s in w.getSelectedPaths() }, { "/a/c" } )
+
 	@staticmethod
 	def __emitPathChanged( widget ) :
 

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -669,7 +669,7 @@ class PathModel : public QAbstractItemModel
 				return result;
 			}
 
-			indicesForPathsWalk( m_rootItem.get(), Path::Names(), QModelIndex(), paths, result );
+			indicesForPathsWalk( m_rootItem.get(), m_rootPath->names(), QModelIndex(), paths, result );
 			return result;
 		}
 

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -1307,7 +1307,7 @@ class PathModel : public QAbstractItemModel
 					if( model->m_expandNonLeafSelection )
 					{
 						// OK to read `m_selectedPaths` from background thread, because write on UI
-						// thread is preceded by `cancelUpdate().
+						// thread is preceded by `cancelUpdate()`.
 						const unsigned selectionMatch = model->m_selectedPaths.match( path->names() );
 						/// \todo I don't understand the purpose of this logic. It seems it might be
 						/// more useful to expand all ancestors of the selection (even if they're not
@@ -1334,7 +1334,6 @@ class PathModel : public QAbstractItemModel
 
 					m_expansionDirty = false;
 				}
-
 
 				// Returns the updated ChildContainer. This will not be visible in the model
 				// until the queued edit is executed. It is returned so that we can update


### PR DESCRIPTION
@ivanimanishi, this fixes the repro you provided in #4510. The fix is very specific to the case where the PathListingWidget isn't showing the contents of the root path (e.g. it is showing the contents of `/some/path` rather than `/`), so it may be that there are other problems outstanding - would be good if you could test.

It would also be great if we could find a bit of time to chat about transitioning away from the `setSelectedPaths/getSelectedPaths` APIs as they have been deprecated for some time, and have significantly worse performance than the alternative. There's some subtlety there as the replacements aren't semantically identical, and I'd like to pick your brain to see if anything is missing or could be improved.