### PR TITLE
SpreadsheetUI : Improve useability of read-only Spreadsheets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 - SceneViewInspector :
   - Updated to align colour scheme and interaction patterns with the LightEditor.
   - Reduced overhead when the Viewer is not visible in the UI.
+- Spreadsheet : Improved interaction with read-only spreadsheets. Previously it was impossible to switch between sections or scroll the cells (#4529).
 
 Fixes
 -----

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -118,6 +118,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# Build menu. We'll list every preset we found, but disable
 		# any which aren't available for all plugs.
+		readOnly = any( Gaffer.MetadataAlgo.readOnly( p ) for p in self.getPlugs() )
 		for preset in presets :
 
 			menuPath = preset if preset.startswith( "/" ) else "/" + preset
@@ -126,7 +127,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__applyPreset ), preset = preset ),
 					"checkBox" : preset == currentPreset and not isCustom,
-					"active" : presetCounts[preset] == len( self.getPlugs() )
+					"active" : ( presetCounts[preset] == len( self.getPlugs() ) ) and not readOnly
 				}
 			)
 
@@ -137,6 +138,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				{
 					"command" : Gaffer.WeakMethod( self.__applyCustomPreset ),
 					"checkBox" : isCustom,
+					"active" : not readOnly,
 				}
 			)
 

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -107,13 +107,13 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1, 4 ), maximumSize = imath.V2i( 1, 4 ) )
 
-				addColumnButton = GafferUI.MenuButton(
+				self.__addColumnButton = GafferUI.MenuButton(
 					image="plus.png", hasFrame=False, toolTip = "Click to add column, or drop plug to connect",
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__addColumnMenuDefinition ) )
 				)
-				addColumnButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDragEnter ), scoped = False )
-				addColumnButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDragLeave ), scoped = False )
-				addColumnButton.dropSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDrop ), scoped = False )
+				self.__addColumnButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDragEnter ), scoped = False )
+				self.__addColumnButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDragLeave ), scoped = False )
+				self.__addColumnButton.dropSignal().connect( Gaffer.WeakMethod( self.__addColumnButtonDrop ), scoped = False )
 
 			self.__rowNamesTable = _PlugTableView(
 				selectionModel, _PlugTableView.Mode.RowNames,
@@ -144,16 +144,16 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				}
 			)
 
-			addRowButton = GafferUI.Button(
+			self.__addRowButton = GafferUI.Button(
 				image="plus.png", hasFrame=False, toolTip = "Click to add row, or drop new row names",
 				parenting = {
 					"index" : ( 0, 4 )
 				}
 			)
-			addRowButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addRowButtonClicked ), scoped = False )
-			addRowButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragEnter ), scoped = False )
-			addRowButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragLeave ), scoped = False )
-			addRowButton.dropSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDrop ), scoped = False )
+			self.__addRowButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addRowButtonClicked ), scoped = False )
+			self.__addRowButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragEnter ), scoped = False )
+			self.__addRowButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDragLeave ), scoped = False )
+			self.__addRowButton.dropSignal().connect( Gaffer.WeakMethod( self.__addRowButtonDrop ), scoped = False )
 
 			if isinstance( plug.node(), Gaffer.Reference ) :
 				# Currently we only allow new rows to be added to references
@@ -163,14 +163,14 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# features in future.
 				for row in plug.children()[1:] :
 					if not plug.node().isChildEdit( row ) :
-						addRowButton.setVisible( False )
+						self.__addRowButton.setVisible( False )
 						break
 
 			# Because dragging plugs to the add button involves making
 			# an output connection from the spreadsheet, it doesn't make
 			# sense to allow it on promoted plugs.
 			if not isinstance( plug.node(), Gaffer.Spreadsheet ) :
-				addColumnButton.setVisible( False )
+				self.__addColumnButton.setVisible( False )
 
 			self.__statusLabel = GafferUI.Label(
 				"",
@@ -184,7 +184,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# otherwise large status labels can force cells off the screen.
 			self.__statusLabel._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
 
-		for widget in [ addRowButton, addColumnButton ] :
+		for widget in [ self.__addRowButton, self.__addColumnButton ] :
 			widget.enterSignal().connect( Gaffer.WeakMethod( self.__enterToolTippedWidget ), scoped = False )
 			widget.leaveSignal().connect( Gaffer.WeakMethod( self.__leaveToolTippedWidget ), scoped = False )
 
@@ -229,9 +229,9 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _updateFromPlug( self ) :
 
-		self.__grid.setEnabled(
-			self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
-		)
+		editable = self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+		self.__addRowButton.setEnabled( editable )
+		self.__addColumnButton.setEnabled( editable )
 
 	def __addRowButtonClicked( self, *unused ) :
 

--- a/python/GafferUI/SpreadsheetUI/_SectionChooser.py
+++ b/python/GafferUI/SpreadsheetUI/_SectionChooser.py
@@ -351,17 +351,21 @@ class _SectionChooser( GafferUI.Widget ) :
 
 		m.append( "/__EditDivider__", { "divider" : True } )
 
+		readOnly = Gaffer.MetadataAlgo.readOnly( self.__rowsPlug )
+
 		m.append(
 			"/Rename...",
 			{
-				"command" : functools.partial( Gaffer.WeakMethod( self.__renameSection ), sectionName )
+				"command" : functools.partial( Gaffer.WeakMethod( self.__renameSection ), sectionName ),
+				"active" : not readOnly,
 			}
 		)
 
 		m.append(
 			"/Set Description...",
 			{
-				"command" : functools.partial( Gaffer.WeakMethod( self.__setSectionDescription ), sectionName )
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setSectionDescription ), sectionName ),
+				"active" : not readOnly,
 			}
 		)
 
@@ -371,7 +375,7 @@ class _SectionChooser( GafferUI.Widget ) :
 				"/Move Columns To/{}".format( toSectionName ),
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__moveSection ), sectionName, toSectionName ),
-					"active" : toSectionName != sectionName,
+					"active" : toSectionName != sectionName and not readOnly,
 				}
 			)
 
@@ -380,7 +384,8 @@ class _SectionChooser( GafferUI.Widget ) :
 		m.append(
 			"/Delete",
 			{
-				"command" : functools.partial( Gaffer.WeakMethod( self.__deleteSection ), sectionName )
+				"command" : functools.partial( Gaffer.WeakMethod( self.__deleteSection ), sectionName ),
+				"active" : not readOnly,
 			}
 		)
 
@@ -389,7 +394,8 @@ class _SectionChooser( GafferUI.Widget ) :
 		m.append(
 			"/Remove Sectioning",
 			{
-				"command" : functools.partial( Gaffer.WeakMethod( self.__removeSectioning ) )
+				"command" : functools.partial( Gaffer.WeakMethod( self.__removeSectioning ) ),
+				"active" : not readOnly,
 			}
 		)
 


### PR DESCRIPTION
Before we were simply disabling the entire widget, which made it impossible to switch between sections and scroll to see all the rows. We now keep the widget enabled and disable the specific editing actions within it.

Fixes #4529. Note that the issue also complains of read-only spreadsheets being very dark with hard-to-read text. This PR has improved the contrast slightly by virtue of not calling `setEnabled( False )`, but it's still quite subtle.
