### PR TITLE
CI : Replace Arnold 7.0.0.0 with Arnold 7.0.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
 
     - name: Build and test Arnold extension
       run: |
-        for arnoldVersion in 6.2.0.1 7.0.0.0
+        for arnoldVersion in 6.2.0.1 7.0.0.2
         do
           # Install Arnold
           ./.github/workflows/main/installArnold.sh $arnoldVersion

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -69,12 +69,6 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.__scriptFileName = self.temporaryDirectory() + "/test.gfr"
 
-		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
-			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
-			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release.
-			self.skipTest( "Exposes Arnold bug" )
-
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -58,12 +58,6 @@ class RendererTest( GafferTest.TestCase ) :
 
 		GafferTest.TestCase.setUp( self )
 
-		if GafferTest.inCI() and [ int( v ) for v in arnold.AiGetVersion() ] == [ 7, 0, 0, 0 ] :
-			# Skipping due to multiple-render-session bugs in Arnold 7.0.0.0. We have
-			# reported the bug with a small repro and it is confirmed as fixed for the
-			# upcoming 7.0.0.1 release.
-			self.skipTest( "Exposes Arnold bug" )
-
 	def assertReferSameNode( self, a, b ):
 		self.assertEqual( arnold.addressof( a.contents ), arnold.addressof( b.contents ) )
 


### PR DESCRIPTION
This allows us to re-enable some previously disabled tests.
