### PR TITLE
SceneAlgo::history : Don't store CapturedProcess for entries that won't be output

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Fixes
 - ArnoldRender : Stopped instancing of polygon meshes when both `ai:subdivide_polygons` and adaptive subdivision are on.
 - GLWidget : Fixed bug which made overlays unresponsive on high resolution displays.
 - CropWindowTool : Fixed bug (introduced in 0.61.0.0) which prevented the free drawing of a new crop region outside the current one. (#4530).
+- SceneAlgo::history ( used in SceneInspector and Viewer Inspector ): Fixed massive memory usage when viewing an attribute triggers a massive scene evaluation
 
 API
 ---


### PR DESCRIPTION
This fixes a massive amount of memory being used in cases where an attribute compute triggers a massive scene evaluation.

Implementation as discussed.  Next step is to replace this with something more performant.
