### PR TITLE
PathListingWidget : Release GIL before cancelling update

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
 -----
 
 - Viewer : Fixed gnomon, which went missing in Gaffer 0.61.0.0.
+- PathListingWidget : Fixed hangs triggered by hiding a widget while Python-based columns were being queried.
 - VectorDataWidget : Fixed header visibility when `setHeader()` is called after construction.
 
 API


### PR DESCRIPTION
PySide puts us in a position where we're running pure C++ code while unwittingly holding the GIL. So we must do a manual release to avoid deadlock when cancelling a background update involving Python-derived columns.