### PR TITLE
Signal binding improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.62.x.x
 ========
 
+API
+---
+
+- Signals : Removed usage of `boost::signals::detail::unusable` as a substitute for the `void` return type in the Signal bindings. Custom SlotCallers may now use a standard `void` return type.
+
 Build
 -----
 

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -307,7 +307,7 @@ struct PreDispatchSlotCaller
 
 struct DispatchSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes )
+	void operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes )
 	{
 		try
 		{
@@ -323,13 +323,12 @@ struct DispatchSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
 struct PostDispatchSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes, bool success )
+	void operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes, bool success )
 	{
 		try
 		{
@@ -345,7 +344,6 @@ struct PostDispatchSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferImageModule/CatalogueBinding.cpp
+++ b/src/GafferImageModule/CatalogueBinding.cpp
@@ -57,7 +57,7 @@ namespace
 
 struct DriverCreatedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, IECoreImage::DisplayDriver *driver, const IECore::CompoundData *parameters )
+	void operator()( boost::python::object slot, IECoreImage::DisplayDriver *driver, const IECore::CompoundData *parameters )
 	{
 		try
 		{
@@ -67,7 +67,6 @@ struct DriverCreatedSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferImageUIModule/ImageGadgetBinding.cpp
+++ b/src/GafferImageUIModule/ImageGadgetBinding.cpp
@@ -82,7 +82,7 @@ Imath::V2f pixelAt( const ImageGadget &g, const IECore::LineSegment3f &lineInGad
 
 struct ImageGadgetSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ImageGadgetPtr g )
+	void operator()( boost::python::object slot, ImageGadgetPtr g )
 	{
 		try
 		{
@@ -92,7 +92,6 @@ struct ImageGadgetSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/AnimationBinding.cpp
+++ b/src/GafferModule/AnimationBinding.cpp
@@ -184,8 +184,7 @@ void removeInactiveKeys( Animation::CurvePlug &p )
 
 struct CurvePlugKeySlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot,
-		const Animation::CurvePlugPtr c, const Animation::KeyPtr k )
+	void operator()( boost::python::object slot, const Animation::CurvePlugPtr c, const Animation::KeyPtr k )
 	{
 		try
 		{
@@ -195,7 +194,6 @@ struct CurvePlugKeySlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/ApplicationRootBinding.cpp
+++ b/src/GafferModule/ApplicationRootBinding.cpp
@@ -114,7 +114,7 @@ IECore::ObjectPtr getClipboardContents( ApplicationRoot &a )
 
 struct ClipboardSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ApplicationRootPtr a )
+	void operator()( boost::python::object slot, ApplicationRootPtr a )
 	{
 		try
 		{
@@ -124,7 +124,6 @@ struct ClipboardSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/ContextBinding.cpp
+++ b/src/GafferModule/ContextBinding.cpp
@@ -130,7 +130,7 @@ list names( const Context &context )
 
 struct ChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ConstContextPtr context, const IECore::InternedString &name )
+	void operator()( boost::python::object slot, ConstContextPtr context, const IECore::InternedString &name )
 	{
 		try
 		{
@@ -140,7 +140,6 @@ struct ChangedSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/ExpressionBinding.cpp
+++ b/src/GafferModule/ExpressionBinding.cpp
@@ -92,7 +92,7 @@ struct ExpressionEngineCreator
 
 struct ExpressionChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ExpressionPtr e )
+	void operator()( boost::python::object slot, ExpressionPtr e )
 	{
 		try
 		{
@@ -102,7 +102,6 @@ struct ExpressionChangedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -255,7 +255,7 @@ std::string repr( const GraphComponent *g )
 
 struct UnarySlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, GraphComponentPtr g )
+	void operator()( boost::python::object slot, GraphComponentPtr g )
 	{
 		try
 		{
@@ -265,14 +265,13 @@ struct UnarySlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
 struct BinarySlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, GraphComponentPtr g, GraphComponentPtr gg )
+	void operator()( boost::python::object slot, GraphComponentPtr g, GraphComponentPtr gg )
 	{
 		try
 		{
@@ -282,14 +281,13 @@ struct BinarySlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
 struct ChildrenReorderedSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, GraphComponentPtr g, const std::vector<size_t> &oldIndices )
+	void operator()( boost::python::object slot, GraphComponentPtr g, const std::vector<size_t> &oldIndices )
 	{
 		try
 		{
@@ -304,7 +302,6 @@ struct ChildrenReorderedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -248,34 +248,29 @@ void registerPlugValue( IECore::TypeId nodeTypeId, const char *plugPath, IECore:
 struct ValueChangedSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::InternedString target, IECore::InternedString key )
+	void operator()( boost::python::object slot, IECore::InternedString target, IECore::InternedString key )
 	{
 		slot( target.c_str(), key.c_str() );
-		return boost::signals::detail::unusable();
 	}
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, Node *node, IECore::InternedString key, Metadata::ValueChangedReason reason )
+	void operator()( boost::python::object slot, Node *node, IECore::InternedString key, Metadata::ValueChangedReason reason )
 	{
 		slot( NodePtr( node ), key.c_str(), reason );
-		return boost::signals::detail::unusable();
 	}
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, Plug *plug, IECore::InternedString key, Metadata::ValueChangedReason reason )
+	void operator()( boost::python::object slot, Plug *plug, IECore::InternedString key, Metadata::ValueChangedReason reason )
 	{
 		slot( PlugPtr( plug ), key.c_str(), reason );
-		return boost::signals::detail::unusable();
 	}
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::TypeId nodeTypeId, IECore::InternedString key, Node *node )
+	void operator()( boost::python::object slot, IECore::TypeId nodeTypeId, IECore::InternedString key, Node *node )
 	{
 		slot( nodeTypeId, key.c_str(), NodePtr( node ) );
-		return boost::signals::detail::unusable();
 	}
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Plug *plug )
+	void operator()( boost::python::object slot, IECore::TypeId nodeTypeId, const StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Plug *plug )
 	{
 		slot( nodeTypeId, plugPath.c_str(), key.c_str(), PlugPtr( plug ) );
-		return boost::signals::detail::unusable();
 	}
 
 };

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -60,7 +60,7 @@ namespace
 
 struct UnaryPlugSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, PlugPtr p )
+	void operator()( boost::python::object slot, PlugPtr p )
 	{
 		try
 		{
@@ -70,14 +70,13 @@ struct UnaryPlugSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
 struct BinaryPlugSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, PlugPtr p1, PlugPtr p2 )
+	void operator()( boost::python::object slot, PlugPtr p1, PlugPtr p2 )
 	{
 		try
 		{
@@ -87,13 +86,12 @@ struct BinaryPlugSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
 struct ErrorSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, const Plug *plug, const Plug *source, const std::string &error )
+	void operator()( boost::python::object slot, const Plug *plug, const Plug *source, const std::string &error )
 	{
 		try
 		{
@@ -103,7 +101,6 @@ struct ErrorSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -435,10 +435,9 @@ void delSlice( Path &p, boost::python::slice s )
 
 struct PathChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, PathPtr p )
+	void operator()( boost::python::object slot, PathPtr p )
 	{
 		slot( p );
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/PathFilterBinding.cpp
+++ b/src/GafferModule/PathFilterBinding.cpp
@@ -125,10 +125,9 @@ list filter( PathFilter &f, list pythonPaths, const IECore::Canceller *canceller
 
 struct ChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, PathFilterPtr f )
+	void operator()( boost::python::object slot, PathFilterPtr f )
 	{
 		slot( f );
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -488,7 +488,7 @@ bool importFile( ScriptNode &s, const std::string &fileName, Node *parent, bool 
 struct ActionSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, ScriptNodePtr script, ConstActionPtr action, Action::Stage stage )
+	void operator()( boost::python::object slot, ScriptNodePtr script, ConstActionPtr action, Action::Stage stage )
 	{
 		try
 		{
@@ -498,7 +498,6 @@ struct ActionSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 
 };
@@ -506,7 +505,7 @@ struct ActionSlotCaller
 struct UndoAddedSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, ScriptNodePtr script )
+	void operator()( boost::python::object slot, ScriptNodePtr script )
 	{
 		try
 		{
@@ -516,7 +515,6 @@ struct UndoAddedSlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 
 };
@@ -524,7 +522,7 @@ struct UndoAddedSlotCaller
 struct FocusChangedSlotCaller
 {
 
-	boost::signals::detail::unusable operator()( boost::python::object slot, ScriptNodePtr script, NodePtr node )
+	void operator()( boost::python::object slot, ScriptNodePtr script, NodePtr node )
 	{
 		try
 		{
@@ -534,7 +532,6 @@ struct FocusChangedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 
 };

--- a/src/GafferModule/SetBinding.cpp
+++ b/src/GafferModule/SetBinding.cpp
@@ -103,7 +103,7 @@ boost::python::list getSlice( Set &s, boost::python::slice sl )
 
 struct MemberSignalSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, const SetPtr s, const Set::MemberPtr m )
+	void operator()( boost::python::object slot, const SetPtr s, const Set::MemberPtr m )
 	{
 		try
 		{
@@ -113,7 +113,6 @@ struct MemberSignalSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferModule/SignalBinding.cpp
+++ b/src/GafferModule/SignalBinding.cpp
@@ -166,36 +166,6 @@ void bind( const char *name )
 
 }
 
-// If a boost::signal has a return type of void, it gets converted
-// to a return type of boost::signals::detail::unusable. We register
-// this converter so that we can accept a None return from a python
-// slot where boost::signals::detail::unusable is expected.
-struct UnusableFromNone
-{
-
-	UnusableFromNone()
-	{
-		boost::python::converter::registry::push_back(
-			&convertible,
-			&construct,
-			boost::python::type_id<boost::signals::detail::unusable>()
-		);
-	}
-
-	static void *convertible( PyObject *obj )
-	{
-		return obj == Py_None ? obj : nullptr;
-	}
-
-	static void construct( PyObject *obj, boost::python::converter::rvalue_from_python_stage1_data *data )
-	{
-		void *storage = (( converter::rvalue_from_python_storage<boost::signals::detail::unusable>* ) data )->storage.bytes;
-		boost::signals::detail::unusable *unusable = new( storage ) boost::signals::detail::unusable();
-		data->convertible = unusable;
-	}
-
-};
-
 } // namespace
 
 void GafferModule::bindSignal()
@@ -212,7 +182,5 @@ void GafferModule::bindSignal()
 	bind<Signal1>( "Signal1" );
 	bind<Signal2>( "Signal2" );
 	bind<Signal3>( "Signal3" );
-
-	UnusableFromNone();
 
 }

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -261,7 +261,7 @@ namespace
 
 struct ReferenceLoadedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ReferencePtr r )
+	void operator()( boost::python::object slot, ReferencePtr r )
 	{
 		try
 		{
@@ -271,7 +271,6 @@ struct ReferenceLoadedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -99,7 +99,7 @@ void waitForCompletion( SceneGadget &g )
 
 struct SceneGadgetSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, SceneGadgetPtr g )
+	void operator()( boost::python::object slot, SceneGadgetPtr g )
 	{
 		try
 		{
@@ -109,7 +109,6 @@ struct SceneGadgetSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -78,7 +78,7 @@ Gaffer::BoolPlugPtr cropWindowToolEnabledPlugWrapper( CropWindowTool &tool )
 
 struct StatusChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, CropWindowTool &t )
+	void operator()( boost::python::object slot, CropWindowTool &t )
 	{
 		try
 		{
@@ -88,7 +88,6 @@ struct StatusChangedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
@@ -116,7 +115,7 @@ bool selectionEditable( const TransformTool &tool )
 
 struct SelectionChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, TransformTool &t )
+	void operator()( boost::python::object slot, TransformTool &t )
 	{
 		try
 		{
@@ -126,7 +125,6 @@ struct SelectionChangedSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferSceneUIModule/ViewBinding.cpp
+++ b/src/GafferSceneUIModule/ViewBinding.cpp
@@ -226,18 +226,16 @@ boost::python::list registeredScenes( const IECore::InternedString &shaderPrefix
 
 struct SceneChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ShaderViewPtr v )
+	void operator()( boost::python::object slot, ShaderViewPtr v )
 	{
 		try
 		{
 			slot( v );
-			return boost::signals::detail::unusable();
 		}
 		catch( const boost::python::error_already_set &e )
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 
@@ -258,7 +256,7 @@ void setPaused( UVView &v, bool paused )
 
 struct UVViewSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, UVViewPtr g )
+	void operator()( boost::python::object slot, UVViewPtr g )
 	{
 		try
 		{
@@ -268,7 +266,6 @@ struct UVViewSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -58,10 +58,9 @@ namespace
 
 struct VisibilityChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, GadgetPtr g )
+	void operator()( boost::python::object slot, GadgetPtr g )
 	{
 		slot( g );
-		return boost::signals::detail::unusable();
 	}
 };
 
@@ -83,17 +82,15 @@ struct ButtonSlotCaller
 
 struct EnterLeaveSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, GadgetPtr g, const ButtonEvent &event )
+	void operator()( boost::python::object slot, GadgetPtr g, const ButtonEvent &event )
 	{
 		try
 		{
 			slot( g, event );
-			return boost::signals::detail::unusable();
 		}
 		catch( const boost::python::error_already_set &e )
 		{
 			PyErr_PrintEx( 0 ); // also clears the python error status
-			return boost::signals::detail::unusable();
 		}
 	}
 };

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -76,10 +76,9 @@ void setFilter( GraphGadget &graphGadget, Gaffer::SetPtr filter )
 
 struct RootChangedSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, GraphGadgetPtr g, Gaffer::NodePtr n )
+	void operator()( boost::python::object slot, GraphGadgetPtr g, Gaffer::NodePtr n )
 	{
 		slot( g , n );
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -66,7 +66,7 @@ namespace
 
 struct NoduleSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, NodeGadget *nodeGadget, Nodule *nodule )
+	void operator()( boost::python::object slot, NodeGadget *nodeGadget, Nodule *nodule )
 	{
 		try
 		{
@@ -76,7 +76,6 @@ struct NoduleSlotCaller
 		{
 			ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -158,7 +158,7 @@ void cellDataSetToolTip( PathColumn::CellData &cellData, const ConstDataPtr &dat
 
 struct ChangedSignalSlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, PathColumnPtr c )
+	void operator()( boost::python::object slot, PathColumnPtr c )
 	{
 		try
 		{
@@ -168,7 +168,6 @@ struct ChangedSignalSlotCaller
 		{
 			IECorePython::ExceptionAlgo::translatePythonException();
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferUIModule/StyleBinding.cpp
+++ b/src/GafferUIModule/StyleBinding.cpp
@@ -58,10 +58,9 @@ namespace
 
 struct UnarySlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, StylePtr s )
+	void operator()( boost::python::object slot, StylePtr s )
 	{
 		slot( s );
-		return boost::signals::detail::unusable();
 	}
 };
 

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -120,7 +120,7 @@ list gadgetsAt2( ViewportGadget &v, const Imath::Box2f &region, Gadget::Layer fi
 
 struct UnarySlotCaller
 {
-	boost::signals::detail::unusable operator()( boost::python::object slot, ViewportGadgetPtr g )
+	void operator()( boost::python::object slot, ViewportGadgetPtr g )
 	{
 		try
 		{
@@ -130,7 +130,6 @@ struct UnarySlotCaller
 		{
 			PyErr_PrintEx( 0 ); // clears the error status
 		}
-		return boost::signals::detail::unusable();
 	}
 };
 


### PR DESCRIPTION
This tidies up some aspects of our signal bindings, helping pave the way for an eventual replacement of the defunct `boost::signal` library that we currently rely on.