### PR TITLE
Instancer : Remove unnecessary error in RootsPerVertex mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Instancer : Fixed RootsPerVertex mode in the case that the input object has no vertices. Previously an empty `prototypeRoots` variable would cause an unnecessary error in this case, which was incompatible with the output from DeletePoints.
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 
 0.60.12.1 (relative to 0.60.12.0)

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -762,11 +762,6 @@ class Instancer::EngineData : public Data
 
 					m_indices = view->indices();
 					rootStrings = &view->data();
-					if( rootStrings->empty() )
-					{
-						throw IECore::Exception( boost::str( boost::format( "prototypeRoots primitive variable \"%1%\" must specify at least one root location" ) % rootsVariable ) );
-					}
-
 					break;
 				}
 			}


### PR DESCRIPTION
We were erroring if the `prototypeRoots` variable was empty, but we don't need any prototypes if there are no vertices.

Removed the old test not only because it asserts the opposite of what we want, but because it was creating an invalid primitive variable in order to do so.

Fixes #4525.
