### PR TITLE
GraphEditor : Hide focus gadget for auxiliary nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Improvements
 ------------
 
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes.
-- GraphEditor : The focus widget now ignores right clicks, avoiding situations where attempting to open a context menu could accidentally change focus.
+- GraphEditor :
+  - The focus widget now ignores right clicks, avoiding situations where attempting to open a context menu could accidentally change focus.
+  - Removed the focus widget from Expression, Random and Animation nodes.
 - StandardAttributes : Added `attributes.displayColor` plug, for controlling the colour of objects in the Viewer.
 - UI : The UI is now scaled automatically for high-resolution monitors on Linux (#2157). Set the `QT_ENABLE_HIGHDPI_SCALING` environment variable to `0` to disable.
 
@@ -23,6 +25,7 @@ Fixes
 API
 ---
 
+- StandardNodeGadget : Added `nodeGadget:focusGadgetVisible` metadata.
 - VectorDataPlugValueWidget :
   - Added support for showing plugs with children, with each child forming a column in the UI.
   - Added `vectorDataPlugValueWidget:elementDefaultValue` metadata, used to provide the initial

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -162,6 +162,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		void updateNodeEnabled( const Gaffer::Plug *dirtiedPlug = nullptr );
 		void updateIcon();
 		bool updateShape();
+		void updateFocusGadgetVisibility();
 		void updateTextDimming();
 
 		IE_CORE_FORWARDDECLARE( ErrorGadget );

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -54,6 +54,7 @@ Gaffer.Metadata.registerNode(
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
 	"auxiliaryNodeGadget:label", "a",
+	"nodeGadget:focusGadgetVisible", False,
 
 	plugs = {
 

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -58,6 +58,7 @@ Gaffer.Metadata.registerNode(
 	"nodeGadget:shape", "oval",
 	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
 	"auxiliaryNodeGadget:label", "e",
+	"nodeGadget:focusGadgetVisible", False,
 
 	plugs = {
 

--- a/python/GafferUI/RandomChoiceUI.py
+++ b/python/GafferUI/RandomChoiceUI.py
@@ -58,6 +58,7 @@ Gaffer.Metadata.registerNode(
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
 	"auxiliaryNodeGadget:label", "r",
+	"nodeGadget:focusGadgetVisible", False,
 
 	"layout:activator:isSetup", lambda node : "out" in node,
 	"layout:activator:isNotSetup", lambda node : "out" not in node,

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -58,6 +58,7 @@ Gaffer.Metadata.registerNode(
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
 	"auxiliaryNodeGadget:label", "r",
+	"nodeGadget:focusGadgetVisible", False,
 
 	plugs = {
 

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -87,6 +87,7 @@ Gaffer.Metadata.registerNode(
 	"nodeGadget:shape", "oval",
 	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
 	"auxiliaryNodeGadget:label", "#",
+	"nodeGadget:focusGadgetVisible", False,
 
 	plugs = {
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -508,6 +508,7 @@ static IECore::InternedString g_minWidthKey( "nodeGadget:minWidth"  );
 static IECore::InternedString g_paddingKey( "nodeGadget:padding"  );
 static IECore::InternedString g_colorKey( "nodeGadget:color" );
 static IECore::InternedString g_shapeKey( "nodeGadget:shape" );
+static IECore::InternedString g_focusGadgetVisibleKey( "nodeGadget:focusGadgetVisible" );
 static IECore::InternedString g_iconKey( "icon" );
 static IECore::InternedString g_iconScaleKey( "iconScale" );
 static IECore::InternedString g_errorGadgetName( "__error" );
@@ -664,6 +665,7 @@ StandardNodeGadget::StandardNodeGadget( Gaffer::NodePtr node, bool auxiliary  )
 	updateNodeEnabled();
 	updateIcon();
 	updateShape();
+	updateFocusGadgetVisibility();
 }
 
 StandardNodeGadget::~StandardNodeGadget()
@@ -1218,6 +1220,10 @@ void StandardNodeGadget::nodeMetadataChanged( IECore::InternedString key )
 			dirty( DirtyType::Render );
 		}
 	}
+	else if( key == g_focusGadgetVisibleKey )
+	{
+		updateFocusGadgetVisibility();
+	}
 }
 
 bool StandardNodeGadget::updateUserColor()
@@ -1354,6 +1360,12 @@ bool StandardNodeGadget::updateShape()
 	m_oval = oval;
 	static_cast<FocusGadget *>( m_focusGadget.get() )->setOval( oval );
 	return true;
+}
+
+void StandardNodeGadget::updateFocusGadgetVisibility()
+{
+	auto d = Metadata::value<IECore::BoolData>( node(), g_focusGadgetVisibleKey );
+	m_focusGadget->setVisible( !d || d->readable() );
 }
 
 StandardNodeGadget::ErrorGadget *StandardNodeGadget::errorGadget( bool createIfMissing )


### PR DESCRIPTION
Because such nodes are small, it is too easy to accidentally hit the focus gadget instead when trying to select them. Rather than hide the gadget unconditionally, the visibility is controlled by metadata. This gives us more fine-grained control for future use, and a get-out-of-jail-free card if somebody prefers the old behaviour.

This has got me wondering why we added focusability to these nodes in the first place. Maybe we thought it would be useful to focus an expression to reveal which upstream nodes were active from its point of view? This does still seem potentially useful, so I wonder if we want a "Focus" option in the node context menu to cater to that? 