### PR TITLE
CatalogueUI : Fix unwanted error caused by missing images

### DIFF
--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -116,6 +116,8 @@ class Column( GafferUI.PathColumn ) :
 					else :
 						return self.CellData( value = self.value( image, catalogue ) )
 
+		return self.CellData()
+
 	def headerData( self, canceller ) :
 
 		return self.CellData( value = self.__title )
@@ -244,6 +246,7 @@ class __StatusIconColumn( Column ) :
 	def _imageCellData( self, image, catalogue ) :
 
 		icon = "catalogueStatusDisplay.png"
+		toolTip = None
 
 		fileName = image["fileName"].getValue()
 		if fileName :
@@ -252,10 +255,11 @@ class __StatusIconColumn( Column ) :
 			# are going to do this anyway, we're not adding too much overhead here.
 			try :
 				catalogue["out"].metadata()
-			except Gaffer.ProcessException :
+			except Gaffer.ProcessException as e :
 				icon = "errorSmall.png"
+				toolTip = str( e )
 
-		return self.CellData( icon = icon )
+		return self.CellData( icon = icon, toolTip = toolTip )
 
 registerColumn( "Status", __StatusIconColumn() )
 registerColumn( "Name", GafferUI.PathListingWidget.defaultNameColumn )


### PR DESCRIPTION
`Column.cellData()` was returning `None` in this case, which is not convertible to `CellData`, causing this warning to be printed in the terminal :

```
WARNING : PathListingWidget : TypeError: No registered converter was able to produce a C++ rvalue of type GafferUI::PathColumn::CellData from this Python object of type NoneType
```

We now return empty CellData, and also show the underlying cause as a tooltip on the icon column, where the error icon is being shown.

Generally describe what this PR will do, and why it is needed

- List specific new features and changes to project components

### Related issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

- List any other unmerged PRs that this PR depends on

### Breaking changes ###

- List any breaking API/ABI changes  (and apply the pr-majorVersion label)

### Checklist ###

- [ ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Gaffer project's prevailing coding style and conventions.
