### PR TITLE
CropWindowTool : Fix bugs in render bound

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
 - Button : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
 - ArnoldRender : Stopped instancing of polygon meshes when both `ai:subdivide_polygons` and adaptive subdivision are on.
 - GLWidget : Fixed bug which made overlays unresponsive on high resolution displays.
+- CropWindowTool : Fixed bug (introduced in 0.61.0.0) which prevented the free drawing of a new crop region outside the current one. (#4530).
 
 API
 ---

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -277,9 +277,11 @@ class CropWindowTool::Rectangle : public GafferUI::Gadget
 
 		Imath::Box3f renderBound() const override
 		{
-			if( m_rasterSpace )
+			if( m_rasterSpace || m_editable || m_masked )
 			{
-				// We draw in raster space so don't have a sensible bound
+				// We don't have a sensible bound when we're drawing
+				// in raster space or drawing an "infinite" mask outside
+				// the rectangle.
 				Box3f b;
 				b.makeInfinite();
 				return b;


### PR DESCRIPTION
We draw outside of the main rectangle in almost all drawing modes, and this needs to be accounted for in `renderBound()`. Fixes #4530.
