### PR TITLE
SceneHistoryUI : Allow "Edit Source" to show referenced nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Instancer : Fixed RootsPerVertex mode in the case that the input object has no vertices. Previously an empty `prototypeRoots` variable would cause an unnecessary error in this case, which was incompatible with the output from DeletePoints.
+- Viewer/HierarchyView : Fixed "Edit Source" operation when the source node is inside a Reference. Previously the Reference node was shown, but now the node itself will be (albeit in read-only form).
 - ValuePlugSerialiser : Fixed crash if `valueRepr()` was called with a CompoundObject value and a null `serialisation`.
 
 0.60.12.1 (relative to 0.60.12.0)

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -123,7 +123,7 @@ def __editSourceNode( context, scene, path, nodeEditor = None ) :
 		return
 
 	node = source.node()
-	node = __ancestorWithReadOnlyChildNodes( node ) or node
+	node = __ancestorWithNonViewableChildNodes( node ) or node
 	if nodeEditor is not None :
 		nodeEditor.setNodeSet( Gaffer.StandardSet( [ node ] ) )
 	else :
@@ -153,17 +153,17 @@ def __editTweaksNode( context, scene, path, nodeEditor = None ) :
 	if tweaks is None :
 		return
 
-	node = __ancestorWithReadOnlyChildNodes( tweaks ) or tweaks
+	node = __ancestorWithNonViewableChildNodes( tweaks ) or tweaks
 	if nodeEditor is not None :
 		nodeEditor.setNodeSet( Gaffer.StandardSet( [ node ] ) )
 	else :
 		GafferUI.NodeEditor.acquire( node, floating = True )
 
-def __ancestorWithReadOnlyChildNodes( node ) :
+def __ancestorWithNonViewableChildNodes( node ) :
 
 	result = None
 	while isinstance( node, Gaffer.Node ) :
-		if Gaffer.MetadataAlgo.getChildNodesAreReadOnly( node ) :
+		if Gaffer.Metadata.value( node, "graphEditor:childrenViewable" ) == False :
 			result = node
 		node = node.parent()
 


### PR DESCRIPTION
When we designed this, we thought the priority was to show a node that could truly be edited. So when the source node was inside a Reference, we showed the reference node for editing, on the assumption that some plugs of the source node would have been promoted. But in practice, this is rarely the case, and when using "Edit Source" in this scenario, users want to see the true source node still so that they can inspect its parameters etc.

