### PR TITLE
Bookmarks UI : Menu option and shortcuts for setting focus to bookmark ( alternate )

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
   - Updated to align colour scheme and interaction patterns with the LightEditor.
   - Reduced overhead when the Viewer is not visible in the UI.
 - Spreadsheet : Improved interaction with read-only spreadsheets. Previously it was impossible to switch between sections or scroll the cells (#4529).
+- Focus Node : Added <kbd>Alt+1</kbd>-<kbd>Alt+9</kbd> hotkeys for setting focus to a bookmark (also available in the "Edit/Assign Focus" menu).
 
 Fixes
 -----

--- a/python/GafferUI/GraphBookmarksUI.py
+++ b/python/GafferUI/GraphBookmarksUI.py
@@ -145,6 +145,22 @@ def appendNodeSetMenuDefinitions( editor, menuDefinition ) :
 			"checkBox" : isCurrent,
 		} )
 
+def appendScriptWindowMenuDefinitions( menuDefinition, prefix="" ) :
+
+	# Follow bookmarks
+
+	def assignFocus( i, menu ) :
+		script = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
+		script.setFocus( Gaffer.MetadataAlgo.getNumericBookmark( script, i ) )
+
+	menuDefinition.append( prefix + "/AssignFocusDivider", { "divider" : True } )
+
+	for i in range( 1, 10 ) :
+		menuDefinition.append( prefix + "/Assign Focus/Bookmark %i" % i, {
+			"command" : functools.partial( assignFocus, i ),
+			"shortCut" : "Alt+%i" % i
+		} )
+
 def connectToEditor( editor ) :
 
 	editor.keyPressSignal().connect( __editorKeyPress, scoped = False )
@@ -327,6 +343,8 @@ def __editorKeyPress( editor, event ) :
 			if node is not None :
 				__assignNumericBookmark( node, numericBookmark )
 
+			return True
+
 		elif not event.modifiers :
 
 			# Find
@@ -339,6 +357,6 @@ def __editorKeyPress( editor, event ) :
 			elif isinstance( editor, GafferUI.NodeSetEditor ) :
 				editor.setNodeSet( editor.scriptNode().selection() )
 
-		return True
+			return True
 
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -59,6 +59,7 @@ GafferUI.EditMenu.appendDefinitions( scriptWindowMenu, prefix="/Edit" )
 GafferUI.LayoutMenu.appendDefinitions( scriptWindowMenu, name="/Layout" )
 GafferDispatchUI.DispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
 GafferDispatchUI.LocalDispatcherUI.appendMenuDefinitions( scriptWindowMenu, prefix="/Execute" )
+GafferUI.GraphBookmarksUI.appendScriptWindowMenuDefinitions( scriptWindowMenu, prefix="/Edit" )
 
 # Turn on backups by default, so they are supported by the open functions
 # in the file menu. They can be turned off again in the preferences menu.


### PR DESCRIPTION
Alternate version of #4544

After actually trying it with my hand, and talking to a random couple of users, it seems like Alt+3 is actually easier to hit than Shift+3 ( thumb on modifier is stronger and more comfortable than pinky ).  In combination with the UI looking better without the weird name "Shift+#", maybe this is the better option?   I figured I'd just upload both, and let you decide which to merge.