### PR TITLE
Arnold metadata : Hide ramp shaders from the node menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.62.x.x
 ========
 
+Improvements
+------------
+
+- Node menu : Removed unsupported Arnold shaders `ramp_rgb` and `ramp_float`. The OSL `ColorSpline` and `FloatSpline` shaders should be used instead.
+
 API
 ---
 

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -1408,12 +1408,18 @@
 
 [node ramp_float]
 
-	gaffer.nodeMenu.category STRING "Utility"
+	# Hidden, because we don't have support for
+	# array parameters or a UI to match Arnold's
+	# interpolation modes.
+	gaffer.nodeMenu.category STRING ""
 
 
 [node ramp_rgb]
 
-	gaffer.nodeMenu.category STRING "Utility"
+	# Hidden, because we don't have support for
+	# array parameters or a UI to match Arnold's
+	# interpolation modes.
+	gaffer.nodeMenu.category STRING ""
 
 
 [node random]


### PR DESCRIPTION
We don't support them, and their presence is confusing to users.
