### PR TITLE
RandomChoice : Add new node for randomisation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ Fixes
 
 - VectorDataWidget : Fixed header visibility when `setHeader()` is called after construction.
 
+API
+---
+
+- VectorDataPlugValueWidget : Added support for showing plugs with children, with each child forming a column in the UI.
+
 0.61.2.0 (relative to 0.61.1.1)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.61.x.x (relative to 0.61.2.0)
 ========
 
+Features
+--------
+
+- RandomChoice : Added new node for choosing a random value from a list of weighted choices.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,11 @@ Improvements
 - StandardAttributes : Added `attributes.displayColor` plug, for controlling the colour of objects in the Viewer.
 - UI : The UI is now scaled automatically for high-resolution monitors on Linux (#2157). Set the `QT_ENABLE_HIGHDPI_SCALING` environment variable to `0` to disable.
 
+Fixes
+-----
+
+- VectorDataWidget : Fixed header visibility when `setHeader()` is called after construction.
+
 0.61.2.0 (relative to 0.61.1.1)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,10 @@ Fixes
 API
 ---
 
-- VectorDataPlugValueWidget : Added support for showing plugs with children, with each child forming a column in the UI.
+- VectorDataPlugValueWidget :
+  - Added support for showing plugs with children, with each child forming a column in the UI.
+  - Added `vectorDataPlugValueWidget:elementDefaultValue` metadata, used to provide the initial
+    value for newly added rows.
 
 0.61.2.0 (relative to 0.61.1.1)
 ========

--- a/include/Gaffer/Random.h
+++ b/include/Gaffer/Random.h
@@ -46,7 +46,6 @@ namespace Gaffer
 
 IE_CORE_FORWARDDECLARE( StringPlug )
 
-/// Base class for nodes which generate random values based on Context values.
 class GAFFER_API Random : public ComputeNode
 {
 

--- a/include/Gaffer/RandomChoice.h
+++ b/include/Gaffer/RandomChoice.h
@@ -1,0 +1,118 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_RANDOMCHOICE_H
+#define GAFFER_RANDOMCHOICE_H
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+namespace Gaffer
+{
+
+class GAFFER_API RandomChoice : public ComputeNode
+{
+
+	public :
+
+		RandomChoice( const std::string &name=defaultName<RandomChoice>() );
+		~RandomChoice() override;
+
+		GAFFER_NODE_DECLARE_TYPE( Gaffer::RandomChoice, RandomChoiceTypeId, ComputeNode );
+
+		/// Sets up the node to output the specified plug type. The passed plug
+		/// is used as a template, but will not be parented to the node
+		/// itself - typically you will pass a plug which you will connect to
+		/// the node after calling `setup()`.
+		/// \undoable
+		void setup( const ValuePlug *plug );
+		/// Returns true if `plug` is suitable for passing to `setup()`. Not
+		/// all plug types are supported.
+		static bool canSetup( const ValuePlug *plug );
+
+		IntPlug *seedPlug();
+		const IntPlug *seedPlug() const;
+
+		StringPlug *seedVariablePlug();
+		const StringPlug *seedVariablePlug() const;
+
+		/// Compound plug that groups the `choices.values` and `choices.weights`
+		/// plugs.
+		ValuePlug *choicesPlug();
+		const ValuePlug *choicesPlug() const;
+
+		/// The type of the `choices.values` plug is dictated by the type of
+		/// `outPlug`. For example, `choices.values` is a StringVectorDataPlug when
+		/// `out` is a StringPlug.
+		template<typename T=ValuePlug>
+		T *choicesValuesPlug();
+		template<typename T=ValuePlug>
+		const T *choicesValuesPlug() const;
+
+		FloatVectorDataPlug *choicesWeightsPlug();
+		const FloatVectorDataPlug *choicesWeightsPlug() const;
+
+		/// The type of the `out` plug matches the type passed to `setup()`.
+		template<typename T=ValuePlug>
+		T *outPlug();
+		template<typename T=ValuePlug>
+		const T *outPlug() const;
+
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context ) const override;
+
+	private :
+
+		ValuePlug *outPlugInternal();
+		const ValuePlug *outPlugInternal() const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( RandomChoice )
+
+} // namespace Gaffer
+
+#include "Gaffer/RandomChoice.inl"
+
+#endif // GAFFER_RANDOMCHOICE_H

--- a/include/Gaffer/RandomChoice.inl
+++ b/include/Gaffer/RandomChoice.inl
@@ -1,0 +1,79 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_RANDOMCHOICE_INL
+#define GAFFER_RANDOMCHOICE_INL
+
+namespace Gaffer
+{
+
+template<typename T>
+T *RandomChoice::choicesValuesPlug()
+{
+	ValuePlug *c = choicesPlug();
+	if( c->children().size() == 2 )
+	{
+		return c->getChild<T>( 1 );
+	}
+	return nullptr;
+}
+
+template<typename T>
+const T *RandomChoice::choicesValuesPlug() const
+{
+	const ValuePlug *c = choicesPlug();
+	if( c->children().size() == 2 )
+	{
+		return c->getChild<T>( 1 );
+	}
+	return nullptr;
+}
+
+template<typename T>
+T *RandomChoice::outPlug()
+{
+	return IECore::runTimeCast<T>( outPlugInternal() );
+}
+
+template<typename T>
+const T *RandomChoice::outPlug() const
+{
+	return IECore::runTimeCast<const T>( outPlugInternal() );
+}
+
+} // namespace Gaffer
+
+#endif // GAFFER_RANDOMCHOICE_INL

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -142,6 +142,7 @@ enum TypeId
 	M33fVectorDataPlugTypeId = 110095,
 	ScriptNodeFocusSetTypeId = 110096,
 	AnimationKeyTypeId = 110097,
+	RandomChoiceTypeId = 110098,
 
 	LastTypeId = 110159,
 

--- a/python/GafferTest/RandomChoiceTest.py
+++ b/python/GafferTest/RandomChoiceTest.py
@@ -1,0 +1,204 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import collections
+import unittest
+import six
+import imath
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class RandomChoiceTest( GafferTest.TestCase ) :
+
+	def testSetup( self ) :
+
+		for plugType, valuesPlugType in [
+			( Gaffer.BoolPlug, Gaffer.BoolVectorDataPlug ),
+			( Gaffer.IntPlug, Gaffer.IntVectorDataPlug ),
+			( Gaffer.FloatPlug, Gaffer.FloatVectorDataPlug ),
+			( Gaffer.StringPlug, Gaffer.StringVectorDataPlug ),
+			( Gaffer.V2iPlug, Gaffer.V2iVectorDataPlug ),
+			( Gaffer.V3fPlug, Gaffer.V3fVectorDataPlug ),
+			( Gaffer.Color3fPlug, Gaffer.Color3fVectorDataPlug ),
+		] :
+
+			examplePlug = plugType()
+			self.assertTrue( Gaffer.RandomChoice.canSetup( examplePlug ) )
+
+			node = Gaffer.RandomChoice()
+			node.setup( examplePlug )
+			self.assertIsInstance( node["out"], plugType )
+			self.assertFalse( node["out"].isSame( examplePlug ) )
+			self.assertIsNone( examplePlug.getInput() )
+			self.assertEqual( node["out"].defaultValue(), examplePlug.defaultValue() )
+
+			self.assertIsInstance( node["choices"]["values"], valuesPlugType )
+			self.assertEqual( len( node["choices"]["values"].getValue() ), 0 )
+
+			with six.assertRaisesRegex( self, Exception, "Already set up" ) :
+				node.setup( examplePlug )
+
+		for unsupportedPlug in [
+			Gaffer.CompoundDataPlug(),
+			Gaffer.CompoundObjectPlug( defaultValue = IECore.CompoundObject() ),
+		] :
+			self.assertFalse( Gaffer.RandomChoice.canSetup( unsupportedPlug ) )
+			node = Gaffer.RandomChoice()
+			with six.assertRaisesRegex( self, RuntimeError, "Unsupported plug type" ) :
+				node.setup( unsupportedPlug )
+
+	def testChoice( self ) :
+
+		node = Gaffer.RandomChoice()
+
+		node.setup( Gaffer.StringPlug() )
+		node["choices"]["values"].setValue( IECore.StringVectorData( [ "apple", "pear", "hat" ] ) )
+		node["choices"]["weights"].setValue( IECore.FloatVectorData( [ 0.25, 0.5, 0.25 ] ) )
+
+		iterations = 100000
+
+		count = collections.Counter()
+		for seed in range( 0, iterations ) :
+			node["seed"].setValue( seed )
+			count[node["out"].getValue()] += 1
+
+		for choice, weight in zip( node["choices"]["values"].getValue(), node["choices"]["weights"].getValue() ) :
+			self.assertAlmostEqual(
+				count[choice] / float( iterations ), weight,
+				places = 2
+			)
+
+	def testSeedVariable( self ) :
+
+		node = Gaffer.RandomChoice()
+
+		node.setup( Gaffer.StringPlug() )
+		node["seedVariable"].setValue( "seed" )
+		node["choices"]["values"].setValue( IECore.StringVectorData( [ "apple", "pear", "hat" ] ) )
+		node["choices"]["weights"].setValue( IECore.FloatVectorData( [ 0.25, 0.5, 0.25 ] ) )
+
+		iterations = 100000
+
+		count = collections.Counter()
+		with Gaffer.Context() as context :
+			for seed in range( 0, iterations ) :
+				context["seed"] = seed
+				count[node["out"].getValue()] += 1
+
+		for choice, weight in zip( node["choices"]["values"].getValue(), node["choices"]["weights"].getValue() ) :
+			self.assertAlmostEqual(
+				count[choice] / float( iterations ), weight,
+				places = 2
+			)
+
+	def testNoChoices( self ) :
+
+		for defaultValue in range( 0, 10 ) :
+
+			# Empty list of choices. Expect the default value
+			# the node was set up with.
+			node = Gaffer.RandomChoice()
+			node.setup( Gaffer.IntPlug( defaultValue = defaultValue ) )
+			self.assertEqual( node["out"].getValue(), defaultValue )
+
+			# Choices, but all with 0 weight. As above.
+			node["choices"]["values"].setValue( IECore.IntVectorData( [ 1, 2, 3 ] ) )
+			node["choices"]["weights"].setValue( IECore.FloatVectorData( [ 0, 0, 0 ] ) )
+			self.assertEqual( node["out"].getValue(), defaultValue )
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["uninitialised"] = Gaffer.RandomChoice()
+		script["initialised"] = Gaffer.RandomChoice()
+
+		script["initialised"].setup( Gaffer.StringPlug( defaultValue = "default" )  )
+		script["initialised"]["choices"]["values"].setValue( IECore.StringVectorData( [ "one", "two" ] ) )
+		script["initialised"]["choices"]["weights"].setValue( IECore.FloatVectorData( [ 1.0, 2.0 ] ) )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+
+		self.assertNotIn( "out", script2["uninitialised"] )
+		self.assertNotIn( "values", script2["uninitialised"]["choices"] )
+
+		self.assertEqual( script2["initialised"]["choices"]["values"].getValue(), script["initialised"]["choices"]["values"].getValue() )
+		self.assertEqual( script2["initialised"]["out"].defaultValue(), script["initialised"]["out"].defaultValue() )
+
+	def testCompoundNumericPlugs( self ) :
+
+		node = Gaffer.RandomChoice()
+		node.setup( Gaffer.V3fPlug() )
+		node["choices"]["values"].setValue(
+			IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] )
+		)
+		node["choices"]["weights"].setValue(
+			IECore.FloatVectorData( [ 0, 1.0 ] )
+		)
+
+		self.assertEqual( node["out"].getValue(), imath.V3f( 4, 5,6 ) )
+
+	def testMismatchedLengths( self ) :
+
+		node = Gaffer.RandomChoice()
+		node.setup( Gaffer.StringPlug() )
+		node["choices"]["values"].setValue(
+			IECore.StringVectorData( [ "a", "b", "c" ] )
+		)
+
+		with six.assertRaisesRegex(
+			self, Gaffer.ProcessException,
+			r".*Length of `choices.weights` does not match length of `choices.values` \(0 but should be 3\).*"
+		) :
+			node["out"].getValue()
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ) :
+
+		node = Gaffer.RandomChoice()
+		node.setup( Gaffer.IntPlug() )
+		node["seedVariable"].setValue( "seed" )
+		node["choices"]["values"].setValue( IECore.IntVectorData( range( 0, 100000 ) ) )
+		node["choices"]["weights"].setValue( IECore.FloatVectorData( [ 1 ] * 100000 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( node["out"], 100000, "seed" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -164,6 +164,7 @@ from .NameSwitchTest import NameSwitchTest
 from .SpreadsheetTest import SpreadsheetTest
 from .ShufflePlugTest import ShufflePlugTest
 from .EditScopeTest import EditScopeTest
+from .RandomChoiceTest import RandomChoiceTest
 
 from .IECorePreviewTest import *
 

--- a/python/GafferUI/RandomChoiceUI.py
+++ b/python/GafferUI/RandomChoiceUI.py
@@ -1,0 +1,260 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.RandomChoice,
+
+	"description",
+	"""
+	Chooses random values from a list of choices, with optional weights
+	to specify the relative probability of each choice.
+
+	The randomness is generated from a seed and a context
+	variable; to get useful variation either the seed or the
+	value of the context variable must be varied too.
+	""",
+
+	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
+	"auxiliaryNodeGadget:label", "r",
+
+	"layout:activator:isSetup", lambda node : "out" in node,
+	"layout:activator:isNotSetup", lambda node : "out" not in node,
+
+	"layout:customWidget:setupButton:widgetType", "GafferUI.RandomChoiceUI._SetupButton",
+	"layout:customWidget:setupButton:section", "Settings",
+	"layout:customWidget:setupButton:index", -1,
+	"layout:customWidget:setupButton:visibilityActivator", "isNotSetup",
+
+	plugs = {
+
+		"*" : [
+
+			# Prevents creation of unwanted BoxIn nodes when
+			# plugs are promoted.
+			"nodule:type", "",
+
+		],
+
+		"seed" : [
+
+			"description",
+			"""
+			Seed for the random number generator. Different seeds
+			produce different random numbers. When controlling two
+			different properties using the same context variable,
+			different seeds may be used to ensure that the generated
+			values are different.
+			""",
+
+		],
+
+		"seedVariable" : [
+
+			"description",
+			"""
+			The most important plug for achieving interesting variation.
+			Should be set to the name of a context variable which will
+			be different for each evaluation of the node. Good examples
+			are `scene:path` to generate a different value per scene
+			location, or `frame` to generate a different value per frame.
+			""",
+
+			"preset:Time", "frame",
+			"preset:Scene Location", "scene:path",
+
+		],
+
+		"choices" : [
+
+			"description",
+			"""
+			The choices that will be randomly selected between based on the seed.
+			""",
+
+			"plugValueWidget:type", "GafferUI.VectorDataPlugValueWidget",
+
+			"layout:visibilityActivator", "isSetup",
+
+		],
+
+		"choices.values" : [
+
+			"description",
+			"""
+			The list of values for the choices. Use the `choices.weights` plug
+			to assign a relative probability to each choice.
+			""",
+
+			"vectorDataPlugValueWidget:header", "Value",
+
+		],
+
+		"choices.weights" : [
+
+			"description",
+			"""
+			The list of weights for the choices. Choices with a higher weight
+			have a greater chance of being chosen.
+			""",
+
+			"vectorDataPlugValueWidget:header", "Weight",
+			"vectorDataPlugValueWidget:index", -1,
+			"vectorDataPlugValueWidget:elementDefaultValue", 1.0,
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			Outputs a random choice from the `choices` plug.
+			""",
+
+		]
+
+	}
+
+)
+
+# _SetupButton
+# ============
+
+class _SetupButton( GafferUI.Widget ) :
+
+	def __init__( self, node ) :
+
+		self.__node = node
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.Widget.__init__( self, self.__row )
+
+		with self.__row :
+
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.MenuButton(
+					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ), title = "Add Output" ),
+					image = "plus.png", hasFrame = False
+				)
+
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def __menuDefinition( self, menu ) :
+
+		result = IECore.MenuDefinition()
+
+		def setup( node, plugType ) :
+
+			with Gaffer.UndoScope( node.scriptNode() ) :
+				node.setup( plugType() )
+
+		for plugType in (
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			None,
+			Gaffer.StringPlug,
+			None,
+			Gaffer.V2iPlug,
+			Gaffer.V3fPlug,
+			None,
+			Gaffer.Color3fPlug
+		) :
+			if plugType is None :
+				result.append( "/Divider{}".format( result.size() ), { "divider" : True } )
+			else :
+				result.append(
+					plugType.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( setup, self.__node, plugType ),
+						"active" : not Gaffer.MetadataAlgo.readOnly( self.__node ),
+					}
+				)
+
+		return result
+
+# PlugValueWidget popup menu
+# ==========================
+
+def __createRandomChoice( plugs ) :
+
+	parentNode = plugs[0].node().parent()
+
+	with Gaffer.UndoScope( parentNode.scriptNode() ) :
+
+		node = Gaffer.RandomChoice()
+		node.setup( plugs[0] )
+		parentNode.addChild( node )
+
+		for plug in plugs :
+			plug.setInput( node["out"] )
+
+	GafferUI.NodeEditor.acquire( node )
+
+def __popupMenu( menuDefinition, plugValueWidget ) :
+
+	if not plugValueWidget._editable() :
+		return
+
+	for plug in plugValueWidget.getPlugs() :
+		if plug.getInput() is not None or Gaffer.MetadataAlgo.readOnly( plug ) :
+			return
+		if not Gaffer.RandomChoice.canSetup( plug ) :
+			return
+		if plug.node() is None or plug.node().parent() is None :
+			return
+
+	# If we can, put ourselves in the same section as the item created by RandomUI.
+	# Otherwise make out own section.
+
+	item = { "command" : functools.partial( __createRandomChoice, list( plugValueWidget.getPlugs() ) ) }
+
+	try :
+		menuDefinition.insertAfter( "/Randomise (Choice)...", item, "/Randomise..." )
+	except KeyError :
+		menuDefinition.prepend( "/RandomiseDivider", { "divider" : True } )
+		menuDefinition.prepend( "/Randomise...", item )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __popupMenu, scoped = False )

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -47,6 +47,8 @@ import GafferUI
 # - "vectorDataPlugValueWidget:dragPointer"
 # - "vectorDataPlugValueWidget:index" : Used to order child plugs
 # - "vectorDataPlugValueWidget:header" : Provides custom headers for child plugs
+# - "vectorDataPlugValueWidget:elementDefaultValue" : Default
+#   value for elements in newly added rows.
 class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	# If `plug` has children, then they will be used to form
@@ -54,7 +56,7 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 	# children, it will be shown as a single column.
 	def __init__( self, plug, **kw ) :
 
-		self.__dataWidget = GafferUI.VectorDataWidget()
+		self.__dataWidget = _VectorDataWidget()
 
 		GafferUI.PlugValueWidget.__init__( self, self.__dataWidget, plug, **kw )
 
@@ -115,6 +117,25 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 				data = self.__dataWidget.getData()
 				for plug, value in zip( self.__dataPlugs(), self.__dataWidget.getData() ) :
 					plug.setValue( value )
+
+class _VectorDataWidget( GafferUI.VectorDataWidget ) :
+
+	def __init__( self, **kw ) :
+
+		GafferUI.VectorDataWidget.__init__( self, **kw )
+
+	def _createRows( self ) :
+
+		plugValueWidget = self.ancestor( VectorDataPlugValueWidget )
+		plugs = plugValueWidget._VectorDataPlugValueWidget__dataPlugs()
+		rows = GafferUI.VectorDataWidget._createRows( self )
+
+		for row, plug in zip( rows, plugs ) :
+			value = Gaffer.Metadata.value( plug, "vectorDataPlugValueWidget:elementDefaultValue" )
+			if value is not None :
+				row[0] = value
+
+		return rows
 
 GafferUI.PlugValueWidget.registerType( Gaffer.BoolVectorDataPlug, VectorDataPlugValueWidget )
 GafferUI.PlugValueWidget.registerType( Gaffer.IntVectorDataPlug, VectorDataPlugValueWidget )

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -95,7 +95,6 @@ class VectorDataWidget( GafferUI.Widget ) :
 
 		self.__tableView = _TableView( minimumVisibleRows = minimumVisibleRows )
 
-		self.__tableView.horizontalHeader().setVisible( bool( header ) )
 		self.__tableView.horizontalHeader().setMinimumSectionSize( 70 )
 
 		self.__tableView.verticalHeader().setVisible( showIndices )
@@ -265,6 +264,8 @@ class VectorDataWidget( GafferUI.Widget ) :
 			self.__header = header
 		else :
 			self.__header = None
+
+		self.__tableView.horizontalHeader().setVisible( bool( header ) )
 
 	def getHeader( self ):
 

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -280,6 +280,7 @@ from . import AnnotationsUI
 from . import DependencyNodeUI
 from . import ComputeNodeUI
 from . import RandomUI
+from . import RandomChoiceUI
 from . import SpreadsheetUI
 from . import ExpressionUI
 from . import BoxUI

--- a/src/Gaffer/RandomChoice.cpp
+++ b/src/Gaffer/RandomChoice.cpp
@@ -1,0 +1,371 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/RandomChoice.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+#include "Gaffer/TypedPlug.h"
+
+#include "IECore/TypeTraits.h"
+
+#include "OpenEXR/ImathRandom.h"
+
+#include <numeric>
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// Types for the `choices.values` plug, templated on the value
+// type of the `out` plug.
+
+template<typename T>
+using ValuesDataType = std::conditional_t<
+	IECore::TypeTraits::IsVec<T>::value,
+	IECore::GeometricTypedData<vector<T>>,
+	IECore::TypedData<vector<T>>
+>;
+
+template<typename T>
+using ValuesPlugType = Gaffer::TypedObjectPlug<ValuesDataType<T>>;
+
+// If `plug` is a supported type, downcasts it to its true type and
+// calls `functor( plug, args )`. Otherwise, does nothing.
+template<typename F>
+void dispatchPlugFunction( const ValuePlug *plug, F &&functor )
+{
+	const IECore::TypeId typeId = plug->typeId();
+
+	switch( (int)typeId )
+	{
+		case BoolPlugTypeId :
+			functor( static_cast<const BoolPlug *>( plug ) );
+			break;
+		case IntPlugTypeId :
+			functor( static_cast<const IntPlug *>( plug ) );
+			break;
+		case FloatPlugTypeId :
+			functor( static_cast<const FloatPlug *>( plug ) );
+			break;
+		case StringPlugTypeId :
+			functor( static_cast<const StringPlug *>( plug ) );
+			break;
+		case V2iPlugTypeId :
+			functor( static_cast<const V2iPlug *>( plug ) );
+			break;
+		case V3fPlugTypeId :
+			functor( static_cast<const V3fPlug *>( plug ) );
+			break;
+		case Color3fPlugTypeId :
+			functor( static_cast<const Color3fPlug *>( plug ) );
+			break;
+		default :
+			break;
+	}
+}
+
+// Utility for setting the value of an individual leaf plug, given the value for a main plug.
+// This is needed because `ComputeNode::compute()` operates only on leaf plugs, but our implementation
+// naturally ends up with a value for an entire CompoundNumericPlug.
+
+template<typename PlugType>
+void setValue( const PlugType *plug, const typename PlugType::ValueType &value, ValuePlug *leafPlug )
+{
+	assert( leafPlug == plug );
+	static_cast<PlugType *>( leafPlug )->setValue( value );
+}
+
+template<typename T>
+void setValue( const CompoundNumericPlug<T> *plug, const typename CompoundNumericPlug<T>::ValueType &value, ValuePlug *leafPlug )
+{
+	assert( leafPlug->parent() == plug );
+	for( size_t i = 0, e = plug->children().size(); i < e; ++i )
+	{
+		if( leafPlug == plug->getChild( i ) )
+		{
+			static_cast<typename CompoundNumericPlug<T>::ChildType *>( leafPlug )->setValue( value[i] );
+			return;
+		}
+	}
+}
+
+const InternedString g_outPlugName( "out" );
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// RandomChoice
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_NODE_DEFINE_TYPE( RandomChoice );
+
+size_t RandomChoice::g_firstPlugIndex = 0;
+
+RandomChoice::RandomChoice( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new IntPlug( "seed", Plug::In, 0, 0 ) );
+	addChild( new StringPlug( "seedVariable" ) );
+	addChild( new ValuePlug( "choices" ) );
+	choicesPlug()->addChild( new FloatVectorDataPlug( "weights", Plug::In, new FloatVectorData ) );
+}
+
+RandomChoice::~RandomChoice()
+{
+}
+
+void RandomChoice::setup( const ValuePlug *plug )
+{
+	if( outPlug() || choicesValuesPlug() )
+	{
+		throw IECore::Exception( "Already set up" );
+	}
+
+	dispatchPlugFunction(
+		plug,
+		[this] ( const auto plug ) {
+			using ValueType = typename remove_pointer_t<decltype( plug )>::ValueType;
+			ValuePlugPtr valuesPlug = new ValuesPlugType<ValueType>( "values", Plug::In, new ValuesDataType<ValueType> );
+			this->choicesPlug()->addChild( valuesPlug );
+			this->addChild( plug->createCounterpart( g_outPlugName, Plug::Out ) );
+		}
+	);
+
+	if( !outPlug() )
+	{
+		throw IECore::Exception( "Unsupported plug type" );
+	}
+}
+
+bool RandomChoice::canSetup( const ValuePlug *plug )
+{
+	bool result = false;
+	dispatchPlugFunction(
+		plug,
+		[&result] ( const auto plug ) {
+			result = true;
+		}
+	);
+	return result;
+}
+
+IntPlug *RandomChoice::seedPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const IntPlug *RandomChoice::seedPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+StringPlug *RandomChoice::seedVariablePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const StringPlug *RandomChoice::seedVariablePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+ValuePlug *RandomChoice::choicesPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+const ValuePlug *RandomChoice::choicesPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 2 );
+}
+
+FloatVectorDataPlug *RandomChoice::choicesWeightsPlug()
+{
+	return choicesPlug()->getChild<FloatVectorDataPlug>( 0 );
+}
+
+const FloatVectorDataPlug *RandomChoice::choicesWeightsPlug() const
+{
+	return choicesPlug()->getChild<FloatVectorDataPlug>( 0 );
+}
+
+ValuePlug *RandomChoice::outPlugInternal()
+{
+	return getChild<ValuePlug>( g_outPlugName );
+}
+
+const ValuePlug *RandomChoice::outPlugInternal() const
+{
+	return getChild<ValuePlug>( g_outPlugName );
+}
+
+void RandomChoice::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if(
+		input == seedPlug() ||
+		input == seedVariablePlug() ||
+		input == choicesWeightsPlug() ||
+		input == choicesValuesPlug()
+	)
+	{
+		if( const Plug *p = outPlug() )
+		{
+			if( p->children().size() )
+			{
+				for( const auto &cp : Plug::Range( *p ) )
+				{
+					outputs.push_back( cp.get() );
+				}
+			}
+			else
+			{
+				outputs.push_back( p );
+			}
+		}
+	}
+}
+
+void RandomChoice::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	ComputeNode::hash( output, context, h );
+
+	if( output == outPlug() || output->parent() == outPlug() )
+	{
+		seedPlug()->hash( h );
+		const string seedVariable = seedVariablePlug()->getValue();
+		if( !seedVariable.empty() )
+		{
+			h.append( context->variableHash( seedVariable ) );
+		}
+		choicesWeightsPlug()->hash( h );
+		choicesValuesPlug()->hash( h );
+		h.append( output->defaultHash() );
+	}
+}
+
+void RandomChoice::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == outPlug() || output->parent() == outPlug() )
+	{
+		ConstFloatVectorDataPtr weightsData = choicesWeightsPlug()->getValue();
+		const vector<float> &weights = weightsData->readable();
+
+		size_t seed = seedPlug()->getValue();
+		const string seedVariable = seedVariablePlug()->getValue();
+		if( !seedVariable.empty() )
+		{
+			/// \todo See comments in `Random::computeSeed()`.
+			IECore::DataPtr contextData = context->getAsData( seedVariable, nullptr );
+			if( contextData )
+			{
+				const MurmurHash hash = contextData->Object::hash();
+				seed += hash.h1();
+			}
+		}
+		Imath::Rand48 random( seed );
+
+		dispatchPlugFunction(
+			outPlug(),
+			[this, output, &weights, &random] ( auto plug ) {
+
+				using PlugType = remove_const_t<remove_pointer_t<decltype( plug )>>;
+				using ValueType = typename PlugType::ValueType;
+
+				auto choicesData = this->choicesValuesPlug<ValuesPlugType<ValueType>>()->getValue();
+				const auto &choices = choicesData->readable();
+				if( !choices.size() )
+				{
+					output->setToDefault();
+					return;
+				}
+
+				if( weights.size() != choices.size() )
+				{
+					throw IECore::Exception( boost::str(
+						boost::format(
+							"Length of `choices.weights` does not match length of `choices.values` "
+							"(%1% but should be %2%)."
+						) % weights.size() % choices.size()
+					) );
+				}
+
+				const float weightsSum = accumulate(
+					weights.begin(), weights.end(), 0.0f
+				);
+				if( weightsSum == 0.0f )
+				{
+					output->setToDefault();
+					return;
+				}
+
+				const float r = random.nextf( 0, weightsSum );
+
+				// We currently do a simple linear search until the summed
+				// weight exceeds `r`. Theoretically this could be improved by
+				// storing a vector of cumulative weights on an internal plug
+				// and doing a binary search on that. But in practice, for the
+				// sizes we expect to be dealing with (10s most commonly, perhaps
+				// 1000s in the extreme), this appears not to be a win.
+				float s = 0;
+				for( size_t i = 0; i < choices.size(); ++i )
+				{
+					s += weights[i];
+					if( s >= r )
+					{
+						setValue( plug, choices[i], output );
+						return;
+					}
+				}
+
+			}
+		);
+	}
+	ComputeNode::compute( output, context );
+}

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -60,6 +60,7 @@ Gaffer.Metadata.registerValue( Gaffer.BoxIO, "nodeGadget:color", imath.Color3f( 
 Gaffer.Metadata.registerValue( Gaffer.EditScope, "nodeGadget:color", imath.Color3f( 0.1876, 0.3908, 0.6 ) )
 
 Gaffer.Metadata.registerValue( Gaffer.Random, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
+Gaffer.Metadata.registerValue( Gaffer.RandomChoice, "nodeGadget:color", imath.Color3f( 0.45, 0.3, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Expression, "nodeGadget:color", imath.Color3f( 0.3, 0.45, 0.3 ) )
 Gaffer.Metadata.registerValue( Gaffer.Animation, "nodeGadget:color", imath.Color3f( 0.3, 0.3, 0.45 ) )
 Gaffer.Metadata.registerValue( Gaffer.Spreadsheet, "nodeGadget:color", imath.Color3f( 0.69, 0.5445, 0.2208 ) )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -502,6 +502,7 @@ nodeMenu.append( "/Dispatch/Frame Mask", GafferDispatch.FrameMask, searchText = 
 nodeMenu.append( "/Utility/Expression", Gaffer.Expression )
 nodeMenu.append( "/Utility/Node", Gaffer.Node )
 nodeMenu.append( "/Utility/Random", Gaffer.Random )
+nodeMenu.append( "/Utility/RandomChoice", Gaffer.RandomChoice )
 nodeMenu.append( "/Utility/Box", GafferUI.BoxUI.nodeMenuCreateCommand )
 nodeMenu.append( "/Utility/BoxIn", Gaffer.BoxIn )
 nodeMenu.append( "/Utility/BoxOut", Gaffer.BoxOut )


### PR DESCRIPTION
I've been asked a few times now about how to randomly choose from a set of values based on some criteria - different textures per `scene:path` for instance. It was trivial to do with a Python expression, but that has all the performance pitfalls of Python expressions. It was a lot fiddlier to do with OSL expressions, but with massively improvemed performance. So I thought it was time we provided a first-class node specifically for this purpose...

<img src=https://user-images.githubusercontent.com/1133871/152331094-97a50cef-5db7-4fbc-8347-876cdd6c075d.png width=400px>
