### PR TITLE
Use C++17 features

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ API
 
 - Signals : Removed usage of `boost::signals::detail::unusable` as a substitute for the `void` return type in the Signal bindings. Custom SlotCallers may now use a standard `void` return type.
 
+Breaking Changes
+----------------
+
+- Replaced all usage of `boost::optional` with `std::optional`.
+
 Build
 -----
 

--- a/include/Gaffer/ContextAlgo.h
+++ b/include/Gaffer/ContextAlgo.h
@@ -69,7 +69,7 @@ class GAFFER_API GlobalScope : boost::noncopyable
 
 	private :
 
-		boost::optional<Context::EditableScope> m_scope;
+		std::optional<Context::EditableScope> m_scope;
 
 };
 

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -122,7 +122,7 @@ class LRUCache : private boost::noncopyable
 
 		/// Retrieves an item from the cache if it has been computed or set
 		/// previously. Throws if a previous call to `get()` failed.
-		boost::optional<Value> getIfCached( const Key &key );
+		std::optional<Value> getIfCached( const Key &key );
 
 		/// Adds an item to the cache directly, bypassing the GetterFunction.
 		/// Returns true for success and false on failure - failure can occur

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -1154,12 +1154,12 @@ Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key, const 
 }
 
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
-boost::optional<Value> LRUCache<Key, Value, Policy, GetterKey>::getIfCached( const Key &key )
+std::optional<Value> LRUCache<Key, Value, Policy, GetterKey>::getIfCached( const Key &key )
 {
 	typename Policy<LRUCache>::Handle handle;
 	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindReadable, /* canceller = */ nullptr ) )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 
 	const CacheEntry &cacheEntry = handle.readable();
@@ -1167,7 +1167,7 @@ boost::optional<Value> LRUCache<Key, Value, Policy, GetterKey>::getIfCached( con
 
 	if( status==Uncached )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 	else if( status==Cached )
 	{

--- a/include/Gaffer/Private/IECorePreview/Messages.h
+++ b/include/Gaffer/Private/IECorePreview/Messages.h
@@ -40,9 +40,8 @@
 #include "IECore/MessageHandler.h"
 #include "IECore/MurmurHash.h"
 
-#include <boost/optional.hpp>
-
 #include <array>
+#include <optional>
 #include <vector>
 
 namespace IECorePreview
@@ -94,11 +93,11 @@ class GAFFER_API Messages
 		size_t count( const IECore::MessageHandler::Level &level ) const;
 
 		/// The index of the first message that differs to the messages in
-		/// the other container. boost::none is returned if:
+		/// the other container. std::nullopt is returned if :
 		///  - This container is empty.
-		///  - This containers messages match those in others, and others
+		///  - This container's messages match those in others, and others
 		///    is of equal or greater size.
-		boost::optional<size_t> firstDifference( const Messages &others ) const;
+		std::optional<size_t> firstDifference( const Messages &others ) const;
 
 		/// The hash of all messages in the container.  Messages are hashed
 		/// when they are added, so this is cheap.

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -188,7 +188,7 @@ class TaskMutex : boost::noncopyable
 						}
 					};
 
-					boost::optional<tbb::task_group_status> status;
+					std::optional<tbb::task_group_status> status;
 					m_mutex->m_executionState->arena.execute(
 						[this, &fWrapper, &status] {
 							// Prior to TBB 2018 Update 3, `run_and_wait()` is buggy,

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -44,8 +44,6 @@
 
 #include "IECore/CompoundData.h"
 
-#include "boost/optional.hpp"
-
 namespace Gaffer
 {
 
@@ -183,7 +181,7 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 
 		/// Returns the path specified by `parentPlug()`, only if it is non-empty
 		/// and is valid within the input scene.
-		boost::optional<ScenePlug::ScenePath> parentPlugPath() const;
+		std::optional<ScenePlug::ScenePath> parentPlugPath() const;
 
 		/// BranchesData telling us what branches we need to make.
 		Gaffer::ObjectPlug *branchesPlug();

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -115,7 +115,7 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 			const ScenePlug *scene;
 		};
 
-		boost::optional<Target> target() const;
+		std::optional<Target> target() const;
 
 		static size_t g_firstPlugIndex;
 

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -97,7 +97,7 @@ struct GAFFERSCENE_API TransformEdit
 };
 
 GAFFERSCENE_API bool hasTransformEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
-GAFFERSCENE_API boost::optional<TransformEdit> acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary = true );
+GAFFERSCENE_API std::optional<TransformEdit> acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary = true );
 GAFFERSCENE_API void removeTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
 GAFFERSCENE_API const Gaffer::GraphComponent *transformEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path );
 

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -98,7 +98,7 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 
 				// Initialised lazily when we first
 				// acquire the transform plug.
-				mutable boost::optional<Imath::Eulerf> m_originalRotation; // Radians
+				mutable std::optional<Imath::Eulerf> m_originalRotation; // Radians
 
 		};
 

--- a/include/GafferSceneUI/ScaleTool.h
+++ b/include/GafferSceneUI/ScaleTool.h
@@ -88,7 +88,7 @@ class GAFFERSCENEUI_API ScaleTool : public TransformTool
 
 				// Initialised lazily when we first
 				// acquire the transform plug.
-				boost::optional<Imath::V3f> m_originalScale;
+				std::optional<Imath::V3f> m_originalScale;
 
 		};
 

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -132,7 +132,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 			/// Returns the plugs to edit. Throws if `status() != Editable`.
 			/// > Caution : When using EditScopes, this may edit the graph
 			/// > to create the plug unless `createIfNecessary == false`.
-			boost::optional<TransformEdit> acquireTransformEdit( bool createIfNecessary = true ) const;
+			std::optional<TransformEdit> acquireTransformEdit( bool createIfNecessary = true ) const;
 			/// The EditScope passed to the constructor.
 			const Gaffer::EditScope *editScope() const;
 			/// Returns the GraphComponent that will be edited.
@@ -193,7 +193,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 				bool m_editable;
 				std::string m_warning;
 				Gaffer::EditScopePtr m_editScope;
-				mutable boost::optional<TransformEdit> m_transformEdit;
+				mutable std::optional<TransformEdit> m_transformEdit;
 				Imath::M44f m_transformSpace;
 				bool m_aimConstraint;
 

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -96,7 +96,7 @@ class GAFFERSCENEUI_API TranslateTool : public TransformTool
 
 				// Initialised lazily when we first
 				// acquire the transform plug.
-				boost::optional<Imath::V3f> m_origin;
+				std::optional<Imath::V3f> m_origin;
 
 		};
 

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -42,8 +42,6 @@
 #include "Gaffer/Animation.h"
 #include "Gaffer/StandardSet.h"
 
-#include "boost/optional.hpp"
-
 namespace Gaffer
 {
 
@@ -197,7 +195,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 		int m_textScale;
 		int m_labelPadding;
 
-		boost::optional<int> m_frameIndicatorPreviewFrame;
+		std::optional<int> m_frameIndicatorPreviewFrame;
 
 };
 

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -104,7 +104,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 		int m_verticalDragEdge;
 		int m_mergeGroupId;
 
-		boost::optional<Imath::Color3f> m_userColor;
+		std::optional<Imath::Color3f> m_userColor;
 
 		static NodeGadgetTypeDescription<BackdropNodeGadget> g_nodeGadgetTypeDescription;
 

--- a/include/GafferUI/StandardConnectionGadget.h
+++ b/include/GafferUI/StandardConnectionGadget.h
@@ -135,7 +135,7 @@ class GAFFERUI_API StandardConnectionGadget : public ConnectionGadget
 		/// classes so we can show which end is being
 		/// hovered.
 		bool m_hovering;
-		boost::optional<Imath::Color3f> m_userColor;
+		std::optional<Imath::Color3f> m_userColor;
 
 		bool m_dotPreview;
 		Imath::V3f m_dotPreviewLocation;

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -177,7 +177,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		// the user with a bigger drag target that is easier
 		// to hit.
 		ConnectionCreator *m_dragDestination;
-		boost::optional<Imath::Color3f> m_userColor;
+		std::optional<Imath::Color3f> m_userColor;
 		bool m_oval;
 		bool m_auxiliary;
 

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -102,7 +102,7 @@ class GAFFERUI_API StandardNodule : public Nodule
 		bool m_draggingConnection;
 		Imath::V3f m_dragPosition;
 		Imath::V3f m_dragTangent;
-		boost::optional<Imath::Color3f> m_userColor;
+		std::optional<Imath::Color3f> m_userColor;
 
 		static NoduleTypeDescription<StandardNodule> g_noduleTypeDescription;
 

--- a/src/Gaffer/IECorePreview/Messages.cpp
+++ b/src/Gaffer/IECorePreview/Messages.cpp
@@ -119,11 +119,11 @@ size_t Messages::count( const IECore::MessageHandler::Level &level ) const
 	return m_counts[ int(level) ];
 }
 
-boost::optional<size_t> Messages::firstDifference( const Messages &other ) const
+std::optional<size_t> Messages::firstDifference( const Messages &other ) const
 {
 	if( size() == 0 )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 
 	if( other.size() == 0 )
@@ -170,7 +170,7 @@ boost::optional<size_t> Messages::firstDifference( const Messages &other ) const
 		return numComparableMessages;
 	}
 
-	return boost::none;
+	return std::nullopt;
 }
 
 IECore::MurmurHash Messages::hash() const

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -49,7 +49,6 @@
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
-#include "boost/optional.hpp"
 
 #include "tbb/tbb.h"
 
@@ -327,7 +326,7 @@ InstanceValues *instanceMetadata( const GraphComponent *instance, bool createIfM
 // It's valid to register null as an instance value and expect it to override
 // any non-null registration. We use OptionalData as a way of distinguishing
 // between an explicit registration of null and no registration at all.
-typedef boost::optional<ConstDataPtr> OptionalData;
+typedef std::optional<ConstDataPtr> OptionalData;
 
 OptionalData instanceValue( const GraphComponent *instance, InternedString key, bool *persistent = nullptr )
 {

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -333,7 +333,7 @@ class RowsMapScope : boost::noncopyable, public Context::SubstitutionProvider
 	private :
 
 		const Context *m_context;
-		mutable boost::optional<Context::EditableScope> m_scope;
+		mutable std::optional<Context::EditableScope> m_scope;
 		RowsMap::Selector m_selector;
 
 };

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -320,7 +320,7 @@ size_t Switch::inputIndex( const Context *context ) const
 	// Create a GlobalScope if either the `index` or `enabled` plugs will launch
 	// an upstream compute. This avoids leakage of context variables such as
 	// `scene:path`.
-	boost::optional<ContextAlgo::GlobalScope> globalScope;
+	std::optional<ContextAlgo::GlobalScope> globalScope;
 	if( variesWithContext( enabledPlug ) || variesWithContext( indexPlug ) )
 	{
 		globalScope.emplace( context, globalScopePlug );

--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -154,7 +154,7 @@ class ImageTransform::ChainingScope : boost::noncopyable
 
 		// We use `optional` here to avoid the expense of constructing
 		// an EditableScope when we don't need one.
-		boost::optional<Context::EditableScope> m_scope;
+		std::optional<Context::EditableScope> m_scope;
 		bool m_chained;
 		bool m_true;
 
@@ -190,7 +190,7 @@ class ImageTransform::CleanScope : boost::noncopyable
 	private :
 
 		const Context *m_context;
-		boost::optional<Context::EditableScope> m_scope;
+		std::optional<Context::EditableScope> m_scope;
 
 };
 

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -519,12 +519,12 @@ void BranchCreator::affects( const Plug *input, AffectedPlugsContainer &outputs 
 	}
 }
 
-boost::optional<ScenePlug::ScenePath> BranchCreator::parentPlugPath() const
+std::optional<ScenePlug::ScenePath> BranchCreator::parentPlugPath() const
 {
 	const string parentAsString = parentPlug()->getValue();
 	if( parentAsString.empty() )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 
 	ScenePlug::ScenePath parent;
@@ -534,7 +534,7 @@ boost::optional<ScenePlug::ScenePath> BranchCreator::parentPlugPath() const
 		return parent;
 	}
 
-	return boost::none;
+	return std::nullopt;
 }
 
 void BranchCreator::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -48,8 +48,6 @@
 
 #include "tbb/spin_mutex.h"
 
-#include "boost/make_unique.hpp"
-
 #include <unordered_map>
 
 using namespace std;
@@ -334,7 +332,7 @@ class BranchCreator::BranchesData : public IECore::Data
 				if( inserted.second )
 				{
 					const bool exists = location->depth < existing.size();
-					inserted.first->second = boost::make_unique<Location>( location->depth + 1, exists );
+					inserted.first->second = std::make_unique<Location>( location->depth + 1, exists );
 					if( !exists )
 					{
 						if( !location->newChildNames )

--- a/src/GafferScene/Constraint.cpp
+++ b/src/GafferScene/Constraint.cpp
@@ -484,7 +484,7 @@ struct UVIndexer
 private:
 
 	const std::vector< int >* m_indices;
-	boost::optional< IECoreScene::PrimitiveVariable::IndexedView< Imath::V2f > > m_view;
+	std::optional<IECoreScene::PrimitiveVariable::IndexedView<Imath::V2f>> m_view;
 };
 
 void computePrimitiveVertexLocalFrame( const IECoreScene::Primitive& primitive, Imath::M44f& m, const int vertexId, const bool throwOnError )
@@ -1050,12 +1050,12 @@ Imath::M44f Constraint::computeProcessedTransform( const ScenePath &path, const 
 	return fullConstrainedTransform * parentTransform.inverse();
 }
 
-boost::optional<Constraint::Target> Constraint::target() const
+std::optional<Constraint::Target> Constraint::target() const
 {
 	std::string targetPathAsString = targetPlug()->getValue();
 	if( targetPathAsString == "" )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 
 	ScenePath targetPath;
@@ -1073,7 +1073,7 @@ boost::optional<Constraint::Target> Constraint::target() const
 	{
 		if( ignoreMissingTargetPlug()->getValue() )
 		{
-			return boost::none;
+			return std::nullopt;
 		}
 		else
 		{

--- a/src/GafferScene/CopyPrimitiveVariables.cpp
+++ b/src/GafferScene/CopyPrimitiveVariables.cpp
@@ -123,15 +123,11 @@ void CopyPrimitiveVariables::hashProcessedObject( const ScenePath &path, const G
 	primitiveVariablesPlug()->hash( h );
 	prefixPlug()->hash( h );
 
-	boost::optional<ScenePath> sourceLocationPath;
+	std::optional<ScenePath> sourceLocationPath;
 	const string sourceLocation = sourceLocationPlug()->getValue();
 	if( !sourceLocation.empty() )
 	{
-		/// \todo When we can use `std::optional` from C++17, `emplace()`
-		/// will return a reference, allowing us to call
-		/// `stringToPath( sourceLocation, sourceLocationPath.emplace() )`.
-		sourceLocationPath.emplace();
-		ScenePlug::stringToPath( sourceLocation, *sourceLocationPath );
+		ScenePlug::stringToPath( sourceLocation, sourceLocationPath.emplace() );
 	}
 
 	if( !sourcePlug()->exists( sourceLocationPath ? *sourceLocationPath : path ) )
@@ -166,15 +162,11 @@ IECore::ConstObjectPtr CopyPrimitiveVariables::computeProcessedObject( const Sce
 
 	const string prefix = prefixPlug()->getValue();
 
-	boost::optional<ScenePath> sourceLocationPath;
+	std::optional<ScenePath> sourceLocationPath;
 	const string sourceLocation = sourceLocationPlug()->getValue();
 	if( !sourceLocation.empty() )
 	{
-		/// \todo When we can use `std::optional` from C++17, `emplace()`
-		/// will return a reference, allowing us to call
-		/// `stringToPath( sourceLocation, copyFromPath.emplace() )`.
-		sourceLocationPath.emplace();
-		ScenePlug::stringToPath( sourceLocation, *sourceLocationPath );
+		ScenePlug::stringToPath( sourceLocation, sourceLocationPath.emplace() );
 	}
 
 	if( !sourcePlug()->exists( sourceLocationPath ? *sourceLocationPath : path ) )

--- a/src/GafferScene/CurveSampler.cpp
+++ b/src/GafferScene/CurveSampler.cpp
@@ -103,8 +103,8 @@ PrimitiveSampler::SamplingFunction CurveSampler::computeSamplingFunction( const 
 	const std::string curveIndex = curveIndexPlug()->getValue();
 	const std::string v = vPlug()->getValue();
 
-	boost::optional<PrimitiveVariable::IndexedView<int>> curveIndexView;
-	boost::optional<PrimitiveVariable::IndexedView<float>> vView;
+	std::optional<PrimitiveVariable::IndexedView<int>> curveIndexView;
+	std::optional<PrimitiveVariable::IndexedView<float>> vView;
 
 	if( !curveIndex.empty() )
 	{

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -254,7 +254,7 @@ bool EditScopeAlgo::TransformEdit::operator != ( const TransformEdit &rhs ) cons
 	return !(*this == rhs);
 }
 
-boost::optional<GafferScene::EditScopeAlgo::TransformEdit> GafferScene::EditScopeAlgo::acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary )
+std::optional<GafferScene::EditScopeAlgo::TransformEdit> GafferScene::EditScopeAlgo::acquireTransformEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, bool createIfNecessary )
 {
 	string pathString;
 	ScenePlug::pathToString( path, pathString );
@@ -262,7 +262,7 @@ boost::optional<GafferScene::EditScopeAlgo::TransformEdit> GafferScene::EditScop
 	auto *processor = scope->acquireProcessor<SceneProcessor>( "TransformEdits", createIfNecessary );
 	if( !processor )
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 
 	auto *rows = processor->getChild<Spreadsheet::RowsPlug>( "edits" );
@@ -271,7 +271,7 @@ boost::optional<GafferScene::EditScopeAlgo::TransformEdit> GafferScene::EditScop
 	{
 		if( !createIfNecessary )
 		{
-			return boost::none;
+			return std::nullopt;
 		}
 		row = rows->addRow();
 		row->namePlug()->setValue( pathString );

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -543,8 +543,7 @@ class Instancer::EngineData : public Data
 				totalHashAccumulate.insert( totalHash );
 			}
 
-			// \todo - should use make_unique once we standardize on C++14
-			std::unique_ptr<PrototypeHashes> result( new PrototypeHashes() );
+			auto result = std::make_unique<PrototypeHashes>();
 			for( unsigned int j = 0; j < m_prototypeContextVariables.size(); j++ )
 			{
 				(*result)[ m_prototypeContextVariables[j].name ] = variableHashAccumulate[j];

--- a/src/GafferScene/Orientation.cpp
+++ b/src/GafferScene/Orientation.cpp
@@ -222,7 +222,7 @@ PrimitiveVariable inAim( const Primitive *inputPrimitive, Primitive *outputPrimi
 {
 	ViewSpec spec;
 
-	using OptionalVector = boost::optional<PrimitiveVariable::IndexedView<V3f>>;
+	using OptionalVector = std::optional<PrimitiveVariable::IndexedView<V3f>>;
 	OptionalVector xAxis, yAxis, zAxis;
 
 	if( xAxisName != "" )

--- a/src/GafferScene/Unencapsulate.cpp
+++ b/src/GafferScene/Unencapsulate.cpp
@@ -131,7 +131,7 @@ class CapsuleScope : boost::noncopyable
 
 		// We use `optional` here to avoid the expense of constructing
 		// an EditableScope when we don't need one.
-		boost::optional<Context::EditableScope> m_scope;
+		std::optional<Context::EditableScope> m_scope;
 		IECore::ConstObjectPtr m_object;
 		const Capsule* m_capsule;
 		ScenePlug::ScenePath m_capsulePath;

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -221,7 +221,7 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 			/// raster scope bit manually? Maybe that would let us write more reusable
 			/// gadgets, which could be used in any space, and we wouldn't need
 			/// eventPosition().
-			boost::optional<ViewportGadget::RasterScope> rasterScope;
+			std::optional<ViewportGadget::RasterScope> rasterScope;
 			if( m_rasterSpace )
 			{
 				rasterScope.emplace( ancestor<ViewportGadget>() );

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -584,7 +584,7 @@ const std::string &TransformTool::Selection::warning() const
 	return m_warning;
 }
 
-boost::optional<TransformTool::Selection::TransformEdit> TransformTool::Selection::acquireTransformEdit( bool createIfNecessary ) const
+std::optional<TransformTool::Selection::TransformEdit> TransformTool::Selection::acquireTransformEdit( bool createIfNecessary ) const
 {
 	throwIfNotEditable();
 	if( !m_transformEdit && createIfNecessary )

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -512,7 +512,7 @@ AnimationGadget::AnimationGadget()
 , m_yMargin( 20 )
 , m_textScale( 10 )
 , m_labelPadding( 5 )
-, m_frameIndicatorPreviewFrame( boost::none )
+, m_frameIndicatorPreviewFrame( std::nullopt )
 {
 	buttonPressSignal().connect( boost::bind( &AnimationGadget::buttonPress, this, ::_1,  ::_2 ) );
 	buttonReleaseSignal().connect( boost::bind( &AnimationGadget::buttonRelease, this, ::_1,  ::_2 ) );
@@ -684,7 +684,7 @@ void AnimationGadget::renderLayer( Layer layer, const Style *style, RenderReason
 
 		if( m_frameIndicatorPreviewFrame )
 		{
-			renderFrameIndicator( m_frameIndicatorPreviewFrame.get(), style, /* preview = */ true );
+			renderFrameIndicator( m_frameIndicatorPreviewFrame.value(), style, /* preview = */ true );
 		}
 
 		renderFrameIndicator( static_cast<int>( m_context->getFrame() ), style );
@@ -1103,8 +1103,8 @@ bool AnimationGadget::buttonPress( GadgetPtr gadget, const ButtonEvent &event )
 
 	if( event.button == ButtonEvent::Left && m_frameIndicatorPreviewFrame )
 	{
-		m_context->setFrame( m_frameIndicatorPreviewFrame.get() );
-		m_frameIndicatorPreviewFrame = boost::none;
+		m_context->setFrame( m_frameIndicatorPreviewFrame.value() );
+		m_frameIndicatorPreviewFrame = std::nullopt;
 	}
 
 	return true;
@@ -1247,7 +1247,7 @@ IECore::RunTimeTypedPtr AnimationGadget::dragBegin( GadgetPtr gadget, const Drag
 		else if( ( onTimeAxis( event.line ) && ! onValueAxis( event.line ) ) || frameIndicatorUnderMouse( event.line ) )
 		{
 			m_dragMode = DragMode::MoveFrame;
-			m_frameIndicatorPreviewFrame = boost::none;
+			m_frameIndicatorPreviewFrame = std::nullopt;
 		}
 		else // treating everything else as background and start selection
 		{
@@ -1322,7 +1322,7 @@ bool AnimationGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
 	}
 	else
 	{
-		m_frameIndicatorPreviewFrame = boost::none;
+		m_frameIndicatorPreviewFrame = std::nullopt;
 	}
 
 	std::pair<Gaffer::Animation::KeyPtr, Gaffer::Animation::Direction> tangent = tangentAt( event.line );
@@ -1533,7 +1533,7 @@ bool AnimationGadget::leave()
 {
 	if( m_frameIndicatorPreviewFrame )
 	{
-		m_frameIndicatorPreviewFrame = boost::none;
+		m_frameIndicatorPreviewFrame = std::nullopt;
 		dirty( DirtyType::Render );
 	}
 	return true;

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -308,7 +308,11 @@ void BackdropNodeGadget::renderLayer( Layer layer, const Style *style, RenderRea
 	{
 		// normal drawing mode
 
-		style->renderBackdrop( bound, getHighlighted() ? Style::HighlightedState : Style::NormalState, m_userColor.get_ptr() );
+		style->renderBackdrop(
+			bound,
+			getHighlighted() ? Style::HighlightedState : Style::NormalState,
+			m_userColor ? &m_userColor.value() : nullptr
+		);
 
 		std::string title, description;
 		titleAndDescriptionFromPlugs( backdrop->titlePlug(), backdrop->descriptionPlug(), title, description );
@@ -573,7 +577,7 @@ void BackdropNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 
 bool BackdropNodeGadget::updateUserColor()
 {
-	boost::optional<Color3f> c;
+	std::optional<Color3f> c;
 	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( node(), g_colorKey ) )
 	{
 		c = d->readable();

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -338,18 +338,27 @@ void StandardConnectionGadget::renderLayer( Layer layer, const Style *style, Ren
 	}
 	else
 	{
-		style->renderConnection( minimisedSrcPos, minimisedSrcTangent, m_dstPos, m_dstTangent, state, m_userColor.get_ptr() );
+		style->renderConnection(
+			minimisedSrcPos, minimisedSrcTangent, m_dstPos, m_dstTangent,
+			state, m_userColor ? &m_userColor.value() : nullptr
+		);
 	}
 
 	if(m_addingConnection)
 	{
-		style->renderConnection( m_srcPos, m_srcTangent, m_dstPosOrig, m_dstTangentOrig, state, m_userColor.get_ptr() );
+		style->renderConnection(
+			m_srcPos, m_srcTangent, m_dstPosOrig, m_dstTangentOrig,
+			state, m_userColor ? &m_userColor.value() : nullptr
+		);
 	}
 
 	if( m_dotPreview )
 	{
 		Imath::Box2f bounds = Imath::Box2f( V2f( m_dotPreviewLocation.x, m_dotPreviewLocation.y ) );
-		style->renderNodeFrame(bounds, 1.0, state, m_userColor.get_ptr()  );
+		style->renderNodeFrame(
+			bounds, 1.0, state,
+			m_userColor ? &m_userColor.value() : nullptr
+		);
 	}
 }
 
@@ -710,7 +719,7 @@ void StandardConnectionGadget::plugMetadataChanged( const Gaffer::Plug *plug, IE
 
 bool StandardConnectionGadget::updateUserColor()
 {
-	boost::optional<Color3f> c;
+	std::optional<Color3f> c;
 	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( dstNodule()->plug(), g_colorKey ) )
 	{
 		c = d->readable();

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -699,7 +699,7 @@ void StandardNodeGadget::renderLayer( Layer layer, const Style *style, RenderRea
 				Box2f( V2f( b.min.x, b.min.y ) + V2f( borderWidth ), V2f( b.max.x, b.max.y ) - V2f( borderWidth ) ),
 				borderWidth,
 				state,
-				m_userColor.get_ptr()
+				userColor()
 			);
 
 			break;
@@ -801,7 +801,7 @@ Imath::Box3f StandardNodeGadget::renderBound() const
 
 const Imath::Color3f *StandardNodeGadget::userColor() const
 {
-	return m_userColor.get_ptr();
+	return m_userColor ? &m_userColor.value() : nullptr;
 }
 
 Nodule *StandardNodeGadget::nodule( const Gaffer::Plug *plug )
@@ -1214,7 +1214,7 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 
 bool StandardNodeGadget::updateUserColor()
 {
-	boost::optional<Color3f> c;
+	std::optional<Color3f> c;
 	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( node(), g_colorKey ) )
 	{
 		c = d->readable();

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -173,7 +173,7 @@ void StandardNodule::renderLayer( Layer layer, const Style *style, RenderReason 
 
 			if( !getHighlighted() )
 			{
-				style->renderNodule( 0.5f, Style::NormalState, m_userColor.get_ptr() );
+				style->renderNodule( 0.5f, Style::NormalState, m_userColor ? &m_userColor.value() : nullptr );
 			}
 			break;
 
@@ -181,7 +181,7 @@ void StandardNodule::renderLayer( Layer layer, const Style *style, RenderReason 
 
 			if( getHighlighted() )
 			{
-				style->renderNodule( 1.0f, Style::HighlightedState, m_userColor.get_ptr() );
+				style->renderNodule( 1.0f, Style::HighlightedState, m_userColor ? &m_userColor.value() : nullptr );
 			}
 			break;
 
@@ -498,7 +498,7 @@ void StandardNodule::plugMetadataChanged( const Gaffer::Plug *plug, IECore::Inte
 
 bool StandardNodule::updateUserColor()
 {
-	boost::optional<Color3f> c;
+	std::optional<Color3f> c;
 	if( IECore::ConstColor3fDataPtr d = Metadata::value<IECore::Color3fData>( plug(), g_colorKey ) )
 	{
 		c = d->readable();

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -1655,12 +1655,12 @@ class PathModel : public QAbstractItemModel
 
 		IECore::PathMatcher m_expandedPaths;
 		bool m_modifyingTreeViewExpansion;
-		boost::optional<Path::Names> m_recursiveExpansionPath;
+		std::optional<Path::Names> m_recursiveExpansionPath;
 
 		IECore::PathMatcher m_selectedPaths;
 		// Parameters used to control expansion update following call to
 		// `setSelection()`.
-		boost::optional<IECore::PathMatcher> m_scrollToCandidates;
+		std::optional<IECore::PathMatcher> m_scrollToCandidates;
 		bool m_expandNonLeafSelection;
 
 		std::unique_ptr<Gaffer::BackgroundTask> m_updateTask;

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -69,7 +69,6 @@
 #include "boost/filesystem/operations.hpp"
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"
-#include "boost/optional.hpp"
 
 #include "ai_array.h"
 #include "ai_msg.h"
@@ -1527,11 +1526,11 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 			IECore::ConstStringVectorDataPtr volumeGrids;
 			IECore::ConstStringVectorDataPtr velocityGrids;
-			boost::optional<float> velocityScale;
-			boost::optional<float> velocityFPS;
-			boost::optional<float> velocityOutlierThreshold;
-			boost::optional<float> stepSize;
-			boost::optional<float> stepScale;
+			std::optional<float> velocityScale;
+			std::optional<float> velocityFPS;
+			std::optional<float> velocityOutlierThreshold;
+			std::optional<float> stepSize;
+			std::optional<float> stepScale;
 
 			void hash( IECore::MurmurHash &h ) const
 			{
@@ -1545,11 +1544,11 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					velocityGrids->hash( h );
 				}
 
-				h.append( velocityScale.get_value_or( 1.0f ) );
-				h.append( velocityFPS.get_value_or( 24.0f ) );
-				h.append( velocityOutlierThreshold.get_value_or( 0.001f ) );
-				h.append( stepSize.get_value_or( 0.0f ) );
-				h.append( stepScale.get_value_or( 1.0f ) );
+				h.append( velocityScale.value_or( 1.0f ) );
+				h.append( velocityFPS.value_or( 24.0f ) );
+				h.append( velocityOutlierThreshold.value_or( 0.001f ) );
+				h.append( stepSize.value_or( 0.0f ) );
+				h.append( stepScale.value_or( 1.0f ) );
 			}
 
 			void apply( AtNode *node ) const
@@ -1566,7 +1565,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeSetArray( node, g_velocityGridsArnoldString, array );
 				}
 
-				if( !velocityScale || velocityScale.get() > 0 )
+				if( !velocityScale || velocityScale.value() > 0 )
 				{
 					AtNode *options = AiUniverseGetOptions( AiNodeGetUniverse( node ) );
 					const AtNode *arnoldCamera = static_cast<const AtNode *>( AiNodeGetPtr( options, g_cameraArnoldString ) );
@@ -1587,26 +1586,26 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 
 				if( velocityScale )
 				{
-					AiNodeSetFlt( node, g_velocityScaleArnoldString, velocityScale.get() );
+					AiNodeSetFlt( node, g_velocityScaleArnoldString, velocityScale.value() );
 				}
 
 				if( velocityFPS )
 				{
-					AiNodeSetFlt( node, g_velocityFPSArnoldString, velocityFPS.get() );
+					AiNodeSetFlt( node, g_velocityFPSArnoldString, velocityFPS.value() );
 				}
 
 				if( velocityOutlierThreshold )
 				{
-					AiNodeSetFlt( node, g_velocityOutlierThresholdArnoldString, velocityOutlierThreshold.get() );
+					AiNodeSetFlt( node, g_velocityOutlierThresholdArnoldString, velocityOutlierThreshold.value() );
 				}
 
 				if ( stepSize )
 				{
-					AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.get() * stepScale.get_value_or( 1.0f ) );
+					AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.value() * stepScale.value_or( 1.0f ) );
 				}
 				else if ( stepScale )
 				{
-					AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.get() );
+					AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.value() );
 				}
 			}
 		};
@@ -1641,11 +1640,11 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		}
 
 		template<typename T>
-		static boost::optional<T> optionalAttribute( const IECore::InternedString &name, const IECore::CompoundObject *attributes )
+		static std::optional<T> optionalAttribute( const IECore::InternedString &name, const IECore::CompoundObject *attributes )
 		{
 			typedef IECore::TypedData<T> DataType;
 			const DataType *data = attribute<DataType>( name, attributes );
-			return data ? data->readable() : boost::optional<T>();
+			return data ? data->readable() : std::optional<T>();
 		}
 
 		static void updateVisibility( unsigned char &visibility, const IECore::InternedString &name, unsigned char rayType, const IECore::CompoundObject *attributes )
@@ -3131,7 +3130,7 @@ class ArnoldGlobals
 			{
 				if( value == nullptr )
 				{
-					m_frame = boost::none;
+					m_frame = std::nullopt;
 				}
 				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
 				{
@@ -3288,7 +3287,7 @@ class ArnoldGlobals
 			{
 				if( value == nullptr )
 				{
-					m_progressiveMinAASamples = boost::none;
+					m_progressiveMinAASamples = std::nullopt;
 				}
 				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
 				{
@@ -3300,7 +3299,7 @@ class ArnoldGlobals
 			{
 				if( value == nullptr )
 				{
-					m_aaSeed = boost::none;
+					m_aaSeed = std::nullopt;
 				}
 				else if( const IECore::IntData *d = reportedCast<const IECore::IntData>( value, "option", name ) )
 				{
@@ -3498,7 +3497,7 @@ class ArnoldGlobals
 
 			AiNodeSetInt(
 				options, g_aaSeedArnoldString,
-				m_aaSeed.get_value_or( m_frame.get_value_or( 1 ) )
+				m_aaSeed.value_or( m_frame.value_or( 1 ) )
 			);
 
 			AtNode *dicingCamera = nullptr;
@@ -3577,7 +3576,7 @@ class ArnoldGlobals
 					// two different versions of "progressive". Instead we enable #1 only when #2
 					// is enabled.
 
-					const int minAASamples = m_progressiveMinAASamples.get_value_or( -4 );
+					const int minAASamples = m_progressiveMinAASamples.value_or( -4 );
 					// Must never set `progressive_min_AA_samples > -1`, as it'll get stuck and
 					// Arnold will never let us set it back.
 					AiRenderSetHintInt( m_renderSession.get(), AtString( "progressive_min_AA_samples" ), std::min( minAASamples, -1 ) );
@@ -3914,7 +3913,7 @@ class ArnoldGlobals
 		std::unique_ptr<UniverseBlock> m_universeBlock;
 		std::unique_ptr<AtRenderSession, decltype(&AiRenderSessionDestroy)> m_renderSession;
 		IECore::MessageHandlerPtr m_messageHandler;
-		boost::optional<unsigned> m_messageCallbackId;
+		std::optional<unsigned> m_messageCallbackId;
 
 		typedef std::map<IECore::InternedString, ArnoldOutputPtr> OutputMap;
 		OutputMap m_outputs;
@@ -3935,10 +3934,10 @@ class ArnoldGlobals
 
 		int m_logFileFlags;
 		int m_consoleFlags;
-		boost::optional<int> m_frame;
-		boost::optional<int> m_aaSeed;
+		std::optional<int> m_frame;
+		std::optional<int> m_aaSeed;
 		bool m_enableProgressiveRender;
-		boost::optional<int> m_progressiveMinAASamples;
+		std::optional<int> m_progressiveMinAASamples;
 		ShaderCachePtr m_shaderCache;
 
 		bool m_renderBegun;


### PR DESCRIPTION
Now we require C++17 (for the upcoming Gaffer 0.62), we can use `std::make_unique` and `std::optional` rather than the boost equivalents. That's what this PR does.