### PR TITLE
Bookmarks UI : Menu option and shortcuts for setting focus to bookmark

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - SceneViewInspector :
   - Updated to align colour scheme and interaction patterns with the LightEditor.
   - Reduced overhead when the Viewer is not visible in the UI.
+- Added <kbd>Shift+1</kbd>-<kbd>Shift+9</kbd> hotkeys for setting focus to a bookmark ( also available in the "Edit/Assign Focus" menu )
 
 Fixes
 -----

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -145,6 +145,22 @@ def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 			"checkBox" : isCurrent,
 		} )
 
+def appendScriptWindowMenuDefinitions( menuDefinition, prefix="" ) :
+
+	# Follow bookmarks
+
+	def assignFocus( i, menu ) :
+		script = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
+		script.setFocus( Gaffer.MetadataAlgo.getNumericBookmark( script, i ) )
+
+	menuDefinition.append( prefix + "/AssignFocusDivider", { "divider" : True } )
+
+	for i in range( 1, 10 ) :
+		menuDefinition.append( prefix + "/Assign Focus/Bookmark %i" % i, {
+			"command" : functools.partial( assignFocus, i ),
+			"shortCut" : "Shift+%s" % ( ")!@#$%^&*("[i] )
+		} )
+
 def connectToEditor( editor ) :
 
 	editor.keyPressSignal().connect( __editorKeyPress, scoped = False )
@@ -327,6 +343,8 @@ def __editorKeyPress( editor, event ) :
 			if node is not None :
 				__assignNumericBookmark( node, numericBookmark )
 
+			return True
+
 		elif not event.modifiers :
 
 			# Find
@@ -339,6 +357,6 @@ def __editorKeyPress( editor, event ) :
 			elif isinstance( editor, GafferUI.NodeSetEditor ) :
 				editor.setNodeSet( editor.scriptNode().selection() )
 
-		return True
+			return True
 
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -59,6 +59,7 @@ GafferUI.EditMenu.appendDefinitions( scriptWindowMenu, prefix="/Edit" )
 GafferUI.LayoutMenu.appendDefinitions( scriptWindowMenu, name="/Layout" )
 GafferDispatchUI.DispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
 GafferDispatchUI.LocalDispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
+GafferUI.GraphBookmarksUI.appendScriptWindowMenuDefinitions( scriptWindowMenu, prefix="/Edit" )
 
 # Turn on backups by default, so they are supported by the open functions
 # in the file menu. They can be turned off again in the preferences menu.


### PR DESCRIPTION
This should have been trivial, but the combination of two silly things was enough to confuse me for a bit:
* __editorKeyPress was incorrectly consuming any numeric keypresses
*  Qt requires that "Shift+3" instead be named "Shift+#".  In addition to confusing me, this also looks quite ugly in the menu, but I guess after staring at it for a bit, a user would eventually figure out what it means.  Short of doing some deep Qt hacking, I don't see any fix for this other than switching to using Alt ( I was thinking of just using Alt, but then decided maybe it's easier to get through if I switch back the plan ).