### PR TITLE
StandardAttributes : Add `render:displayColor` attribute

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes.
 - GraphEditor : The focus widget now ignores right clicks, avoiding situations where attempting to open a context menu could accidentally change focus.
+- StandardAttributes : Added `attributes.displayColor` plug, for controlling the colour of objects in the Viewer.
 
 0.61.2.0 (relative to 0.61.1.1)
 ========

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -45,6 +45,8 @@ def __attributesSummary( plug ) :
 		info.append( "Visible" if plug["visibility"]["value"].getValue() else "Invisible" )
 	if plug["doubleSided"]["enabled"].getValue() :
 		info.append( "Double Sided" if plug["doubleSided"]["value"].getValue() else "Single Sided" )
+	if plug["displayColor"]["enabled"].getValue() :
+		info.append( "Display Color" )
 
 	return ", ".join( info )
 
@@ -111,6 +113,22 @@ Gaffer.Metadata.registerNode(
 			Whether or not the object can be seen from both sides.
 			Single sided objects appear invisible when seen from
 			the back.
+			""",
+
+			"layout:section", "Attributes",
+
+		],
+
+		"attributes.displayColor" : [
+
+			"description",
+			"""
+			The default colour used to display the object in the absence
+			of a specific shader assignment. Commonly used to control
+			basic object appearance in the Viewer.
+
+			> Tip : For more detailed control of object appearance in the
+			> Viewer, use the OpenGLAttributes node.
 			""",
 
 			"layout:section", "Attributes",

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -52,6 +52,7 @@ StandardAttributes::StandardAttributes( const std::string &name )
 
 	attributes->addChild( new Gaffer::NameValuePlug( "scene:visible", new IECore::BoolData( true ), false, "visibility" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "doubleSided", new IECore::BoolData( true ), false, "doubleSided" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "render:displayColor", new IECore::Color3fData( Imath::Color3f( 1 ) ), false, "displayColor" ) );
 
 	// motion blur
 


### PR DESCRIPTION
I debated putting this in OpenGLAttributes rather than StandardAttributes, but decide on the latter because :

- `displayColor` is enshrined in the UsdGeomGprim schema, so is more universally useful/meaningful.
- As we explore options for a future Viewer, OpenGLAttributes may or may not survive.
