### PR TITLE
Mac documentation fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,3 +224,17 @@ jobs:
       # unbounded growth. In practice, the archives that get uploaded are much smaller
       # than the limit we apply here, because they're compressed.
       run: ./.github/workflows/main/limitDirectorySize.py --directory ./sconsCache --megabytes ${{ matrix.sconsCacheMegabytes }} --verbose
+
+    - name: Debug Failures
+      run: |
+        # Give MacOS crash reporter time to do its thing
+        sleep 20
+        # Print SCons logs and MacOS crash logs
+        shopt -s nullglob
+        for logFile in config.log ~/Library/Logs/DiagnosticReports/*.crash
+        do
+         echo $logFile
+         cat $logFile
+        done
+      if: failure()
+

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -228,13 +228,6 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 		self.setVerticalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 
 		glWidget = self.__createQGLWidget( format )
-
-		# On mac, we need to hide the GL widget until the last
-		# possible moment, otherwise we get "invalid drawable"
-		# errors spewing all over the place. See event() for the
-		# spot where we show the widget.
-		glWidget.hide()
-
 		self.setViewport( glWidget )
 		self.setViewportUpdateMode( self.FullViewportUpdate )
 
@@ -245,17 +238,6 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 	def minimumSizeHint( self ) :
 
 		return QtCore.QSize()
-
-	def event( self, event ) :
-
-		if event.type() == event.PolishRequest :
-			# This seems to be the one signal that reliably
-			# lets us know we're becoming genuinely visible
-			# on screen. We use it to show the GL widget we
-			# hid in our constructor.
-			self.viewport().show()
-
-		return QtWidgets.QGraphicsView.event( self, event )
 
 	def resizeEvent( self, event ) :
 


### PR DESCRIPTION
I've been trying to get to the bottom of the crashes and hangs we've been seeing when running the documentation build under Mac CI. This adds some useful debug information and one fix that I think is part of the answer. More to follow...