### PR TITLE
NodeSetEditor : Always show node names in tab label

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -720,6 +720,7 @@ class _TabbedContainer( GafferUI.TabbedContainer ) :
 		if not GafferUI._qtObjectIsValid( self._qtWidget() ) :
 			return
 
+		print( "SETTING LABEL", editor, editor.getTitle() )
 		self.setLabel( editor, editor.getTitle() )
 
 	def __currentTabChanged( self, tabbedContainer, currentEditor ) :

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -182,7 +182,7 @@ class NodeSetEditor( GafferUI.Editor ) :
 	# All implementations must first call the base class implementation.
 	def _updateFromSet( self ) :
 
-		self.__dirtyTitle()
+		pass
 
 	# May be called to ensure that _updateFromSet() is called
 	# immediately if a lazy update has been scheduled but not
@@ -201,29 +201,30 @@ class NodeSetEditor( GafferUI.Editor ) :
 		else :
 			result = [ _prefix ]
 
-		# Only add node names if we're pinned in some way shape or form
-		if self.getNodeSet() != self.scriptNode().focusSet() and self.getNodeSet() != self.scriptNode().selection():
+		pinned = self.getNodeSet() != self.scriptNode().focusSet() and self.getNodeSet() != self.scriptNode().selection()
 
-			result.append( " [" )
+		#if pinned :
+		result.append( " [" )
 
-			numNames = min( _maxNodes, len( self.__nodeSet ) )
-			if numNames :
+		numNames = min( _maxNodes, len( self.__nodeSet ) )
+		if numNames :
 
-				if _reverseNodes :
-					nodes = self.__nodeSet[len(self.__nodeSet)-numNames:]
-					nodes.reverse()
-				else :
-					nodes = self.__nodeSet[:numNames]
+			if _reverseNodes :
+				nodes = self.__nodeSet[len(self.__nodeSet)-numNames:]
+				nodes.reverse()
+			else :
+				nodes = self.__nodeSet[:numNames]
 
-				for i, node in enumerate( nodes ) :
-					result.append( node )
-					if i < numNames - 1 :
-						result.append( ", " )
+			for i, node in enumerate( nodes ) :
+				result.append( node )
+				if i < numNames - 1 :
+					result.append( ", " )
 
-				if _ellipsis and len( self.__nodeSet ) > _maxNodes :
-					result.append( "..." )
+			if _ellipsis and len( self.__nodeSet ) > _maxNodes :
+				result.append( "..." )
 
-			result.append( "]" )
+		#if pinned :
+		result.append( "]" )
 
 		return result
 
@@ -234,6 +235,7 @@ class NodeSetEditor( GafferUI.Editor ) :
 		self.__nameChangedConnections = []
 		self.__titleFormat = None
 
+		print( "DIRTYING TITLE", self )
 		self.titleChangedSignal()( self )
 
 	def __setNodeSetInternal( self, nodeSet, callUpdateFromSet ) :
@@ -270,6 +272,7 @@ class NodeSetEditor( GafferUI.Editor ) :
 
 	def __membersChanged( self, set, member ) :
 
+		self.__dirtyTitle()
 		self.__lazyUpdate()
 
 	@GafferUI.LazyMethod()


### PR DESCRIPTION
This essentially reverts 7941677175a07fb7ae2248b651b66f00091bee74, where we removed them because :

- The tabs were taking up a lot of space, and felt a bit cluttered. Particularly in the NodeEditor/SceneInspector panel, there often wasn't enough space to show them all.
- The tab sizes changing every time you choose a node is distracting.

Bringing the names back as an experiment in response to a request from a user. I have some sympathy for this as I myself have sometimes missed the "at a glance" confirmation of what is in the Viewer. But having tried it, I can't say I like it - I prefer the cleaner look, and I don't think we should merge. One justification for why it might be more acceptable this time around is we now have the burger menu to choose tabs when there isn't enough space to show them all. But that still doesn't swing it for me.

Other possibilities :

- Keep the names, but use a smaller/fainter font for them. This is tricky because QTabBar doesn't support rich text out of the box. I've had some success inserting a QLabel instead, but am currently thwarted by layout/sizing issues. Even if this works, it will still take space, and still jump in size when swapping nodes.
- Make sure all editors show the node name internally somewhere, so it's not needed in the tab label. This is already the case for the NodeEditor,SceneInspector and PrimitiveInspector.
	- One logical extension of this might be to move the editor focus menu out of the tab bar, so that each editor has their own focus menu internally. Originally it was in the tab bar to save space, but it would be more logical inside the editor, since it modifies properties of the editor.
- Display the name of the focus node globally somewhere, perhaps in the top right of the main menu? This isn't what the user requested exactly, but it does seem that their motivation was to know what was focussed, when jumping focus between bookmarks frequently.
	- This seems related to the problem of where to choose an EditScope. We've already established that choosing a scope in each editor is going to become confusing as we make more editors scope-aware. I quite like the idea of a combined focus/editscope widget in the top right of the main menu. I also wonder if editscopes should be tied to the focus somehow, so switching focus automatically switches scope.

All this is to say, "I have tried, here's a PR if you'd like to see it, but on balance I don't think we should merge it". But I do think there are a bunch of interrelated questions here that we will have to address one way or another soonish.

