### PR TITLE
StyleSheet : Remove QHeaderView height hack

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - PrimitiveInspector :
   - Fixed errors displaying Constant primitive variables with differing array lengths.
   - Fixed header tooltip formatting to match the SceneInspector.
+- LightEditor : Fixed column widths. This was only an issue in Qt 5.12 builds, not the official GafferHQ builds.
 
 API
 ---

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -79,7 +79,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		tableView.verticalHeader().setVisible( False )
 
 		self.__horizontalHeader = GafferUI.Widget( QtWidgets.QHeaderView( QtCore.Qt.Horizontal, tableView ) )
-		self.__horizontalHeader._qtWidget().setDefaultAlignment( QtCore.Qt.AlignLeft )
+		self.__horizontalHeader._qtWidget().setDefaultAlignment( QtCore.Qt.AlignLeft | QtCore.Qt.AlignVCenter )
 		tableView.setHorizontalHeader( self.__horizontalHeader._qtWidget() )
 		self.__horizontalHeader.buttonPressSignal().connect( Gaffer.WeakMethod( self.__headerButtonPress ), scoped = False )
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -837,19 +837,13 @@ _styleSheet = string.Template(
 	QHeaderView::section {
 		border: 1px solid $backgroundLowlight;
 		border-radius: 0;
-		padding: 3px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+		padding-left: 3px;
+		padding-right: 3px;
 		font-weight: bold;
 		margin: 0px;
 		background-color: $tintLighter;
-	}
-
-	/* For some reason, in Qt 5.12+ we're seeing extra vertical space in the */
-	/* horizontal headers. Fixing the size here doesn't seem right, but have */
-	/* been unable to work out where it is coming from.                      */
-	_TableView QHeaderView::section:horizontal,
-	*[gafferClass="GafferUI.PathListingWidget"] QHeaderView::section::horizontal
-	{
-		height: 13px;
 	}
 
 	_TableView QHeaderView::section:vertical:first {


### PR DESCRIPTION
I don't know the history for this, but it's causing more trouble than its worth now. In Qt 5.12 it causes `QStyleSheetStyle::sizeFromContents()` to completely ignore the header contents (even in the horizontal direction), which in turn means that PathListingWidget headings are way too narrow, which means the LightEditor is basically unreadable. This isn't an issue in our standard Qt 5.15 builds where `sizeFromContents()` is fixed, but certain folks are partial to their custom retro Qt 5.12 builds.

Instead of hacking the height, we now just ask for zero padding in the vertical direction. While it sure looks like there's still a bit of padding, the sizes are reasonable and are a close enough match to the old behaviour, in both Qt 5.12 and 5.15.

This also exposed a small bug in the Spreadsheet UI - we need to specify a vertical alignment for the header, otherwise it gets aligned to the top.

