### PR TITLE
Avoid `tbb/tbb.h`

### DIFF
--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -44,7 +44,8 @@
 
 #include "boost/tuple/tuple.hpp"
 
-#include "tbb/tbb.h"
+#include "tbb/pipeline.h"
+#include "tbb/task_scheduler_init.h"
 
 namespace GafferImage
 {

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -51,7 +51,8 @@
 #include "boost/multi_index_container.hpp"
 #include "boost/optional.hpp"
 
-#include "tbb/tbb.h"
+#include "tbb/concurrent_hash_map.h"
+#include "tbb/recursive_mutex.h"
 
 #include <unordered_map>
 

--- a/src/GafferTest/ComputeNodeTest.cpp
+++ b/src/GafferTest/ComputeNodeTest.cpp
@@ -41,7 +41,7 @@
 
 #include "IECore/Timer.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <thread>
 
@@ -66,7 +66,7 @@ struct Edit
 			GafferTest::MultiplyNodePtr m = new GafferTest::MultiplyNode;
 			m->op1Plug()->setValue( 10 );
 			m->op1Plug()->setValue( 20 );
-			tbb::this_tbb_thread::yield();
+			std::this_thread::yield();
 		}
 	}
 

--- a/src/GafferTest/MetadataTest.cpp
+++ b/src/GafferTest/MetadataTest.cpp
@@ -44,7 +44,7 @@
 
 #include "IECore/SimpleTypedData.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 using namespace tbb;
 using namespace IECore;


### PR DESCRIPTION
This has been deprecated and spews warning messages into the build log.
