### PR TITLE
Arnold 7.1 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
 
     - name: Build and test Arnold extension
       run: |
-        for arnoldVersion in 6.2.0.1 7.0.0.0
+        for arnoldVersion in 6.2.0.1 7.0.0.2
         do
           # Install Arnold
           ./.github/workflows/main/installArnold.sh $arnoldVersion

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes.
 
+Build
+-----
+
+- Arnold 7.1 Support
+
 0.61.2.0 (relative to 0.61.1.1)
 ========
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -69,12 +69,6 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.__scriptFileName = self.temporaryDirectory() + "/test.gfr"
 
-		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
-			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
-			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release.
-			self.skipTest( "Exposes Arnold bug" )
-
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -2590,9 +2590,6 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
 		self.assertTrue( "Permission denied" in mh.messages[0].message )
 
-	# This test runs OK in isolation, but previous uses of ArnoldRenderer seem
-	# to stop Arnold from writing the profile file.
-	@unittest.skipIf( [ int( v ) for v in arnold.AiGetVersion()[:3] ] == [ 7, 0, 0 ], "Profiling broken in Arnold 7" )
 	def testStatsAndLog( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
@@ -2641,6 +2638,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 			self.assertTrue( "ray counts" in stats )
 
+		# This test runs OK in isolation, but previous uses of ArnoldRenderer seem
+		# to stop Arnold from writing the profile file.
+		if int(arnold.AiGetVersion()[0]) == 7 :
+			self.skipTest( "Profiling broken in Arnold 7" )
+
 		with open( self.temporaryDirectory() + "/test/test_profile.json", "r" ) as profileHandle :
 			stats = json.load( profileHandle )["traceEvents"]
 			driverEvents = [ x for x in stats if x["name"] == "ieCoreArnold:display:testBeauty" ]
@@ -2685,10 +2687,10 @@ class RendererTest( GafferTest.TestCase ) :
 
 				# We should have at least 1 message from our invalid option plus
 				# _something_ from the renderer's own output stream.
-				if renderType == RenderType.SceneDescription and arnold.AiGetVersion()[:3] == [ '7', '0', '0' ] :
+				if renderType == RenderType.SceneDescription and int(arnold.AiGetVersion()[0]) == 7 :
 					# A bug in Arnold associates the `[ ass ] Writing...` message with the wrong render session
 					# in the message callback.
-					pass
+					self.skipTest( "SceneDescription Messaging broken in Arnold 7" )
 				else :
 					self.assertGreater( len(handler.messages), 1, msg=str(renderType) )
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -54,16 +54,6 @@ import GafferScene
 
 class RendererTest( GafferTest.TestCase ) :
 
-	def setUp( self ) :
-
-		GafferTest.TestCase.setUp( self )
-
-		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
-			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
-			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release.
-			self.skipTest( "Exposes Arnold bug" )
-
 	def assertReferSameNode( self, a, b ):
 		self.assertEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
 

--- a/src/GafferArnoldPlugin/OutputDriver.cpp
+++ b/src/GafferArnoldPlugin/OutputDriver.cpp
@@ -106,13 +106,21 @@ void driverParameters( AtList *params, AtNodeEntry *nentry )
 	AiMetaDataSetStr( nentry, nullptr, "maya.translator", "ie" );
 }
 
+#if ARNOLD_VERSION_NUM < 70100
 void driverInitialize( AtNode *node )
+#else
+void driverInitialize( AtRenderSession *session, AtNode *node )
+#endif
 {
 	AiDriverInitialize( node, true );
 	AiNodeSetLocalData( node, new LocalData );
 }
 
+#if ARNOLD_VERSION_NUM < 70100
 void driverUpdate( AtNode *node )
+#else
+void driverUpdate( AtRenderSession *session, AtNode *node )
+#endif
 {
 }
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -367,6 +367,7 @@ const AtString g_widthArnoldString( "width" );
 const AtString g_xresArnoldString( "xres" );
 const AtString g_yresArnoldString( "yres" );
 const AtString g_filterMapArnoldString( "filtermap" );
+const AtString g_universeArnoldString( "universe" );
 const AtString g_uvRemapArnoldString( "uv_remap" );
 
 } // namespace
@@ -3083,14 +3084,26 @@ class ArnoldGlobals
 			if( m_messageHandler )
 			{
 				m_messageCallbackId = AiMsgRegisterCallback( &messageCallback, m_consoleFlags, this );
+#if ARNOLD_VERSION_NUM < 70100
 				AiMsgSetConsoleFlags( m_renderSession.get(), AI_LOG_NONE );
+#else
+				AiMsgSetConsoleFlags( m_universeBlock->universe(), AI_LOG_NONE );
+#endif
 			}
 			else
 			{
+#if ARNOLD_VERSION_NUM < 70100
 				AiMsgSetConsoleFlags( m_renderSession.get(), m_consoleFlags );
+#else
+				AiMsgSetConsoleFlags( m_universeBlock->universe(), m_consoleFlags );
+#endif
 			}
 
+#if ARNOLD_VERSION_NUM < 70100
 			AiMsgSetLogFileFlags( m_renderSession.get(), m_logFileFlags );
+#else
+			AiMsgSetLogFileFlags( m_universeBlock->universe(), m_logFileFlags );
+#endif
 			// Get OSL shaders onto the shader searchpath.
 			option( g_pluginSearchPathOptionName, new IECore::StringData( "" ) );
 		}
@@ -3705,12 +3718,20 @@ class ArnoldGlobals
 				}
 				else
 				{
+#if ARNOLD_VERSION_NUM < 70100
 					AiMsgSetConsoleFlags( m_renderSession.get(), flags );
+#else
+					AiMsgSetConsoleFlags( m_universeBlock->universe(), flags );
+#endif
 				}
 			}
 			else
 			{
+#if ARNOLD_VERSION_NUM < 70100
 				AiMsgSetLogFileFlags( m_renderSession.get(), flags );
+#else
+				AiMsgSetLogFileFlags( m_universeBlock->universe(), flags );
+#endif
 			}
 
 			return true;
@@ -3859,7 +3880,17 @@ class ArnoldGlobals
 		{
 			const ArnoldGlobals *that = static_cast<ArnoldGlobals *>( userPtr );
 
-#if ARNOLD_VERSION_NUM >= 70000
+#if ARNOLD_VERSION_NUM >= 70100
+			// We get given messages from all render sessions, but can filter them based on the `universe` metadata.
+			void *universe = nullptr;
+			if( AiParamValueMapGetPtr( metadata, g_universeArnoldString, &universe ) )
+			{
+				if( universe != that->m_universeBlock->universe() )
+				{
+					return;
+				}
+			}
+#elif ARNOLD_VERSION_NUM >= 70000
 			// We get given messages from all render sessions, but can filter them based on the
 			// `render_session` metadata.
 			void *renderSession = nullptr;


### PR DESCRIPTION
This gets Gaffer compiling for Arnold 7.1, 7.0, and 6.2

I haven't updated the CI as there isn't a publicly available 7.1 release we could download. Note also I do have some failing tests in 7.1 at IE, I haven't determined if those are a problem with our setup or something that needs fixing in the code.