### PR TITLE
GLWidget : Fix overlay mask on high resolution displays

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 - NodeEditor : Fixed subtle label alignment differences between plugs with default and non-default values.
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 - Button : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
+- GLWidget : Fixed bug which made overlays unresponsive on high resolution displays.
 
 API
 ---

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -464,6 +464,10 @@ class _OverlayProxyWidget( QtWidgets.QGraphicsProxyWidget ) :
 			self.__shape = QtGui.QPainterPath()
 			if self.widget() :
 				pixmap = self.widget().grab()
+				if pixmap.size() != self.widget().size() :
+					# Account for the widget being grabbed at a higher resolution
+					# when using high resolution displays.
+					pixmap = pixmap.scaled( self.widget().size() )
 				self.__shape.addRegion( QtGui.QRegion( pixmap.mask() ) )
 
 		return self.__shape


### PR DESCRIPTION
On retina Macs, the `widget().grab()` call was generating a pixmap at twice the resolution of the widget itself, meaning the mask shape didn't align with the widget.

