### PR TITLE
StandardNodeGadget : Don't toggle focus on right click

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes.
 
+Fixes
+-----
+
+- Graph UI : Don't toggle focus on right click
+
 0.61.2.0 (relative to 0.61.1.1)
 ========
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -174,7 +174,11 @@ class FocusGadget : public Gadget
 
 		bool buttonPressed( GadgetPtr gadget, const ButtonEvent &event )
 		{
-			toggleFocus();
+			if( event.buttons==ButtonEvent::Left )
+			{
+				toggleFocus();
+			}
+
 			return true;
 		}
 
@@ -194,9 +198,13 @@ class FocusGadget : public Gadget
 
 		bool buttonDoubleClick( GadgetPtr gadget, const ButtonEvent &event )
 		{
-			// A user might rapidly click on the focus to toggle on and off - it's more consistent if
-			// all clicks are treated the same, even if they come fast enough to be classified as a "double click"
-			toggleFocus();
+			if( event.buttons==ButtonEvent::Left )
+			{
+				// A user might rapidly click on the focus to toggle on and off - it's more consistent if
+				// all clicks are treated the same, even if they come fast enough to be classified as a "double click"
+				toggleFocus();
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Haven't done anything beyond adding a couple lines of code and briefly confirmed that clicking still works, and right clicking no longer toggles focus, but this is simple enough that it shouldn't need much testing.