### PR TITLE
Signal : Deprecate default value for scoped argument

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Breaking Changes
   - Removed the `Gaffer/BlockedConnection.h` header file. BlockedConnection can now be found in the Signals namespace provided by `Gaffer/Signals.h`.
   - Remove the `Gaffer/CatchingSignalCombiner.h` header file. CatchingSignalCombiner can now be found as `Signals::CatchingCombiner` in `Gaffer/Signals.h`.
   - Moved all Python classes into the `Gaffer.Signals` submodule.
+  - Deprecated the default value for the `scoped` argument to `Signal.connect()`. Pass `scoped = True` to maintain the previous behaviour, or consider using an unscoped connection.
 - Replaced all usage of `boost::optional` with `std::optional`.
 
 Build

--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -219,7 +219,7 @@ class dispatch( Gaffer.Application ) :
 			import GafferDispatchUI
 
 			self.__dialogue = GafferDispatchUI.DispatchDialogue( tasks, dispatchers, nodesToShow )
-			self.__dialogueClosedConnection = self.__dialogue.closedSignal().connect( Gaffer.WeakMethod( self.__dialogueClosed ) )
+			self.__dialogueClosedConnection = self.__dialogue.closedSignal().connect( Gaffer.WeakMethod( self.__dialogueClosed ), scoped = True )
 			self.__dialogue.setVisible( True )
 
 			GafferUI.EventLoop.mainEventLoop().start()

--- a/apps/execute/execute-1.py
+++ b/apps/execute/execute-1.py
@@ -169,7 +169,7 @@ class execute( Gaffer.Application ) :
 
 		with context :
 			for node in nodes :
-				errorConnection = node.errorSignal().connect( Gaffer.WeakMethod( self.__error ) )
+				node.errorSignal().connect( Gaffer.WeakMethod( self.__error ), scoped = False )
 				try :
 					node["task"].executeSequence( frames )
 				except Exception as exception :

--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -131,7 +131,10 @@ class gui( Gaffer.Application ) :
 
 		from Qt import QtWidgets
 
-		self.__clipboardContentsChangedConnection = self.root().clipboardContentsChangedSignal().connect( Gaffer.WeakMethod( self.__clipboardContentsChanged ) )
+		self.__clipboardContentsChangedConnection = self.root().clipboardContentsChangedSignal().connect(
+			Gaffer.WeakMethod( self.__clipboardContentsChanged ),
+			scoped = True
+		)
 		QtWidgets.QApplication.clipboard().dataChanged.connect( Gaffer.WeakMethod( self.__qtClipboardContentsChanged ) )
 		self.__ignoreQtClipboardContentsChanged = False
 		self.__qtClipboardContentsChanged() # Trigger initial sync

--- a/apps/op/op-1.py
+++ b/apps/op/op-1.py
@@ -187,7 +187,7 @@ class op( Gaffer.Application ) :
 			# create a ui to display everything.
 
 			self.__dialogue = GafferCortexUI.OpDialogue( self.root()["scripts"]["script1"]["op"], executeInBackground=True )
-			self.__dialogueClosedConnection = self.__dialogue.closedSignal().connect( Gaffer.WeakMethod( self.__dialogueClosed ) )
+			self.__dialogueClosedConnection = self.__dialogue.closedSignal().connect( Gaffer.WeakMethod( self.__dialogueClosed ), scoped = True )
 			self.__dialogue.setVisible( True )
 			GafferUI.EventLoop.mainEventLoop().start()
 

--- a/apps/view/view-1.py
+++ b/apps/view/view-1.py
@@ -90,7 +90,7 @@ class view( Gaffer.Application ) :
 			)
 		)
 
-		self.__closedConnection = self.__window.closedSignal().connect( Gaffer.WeakMethod( self.__closed ) )
+		self.__closedConnection = self.__window.closedSignal().connect( Gaffer.WeakMethod( self.__closed ), scoped = True )
 
 		## \todo The window doesn't appear without this naughtiness. I think we either need to
 		# add a similar method in the public interface, or maybe make a SizeConstraintContainer

--- a/include/GafferBindings/SignalBinding.inl
+++ b/include/GafferBindings/SignalBinding.inl
@@ -121,16 +121,16 @@ void visit_each( Visitor &visitor, const Slot<Signal, Caller> &slot, int )
 	}
 }
 
-GAFFERBINDINGS_API boost::python::object pythonConnection( const Gaffer::Signals::Connection &connection, bool scoped );
+GAFFERBINDINGS_API boost::python::object pythonConnection( const Gaffer::Signals::Connection &connection, const boost::python::object &scoped );
 
 template<typename Signal, typename SlotCaller>
-boost::python::object connect( Signal &s, boost::python::object &slot, bool scoped )
+boost::python::object connect( Signal &s, boost::python::object &slot, const boost::python::object &scoped )
 {
 	return pythonConnection( s.connect( Slot<Signal, SlotCaller>( slot ) ), scoped );
 }
 
 template<typename Signal, typename SlotCaller>
-boost::python::object connectFront( Signal &s, boost::python::object &slot, bool scoped )
+boost::python::object connectFront( Signal &s, boost::python::object &slot, const boost::python::object &scoped )
 {
 	return pythonConnection( s.connectFront( Slot<Signal, SlotCaller>( slot ) ), scoped );
 }
@@ -179,8 +179,8 @@ template<typename Signal, typename SignalCaller, typename SlotCaller>
 SignalClass<Signal, SignalCaller, SlotCaller>::SignalClass( const char *className, const char *docString )
 	:	boost::python::class_<Signal, boost::noncopyable>( className, docString )
 {
-	this->def( "connect", &Detail::connect<Signal, SlotCaller>, ( boost::python::arg( "slot" ), boost::python::arg( "scoped" ) = true ) );
-	this->def( "connectFront", &Detail::connectFront<Signal, SlotCaller>, (boost::python::arg( "slot" ), boost::python::arg( "scoped" ) = true ) );
+	this->def( "connect", &Detail::connect<Signal, SlotCaller>, ( boost::python::arg( "slot" ), boost::python::arg( "scoped" ) = boost::python::object() ) );
+	this->def( "connectFront", &Detail::connectFront<Signal, SlotCaller>, (boost::python::arg( "slot" ), boost::python::arg( "scoped" ) = boost::python::object() ) );
 	this->def( "disconnectAllSlots", &Signal::disconnectAllSlots );
 	this->def( "numSlots", &Signal::numSlots );
 	this->def( "empty", &Signal::empty );

--- a/python/GafferCortex/ObjectWriter.py
+++ b/python/GafferCortex/ObjectWriter.py
@@ -63,7 +63,7 @@ class ObjectWriter( GafferDispatch.TaskNode ) :
 		self.__parameterHandler = GafferCortex.CompoundParameterHandler( self.__exposedParameters )
 		self.__parameterHandler.setupPlug( self )
 
-		self.__plugSetConnection = self.plugSetSignal().connect( Gaffer.WeakMethod( self.__plugSet ) )
+		self.__plugSetConnection = self.plugSetSignal().connect( Gaffer.WeakMethod( self.__plugSet ), scoped = True )
 
 	def parameterHandler( self ) :
 

--- a/python/GafferCortexUI/CompoundPlugValueWidget.py
+++ b/python/GafferCortexUI/CompoundPlugValueWidget.py
@@ -76,7 +76,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 			## \todo This is fighting the default sizing applied in the Label constructor. Really we need a standard
 			# way of controlling size behaviours for all widgets in the public API.
 			self.__collapsible.getCornerWidget()._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Fixed )
-			self.__collapseStateChangedConnection = self.__collapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__collapseStateChanged ) )
+			self.__collapseStateChangedConnection = self.__collapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__collapseStateChanged ), scoped = True )
 
 		GafferUI.PlugValueWidget.__init__(
 			self,
@@ -85,8 +85,8 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 			**kw
 		)
 
-		self.__plugAddedConnection = plug.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ) )
-		self.__plugRemovedConnection = plug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ) )
+		self.__plugAddedConnection = plug.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = True )
+		self.__plugRemovedConnection = plug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = True )
 		self.__childrenChangedPending = False
 
 		# arrange to build the rest of the ui in a deferred fashion. this means that we will be
@@ -97,11 +97,11 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# allows the top level window to get the sizing right, and for collapsed uis we build when the
 		# the ui first becomes visible due to being opened.
 		if collapsed == True :
-			self.__visibilityChangedConnection = self.__column.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ) )
+			self.__visibilityChangedConnection = self.__column.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = True )
 		else :
-			self.__parentChangedConnection = self.parentChangedSignal().connect( Gaffer.WeakMethod( self.__parentChanged ) )
+			self.__parentChangedConnection = self.parentChangedSignal().connect( Gaffer.WeakMethod( self.__parentChanged ), scoped = True )
 
-		self.__visibilityChangedConnection = self.__column.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ) )
+		self.__visibilityChangedConnection = self.__column.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = True )
 
 		self.__childPlugUIs = {} # mapping from child plug to PlugWidget
 

--- a/python/GafferCortexUI/FileIndexedIOPathPreview.py
+++ b/python/GafferCortexUI/FileIndexedIOPathPreview.py
@@ -86,7 +86,7 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 	def _deferredUpdate( self, indexedIO ) :
 
 		self.__indexedIOPath = GafferCortex.IndexedIOPath( indexedIO, "/" )
-		self.__indexedIOPathChangedConnection = self.__indexedIOPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__indexedIOPathChanged ) )
+		self.__indexedIOPathChangedConnection = self.__indexedIOPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__indexedIOPathChanged ), scoped = True )
 
 		self.__pathWidget.setPath( self.__indexedIOPath )
 		self.__pathPreview.setPath( self.__indexedIOPath )
@@ -94,7 +94,7 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 		# we use a separate path for the listing so it'll always be rooted at the start
 		listingPath = GafferCortex.IndexedIOPath( indexedIO, "/" )
 		self.__pathListing.setPath( listingPath )
-		self.__pathListingSelectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__pathListingSelectionChanged ) )
+		self.__pathListingSelectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__pathListingSelectionChanged ), scoped = True )
 
 	def __indexedIOPathChanged( self, path ) :
 

--- a/python/GafferCortexUI/OpBrowserMode.py
+++ b/python/GafferCortexUI/OpBrowserMode.py
@@ -56,7 +56,7 @@ class OpMode( GafferUI.BrowserEditor.Mode ) :
 
 		GafferUI.BrowserEditor.Mode.connect( self )
 
-		self.__pathSelectedConnection = self.browser().pathChooser().pathListingWidget().pathSelectedSignal().connect( Gaffer.WeakMethod( self.__pathSelected ) )
+		self.__pathSelectedConnection = self.browser().pathChooser().pathListingWidget().pathSelectedSignal().connect( Gaffer.WeakMethod( self.__pathSelected ), scoped = True )
 
 	def disconnect( self ) :
 

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -185,7 +185,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 				# connect to the collapsible state change so we can increase the window
 				# size when the details pane is first shown.
 				self.__messageCollapsibleStateChangedConnection = self.__messageCollapsible.stateChangedSignal().connect(
-					Gaffer.WeakMethod( self.__messageCollapsibleStateChanged )
+					Gaffer.WeakMethod( self.__messageCollapsibleStateChanged ), scoped = True
 				)
 
 		# add buttons. our buttons mean different things depending on our current state,
@@ -261,7 +261,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__backButton.setText( "Cancel" )
 		self.__backButton.setEnabled( True )
 		self.__backButton.setVisible( True )
-		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__close ) )
+		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 		executeLabel = "OK"
 		with IECore.IgnoredExceptions( KeyError ) :
@@ -270,7 +270,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__forwardButton.setText( executeLabel )
 		self.__forwardButton.setEnabled( True )
 		self.__forwardButton.setVisible( True )
-		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateExecution ) )
+		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateExecution ), scoped = True )
 
 		self.__frame.setChild( self.__parameterEditingUI )
 
@@ -367,12 +367,12 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__backButton.setVisible( True )
 		self.__backButton.setText( "Cancel" )
 		self.__backButton.setEnabled( True )
-		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ) )
+		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 		self.__forwardButton.setVisible( True )
 		self.__forwardButton.setText( "Retry" )
 		self.__forwardButton.setEnabled( True )
-		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connect( Gaffer.WeakMethod( self.__initiateParameterEditing ) )
+		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connect( Gaffer.WeakMethod( self.__initiateParameterEditing ), scoped = True )
 
 		self.__messageWidget.messageHandler().handle(
 			IECore.Msg.Level.Debug,
@@ -432,12 +432,12 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__backButton.setText( "Close" )
 		self.__backButton.setEnabled( True )
 		self.__backButton.setVisible( True )
-		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ) )
+		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 		self.__forwardButton.setText( "Again!" )
 		self.__forwardButton.setEnabled( True )
 		self.__forwardButton.setVisible( True )
-		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connect( Gaffer.WeakMethod( self.__initiateParameterEditing ) )
+		self.__forwardButtonClickedConnection = self.__forwardButton.clickedSignal().connect( Gaffer.WeakMethod( self.__initiateParameterEditing ), scoped = True )
 
 		if self.__postExecuteBehaviour in ( self.PostExecuteBehaviour.DisplayResultAndClose, self.PostExecuteBehaviour.Close ) :
 			self.__forwardButton.setVisible( False )

--- a/python/GafferCortexUI/ParameterPresets.py
+++ b/python/GafferCortexUI/ParameterPresets.py
@@ -74,7 +74,7 @@ class PresetDialogue( GafferUI.Dialogue ) :
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 				allowMultipleSelection = allowMultipleSelection,
 			)
-			self.__locationMenuChangedConnection = self._locationMenu().currentIndexChangedSignal().connect( Gaffer.WeakMethod( self.__locationChanged ) )
+			self.__locationMenuChangedConnection = self._locationMenu().currentIndexChangedSignal().connect( Gaffer.WeakMethod( self.__locationChanged ), scoped = True )
 			self._updatePresetListing()
 
 		return self.__presetListing
@@ -157,10 +157,10 @@ class SavePresetDialogue( PresetDialogue ) :
 				)
 				self.__presetNameWidget = GafferUI.TextWidget( self.__defaultName, parenting = { "index" : ( 1, 1 ) } )
 				self.__presetNameWidget.setSelection( None, None ) # select all
-				self.__presetNameChangedConnection = self.__presetNameWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__presetNameChanged ) )
+				self.__presetNameChangedConnection = self.__presetNameWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__presetNameChanged ), scoped = True )
 
 				self.__loadAutomaticallyWidget = GafferUI.BoolWidget( "Load automatically", parenting = { "index" : ( 2, 1 ) } )
-				self.__loadAutomaticallyChangedConnection = self.__loadAutomaticallyWidget.stateChangedSignal().connect( Gaffer.WeakMethod( self.__loadAutomaticallyChanged ) )
+				self.__loadAutomaticallyChangedConnection = self.__loadAutomaticallyWidget.stateChangedSignal().connect( Gaffer.WeakMethod( self.__loadAutomaticallyChanged ), scoped = True )
 
 				GafferUI.Label(
 					"<h3>Description</h3>",
@@ -174,7 +174,7 @@ class SavePresetDialogue( PresetDialogue ) :
 				)
 
 				self.__presetDescriptionWidget = GafferUI.MultiLineTextWidget( parenting = { "index" : ( slice( 1, 3 ), 2 ) } )
-				self.__presetDescriptionChangedConnection = self.__presetDescriptionWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__updateSaveButton ) )
+				self.__presetDescriptionChangedConnection = self.__presetDescriptionWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__updateSaveButton ), scoped = True )
 
 			with GafferUI.Collapsible( "Parameters To Save", collapsed=True ) as cl :
 
@@ -190,7 +190,7 @@ class SavePresetDialogue( PresetDialogue ) :
 				self.__parameterListing.setSelectedPaths( self.__allPaths( parameterPath ) )
 				self.__haveSelectedParameters = True
 				self.__selectionChangedConnection = self.__parameterListing.selectionChangedSignal().connect(
-					Gaffer.WeakMethod( self.__selectionChanged )
+					Gaffer.WeakMethod( self.__selectionChanged ), scoped = True
 				)
 
 		self._setWidget( column )
@@ -335,7 +335,7 @@ class LoadPresetDialogue( PresetDialogue ) :
 					self._locationMenu()
 
 				presetListing = self._presetListing()
-				self.__selectionChangedConnection = presetListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
+				self.__selectionChangedConnection = presetListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ), scoped = True )
 
 			with GafferUI.ListContainer( spacing=4 ) :
 				self.__presetDetailsLabel = GafferUI.Label( "<h3>Description</h3>" )
@@ -399,14 +399,14 @@ class DeletePresetsDialogue( PresetDialogue ) :
 				self._locationMenu( owned=True )
 
 			presetListing = self._presetListing( allowMultipleSelection=True )
-			self.__selectionChangedConnection = presetListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
+			self.__selectionChangedConnection = presetListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ), scoped = True )
 
 		self._setWidget( column )
 
 		self._addButton( "Close" )
 		self.__deleteButton = self._addButton( "Delete" )
 		self.__deleteButton.setEnabled( False )
-		self.__deleteButtonPressedConnection = self.__deleteButton.clickedSignal().connect( Gaffer.WeakMethod( self.__delete ) )
+		self.__deleteButtonPressedConnection = self.__deleteButton.clickedSignal().connect( Gaffer.WeakMethod( self.__delete ), scoped = True )
 
 	def waitForClose( self, **kw ) :
 

--- a/python/GafferCortexUI/ParameterValueWidget.py
+++ b/python/GafferCortexUI/ParameterValueWidget.py
@@ -175,7 +175,7 @@ def __parameterPopupMenu( menuDefinition, parameterValueWidget ) :
 	for name in parameterHandler.parameter().presetNames() :
 		menuDefinition.append( "/" + name, { "command" : IECore.curry( __setValue, parameterHandler, name ) } )
 
-__parameterPopupMenuConnection = ParameterValueWidget.popupMenuSignal().connect( __parameterPopupMenu )
+__parameterPopupMenuConnection = ParameterValueWidget.popupMenuSignal().connect( __parameterPopupMenu, scoped = True )
 
 def __setValue( parameterHandler, value ) :
 

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -218,7 +218,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 			return False
 
-		preConnection = GafferDispatch.Dispatcher.preDispatchSignal().connect( onlyRunOnce )
+		preConnection = GafferDispatch.Dispatcher.preDispatchSignal().connect( onlyRunOnce, scoped = True )
 		connection = GafferTest.CapturingSlot( GafferDispatch.Dispatcher.dispatchSignal() )
 
 		dispatcher = GafferDispatch.Dispatcher.create( "testDispatcher" )
@@ -246,7 +246,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 			def __init__( self, signal ) :
 
-				self.__connection = signal.connect( Gaffer.WeakMethod( self.__slot ) )
+				self.__connection = signal.connect( Gaffer.WeakMethod( self.__slot ), scoped = True )
 
 			def __slot( self, *args ) :
 

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -97,7 +97,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 						self.__dispatchersMenu = GafferUI.MultiSelectionMenu( allowMultipleSelection = False, allowEmptySelection = False )
 						self.__dispatchersMenu.append( [ x.getName() for x in self.__dispatchers ] )
 						self.__dispatchersMenu.setSelection( [ self.__dispatchers[0].getName() ] )
-						self.__dispatchersMenuChanged = self.__dispatchersMenu.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__dispatcherChanged ) )
+						self.__dispatchersMenu.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__dispatcherChanged ), scoped = False )
 						dispatcherMenuColumn.setVisible( len(self.__dispatchers) > 1 )
 
 					self.__dispatcherFrame = GafferUI.Frame( borderStyle=GafferUI.Frame.BorderStyle.None_, borderWidth=0 )
@@ -118,10 +118,10 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 				self.__messageWidget = GafferUI.MessageWidget( toolbars = True )
 				# connect to the collapsible state change so we can increase the window
 				# size when the details pane is first shown.
-				self.__messageCollapsibleConneciton = self.__messageCollapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__messageCollapsibleChanged ) )
+				self.__messageCollapsibleConnection = self.__messageCollapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__messageCollapsibleChanged ), scoped = False )
 
 		self.__backButton = self._addButton( "Back" )
-		self.__backButtonConnection = self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateSettings ) )
+		self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateSettings ), scoped = False )
 
 		self.__primaryButton = self._addButton( "Dispatch" )
 
@@ -200,7 +200,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__primaryButton.setText( "Dispatch" )
 		self.__primaryButton.setEnabled( True )
 		self.__primaryButton.setVisible( True )
-		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateDispatch ) )
+		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateDispatch ), scoped = True )
 
 		self.__tabs.setCurrent( self.__tabs[0] )
 		self._getWidget().setChild( self.__settings )
@@ -278,7 +278,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__primaryButton.setText( "Quit" )
 		self.__primaryButton.setEnabled( True )
 		self.__primaryButton.setVisible( True )
-		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ) )
+		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 	def __initiateResultDisplay( self ) :
 
@@ -313,7 +313,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__primaryButton.setText( "Ok" )
 		self.__primaryButton.setEnabled( True )
 		self.__primaryButton.setVisible( True )
-		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ) )
+		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )
 		self.__primaryButton._qtWidget().setFocus()
 
 	def __close( self, *unused ) :
@@ -329,4 +329,4 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 			# remove our connection - we only want to resize the first time we
 			# show the messages. after this we assume that if the window is smaller
 			# it is because the user has made it so, and wishes it to remain so.
-			self.__messageCollapsibleConneciton = None
+			self.__messageCollapsibleConnection.disconnect()

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -164,7 +164,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		node = GafferImage.Display()
 		server = IECoreImage.DisplayDriverServer()
-		driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( lambda driver, parameters : node.setDriver( driver ) )
+		driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( lambda driver, parameters : node.setDriver( driver ), scoped = True )
 
 		dataWindow = imath.Box2i( imath.V2i( -100, -200 ), imath.V2i( 303, 557 ) )
 		driver = self.Driver(
@@ -318,7 +318,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 		node = GafferImage.Display()
 		server = IECoreImage.DisplayDriverServer()
-		driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( lambda driver, parameters : node.setDriver( driver ) )
+		driverCreatedConnection = GafferImage.Display.driverCreatedSignal().connect( lambda driver, parameters : node.setDriver( driver ), scoped = True )
 
 		self.assertEqual( len( imagesReceived ), 0 )
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -595,11 +595,11 @@ class _ImagesPath( Gaffer.Path ) :
 		# Connect to all the signals we need to in order
 		# to emit pathChangedSignal at the appropriate times.
 
-		self.__childAddedConnection = self.__images.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAdded ) )
-		self.__childRemovedConnection = self.__images.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childRemoved ) )
-		self.__cataloguePlugDirtiedConnection = self.__catalogue.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__cataloguePlugDirtied ) )
+		self.__childAddedConnection = self.__images.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAdded ), scoped = True )
+		self.__childRemovedConnection = self.__images.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childRemoved ), scoped = True )
+		self.__cataloguePlugDirtiedConnection = self.__catalogue.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__cataloguePlugDirtied ), scoped = True )
 		self.__nameChangedConnections = {
-			image : image.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+			image : image.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ), scoped = True )
 			for image in self.__images
 		}
 
@@ -612,7 +612,7 @@ class _ImagesPath( Gaffer.Path ) :
 	def __childAdded( self, parent, child ) :
 
 		assert( parent.isSame( self.__images ) )
-		self.__nameChangedConnections[child] = child.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+		self.__nameChangedConnections[child] = child.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ), scoped = True )
 		self._emitPathChanged()
 
 	def __childRemoved( self, parent, child ) :

--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -495,4 +495,4 @@ def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
 
 		)
 
-__nodeEditorToolMenuConnection = GafferUI.NodeEditor.toolMenuSignal().connect( __nodeEditorToolMenu )
+GafferUI.NodeEditor.toolMenuSignal().connect( __nodeEditorToolMenu, scoped = False )

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -81,8 +81,8 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 			self.__pathListing.setDragPointer( "objects" )
 			self.__pathListing.setSortable( False )
 
-			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ) )
-			self.__expansionChangedConnection = self.__pathListing.expansionChangedSignal().connect( Gaffer.WeakMethod( self.__expansionChanged ) )
+			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ), scoped = False )
+			self.__expansionChangedConnection = self.__pathListing.expansionChangedSignal().connect( Gaffer.WeakMethod( self.__expansionChanged ), scoped = False )
 
 			self.__pathListing.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenuSignal ), scoped = False )
 			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPressSignal ), scoped = False )
@@ -109,7 +109,9 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 		if node is not None :
 			self.__plug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
 			if self.__plug is not None :
-				self.__plugParentChangedConnection = self.__plug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) )
+				self.__plugParentChangedConnection = self.__plug.parentChangedSignal().connect(
+					Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True
+				)
 
 		# call base class update - this will trigger a call to _titleFormat(),
 		# hence the need for already figuring out the plug.

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -113,7 +113,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 			if not statePlug.isSame( self.__stateWidget.getPlug() ) :
 				self.__stateWidget.setPlug( statePlug )
 				self.__messagesWidget.setPlug( renderNode["messages"] )
-				self.__renderNodePlugDirtiedConnection = renderNode.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__renderNodePlugDirtied ) )
+				self.__renderNodePlugDirtiedConnection = renderNode.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__renderNodePlugDirtied ), scoped = True )
 
 			# We disable the controls if a render is in progress, but not being viewed
 			with self.__view.getContext() :

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -110,7 +110,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			self.__pathListing.setDragPointer( "objects" )
 			self.__pathListing.setSortable( False )
 			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect(
-				Gaffer.WeakMethod( self.__selectionChanged )
+				Gaffer.WeakMethod( self.__selectionChanged ), scoped = False
 			)
 			self.__pathListing.buttonDoubleClickSignal().connectFront( Gaffer.WeakMethod( self.__buttonDoubleClick ), scoped = False )
 

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -238,8 +238,8 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		if node :
 			self.__scenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
 			if self.__scenePlug :
-				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) ) )
-				self.__parentChangedConnections.append( self.__scenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
+				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True ) )
+				self.__parentChangedConnections.append( self.__scenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True ) )
 
 		self.__updateLazily()
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -236,8 +236,8 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 			outputScenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
 			if outputScenePlug :
 				self.__scenePlugs.append( outputScenePlug )
-				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) ) )
-				self.__parentChangedConnections.append( outputScenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ) ) )
+				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True ) )
+				self.__parentChangedConnections.append( outputScenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True ) )
 
 		self.__updateLazily()
 

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -188,12 +188,12 @@ class _StateWidget( GafferUI.Widget ) :
 
 		self.__uvView = uvView
 
-		self.__buttonClickedConnection = self.__button.clickedSignal().connect(
-			Gaffer.WeakMethod( self.__buttonClick )
+		self.__button.clickedSignal().connect(
+			Gaffer.WeakMethod( self.__buttonClick ), scoped = False
 		)
 
-		self.__stateChangedConnection = self.__uvView.stateChangedSignal().connect(
-			Gaffer.WeakMethod( self.__stateChanged )
+		self.__uvView.stateChangedSignal().connect(
+			Gaffer.WeakMethod( self.__stateChanged ), scoped = False
 		)
 
 		self.__update()

--- a/python/GafferTest/AnimationTest.py
+++ b/python/GafferTest/AnimationTest.py
@@ -408,8 +408,8 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c1 = curve.keyAddedSignal().connect( added )
-		c2 = curve.keyRemovedSignal().connect( removed )
+		c1 = curve.keyAddedSignal().connect( added, scoped = True )
+		c2 = curve.keyRemovedSignal().connect( removed, scoped = True )
 
 		k = Gaffer.Animation.Key( 0, 0 )
 
@@ -447,8 +447,8 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c1 = curve.keyAddedSignal().connect( added )
-		c2 = curve.keyRemovedSignal().connect( removed )
+		c1 = curve.keyAddedSignal().connect( added, scoped = True )
+		c2 = curve.keyRemovedSignal().connect( removed, scoped = True )
 
 		k = Gaffer.Animation.Key( 0, 0 )
 
@@ -893,7 +893,7 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c = curve.keyValueChangedSignal().connect( changed )
+		c = curve.keyValueChangedSignal().connect( changed, scoped = True )
 
 		k0 = Gaffer.Animation.Key( 0, 1 )
 		k1 = Gaffer.Animation.Key( 2, 8 )
@@ -983,7 +983,7 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c = curve.keyInterpolationChangedSignal().connect( changed )
+		c = curve.keyInterpolationChangedSignal().connect( changed, scoped = True )
 
 		k0 = Gaffer.Animation.Key( 0, 1 )
 		k1 = Gaffer.Animation.Key( 12, 8 )
@@ -1080,7 +1080,7 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c = curve.keyTimeChangedSignal().connect( changed )
+		c = curve.keyTimeChangedSignal().connect( changed, scoped = True )
 
 		k0 = Gaffer.Animation.Key( 0, 1 )
 		k1 = Gaffer.Animation.Key( 12, 8 )
@@ -1227,7 +1227,7 @@ class AnimationTest( GafferTest.TestCase ) :
 
 		curve = Gaffer.Animation.acquire( s["n"]["user"]["f"] )
 
-		c = curve.keyTieModeChangedSignal().connect( changed )
+		c = curve.keyTieModeChangedSignal().connect( changed, scoped = True )
 
 		k0 = Gaffer.Animation.Key( 0, 1 )
 		k1 = Gaffer.Animation.Key( 12, 8 )

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -119,7 +119,7 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 			self.assertTrue( app.isSame( a ) )
 			d.append( app.getClipboardContents() )
 
-		c = a.clipboardContentsChangedSignal().connect( f )
+		c = a.clipboardContentsChangedSignal().connect( f, scoped = True )
 
 		self.assertEqual( len( d ), 0 )
 		self.assertEqual( a.getClipboardContents(), None )

--- a/python/GafferTest/BackgroundTaskTest.py
+++ b/python/GafferTest/BackgroundTaskTest.py
@@ -67,7 +67,8 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferTest.AddNode()
 		c = s["n"].plugSetSignal().connect(
-			lambda plug : operations.append( "set" )
+			lambda plug : operations.append( "set" ),
+			scoped = True
 		)
 
 		def f( canceller ) :
@@ -103,7 +104,8 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 					IECore.Canceller.check( canceller )
 
 		c = s["n"].plugSetSignal().connect(
-			lambda plug : operations.append( "undo" )
+			lambda plug : operations.append( "undo" ),
+			scoped = True
 		)
 		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
 		time.sleep( 0.01 ) # Give task a chance to start before we cancel it
@@ -113,7 +115,8 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 
 		del operations[:]
 		c = s["n"].plugSetSignal().connect(
-			lambda plug : operations.append( "redo" )
+			lambda plug : operations.append( "redo" ),
+			scoped = True
 		)
 		t = Gaffer.BackgroundTask( s["n"]["sum"], f )
 		time.sleep( 0.01 ) # Give task a chance to start before we cancel it

--- a/python/GafferTest/BlockedConnectionTest.py
+++ b/python/GafferTest/BlockedConnectionTest.py
@@ -48,7 +48,7 @@ class BlockedConnectionTest( GafferTest.TestCase ) :
 			self.numCalls += 1
 
 		s = Gaffer.Signals.Signal0()
-		c = s.connect( f )
+		c = s.connect( f, scoped = False )
 
 		s()
 		self.assertEqual( self.numCalls, 1 )
@@ -68,7 +68,7 @@ class BlockedConnectionTest( GafferTest.TestCase ) :
 			self.numCalls += 1
 
 		s = Gaffer.Signals.Signal0()
-		c = s.connect( f )
+		c = s.connect( f, scoped = False )
 
 		s()
 		self.assertEqual( self.numCalls, 1 )

--- a/python/GafferTest/CapturingSlot.py
+++ b/python/GafferTest/CapturingSlot.py
@@ -42,7 +42,7 @@ class CapturingSlot( list ) :
 
 		self.__connections = []
 		for s in signals :
-			self.__connections.append( s.connect( Gaffer.WeakMethod( self.__slot ) ) )
+			self.__connections.append( s.connect( Gaffer.WeakMethod( self.__slot ), scoped = True ) )
 
 	def __slot( self, *args ) :
 

--- a/python/GafferTest/ChildSetTest.py
+++ b/python/GafferTest/ChildSetTest.py
@@ -74,8 +74,8 @@ class ChildSetTest( GafferTest.TestCase ) :
 		p = Gaffer.GraphComponent()
 		s = Gaffer.ChildSet( p )
 
-		addedConnection = s.memberAddedSignal().connect( added )
-		removedConnection = s.memberRemovedSignal().connect( removed )
+		addedConnection = s.memberAddedSignal().connect( added, scoped = False )
+		removedConnection = s.memberRemovedSignal().connect( removed, scoped = False )
 
 		p["one"] = Gaffer.GraphComponent()
 

--- a/python/GafferTest/CompoundPathFilterTest.py
+++ b/python/GafferTest/CompoundPathFilterTest.py
@@ -80,7 +80,7 @@ class CompoundPathFilterTest( GafferTest.TestCase ) :
 		f1 = Gaffer.FileNamePathFilter( [ "*.gfr" ] )
 		f2 = Gaffer.FileNamePathFilter( [ "*.tif" ] )
 
-		c = cf.changedSignal().connect( f )
+		cf.changedSignal().connect( f, scoped = False )
 		self.assertEqual( self.__numChanges, 0 )
 
 		cf.addFilter( f1 )
@@ -118,7 +118,7 @@ class CompoundPathFilterTest( GafferTest.TestCase ) :
 		f1 = Gaffer.FileNamePathFilter( [ "*.gfr" ] )
 		f2 = Gaffer.FileNamePathFilter( [ "*.tif" ] )
 
-		c = cf.changedSignal().connect( f )
+		cf.changedSignal().connect( f, scoped = False )
 		self.assertEqual( self.__numChanges, 0 )
 
 		cf.setFilters( [ f1, f2 ] )

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -443,7 +443,7 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 			self.fRan = True
 
 		n = GafferTest.BadNode()
-		c = n.errorSignal().connect( f )
+		c = n.errorSignal().connect( f, scoped = True )
 
 		with IECore.IgnoredExceptions( Exception ) :
 			n["out1"].getValue()

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -67,7 +67,7 @@ class ContextTest( GafferTest.TestCase ) :
 			self.assertTrue( context.isSame( c ) )
 			changes.append( ( name, context.get( name, None ), context.hash() ) )
 
-		cn = c.changedSignal().connect( f )
+		c.changedSignal().connect( f, scoped = False )
 
 		c["a"] = 2
 		hash1 = c.hash()

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -489,7 +489,7 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 					self.assertTrue( state.s is None )
 					self.assertTrue( state.f is None )
 
-		c = n3.plugDirtiedSignal().connect( plugDirtied )
+		n3.plugDirtiedSignal().connect( plugDirtied, scoped = False )
 
 		n3["p"].setInput( n1["o"] )
 		assertStatesValid()
@@ -546,7 +546,7 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 				valuesWhenDirtied.append( plug.getValue() )
 
 		n = DynamicAddNode()
-		c = n.plugDirtiedSignal().connect( plugDirtied )
+		n.plugDirtiedSignal().connect( plugDirtied, scoped = False )
 
 		n["in"] = Gaffer.IntPlug( defaultValue = 1, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		self.assertEqual( valuesWhenDirtied, [ 1 ] )
@@ -628,7 +628,7 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 			del s["n3"]
 			del s["n4"]
 
-		c = s["n2"].plugInputChangedSignal().connect( inputChanged )
+		c = s["n2"].plugInputChangedSignal().connect( inputChanged, scoped = True )
 
 		s["n2"]["op1"].setInput( s["n1"]["product"] )
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -154,7 +154,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		s["m1"] = GafferTest.MultiplyNode()
 
-		c = s["m1"].plugDirtiedSignal().connect( f )
+		s["m1"].plugDirtiedSignal().connect( f, scoped = False )
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression(
@@ -864,7 +864,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s["e"] = Gaffer.Expression()
 		self.assertEqual( s["e"].getExpression(), ( "", "" ) )
 
-		c = s["e"].expressionChangedSignal().connect( f )
+		s["e"].expressionChangedSignal().connect( f, scoped = False )
 
 		with Gaffer.UndoScope( s ) :
 			s["e"].setExpression( 'parent["n"]["user"]["p"] = 10' )

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -57,7 +57,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		def f( c ) :
 			GraphComponentTest.name = c.getName()
 
-		con = c.nameChangedSignal().connect( f )
+		con = c.nameChangedSignal().connect( f, scoped = True )
 		GraphComponentTest.name = "xxx"
 		c.setName( "newName" )
 		self.assertEqual( GraphComponentTest.name, "newName" )
@@ -79,7 +79,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertEqual( child1.getName(), "GraphComponent" )
 		self.assertEqual( child1.fullName(), "newName.GraphComponent" )
 
-		con = child2.nameChangedSignal().connect( f )
+		con = child2.nameChangedSignal().connect( f, scoped = True )
 		GraphComponentTest.name = "xxx"
 		c.addChild( child2 )
 		self.assertEqual( child2.getName(), "GraphComponent1" )
@@ -123,8 +123,8 @@ class GraphComponentTest( GafferTest.TestCase ) :
 
 			GraphComponentTest.parenting = ( p, c )
 
-		c1 = child.parentChangedSignal().connect( f )
-		c2 = parent.childAddedSignal().connect( ff )
+		c1 = child.parentChangedSignal().connect( f, scoped = True )
+		c2 = parent.childAddedSignal().connect( ff, scoped = True )
 
 		GraphComponentTest.newParent = None
 		GraphComponentTest.oldParent = None
@@ -138,7 +138,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		GraphComponentTest.newParent = "xxx"
 		GraphComponentTest.oldParent = None
 		GraphComponentTest.parenting = None
-		c2 = parent.childRemovedSignal().connect( ff )
+		c2 = parent.childRemovedSignal().connect( ff, scoped = True )
 		parent.removeChild( child )
 		self.assertIsNone( GraphComponentTest.newParent )
 		self.assertTrue( GraphComponentTest.oldParent.isSame( parent ) )
@@ -166,7 +166,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 
 		p1["c"] = c
 
-		connection = c.parentChangedSignal().connect( f )
+		c.parentChangedSignal().connect( f, scoped = False )
 
 		p2["c"] = c
 
@@ -186,7 +186,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 			GraphComponentTest.newParent = child.parent()
 			GraphComponentTest.previousParent = previousParent
 
-		c = child.parentChangedSignal().connect( f )
+		child.parentChangedSignal().connect( f, scoped = False )
 
 		GraphComponentTest.newParent = "XXX"
 		GraphComponentTest.previousParent = "XXX"
@@ -216,8 +216,8 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		def f( a, b=None ) :
 			GraphComponentTest.numSignals += 1
 
-		c1 = child.parentChangedSignal().connect( f )
-		c2 = parent.childAddedSignal().connect( f )
+		child.parentChangedSignal().connect( f, scoped = False )
+		parent.childAddedSignal().connect( f, scoped = False )
 
 		parent.addChild( child )
 
@@ -535,10 +535,10 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		def f( *args ) :
 			GraphComponentTest.numSignals += 1
 
-		c1 = child.parentChangedSignal().connect( f )
-		c2 = parent.childAddedSignal().connect( f )
-		c3 = parent.childRemovedSignal().connect( f )
-		c4 = child.nameChangedSignal().connect( f )
+		child.parentChangedSignal().connect( f, scoped = False )
+		parent.childAddedSignal().connect( f, scoped = False )
+		parent.childRemovedSignal().connect( f, scoped = False )
+		child.nameChangedSignal().connect( f, scoped = False )
 
 		parent.setChild( "c", child )
 

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -222,7 +222,7 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 			ancestorAffected.append( Gaffer.MetadataAlgo.ancestorAffectedByChange( n["p"]["s"], nodeTypeId, plugPath, plug ) )
 			childAffected.append( Gaffer.MetadataAlgo.childAffectedByChange( n["p"], nodeTypeId, plugPath, plug ) )
 
-		c = Gaffer.Metadata.plugValueChangedSignal().connect( plugValueChanged )
+		c = Gaffer.Metadata.plugValueChangedSignal().connect( plugValueChanged, scoped = True )
 
 		Gaffer.Metadata.registerValue( Gaffer.Node, "user", "test", 1 )
 		self.assertEqual( affected, [ False ] )
@@ -274,7 +274,7 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 			affected.append( Gaffer.MetadataAlgo.affectedByChange( n, nodeTypeId, node ) )
 			childAffected.append( Gaffer.MetadataAlgo.childAffectedByChange( n, nodeTypeId, node ) )
 
-		c = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged )
+		c = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged, scoped = True )
 
 		Gaffer.Metadata.registerValue( Gaffer.Node, "metadataAlgoTest", 1 )
 		self.assertEqual( affected, [ True ] )
@@ -310,7 +310,7 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 			affected.append( a )
 
-		c = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged )
+		c = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged, scoped = True )
 
 		Gaffer.Metadata.registerValue( s["b"]["n"], "metadataAlgoTest", "test" )
 		self.assertEqual( len( affected ), 1 )
@@ -436,7 +436,7 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 			affected.append( a )
 
-		c1 = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged )
+		c1 = Gaffer.Metadata.nodeValueChangedSignal().connect( nodeValueChanged, scoped = True )
 
 		def plugValueChanged( nodeTypeId, plugPath, key, plug ) :
 
@@ -447,7 +447,7 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 			affected.append( a )
 
-		c2 = Gaffer.Metadata.plugValueChangedSignal().connect( plugValueChanged )
+		c2 = Gaffer.Metadata.plugValueChangedSignal().connect( plugValueChanged, scoped = True )
 
 		Gaffer.Metadata.registerValue( s["b"]["n"]["op1"], "metadataAlgoTest", "test" )
 		self.assertEqual( len( affected ), 1 )

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -498,8 +498,8 @@ class MetadataTest( GafferTest.TestCase ) :
 
 			self.__goodSlotExecuted = True
 
-		badConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( badSlot )
-		goodConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( goodSlot )
+		badConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( badSlot, scoped = True )
+		goodConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( goodSlot, scoped = True )
 
 		n = Gaffer.Node()
 		with IECore.CapturingMessageHandler() as mh :

--- a/python/GafferTest/NumericBookmarkSetTest.py
+++ b/python/GafferTest/NumericBookmarkSetTest.py
@@ -102,8 +102,8 @@ class NumericBookmarkSetTest( GafferTest.TestCase ) :
 
 		b = Gaffer.NumericBookmarkSet( s, 1 )
 
-		ca = b.memberAddedSignal().connect( added )
-		cr = b.memberRemovedSignal().connect( removed )
+		b.memberAddedSignal().connect( added, scoped = False )
+		b.memberRemovedSignal().connect( removed, scoped = False )
 
 		self.assertEqual( set(b), mirror )
 
@@ -131,7 +131,7 @@ class NumericBookmarkSetTest( GafferTest.TestCase ) :
 			if set(b) != set() :
 				callbackFailures["removed"] += 1
 
-		cr = b.memberRemovedSignal().connect( removed )
+		cr = b.memberRemovedSignal().connect( removed, scoped = True )
 
 		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
 		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["b"] )
@@ -143,7 +143,7 @@ class NumericBookmarkSetTest( GafferTest.TestCase ) :
 			if set(b) != { s["a"] } :
 				callbackFailures["added"] += 1
 
-		ca = b.memberAddedSignal().connect( added )
+		ca = b.memberAddedSignal().connect( added, scoped = True )
 
 		Gaffer.MetadataAlgo.setNumericBookmark( s, 1, s["a"] )
 		self.assertEqual( callbackFailures["added"], 0 )

--- a/python/GafferTest/PathFilterTest.py
+++ b/python/GafferTest/PathFilterTest.py
@@ -110,7 +110,7 @@ class PathFilterTest( GafferTest.TestCase ) :
 			self.assertTrue( pf.isSame( pathFilter ) )
 			enabledStates.append( pf.getEnabled() )
 
-		c = pathFilter.changedSignal().connect( f )
+		pathFilter.changedSignal().connect( f, scoped = False )
 
 		pathFilter.setEnabled( False )
 		pathFilter.setEnabled( False )

--- a/python/GafferTest/PathTest.py
+++ b/python/GafferTest/PathTest.py
@@ -89,7 +89,7 @@ class PathTest( GafferTest.TestCase ) :
 			changedPaths.append( str( path ) )
 
 		p = Gaffer.Path( "/" )
-		c = p.pathChangedSignal().connect( f )
+		p.pathChangedSignal().connect( f, scoped = False )
 
 		p.append( "hello" )
 		p.append( "goodbye" )
@@ -107,7 +107,7 @@ class PathTest( GafferTest.TestCase ) :
 		def f( path ) :
 			changedPaths.append( str( path ) )
 
-		c = p.pathChangedSignal().connect( f )
+		p.pathChangedSignal().connect( f, scoped = False )
 		self.assertEqual( len( changedPaths ), 0 )
 
 		filter = Gaffer.FileNamePathFilter( [ "*.gfr" ] )

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -102,7 +102,7 @@ class PlugTest( GafferTest.TestCase ) :
 		p2 = Gaffer.Plug( direction=Gaffer.Plug.Direction.In )
 		n2.addChild( p2 )
 
-		c = n2.plugInputChangedSignal().connect( f )
+		n2.plugInputChangedSignal().connect( f, scoped = False )
 		p2.setInput( p1 )
 		self.assertTrue( PlugTest.__connection[0].isSame( p2 ) )
 		self.assertTrue( PlugTest.__connection[1].isSame( p1 ) )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -914,7 +914,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		def referenceLoaded( node ) :
 			states.append( State( keys = node.keys(), fileName = node.fileName() ) )
 
-		c = s["r"].referenceLoadedSignal().connect( referenceLoaded )
+		s["r"].referenceLoadedSignal().connect( referenceLoaded, scoped = False )
 
 		with Gaffer.UndoScope( s ) :
 			s["r"].load( self.temporaryDirectory() + "/test.grf" )

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -944,7 +944,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		def f( plug ) :
 			values.append( plug.getValue() )
 
-		c = s["n"].plugSetSignal().connect( f )
+		s["n"].plugSetSignal().connect( f, scoped = False )
 
 		with Gaffer.UndoScope( s ) :
 			s["n"]["p"].setValue( 10 )
@@ -1061,7 +1061,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 				self.assertFalse( s.undoAvailable() )
 				self.assertFalse( s.redoAvailable() )
 
-		c = s["n"].plugSetSignal().connect( f )
+		s["n"].plugSetSignal().connect( f, scoped = False )
 
 		self.assertEqual( s.currentActionStage(), Gaffer.Action.Stage.Invalid )
 		self.assertEqual( len( actionStages ), 0 )
@@ -1339,7 +1339,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		def f( script, child ) :
 			self.__wasExecuting.append( script.isExecuting() )
 
-		c = s.childAddedSignal().connect( f )
+		s.childAddedSignal().connect( f, scoped = False )
 
 		s["n"] = GafferTest.AddNode()
 

--- a/python/GafferTest/SplinePlugTest.py
+++ b/python/GafferTest/SplinePlugTest.py
@@ -272,7 +272,7 @@ class SplinePlugTest( GafferTest.TestCase ) :
 			if plug.isSame( p ) :
 				self.__plugSetCount += 1
 
-		c = n.plugSetSignal().connect( plugSet )
+		n.plugSetSignal().connect( plugSet, scoped = False )
 
 		p.pointYPlug( 2 ).setValue( 1.0 )
 

--- a/python/GafferTest/StandardSetTest.py
+++ b/python/GafferTest/StandardSetTest.py
@@ -163,8 +163,8 @@ class StandardSetTest( GafferTest.TestCase ) :
 
 		s = Gaffer.StandardSet()
 
-		c1 = s.memberAddedSignal().connect( added )
-		c2 = s.memberRemovedSignal().connect( removed )
+		s.memberAddedSignal().connect( added, scoped = False )
+		s.memberRemovedSignal().connect( removed, scoped = False )
 
 		n1 = Gaffer.Node()
 		n2 = Gaffer.Node()
@@ -220,7 +220,7 @@ class StandardSetTest( GafferTest.TestCase ) :
 
 			return m.isInstanceOf( Gaffer.Plug.staticTypeId() )
 
-		c = s.memberAcceptanceSignal().connect(	f )
+		s.memberAcceptanceSignal().connect(	f, scoped = False )
 
 		n = Gaffer.Node()
 		p = Gaffer.Plug()
@@ -268,7 +268,7 @@ class StandardSetTest( GafferTest.TestCase ) :
 
 			pass
 
-		c = s.memberRemovedSignal().connect( f )
+		s.memberRemovedSignal().connect( f, scoped = False )
 
 		s.clear()
 

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -429,7 +429,7 @@ class ValuePlugTest( GafferTest.TestCase ) :
 			if plug.isSame( c ) :
 				self.set = True
 
-		cn = n.plugSetSignal().connect( setCallback )
+		n.plugSetSignal().connect( setCallback, scoped = False )
 
 		self.set = False
 
@@ -450,7 +450,7 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 			self.setPlugs.append( plug.getName() )
 
-		cn = n.plugSetSignal().connect( setCallback )
+		n.plugSetSignal().connect( setCallback, scoped = False )
 
 		self.setPlugs = []
 
@@ -471,7 +471,7 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 			self.setPlugs.append( plug.getName() )
 
-		cn = n.plugSetSignal().connect( setCallback )
+		n.plugSetSignal().connect( setCallback, scoped = False )
 
 		self.setPlugs = []
 

--- a/python/GafferTest/pythonScripts/unloadExceptionScript.py
+++ b/python/GafferTest/pythonScripts/unloadExceptionScript.py
@@ -44,9 +44,9 @@ class TestNode( Gaffer.Node ) :
 
 	def __init__( self, name = "TestNode" ):
 		super( TestNode, self ).__init__( name=name )
-		self._nodeValueChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__nodeValueChanged ) )
-		self._plugValueChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
-		self._valueChangedConnection = Gaffer.Metadata.valueChangedSignal().connect( Gaffer.WeakMethod( self.__valueMetadataChanged ) )
+		self._nodeValueChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__nodeValueChanged ), scoped = True )
+		self._plugValueChangedConnection = Gaffer.Metadata.plugValueChangedSignal().connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
+		self._valueChangedConnection = Gaffer.Metadata.valueChangedSignal().connect( Gaffer.WeakMethod( self.__valueMetadataChanged ), scoped = True )
 
 	def __nodeValueChanged( self, nodeTypeId, key, node ) :
 		pass

--- a/python/GafferTractorTest/TractorDispatcherTest.py
+++ b/python/GafferTractorTest/TractorDispatcherTest.py
@@ -68,7 +68,7 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 
 			jobs.append( job )
 
-		c = GafferTractor.TractorDispatcher.preSpoolSignal().connect( f )
+		c = GafferTractor.TractorDispatcher.preSpoolSignal().connect( f, scoped = True )
 
 		if dispatcher is None :
 			dispatcher = self.__dispatcher()
@@ -89,7 +89,7 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 
 			spooled.append( ( dispatcher, job ) )
 
-		c = GafferTractor.TractorDispatcher.preSpoolSignal().connect( f )
+		c = GafferTractor.TractorDispatcher.preSpoolSignal().connect( f, scoped = True )
 
 		dispatcher = self.__dispatcher()
 		dispatcher.dispatch( [ s["n"] ] )

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -67,7 +67,7 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 				else :
 					break
 
-		self.__plugInputChangedConnections = [ node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ) ) for node in selection ]
+		self.__plugInputChangedConnections = [ node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ), scoped = True ) for node in selection ]
 		self.__nameChangedConnections = []
 
 	def _filter( self, paths, canceller ) :
@@ -98,7 +98,7 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 			# Hack to report name changes on paths we keep. Really this
 			# should be dealt with for us by GraphComponentPath.
 			self.__nameChangedConnections.append(
-				path.property( "graphComponent:graphComponent" ).nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+				path.property( "graphComponent:graphComponent" ).nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ), scoped = True )
 			)
 
 		return result

--- a/python/GafferUI/ApplicationMenu.py
+++ b/python/GafferUI/ApplicationMenu.py
@@ -115,9 +115,9 @@ def preferences( menu ) :
 	else :
 		window = GafferUI.Dialogue( "Preferences" )
 		closeButton = window._addButton( "Close" )
-		window.__closeButtonConnection = closeButton.clickedSignal().connect( __closePreferences )
+		closeButton.clickedSignal().connect( __closePreferences, scoped = False )
 		saveButton = window._addButton( "Save" )
-		window.__saveButtonConnection = saveButton.clickedSignal().connect( __savePreferences )
+		saveButton.clickedSignal().connect( __savePreferences, scoped = False )
 		window._setWidget( GafferUI.NodeUI.create( application["preferences"] ) )
 		__preferencesWindows[application] = weakref.ref( window )
 		scriptWindow.addChildWindow( window )

--- a/python/GafferUI/BackgroundMethod.py
+++ b/python/GafferUI/BackgroundMethod.py
@@ -154,7 +154,8 @@ class BackgroundMethod( object ) :
 					widget,
 					method.__name__ + "__VisibilityChangedConnection",
 					widget.visibilityChangedSignal().connect(
-						functools.partial( self.__visibilityChanged, method = method, foregroundFunction = foregroundFunction )
+						functools.partial( self.__visibilityChanged, method = method, foregroundFunction = foregroundFunction ),
+						scoped = True
 					)
 				)
 

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -64,7 +64,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self._addPopupMenu( self.__boolWidget )
 
-		self.__stateChangedConnection = self.__boolWidget.stateChangedSignal().connect( Gaffer.WeakMethod( self.__stateChanged ) )
+		self.__stateChangedConnection = self.__boolWidget.stateChangedSignal().connect( Gaffer.WeakMethod( self.__stateChanged ), scoped = False )
 
 		self._updateFromPlugs()
 

--- a/python/GafferUI/BrowserEditor.py
+++ b/python/GafferUI/BrowserEditor.py
@@ -143,7 +143,9 @@ class BrowserEditor( GafferUI.Editor ) :
 				)
 			)
 
-			self.__contextMenuConnection = self.browser().pathChooser().pathListingWidget().contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenu ) )
+			self.__contextMenuConnection = self.browser().pathChooser().pathListingWidget().contextMenuSignal().connect(
+				Gaffer.WeakMethod( self.__contextMenu ), scoped = True
+			)
 
 			splitContainer = self.browser().pathChooser().pathListingWidget().ancestor( GafferUI.SplitContainer )
 			splitContainer.setSizes( ( self.__splitPosition, 1.0 - self.__splitPosition ) )

--- a/python/GafferUI/ButtonPlugValueWidget.py
+++ b/python/GafferUI/ButtonPlugValueWidget.py
@@ -65,9 +65,9 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__nameChangedConnection = None
 		self.__plugMetadataChangedConnection = None
 		if plug is not None :
-			self.__nameChangedConnection = plug.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) )
+			self.__nameChangedConnection = plug.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ), scoped = True )
 			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect(
-				Gaffer.WeakMethod( self.__plugMetadataChanged )
+				Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True
 			)
 
 		self.__updateLabel()

--- a/python/GafferUI/CompoundPathPreview.py
+++ b/python/GafferUI/CompoundPathPreview.py
@@ -58,7 +58,9 @@ class CompoundPathPreview( GafferUI.PathPreviewWidget ) :
 			widget = GafferUI.PathPreviewWidget.create( type, path )
 			self.__labelsAndTabs.append( ( type, widget ) )
 
-		self.__currentTabChangedConnection = self.__tabbedContainer.currentChangedSignal().connect( Gaffer.WeakMethod( self.__currentTabChanged ) )
+		self.__currentTabChangedConnection = self.__tabbedContainer.currentChangedSignal().connect(
+			Gaffer.WeakMethod( self.__currentTabChanged ), scoped = False
+		)
 
 		self.__preferredTab = None
 

--- a/python/GafferUI/ConnectionPlugValueWidget.py
+++ b/python/GafferUI/ConnectionPlugValueWidget.py
@@ -60,12 +60,10 @@ class ConnectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 		row.append( self.__inputLabel, horizontalAlignment = GafferUI.HorizontalAlignment.Center, expand = True )
 		self.__frame.setChild( row )
 
-		self.__connections = [
-			self.__frame.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ) ),
-			self.__inputLabel.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ) ),
-			self.__frame.enterSignal().connect( functools.partial( GafferUI.Frame.setHighlighted, highlighted=True ) ),
-			self.__frame.leaveSignal().connect( functools.partial( GafferUI.Frame.setHighlighted, highlighted=False ) ),
-		]
+		self.__frame.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ), scoped = False )
+		self.__inputLabel.buttonReleaseSignal().connect( Gaffer.WeakMethod( self.__buttonRelease ), scoped = False )
+		self.__frame.enterSignal().connect( functools.partial( GafferUI.Frame.setHighlighted, highlighted=True ), scoped = False )
+		self.__frame.leaveSignal().connect( functools.partial( GafferUI.Frame.setHighlighted, highlighted=False ), scoped = False )
 
 		self._addPopupMenu( self.__frame )
 

--- a/python/GafferUI/Dialogue.py
+++ b/python/GafferUI/Dialogue.py
@@ -85,7 +85,7 @@ class Dialogue( GafferUI.Window ) :
 			self._qtWidget().setWindowModality( QtCore.Qt.ApplicationModal )
 			self.setVisible( True )
 
-			self.__closeConnection = self.closedSignal().connect( Gaffer.WeakMethod( self.__close ) )
+			self.__closeConnection = self.closedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 			self.__modalEventLoop = GafferUI.EventLoop()
 			self.__modalEventLoop.start()
@@ -124,7 +124,7 @@ class Dialogue( GafferUI.Window ) :
 		self.__resultOfWait = None
 		self.__buttonConnections = []
 		for button in self.__buttonRow :
-			self.__buttonConnections.append( button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ) ) )
+			self.__buttonConnections.append( button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = True ) )
 
 		self.setModal( True, parentWindow )
 

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -138,7 +138,7 @@ class Editor( six.with_metaclass( _EditorMetaclass, GafferUI.Widget ) ) :
 		previousContext = self.__context
 		self.__context = context
 		if self.__context is not None :
-			self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
+			self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = True )
 		else :
 			## \todo I'm not sure why this code allows a None context - surely we
 			# should always have a valid one?

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -309,7 +309,7 @@ class EventLoop( object ) :
 		for thrust in range( 0, thrusts ) :
 			self.__qtEventLoop.processEvents()
 
-_gadgetIdleSignalAccessedConnection = GafferUI.Gadget._idleSignalAccessedSignal().connect( EventLoop._gadgetIdleSignalAccessed )
+GafferUI.Gadget._idleSignalAccessedSignal().connect( EventLoop._gadgetIdleSignalAccessed, scoped = False )
 
 # Internal implementation for `EventLoop.executeOnUIThread()`. There are
 # multiple ways of achieving this in Qt, but they all boil down to scheduling an

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -351,7 +351,7 @@ def importFile( menu ) :
 	with Gaffer.UndoScope( scope.script ), errorHandler :
 
 		newChildren = []
-		c = scope.parent.childAddedSignal().connect( lambda parent, child : newChildren.append( child ) )
+		c = scope.parent.childAddedSignal().connect( lambda parent, child : newChildren.append( child ), scoped = True )
 
 		scope.script.importFile( str( path ), parent = scope.parent, continueOnError = True )
 

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -108,7 +108,7 @@ class GadgetWidget( GafferUI.GLWidget ) :
 			self.__viewportGadget.setVisible( False )
 
 		self.__viewportGadget = viewportGadget
-		self.__renderRequestConnection = self.__viewportGadget.renderRequestSignal().connect( Gaffer.WeakMethod( self.__renderRequest ) )
+		self.__viewportGadget.renderRequestSignal().connect( Gaffer.WeakMethod( self.__renderRequest ), scoped = False )
 		size = self.size()
 		if size.x and size.y :
 			self.__viewportGadget.setViewport( size )

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -63,7 +63,7 @@ class GraphEditor( GafferUI.Editor ) :
 		GafferUI.Editor.__init__( self, self.__gadgetWidget, scriptNode, **kw )
 
 		graphGadget = GafferUI.GraphGadget( self.scriptNode() )
-		self.__rootChangedConnection = graphGadget.rootChangedSignal().connect( Gaffer.WeakMethod( self.__rootChanged ) )
+		graphGadget.rootChangedSignal().connect( Gaffer.WeakMethod( self.__rootChanged ), scoped = False )
 
 		self.__gadgetWidget.getViewportGadget().setPrimaryChild( graphGadget )
 		self.__gadgetWidget.getViewportGadget().setDragTracking( GafferUI.ViewportGadget.DragTracking.XDragTracking | GafferUI.ViewportGadget.DragTracking.YDragTracking )
@@ -559,8 +559,8 @@ class GraphEditor( GafferUI.Editor ) :
 			# We have to track the root _and_ its ancestors
 			node = graphGadget.getRoot()
 			while node and not isinstance( node, Gaffer.ScriptNode ) :
-				self.__changeConnections.append( node.nameChangedSignal().connect( Gaffer.WeakMethod( self.__rootNameChanged ) ) )
-				self.__changeConnections.append( node.parentChangedSignal().connect( Gaffer.WeakMethod( self.__rootParentChanged ) ) )
+				self.__changeConnections.append( node.nameChangedSignal().connect( Gaffer.WeakMethod( self.__rootNameChanged ), scoped = True ) )
+				self.__changeConnections.append( node.parentChangedSignal().connect( Gaffer.WeakMethod( self.__rootParentChanged ), scoped = True ) )
 				node = node.parent()
 
 		self.titleChangedSignal()( self )

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -198,7 +198,9 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if renameable != True :
 			return
 
-		self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__labelDoubleClicked ) )
+		self.__labelDoubleClickConnection = self.__label.buttonDoubleClickSignal().connect(
+			Gaffer.WeakMethod( self.__labelDoubleClicked ), scoped = True
+		)
 
 	def __labelDoubleClicked( self, label, event ) :
 
@@ -212,7 +214,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__editableLabel._qtWidget().setMinimumSize( self.label()._qtWidget().minimumSize() )
 			self.__editableLabel._qtWidget().setMaximumSize( self.label()._qtWidget().maximumSize() )
 			# Connect at front so we're called before the NameWidget's own slots.
-			self.__labelEditingFinishedConnection = self.__editableLabel.editingFinishedSignal().connectFront( Gaffer.WeakMethod( self.__labelEditingFinished ) )
+			self.__editableLabel.editingFinishedSignal().connectFront( Gaffer.WeakMethod( self.__labelEditingFinished ), scoped = False )
 			self._qtWidget().layout().insertWidget( 0, self.__editableLabel._qtWidget() )
 
 		self.__label.setVisible( False )
@@ -242,7 +244,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		nodes = { plug.node() for plug in self.getPlugs() }
 		self.__plugMetadataChangedConnections = [
-			Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+			Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
 			for node in nodes
 		]
 

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -89,7 +89,8 @@ class LazyMethod( object ) :
 					widget,
 					method.__name__ + "__VisibilityChangedConnection",
 					widget.visibilityChangedSignal().connect(
-						functools.partial( self.__visibilityChanged, method = method )
+						functools.partial( self.__visibilityChanged, method = method ),
+						scoped = True
 					)
 				)
 
@@ -99,7 +100,8 @@ class LazyMethod( object ) :
 					widget,
 					method.__name__ + "__PlaybackStateChangedConnection",
 					self.__playback( widget ).stateChangedSignal().connect(
-						functools.partial( self.__playbackStateChanged, widgetWeakref = weakref.ref( widget ), method = method )
+						functools.partial( self.__playbackStateChanged, widgetWeakref = weakref.ref( widget ), method = method ),
+						scoped = True
 					)
 				)
 

--- a/python/GafferUI/MenuButton.py
+++ b/python/GafferUI/MenuButton.py
@@ -67,7 +67,10 @@ class MenuButton( GafferUI.Button ) :
 		self.__menu = menu
 
 		if self.__menu is not None :
-			self.__menuVisibilityChangedConnection = self.__menu.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__menuVisibilityChanged ) )
+			self.__menuVisibilityChangedConnection = self.__menu.visibilityChangedSignal().connect(
+				Gaffer.WeakMethod( self.__menuVisibilityChanged ),
+				scoped = True
+			)
 		else :
 			self.__menuVisibilityChangedConnection = None
 

--- a/python/GafferUI/MetadataWidget.py
+++ b/python/GafferUI/MetadataWidget.py
@@ -68,11 +68,13 @@ class MetadataWidget( GafferUI.Widget ) :
 
 		if isinstance( self.__target, Gaffer.Node ) :
 			self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal( self.__target ).connect(
-				Gaffer.WeakMethod( self.__metadataChanged )
+				Gaffer.WeakMethod( self.__metadataChanged ),
+				scoped = True
 			)
 		elif isinstance( self.__target, Gaffer.Plug ) :
 			self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__target.node() ).connect(
-				Gaffer.WeakMethod( self.__metadataChanged )
+				Gaffer.WeakMethod( self.__metadataChanged ),
+				scoped = True
 			)
 		else :
 			self.__metadataChangedConnection = None

--- a/python/GafferUI/NameLabel.py
+++ b/python/GafferUI/NameLabel.py
@@ -177,11 +177,17 @@ class NameLabel( GafferUI.Label ) :
 			if reuse :
 				updatedConnections.extend( self.__connections[ component ][ n*2 : n*2+2 ] )
 			else :
-				updatedConnections.append( g.nameChangedSignal().connect( Gaffer.WeakMethod( self.__setText ) ) )
+				updatedConnections.append(
+					g.nameChangedSignal().connect(
+						Gaffer.WeakMethod( self.__setText ),
+						scoped = True
+					)
+				)
 				if n < self.__numComponents - 1 :
 					updatedConnections.append(
 						g.parentChangedSignal().connect(
-							functools.partial( Gaffer.WeakMethod( self.__parentChanged ), component )
+							functools.partial( Gaffer.WeakMethod( self.__parentChanged ), component ),
+							scoped = True
 						)
 					)
 

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -63,11 +63,17 @@ class NameWidget( GafferUI.TextWidget ) :
 
 		self.__graphComponent = graphComponent
 		if self.__graphComponent is not None :
-			self.__nameChangedConnection = self.__graphComponent.nameChangedSignal().connect( Gaffer.WeakMethod( self.__setText ) )
+			self.__nameChangedConnection = self.__graphComponent.nameChangedSignal().connect(
+				Gaffer.WeakMethod( self.__setText ), scoped = True
+			)
 			if isinstance( self.__graphComponent, Gaffer.Node ) :
-				self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__nodeMetadataChanged ) )
+				self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect(
+					Gaffer.WeakMethod( self.__nodeMetadataChanged ), scoped = True
+				)
 			elif isinstance( self.__graphComponent, Gaffer.Plug ) :
-				self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__graphComponent.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+				self.__metadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__graphComponent.node() ).connect(
+					Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True
+				)
 			else :
 				self.__metadataChangedConnection = None
 		else :

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -100,7 +100,9 @@ class NodeSetEditor( GafferUI.Editor ) :
 			self.__nameChangedConnections = []
 			for n in self.__titleFormat :
 				if isinstance( n, Gaffer.GraphComponent ) :
-					self.__nameChangedConnections.append( n.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ) ) )
+					self.__nameChangedConnections.append(
+						n.nameChangedSignal().connect( Gaffer.WeakMethod( self.__nameChanged ), scoped = True )
+					)
 
 		result = ""
 		for t in self.__titleFormat :
@@ -243,8 +245,12 @@ class NodeSetEditor( GafferUI.Editor ) :
 
 		prevSet = self.__nodeSet
 		self.__nodeSet = nodeSet
-		self.__memberAddedConnection = self.__nodeSet.memberAddedSignal().connect( Gaffer.WeakMethod( self.__membersChanged ) )
-		self.__memberRemovedConnection = self.__nodeSet.memberRemovedSignal().connect( Gaffer.WeakMethod( self.__membersChanged ) )
+		self.__memberAddedConnection = self.__nodeSet.memberAddedSignal().connect(
+			Gaffer.WeakMethod( self.__membersChanged ), scoped = True
+		)
+		self.__memberRemovedConnection = self.__nodeSet.memberRemovedSignal().connect(
+			Gaffer.WeakMethod( self.__membersChanged ), scoped = True
+		)
 		self.__dirtyTitle()
 
 		if isinstance( nodeSet, Gaffer.StandardSet ) :

--- a/python/GafferUI/PathChooserWidget.py
+++ b/python/GafferUI/PathChooserWidget.py
@@ -155,9 +155,15 @@ class PathChooserWidget( GafferUI.Widget ) :
 			self.__previewWidget.setPath( self.__path )
 
 		# set up the signals we need to keep everything glued together
-		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ) )
-		self.__dirPathChangedConnection = self.__dirPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__dirPathChanged ) )
-		self.__listingPathChangedConnection = self.__listingPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__listingPathChanged ) )
+		self.__pathChangedConnection = self.__path.pathChangedSignal().connect(
+			Gaffer.WeakMethod( self.__pathChanged ), scoped = True
+		)
+		self.__dirPathChangedConnection = self.__dirPath.pathChangedSignal().connect(
+			Gaffer.WeakMethod( self.__dirPathChanged ), scoped = True
+		)
+		self.__listingPathChangedConnection = self.__listingPath.pathChangedSignal().connect(
+			Gaffer.WeakMethod( self.__listingPathChanged ), scoped = True
+		)
 
 		self.__updateFilter()
 		self.__pathChanged( self.__path )

--- a/python/GafferUI/PathFilterWidget.py
+++ b/python/GafferUI/PathFilterWidget.py
@@ -47,7 +47,7 @@ class PathFilterWidget( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
 
 		self.__pathFilter = pathFilter
-		self.__pathFilterChangedConnection = self.__pathFilter.changedSignal().connect( Gaffer.WeakMethod( self.__pathFilterChanged ) )
+		self.__pathFilterChangedConnection = self.__pathFilter.changedSignal().connect( Gaffer.WeakMethod( self.__pathFilterChanged ), scoped = False )
 
 	## Returns the PathFilter object this UI represents.
 	def pathFilter( self ) :

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -158,7 +158,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			return
 
 		self.__path = path
-		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ) )
+		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ), scoped = True )
 		self.__currentDir = None
 		self.__currentPath = ""
 		self.__update()

--- a/python/GafferUI/PathPreviewWidget.py
+++ b/python/GafferUI/PathPreviewWidget.py
@@ -58,7 +58,9 @@ class PathPreviewWidget( GafferUI.Widget ) :
 		prevPath = self.__path
 		self.__path = path
 		self.__currentPath = None
-		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ) )
+		self.__pathChangedConnection = self.__path.pathChangedSignal().connect(
+			Gaffer.WeakMethod( self.__pathChanged ), scoped = True
+		)
 
 		if prevPath != None :
 			# we don't call _updateFromPath when setPath is called from __init__,

--- a/python/GafferUI/PathWidget.py
+++ b/python/GafferUI/PathWidget.py
@@ -75,7 +75,10 @@ class PathWidget( GafferUI.TextWidget ) :
 	def setPath( self, path ) :
 
 		self.__path = path
-		self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged, fallbackResult = None ) )
+		self.__pathChangedConnection = self.__path.pathChangedSignal().connect(
+			Gaffer.WeakMethod( self.__pathChanged, fallbackResult = None ),
+			scoped = True
+		)
 		self.setText( str( self.__path ) )
 
 	def getPath( self ) :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -161,7 +161,9 @@ class PlugLayout( GafferUI.Widget ) :
 	def setContext( self, context ) :
 
 		self.__context = context
-		self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
+		self.__contextChangedConnection = self.__context.changedSignal().connect(
+			Gaffer.WeakMethod( self.__contextChanged ), scoped = True
+		)
 
 		for widget in self.__widgets.values() :
 			self.__applyContext( widget, context )
@@ -661,7 +663,8 @@ class _TabLayout( _Layout ) :
 					self.__tabbedContainer._qtWidget().setSizePolicy( QtWidgets.QSizePolicy( QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Expanding ) )
 
 		self.__currentTabChangedConnection = self.__tabbedContainer.currentChangedSignal().connect(
-			Gaffer.WeakMethod( self.__currentTabChanged )
+			Gaffer.WeakMethod( self.__currentTabChanged ),
+			scoped = False
 		)
 
 	def update( self, section ) :

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -503,15 +503,15 @@ class PlugValueWidget( GafferUI.Widget ) :
 		self.__plugs = plugs
 
 		self.__plugDirtiedConnections = [
-			node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
+			node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True )
 			for node in nodes
 		]
 		self.__plugInputChangedConnections = [
-			node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ) )
+			node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ), scoped = True )
 			for node in nodes
 		]
 		self.__plugMetadataChangedConnections = [
-			Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+			Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
 			for node in nodes
 		]
 
@@ -532,7 +532,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			context = None
 
 		if context is not None :
-			self.__contextChangedConnection = context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
+			self.__contextChangedConnection = context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = True )
 		else :
 			self.__contextChangedConnection = None
 

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -202,8 +202,8 @@ class _WindowTitleBehaviour :
 		self.__window = weakref.ref( window )
 		self.__script = weakref.ref( script )
 
-		self.__scriptPlugSetConnection = script.plugSetSignal().connect( Gaffer.WeakMethod( self.__scriptPlugChanged ) )
-		self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__metadataChanged ) )
+		self.__scriptPlugSetConnection = script.plugSetSignal().connect( Gaffer.WeakMethod( self.__scriptPlugChanged ), scoped = True )
+		self.__metadataChangedConnection = Gaffer.Metadata.nodeValueChangedSignal().connect( Gaffer.WeakMethod( self.__metadataChanged ), scoped = True )
 
 		self.__updateTitle()
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
@@ -59,14 +59,14 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		self.__rowsPlug = rowsPlug
 		self.__context = context
 
-		self.__plugDirtiedConnection = rowsPlug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
-		self.__rowAddedConnection = rowsPlug.childAddedSignal().connect( Gaffer.WeakMethod( self.__rowAdded ) )
-		self.__rowRemovedConnection = rowsPlug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__rowRemoved ) )
-		self.__rowsReorderedConnection = rowsPlug.childrenReorderedSignal().connect( Gaffer.WeakMethod( self.__rowsReordered ) )
-		self.__columnAddedConnection = rowsPlug.defaultRow()["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ) )
-		self.__columnRemovedConnection = rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ) )
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
-		self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
+		self.__plugDirtiedConnection = rowsPlug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True )
+		self.__rowAddedConnection = rowsPlug.childAddedSignal().connect( Gaffer.WeakMethod( self.__rowAdded ), scoped = True )
+		self.__rowRemovedConnection = rowsPlug.childRemovedSignal().connect( Gaffer.WeakMethod( self.__rowRemoved ), scoped = True )
+		self.__rowsReorderedConnection = rowsPlug.childrenReorderedSignal().connect( Gaffer.WeakMethod( self.__rowsReordered ), scoped = True )
+		self.__columnAddedConnection = rowsPlug.defaultRow()["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ), scoped = True )
+		self.__columnRemovedConnection = rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ), scoped = True )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
+		self.__contextChangedConnection = self.__context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = True )
 
 	# Methods of our own
 	# ------------------

--- a/python/GafferUI/SpreadsheetUI/_SectionChooser.py
+++ b/python/GafferUI/SpreadsheetUI/_SectionChooser.py
@@ -67,7 +67,10 @@ class _SectionChooser( GafferUI.Widget ) :
 		tabBar.currentChanged.connect( Gaffer.WeakMethod( self.__currentChanged ) )
 		self.__ignoreCurrentChanged = False
 		tabBar.tabMoved.connect( Gaffer.WeakMethod( self.__tabMoved ) )
-		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__rowsPlug.node() ).connect(
+			Gaffer.WeakMethod( self.__plugMetadataChanged ),
+			scoped = False
+		)
 		self.__rowsPlug.defaultRow()["cells"].childAddedSignal().connect( Gaffer.WeakMethod( self.__columnAdded ), scoped = False )
 		self.__rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ), scoped = False )
 

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -118,8 +118,12 @@ class Timeline( GafferUI.Editor ) :
 		if self.__playback is None or not self.__playback.context().isSame( self.getContext() ) :
 			self.__playback = GafferUI.Playback.acquire( self.getContext() )
 			self.__playback.setFrameRange( self.__sliderRangeStart.getValue(), self.__sliderRangeEnd.getValue() )
-			self.__playbackStateChangedConnection = self.__playback.stateChangedSignal().connect( Gaffer.WeakMethod( self.__playbackStateChanged ) )
-			self.__playbackFrameRangeChangedConnection = self.__playback.frameRangeChangedSignal().connect( Gaffer.WeakMethod( self.__playbackFrameRangeChanged ) )
+			self.__playbackStateChangedConnection = self.__playback.stateChangedSignal().connect(
+				Gaffer.WeakMethod( self.__playbackStateChanged ), scoped = True
+			)
+			self.__playbackFrameRangeChangedConnection = self.__playback.frameRangeChangedSignal().connect(
+				Gaffer.WeakMethod( self.__playbackFrameRangeChanged ), scoped = True
+			)
 
 		if "frame" not in modifiedItems :
 			return

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -632,13 +632,17 @@ class _PlugListing( GafferUI.Widget ) :
 
 		if self.__parent is not None :
 
-			self.__childAddedConnection = self.__parent.childAddedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ) )
-			self.__childRemovedConnection = self.__parent.childRemovedSignal().connect( Gaffer.WeakMethod( self.__childAddedOrRemoved ) )
+			self.__childAddedConnection = self.__parent.childAddedSignal().connect(
+				Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = True
+			)
+			self.__childRemovedConnection = self.__parent.childRemovedSignal().connect(
+				Gaffer.WeakMethod( self.__childAddedOrRemoved ), scoped = True
+			)
 
 			node = self.__parent if isinstance( self.__parent, Gaffer.Node ) else self.__parent.node()
 			self.__metadataChangedConnections = [
-				Gaffer.Metadata.nodeValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__nodeMetadataChanged ) ),
-				Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+				Gaffer.Metadata.nodeValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__nodeMetadataChanged ), scoped = True ),
+				Gaffer.Metadata.plugValueChangedSignal( node ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
 			]
 
 			for child in self.__parent.children() :
@@ -800,7 +804,7 @@ class _PlugListing( GafferUI.Widget ) :
 
 		if self.__parent.isSame( child.parent() ) :
 			if child not in self.__childNameChangedConnections :
-				self.__childNameChangedConnections[child] = child.nameChangedSignal().connect( Gaffer.WeakMethod( self.__childNameChanged ) )
+				self.__childNameChangedConnections[child] = child.nameChangedSignal().connect( Gaffer.WeakMethod( self.__childNameChanged ), scoped = True )
 		else :
 			if child in self.__childNameChangedConnections :
 				del self.__childNameChangedConnections[child]
@@ -1112,7 +1116,9 @@ class _PresetsEditor( GafferUI.Widget ) :
 		# We make a UI for editing preset values by copying the plug
 		# onto this node and then making a PlugValueWidget for it.
 		self.__valueNode = Gaffer.Node( "PresetEditor" )
-		self.__valuePlugSetConnection = self.__valueNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__valuePlugSet ) )
+		self.__valuePlugSetConnection = self.__valueNode.plugSetSignal().connect(
+			Gaffer.WeakMethod( self.__valuePlugSet ), scoped = False
+		)
 
 	def setPlug( self, plug ) :
 
@@ -1123,7 +1129,10 @@ class _PresetsEditor( GafferUI.Widget ) :
 
 		plugValueWidget = None
 		if self.__plug is not None :
-			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
+			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect(
+				Gaffer.WeakMethod( self.__plugMetadataChanged ),
+				scoped = True
+			)
 			self.__valueNode["presetValue"] = plug.createCounterpart( "presetValue", plug.Direction.In )
 			if hasattr( self.__plug, "getValue" ) :
 				plugValueWidget = GafferUI.PlugValueWidget.create( self.__valueNode["presetValue"], useTypeOnly = True )
@@ -1410,7 +1419,7 @@ class _PlugEditor( GafferUI.Widget ) :
 		self.__plugMetadataChangedConnection = None
 		if self.__plug is not None :
 			self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( self.__plug.node() ).connect(
-				Gaffer.WeakMethod( self.__plugMetadataChanged )
+				Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True
 			)
 
 		self.__updateWidgetMenuText()

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -116,8 +116,8 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				self.__toolChooser = _ToolChooser()
-				self.__primaryToolChangedConnection = self.__toolChooser.primaryToolChangedSignal().connect(
-					Gaffer.WeakMethod( self.__primaryToolChanged )
+				self.__toolChooser.primaryToolChangedSignal().connect(
+					Gaffer.WeakMethod( self.__primaryToolChanged ), scoped = False
 				)
 
 				for toolbarContainer in [ self.__viewToolbars, self.__nodeToolbars, self.__toolToolbars ] :
@@ -461,7 +461,7 @@ class _ToolChooser( GafferUI.Frame ) :
 		self.__primaryToolChangedConnection = None
 		if viewTools is not None :
 			self.__primaryToolChangedConnection = viewTools.primaryToolChangedSignal.connect(
-				Gaffer.WeakMethod( self.__primaryToolChanged )
+				Gaffer.WeakMethod( self.__primaryToolChanged ), scoped = True
 			)
 
 		self.__view = view

--- a/python/GafferUI/_Pointer.py
+++ b/python/GafferUI/_Pointer.py
@@ -63,4 +63,4 @@ def __pointerChanged() :
 			application.setOverrideCursor( cursor )
 			__cursorOverridden = True
 
-__changedConnection = GafferUI.Pointer.changedSignal().connect( __pointerChanged )
+GafferUI.Pointer.changedSignal().connect( __pointerChanged, scoped = False )

--- a/python/GafferUITest/BoolWidgetTest.py
+++ b/python/GafferUITest/BoolWidgetTest.py
@@ -60,7 +60,7 @@ class BoolWidgetTest( GafferUITest.TestCase ) :
 			self.emissions += 1
 
 		w = GafferUI.BoolWidget()
-		c = w.stateChangedSignal().connect( f )
+		w.stateChangedSignal().connect( f, scoped = False )
 
 		w.setState( True )
 		self.assertEqual( w.getState(), True )

--- a/python/GafferUITest/CollapsibleTest.py
+++ b/python/GafferUITest/CollapsibleTest.py
@@ -66,7 +66,7 @@ class CollapsibleTest( GafferUITest.TestCase ) :
 			self.__states.append( widget.getCollapsed( ) )
 
 		c = GafferUI.Collapsible( collapsed=True )
-		stateChangedConnection = c.stateChangedSignal().connect( stateChanged )
+		c.stateChangedSignal().connect( stateChanged, scoped = False )
 
 		c.setCollapsed( False )
 		self.assertEqual( self.__states, [ False ] )

--- a/python/GafferUITest/EditorTest.py
+++ b/python/GafferUITest/EditorTest.py
@@ -94,12 +94,12 @@ class EditorTest( GafferUITest.TestCase ) :
 		editorsCreated = []
 		def editorCreated( editor ) :
 			editorsCreated.append( editor )
-		editorCreatedConnection = GafferUI.Editor.instanceCreatedSignal().connect( editorCreated )
+		editorCreatedConnection = GafferUI.Editor.instanceCreatedSignal().connect( editorCreated, scoped = True )
 
 		pythonEditorsCreated = []
 		def pythonEditorCreated( editor ) :
 			pythonEditorsCreated.append( editor )
-		pythonEditorCreatedConnection = GafferUI.PythonEditor.instanceCreatedSignal().connect( pythonEditorCreated )
+		pythonEditorCreatedConnection = GafferUI.PythonEditor.instanceCreatedSignal().connect( pythonEditorCreated, scoped = True )
 
 		s = Gaffer.ScriptNode()
 

--- a/python/GafferUITest/EventSignalCombinerTest.py
+++ b/python/GafferUITest/EventSignalCombinerTest.py
@@ -72,8 +72,8 @@ class EventSignalCombinerTest( GafferUITest.TestCase ) :
 	def testShortCutting( self ) :
 
 		s = GafferUI.Gadget.ButtonSignal()
-		c1 = s.connect( self.trueSlot )
-		c2 = s.connect( self.falseSlot )
+		s.connect( self.trueSlot, scoped = False )
+		s.connect( self.falseSlot, scoped = False )
 
 		self.assertEqual( self.trueSlotCalled, False )
 		self.assertEqual( self.falseSlotCalled, False )
@@ -86,8 +86,8 @@ class EventSignalCombinerTest( GafferUITest.TestCase ) :
 	def testNoShortCutting( self ) :
 
 		s = GafferUI.Gadget.ButtonSignal()
-		c1 = s.connect( self.falseSlot )
-		c2 = s.connect( self.trueSlot )
+		s.connect( self.falseSlot, scoped = False )
+		s.connect( self.trueSlot, scoped = False )
 
 		self.assertEqual( self.trueSlotCalled, False )
 		self.assertEqual( self.falseSlotCalled, False )
@@ -104,8 +104,8 @@ class EventSignalCombinerTest( GafferUITest.TestCase ) :
 		# those slots being printed to stderr.
 
 		s = GafferUI.Gadget.ButtonSignal()
-		c1 = s.connect( self.exceptionSlot )
-		c2 = s.connect( self.trueSlot )
+		s.connect( self.exceptionSlot, scoped = False )
+		s.connect( self.trueSlot, scoped = False )
 
 		self.assertEqual( self.exceptionSlotCalled, False )
 		self.assertEqual( self.trueSlotCalled, False )

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -291,12 +291,10 @@ class GadgetTest( GafferUITest.TestCase ) :
 
 			events.append( ( gadget, gadget.visible() ) )
 
-		connnections = [
-			g.visibilityChangedSignal().connect( visibilityChanged ),
-			g["a"].visibilityChangedSignal().connect( visibilityChanged ),
-			g["a"]["c"].visibilityChangedSignal().connect( visibilityChanged ),
-			g["b"].visibilityChangedSignal().connect( visibilityChanged ),
-		]
+		g.visibilityChangedSignal().connect( visibilityChanged, scoped = False )
+		g["a"].visibilityChangedSignal().connect( visibilityChanged, scoped = False )
+		g["a"]["c"].visibilityChangedSignal().connect( visibilityChanged, scoped = False )
+		g["b"].visibilityChangedSignal().connect( visibilityChanged, scoped = False )
 
 		g["b"].setVisible( True )
 		self.assertEqual( len( events ), 0 )

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -571,7 +571,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 			previousRoots.append( previousRoot )
 
 		g = GafferUI.GraphGadget( s )
-		c = g.rootChangedSignal().connect( f )
+		g.rootChangedSignal().connect( f, scoped = False )
 
 		self.assertEqual( len( roots ), 0 )
 		self.assertEqual( len( previousRoots ), 0 )

--- a/python/GafferUITest/NodeSetEditorTest.py
+++ b/python/GafferUITest/NodeSetEditorTest.py
@@ -87,9 +87,8 @@ class NodeSetEditorTest( GafferUITest.TestCase ) :
 			else :
 				signalData['ne2nodeSetMirror'] = d
 
-		c1 = ne1.nodeSetChangedSignal().connect( nodeSetChangedCallback )
-
-		c4 = ne2.nodeSetChangedSignal().connect( nodeSetChangedCallback )
+		ne1.nodeSetChangedSignal().connect( nodeSetChangedCallback, scoped = False )
+		ne2.nodeSetChangedSignal().connect( nodeSetChangedCallback, scoped = False )
 
 		ne1.setNodeSet( n1 )
 		ne2.setNodeSet( n2 )

--- a/python/GafferUITest/SelectionMenuTest.py
+++ b/python/GafferUITest/SelectionMenuTest.py
@@ -99,7 +99,7 @@ class SelectionMenuTest( GafferUITest.TestCase ) :
 			def f( w ) :
 				self.emissions += 1
 
-			c = s.currentIndexChangedSignal().connect(f)
+			s.currentIndexChangedSignal().connect( f, scoped = False )
 
 			s.addItem("Test1")
 			s.addItem("Test2")

--- a/python/GafferUITest/TabbedContainerTest.py
+++ b/python/GafferUITest/TabbedContainerTest.py
@@ -132,7 +132,7 @@ class TabbedContainerTest( GafferUITest.TestCase ) :
 			self.assertTrue( t is tc )
 			self.__current = c
 
-		c = tc.currentChangedSignal().connect( s )
+		c = tc.currentChangedSignal().connect( s, scoped = True )
 		self.__current = None
 
 		self.assertIsNone( tc.getCurrent() )

--- a/python/GafferUITest/TextWidgetTest.py
+++ b/python/GafferUITest/TextWidgetTest.py
@@ -62,7 +62,7 @@ class TextWidgetTest( GafferUITest.TestCase ) :
 			self.emissions += 1
 
 		w = GafferUI.TextWidget()
-		c = w.textChangedSignal().connect( f )
+		w.textChangedSignal().connect( f, scoped = False )
 
 		w.setText( "hello" )
 		self.assertEqual( w.getText(), "hello" )

--- a/python/GafferUITest/WidgetSignalTest.py
+++ b/python/GafferUITest/WidgetSignalTest.py
@@ -59,11 +59,11 @@ class WidgetSignalTest( GafferUITest.TestCase ) :
 			self.__widget = ww
 			return True
 
-		c = s.connect( f )
+		s.connect( f, scoped = False )
 		self.assertEqual( s( w ), True )
 		self.assertTrue( self.__widget is w )
 
-	def testDeletionOfConnectionDisconnects( self ) :
+	def testDeletionOfScopedConnectionDisconnects( self ) :
 
 		w = GafferUI.TabbedContainer()
 
@@ -74,7 +74,7 @@ class WidgetSignalTest( GafferUITest.TestCase ) :
 
 			return True
 
-		c = s.connect( f )
+		c = s.connect( f, scoped = True )
 
 		self.assertEqual( s( w ), True )
 
@@ -104,7 +104,7 @@ class WidgetSignalTest( GafferUITest.TestCase ) :
 		a = A()
 		self.assertEqual( a.signal( a ), False )
 
-		a.c = a.signal.connect( A.f )
+		a.c = a.signal.connect( A.f, scoped = True )
 		self.assertEqual( a.signal( a ), True )
 
 		w = weakref.ref( a )
@@ -117,7 +117,7 @@ class WidgetSignalTest( GafferUITest.TestCase ) :
 
 		# it is imperative to connect to a WeakMethod to prevent
 		# unbreakable circular references from forming.
-		a2.c = a2.signal.connect( Gaffer.WeakMethod( a2.ff ) )
+		a2.c = a2.signal.connect( Gaffer.WeakMethod( a2.ff ), scoped = True )
 		self.assertEqual( a2.signal( a2 ), True )
 
 		w = weakref.ref( a2 )

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -178,7 +178,7 @@ class WidgetTest( GafferUITest.TestCase ) :
 
 			WidgetTest.signalsEmitted += 1
 
-		c = w.buttonPressSignal().connect( f )
+		w.buttonPressSignal().connect( f, scoped = False )
 
 		WidgetTest.signalsEmitted = 0
 

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -182,7 +182,7 @@ class WindowTest( GafferUITest.TestCase ) :
 		w.setVisible( True )
 		self.assertEqual( w.getVisible(), True )
 
-		c = w.closedSignal().connect( closeFn )
+		w.closedSignal().connect( closeFn, scoped = False )
 
 		self.assertEqual( w.close(), True )
 		self.assertEqual( w.getVisible(), False )
@@ -199,7 +199,7 @@ class WindowTest( GafferUITest.TestCase ) :
 		w.setVisible( True )
 		self.assertEqual( w.getVisible(), True )
 
-		c = w.closedSignal().connect( closeFn )
+		w.closedSignal().connect( closeFn, scoped = False )
 
 		# simulate user clicking on the x
 		w._qtWidget().close()
@@ -228,7 +228,7 @@ class WindowTest( GafferUITest.TestCase ) :
 		w.setVisible( True )
 		self.assertEqual( w.getVisible(), True )
 
-		c = w.closedSignal().connect( closeFn )
+		w.closedSignal().connect( closeFn, scoped = False )
 
 		self.assertEqual( w.close(), False )
 		self.assertEqual( w.getVisible(), True )

--- a/src/GafferBindings/SignalBinding.cpp
+++ b/src/GafferBindings/SignalBinding.cpp
@@ -47,9 +47,29 @@ namespace GafferBindings
 namespace Detail
 {
 
-boost::python::object pythonConnection( const Gaffer::Signals::Connection &connection, bool scoped )
+boost::python::object pythonConnection( const Gaffer::Signals::Connection &connection, const boost::python::object &scoped )
 {
-	if( scoped )
+	bool useScopedConnection;
+	if( scoped == boost::python::object() )
+	{
+		const char *warning =
+			"The default value for `scoped` is deprecated. "
+			"Please pass `scoped = True` to keep the previous behaviour, "
+			"or consider using an unscoped connection."
+		;
+		if( PyErr_WarnEx( PyExc_DeprecationWarning, warning, 1 ) == -1 )
+		{
+			// Warning being treated as an error.
+			throw_error_already_set();
+		}
+		useScopedConnection = true;
+	}
+	else
+	{
+		useScopedConnection = extract<bool>( scoped );
+	}
+
+	if( useScopedConnection )
 	{
 		// Simply returning `object( scoped_connection( connection ) )`
 		// doesn't work - somehow the scoped_connection dies and the

--- a/startup/GafferScene/cameraCompatibility.py
+++ b/startup/GafferScene/cameraCompatibility.py
@@ -70,7 +70,7 @@ def __initWrapper( originalInit, defaultName ):
 
 	def init( self, name = defaultName ):
 		originalInit( self, name )
-		self.__compatibilityCallback = self.parentChangedSignal().connect( __compatibilityFunc )
+		self.__compatibilityCallback = self.parentChangedSignal().connect( __compatibilityFunc, scoped = True )
 
 	return init
 


### PR DESCRIPTION
Instead, require that either `scoped = True` or `scoped = False` is passed explicitly. There's a bit of a long back story to this one...

When I first made the signal bindings for Python way back in the mists of time, I made the mistake of _not_ mirroring the C++ API directly. In C++, `connect()` returns a `Connection` object which can be used to manage the connection. In Python I returned a `ScopedConnection` instead, which is like `Connection` but _also_ disconnects the slot automatically when the `ScopedConnection` is destroyed. This naturally lead to confusion :

```
# The slot will never be called, because the returned ScopedConnection is
# destroyed immediately.
signal.connect( mySlot )
# The slot will be called as expected, but finding somewhere to store
# `connection` can be inconvenient, particularly in config files.
connection = signal.connect( mySlot )
```

In `0.14.0.0` we added a `scoped` argument, which can be used to request the same behaviour as the C++ default, with a regular `Connection` object being returned from `connect()`.

```
# Works!
signal.connect( mySlot, scoped = False )
# Still doesn't work - the default is `scoped = True`
signal.connect( mySlot )
```

In `0.54.0.0` we went further, and introduced a new Trackable Python class that negated one of the major reasons for wanting to use `scoped = True` in Python (#3179). By deriving from Trackable, classes get automatic disconnection of their slots on class destruction, regardless of what type of connection they made. This closely matches the typical C++ usage, which is what we are striving for in the Python bindings.

Despite these improvements, the original problem remains : the default behaviour of `connect()` is confusing and unhelpful, and continues to trip people up, new and old hands alike. We really want the default to be `scoped = False`. In the absence of a time machine, this PR makes the first step in this direction by deprecating the usage of the default value. Once everyone has updated to use `scoped = something` universally, we can then change the default value to `scoped = False` in a future version without fear of breaking everything.

The deprecation is handled by emitting DeprecationWarning via Python's standard `warnings` mechanism, in `src/GafferBindings/SignalBinding.cpp`. This warning is turned into a failure in `gaffer test`, and printed to the terminal in a regular `gaffer` session. Downstream users can configure alternative behaviours using `warnings.simplefilter()` etc.

After updating all call sites in Gaffer appropriately, we are left with 645 calls with `scoped = False` and 173 with `scoped = True`. This provides further weight to the idea that `False` is the correct default.

(Built on #4533 - only the final commit is unique to this PR).