### PR TITLE
Arnold imagers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - RandomChoice : Added new node for choosing a random value from a list of weighted choices.
+- ArnoldImager : Added new node for adding Arnold imagers to the scene globals.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - Removed the focus widget from Expression, Random, Spreadsheet and Animation nodes.
 - StandardAttributes : Added `attributes.displayColor` plug, for controlling the colour of objects in the Viewer.
 - UI : The UI is now scaled automatically for high-resolution monitors on Linux (#2157). Set the `QT_ENABLE_HIGHDPI_SCALING` environment variable to `0` to disable.
+- ArnoldOptions : Added `ignore_imagers` option.
 
 Fixes
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -684,6 +684,9 @@ else :
 
 arnoldInstallRoot = ""
 if env["ARNOLD_ROOT"] :
+
+	# Version
+
 	arnoldHeader = env.subst( "$ARNOLD_ROOT/include/ai_version.h" )
 	if not os.path.exists( arnoldHeader ) :
 		sys.stderr.write( "ERROR : unable to find \"{}\".\n".format( arnoldHeader ) )
@@ -699,7 +702,57 @@ if env["ARNOLD_ROOT"] :
 		sys.stderr.write( "ERROR : unable to parse \"{}\".\n".format( arnoldHeader ) )
 		Exit( 1 )
 
+	# Install root
+
 	arnoldInstallRoot = "${{BUILD_DIR}}/arnold/{ARCH}.{MAJOR}".format( **arnoldVersions )
+
+	# Metadata. Our `arnoldPlugins/gaffer.mtd` contains metadata for all the Arnold
+	# nodes we know about, in all Arnold versions. We need to filter this down
+	# to only the nodes in _this_ Arnold version during installation. Arnold emits
+	# warnings if we attempt to register metadata for nodes that don't exist.
+
+	def filterMetadata( target, source, env ) :
+
+		# Get set of built-in nodes
+
+		kickEnv = env["ENV"].copy()
+		kickEnv["PATH"] = os.pathsep.join( [ os.path.join( env["ARNOLD_ROOT"], "bin" ), kickEnv["PATH"] ] )
+		kickOutput = subprocess.check_output(
+			[ "kick", "-nodes" ],
+			env = kickEnv,
+			universal_newlines = True,
+		)
+
+		nodeDefRegex = re.compile( r"\s*([a-zA-Z0-9_]+)\s+(driver|color_manager|driver|filter|light|operator|options|override|shader|shape)" )
+		nodes = set()
+		for line in kickOutput.split( "\n" ) :
+			m = nodeDefRegex.match( line )
+			if m :
+				nodes.add( m.group( 1 ) )
+
+		# Filter the input metadata file so that we only include metadata
+		# for nodes that exist.
+
+		newNodeRegex = re.compile( r"^\[node ([a-zA-Z_0-9]+)\]" )
+		with open( str( source[0] ) ) as inFile :
+			with open( str( target[0] ), "w" ) as outFile :
+				omit = False
+				for line in inFile.readlines() :
+					m = newNodeRegex.match( line )
+					if m :
+						nodeName = m.group( 1 )
+						omit = nodeName not in nodes
+						if omit :
+							sys.stderr.write( "Omitting non-existent node {}\n".format( nodeName ) )
+					if not omit :
+						outFile.write( line )
+
+	metadataInstall = env.Command(
+		os.path.join( arnoldInstallRoot, "arnoldPlugins/gaffer.mtd" ),
+		"arnoldPlugins/gaffer.mtd",
+		filterMetadata
+	)
+	env.Alias( "build", metadataInstall )
 
 ###############################################################################################
 # Definitions for the libraries we wish to build
@@ -902,7 +955,6 @@ libraries = {
 			"CPPPATH" : [ "$ARNOLD_ROOT/include" ],
 		},
 		"requiredOptions" : [ "ARNOLD_ROOT" ],
-		"additionalFiles" : [ "arnoldPlugins/gaffer.mtd" ],
 		"installRoot" : arnoldInstallRoot,
 	},
 

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -2104,3 +2104,53 @@
 	[attr linear_chromaticities]
 		# Disable because we don't support array plugs yet
 		gaffer.plugType STRING ""
+
+# Standard Arnold Imagers
+##########################################################################
+
+[node imager_color_correct]
+
+	primaryInput STRING "input"
+
+[node imager_color_curves]
+
+	primaryInput STRING "input"
+
+	# Hide, because we don't support array parameters, or have a spline
+	# UI to match Arnold's interpolation.
+	gaffer.nodeMenu.category STRING ""
+
+[node imager_denoiser_noice]
+
+	primaryInput STRING "input"
+
+[node imager_denoiser_oidn]
+
+	primaryInput STRING "input"
+
+[node imager_denoiser_oidn]
+
+	primaryInput STRING "input"
+
+[node imager_exposure]
+
+	primaryInput STRING "input"
+
+[node imager_lens_effects]
+
+	primaryInput STRING "input"
+
+[node imager_light_mixer]
+
+	primaryInput STRING "input"
+
+	# Hide, because we don't support array parameters.
+	gaffer.nodeMenu.category STRING ""
+
+[node imager_tonemap]
+
+	primaryInput STRING "input"
+
+[node imager_white_balance]
+
+	primaryInput STRING "input"

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -2128,7 +2128,7 @@
 
 	primaryInput STRING "input"
 
-[node imager_denoiser_oidn]
+[node imager_denoiser_optix]
 
 	primaryInput STRING "input"
 

--- a/include/GafferArnold/ArnoldImager.h
+++ b/include/GafferArnold/ArnoldImager.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,34 +34,58 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERARNOLD_TYPEIDS_H
-#define GAFFERARNOLD_TYPEIDS_H
+#ifndef GAFFERARNOLD_ARNOLDIMAGER_H
+#define GAFFERARNOLD_ARNOLDIMAGER_H
+
+#include "GafferArnold/Export.h"
+#include "GafferArnold/TypeIds.h"
+
+#include "GafferScene/GlobalsProcessor.h"
+#include "GafferScene/ShaderPlug.h"
 
 namespace GafferArnold
 {
 
-enum TypeId
+class GAFFERARNOLD_API ArnoldImager : public GafferScene::GlobalsProcessor
 {
-	ArnoldShaderTypeId = 110900,
-	ArnoldOptionsTypeId = 110901,
-	ArnoldAttributesTypeId = 110902,
-	ArnoldLightTypeId = 110903,
-	ArnoldVDBTypeId = 110904,
-	InteractiveArnoldRenderTypeId = 110905,
-	ArnoldRenderTypeId = 110906,
-	ArnoldDisplacementTypeId = 110907,
-	ArnoldMeshLightTypeId = 110908,
-	ArnoldAOVShaderTypeId = 110909,
-	ArnoldAtmosphereTypeId = 110910,
-	ArnoldBackgroundTypeId = 110911,
-	ArnoldCameraShadersTypeId = 110912,
-	ArnoldLightFilterTypeId = 110913,
-	ArnoldColorManagerTypeId = 110914,
-	ArnoldImagerTypeId = 110915,
 
-	LastTypeId = 110924
+	public :
+
+		ArnoldImager( const std::string &name=defaultName<ArnoldImager>() );
+		~ArnoldImager() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldImager, ArnoldImagerTypeId, GafferScene::GlobalsProcessor );
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+		enum class Mode
+		{
+			Replace,
+			InsertFirst,
+			InsertLast
+		};
+
+		GafferScene::ShaderPlug *imagerPlug();
+		const GafferScene::ShaderPlug *imagerPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+	protected :
+
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( ArnoldImager )
 
 } // namespace GafferArnold
 
-#endif // GAFFERARNOLD_TYPEIDS_H
+#endif // GAFFERARNOLD_ARNOLDIMAGER_H

--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -63,6 +63,10 @@ class GAFFERARNOLD_API ArnoldShader : public GafferScene::Shader
 
 		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
+	protected :
+
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+
 	private :
 
 		// Shader metadata is stored in a "shader" member of the result and

--- a/python/GafferArnoldTest/ArnoldImagerTest.py
+++ b/python/GafferArnoldTest/ArnoldImagerTest.py
@@ -1,0 +1,131 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECoreScene
+
+import GafferTest
+import GafferSceneTest
+import GafferArnold
+
+class ArnoldImagerTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		imager = GafferArnold.ArnoldShader()
+		imager.loadShader( "imager_exposure" )
+		imager["parameters"]["exposure"].setValue( 5 )
+
+		node = GafferArnold.ArnoldImager()
+		node["imager"].setInput( imager["out"] )
+
+		for mode in node.Mode.values.values() :
+
+			# Since there is no upstream imager, all modes
+			# should have the same effect.
+			node["mode"].setValue( mode )
+
+			self.assertEqual(
+				node["out"].globals()["option:ai:imager"],
+				imager.attributes()["ai:imager"]
+			)
+
+	def testRejectsNonImagerInputs( self ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "flat" )
+
+		node = GafferArnold.ArnoldImager()
+		self.assertFalse( node["imager"].acceptsInput( shader["out"] ) )
+
+	def testModes( self ) :
+
+		def order( scene ) :
+
+			network = scene.globals()["option:ai:imager"]
+
+			result = []
+			shaderHandle = network.getOutput().shader
+			while shaderHandle :
+				result.append( network.getShader( shaderHandle ).parameters["exposure"].value )
+				shaderHandle = network.input( ( shaderHandle, "input" ) ).shader
+
+			result.reverse()
+			return result
+
+		imager1 = GafferArnold.ArnoldShader()
+		imager1.loadShader( "imager_exposure" )
+		imager1["parameters"]["exposure"].setValue( 1 )
+
+		imager2 = GafferArnold.ArnoldShader()
+		imager2.loadShader( "imager_exposure" )
+		imager2["parameters"]["exposure"].setValue( 2 )
+
+		imager3 = GafferArnold.ArnoldShader()
+		imager3.loadShader( "imager_exposure" )
+		imager3["parameters"]["exposure"].setValue( 3 )
+
+		node1 = GafferArnold.ArnoldImager()
+		node1["imager"].setInput( imager1["out"] )
+		self.assertEqual( order( node1["out"] ), [ 1 ] )
+
+		node2 = GafferArnold.ArnoldImager()
+		node2["in"].setInput( node1["out"] )
+		node2["imager"].setInput( imager2["out"] )
+		self.assertEqual( order( node2["out"] ), [ 2 ] )
+
+		node2["mode"].setValue( GafferArnold.ArnoldImager.Mode.InsertLast )
+		self.assertEqual( order( node2["out"] ), [ 1, 2 ] )
+
+		node2["mode"].setValue( GafferArnold.ArnoldImager.Mode.InsertFirst )
+		self.assertEqual( order( node2["out"] ), [ 2, 1 ] )
+
+		node3 = GafferArnold.ArnoldImager()
+		node3["in"].setInput( node2["out"] )
+		node3["imager"].setInput( imager3["out"] )
+		self.assertEqual( order( node3["out"] ), [ 3 ] )
+
+		node3["mode"].setValue( GafferArnold.ArnoldImager.Mode.InsertLast )
+		self.assertEqual( order( node3["out"] ), [ 2, 1, 3 ] )
+
+		node3["mode"].setValue( GafferArnold.ArnoldImager.Mode.InsertFirst )
+		self.assertEqual( order( node3["out"] ), [ 3, 2, 1 ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferArnoldUI/ArnoldImagerUI.py
+++ b/python/GafferArnoldUI/ArnoldImagerUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,27 +34,62 @@
 #
 ##########################################################################
 
-from .ArnoldShaderTest import ArnoldShaderTest
-from .ArnoldRenderTest import ArnoldRenderTest
-from .ArnoldOptionsTest import ArnoldOptionsTest
-from .ArnoldAttributesTest import ArnoldAttributesTest
-from .ArnoldVDBTest import ArnoldVDBTest
-from .ArnoldLightTest import ArnoldLightTest
-from .ArnoldMeshLightTest import ArnoldMeshLightTest
-from .InteractiveArnoldRenderTest import InteractiveArnoldRenderTest
-from .ArnoldDisplacementTest import ArnoldDisplacementTest
-from .LightToCameraTest import LightToCameraTest
-from .ArnoldAOVShaderTest import ArnoldAOVShaderTest
-from .ArnoldAtmosphereTest import ArnoldAtmosphereTest
-from .ArnoldBackgroundTest import ArnoldBackgroundTest
-from .ArnoldTextureBakeTest import ArnoldTextureBakeTest
-from .ModuleTest import ModuleTest
-from .ArnoldShaderBallTest import ArnoldShaderBallTest
-from .ArnoldCameraShadersTest import ArnoldCameraShadersTest
-from .ArnoldLightFilterTest import ArnoldLightFilterTest
-from .ArnoldColorManagerTest import ArnoldColorManagerTest
-from .ArnoldImagerTest import ArnoldImagerTest
+import Gaffer
+import GafferArnold
 
-if __name__ == "__main__":
-	import unittest
-	unittest.main()
+Gaffer.Metadata.registerNode(
+
+	GafferArnold.ArnoldImager,
+
+	"description",
+	"""
+	Assigns an imager. This is stored as an `ai:imager` option in Gaffer's
+	globals, and applied to all render outputs.
+
+	> Tip : Use the `layer_selection` parameter on each imager to control
+	> which AOVs the imager applies to.
+	""",
+
+	plugs = {
+
+		"imager" : [
+
+			"description",
+			"""
+			The imager to be assigned. The output of an ArnoldShader node
+			holding an imager should be connected here. Multiple imagers may be
+			assigned at once by chaining them together via their `input`
+			parameters, and then assigning the final imager via the ArnoldImager
+			node.
+			""",
+
+			"noduleLayout:section", "left",
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"mode" : [
+
+			"description",
+			"""
+			The mode used to combine the `imager` input with any imagers that
+			already exist in the globals.
+
+			- Replace : Removes all pre-existing imagers, and replaces them with
+			  the new ones.
+			- InsertFirst : Inserts the new imagers so that they will be run before
+			  any pre-existing imagers.
+			- InsertLast : Inserts the new imagers so that they will be run after
+			  any pre-existing imagers.
+			""",
+
+			"preset:Replace", GafferArnold.ArnoldImager.Mode.Replace,
+			"preset:InsertFirst", GafferArnold.ArnoldImager.Mode.InsertFirst,
+			"preset:InsertLast", GafferArnold.ArnoldImager.Mode.InsertLast,
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+	}
+
+)

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -154,6 +154,7 @@ def __featuresSummary( plug ) :
 		( "ignoreDisplacement", "Disp" ),
 		( "ignoreBump", "Bump" ),
 		( "ignoreSSS", "SSS" ),
+		( "ignoreImagers", "Imagers" ),
 	) :
 		if plug[childName]["enabled"].getValue() :
 			info.append( label + ( " Off " if plug[childName]["value"].getValue() else " On" ) )
@@ -856,6 +857,17 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Disables all subsurface scattering.
+			""",
+
+			"layout:section", "Features",
+
+		],
+
+		"options.ignoreImagers" : [
+
+			"description",
+			"""
+			Disables all imagers.
 			""",
 
 			"layout:section", "Features",

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -372,7 +372,7 @@ def __translateNodeMetadata( nodeEntry ) :
 
 with IECoreArnold.UniverseBlock( writable = False ) :
 
-	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER )
+	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER | arnold.AI_NODE_DRIVER )
 	while not arnold.AiNodeEntryIteratorFinished( nodeIt ) :
 
 		__translateNodeMetadata( arnold.AiNodeEntryIteratorGetNext( nodeIt ) )

--- a/python/GafferArnoldUI/__init__.py
+++ b/python/GafferArnoldUI/__init__.py
@@ -56,6 +56,7 @@ from . import ArnoldTextureBakeUI
 from . import ArnoldCameraShadersUI
 from . import ArnoldLightFilterUI
 from . import ArnoldColorManagerUI
+from . import ArnoldImagerUI
 from . import CacheMenu
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferArnoldUI" )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3460,6 +3460,85 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertAlmostEqual( arnold.AiArrayGetFlt( array, 0 ), c1.calculateFieldOfView().x, delta = 0.00001 )
 			self.assertAlmostEqual( arnold.AiArrayGetFlt( array, 1 ), c2.calculateFieldOfView().x, delta = 0.00001 )
 
+	def testImager( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			self.temporaryDirectory() + "/test.ass"
+		)
+
+		# Create an output
+
+		r.output(
+			"test1",
+			IECoreScene.Output(
+				self.temporaryDirectory() + "/beauty1.exr", "exr", "rgba", {}
+			)
+		)
+
+		# Specify the imagers
+
+		r.option(
+			"ai:imager",
+			IECoreScene.ShaderNetwork(
+				{
+					"exposure" : IECoreScene.Shader(
+						"imager_exposure", "ai:imager",
+						{ "exposure" : 2.5 },
+					),
+					"lensEffects" : IECoreScene.Shader(
+						"imager_lens_effects", "ai:imager",
+						{ "bloom_radius" : 5 },
+					),
+				},
+				connections = [
+					( "exposure", ( "lensEffects", "input" ) )
+				],
+				output = "lensEffects",
+			)
+		)
+
+		# Create a second output
+
+		r.output(
+			"test2",
+			IECoreScene.Output(
+				self.temporaryDirectory() + "/beauty2.exr", "exr", "rgba", {}
+			)
+		)
+
+		r.render()
+		del r
+
+		# We expect the imager to be applied to both outputs (independent of
+		# creation order).
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
+
+			drivers = self.__allNodes( universe, type = arnold.AI_NODE_DRIVER, nodeEntryName = "driver_exr" )
+			self.assertEqual( len( drivers ), 2 )
+
+			for driver in drivers :
+
+				lensEffects = arnold.AiNodeGetPtr( driver, "input" )
+				self.assertIsNotNone( lensEffects )
+				self.assertEqual(
+					arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( lensEffects ) ),
+					"imager_lens_effects",
+				)
+				self.assertEqual( arnold.AiNodeGetInt( lensEffects, "bloom_radius" ), 5 )
+
+				exposure = arnold.AiNodeGetPtr( lensEffects, "input" )
+				self.assertIsNotNone( exposure )
+				self.assertEqual(
+					arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( exposure ) ),
+					"imager_exposure",
+				)
+				self.assertEqual( arnold.AiNodeGetFlt( exposure, "exposure" ), 2.5 )
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/src/GafferArnold/ArnoldImager.cpp
+++ b/src/GafferArnold/ArnoldImager.cpp
@@ -1,0 +1,227 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferArnold/ArnoldImager.h"
+
+#include "GafferScene/Shader.h"
+#include "GafferScene/ShaderPlug.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+#include "IECoreScene/ShaderNetworkAlgo.h"
+
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferArnold;
+
+namespace
+{
+
+const InternedString g_inputParameterName( "input" );
+const InternedString g_imagerAttributeName( "ai:imager" );
+const InternedString g_imagerOptionName( "option:ai:imager" );
+
+ShaderNetwork::Parameter firstInput( const ShaderNetwork *network, const InternedString &shader )
+{
+	ShaderNetwork::Parameter result( shader, g_inputParameterName );
+	while( true )
+	{
+		if( auto input = network->input( result ) )
+		{
+			result.shader = input.shader;
+		}
+		else
+		{
+			return result;
+		}
+	}
+}
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( ArnoldImager );
+
+size_t ArnoldImager::g_firstPlugIndex = 0;
+
+ArnoldImager::ArnoldImager( const std::string &name )
+	:	GlobalsProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ShaderPlug( "imager" ) );
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::Replace, (int)Mode::Replace, (int)Mode::InsertLast ) );
+}
+
+ArnoldImager::~ArnoldImager()
+{
+}
+
+GafferScene::ShaderPlug *ArnoldImager::imagerPlug()
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex );
+}
+
+const GafferScene::ShaderPlug *ArnoldImager::imagerPlug() const
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex );
+}
+
+Gaffer::IntPlug *ArnoldImager::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::IntPlug *ArnoldImager::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+bool ArnoldImager::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !GlobalsProcessor::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( plug != imagerPlug() )
+	{
+		return true;
+	}
+
+	if( !inputPlug )
+	{
+		return true;
+	}
+
+	const Plug *sourcePlug = inputPlug->source();
+	auto *sourceShader = runTimeCast<const GafferScene::Shader>( sourcePlug->node() );
+	if( !sourceShader )
+	{
+		return true;
+	}
+
+	const Plug *sourceShaderOutPlug = sourceShader->outPlug();
+	if( !sourceShaderOutPlug )
+	{
+		return true;
+	}
+
+	if( sourcePlug != sourceShaderOutPlug && !sourceShaderOutPlug->isAncestorOf( sourcePlug ) )
+	{
+		return true;
+	}
+
+	return sourceShader->typePlug()->getValue() == "ai:imager";
+}
+
+void ArnoldImager::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	GlobalsProcessor::affects( input, outputs );
+
+	if( input == imagerPlug() || input == modePlug() )
+	{
+		outputs.push_back( outPlug()->globalsPlug() );
+	}
+}
+
+void ArnoldImager::hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	h.append( imagerPlug()->attributesHash() );
+	modePlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr ArnoldImager::computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const
+{
+	ConstCompoundObjectPtr attributes = imagerPlug()->attributes();
+	if( attributes->members().empty() )
+	{
+		return inputGlobals;
+	}
+
+	const IECoreScene::ShaderNetwork *imager = attributes->member<IECoreScene::ShaderNetwork>( g_imagerAttributeName );
+	if( !imager )
+	{
+		throw IECore::Exception( "Imager not found" );
+	}
+
+	CompoundObjectPtr result = new CompoundObject;
+	// Since we're not going to modify any existing members (only add new ones),
+	// and our result becomes const on returning it, we can directly reference
+	// the input members in our result without copying. Be careful not to modify
+	// them though!
+	result->members() = inputGlobals->members();
+
+	const Mode mode = (Mode)modePlug()->getValue();
+	if( mode == Mode::InsertFirst || mode == Mode::InsertLast )
+	{
+		const ShaderNetwork *inputImager = inputGlobals->member<ShaderNetwork>( g_imagerOptionName );
+		if( !inputImager || !inputImager->size() )
+		{
+			result->members()[g_imagerOptionName] = const_cast<ShaderNetwork *>( imager );
+		}
+		else
+		{
+			ShaderNetworkPtr mergedImager = inputImager->copy();
+			ShaderNetwork::Parameter insertedOut = ShaderNetworkAlgo::addShaders( mergedImager.get(), imager );
+			if( mode == Mode::InsertLast )
+			{
+				mergedImager->addConnection( {
+					mergedImager->getOutput(),
+					firstInput( mergedImager.get(), insertedOut.shader )
+				} );
+				mergedImager->setOutput( insertedOut );
+			}
+			else
+			{
+				assert( mode == Mode::InsertFirst );
+				mergedImager->addConnection( {
+					insertedOut,
+					firstInput( mergedImager.get(), mergedImager->getOutput().shader )
+				} );
+			}
+			result->members()[g_imagerOptionName] = mergedImager;
+		}
+	}
+	else
+	{
+		assert( mode == Mode::Replace );
+		result->members()[g_imagerOptionName] = const_cast<ShaderNetwork *>( imager );
+	}
+
+	return result;
+}

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -112,6 +112,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_displacement", new IECore::BoolData( false ), false, "ignoreDisplacement" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_bump", new IECore::BoolData( false ), false, "ignoreBump" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_sss", new IECore::BoolData( false ), false, "ignoreSSS" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:ignore_imagers", new IECore::BoolData( false ), false, "ignoreImagers" ) );
 
 	// Searchpath parameters
 

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -278,6 +278,20 @@ Gaffer::Plug *setupClosurePlug( const IECore::InternedString &parameterName, Gaf
 	return plug.get();
 }
 
+Gaffer::Plug *setupNodePlug( const AtNodeEntry *nodeEntry, const InternedString &parameterName, GraphComponent *plugParent, Plug::Direction direction )
+{
+	if( AiNodeEntryGetType( nodeEntry ) == AI_NODE_DRIVER && parameterName == "input" )
+	{
+		return setupPlug( parameterName, plugParent, direction );
+	}
+	else
+	{
+		// We don't know what type of Arnold node this parameter expects to be
+		// connected to.
+		return nullptr;
+	}
+}
+
 const string nodeName ( Gaffer::GraphComponent *plugParent )
 {
 	const Gaffer::Node *node = IECore::runTimeCast<const Gaffer::Node>( plugParent );
@@ -514,6 +528,16 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 		case AI_TYPE_CLOSURE :
 
 			plug = setupClosurePlug(
+				AiParamGetName( parameter ).c_str(),
+				plugParent,
+				direction
+			);
+			break;
+
+		case AI_TYPE_NODE :
+
+			plug = setupNodePlug(
+				node,
 				AiParamGetName( parameter ).c_str(),
 				plugParent,
 				direction

--- a/src/GafferArnoldModule/GafferArnoldModule.cpp
+++ b/src/GafferArnoldModule/GafferArnoldModule.cpp
@@ -43,6 +43,7 @@
 #include "GafferArnold/ArnoldCameraShaders.h"
 #include "GafferArnold/ArnoldColorManager.h"
 #include "GafferArnold/ArnoldDisplacement.h"
+#include "GafferArnold/ArnoldImager.h"
 #include "GafferArnold/ArnoldLight.h"
 #include "GafferArnold/ArnoldMeshLight.h"
 #include "GafferArnold/ArnoldOptions.h"
@@ -125,4 +126,12 @@ BOOST_PYTHON_MODULE( _GafferArnold )
 	;
 	GafferDispatchBindings::TaskNodeClass<ArnoldRender>();
 
+	{
+		scope s = GafferBindings::DependencyNodeClass<ArnoldImager>();
+		enum_<ArnoldImager::Mode>( "Mode" )
+			.value( "Replace", ArnoldImager::Mode::Replace )
+			.value( "InsertFirst", ArnoldImager::Mode::InsertFirst )
+			.value( "InsertLast", ArnoldImager::Mode::InsertLast )
+		;
+	}
 }

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -263,7 +263,22 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 			// map building that needs to happen when a connection is made to the color parameter )
 			AiNodeResetParameter( node, "color" );
 		}
-		AiNodeLinkOutput( sourceNode, sourceName.c_str(), node, parameterName.c_str() );
+
+		const AtString parameterNameArnold( parameterName.c_str() );
+		const uint8_t paramType = AiParamGetType(
+			AiNodeEntryLookUpParameter(
+				AiNodeGetNodeEntry( node ), parameterNameArnold
+			)
+		);
+
+		if( paramType == AI_TYPE_NODE )
+		{
+			AiNodeSetPtr( node, parameterNameArnold, sourceNode );
+		}
+		else
+		{
+			AiNodeLinkOutput( sourceNode, sourceName.c_str(), node, parameterName.c_str() );
+		}
 	}
 
 	nodes.push_back( node );

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -123,6 +123,7 @@ if moduleSearchPath.find( "arnold" ) :
 		nodeMenu.append( "/Arnold/Globals/Atmosphere", GafferArnold.ArnoldAtmosphere, searchText = "ArnoldAtmosphere" )
 		nodeMenu.append( "/Arnold/Globals/Background", GafferArnold.ArnoldBackground, searchText = "ArnoldBackground" )
 		nodeMenu.append( "/Arnold/Globals/AOVShader", GafferArnold.ArnoldAOVShader, searchText = "ArnoldAOVShader" )
+		nodeMenu.append( "/Arnold/Globals/Imager", GafferArnold.ArnoldImager, searchText = "ArnoldImager" )
 		nodeMenu.append( "/Arnold/Displacement", GafferArnold.ArnoldDisplacement, searchText = "ArnoldDisplacement"  )
 		nodeMenu.append( "/Arnold/CameraShaders", GafferArnold.ArnoldCameraShaders, searchText = "ArnoldCameraShaders"  )
 		nodeMenu.append( "/Arnold/VDB", GafferArnold.ArnoldVDB, searchText = "ArnoldVDB"  )


### PR DESCRIPTION
This adds support for Arnold imagers. Imagers can be loaded via the ArnoldShader node, chained together to define an imager stack, and then assigned into the scene via a new ArnoldImager node :

![image](https://user-images.githubusercontent.com/1133871/153629551-1d08d3df-e222-480c-9f93-89a5ce1ce532.png)

As things stand, this is most suited for situations where you want to connect an imager and forget about it - like the interactive denoisers. It's less ideal for something like the lens effect imager where you might want to tweak the settings interactively. In this case, when the render has converged, you want to tweak the imager and just re-run it on the already-converged image. But the default implementation here uses the standard IPR-scene-edit code path and restarts the render from scratch. I'm informed that Arnold has some render hints that can be used to avoid this, but I have been unable to get them to work so far. I'd like to get this merged as it is, and treat the render hint stuff as followup work.