### PR TITLE
EventLoop : Set Qt's `AA_EnableHighDpiScaling` attribute

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes.
 - GraphEditor : The focus widget now ignores right clicks, avoiding situations where attempting to open a context menu could accidentally change focus.
 - StandardAttributes : Added `attributes.displayColor` plug, for controlling the colour of objects in the Viewer.
+- UI : The UI is now scaled automatically for high-resolution monitors on Linux (#2157). Set the `QT_ENABLE_HIGHDPI_SCALING` environment variable to `0` to disable.
 
 0.61.2.0 (relative to 0.61.1.1)
 ========

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -159,6 +159,9 @@ class EventLoop( object ) :
 		# environment, which could mess with our own style (on GNOME for instance,
 		# our icons can come out the wrong size).
 		style = QtWidgets.QApplication.setStyle( "Fusion" )
+		# Stop icons/fonts being tiny on high-dpi monitors. Must be set before
+		# the application is created.
+		QtWidgets.QApplication.setAttribute( QtCore.Qt.AA_EnableHighDpiScaling )
 		assert( style is not None )
 		__qtApplication = QtWidgets.QApplication( [ "gaffer" ] )
 		# Fixes laggy interaction with tablets, equivalent to the old


### PR DESCRIPTION
This makes Linux behave similar to Mac, with the UI automatically being scaled on high resolution monitors.

@boberfly, I've only got a single monitor for testing this on, and I think you were also concerned about a two-monitor setup with one being high and one being low res? If you have a chance to test, would be good to know how this works for you...

Fixes #2157.