### PR TITLE
IECoreArnold : Fix instancing of adaptive subdiv poly meshes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 - NodeEditor : Fixed subtle label alignment differences between plugs with default and non-default values.
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 - Button : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
+- IECoreArnold : Don't instance poly meshes using subdivide_polygons and adaptive subdivision
 
 API
 ---

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1034,6 +1034,17 @@ class RendererTest( GafferTest.TestCase ) :
 				"ai:polymesh:subdiv_adaptive_space" : IECore.StringData( "object" ),
 			} )
 		)
+		subdivideLinear = r.attributes(
+			IECore.CompoundObject( {
+				"ai:polymesh:subdivide_polygons" : IECore.BoolData( True )
+			} )
+		)
+		subdivideLinearAdaptive = r.attributes(
+			IECore.CompoundObject( {
+				"ai:polymesh:subdivide_polygons" : IECore.BoolData( True ),
+				"ai:polymesh:subdiv_adaptive_error" : IECore.FloatData( 0.1 ),
+			} )
+		)
 		smoothDerivsTrueAttributes = r.attributes(
 			IECore.CompoundObject( {
 				"ai:polymesh:subdiv_smooth_derivs" : IECore.BoolData( True )
@@ -1070,6 +1081,14 @@ class RendererTest( GafferTest.TestCase ) :
 		r.object( "subdivAdaptiveObjectSpaceAttributes1", subdivPlane.copy(), adaptiveObjectSpaceAttributes )
 		r.object( "subdivAdaptiveObjectSpaceAttributes2", subdivPlane.copy(), adaptiveObjectSpaceAttributes )
 
+		# With subdivide_polygons on, poly meshes need the same behaviour as subdivs, breaking instancing
+		# when adaptive is on
+		r.object( "polySubdivideLinearAttributes1", polyPlane.copy(), subdivideLinear )
+		r.object( "polySubdivideLinearAttributes2", polyPlane.copy(), subdivideLinear )
+
+		r.object( "polyAdaptiveSubdivideLinearAttributes1", polyPlane.copy(), subdivideLinearAdaptive )
+		r.object( "polyAdaptiveSubdivideLinearAttributes2", polyPlane.copy(), subdivideLinearAdaptive )
+
 		# If smooth derivatives are required, that'll require creating a separate polymesh and an instance of it
 
 		r.object( "subdivSmoothDerivsAttributes1", subdivPlane.copy(), smoothDerivsTrueAttributes )
@@ -1086,8 +1105,8 @@ class RendererTest( GafferTest.TestCase ) :
 			numInstances = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "ginstance" ] )
 			numPolyMeshes = len( [ s for s in shapes if arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( s ) ) == "polymesh" ] )
 
-			self.assertEqual( numPolyMeshes, 6 )
-			self.assertEqual( numInstances, 11 )
+			self.assertEqual( numPolyMeshes, 9 )
+			self.assertEqual( numInstances, 13 )
 
 			self.__assertInstanced(
 				universe,
@@ -1115,6 +1134,18 @@ class RendererTest( GafferTest.TestCase ) :
 				universe,
 				"subdivAdaptiveObjectSpaceAttributes1",
 				"subdivAdaptiveObjectSpaceAttributes2",
+			)
+
+			self.__assertInstanced(
+				universe,
+				"polySubdivideLinearAttributes1",
+				"polySubdivideLinearAttributes2",
+			)
+
+			self.__assertNotInstanced(
+				universe,
+				"polyAdaptiveSubdivideLinearAttributes1",
+				"polyAdaptiveSubdivideLinearAttributes2",
 			)
 
 	def testTransformTypeAttribute( self ) :

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1049,7 +1049,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			if( const IECoreScene::MeshPrimitive *mesh = IECore::runTimeCast<const IECoreScene::MeshPrimitive>( object ) )
 			{
-				if( mesh->interpolation() == "linear" )
+				if( mesh->interpolation() == "linear" && !m_polyMesh.subdividePolygons )
 				{
 					return true;
 				}


### PR DESCRIPTION
Don't instance poly meshes using subdivide_polygons and adaptive subdivision.  It's a one line fix to test for subdividePolygons.  Added unit tests, and verified that this fixes the issue interactively.