### PR TITLE
Replace `typedef` with `using`

### DIFF
--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -85,7 +85,7 @@ class GAFFER_API Action : public IECore::RunTimeTyped
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Action, ActionTypeId, IECore::RunTimeTyped );
 
-		typedef std::function<void ()> Function;
+		using Function = std::function<void ()>;
 
 		/// Enacts the specified action by calling doAction() and
 		/// adding it to the undo queue in the appropriate ScriptNode.

--- a/include/Gaffer/Animation.h
+++ b/include/Gaffer/Animation.h
@@ -277,14 +277,15 @@ class GAFFER_API Animation : public ComputeNode
 
 				void throwIfStateNotAsExpected( const CurvePlug*, bool, float ) const;
 
-				typedef boost::intrusive::avl_set_member_hook<
+				using Hook = boost::intrusive::avl_set_member_hook<
 					boost::intrusive::link_mode<
-#					ifndef NDEBUG
-					boost::intrusive::safe_link
-#					else
-					boost::intrusive::normal_link
-#					endif
-					> > Hook;
+#						ifndef NDEBUG
+							boost::intrusive::safe_link
+#						else
+							boost::intrusive::normal_link
+#						endif
+					>
+				>;
 
 				struct Dispose
 				{
@@ -440,15 +441,15 @@ class GAFFER_API Animation : public ComputeNode
 
 				struct TimeKey
 				{
-					typedef float type;
+					using type = float;
 					type operator()( const Animation::Key& ) const; // NOTE : must NEVER throw
 				};
 
-				typedef boost::intrusive::member_hook< Key, Key::Hook, &Key::m_hook > KeyHook;
-				typedef boost::intrusive::key_of_value< TimeKey > KeyOfValue;
+				using KeyHook = boost::intrusive::member_hook<Key, Key::Hook, &Key::m_hook>;
+				using KeyOfValue = boost::intrusive::key_of_value<TimeKey>;
 
-				typedef boost::intrusive::avl_set< Key, KeyHook, KeyOfValue > Keys;
-				typedef boost::intrusive::avl_multiset< Key, KeyHook, KeyOfValue > InactiveKeys;
+				using Keys = boost::intrusive::avl_set<Key, KeyHook, KeyOfValue>;
+				using InactiveKeys = boost::intrusive::avl_multiset< Key, KeyHook, KeyOfValue>;
 
 				static ConstExtrapolatorPtr CurvePlug::* const m_extrapolators[ 2 ];
 

--- a/include/Gaffer/BackgroundTask.h
+++ b/include/Gaffer/BackgroundTask.h
@@ -71,7 +71,7 @@ class GAFFER_API BackgroundTask : public boost::noncopyable
 
 	public :
 
-		typedef std::function<void ( const IECore::Canceller &canceller )> Function;
+		using Function = std::function<void ( const IECore::Canceller & )>;
 
 		/// Launches a background task to run `function`, which is expected
 		/// to perform asynchronous computes using the `subject` plug.

--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -78,8 +78,8 @@ class GAFFER_API Box : public SubGraph
 };
 
 /// \deprecated Use Box::Iterator etc instead.
-typedef FilteredChildIterator<TypePredicate<Box> > BoxIterator;
-typedef FilteredRecursiveChildIterator<TypePredicate<Box> > RecursiveBoxIterator;
+using BoxIterator = FilteredChildIterator<TypePredicate<Box> >;
+using RecursiveBoxIterator = FilteredRecursiveChildIterator<TypePredicate<Box> >;
 
 } // namespace Gaffer
 

--- a/include/Gaffer/BoxPlug.h
+++ b/include/Gaffer/BoxPlug.h
@@ -56,9 +56,9 @@ class GAFFER_API BoxPlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
-		typedef typename IECore::BoxTraits<T>::BaseType PointType;
-		typedef CompoundNumericPlug<PointType> ChildType;
+		using ValueType = T;
+		using PointType = typename IECore::BoxTraits<T>::BaseType;
+		using ChildType = CompoundNumericPlug<PointType>;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( BoxPlug<T>, ValuePlug );
 
@@ -108,11 +108,11 @@ class GAFFER_API BoxPlug : public ValuePlug
 
 };
 
-typedef BoxPlug<Imath::Box2i> Box2iPlug;
-typedef BoxPlug<Imath::Box3i> Box3iPlug;
+using Box2iPlug = BoxPlug<Imath::Box2i>;
+using Box3iPlug = BoxPlug<Imath::Box3i>;
 
-typedef BoxPlug<Imath::Box2f> Box2fPlug;
-typedef BoxPlug<Imath::Box3f> Box3fPlug;
+using Box2fPlug = BoxPlug<Imath::Box2f>;
+using Box3fPlug = BoxPlug<Imath::Box3f>;
 
 IE_CORE_DECLAREPTR( Box2iPlug );
 IE_CORE_DECLAREPTR( Box3iPlug );

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -57,8 +57,8 @@ class GAFFER_API CompoundNumericPlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
-		typedef NumericPlug<typename T::BaseType> ChildType;
+		using ValueType = T;
+		using ChildType = NumericPlug<typename T::BaseType>;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( CompoundNumericPlug<T>, ValuePlug );
 
@@ -127,14 +127,14 @@ class GAFFER_API CompoundNumericPlug : public ValuePlug
 
 };
 
-typedef CompoundNumericPlug<Imath::V2f> V2fPlug;
-typedef CompoundNumericPlug<Imath::V3f> V3fPlug;
+using V2fPlug = CompoundNumericPlug<Imath::V2f>;
+using V3fPlug = CompoundNumericPlug<Imath::V3f>;
 
-typedef CompoundNumericPlug<Imath::V2i> V2iPlug;
-typedef CompoundNumericPlug<Imath::V3i> V3iPlug;
+using V2iPlug = CompoundNumericPlug<Imath::V2i>;
+using V3iPlug = CompoundNumericPlug<Imath::V3i>;
 
-typedef CompoundNumericPlug<Imath::Color3f> Color3fPlug;
-typedef CompoundNumericPlug<Imath::Color4f> Color4fPlug;
+using Color3fPlug = CompoundNumericPlug<Imath::Color3f>;
+using Color4fPlug = CompoundNumericPlug<Imath::Color4f>;
 
 IE_CORE_DECLAREPTR( V2fPlug );
 IE_CORE_DECLAREPTR( V3fPlug );

--- a/include/Gaffer/CompoundPathFilter.h
+++ b/include/Gaffer/CompoundPathFilter.h
@@ -51,7 +51,7 @@ class GAFFER_API CompoundPathFilter : public Gaffer::PathFilter
 
 	public :
 
-		typedef std::vector<PathFilterPtr> Filters;
+		using Filters = std::vector<PathFilterPtr>;
 
 		CompoundPathFilter( IECore::CompoundDataPtr userData = nullptr );
 		~CompoundPathFilter() override;

--- a/include/Gaffer/Container.h
+++ b/include/Gaffer/Container.h
@@ -64,7 +64,7 @@ class Container : public Base
 		static const char *staticTypeName();
 		static bool inheritsFrom( IECore::TypeId typeId );
 		static bool inheritsFrom( const char *typeName );
-		typedef Base BaseClass;
+		using BaseClass = Base;
 		//@}
 
 		/// Accepts only type T.

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -373,7 +373,7 @@ class GAFFER_API Context : public IECore::RefCounted
 		// Returns nullptr if variable doesn't exist.
 		const Value *internalGetIfExists( const IECore::InternedString &name ) const;
 
-		typedef boost::container::flat_map<IECore::InternedString, Value> Map;
+		using Map = boost::container::flat_map<IECore::InternedString, Value>;
 
 		Map m_map;
 		ChangedSignal *m_changedSignal;
@@ -385,7 +385,7 @@ class GAFFER_API Context : public IECore::RefCounted
 		// alive at least as long as the m_map used for actual accesses is using it, though it may
 		// hold data longer than it is actually in use.  ( ie. a fast pointer based set through
 		// EditableScope could overwrite a variable without updating m_allocMap )
-		typedef boost::container::flat_map<IECore::InternedString, IECore::ConstDataPtr > AllocMap;
+		using AllocMap = boost::container::flat_map<IECore::InternedString, IECore::ConstDataPtr>;
 		AllocMap m_allocMap;
 
 };

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -63,7 +63,7 @@ template<typename T>
 struct DataTraits
 {
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 
 };
 
@@ -71,7 +71,7 @@ template<typename T>
 struct DataTraits<Imath::Vec2<T> >
 {
 
-	typedef IECore::GeometricTypedData<Imath::Vec2<T> > DataType;
+	using DataType = IECore::GeometricTypedData<Imath::Vec2<T>>;
 
 };
 
@@ -79,7 +79,7 @@ template<typename T>
 struct DataTraits<Imath::Vec3<T> >
 {
 
-	typedef IECore::GeometricTypedData<Imath::Vec3<T> > DataType;
+	using DataType = IECore::GeometricTypedData<Imath::Vec3<T>>;
 
 };
 
@@ -158,7 +158,7 @@ void Context::set( const IECore::InternedString &name, const T &value )
 {
 	// Allocate a new typed Data, store it in m_allocMap so that it won't be deallocated,
 	// and call internalSet to reference it in the main m_map
-	typedef typename Gaffer::Detail::DataTraits<T>::DataType DataType;
+	using DataType = typename Gaffer::Detail::DataTraits<T>::DataType;
 	typename DataType::Ptr d = new DataType( value );
 	if( internalSet( name, Value( name, &d->readable() ) ) )
 	{

--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -86,16 +86,16 @@ class GAFFER_API ContextMonitor : public Monitor
 
 			private :
 
-				typedef boost::unordered_set<IECore::MurmurHash> ContextSet;
-				typedef boost::unordered_map<IECore::MurmurHash, size_t> CountingMap;
-				typedef std::map<IECore::InternedString, CountingMap> VariableMap;
+				using ContextSet = boost::unordered_set<IECore::MurmurHash>;
+				using CountingMap = boost::unordered_map<IECore::MurmurHash, size_t>;
+				using VariableMap = std::map<IECore::InternedString, CountingMap>;
 
 				ContextSet m_contexts;
 				VariableMap m_variables;
 
 		};
 
-		typedef boost::unordered_map<ConstPlugPtr, Statistics> StatisticsMap;
+		using StatisticsMap = boost::unordered_map<ConstPlugPtr, Statistics>;
 
 		const StatisticsMap &allStatistics() const;
 		const Statistics &plugStatistics( const Plug *plug ) const;

--- a/include/Gaffer/DependencyNode.h
+++ b/include/Gaffer/DependencyNode.h
@@ -60,7 +60,7 @@ class GAFFER_API DependencyNode : public Node
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::DependencyNode, DependencyNodeTypeId, Node );
 
-		typedef std::vector<const Plug *> AffectedPlugsContainer;
+		using AffectedPlugsContainer = std::vector<const Plug *>;
 
 		/// Must be implemented to fill outputs with all the plugs whose computation
 		/// will be affected by the specified input. It is an error to pass a compound plug

--- a/include/Gaffer/DownstreamIterator.h
+++ b/include/Gaffer/DownstreamIterator.h
@@ -229,7 +229,7 @@ class DownstreamIterator : public boost::iterator_facade<DownstreamIterator, con
 
 		};
 
-		typedef std::vector<Level> Levels;
+		using Levels = std::vector<Level>;
 		Levels m_stack;
 		const Plug *m_root;
 		bool m_pruned;

--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -154,7 +154,7 @@ class GAFFER_API Expression : public ComputeNode
 				/// Creates an engine of the specified type.
 				static EnginePtr create( const std::string engineType );
 
-				typedef std::function<EnginePtr ()> Creator;
+				using Creator = std::function<EnginePtr ()>;
 				static void registerEngine( const std::string engineType, Creator creator );
 				static void registeredEngines( std::vector<std::string> &engineTypes );
 
@@ -169,7 +169,7 @@ class GAFFER_API Expression : public ComputeNode
 
 				friend class Expression;
 
-				typedef std::map<std::string, Creator> CreatorMap;
+				using CreatorMap = std::map<std::string, Creator>;
 				static CreatorMap &creators();
 
 		};

--- a/include/Gaffer/FilteredChildIterator.h
+++ b/include/Gaffer/FilteredChildIterator.h
@@ -47,7 +47,7 @@ namespace Gaffer
 template<typename T>
 struct TypePredicate
 {
-	typedef T ChildType;
+	using ChildType = T;
 
 	bool operator()( const GraphComponentPtr &g ) const
 	{
@@ -61,16 +61,16 @@ class FilteredChildIterator : public boost::filter_iterator<Predicate, GraphComp
 
 	public :
 
-		typedef typename Predicate::ChildType ChildType;
-		typedef boost::filter_iterator<Predicate, GraphComponent::ChildIterator> BaseIterator;
+		using ChildType = typename Predicate::ChildType;
+		using BaseIterator = boost::filter_iterator<Predicate, GraphComponent::ChildIterator>;
 
 		/// \todo It's inconvenient that our reference type
 		/// is ChildType::Ptr rather than just ChildType. It
 		/// leads to lots of ugly `it->get()` and `(*it)->`
 		/// calls. Change this for this class and also for
 		/// the RecursiveIterator classes.
-		typedef const typename ChildType::Ptr &reference;
-		typedef const typename ChildType::Ptr *pointer;
+		using reference = const typename ChildType::Ptr &;
+		using pointer = const typename ChildType::Ptr *;
 
 		FilteredChildIterator()
 			:	BaseIterator()

--- a/include/Gaffer/FilteredRecursiveChildIterator.h
+++ b/include/Gaffer/FilteredRecursiveChildIterator.h
@@ -51,8 +51,8 @@ class FilteredRecursiveChildIterator : public boost::iterator_adaptor<FilteredRe
 
 	public :
 
-		typedef typename Predicate::ChildType ChildType;
-		typedef boost::iterator_adaptor<FilteredRecursiveChildIterator<Predicate, RecursionPredicate>, RecursiveChildIterator, const typename Predicate::ChildType::Ptr> BaseIterator;
+		using ChildType = typename Predicate::ChildType;
+		using BaseIterator = boost::iterator_adaptor<FilteredRecursiveChildIterator<Predicate, RecursionPredicate>, RecursiveChildIterator, const typename Predicate::ChildType::Ptr>;
 
 		FilteredRecursiveChildIterator()
 			:	BaseIterator(),

--- a/include/Gaffer/GraphComponent.inl
+++ b/include/Gaffer/GraphComponent.inl
@@ -95,7 +95,7 @@ inline const T *GraphComponent::descendant( const std::string &relativePath ) co
 		return nullptr;
 	}
 
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 
 	Tokenizer t( relativePath, boost::char_separator<char>( "." ) );
 	const GraphComponent *result = this;

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -62,9 +62,9 @@ class GAFFER_API Metadata
 
 	public :
 
-		typedef std::function<IECore::ConstDataPtr ()> ValueFunction;
-		typedef std::function<IECore::ConstDataPtr ( const GraphComponent *graphComponent )> GraphComponentValueFunction;
-		typedef std::function<IECore::ConstDataPtr ( const Plug *plug )> PlugValueFunction;
+		using ValueFunction = std::function<IECore::ConstDataPtr ()>;
+		using GraphComponentValueFunction = std::function<IECore::ConstDataPtr ( const GraphComponent * )>;
+		using PlugValueFunction = std::function<IECore::ConstDataPtr ( const Plug * )>;
 
 		/// Value registration
 		/// ==================

--- a/include/Gaffer/NumericPlug.h
+++ b/include/Gaffer/NumericPlug.h
@@ -53,7 +53,7 @@ class GAFFER_API NumericPlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
+		using ValueType = T;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( NumericPlug<T>, ValuePlug );
 
@@ -91,16 +91,16 @@ class GAFFER_API NumericPlug : public ValuePlug
 
 	private :
 
-		typedef IECore::TypedData<T> DataType;
-		typedef typename DataType::Ptr DataTypePtr;
+		using DataType = IECore::TypedData<T>;
+		using DataTypePtr = typename DataType::Ptr;
 
 		T m_minValue;
 		T m_maxValue;
 
 };
 
-typedef NumericPlug<float> FloatPlug;
-typedef NumericPlug<int> IntPlug;
+using FloatPlug = NumericPlug<float>;
+using IntPlug = NumericPlug<int>;
 
 IE_CORE_DECLAREPTR( FloatPlug );
 IE_CORE_DECLAREPTR( IntPlug );

--- a/include/Gaffer/ParallelAlgo.h
+++ b/include/Gaffer/ParallelAlgo.h
@@ -60,7 +60,7 @@ namespace ParallelAlgo
 /// > Caution : If calling a member function, you _must_ guarantee that
 /// > the class instance will still be alive when the member function is
 /// > called. Typically this means binding `this` via a smart pointer.
-typedef std::function<void ()> UIThreadFunction;
+using UIThreadFunction = std::function<void ()>;
 GAFFER_API void callOnUIThread( const UIThreadFunction &function );
 
 /// Push/pop a handler to service requests made to `callOnUIThread()`. We
@@ -69,7 +69,7 @@ GAFFER_API void callOnUIThread( const UIThreadFunction &function );
 /// > Note : This is an implementation detail. It is only exposed to allow
 /// > emulation of the UI in unit tests, and theoretically to allow an
 /// > alternative UI framework to be connected.
-typedef std::function<void ( const UIThreadFunction & )> UIThreadCallHandler;
+using UIThreadCallHandler = std::function<void ( const UIThreadFunction & )>;
 GAFFER_API void pushUIThreadCallHandler( const UIThreadCallHandler &handler );
 GAFFER_API void popUIThreadCallHandler();
 
@@ -79,7 +79,7 @@ GAFFER_API void popUIThreadCallHandler();
 /// `BackgroundTask`, allowing the background work to be cancelled
 /// explicitly. Implicit cancellation is also performed using the `subject`
 /// argument : see the `BackgroundTask` documentation for details.
-typedef std::function<void ()> BackgroundFunction;
+using BackgroundFunction = std::function<void ()>;
 GAFFER_API std::unique_ptr<BackgroundTask> callOnBackgroundThread( const Plug *subject, BackgroundFunction function );
 
 } // namespace ParallelAlgo

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -76,7 +76,7 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 
 	public :
 
-		typedef std::vector<IECore::InternedString> Names;
+		using Names = std::vector<IECore::InternedString>;
 
 		Path( PathFilterPtr filter = nullptr );
 		Path( const std::string &path, PathFilterPtr filter = nullptr );

--- a/include/Gaffer/PerformanceMonitor.h
+++ b/include/Gaffer/PerformanceMonitor.h
@@ -87,7 +87,7 @@ class GAFFER_API PerformanceMonitor : public Monitor
 
 		};
 
-		typedef boost::unordered_map<ConstPlugPtr, Statistics> StatisticsMap;
+		using StatisticsMap = boost::unordered_map<ConstPlugPtr, Statistics>;
 
 		const StatisticsMap &allStatistics() const;
 		const Statistics &plugStatistics( const Plug *plug ) const;
@@ -110,7 +110,7 @@ class GAFFER_API PerformanceMonitor : public Monitor
 			// Stack of durations pointing into the statistics map.
 			// The top of the stack is the duration we're billing the
 			// current chunk of time to.
-			typedef std::stack<boost::chrono::nanoseconds *> DurationStack;
+			using DurationStack = std::stack<boost::chrono::nanoseconds *>;
 			DurationStack durationStack;
 			// The last time measurement we made.
 			boost::chrono::high_resolution_clock::time_point then;

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -180,7 +180,7 @@ class GAFFER_API Plug : public GraphComponent
 		/// @name Connections
 		///////////////////////////////////////////////////////////////////////
 		//@{
-		typedef std::list<Plug *> OutputContainer;
+		using OutputContainer = std::list<Plug *>;
 		/// Plugs may accept or reject a potential input by
 		/// implementing this method to return true for
 		/// acceptance and false for rejection. Implementations
@@ -282,7 +282,7 @@ IE_CORE_DECLAREPTR( Plug );
 template<typename T, Plug::Direction D>
 struct Plug::TypePredicate
 {
-	typedef T ChildType;
+	using ChildType = T;
 
 	bool operator()( const GraphComponentPtr &g ) const
 	{
@@ -303,7 +303,7 @@ struct Plug::TypePredicate
 template<Plug::Direction D=Plug::Invalid, typename T=Plug>
 struct PlugPredicate
 {
-	typedef T ChildType;
+	using ChildType = T;
 
 	bool operator()( const GraphComponentPtr &g ) const
 	{

--- a/include/Gaffer/PlugType.h
+++ b/include/Gaffer/PlugType.h
@@ -51,14 +51,14 @@ namespace Gaffer
 template<typename T>
 struct PlugType
 {
-	typedef void Type;
+	using Type = void;
 };
 
 #define GAFFER_PLUGTYPE_SPECIALISE( VALUETYPE, PLUGTYPE ) 	\
 	template<>												\
 	struct PlugType<VALUETYPE>								\
 	{														\
-		typedef PLUGTYPE Type;								\
+		using Type = PLUGTYPE;								\
 	};														\
 
 GAFFER_PLUGTYPE_SPECIALISE( float, FloatPlug )

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -97,16 +97,16 @@ class LRUCache : private boost::noncopyable
 {
 	public:
 
-		typedef size_t Cost;
-		typedef Key KeyType;
+		using Cost = size_t;
+		using KeyType = Key;
 
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
 		/// any reason. Cancellation support requires that `IECore::Canceller::check( canceller )`
 		/// is called periodically.
-		typedef boost::function<Value ( const GetterKey &key, Cost &cost, const IECore::Canceller *canceller )> GetterFunction;
+		using GetterFunction = boost::function<Value ( const GetterKey &key, Cost &cost, const IECore::Canceller *canceller )>;
 		/// The optional RemovalCallback is called whenever an item is discarded from the cache.
-		typedef boost::function<void ( const Key &key, const Value &data )> RemovalCallback;
+		using RemovalCallback = boost::function<void ( const Key &key, const Value &data )>;
 
 		LRUCache( GetterFunction getter, Cost maxCost, RemovalCallback removalCallback = RemovalCallback(), bool cacheErrors = true );
 		virtual ~LRUCache();
@@ -186,7 +186,7 @@ class LRUCache : private boost::noncopyable
 			// - Uncached : A boost::blank instance
 			// - Cached : The Value itself
 			// - Failed : The exception thrown by the GetterFn
-			typedef boost::variant<boost::blank, Value, std::exception_ptr> State;
+			using State = boost::variant<boost::blank, Value, std::exception_ptr>;
 
 			State state;
 			Cost cost; // the cost for this item

--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -94,8 +94,8 @@ class Serial
 
 	public :
 
-		typedef typename LRUCache::CacheEntry CacheEntry;
-		typedef typename LRUCache::KeyType Key;
+		using CacheEntry = typename LRUCache::CacheEntry;
+		using Key = typename LRUCache::KeyType;
 
 		struct Item
 		{
@@ -114,7 +114,7 @@ class Serial
 			mutable size_t handleCount;
 		};
 
-		typedef boost::multi_index_container<
+		using MapAndList = boost::multi_index_container<
 			Item,
 			boost::multi_index::indexed_by<
 				// First index is equivalent to std::unordered_map,
@@ -125,10 +125,10 @@ class Serial
 				// Second index is equivalent to std::list.
 				boost::multi_index::sequenced<>
 			>
-		> MapAndList;
+		>;
 
-		typedef typename MapAndList::iterator MapIterator;
-		typedef typename MapAndList::template nth_index<1>::type List;
+		using MapIterator = typename MapAndList::iterator;
+		using List = typename MapAndList::template nth_index<1>::type;
 
 		Serial()
 			:	currentCost( 0 )
@@ -302,9 +302,9 @@ class Parallel
 
 	public :
 
-		typedef typename LRUCache::CacheEntry CacheEntry;
-		typedef typename LRUCache::KeyType Key;
-		typedef std::atomic<typename LRUCache::Cost> AtomicCost;
+		using CacheEntry = typename LRUCache::CacheEntry;
+		using Key = typename LRUCache::KeyType;
+		using AtomicCost = std::atomic<typename LRUCache::Cost>;
 
 		struct Item
 		{
@@ -314,7 +314,7 @@ class Parallel
 			Key key;
 			mutable CacheEntry cacheEntry;
 			// Mutex to protect cacheEntry.
-			typedef tbb::spin_rw_mutex Mutex;
+			using Mutex = tbb::spin_rw_mutex;
 			mutable Mutex mutex;
 			// Flag used in second-chance algorithm.
 			mutable std::atomic_bool recentlyUsed;
@@ -328,7 +328,7 @@ class Parallel
 		// container, but split our storage into multiple bins with a
 		// container in each bin. This way concurrent operations do not
 		// contend on a lock unless they happen to target the same bin.
-		typedef boost::multi_index::multi_index_container<
+		using Map = boost::multi_index::multi_index_container<
 			Item,
 			boost::multi_index::indexed_by<
 				// Equivalent to std::unordered_map, using Item::key
@@ -345,9 +345,9 @@ class Parallel
 					boost::multi_index::member<Item, Key, &Item::key>
 				>
 			>
-		> Map;
+		>;
 
-		typedef typename Map::iterator MapIterator;
+		using MapIterator = typename Map::iterator;
 
 		struct Bin
 		{
@@ -355,11 +355,11 @@ class Parallel
 			Bin( const Bin &other ) : map( other.map ) {}
 			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
 			Map map;
-			typedef tbb::spin_rw_mutex Mutex;
+			using Mutex = tbb::spin_rw_mutex;
 			Mutex mutex;
 		};
 
-		typedef std::vector<Bin> Bins;
+		using Bins = std::vector<Bin>;
 
 		Parallel()
 		{
@@ -619,7 +619,7 @@ class Parallel
 			return m_bins[binIndex];
 		};
 
-		typedef tbb::spin_mutex PopMutex;
+		using PopMutex = tbb::spin_mutex;
 		PopMutex m_popMutex;
 		size_t m_popBinIndex;
 		MapIterator m_popIterator;
@@ -648,9 +648,9 @@ class TaskParallel
 
 	public :
 
-		typedef typename LRUCache::CacheEntry CacheEntry;
-		typedef typename LRUCache::KeyType Key;
-		typedef std::atomic<typename LRUCache::Cost> AtomicCost;
+		using CacheEntry = typename LRUCache::CacheEntry;
+		using Key = typename LRUCache::KeyType;
+		using AtomicCost = std::atomic<typename LRUCache::Cost>;
 
 		struct Item
 		{
@@ -660,7 +660,7 @@ class TaskParallel
 			Key key;
 			mutable CacheEntry cacheEntry;
 			// Mutex to protect cacheEntry.
-			typedef TaskMutex Mutex;
+			using Mutex = TaskMutex;
 			mutable Mutex mutex;
 			// Flag used in second-chance algorithm.
 			mutable std::atomic_bool recentlyUsed;
@@ -674,7 +674,7 @@ class TaskParallel
 		// container, but split our storage into multiple bins with a
 		// container in each bin. This way concurrent operations do not
 		// contend on a lock unless they happen to target the same bin.
-		typedef boost::multi_index::multi_index_container<
+		using Map = boost::multi_index::multi_index_container<
 			Item,
 			boost::multi_index::indexed_by<
 				// Equivalent to std::unordered_map, using Item::key
@@ -691,9 +691,9 @@ class TaskParallel
 					boost::multi_index::member<Item, Key, &Item::key>
 				>
 			>
-		> Map;
+		>;
 
-		typedef typename Map::iterator MapIterator;
+		using MapIterator = typename Map::iterator;
 
 		struct Bin
 		{
@@ -701,11 +701,11 @@ class TaskParallel
 			Bin( const Bin &other ) : map( other.map ) {}
 			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
 			Map map;
-			typedef tbb::spin_rw_mutex Mutex;
+			using Mutex = tbb::spin_rw_mutex;
 			Mutex mutex;
 		};
 
-		typedef std::vector<Bin> Bins;
+		using Bins = std::vector<Bin>;
 
 		TaskParallel()
 		{
@@ -1023,7 +1023,7 @@ class TaskParallel
 			return m_bins[binIndex];
 		};
 
-		typedef tbb::spin_mutex PopMutex;
+		using PopMutex = tbb::spin_mutex;
 		PopMutex m_popMutex;
 		size_t m_popBinIndex;
 		MapIterator m_popIterator;

--- a/include/Gaffer/Private/IECorePreview/MessagesData.h
+++ b/include/Gaffer/Private/IECorePreview/MessagesData.h
@@ -49,7 +49,7 @@ IECORE_DECLARE_TYPEDDATA( MessagesData, IECorePreview::Messages, void, IECore::S
 namespace IECorePreview
 {
 
-typedef IECore::MessagesData MessagesData;
+using MessagesData = IECore::MessagesData;
 IE_CORE_DECLAREPTR( MessagesData );
 
 } // namespace IECorePreview

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -104,7 +104,7 @@ namespace IECorePreview
 class TaskMutex : boost::noncopyable
 {
 
-	typedef tbb::spin_rw_mutex InternalMutex;
+	using InternalMutex = tbb::spin_rw_mutex;
 
 	public :
 
@@ -408,7 +408,7 @@ class TaskMutex : boost::noncopyable
 		};
 		IE_CORE_DECLAREPTR( ExecutionState );
 
-		typedef tbb::spin_mutex ExecutionStateMutex;
+		using ExecutionStateMutex = tbb::spin_mutex;
 		ExecutionStateMutex m_executionStateMutex; // Protects m_executionState
 		ExecutionStatePtr m_executionState;
 

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -69,7 +69,7 @@ IE_CORE_FORWARDDECLARE( StandardSet );
 IE_CORE_FORWARDDECLARE( CompoundDataPlug );
 IE_CORE_FORWARDDECLARE( StringPlug );
 
-typedef Container<GraphComponent, ScriptNode> ScriptContainer;
+using ScriptContainer = Container<GraphComponent, ScriptNode>;
 IE_CORE_DECLAREPTR( ScriptContainer );
 
 /// The ScriptNode class represents a script - that is a single collection of
@@ -326,9 +326,9 @@ class GAFFER_API ScriptNode : public Node
 		// Called by undo/redo to cleanup after action stage
 		void postActionStageCleanup();
 
-		typedef std::stack<UndoScope::State> UndoStateStack;
-		typedef std::list<CompoundActionPtr> UndoList;
-		typedef UndoList::iterator UndoIterator;
+		using UndoStateStack = std::stack<UndoScope::State>;
+		using UndoList = std::list<CompoundActionPtr>;
+		using UndoIterator = UndoList::iterator;
 
 		ActionSignal m_actionSignal;
 		UndoAddedSignal m_undoAddedSignal;
@@ -344,8 +344,8 @@ class GAFFER_API ScriptNode : public Node
 		std::string serialiseInternal( const Node *parent, const Set *filter ) const;
 		bool executeInternal( const std::string &serialisation, Node *parent, bool continueOnError, const std::string &context = "" );
 
-		typedef std::function<std::string ( const Node *, const Set * )> SerialiseFunction;
-		typedef std::function<bool ( ScriptNode *, const std::string &, Node *, bool, const std::string &context )> ExecuteFunction;
+		using SerialiseFunction = std::function<std::string ( const Node *, const Set * )>;
+		using ExecuteFunction = std::function<bool ( ScriptNode *, const std::string &, Node *, bool, const std::string & )>;
 
 		// Actual implementations reside in libGafferBindings (due to Python
 		// dependency), and are injected into these functions.

--- a/include/Gaffer/Set.h
+++ b/include/Gaffer/Set.h
@@ -64,9 +64,9 @@ class GAFFER_API Set : public IECore::RunTimeTyped, public Signals::Trackable
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Set, SetTypeId, IECore::RunTimeTyped );
 
-		typedef IECore::RunTimeTyped Member;
-		typedef Member::Ptr MemberPtr;
-		typedef Member::ConstPtr ConstMemberPtr;
+		using Member = IECore::RunTimeTyped;
+		using MemberPtr = Member::Ptr;
+		using ConstMemberPtr = Member::ConstPtr;
 
 		/// Returns the number of members of the set.
 		virtual size_t size() const = 0;
@@ -86,8 +86,8 @@ class GAFFER_API Set : public IECore::RunTimeTyped, public Signals::Trackable
 		/// the responsibility of derived classes to emit this when appropriate.
 		MemberSignal &memberRemovedSignal();
 
-		typedef SetIterator<Set, Member> Iterator;
-		typedef SetIterator<Set const, Member const> ConstIterator;
+		using Iterator = SetIterator<Set, Member>;
+		using ConstIterator = SetIterator<Set const, Member const>;
 
 		Iterator begin();
 		ConstIterator begin() const;

--- a/include/Gaffer/SplinePlug.h
+++ b/include/Gaffer/SplinePlug.h
@@ -61,10 +61,10 @@ enum SplineDefinitionInterpolation
 template<typename T>
 struct GAFFER_API SplineDefinition
 {
-	typedef typename T::XType XType;
-	typedef typename T::YType YType;
-	typedef typename T::PointContainer PointContainer;
-	typedef typename PointContainer::value_type Point;
+	using XType = typename T::XType;
+	using YType = typename T::YType;
+	using PointContainer = typename T::PointContainer;
+	using Point = typename PointContainer::value_type;
 
 	SplineDefinition() : interpolation( SplineDefinitionInterpolationCatmullRom )
 	{
@@ -120,9 +120,9 @@ class GAFFER_API SplinePlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
-		typedef typename PlugType<typename T::XType>::Type XPlugType;
-		typedef typename PlugType<typename T::YType>::Type YPlugType;
+		using ValueType = T;
+		using XPlugType = typename PlugType<typename T::XType>::Type;
+		using YPlugType = typename PlugType<typename T::YType>::Type;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( SplinePlug<T>, ValuePlug );
 
@@ -178,13 +178,13 @@ class GAFFER_API SplinePlug : public ValuePlug
 		T m_defaultValue;
 };
 
-typedef SplineDefinition<IECore::Splineff> SplineDefinitionff;
-typedef SplineDefinition<IECore::SplinefColor3f> SplineDefinitionfColor3f;
-typedef SplineDefinition<IECore::SplinefColor4f> SplineDefinitionfColor4f;
+using SplineDefinitionff = SplineDefinition<IECore::Splineff>;
+using SplineDefinitionfColor3f = SplineDefinition<IECore::SplinefColor3f>;
+using SplineDefinitionfColor4f = SplineDefinition<IECore::SplinefColor4f>;
 
-typedef SplinePlug< SplineDefinitionff > SplineffPlug;
-typedef SplinePlug< SplineDefinitionfColor3f > SplinefColor3fPlug;
-typedef SplinePlug< SplineDefinitionfColor4f > SplinefColor4fPlug;
+using SplineffPlug = SplinePlug<SplineDefinitionff>;
+using SplinefColor3fPlug = SplinePlug<SplineDefinitionfColor3f>;
+using SplinefColor4fPlug = SplinePlug<SplineDefinitionfColor4f>;
 
 IE_CORE_DECLAREPTR( SplineffPlug );
 IE_CORE_DECLAREPTR( SplinefColor3fPlug );

--- a/include/Gaffer/StandardSet.h
+++ b/include/Gaffer/StandardSet.h
@@ -52,7 +52,7 @@ namespace Detail
 
 struct MemberAcceptanceCombiner
 {
-	typedef bool result_type;
+	using result_type = bool;
 
 	template<typename InputIterator>
 	bool operator()( InputIterator first, InputIterator last ) const
@@ -152,16 +152,16 @@ class GAFFER_API StandardSet : public Gaffer::Set
 
 		MemberAcceptanceSignal m_memberAcceptanceSignal;
 
-		typedef boost::multi_index::multi_index_container<
+		using MemberContainer = boost::multi_index::multi_index_container<
 			MemberPtr,
 			boost::multi_index::indexed_by<
 				boost::multi_index::ordered_unique<boost::multi_index::identity<MemberPtr> >,
 				boost::multi_index::random_access<>
 			>
-		> MemberContainer;
+		> ;
 
-		typedef const MemberContainer::nth_index<0>::type OrderedIndex;
-		typedef const MemberContainer::nth_index<1>::type SequencedIndex;
+		using OrderedIndex = const MemberContainer::nth_index<0>::type;
+		using SequencedIndex = const MemberContainer::nth_index<1>::type;
 
 		MemberContainer m_members;
 		bool m_removeOrphans;

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -86,7 +86,7 @@ class GAFFER_API StringPlug : public ValuePlug
 
 	public :
 
-		typedef std::string ValueType;
+		using ValueType = std::string;
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::StringPlug, StringPlugTypeId, ValuePlug );
 

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -126,9 +126,9 @@ class IECORE_EXPORT Switch : public ComputeNode
 
 IE_CORE_DECLAREPTR( Switch );
 
-typedef Switch SwitchComputeNode;
-typedef SwitchPtr SwitchComputeNodePtr;
-typedef ConstSwitchPtr ConstSwitchComputeNodePtr;
+using SwitchComputeNode = Switch;
+using SwitchComputeNodePtr = SwitchPtr;
+using ConstSwitchComputeNodePtr = ConstSwitchPtr;
 
 } // namespace Gaffer
 

--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -62,9 +62,9 @@ class IECORE_EXPORT TypedObjectPlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
-		typedef typename ValueType::Ptr ValuePtr;
-		typedef typename ValueType::ConstPtr ConstValuePtr;
+		using ValueType = T;
+		using ValuePtr = typename ValueType::Ptr;
+		using ConstValuePtr = typename ValueType::ConstPtr;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( TypedObjectPlug<T>, ValuePlug );
 
@@ -140,21 +140,21 @@ extern template class TypedObjectPlug<IECore::PathMatcherData>;
 
 #endif
 
-typedef TypedObjectPlug<IECore::Object> ObjectPlug;
-typedef TypedObjectPlug<IECore::BoolVectorData> BoolVectorDataPlug;
-typedef TypedObjectPlug<IECore::IntVectorData> IntVectorDataPlug;
-typedef TypedObjectPlug<IECore::FloatVectorData> FloatVectorDataPlug;
-typedef TypedObjectPlug<IECore::StringVectorData> StringVectorDataPlug;
-typedef TypedObjectPlug<IECore::InternedStringVectorData> InternedStringVectorDataPlug;
-typedef TypedObjectPlug<IECore::V2iVectorData> V2iVectorDataPlug;
-typedef TypedObjectPlug<IECore::V3fVectorData> V3fVectorDataPlug;
-typedef TypedObjectPlug<IECore::Color3fVectorData> Color3fVectorDataPlug;
-typedef TypedObjectPlug<IECore::M44fVectorData> M44fVectorDataPlug;
-typedef TypedObjectPlug<IECore::M33fVectorData> M33fVectorDataPlug;
-typedef TypedObjectPlug<IECore::ObjectVector> ObjectVectorPlug;
-typedef TypedObjectPlug<IECore::CompoundObject> CompoundObjectPlug;
-typedef TypedObjectPlug<IECore::CompoundData> AtomicCompoundDataPlug;
-typedef TypedObjectPlug<IECore::PathMatcherData> PathMatcherDataPlug;
+using ObjectPlug = TypedObjectPlug<IECore::Object>;
+using BoolVectorDataPlug = TypedObjectPlug<IECore::BoolVectorData>;
+using IntVectorDataPlug = TypedObjectPlug<IECore::IntVectorData>;
+using FloatVectorDataPlug = TypedObjectPlug<IECore::FloatVectorData>;
+using StringVectorDataPlug = TypedObjectPlug<IECore::StringVectorData>;
+using InternedStringVectorDataPlug = TypedObjectPlug<IECore::InternedStringVectorData>;
+using V2iVectorDataPlug = TypedObjectPlug<IECore::V2iVectorData>;
+using V3fVectorDataPlug = TypedObjectPlug<IECore::V3fVectorData>;
+using Color3fVectorDataPlug = TypedObjectPlug<IECore::Color3fVectorData>;
+using M44fVectorDataPlug = TypedObjectPlug<IECore::M44fVectorData>;
+using M33fVectorDataPlug = TypedObjectPlug<IECore::M33fVectorData>;
+using ObjectVectorPlug = TypedObjectPlug<IECore::ObjectVector>;
+using CompoundObjectPlug = TypedObjectPlug<IECore::CompoundObject>;
+using AtomicCompoundDataPlug = TypedObjectPlug<IECore::CompoundData>;
+using PathMatcherDataPlug = TypedObjectPlug<IECore::PathMatcherData>;
 
 IE_CORE_DECLAREPTR( ObjectPlug );
 IE_CORE_DECLAREPTR( BoolVectorDataPlug );

--- a/include/Gaffer/TypedPlug.h
+++ b/include/Gaffer/TypedPlug.h
@@ -51,7 +51,7 @@ class IECORE_EXPORT TypedPlug : public ValuePlug
 
 	public :
 
-		typedef T ValueType;
+		using ValueType = T;
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( TypedPlug<T>, ValuePlug );
 
@@ -88,17 +88,17 @@ class IECORE_EXPORT TypedPlug : public ValuePlug
 
 	private :
 
-		typedef IECore::TypedData<T> DataType;
-		typedef typename DataType::Ptr DataTypePtr;
+		using DataType = IECore::TypedData<T>;
+		using DataTypePtr = typename DataType::Ptr;
 
 };
 
-typedef TypedPlug<bool> BoolPlug;
-typedef TypedPlug<Imath::M33f> M33fPlug;
-typedef TypedPlug<Imath::M44f> M44fPlug;
-typedef TypedPlug<Imath::Box2f> AtomicBox2fPlug;
-typedef TypedPlug<Imath::Box3f> AtomicBox3fPlug;
-typedef TypedPlug<Imath::Box2i> AtomicBox2iPlug;
+using BoolPlug = TypedPlug<bool>;
+using M33fPlug = TypedPlug<Imath::M33f>;
+using M44fPlug = TypedPlug<Imath::M44f>;
+using AtomicBox2fPlug = TypedPlug<Imath::Box2f>;
+using AtomicBox3fPlug = TypedPlug<Imath::Box3f>;
+using AtomicBox2iPlug = TypedPlug<Imath::Box2i>;
 
 IE_CORE_DECLAREPTR( BoolPlug );
 IE_CORE_DECLAREPTR( M33fPlug );

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -70,7 +70,7 @@ class NodeWrapper : public GraphComponentWrapper<T>
 {
 	public :
 
-		typedef T WrappedType;
+		using WrappedType = T;
 
 		template<typename... Args>
 		NodeWrapper( PyObject *self, Args&&... args )

--- a/include/GafferBindings/RawConstructor.inl
+++ b/include/GafferBindings/RawConstructor.inl
@@ -49,7 +49,7 @@ template <class F>
 struct RawConstructorDispatcher
 {
 
-	typedef typename boost::binary_traits<F>::result_type ResultType;
+	using ResultType = typename boost::binary_traits<F>::result_type;
 
 	RawConstructorDispatcher( F f )
 		: m_f( f )

--- a/include/GafferBindings/Serialisation.h
+++ b/include/GafferBindings/Serialisation.h
@@ -173,7 +173,7 @@ class GAFFERBINDINGS_API Serialisation : boost::noncopyable
 
 		void walk( const Gaffer::GraphComponent *parent, const std::string &parentIdentifier, const Serialiser *parentSerialiser, const IECore::Canceller *canceller );
 
-		typedef std::map<IECore::TypeId, SerialiserPtr> SerialiserMap;
+		using SerialiserMap = std::map<IECore::TypeId, SerialiserPtr>;
 		static SerialiserMap &serialiserMap();
 
 };

--- a/include/GafferBindings/TypedPlugBinding.inl
+++ b/include/GafferBindings/TypedPlugBinding.inl
@@ -69,7 +69,7 @@ template<typename T, typename TWrapper>
 TypedPlugClass<T, TWrapper>::TypedPlugClass( const char *docString )
 	:	PlugClass<T, TWrapper>( docString )
 {
-	typedef typename T::ValueType V;
+	using V = typename T::ValueType;
 
 	this->def(
 		boost::python::init<const std::string &, Gaffer::Plug::Direction, const V &, unsigned>(

--- a/include/GafferCortex/CompoundParameterHandler.h
+++ b/include/GafferCortex/CompoundParameterHandler.h
@@ -81,7 +81,7 @@ class GAFFERCORTEX_API CompoundParameterHandler : public ParameterHandler
 		Gaffer::PlugPtr m_plug;
 
 		ParameterHandler *handler( IECore::Parameter *child, bool createIfMissing = false );
-		typedef std::map<IECore::ParameterPtr, ParameterHandlerPtr> HandlerMap;
+		using HandlerMap = std::map<IECore::ParameterPtr, ParameterHandlerPtr>;
 		HandlerMap m_handlers;
 
 		static ParameterHandlerDescription<CompoundParameterHandler, IECore::CompoundParameter> g_description;

--- a/include/GafferCortex/NumericParameterHandler.h
+++ b/include/GafferCortex/NumericParameterHandler.h
@@ -55,8 +55,8 @@ class GAFFERCORTEX_API NumericParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( NumericParameterHandler<T> );
 
-		typedef IECore::NumericParameter<T> ParameterType;
-		typedef Gaffer::NumericPlug<T> PlugType;
+		using ParameterType = IECore::NumericParameter<T>;
+		using PlugType = Gaffer::NumericPlug<T>;
 
 		NumericParameterHandler( typename ParameterType::Ptr parameter );
 		~NumericParameterHandler() override;

--- a/include/GafferCortex/ParameterHandler.h
+++ b/include/GafferCortex/ParameterHandler.h
@@ -86,7 +86,7 @@ class GAFFERCORTEX_API ParameterHandler : public IECore::RefCounted
 		static ParameterHandlerPtr create( IECore::ParameterPtr parameter );
 		/// A function for creating ParameterHandlers which will represent a Parameter with a plug on a given
 		/// parent.
-		typedef std::function<ParameterHandlerPtr ( IECore::ParameterPtr )> Creator;
+		using Creator = std::function<ParameterHandlerPtr ( IECore::ParameterPtr )>;
 		/// Registers a function which can return a ParameterHandler for a given Parameter type.
 		static void registerParameterHandler( IECore::TypeId parameterType, Creator creator );
 
@@ -110,7 +110,7 @@ class GAFFERCORTEX_API ParameterHandler : public IECore::RefCounted
 
 	private :
 
-		typedef std::map<IECore::TypeId, Creator> CreatorMap;
+		using CreatorMap = std::map<IECore::TypeId, Creator>;
 		static CreatorMap &creators();
 
 };

--- a/include/GafferCortex/ParameterisedHolder.h
+++ b/include/GafferCortex/ParameterisedHolder.h
@@ -123,10 +123,10 @@ class GAFFERCORTEX_API ParameterisedHolder : public BaseType
 
 };
 
-typedef ParameterisedHolder<Gaffer::Node> ParameterisedHolderNode;
-typedef ParameterisedHolder<Gaffer::DependencyNode> ParameterisedHolderDependencyNode;
-typedef ParameterisedHolder<Gaffer::ComputeNode> ParameterisedHolderComputeNode;
-typedef ParameterisedHolder<GafferDispatch::TaskNode> ParameterisedHolderTaskNode;
+using ParameterisedHolderNode = ParameterisedHolder<Gaffer::Node>;
+using ParameterisedHolderDependencyNode = ParameterisedHolder<Gaffer::DependencyNode>;
+using ParameterisedHolderComputeNode = ParameterisedHolder<Gaffer::ComputeNode>;
+using ParameterisedHolderTaskNode = ParameterisedHolder<GafferDispatch::TaskNode>;
 
 IE_CORE_DECLAREPTR( ParameterisedHolderNode )
 IE_CORE_DECLAREPTR( ParameterisedHolderDependencyNode )

--- a/include/GafferCortex/TypedParameterHandler.h
+++ b/include/GafferCortex/TypedParameterHandler.h
@@ -55,8 +55,8 @@ class GAFFERCORTEX_API TypedParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( TypedParameterHandler<T> );
 
-		typedef IECore::TypedParameter<T> ParameterType;
-		typedef typename Gaffer::PlugType<T>::Type PlugType;
+		using ParameterType = IECore::TypedParameter<T>;
+		using PlugType = typename Gaffer::PlugType<T>::Type;
 
 		TypedParameterHandler( typename ParameterType::Ptr parameter );
 		~TypedParameterHandler() override;

--- a/include/GafferCortex/VectorTypedParameterHandler.h
+++ b/include/GafferCortex/VectorTypedParameterHandler.h
@@ -53,8 +53,8 @@ class GAFFERCORTEX_API VectorTypedParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( VectorTypedParameterHandler<ParameterType> );
 
-		typedef typename ParameterType::ObjectType DataType;
-		typedef Gaffer::TypedObjectPlug<DataType> PlugType;
+		using DataType = typename ParameterType::ObjectType;
+		using PlugType = Gaffer::TypedObjectPlug<DataType>;
 
 		VectorTypedParameterHandler( typename ParameterType::Ptr parameter );
 		~VectorTypedParameterHandler() override;

--- a/include/GafferDelight/IECoreDelightPreview/NodeAlgo.h
+++ b/include/GafferDelight/IECoreDelightPreview/NodeAlgo.h
@@ -62,8 +62,8 @@ bool convert( const std::vector<const IECore::Object *> &samples, const std::vec
 
 /// Signature of a function which can convert an IECore::Object
 /// into an NSI node.
-typedef bool (*Converter)( const IECore::Object *, NSIContext_t, const char * );
-typedef bool (*MotionConverter)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, NSIContext_t context, const char * );
+using Converter = bool (*)( const IECore::Object *, NSIContext_t, const char * );
+using MotionConverter = bool (*)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, NSIContext_t constant, const char * );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -79,8 +79,8 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		typedef bool (*Converter)( const T *, NSIContext_t, const char * );
-		typedef bool (*MotionConverter)( const std::vector<const T *> &, const std::vector<float> &, NSIContext_t, const char * );
+		using Converter = bool (*)( const T *, NSIContext_t, const char * );
+		using MotionConverter = bool (*)( const std::vector<const T *> &, const std::vector<float> &, NSIContext_t, const char * );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -69,7 +69,7 @@ namespace Detail
 
 struct PreDispatchSignalCombiner
 {
-	typedef bool result_type;
+	using result_type = bool;
 
 	template<typename InputIterator>
 	bool operator()( InputIterator first, InputIterator last ) const
@@ -105,9 +105,9 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDispatch::Dispatcher, DispatcherTypeId, Gaffer::Node );
 
-		using PreDispatchSignal = Gaffer::Signals::Signal<bool (const Dispatcher *, const std::vector<TaskNodePtr> &), Detail::PreDispatchSignalCombiner>;
-		using DispatchSignal = Gaffer::Signals::Signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &), Gaffer::Signals::CatchingCombiner<void>>;
-		using PostDispatchSignal = Gaffer::Signals::Signal<void (const Dispatcher *, const std::vector<TaskNodePtr> &, bool), Gaffer::Signals::CatchingCombiner<void>>;
+		using PreDispatchSignal = Gaffer::Signals::Signal<bool ( const Dispatcher *, const std::vector<TaskNodePtr> & ), Detail::PreDispatchSignalCombiner>;
+		using DispatchSignal = Gaffer::Signals::Signal<void ( const Dispatcher *, const std::vector<TaskNodePtr> & ), Gaffer::Signals::CatchingCombiner<void>>;
+		using PostDispatchSignal = Gaffer::Signals::Signal<void ( const Dispatcher *, const std::vector<TaskNodePtr> &, bool ), Gaffer::Signals::CatchingCombiner<void>>;
 		//! @name Dispatch Signals
 		/// These signals are emitted on dispatch events for any registered Dispatcher instance.
 		////////////////////////////////////////////////////////////////////////////////////////
@@ -176,7 +176,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		//@}
 
 		/// A function which creates a Dispatcher.
-		typedef std::function<DispatcherPtr ()> Creator;
+		using Creator = std::function<DispatcherPtr ()>;
 		/// SetupPlugsFn may be registered along with a Dispatcher Creator. It will be called by setupPlugs,
 		/// along with all other registered SetupPlugsFns. It is recommended that each registered dispatcher
 		/// store its plugs contained within a dedicated parent Plug, named according to the registration
@@ -186,7 +186,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		/// the TaskNode constructor, the non-dynamic plugs will always be created according to the current
 		/// definition, and will not be serialized into scripts. The downside of using non-dynamic plugs is that
 		/// loading a script before all Dispatchers have been registered could result in lost settings.
-		typedef std::function<void ( Gaffer::Plug *parentPlug )> SetupPlugsFn;
+		using SetupPlugsFn = std::function<void (Gaffer::Plug *)>;
 
 		//! @name Registration
 		/// Utility functions for registering and retrieving Dispatchers.
@@ -212,7 +212,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 
 		IE_CORE_FORWARDDECLARE( TaskBatch )
 
-		typedef std::vector<TaskBatchPtr> TaskBatches;
+		using TaskBatches = std::vector<TaskBatchPtr>;
 
 		/// A batch of tasks to be executed together, along
 		/// with references to batches of preTasks which must
@@ -281,7 +281,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 
 		void executeAndPruneImmediateBatches( TaskBatch *batch, bool immediate = false ) const;
 
-		typedef std::map<std::string, std::pair<Creator, SetupPlugsFn> > CreatorMap;
+		using CreatorMap = std::map<std::string, std::pair<Creator, SetupPlugsFn>>;
 		static CreatorMap &creators();
 
 		class Batcher;

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -111,7 +111,7 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 
 		};
 
-		typedef std::vector<Task> Tasks;
+		using Tasks = std::vector<Task>;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDispatch::TaskNode, TaskNodeTypeId, Gaffer::DependencyNode );
 

--- a/include/GafferImage/AtomicFormatPlug.h
+++ b/include/GafferImage/AtomicFormatPlug.h
@@ -45,7 +45,7 @@
 namespace GafferImage
 {
 
-typedef Gaffer::TypedPlug<GafferImage::Format> AtomicFormatPlug;
+using AtomicFormatPlug = Gaffer::TypedPlug<GafferImage::Format>;
 
 IE_CORE_DECLAREPTR( AtomicFormatPlug );
 

--- a/include/GafferImage/FormatData.h
+++ b/include/GafferImage/FormatData.h
@@ -50,7 +50,7 @@ namespace IECore
 namespace GafferImage
 {
 
-typedef IECore::FormatData FormatData;
+using FormatData = IECore::FormatData;
 IE_CORE_DECLAREPTR( FormatData );
 
 } // namespace GafferImage

--- a/include/GafferImage/FormatPlug.h
+++ b/include/GafferImage/FormatPlug.h
@@ -61,7 +61,7 @@ class GAFFERIMAGE_API FormatPlug : public Gaffer::ValuePlug
 
 	public :
 
-		typedef Format ValueType;
+		using ValueType = Format;
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferImage::FormatPlug, FormatPlugTypeId, Gaffer::ValuePlug );
 

--- a/include/GafferImage/ImageAlgo.inl
+++ b/include/GafferImage/ImageAlgo.inl
@@ -344,8 +344,8 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 		}
 	}
 
-	typedef typename std::result_of<TileFunctor( const ImagePlug *, const Imath::V2i & )>::type TileFunctorResult;
-	typedef std::pair<Imath::V2i, TileFunctorResult> TileFilterResult;
+	using TileFunctorResult = typename std::result_of<TileFunctor( const ImagePlug *, const Imath::V2i & )>::type;
+	using TileFilterResult = std::pair<Imath::V2i, TileFunctorResult>;
 
 	Detail::TileInputIterator tileIterator( processWindow, tileOrder );
 	const Gaffer::ThreadState &threadState = Gaffer::ThreadState::current();
@@ -398,8 +398,8 @@ void parallelGatherTiles( const ImagePlug *imagePlug, const TileFunctor &tileFun
 template <class TileFunctor, class GatherFunctor>
 void parallelGatherTiles( const ImagePlug *imagePlug, const std::vector<std::string> &channelNames, const TileFunctor &tileFunctor, GatherFunctor &&gatherFunctor, const Imath::Box2i &window, TileOrder tileOrder )
 {
-	typedef typename std::result_of<TileFunctor( const ImagePlug *, const std::string &, const Imath::V2i & )>::type TileFunctorResult;
-	typedef std::vector< TileFunctorResult > WholeTileResult;
+	using TileFunctorResult = typename std::result_of<TileFunctor( const ImagePlug *, const std::string &, const Imath::V2i & )>::type;
+	using WholeTileResult = std::vector<TileFunctorResult>;
 
 	if( channelNames.size() == 0 )
 	{

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -119,7 +119,7 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 		/// A function which can take information about a file being read, and return the colorspace
 		/// of the data within the file. This is used whenever the colorSpace plug is at its default
 		/// value.
-		typedef std::function<const std::string ( const std::string &fileName, const std::string &fileFormat, const std::string &dataType, const IECore::CompoundData *metadata )> DefaultColorSpaceFunction;
+		using DefaultColorSpaceFunction = std::function<const std::string ( const std::string &fileName, const std::string &fileFormat, const std::string &dataType, const IECore::CompoundData *metadata )>;
 		static void setDefaultColorSpaceFunction( DefaultColorSpaceFunction f );
 		static DefaultColorSpaceFunction getDefaultColorSpaceFunction();
 

--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -100,7 +100,7 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 
 		/// Note that this is intentionally identical to the ImageReader's DefaultColorSpaceFunction
 		/// definition, so that the same function can be used with both nodes.
-		typedef std::function<const std::string ( const std::string &fileName, const std::string &fileFormat, const std::string &dataType, const IECore::CompoundData *metadata )> DefaultColorSpaceFunction;
+		using DefaultColorSpaceFunction = std::function<const std::string ( const std::string &fileName, const std::string &fileFormat, const std::string &dataType, const IECore::CompoundData *metadata )>;
 		static void setDefaultColorSpaceFunction( DefaultColorSpaceFunction f );
 		static DefaultColorSpaceFunction getDefaultColorSpaceFunction();
 

--- a/include/GafferImageTest/ContextSanitiser.h
+++ b/include/GafferImageTest/ContextSanitiser.h
@@ -66,12 +66,12 @@ class GAFFERIMAGETEST_API ContextSanitiser : public Gaffer::Monitor
 
 		/// First is the upstream plug where the problem was detected. Second
 		/// is the plug from the parent process responsible for calling upstream.
-		typedef std::pair<Gaffer::ConstPlugPtr, Gaffer::ConstPlugPtr> PlugPair;
-		typedef std::pair<PlugPair, IECore::InternedString> Warning;
+		using PlugPair = std::pair<Gaffer::ConstPlugPtr, Gaffer::ConstPlugPtr>;
+		using Warning = std::pair<PlugPair, IECore::InternedString>;
 
 		void warn( const Gaffer::Process &process, const IECore::InternedString &contextVariable );
 
-		typedef tbb::concurrent_unordered_set<Warning> WarningSet;
+		using WarningSet = tbb::concurrent_unordered_set<Warning>;
 		WarningSet m_warningsEmitted;
 
 };

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -111,7 +111,7 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		Gaffer::Context *getContext();
 		const Gaffer::Context *getContext() const;
 
-		typedef std::array<IECore::InternedString, 4> Channels;
+		using Channels = std::array<IECore::InternedString, 4>;
 		/// Chooses which 4 channels to display as RGBA.
 		/// For instance, to display Z as a greyscale image
 		/// with black alpha you would pass { "Z", "Z", "Z", "" }.
@@ -307,12 +307,12 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 				IECoreGL::TexturePtr m_texture;
 				bool m_active;
 				std::chrono::steady_clock::time_point m_activeStartTime;
-				typedef tbb::spin_mutex Mutex;
+				using Mutex = tbb::spin_mutex;
 				Mutex m_mutex;
 
 		};
 
-		typedef tbb::concurrent_unordered_map<TileIndex, Tile, TileIndex::Hash> Tiles;
+		using Tiles = tbb::concurrent_unordered_map<TileIndex, Tile, TileIndex::Hash>;
 		mutable Tiles m_tiles;
 
 		// Tile update. We update tiles asynchronously from background

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -111,7 +111,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 		void setContext( Gaffer::ContextPtr context ) override;
 
-		typedef std::function<GafferImage::ImageProcessorPtr ()> DisplayTransformCreator;
+		using DisplayTransformCreator = std::function<GafferImage::ImageProcessorPtr ()>;
 
 		static void registerDisplayTransform( const std::string &name, DisplayTransformCreator creator );
 		static void registeredDisplayTransforms( std::vector<std::string> &names );
@@ -164,7 +164,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 		void insertDisplayTransform();
 
-		typedef std::map<std::string, GafferImage::ImageProcessorPtr> DisplayTransformMap;
+		using DisplayTransformMap = std::map<std::string, GafferImage::ImageProcessorPtr>;
 		DisplayTransformMap m_displayTransforms;
 
 		ImageGadgetPtr m_imageGadget;
@@ -175,7 +175,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		class ColorInspector;
 		std::unique_ptr<ColorInspector> m_colorInspector;
 
-		typedef std::map<std::string, DisplayTransformCreator> DisplayTransformCreatorMap;
+		using DisplayTransformCreatorMap = std::map<std::string, DisplayTransformCreator>;
 		static DisplayTransformCreatorMap &displayTransformCreators();
 
 		static ViewDescription<ImageView> g_viewDescription;

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -79,7 +79,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 
 		};
 
-		typedef std::map<IECore::InternedString, Transform> Transforms;
+		using Transforms = std::map<IECore::InternedString, Transform>;
 
 		/// Append a unique hash representing this shading engine to `h`.
 		void hash( IECore::MurmurHash &h ) const;
@@ -97,7 +97,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 		bool m_timeNeeded;
 		std::vector<IECore::InternedString> m_contextVariablesNeeded;
 
-		typedef boost::container::flat_set<std::string> AttributesNeededContainer;
+		using AttributesNeededContainer = boost::container::flat_set<std::string>;
 		AttributesNeededContainer m_attributesNeeded;
 
 		// Set to true if the shader reads attributes who's name is not know at compile time

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -130,7 +130,7 @@ class GAFFERSCENE_API RenderSets : boost::noncopyable
 			IECore::PathMatcher set;
 		};
 
-		typedef boost::container::flat_map<IECore::InternedString, Set> Sets;
+		using Sets = boost::container::flat_map<IECore::InternedString, Set>;
 
 		struct Updater;
 

--- a/include/GafferScene/RenderController.h
+++ b/include/GafferScene/RenderController.h
@@ -77,12 +77,12 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		void setMinimumExpansionDepth( size_t depth );
 		size_t getMinimumExpansionDepth() const;
 
-		using UpdateRequiredSignal = Gaffer::Signals::Signal<void (RenderController &)>;
+		using UpdateRequiredSignal = Gaffer::Signals::Signal<void ( RenderController & )>;
 		UpdateRequiredSignal &updateRequiredSignal();
 
 		bool updateRequired() const;
 
-		typedef std::function<void ( Gaffer::BackgroundTask::Status progress )> ProgressCallback;
+		using ProgressCallback = std::function<void (Gaffer::BackgroundTask::Status)>;
 
 		void update( const ProgressCallback &callback = ProgressCallback() );
 		std::shared_ptr<Gaffer::BackgroundTask> updateInBackground( const ProgressCallback &callback = ProgressCallback(), const IECore::PathMatcher &priorityPaths = IECore::PathMatcher()  );

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -171,7 +171,7 @@ GAFFERSCENE_API IECore::ConstCompoundDataPtr sets( const ScenePlug *scene, const
 struct History : public IECore::RefCounted
 {
 	IE_CORE_DECLAREMEMBERPTR( History )
-	typedef std::vector<Ptr> Predecessors;
+	using Predecessors = std::vector<Ptr>;
 
 	History() = default;
 	History( const ScenePlugPtr &scene, const Gaffer::ContextPtr &context ) : scene( scene ), context( context ) {}
@@ -276,7 +276,7 @@ GAFFERSCENE_API Imath::Box3f bound( const IECore::Object *object );
 
 /// Function to return a SceneProcessor used to adapt the
 /// scene for rendering.
-typedef std::function<SceneProcessorPtr ()> RenderAdaptor;
+using RenderAdaptor = std::function<SceneProcessorPtr ()>;
 /// Registers an adaptor.
 GAFFERSCENE_API void registerRenderAdaptor( const std::string &name, RenderAdaptor adaptor );
 /// Removes a previously registered adaptor.

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -72,7 +72,7 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 
 	protected :
 
-		typedef ScenePlug::ScenePath ScenePath;
+		using ScenePath = ScenePlug::ScenePath;
 
 		/// Implemented to call the hash*() methods below whenever output is part of a ScenePlug and the node is enabled.
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -140,7 +140,7 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 
 		/// The type used to specify the current scene path in
 		/// a Context object.
-		typedef std::vector<IECore::InternedString> ScenePath;
+		using ScenePath = std::vector<IECore::InternedString>;
 		/// The name used to specify the current scene path in a
 		/// Context object. You should use this variable instead
 		/// of hardcoding strings - it is both less error prone

--- a/include/GafferSceneTest/ContextSanitiser.h
+++ b/include/GafferSceneTest/ContextSanitiser.h
@@ -66,12 +66,12 @@ class GAFFERSCENETEST_API ContextSanitiser : public Gaffer::Monitor
 
 		/// First is the upstream plug where the problem was detected. Second
 		/// is the plug from the parent process responsible for calling upstream.
-		typedef std::pair<Gaffer::ConstPlugPtr, Gaffer::ConstPlugPtr> PlugPair;
-		typedef std::pair<PlugPair, IECore::InternedString> Warning;
+		using PlugPair = std::pair<Gaffer::ConstPlugPtr, Gaffer::ConstPlugPtr>;
+		using Warning = std::pair<PlugPair, IECore::InternedString>;
 
 		void warn( const Gaffer::Process &process, const IECore::InternedString &contextVariable );
 
-		typedef tbb::concurrent_unordered_set<Warning> WarningSet;
+		using WarningSet = tbb::concurrent_unordered_set<Warning>;
 		WarningSet m_warningsEmitted;
 
 };

--- a/include/GafferSceneUI/CameraTool.h
+++ b/include/GafferSceneUI/CameraTool.h
@@ -96,7 +96,7 @@ class GAFFERSCENEUI_API CameraTool : public GafferSceneUI::SelectionTool
 		void setCameraCenterOfInterest( const GafferScene::ScenePlug::ScenePath &camera, float centerOfInterest );
 		float getCameraCenterOfInterest( const GafferScene::ScenePlug::ScenePath &camera ) const;
 
-		typedef std::unordered_map<std::string, float> CameraCentersOfInterest;
+		using CameraCentersOfInterest = std::unordered_map<std::string, float>;
 		CameraCentersOfInterest m_cameraCentersOfInterest;
 
 		static ToolDescription<CameraTool, SceneView> g_toolDescription;

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -102,7 +102,7 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 		/// empty bound.
 		const Imath::Box2f &resolutionGate() const;
 
-		typedef std::function<GafferScene::SceneProcessorPtr ()> ShadingModeCreator;
+		using ShadingModeCreator = std::function<GafferScene::SceneProcessorPtr ()>;
 
 		static void registerShadingMode( const std::string &name, ShadingModeCreator );
 		static void registeredShadingModes( std::vector<std::string> &names );

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -76,19 +76,19 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 		void setContext( Gaffer::ContextPtr context ) override;
 
-		typedef std::function<GafferScene::InteractiveRenderPtr ()> RendererCreator;
+		using RendererCreator = std::function<GafferScene::InteractiveRenderPtr ()>;
 		static void registerRenderer( const std::string &shaderPrefix, RendererCreator rendererCreator );
 		static void deregisterRenderer( const std::string &shaderPrefix );
 
-		typedef std::function<Gaffer::NodePtr ()> SceneCreator;
+		using SceneCreator = std::function<Gaffer::NodePtr ()>;
 		static void registerScene( const std::string &shaderPrefix, const std::string &name, SceneCreator sceneCreator );
 		static void registerScene( const std::string &shaderPrefix, const std::string &name, const std::string &referenceFileName );
 		static void registeredScenes( const std::string &shaderPrefix, std::vector<std::string> &names );
 
 	private :
 
-		typedef std::pair<std::string, std::string> PrefixAndName;
-		typedef std::map<PrefixAndName, Gaffer::NodePtr> Scenes;
+		using PrefixAndName = std::pair<std::string, std::string>;
+		using Scenes = std::map<PrefixAndName, Gaffer::NodePtr>;
 
 		GafferImage::Display *display();
 		const GafferImage::Display *display() const;

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -132,7 +132,7 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 
 		// Key is the NodeGadget at the destination end of the connections
 		// tracked by `Connections.dirty`.
-		typedef std::unordered_map<const NodeGadget *, Connections> NodeGadgetConnections;
+		using NodeGadgetConnections = std::unordered_map<const NodeGadget *, Connections>;
 		mutable NodeGadgetConnections m_nodeGadgetConnections;
 
 		// An auxiliary connection that we will draw.

--- a/include/GafferUI/ConnectionGadget.h
+++ b/include/GafferUI/ConnectionGadget.h
@@ -100,7 +100,7 @@ class GAFFERUI_API ConnectionGadget : public ConnectionCreator
 		/// specified Nodules.
 		static ConnectionGadgetPtr create( NodulePtr srcNodule, NodulePtr dstNodule );
 
-		typedef std::function<ConnectionGadgetPtr ( NodulePtr, NodulePtr )> ConnectionGadgetCreator;
+		using ConnectionGadgetCreator = std::function<ConnectionGadgetPtr ( NodulePtr, NodulePtr )>;
 		/// Registers a function which will return a ConnectionGadget instance for a
 		/// destination plug of a specific type.
 		static void registerConnectionGadget( IECore::TypeId dstPlugType, ConnectionGadgetCreator creator );
@@ -134,12 +134,12 @@ class GAFFERUI_API ConnectionGadget : public ConnectionCreator
 
 		bool m_minimised;
 
-		typedef std::map<IECore::TypeId, ConnectionGadgetCreator> CreatorMap;
+		using CreatorMap = std::map<IECore::TypeId, ConnectionGadgetCreator>;
 		static CreatorMap &creators();
 
-		typedef std::pair<boost::regex, ConnectionGadgetCreator> RegexAndCreator;
-		typedef std::vector<RegexAndCreator> RegexAndCreatorVector;
-		typedef std::map<IECore::TypeId, RegexAndCreatorVector> NamedCreatorMap;
+		using RegexAndCreator = std::pair<boost::regex, ConnectionGadgetCreator>;
+		using RegexAndCreatorVector = std::vector<RegexAndCreator>;
+		using NamedCreatorMap = std::map<IECore::TypeId, RegexAndCreatorVector>;
 		static NamedCreatorMap &namedCreators();
 
 

--- a/include/GafferUI/EventSignalCombiner.h
+++ b/include/GafferUI/EventSignalCombiner.h
@@ -50,7 +50,7 @@ template<typename T>
 struct EventSignalCombiner
 {
 
-	typedef T result_type;
+	using result_type = T;
 
 	template<typename InputIterator>
 	result_type operator()( InputIterator first, InputIterator last ) const;

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -289,10 +289,10 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 			Gaffer::Signals::ScopedConnection noduleAddedConnection;
 			Gaffer::Signals::ScopedConnection noduleRemovedConnection;
 		};
-		typedef std::map<const Gaffer::Node *, NodeGadgetEntry> NodeGadgetMap;
+		using NodeGadgetMap = std::map<const Gaffer::Node *, NodeGadgetEntry>;
 		NodeGadgetMap m_nodeGadgets;
 
-		typedef std::map<const Nodule *, ConnectionGadget *> ConnectionGadgetMap;
+		using ConnectionGadgetMap = std::map<const Nodule *, ConnectionGadget *>;
 		ConnectionGadgetMap m_connectionGadgets;
 
 		enum DragMode

--- a/include/GafferUI/NodeGadget.h
+++ b/include/GafferUI/NodeGadget.h
@@ -90,7 +90,7 @@ class GAFFERUI_API NodeGadget : public Gadget
 		/// nullptr will be returned.
 		static NodeGadgetPtr create( Gaffer::NodePtr node );
 
-		typedef std::function<NodeGadgetPtr ( Gaffer::NodePtr )> NodeGadgetCreator;
+		using NodeGadgetCreator = std::function<NodeGadgetPtr ( Gaffer::NodePtr )>;
 		/// Registers a named NodeGadget creator, optionally registering it as the default
 		/// creator for a particular type of node. The nodeGadgetType may subsequently be
 		/// used in a "nodeGadget:type" metadata registration to register the creator with

--- a/include/GafferUI/Nodule.h
+++ b/include/GafferUI/Nodule.h
@@ -79,7 +79,7 @@ class GAFFERUI_API Nodule : public ConnectionCreator
 		/// this case nullptr will be returned.
 		static NodulePtr create( Gaffer::PlugPtr plug );
 
-		typedef std::function<NodulePtr ( Gaffer::PlugPtr )> NoduleCreator;
+		using NoduleCreator = std::function<NodulePtr ( Gaffer::PlugPtr )>;
 		/// Registers a Nodule subclass, optionally registering it as the default
 		/// nodule type for a particular type of plug.
 		static void registerNodule( const std::string &noduleTypeName, NoduleCreator creator, IECore::TypeId plugType = IECore::InvalidTypeId );
@@ -102,10 +102,10 @@ class GAFFERUI_API Nodule : public ConnectionCreator
 
 		Gaffer::PlugPtr m_plug;
 
-		typedef std::map<std::string, NoduleCreator> TypeNameCreatorMap;
+		using TypeNameCreatorMap = std::map<std::string, NoduleCreator>;
 		static TypeNameCreatorMap &typeNameCreators();
 
-		typedef std::map<IECore::TypeId, NoduleCreator> PlugCreatorMap;
+		using PlugCreatorMap = std::map<IECore::TypeId, NoduleCreator>;
 		static PlugCreatorMap &plugCreators();
 
 };

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -93,7 +93,7 @@ class GAFFERUI_API NoduleLayout : public Gadget
 		Gadget *customGadget( const std::string &name );
 		const Gadget *customGadget( const std::string &name ) const;
 
-		typedef std::function<GadgetPtr ( Gaffer::GraphComponentPtr )> CustomGadgetCreator;
+		using CustomGadgetCreator = std::function<GadgetPtr ( Gaffer::GraphComponentPtr )>;
 		/// Registers a custom gadget type that can be added to the layout using
 		/// "noduleLayout:customGadget:*"" metadata entries.
 		static void registerCustomGadget( const std::string &gadgetType, CustomGadgetCreator creator );
@@ -113,10 +113,10 @@ class GAFFERUI_API NoduleLayout : public Gadget
 			GadgetPtr gadget;
 		};
 		// Either a plug or the name of a custom widget
-		typedef boost::variant<const Gaffer::Plug *, IECore::InternedString> GadgetKey;
+		using GadgetKey = boost::variant<const Gaffer::Plug *, IECore::InternedString>;
 		// Map from plugs and custom gadget names to the gadgets
 		// that represent them.
-		typedef std::map<GadgetKey, TypeAndGadget> GadgetMap;
+		using GadgetMap = std::map<GadgetKey, TypeAndGadget>;
 		GadgetMap m_gadgets;
 
 		void childAdded( Gaffer::GraphComponent *child );

--- a/include/GafferUI/Tool.h
+++ b/include/GafferUI/Tool.h
@@ -93,7 +93,7 @@ class GAFFERUI_API Tool : public Gaffer::Node
 		//@{
 		/// Creates a Tool for the specified View.
 		static ToolPtr create( const std::string &toolName, View *view );
-		typedef std::function<ToolPtr ( View * )> ToolCreator;
+		using ToolCreator = std::function<ToolPtr ( View * )>;
 		/// Registers a function which will return a Tool instance for a
 		/// view of a specific type.
 		static void registerTool( const std::string &toolName, IECore::TypeId viewType, ToolCreator creator );

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -121,7 +121,7 @@ class GAFFERUI_API View : public Gaffer::Node
 		//@{
 		/// Creates a View for the specified plug.
 		static ViewPtr create( Gaffer::PlugPtr input );
-		typedef std::function<ViewPtr ( Gaffer::PlugPtr )> ViewCreator;
+		using ViewCreator = std::function<ViewPtr ( Gaffer::PlugPtr )>;
 		/// Registers a function which will return a View instance for a
 		/// plug of a specific type.
 		static void registerView( IECore::TypeId plugType, ViewCreator creator );
@@ -185,12 +185,12 @@ class GAFFERUI_API View : public Gaffer::Node
 		UnarySignal m_contextChangedSignal;
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 
-		typedef std::map<IECore::TypeId, ViewCreator> CreatorMap;
+		using CreatorMap = std::map<IECore::TypeId, ViewCreator>;
 		static CreatorMap &creators();
 
-		typedef std::pair<boost::regex, ViewCreator> RegexAndCreator;
-		typedef std::vector<RegexAndCreator> RegexAndCreatorVector;
-		typedef std::map<IECore::TypeId, RegexAndCreatorVector> NamedCreatorMap;
+		using RegexAndCreator = std::pair<boost::regex, ViewCreator>;
+		using RegexAndCreatorVector = std::vector<RegexAndCreator>;
+		using NamedCreatorMap = std::map<IECore::TypeId, RegexAndCreatorVector>;
 		static NamedCreatorMap &namedCreators();
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -218,7 +218,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 				void end();
 
 				bool m_depthSort;
-				typedef std::unique_ptr<IECoreGL::Selector> SelectorPtr;
+				using SelectorPtr = std::unique_ptr<IECoreGL::Selector>;
 				SelectorPtr m_selector;
 				std::vector<IECoreGL::HitRecord> &m_selection;
 

--- a/include/IECoreArnold/NodeAlgo.h
+++ b/include/IECoreArnold/NodeAlgo.h
@@ -59,10 +59,10 @@ IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &sam
 
 /// Signature of a function which can convert an IECore::Object
 /// into an Arnold object.
-typedef AtNode * (*Converter)( const IECore::Object *, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode );
+using Converter = AtNode *(*)( const IECore::Object *, AtUniverse *, const std::string &, const AtNode * );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Arnold object.
-typedef AtNode * (*MotionConverter)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode );
+using MotionConverter = AtNode *(*)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -78,8 +78,8 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		typedef AtNode *(*Converter)( const T *, AtUniverse *, const std::string&, const AtNode* );
-		typedef AtNode *(*MotionConverter)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string&, const AtNode* );
+		using Converter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode * );
+		using MotionConverter = AtNode *(*)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string &, const AtNode * );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -90,7 +90,7 @@ private:
 	/// Implement to compute the effective scale of the specified tangent
 	virtual double effectiveScale( const Tangent& tangent, double dt, double dv ) const;
 
-	typedef std::vector< ConstInterpolatorPtr > Container;
+	using Container = std::vector<ConstInterpolatorPtr>;
 	static const Container& get();
 
 	Animation::Interpolation m_interpolation;

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -98,7 +98,7 @@ struct ActiveTask
 	ConstScriptNodePtr subject;
 };
 
-typedef boost::multi_index::multi_index_container<
+using ActiveTasks = boost::multi_index::multi_index_container<
 	ActiveTask,
 	boost::multi_index::indexed_by<
 		boost::multi_index::hashed_unique<
@@ -108,7 +108,7 @@ typedef boost::multi_index::multi_index_container<
 			boost::multi_index::member<ActiveTask, ConstScriptNodePtr, &ActiveTask::subject>
 		>
 	>
-> ActiveTasks;
+>;
 
 ActiveTasks &activeTasks()
 {

--- a/src/Gaffer/Box.cpp
+++ b/src/Gaffer/Box.cpp
@@ -209,8 +209,8 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 	// a node remaining outside, we need to reroute the connection
 	// via a promoted plug. This mapping maps source plugs (be they
 	// internal or external) to promoted plugs.
-	typedef std::pair<const Plug *, Plug *> PlugPair;
-	typedef std::map<const Plug *, Plug *> PlugMap;
+	using PlugPair = std::pair<const Plug *, Plug *>;
+	using PlugMap = std::map<const Plug *, Plug *>;
 	PlugMap plugMap;
 
 	for( size_t i = 0, e = verifiedChildNodes->size(); i < e; i++ )
@@ -249,7 +249,7 @@ BoxPtr Box::create( Node *parent, const Set *childNodes )
 				Plug::OutputContainer outputs = plug->outputs();
 				if( !outputs.empty() )
 				{
-					typedef Plug::OutputContainer::const_iterator OutputIterator;
+					using OutputIterator = Plug::OutputContainer::const_iterator;
 					for( OutputIterator oIt = outputs.begin(), eIt = outputs.end(); oIt != eIt; oIt++ )
 					{
 						Plug *output = *oIt;

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -100,7 +100,7 @@ class Environment
 
 	private :
 
-		typedef boost::container::flat_map<IECore::InternedString, IECore::InternedString> Map;
+		using Map = boost::container::flat_map<IECore::InternedString, IECore::InternedString>;
 		Map m_map;
 
 };

--- a/src/Gaffer/ContextAlgo.cpp
+++ b/src/Gaffer/ContextAlgo.cpp
@@ -48,7 +48,7 @@ using namespace Gaffer::ContextAlgo;
 namespace
 {
 
-typedef boost::container::flat_map<IECore::TypeId, vector<InternedString>> GlobalScopeMap;
+using GlobalScopeMap = boost::container::flat_map<IECore::TypeId, vector<InternedString>>;
 GlobalScopeMap &globalScopeMap()
 {
 	static GlobalScopeMap g_m;

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -205,9 +205,9 @@ void emitPlugValueChangedSignals( IECore::TypeId ancestorTypeId, const StringAlg
 // Value storage for string targets
 // ================================
 
-typedef std::pair<InternedString, Metadata::ValueFunction> NamedValue;
+using NamedValue = std::pair<InternedString, Metadata::ValueFunction>;
 
-typedef multi_index::multi_index_container<
+using Values = multi_index::multi_index_container<
 	NamedValue,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
@@ -215,9 +215,9 @@ typedef multi_index::multi_index_container<
 		>,
 		multi_index::sequenced<>
 	>
-> Values;
+>;
 
-typedef std::map<IECore::InternedString, Values> MetadataMap;
+using MetadataMap = std::map<IECore::InternedString, Values>;
 
 MetadataMap &metadataMap()
 {
@@ -231,10 +231,10 @@ MetadataMap &metadataMap()
 struct GraphComponentMetadata
 {
 
-	typedef std::pair<InternedString, Metadata::GraphComponentValueFunction> NamedValue;
-	typedef std::pair<InternedString, Metadata::PlugValueFunction> NamedPlugValue;
+	using NamedValue = std::pair<InternedString, Metadata::GraphComponentValueFunction>;
+	using NamedPlugValue = std::pair<InternedString, Metadata::PlugValueFunction>;
 
-	typedef multi_index::multi_index_container<
+	using Values = multi_index::multi_index_container<
 		NamedValue,
 		multi_index::indexed_by<
 			multi_index::ordered_unique<
@@ -242,9 +242,9 @@ struct GraphComponentMetadata
 			>,
 			multi_index::sequenced<>
 		>
-	> Values;
+	>;
 
-	typedef multi_index::multi_index_container<
+	using PlugValues = multi_index::multi_index_container<
 		NamedPlugValue,
 		multi_index::indexed_by<
 			multi_index::ordered_unique<
@@ -252,16 +252,16 @@ struct GraphComponentMetadata
 			>,
 			multi_index::sequenced<>
 		>
-	> PlugValues;
+	>;
 
-	typedef map<StringAlgo::MatchPatternPath, PlugValues> PlugPathsToValues;
+	using PlugPathsToValues = map<StringAlgo::MatchPatternPath, PlugValues>;
 
 	Values values;
 	PlugPathsToValues plugPathsToValues;
 
 };
 
-typedef std::map<IECore::TypeId, GraphComponentMetadata> GraphComponentMetadataMap;
+using GraphComponentMetadataMap = std::map<IECore::TypeId, GraphComponentMetadata>;
 
 GraphComponentMetadataMap &graphComponentMetadataMap()
 {
@@ -284,7 +284,7 @@ struct NamedInstanceValue
 	bool persistent;
 };
 
-typedef multi_index::multi_index_container<
+using InstanceValues = multi_index::multi_index_container<
 	NamedInstanceValue,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
@@ -292,9 +292,9 @@ typedef multi_index::multi_index_container<
 		>,
 		multi_index::sequenced<>
 	>
-> InstanceValues;
+>;
 
-typedef concurrent_hash_map<const GraphComponent *, InstanceValues *> InstanceMetadataMap;
+using InstanceMetadataMap = concurrent_hash_map<const GraphComponent *, InstanceValues *>;
 
 InstanceMetadataMap &instanceMetadataMap()
 {
@@ -327,7 +327,7 @@ InstanceValues *instanceMetadata( const GraphComponent *instance, bool createIfM
 // It's valid to register null as an instance value and expect it to override
 // any non-null registration. We use OptionalData as a way of distinguishing
 // between an explicit registration of null and no registration at all.
-typedef std::optional<ConstDataPtr> OptionalData;
+using OptionalData = std::optional<ConstDataPtr>;
 
 OptionalData instanceValue( const GraphComponent *instance, InternedString key, bool *persistent = nullptr )
 {

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -63,7 +63,7 @@ namespace
 struct InvalidMetric
 {
 
-	typedef size_t ResultType;
+	using ResultType = size_t;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -79,7 +79,7 @@ struct InvalidMetric
 struct HashCountMetric
 {
 
-	typedef size_t ResultType;
+	using ResultType = size_t;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -95,7 +95,7 @@ struct HashCountMetric
 struct ComputeCountMetric
 {
 
-	typedef size_t ResultType;
+	using ResultType = size_t;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -111,7 +111,7 @@ struct ComputeCountMetric
 struct HashDurationMetric
 {
 
-	typedef boost::chrono::duration<double> ResultType;
+	using ResultType = boost::chrono::duration<double>;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -127,7 +127,7 @@ struct HashDurationMetric
 struct ComputeDurationMetric
 {
 
-	typedef boost::chrono::duration<double> ResultType;
+	using ResultType = boost::chrono::duration<double>;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -143,7 +143,7 @@ struct ComputeDurationMetric
 struct TotalDurationMetric
 {
 
-	typedef boost::chrono::duration<double> ResultType;
+	using ResultType = boost::chrono::duration<double>;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -159,7 +159,7 @@ struct TotalDurationMetric
 struct PerHashDurationMetric
 {
 
-	typedef boost::chrono::duration<double> ResultType;
+	using ResultType = boost::chrono::duration<double>;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -175,7 +175,7 @@ struct PerHashDurationMetric
 struct PerComputeDurationMetric
 {
 
-	typedef boost::chrono::duration<double> ResultType;
+	using ResultType = boost::chrono::duration<double>;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -191,7 +191,7 @@ struct PerComputeDurationMetric
 struct HashesPerComputeMetric
 {
 
-	typedef double ResultType;
+	using ResultType = double;
 
 	ResultType operator() ( const PerformanceMonitor::Statistics &s ) const
 	{
@@ -323,7 +323,7 @@ struct FormatStatistics
 	{
 	}
 
-	typedef std::string ResultType;
+	using ResultType = std::string;
 
 	template<typename Metric>
 	std::string operator() ( const Metric &metric ) const
@@ -372,7 +372,7 @@ struct FormatTotalStatistics
 	{
 	}
 
-	typedef std::pair< std::string, std::string > ResultType;
+	using ResultType = std::pair<std::string, std::string>;
 
 	template<typename Metric>
 	ResultType operator() ( const Metric &metric ) const
@@ -423,7 +423,7 @@ struct Annotate
 	{
 	}
 
-	typedef void ResultType;
+	using ResultType = void;
 
 	template<typename Metric>
 	ResultType operator() ( const Metric &metric ) const

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -217,8 +217,8 @@ class Plug::AcceptsInputCache
 	private :
 
 		struct ThreadData;
-		typedef std::pair<const Plug *, const Plug *> PlugPair;
-		typedef boost::unordered_map<PlugPair, bool> ResultMap;
+		using PlugPair = std::pair<const Plug *, const Plug *>;
+		using ResultMap = boost::unordered_map<PlugPair, bool>;
 
 	public :
 
@@ -818,17 +818,17 @@ class Plug::DirtyPlugs
 		// on the graph to give us an appropriate order to emit the dirty
 		// signals in, so that dirtiness is only signalled for an affected plug
 		// after it has been signalled for all upstream dirty plugs.
-		typedef boost::adjacency_list<vecS, vecS, directedS, PlugPtr> Graph;
-		typedef Graph::vertex_descriptor VertexDescriptor;
-		typedef Graph::edge_descriptor EdgeDescriptor;
+		using Graph = boost::adjacency_list<vecS, vecS, directedS, PlugPtr>;
+		using VertexDescriptor = Graph::vertex_descriptor;
+		using EdgeDescriptor = Graph::edge_descriptor;
 
-		typedef std::unordered_map<const Plug *, VertexDescriptor> PlugMap;
+		using PlugMap = std::unordered_map<const Plug *, VertexDescriptor>;
 
 		// Equivalent to the return type for map::insert - the first
 		// field is the vertex descriptor, and the second field is
 		// false if the vertex was already there, true if it was
 		// inserted.
-		typedef std::pair<VertexDescriptor, bool> InsertedVertex;
+		using InsertedVertex = std::pair<VertexDescriptor, bool>;
 
 		InsertedVertex insertVertex( Plug *plug )
 		{

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -72,7 +72,7 @@ struct Connections
 	vector<PlugPtr> outputs;
 };
 
-typedef vector<Connections> ConnectionsVector;
+using ConnectionsVector = vector<Connections>;
 
 void replacePlugWalk( Plug *existingPlug, Plug *plug, ConnectionsVector &connections )
 {
@@ -183,9 +183,9 @@ ValuePlugPtr boxValuePlug( const std::string &name, Plug::Direction direction, u
 template<typename T>
 ValuePlugPtr compoundNumericValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value )
 {
-	typedef typename T::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
-	typedef CompoundNumericPlug<ValueType> PlugType;
+	using ValueType = typename T::ValueType;
+	using BaseType = typename ValueType::BaseType;
+	using PlugType = CompoundNumericPlug<ValueType>;
 
 	typename PlugType::Ptr result = new PlugType(
 		name,
@@ -202,9 +202,9 @@ ValuePlugPtr compoundNumericValuePlug( const std::string &name, Plug::Direction 
 template<typename T>
 ValuePlugPtr geometricCompoundNumericValuePlug( const std::string &name, Plug::Direction direction, unsigned flags, const T *value )
 {
-	typedef typename T::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
-	typedef CompoundNumericPlug<ValueType> PlugType;
+	using ValueType = typename T::ValueType;
+	using BaseType = typename ValueType::BaseType;
+	using PlugType = CompoundNumericPlug<ValueType>;
 
 	typename PlugType::Ptr result = new PlugType(
 		name,

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -445,7 +445,7 @@ class ValuePlug::HashProcess : public Process
 
 		// Global cache. We use this for heavy hash computations that will spawn subtasks,
 		// so that the work and the result is shared among all threads.
-		typedef IECorePreview::LRUCache<HashCacheKey, IECore::MurmurHash, IECorePreview::LRUCachePolicy::TaskParallel, HashProcessKey> GlobalCache;
+		using GlobalCache = IECorePreview::LRUCache<HashCacheKey, IECore::MurmurHash, IECorePreview::LRUCachePolicy::TaskParallel, HashProcessKey>;
 		static GlobalCache g_globalCache;
 		static std::atomic<uint64_t> g_legacyGlobalDirtyCount;
 
@@ -455,7 +455,7 @@ class ValuePlug::HashProcess : public Process
 		// Per-thread cache. This is our default cache, used for hash computations that are
 		// presumed to be lightweight. Using a per-thread cache limits the contention among
 		// threads.
-		typedef IECorePreview::LRUCache<HashCacheKey, IECore::MurmurHash, IECorePreview::LRUCachePolicy::Serial, HashProcessKey> Cache;
+		using Cache = IECorePreview::LRUCache<HashCacheKey, IECore::MurmurHash, IECorePreview::LRUCachePolicy::Serial, HashProcessKey>;
 
 		struct ThreadData
 		{
@@ -719,7 +719,7 @@ class ValuePlug::ComputeProcess : public Process
 
 		// A cache mapping from ValuePlug::hash() to the result of the previous computation
 		// for that hash. This allows us to cache results for faster repeat evaluation
-		typedef IECorePreview::LRUCache<IECore::MurmurHash, IECore::ConstObjectPtr, IECorePreview::LRUCachePolicy::TaskParallel, ComputeProcessKey> Cache;
+		using Cache = IECorePreview::LRUCache<IECore::MurmurHash, IECore::ConstObjectPtr, IECorePreview::LRUCachePolicy::TaskParallel, ComputeProcessKey>;
 		static Cache g_cache;
 
 		IECore::ConstObjectPtr m_result;

--- a/src/GafferAppleseed/AppleseedShaderAdaptor.cpp
+++ b/src/GafferAppleseed/AppleseedShaderAdaptor.cpp
@@ -67,7 +67,7 @@ IECore::InternedString g_closureParameterName( "in_input" );
 IECore::InternedString g_colorParameterName( "in_color" );
 IECore::InternedString g_scalarParameterName( "in_scalar" );
 
-typedef tbb::concurrent_hash_map<std::string, OSLQuery::Parameter *> ParameterMap;
+using ParameterMap = tbb::concurrent_hash_map<std::string, OSLQuery::Parameter *>;
 
 ParameterMap &parameterMap()
 {

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -240,7 +240,7 @@ class AppleseedRendererBase : public IECoreScenePreview::Renderer
 		ShaderCachePtr m_shaderCache;
 		InstanceMasterCachePtr m_instanceMasterCache;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, string> ProceduralCache;
+		using ProceduralCache = tbb::concurrent_hash_map<IECore::MurmurHash, string>;
 		ProceduralCache m_proceduralCache;
 
 		float m_shutterOpenTime;
@@ -261,8 +261,8 @@ namespace
 
 // appleseed projects are not thread-safe.
 // We need to protect project edits with locks.
-typedef boost::mutex MutexType;
-typedef boost::lock_guard<boost::mutex> LockGuardType;
+using MutexType = boost::mutex;
+using LockGuardType = boost::lock_guard<boost::mutex>;
 
 MutexType g_projectMutex;
 MutexType g_sceneMutex;
@@ -755,7 +755,7 @@ class ShaderCache : public RefCounted
 
 	private :
 
-		typedef tbb::concurrent_hash_map<MurmurHash, AppleseedShaderPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<MurmurHash, AppleseedShaderPtr>;
 		Cache m_cache;
 		asr::Project &m_project;
 		bool m_isInteractive;
@@ -1112,7 +1112,7 @@ class InstanceMasterCache : public IECore::RefCounted
 
 	private :
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, InstanceMasterPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, InstanceMasterPtr>;
 		Cache m_cache;
 };
 

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -280,7 +280,7 @@ static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size
 	return metadata;
 }
 
-typedef IECorePreview::LRUCache<std::string, IECore::ConstCompoundDataPtr> MetadataCache;
+using MetadataCache = IECorePreview::LRUCache<std::string, IECore::ConstCompoundDataPtr>;
 MetadataCache g_arnoldMetadataCache( metadataGetter, 10000 );
 
 const IECore::CompoundData *ArnoldShader::metadata() const

--- a/src/GafferArnold/InteractiveArnoldRender.cpp
+++ b/src/GafferArnold/InteractiveArnoldRender.cpp
@@ -51,7 +51,7 @@ using namespace GafferArnold;
 namespace
 {
 
-typedef boost::unordered_set<InteractiveArnoldRender *> InstanceSet;
+using InstanceSet = boost::unordered_set<InteractiveArnoldRender *>;
 InstanceSet &instances()
 {
 	static InstanceSet i;

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -74,7 +74,7 @@ const AtString g_ClosurePlugArnoldString( "ClosurePlug" );
 template<typename PlugType>
 Gaffer::Plug *setupNumericPlug( const AtNodeEntry *node, const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction )
 {
-	typedef typename PlugType::ValueType ValueType;
+	using ValueType = typename PlugType::ValueType;
 
 	ValueType defaultValue = 0;
 	ValueType minValue = Imath::limits<ValueType>::min();
@@ -191,8 +191,8 @@ Gaffer::Plug *setupTypedPlug( const AtNodeEntry *node, const AtParamEntry *param
 template<typename PlugType>
 Gaffer::Plug *setupColorPlug( const AtNodeEntry *node, const AtParamEntry *parameter, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction )
 {
-	typedef typename PlugType::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
+	using ValueType = typename PlugType::ValueType;
+	using BaseType = typename ValueType::BaseType;
 
 	ValueType defaultValue( 1 );
 

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -110,7 +110,7 @@ CompoundDataPtr surfaceTextureGetter( const SurfaceTextureCacheGetterKey &key, s
 	return nullptr;
 }
 
-typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, SurfaceTextureCacheGetterKey> SurfaceTextureCache;
+using SurfaceTextureCache = IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, SurfaceTextureCacheGetterKey>;
 // Cache cost is in bytes
 SurfaceTextureCache g_surfaceTextureCache( surfaceTextureGetter, 1024 * 1024 * 64 );
 

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -56,8 +56,9 @@ using namespace IECoreGLPreview;
 
 namespace
 {
-typedef std::pair<float, V3f> Knot;
-typedef std::vector<Knot> KnotVector;
+
+using Knot = std::pair<float, V3f>;
+using KnotVector = std::vector<Knot>;
 
 const char *faceCameraVertexSource()
 {

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -100,7 +100,7 @@ IECoreGL::RenderablePtr quadWireframe( const V2f &size )
 template<typename T>
 T parameterOrDefault( const IECore::CompoundData *parameters, const IECore::InternedString &name, const T &defaultValue )
 {
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *d = parameters->member<DataType>( name ) )
 	{
 		return d->readable();
@@ -152,7 +152,7 @@ CompoundDataPtr getter( const OSLTextureCacheGetterKey &key, size_t &cost, const
 	return nullptr;
 }
 
-typedef IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, OSLTextureCacheGetterKey> OSLTextureCache;
+using OSLTextureCache = IECorePreview::LRUCache<IECore::MurmurHash, CompoundDataPtr, IECorePreview::LRUCachePolicy::Parallel, OSLTextureCacheGetterKey>;
 OSLTextureCache g_oslTextureCache( getter, 1024 * 1024 * 64 );
 
 const char *texturedFragSource()

--- a/src/GafferArnoldUI/LightBlockerVisualiser.cpp
+++ b/src/GafferArnoldUI/LightBlockerVisualiser.cpp
@@ -74,7 +74,7 @@ T parameter( InternedString metadataTarget, const IECore::CompoundData *paramete
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *parameterData = parameters->member<DataType>( parameterName->readable() ) )
 	{
 		return parameterData->readable();

--- a/src/GafferArnoldUI/VisualiserAlgo.cpp
+++ b/src/GafferArnoldUI/VisualiserAlgo.cpp
@@ -64,7 +64,7 @@ namespace
 
 const char *g_oslSearchPaths = getenv( "OSL_SHADER_PATHS" );
 
-typedef std::shared_ptr<OSLQuery> OSLQueryPtr;
+using OSLQueryPtr = std::shared_ptr<OSLQuery>;
 
 OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost, const IECore::Canceller *canceller )
 {
@@ -79,7 +79,7 @@ OSLQueryPtr oslQueryGetter( const std::string &shaderName, size_t &cost, const I
 	return nullptr;
 }
 
-typedef IECorePreview::LRUCache<std::string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel> OSLQueryCache;
+using OSLQueryCache = IECorePreview::LRUCache<std::string, OSLQueryPtr, IECorePreview::LRUCachePolicy::Parallel>;
 OSLQueryCache g_oslQueryCache( oslQueryGetter, 128 );
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -106,7 +106,7 @@ std::string modulePathInternal( const boost::python::object &o )
 		objectName = extract<std::string>( o.attr( "__class__" ).attr( "__name__" ) );
 	}
 
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 	std::string sanitisedModulePath;
 	Tokenizer tokens( modulePath, boost::char_separator<char>( "." ) );
 

--- a/src/GafferCortexModule/ExecutableOpHolderBinding.cpp
+++ b/src/GafferCortexModule/ExecutableOpHolderBinding.cpp
@@ -54,7 +54,7 @@ using namespace GafferDispatchBindings;
 using namespace GafferCortex;
 using namespace GafferCortexModule;
 
-typedef ParameterisedHolderWrapper< TaskNodeWrapper<ExecutableOpHolder> > ExecutableOpHolderWrapper;
+using ExecutableOpHolderWrapper = ParameterisedHolderWrapper<TaskNodeWrapper<ExecutableOpHolder> >;
 
 static IECore::OpPtr getOp( ExecutableOpHolder &n )
 {

--- a/src/GafferCortexModule/OpHolderBinding.cpp
+++ b/src/GafferCortexModule/OpHolderBinding.cpp
@@ -54,7 +54,7 @@ using namespace GafferBindings;
 using namespace GafferCortex;
 using namespace GafferCortexModule;
 
-typedef ParameterisedHolderWrapper<DependencyNodeWrapper<OpHolder> > OpHolderWrapper;
+using OpHolderWrapper = ParameterisedHolderWrapper<DependencyNodeWrapper<OpHolder> >;
 
 static IECore::OpPtr getOp( OpHolder &n )
 {

--- a/src/GafferCortexModule/ParameterisedHolderBinding.cpp
+++ b/src/GafferCortexModule/ParameterisedHolderBinding.cpp
@@ -59,10 +59,10 @@ using namespace GafferCortexModule;
 namespace
 {
 
-typedef ParameterisedHolderWrapper<NodeWrapper<ParameterisedHolderNode> > ParameterisedHolderNodeWrapper;
-typedef ParameterisedHolderWrapper<DependencyNodeWrapper<ParameterisedHolderDependencyNode> > ParameterisedHolderDependencyNodeWrapper;
-typedef ParameterisedHolderWrapper<ComputeNodeWrapper<ParameterisedHolderComputeNode> > ParameterisedHolderComputeNodeWrapper;
-typedef ParameterisedHolderWrapper<TaskNodeWrapper<ParameterisedHolderTaskNode> > ParameterisedHolderTaskNodeWrapper;
+using ParameterisedHolderNodeWrapper = ParameterisedHolderWrapper<NodeWrapper<ParameterisedHolderNode> >;
+using ParameterisedHolderDependencyNodeWrapper = ParameterisedHolderWrapper<DependencyNodeWrapper<ParameterisedHolderDependencyNode> >;
+using ParameterisedHolderComputeNodeWrapper = ParameterisedHolderWrapper<ComputeNodeWrapper<ParameterisedHolderComputeNode> >;
+using ParameterisedHolderTaskNodeWrapper = ParameterisedHolderWrapper<TaskNodeWrapper<ParameterisedHolderTaskNode> >;
 
 template<typename T>
 class ParameterisedHolderSerialiser : public NodeSerialiser

--- a/src/GafferDelight/IECoreDelightPreview/NodeAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/NodeAlgo.cpp
@@ -76,7 +76,7 @@ struct Converters
 
 };
 
-typedef std::unordered_map<IECore::TypeId, Converters> Registry;
+using Registry = std::unordered_map<IECore::TypeId, Converters>;
 
 Registry &registry()
 {

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -95,7 +95,7 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *d = reportedCast<const DataType>( it->second.get(), "parameter", name ) )
 	{
 		return d->readable();
@@ -122,7 +122,7 @@ std::string shaderCacheGetter( const std::string &shaderName, size_t &cost, cons
 	}
 }
 
-typedef IECorePreview::LRUCache<std::string, std::string> ShaderSearchPathCache;
+using ShaderSearchPathCache = IECorePreview::LRUCache<std::string, std::string>;
 ShaderSearchPathCache g_shaderSearchPathCache( shaderCacheGetter, 10000 );
 
 } // namespace
@@ -232,8 +232,8 @@ class DelightHandle
 
 };
 
-typedef std::shared_ptr<DelightHandle> DelightHandleSharedPtr;
-typedef std::weak_ptr<DelightHandle> DelightHandleWeakPtr;
+using DelightHandleSharedPtr = std::shared_ptr<DelightHandle>;
+using DelightHandleWeakPtr = std::weak_ptr<DelightHandle>;
 
 } // namespace
 
@@ -561,7 +561,7 @@ class ShaderCache : public IECore::RefCounted
 		NSIContext_t m_context;
 		DelightHandle::Ownership m_ownership;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, DelightShaderPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, DelightShaderPtr>;
 		Cache m_cache;
 
 };
@@ -737,7 +737,7 @@ class AttributesCache : public IECore::RefCounted
 
 		ShaderCachePtr m_shaderCache;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, DelightAttributesPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, DelightAttributesPtr>;
 		Cache m_cache;
 
 };
@@ -843,7 +843,7 @@ class InstanceCache : public IECore::RefCounted
 		NSIContext_t m_context;
 		DelightHandle::Ownership m_ownership;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, DelightHandleSharedPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, DelightHandleSharedPtr>;
 		Cache m_cache;
 
 };
@@ -1482,7 +1482,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 		unordered_map<InternedString, ConstDelightOutputPtr> m_outputs;
 
-		typedef unordered_map<string, ConstCameraPtr> CameraMap;
+		using CameraMap = unordered_map<string, ConstCameraPtr>;
 		CameraMap m_cameras;
 		tbb::spin_mutex m_camerasMutex;
 

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -682,8 +682,8 @@ class Dispatcher::Batcher
 			return static_cast<const TaskNode *>( task.plug()->node() )->dispatcherPlug();
 		}
 
-		typedef std::map<IECore::MurmurHash, TaskBatchPtr> BatchMap;
-		typedef std::map<IECore::MurmurHash, TaskBatchPtr> TaskToBatchMap;
+		using BatchMap = std::map<IECore::MurmurHash, TaskBatchPtr>;
+		using TaskToBatchMap = std::map<IECore::MurmurHash, TaskBatchPtr>;
 
 		TaskBatchPtr m_rootBatch;
 		BatchMap m_currentBatches;

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -126,7 +126,7 @@ class DispatcherWrapper : public NodeWrapper<Dispatcher>
 		// functions because TaskBatch is a protected member of Dispatcher.
 		//////////////////////////////////////////////////////////////////////////
 
-		typedef Dispatcher::TaskBatch TaskBatch;
+		using TaskBatch = Dispatcher::TaskBatch;
 
 		static void taskBatchExecute( const Dispatcher::TaskBatch &batch )
 		{

--- a/src/GafferDispatchModule/TaskNodeBinding.cpp
+++ b/src/GafferDispatchModule/TaskNodeBinding.cpp
@@ -133,7 +133,7 @@ boost::python::list taskPlugPostTasks( const TaskNode::TaskPlug &t )
 
 void GafferDispatchModule::bindTaskNode()
 {
-	typedef TaskNodeWrapper<TaskNode> Wrapper;
+	using Wrapper = TaskNodeWrapper<TaskNode>;
 
 	scope s = TaskNodeClass<TaskNode, Wrapper>();
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -438,8 +438,8 @@ class Catalogue::InternalImage : public ImageNode
 		struct AsynchronousSaver
 		{
 
-			typedef std::shared_ptr<AsynchronousSaver> Ptr;
-			typedef std::weak_ptr<AsynchronousSaver> WeakPtr;
+			using Ptr = std::shared_ptr<AsynchronousSaver>;
+			using WeakPtr = std::weak_ptr<AsynchronousSaver>;
 
 			static Ptr create( InternalImage *client )
 			{
@@ -516,8 +516,8 @@ class Catalogue::InternalImage : public ImageNode
 				m_clients.erase( client );
 			}
 
-			typedef std::pair<std::string, Imath::V2i> TileIndex;
-			typedef boost::unordered_map<TileIndex, IECore::MurmurHash> ChannelDataHashes;
+			using TileIndex = std::pair<std::string, Imath::V2i>;
+			using ChannelDataHashes = boost::unordered_map<TileIndex, IECore::MurmurHash>;
 			ChannelDataHashes channelDataHashes;
 
 			private :

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -651,8 +651,8 @@ void Display::setupDriver( GafferDisplayDriverPtr driver )
 namespace
 {
 
-typedef set<PlugPtr> PlugSet;
-typedef std::unique_ptr<PlugSet> PlugSetPtr;
+using PlugSet = set<PlugPtr>;
+using PlugSetPtr = std::unique_ptr<PlugSet>;
 
 struct PendingUpdates
 {

--- a/src/GafferImage/FilterAlgo.cpp
+++ b/src/GafferImage/FilterAlgo.cpp
@@ -228,7 +228,7 @@ void ensureMinimumParallelogramWidth( V2f &dpdx, V2f &dpdy )
 	}
 }
 
-typedef std::pair<std::string, const OIIO::Filter2D *> FilterPair;
+using FilterPair = std::pair<std::string, const OIIO::Filter2D *>;
 
 tbb::spin_rw_mutex g_filtersInitMutex;
 
@@ -284,7 +284,7 @@ const std::vector<std::string> &GafferImage::FilterAlgo::filterNames()
 
 const OIIO::Filter2D *GafferImage::FilterAlgo::acquireFilter( const std::string &name )
 {
-	typedef std::map<std::string, const OIIO::Filter2D *> FilterMapType;
+	using FilterMapType = std::map<std::string, const OIIO::Filter2D *>;
 	static FilterMapType filterMap;
 
 	{

--- a/src/GafferImage/Format.cpp
+++ b/src/GafferImage/Format.cpp
@@ -43,7 +43,7 @@ using namespace GafferImage;
 namespace
 {
 
-typedef std::map<std::string, Format> FormatMap;
+using FormatMap = std::map<std::string, Format>;
 
 FormatMap &formatMap()
 {

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -153,12 +153,12 @@ void copyDeepArea(
 	}
 }
 
-typedef std::shared_ptr<ImageOutput> ImageOutputPtr;
+using ImageOutputPtr = std::shared_ptr<ImageOutput>;
 
 class TileSampleOffsetsProcessor
 {
 	public:
-		typedef ConstIntVectorDataPtr Result;
+		using Result = ConstIntVectorDataPtr;
 
 		TileSampleOffsetsProcessor() {}
 
@@ -171,7 +171,7 @@ class TileSampleOffsetsProcessor
 class TileChannelDataProcessor
 {
 	public:
-		typedef ConstFloatVectorDataPtr Result;
+		using Result = ConstFloatVectorDataPtr;
 
 		TileChannelDataProcessor() {}
 
@@ -185,7 +185,7 @@ struct V2iHash
 {
 	std::size_t operator()( const V2i &i ) const
 	{
-		typedef std::pair<float, float> Hashable;
+		using Hashable = std::pair<float, float>;
 		return boost::hash<Hashable>()( Hashable( i.x, i.y ) );
 	}
 };
@@ -193,7 +193,7 @@ struct V2iHash
 class SampleOffsetsAccumulator
 {
 	public:
-		typedef std::unordered_map<Imath::V2i, ConstIntVectorDataPtr, V2iHash> Result;
+		using Result = std::unordered_map<Imath::V2i, ConstIntVectorDataPtr, V2iHash>;
 
 		void operator()( const ImagePlug *imagePlug, const V2i &tileOrigin, ConstIntVectorDataPtr sampleOffsets )
 		{

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -268,7 +268,7 @@ inline MergeRegion tileRegion( int i, const Box2i &boundA, const Box2i &boundB, 
 
 struct MergeFunctor
 {
-	typedef void ReturnType;
+	using ReturnType = void;
 
 	// Merge channelData based on the current Op
 	// Based on our convention for merges we output to channelDataB and alphaDataB - we accumulate to the
@@ -481,7 +481,7 @@ struct MergeFunctor
 
 struct PassthroughHashFunctor
 {
-	typedef void ReturnType;
+	using ReturnType = void;
 
 	// There are two completely different strategies we can use for determining a channelData hash
 	// The first is to append hashes for everything that affects the current tile, producing a fully
@@ -552,7 +552,7 @@ struct PassthroughHashFunctor
 
 struct MergeDataWindowFunctor
 {
-	typedef void ReturnType;
+	using ReturnType = void;
 
 
 	// Merge two datawindows based on the current Op

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -60,9 +60,9 @@ namespace
 // On other platforms we use a null_mutex so there should be no
 // performance impact at all.
 #ifdef __APPLE__
-typedef tbb::mutex OCIOMutex;
+using OCIOMutex = tbb::mutex;
 #else
-typedef tbb::null_mutex OCIOMutex;
+using OCIOMutex = tbb::null_mutex;
 #endif
 
 static OCIOMutex g_ocioMutex;

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -658,7 +658,7 @@ class File
 
 
 
-typedef std::shared_ptr<File> FilePtr;
+using FilePtr = std::shared_ptr<File>;
 
 // For success, file should be set, and error left null
 // For failure, file should be left null, and error should be set
@@ -699,7 +699,7 @@ CacheEntry fileCacheGetter( const std::string &fileName, size_t &cost, const IEC
 	return result;
 }
 
-typedef IECorePreview::LRUCache<std::string, CacheEntry> FileHandleCache;
+using FileHandleCache = IECorePreview::LRUCache<std::string, CacheEntry>;
 
 FileHandleCache *fileCache()
 {
@@ -886,7 +886,7 @@ size_t OpenImageIOReader::supportedExtensions( std::vector<std::string> &extensi
 		return extensions.size();
 	}
 
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 	Tokenizer formats( attr, boost::char_separator<char>( ";" ) );
 	for( Tokenizer::const_iterator fIt = formats.begin(), eFIt = formats.end(); fIt != eFIt; ++fIt )
 	{

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -75,7 +75,7 @@ namespace
 // the appropriate library for the current thread.
 FT_Library library()
 {
-	typedef tbb::enumerable_thread_specific<FT_Library> ThreadSpecificLibrary;
+	using ThreadSpecificLibrary = tbb::enumerable_thread_specific<FT_Library>;
 	static ThreadSpecificLibrary g_threadLibraries( FT_Library( nullptr ) );
 
 	FT_Library &l = g_threadLibraries.local();
@@ -93,7 +93,7 @@ FT_Library library()
 // We want to maintain a cache of FT_Faces, because creating them
 // is fairly costly. But since FT_Faces belong to FT_Libraries
 // the cache must be maintained per-thread.
-typedef std::shared_ptr<FT_FaceRec_> FacePtr;
+using FacePtr = std::shared_ptr<FT_FaceRec_>;
 FacePtr faceLoader( const std::string &font, size_t &cost, const IECore::Canceller *canceller )
 {
 	const char *e = getenv( "IECORE_FONT_PATHS" );
@@ -119,8 +119,8 @@ FacePtr faceLoader( const std::string &font, size_t &cost, const IECore::Cancell
 	return result;
 }
 
-typedef IECorePreview::LRUCache<string, FacePtr> FaceCache;
-typedef std::unique_ptr<FaceCache> FaceCachePtr;
+using FaceCache = IECorePreview::LRUCache<string, FacePtr>;
+using FaceCachePtr = std::unique_ptr<FaceCache>;
 FaceCachePtr createFaceCache()
 {
 	return FaceCachePtr( new FaceCache( faceLoader, 500 ) );
@@ -128,7 +128,7 @@ FaceCachePtr createFaceCache()
 
 FacePtr face( const string &font, const V2i &size )
 {
-	typedef tbb::enumerable_thread_specific<FaceCachePtr> ThreadSpecificFaceCache;
+	using ThreadSpecificFaceCache = tbb::enumerable_thread_specific<FaceCachePtr>;
 	static ThreadSpecificFaceCache g_faceCaches( createFaceCache );
 
 	FacePtr face = g_faceCaches.local()->get( font );
@@ -401,7 +401,7 @@ IECore::ConstCompoundObjectPtr Text::computeLayout( const Gaffer::Context *conte
 
 	const std::string text = textPlug()->getValue();
 	/// \todo Does tokenization/wrapping need to be unicode aware?
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 	boost::char_separator<char> separator( "", " \n\t" );
 	Tokenizer tokenizer( text, separator );
 	for( Tokenizer::iterator it = tokenizer.begin(), eIt = tokenizer.end(); it != eIt; ++it )

--- a/src/GafferImageModule/CoreBinding.cpp
+++ b/src/GafferImageModule/CoreBinding.cpp
@@ -307,10 +307,10 @@ void GafferImageModule::bindCore()
 		.def( "whiteTile", &whiteTile, ( arg( "_copy" ) = true ) ).staticmethod( "whiteTile" )
 	;
 
-	typedef ComputeNodeWrapper<ImageNode> ImageNodeWrapper;
+	using ImageNodeWrapper = ComputeNodeWrapper<ImageNode>;
 	GafferBindings::DependencyNodeClass<ImageNode, ImageNodeWrapper>();
 
-	typedef ComputeNodeWrapper<FlatImageSource> FlatImageSourceWrapper;
+	using FlatImageSourceWrapper = ComputeNodeWrapper<FlatImageSource>;
 	GafferBindings::DependencyNodeClass<FlatImageSource, FlatImageSourceWrapper>();
 
 	class_<Format>( "Format" )

--- a/src/GafferImageModule/IOBinding.cpp
+++ b/src/GafferImageModule/IOBinding.cpp
@@ -168,7 +168,7 @@ void GafferImageModule::bindIO()
 	}
 
 	{
-		typedef TaskNodeWrapper<ImageWriter> ImageWriterWrapper;
+		using ImageWriterWrapper = TaskNodeWrapper<ImageWriter>;
 
 		scope s = TaskNodeClass<ImageWriter, ImageWriterWrapper>()
 			.def( "currentFileFormat", &ImageWriter::currentFileFormat )

--- a/src/GafferImageModule/ImageProcessorBinding.cpp
+++ b/src/GafferImageModule/ImageProcessorBinding.cpp
@@ -60,7 +60,7 @@ using namespace GafferImage;
 void GafferImageModule::bindImageProcessor()
 {
 
-	typedef ComputeNodeWrapper<ImageProcessor> ImageProcessorWrapper;
+	using ImageProcessorWrapper = ComputeNodeWrapper<ImageProcessor>;
 	GafferBindings::DependencyNodeClass<ImageProcessor, ImageProcessorWrapper>()
 		.def( init<const std::string &, size_t, size_t>(
 				(

--- a/src/GafferModule/BoxPlugBinding.cpp
+++ b/src/GafferModule/BoxPlugBinding.cpp
@@ -71,9 +71,9 @@ typename T::ValueType getValue( const T *plug )
 template<typename T>
 void bind()
 {
-	typedef typename T::ValueType V;
-	typedef typename T::PointType P;
-	typedef typename P::BaseType B;
+	using V = typename T::ValueType;
+	using P = typename T::PointType;
+	using B = typename P::BaseType;
 
 	PlugClass<T>()
 		.def( init<const std::string &, Plug::Direction, const V&, unsigned>(

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -138,7 +138,7 @@ void ungang( T *plug )
 template<typename T>
 void bind()
 {
-	typedef typename T::ValueType V;
+	using V = typename T::ValueType;
 
 	PlugClass<T>()
 		.def( init<const char *, Plug::Direction, V, V, V, unsigned, IECore::GeometricData::Interpretation>(

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -309,7 +309,7 @@ struct ChildrenReorderedSlotCaller
 
 void GafferModule::bindGraphComponent()
 {
-	typedef GraphComponentWrapper<GraphComponent> Wrapper;
+	using Wrapper = GraphComponentWrapper<GraphComponent>;
 
 	scope s = GraphComponentClass<GraphComponent, Wrapper>()
 		.def( init<>() )

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -108,7 +108,7 @@ struct ErrorSlotCaller
 
 void GafferModule::bindNode()
 {
-	typedef NodeWrapper<Node> NodeWrapper;
+	using NodeWrapper = NodeWrapper<Node>;
 
 	{
 		scope s = NodeClass<Node, NodeWrapper>()
@@ -126,13 +126,13 @@ void GafferModule::bindNode()
 
 	Serialisation::registerSerialiser( Node::staticTypeId(), new NodeSerialiser() );
 
-	typedef SerialiserWrapper<NodeSerialiser> NodeSerialiserWrapper;
+	using NodeSerialiserWrapper = SerialiserWrapper<NodeSerialiser>;
 	SerialiserClass<NodeSerialiser, Serialisation::Serialiser, NodeSerialiserWrapper>( "NodeSerialiser" );
 
-	typedef DependencyNodeWrapper<DependencyNode> DependencyNodeWrapper;
+	using DependencyNodeWrapper = DependencyNodeWrapper<DependencyNode>;
 	DependencyNodeClass<DependencyNode, DependencyNodeWrapper>();
 
-	typedef ComputeNodeWrapper<ComputeNode> ComputeNodeWrapper;
+	using ComputeNodeWrapper = ComputeNodeWrapper<ComputeNode>;
 	DependencyNodeClass<ComputeNode, ComputeNodeWrapper>();
 
 }

--- a/src/GafferModule/NumericPlugBinding.cpp
+++ b/src/GafferModule/NumericPlugBinding.cpp
@@ -77,7 +77,7 @@ typename T::ValueType getValue( const T *plug, const IECore::MurmurHash *precomp
 template<typename T>
 void bind()
 {
-	typedef typename T::ValueType V;
+	using V = typename T::ValueType;
 
 	PlugClass<T>()
 		.def( init<const char *, Plug::Direction, typename T::ValueType, typename T::ValueType, typename T::ValueType, unsigned>(

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -452,7 +452,7 @@ PathFilterPtr createStandardFilter( object pythonExtensions, const std::string &
 
 void GafferModule::bindPath()
 {
-	typedef PathWrapper<Path> Wrapper;
+	using Wrapper = PathWrapper<Path>;
 
 	{
 		scope s = PathClass<Path, Wrapper>()

--- a/src/GafferModule/PathFilterBinding.cpp
+++ b/src/GafferModule/PathFilterBinding.cpp
@@ -201,7 +201,7 @@ void GafferModule::bindPathFilter()
 
 	// PathFilter
 
-	typedef PathFilterWrapper<PathFilter> Wrapper;
+	using Wrapper = PathFilterWrapper<PathFilter>;
 
 	{
 		scope s = RunTimeTypedClass<PathFilter, Wrapper>()

--- a/src/GafferModule/PlugBinding.cpp
+++ b/src/GafferModule/PlugBinding.cpp
@@ -99,7 +99,7 @@ PlugPtr source( Plug &p )
 
 void GafferModule::bindPlug()
 {
-	typedef PlugWrapper<Plug> Wrapper;
+	using Wrapper = PlugWrapper<Plug>;
 
 	PlugClass<Plug, Wrapper> c;
 	{

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -96,7 +96,7 @@ namespace python {
 template<>
 struct base_type_traits<PyCodeObject>
 {
-	typedef PyObject type;
+	using type = PyObject;
 };
 
 } // namespace python

--- a/src/GafferModule/SignalsBinding.cpp
+++ b/src/GafferModule/SignalsBinding.cpp
@@ -97,7 +97,7 @@ struct SlotCallRange
 struct PythonResultCombiner
 {
 
-	typedef object result_type;
+	using result_type = object;
 
 	PythonResultCombiner()
 		:	combiner( object() )
@@ -153,7 +153,7 @@ void bind( const char *name )
 	;
 
 	// bind the appropriate result range type so the custom result combiner can get the slot results.
-	typedef SlotCallRange<typename Signal::SlotCallIterator> Range;
+	using Range = SlotCallRange<typename Signal::SlotCallIterator>;
 	boost::python::class_<Range>( "__SignalResultRange", no_init )
 		.def( "__iter__", &Range::iter, return_self<>() )
 #if PY_MAJOR_VERSION >= 3

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -302,10 +302,10 @@ void load( Reference &r, const std::string &f )
 
 void GafferModule::bindSubGraph()
 {
-	typedef DependencyNodeWrapper<SubGraph> SubGraphWrapper;
+	using SubGraphWrapper = DependencyNodeWrapper<SubGraph>;
 	DependencyNodeClass<SubGraph, SubGraphWrapper>();
 
-	typedef DependencyNodeWrapper<Box> BoxWrapper;
+	using BoxWrapper = DependencyNodeWrapper<Box>;
 
 	DependencyNodeClass<Box, BoxWrapper>()
 		.def( "canPromotePlug", &Box::canPromotePlug, ( arg( "descendantPlug" ) ) )

--- a/src/GafferModule/UndoScopeBinding.cpp
+++ b/src/GafferModule/UndoScopeBinding.cpp
@@ -52,7 +52,7 @@ using namespace Gaffer;
 namespace
 {
 
-typedef std::shared_ptr<UndoScope> UndoScopePtr;
+using UndoScopePtr = std::shared_ptr<UndoScope>;
 
 void deleter( UndoScope *undoScope )
 {

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -241,7 +241,7 @@ class RendererServices : public OSL::RendererServices
 namespace
 {
 
-typedef pair<string, string> Replacement;
+using Replacement = pair<string, string>;
 bool replacementGreater( const Replacement &lhs, const Replacement &rhs )
 {
 	return lhs.first.size() > rhs.first.size();
@@ -804,7 +804,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			// just return it. OSL won't let us load the same shader
 			// again via LoadMemoryCompiledShader anyway.
 
-			typedef map<string, OSL::ShaderGroupRef> ShaderGroups;
+			using ShaderGroups = map<string, OSL::ShaderGroupRef>;
 			static ShaderGroups g_shaderGroups;
 			const ShaderGroups::const_iterator it = g_shaderGroups.find( shaderName );
 			if( it != g_shaderGroups.end() )

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -127,10 +127,10 @@ ConstShadingEnginePtr getter( const ShadingEngineCacheGetterKey &key, size_t &co
 	return new ShadingEngine( network );
 }
 
-typedef IECorePreview::LRUCache<IECore::MurmurHash, ConstShadingEnginePtr, IECorePreview::LRUCachePolicy::Parallel, ShadingEngineCacheGetterKey> ShadingEngineCache;
+using ShadingEngineCache = IECorePreview::LRUCache<IECore::MurmurHash, ConstShadingEnginePtr, IECorePreview::LRUCachePolicy::Parallel, ShadingEngineCacheGetterKey>;
 ShadingEngineCache g_shadingEngineCache( getter, 10000 );
 
-typedef boost::container::flat_set<IECore::InternedString> ShaderTypeSet;
+using ShaderTypeSet = boost::container::flat_set<IECore::InternedString>;
 ShaderTypeSet &compatibleShaders()
 {
 	static ShaderTypeSet g_compatibleShaders;
@@ -325,7 +325,7 @@ Plug *loadStringArrayParameter( const OSLQuery::Parameter *parameter, const Inte
 template<typename PlugType>
 Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, const InternedString &name, Gaffer::Plug *parent, const CompoundData *metadata )
 {
-	typedef typename PlugType::ValueType ValueType;
+	using ValueType = typename PlugType::ValueType;
 
 	ValueType defaultValue( 0 );
 	if( parameter->idefault.size() )
@@ -381,9 +381,9 @@ Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, const Interned
 template<typename PlugType>
 Plug *loadNumericArrayParameter( const OSLQuery::Parameter *parameter, const InternedString &name, Gaffer::Plug *parent, const CompoundData *metadata )
 {
-	typedef typename PlugType::ValueType DataType;
-	typedef typename DataType::ValueType ValueType;
-	typedef typename ValueType::value_type ElementType;
+	using DataType = typename PlugType::ValueType;
+	using ValueType = typename DataType::ValueType;
+	using ElementType = typename ValueType::value_type;
 
 	typename DataType::Ptr defaultValueData = new DataType();
 	ValueType &defaultValueDataWritable = defaultValueData->writable();
@@ -430,8 +430,8 @@ Plug *loadNumericArrayParameter( const OSLQuery::Parameter *parameter, const Int
 template <typename PlugType>
 Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, const InternedString &name, Gaffer::Plug *parent, const CompoundData *metadata )
 {
-	typedef typename PlugType::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
+	using ValueType = typename PlugType::ValueType;
+	using BaseType = typename ValueType::BaseType;
 
 	ValueType defaultValue( 0 );
 	if( parameter->idefault.size() )
@@ -503,10 +503,10 @@ Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, const 
 template <typename PlugType>
 Plug *loadCompoundNumericArrayParameter( const OSLQuery::Parameter *parameter, const InternedString &name, Gaffer::Plug *parent, const CompoundData *metadata )
 {
-	typedef typename PlugType::ValueType DataType;
-	typedef typename DataType::ValueType ValueType;
-	typedef typename ValueType::value_type ElementType;
-	typedef typename ElementType::BaseType BaseType;
+	using DataType = typename PlugType::ValueType;
+	using ValueType = typename DataType::ValueType;
+	using ElementType = typename ValueType::value_type;
+	using BaseType = typename ElementType::BaseType;
 
 	typename DataType::Ptr defaultValueData = new DataType();
 	ValueType &defaultValueDataWritable = defaultValueData->writable();
@@ -1243,7 +1243,7 @@ static IECore::ConstCompoundDataPtr metadataGetter( const std::string &key, size
 	return metadata;
 }
 
-typedef IECorePreview::LRUCache<std::string, IECore::ConstCompoundDataPtr> MetadataCache;
+using MetadataCache = IECorePreview::LRUCache<std::string, IECore::ConstCompoundDataPtr>;
 MetadataCache g_metadataCache( metadataGetter, 10000 );
 
 const IECore::CompoundData *OSLShader::metadata() const

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -387,7 +387,7 @@ class RenderState
 
 	private :
 
-		typedef boost::unordered_map< OIIO::ustring, ShadingEngine::Transform, OIIO::ustringHash > RenderStateTransforms;
+		using RenderStateTransforms = boost::unordered_map< OIIO::ustring, ShadingEngine::Transform, OIIO::ustringHash>;
 		RenderStateTransforms m_transforms;
 
 		struct UserData
@@ -559,7 +559,7 @@ struct DebugParameters
 // Must be held in order to modify the shading system.
 // Should not be acquired before calling shadingSystem(),
 // since shadingSystem() itself will use it.
-typedef tbb::spin_mutex ShadingSystemWriteMutex;
+using ShadingSystemWriteMutex = tbb::spin_mutex;
 ShadingSystemWriteMutex g_shadingSystemWriteMutex;
 
 OSL::ShadingSystem *shadingSystem()
@@ -678,7 +678,7 @@ class ShadingResults
 			void *basePointer;
 		};
 
-		typedef container::flat_map<ustring, DebugResult, OIIO::ustringPtrIsLess> DebugResultsMap;
+		using DebugResultsMap = container::flat_map<ustring, DebugResult, OIIO::ustringPtrIsLess>;
 
 		void addResult( size_t pointIndex, const ClosureColor *result, DebugResultsMap &threadCache )
 		{
@@ -944,7 +944,7 @@ void declareParameters( const CompoundDataMap &parameters, ShadingSystem *shadin
 template <typename T>
 static T uniformValue( const IECore::CompoundData *points, const char *name )
 {
-	typedef TypedData<T> DataType;
+	using DataType = TypedData<T>;
 	const DataType *d = points->member<DataType>( name );
 	if( d )
 	{
@@ -959,7 +959,7 @@ static T uniformValue( const IECore::CompoundData *points, const char *name )
 template<typename T>
 static const T *varyingValue( const IECore::CompoundData *points, const char *name )
 {
-	typedef TypedData<vector<T> > DataType;
+	using DataType = TypedData<vector<T> >;
 	const DataType *d = points->member<DataType>( name );
 	if( d )
 	{

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -318,7 +318,7 @@ GAFFER_NODE_DEFINE_TYPE( Cryptomatte );
 size_t Cryptomatte::g_firstPlugIndex = 0;
 
 // first channel contains id, second contains alpha contribution
-typedef std::unordered_map<std::string, std::string> ChannelMap;
+using ChannelMap = std::unordered_map<std::string, std::string>;
 static const ChannelMap g_channelMap = {
 	{"R", "G"},
 	{"B", "A"},

--- a/src/GafferScene/IECoreGLPreview/AttributeVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/AttributeVisualiser.cpp
@@ -44,7 +44,7 @@ using namespace IECoreGLPreview;
 namespace
 {
 
-typedef std::vector<ConstAttributeVisualiserPtr> AttributeVisualisers;
+using AttributeVisualisers = std::vector<ConstAttributeVisualiserPtr>;
 
 AttributeVisualisers &visualisers()
 {

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -58,9 +58,9 @@ using namespace IECoreGLPreview;
 namespace
 {
 
-typedef std::pair<IECore::InternedString, IECore::InternedString> AttributeAndShaderNames;
+using AttributeAndShaderNames = std::pair<IECore::InternedString, IECore::InternedString>;
 
-typedef boost::container::flat_map<AttributeAndShaderNames, ConstLightFilterVisualiserPtr> LightFilterVisualisers;
+using LightFilterVisualisers = boost::container::flat_map<AttributeAndShaderNames, ConstLightFilterVisualiserPtr>;
 LightFilterVisualisers &lightFilterVisualisers()
 {
 	static LightFilterVisualisers l;

--- a/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightVisualiser.cpp
@@ -56,9 +56,9 @@ using namespace IECoreGLPreview;
 namespace
 {
 
-typedef std::pair<IECore::InternedString, IECore::InternedString> AttributeAndShaderNames;
+using AttributeAndShaderNames = std::pair<IECore::InternedString, IECore::InternedString>;
 
-typedef boost::container::flat_map<AttributeAndShaderNames, ConstLightVisualiserPtr> LightVisualisers;
+using LightVisualisers = boost::container::flat_map<AttributeAndShaderNames, ConstLightVisualiserPtr>;
 LightVisualisers &lightVisualisers()
 {
 	static LightVisualisers l;

--- a/src/GafferScene/IECoreGLPreview/ObjectVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/ObjectVisualiser.cpp
@@ -53,7 +53,7 @@ ObjectVisualiser::~ObjectVisualiser()
 namespace
 {
 
-typedef std::map<IECore::TypeId, ConstObjectVisualiserPtr> ObjectVisualisers;
+using ObjectVisualisers = std::map<IECore::TypeId, ConstObjectVisualiserPtr>;
 
 ObjectVisualisers &objectVisualisers()
 {

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -191,7 +191,7 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *d = reportedCast<const DataType>( it->second.get(), "parameter", name ) )
 	{
 		return d->readable();
@@ -367,8 +367,8 @@ IE_CORE_DECLAREPTR( OpenGLAttributes )
 namespace
 {
 
-typedef std::function<void ()> Edit;
-typedef tbb::concurrent_queue<Edit> EditQueue;
+using Edit = std::function<void ()>;
+using EditQueue = tbb::concurrent_queue<Edit>;
 
 class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 {
@@ -1202,13 +1202,13 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 		// from m_editQueue.
 
 		unordered_map<InternedString, ConstOutputPtr> m_outputs;
-		typedef std::unordered_map<string, OpenGLCameraPtr> CameraMap;
+		using CameraMap = std::unordered_map<string, OpenGLCameraPtr>;
 		CameraMap m_cameras;
 
-		typedef std::vector<OpenGLObjectPtr> OpenGLObjectVector;
+		using OpenGLObjectVector = std::vector<OpenGLObjectPtr>;
 		OpenGLObjectVector m_objects;
 
-		typedef std::vector<OpenGLAttributesPtr> OpenGLAttributesVector;
+		using OpenGLAttributesVector = std::vector<OpenGLAttributesPtr>;
 		OpenGLAttributesVector m_attributes;
 
 		// Registration with factory

--- a/src/GafferScene/IECoreScenePreview/Renderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/Renderer.cpp
@@ -48,7 +48,7 @@ using namespace IECoreScenePreview;
 namespace
 {
 
-typedef Renderer::Ptr (*Creator)( Renderer::RenderType, const std::string &, const IECore::MessageHandlerPtr & );
+using Creator = Renderer::Ptr (*)( Renderer::RenderType, const std::string &, const IECore::MessageHandlerPtr & );
 
 vector<IECore::InternedString> &types()
 {
@@ -56,7 +56,7 @@ vector<IECore::InternedString> &types()
 	return g_types;
 }
 
-typedef map<IECore::InternedString, Creator> CreatorMap;
+using CreatorMap = map<IECore::InternedString, Creator>;
 CreatorMap &creators()
 {
 	static CreatorMap g_creators;

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -505,7 +505,7 @@ class Instancer::EngineData : public Data
 			}
 		}
 
-		typedef std::map< InternedString, boost::unordered_set< IECore::MurmurHash > > PrototypeHashes;
+		using PrototypeHashes = std::map<InternedString, boost::unordered_set<IECore::MurmurHash>>;
 
 		// In order to compute the number of variations, we compute a unique hash for every context we use
 		// for evaluating prototypes.  So that we can track which sources are responsible for variations,
@@ -635,7 +635,7 @@ class Instancer::EngineData : public Data
 
 	private :
 
-		typedef std::function<DataPtr ( size_t )> AttributeCreator;
+		using AttributeCreator = std::function<DataPtr ( size_t )>;
 
 		struct MakeAttributeCreator
 		{
@@ -819,7 +819,7 @@ class Instancer::EngineData : public Data
 		const std::vector<Imath::V3f> *m_scales;
 		const std::vector<float> *m_uniformScales;
 
-		typedef std::unordered_map <int, size_t> IdsToPointIndices;
+		using IdsToPointIndices = std::unordered_map <int, size_t>;
 		IdsToPointIndices m_idsToPointIndices;
 
 		boost::container::flat_map<InternedString, AttributeCreator> m_attributeCreators;
@@ -1792,8 +1792,8 @@ Imath::Box3f Instancer::computeBranchBound( const ScenePath &sourcePath, const S
 			childBound = prototypesPlug()->boundPlug()->getValue();
 		}
 
-		typedef vector<InternedString>::const_iterator Iterator;
-		typedef blocked_range<Iterator> Range;
+		using Iterator = vector<InternedString>::const_iterator;
+		using Range = blocked_range<Iterator>;
 
 		task_group_context taskGroupContext( task_group_context::isolated );
 		return parallel_reduce(

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -69,8 +69,8 @@ using namespace GafferScene;
 namespace
 {
 
-typedef set<PlugPtr> PlugSet;
-typedef std::unique_ptr<PlugSet> PlugSetPtr;
+using PlugSet = set<PlugPtr>;
+using PlugSetPtr = std::unique_ptr<PlugSet>;
 
 struct PendingUpdates
 {

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -78,7 +78,7 @@ T parameter( InternedString metadataTarget, const IECore::CompoundData *paramete
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *parameterData = parameters->member<DataType>( parameterName->readable() ) )
 	{
 		return parameterData->readable();

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -59,8 +59,8 @@ using namespace GafferScene;
 namespace
 {
 
-typedef std::pair<std::string, OutputPtr> NamedOutput;
-typedef multi_index::multi_index_container<
+using NamedOutput = std::pair<std::string, OutputPtr>;
+using OutputMap = multi_index::multi_index_container<
 	NamedOutput,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
@@ -68,7 +68,7 @@ typedef multi_index::multi_index_container<
 		>,
 		multi_index::sequenced<>
 	>
-> OutputMap;
+>;
 
 OutputMap &outputMap()
 {

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -362,8 +362,8 @@ namespace
 struct CapturedProcess
 {
 
-	typedef std::unique_ptr<CapturedProcess> Ptr;
-	typedef vector<Ptr> PtrVector;
+	using Ptr = std::unique_ptr<CapturedProcess>;
+	using PtrVector = vector<Ptr>;
 
 	InternedString type;
 	ConstPlugPtr plug;
@@ -460,11 +460,13 @@ class CapturingMonitor : public Monitor
 
 	private :
 
-		typedef tbb::spin_mutex Mutex;
+		using Mutex = tbb::spin_mutex;
 
 		Mutex m_mutex;
-		typedef boost::variant<CapturedProcess *, std::unique_ptr< Monitor::Scope > > ProcessOrScope;
-		typedef boost::unordered_map< const Process *, ProcessOrScope > ProcessMap;
+
+		using ProcessOrScope = boost::variant<CapturedProcess *, std::unique_ptr< Monitor::Scope>>;
+		using ProcessMap = boost::unordered_map<const Process *, ProcessOrScope>;
+
 		ProcessMap m_processMap;
 		CapturedProcess::PtrVector m_rootProcesses;
 		IECore::InternedString m_scenePlugChildName;
@@ -1092,7 +1094,7 @@ Imath::Box3f GafferScene::SceneAlgo::bound( const IECore::Object *object )
 namespace
 {
 
-typedef boost::container::flat_map<string, SceneAlgo::RenderAdaptor> RenderAdaptors;
+using RenderAdaptors = boost::container::flat_map<string, SceneAlgo::RenderAdaptor>;
 
 RenderAdaptors &renderAdaptors()
 {

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -56,7 +56,7 @@ using namespace IECoreScene;
 using namespace Gaffer;
 using namespace GafferScene;
 
-typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 
 GAFFER_NODE_DEFINE_TYPE( SceneReader );
 

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -88,14 +88,12 @@ std::ostream & operator<<( std::ostream &out, const Op &op )
 
 struct ExpressionAst
 {
-	typedef
-	boost::variant<
+	using type = boost::variant<
 		Nil,
 		std::string, // identifier
 		boost::recursive_wrapper<ExpressionAst>,
 		boost::recursive_wrapper<BinaryOp>
-		>
-	type;
+	>;
 
 	ExpressionAst()
 		: expr( Nil() ) {}
@@ -124,7 +122,7 @@ struct BinaryOp
 struct CreateBinaryOpImplementation
 {
 
-	typedef ExpressionAst & result_type;
+	using result_type = ExpressionAst &;
 
 	ExpressionAst & operator()( ExpressionAst &lhs, Op op, ExpressionAst &rhs ) const
 	{
@@ -145,7 +143,7 @@ boost::phoenix::function<CreateBinaryOpImplementation> createBinaryOp;
 // If one of the operands is an operation itself: op:&(A, op:|(B, C))
 struct AstPrinter
 {
-	typedef void result_type;
+	using result_type = void;
 
 	AstPrinter()
 		: stream( std::cout ) {}
@@ -193,7 +191,7 @@ std::ostream& operator<<( std::ostream& stream, const ExpressionAst& expr )
 // ------------------
 struct AstEvaluator
 {
-	typedef PathMatcher result_type;
+	using result_type = PathMatcher;
 
 	AstEvaluator( const ScenePlug *scene )
 		: m_scene( scene )
@@ -316,7 +314,7 @@ struct AstEvaluator
 // ---------------
 struct AstHasher
 {
-	typedef void result_type;
+	using result_type = void;
 
 	AstHasher( const ScenePlug *scene, IECore::MurmurHash &h ) : m_scene( scene ), m_hash( h )
 	{
@@ -472,8 +470,8 @@ void expressionToAST( const std::string &setExpression, ExpressionAst &ast)
 		return;
 	}
 
-	typedef std::string::const_iterator iterator_type;
-	typedef ExpressionGrammar<iterator_type> ExpressionGrammar;
+	using iterator_type = std::string::const_iterator;
+	using ExpressionGrammar = ExpressionGrammar<iterator_type>;
 
 	ExpressionGrammar grammar;
 

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -65,7 +65,7 @@ bool internedStringCompare( InternedString a, InternedString b )
 	return a.string() < b.string();
 }
 
-typedef std::pair<StringAlgo::MatchPattern, ConstColor3fDataPtr> Override;
+using Override = std::pair<StringAlgo::MatchPattern, ConstColor3fDataPtr>;
 std::vector<Override> unpackOverrides( const CompoundDataPlug *plug )
 {
 	std::vector<Override> overrides;

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -128,7 +128,7 @@ bool isCompoundNumericPlug( const Gaffer::Plug *plug )
 	}
 }
 
-typedef boost::unordered_set<const Shader *> ShaderSet;
+using ShaderSet = boost::unordered_set<const Shader *>;
 
 struct CycleDetector
 {
@@ -549,7 +549,7 @@ class Shader::NetworkBuilder
 			IECore::MurmurHash hash;
 		};
 
-		typedef std::map<const Shader *, HandleAndHash> ShaderMap;
+		using ShaderMap = std::map<const Shader *, HandleAndHash>;
 		ShaderMap m_shaders;
 
 		ShaderSet m_downstreamShaders; // Used for detecting cycles

--- a/src/GafferScene/Text.cpp
+++ b/src/GafferScene/Text.cpp
@@ -75,7 +75,7 @@ FontPtr fontGetter( const std::string &fileName, size_t &cost, const IECore::Can
 	return new Font( resolvedFileName );
 }
 
-typedef IECorePreview::LRUCache<std::string, FontPtr> FontCache;
+using FontCache = IECorePreview::LRUCache<std::string, FontPtr>;
 
 FontCache *fontCache()
 {

--- a/src/GafferSceneModule/CoreBinding.cpp
+++ b/src/GafferSceneModule/CoreBinding.cpp
@@ -55,7 +55,7 @@ using namespace GafferScene;
 namespace
 {
 
-// ScenePlug::ScenePath is just a typedef for std::vector<InternedString>,
+// ScenePlug::ScenePath is just an alias for `std::vector<InternedString>`,
 // which doesn't exist in Python. So we register a conversion from
 // InternedStringVectorData which contains just such a vector.
 /// \todo We could instead do this in the Cortex bindings for all
@@ -120,7 +120,7 @@ struct ScenePathFromString
 		data->convertible = storage;
 
 		std::string s = extract<std::string>( obj );
-		typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+		using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 		Tokenizer t( s, boost::char_separator<char>( "/" ) );
 		for( Tokenizer::const_iterator it = t.begin(), eIt = t.end(); it != eIt; it++ )
 		{
@@ -390,10 +390,10 @@ void GafferSceneModule::bindCore()
 	ScenePathFromInternedStringVectorData();
 	ScenePathFromString();
 
-	typedef ComputeNodeWrapper<SceneNode> SceneNodeWrapper;
+	using SceneNodeWrapper = ComputeNodeWrapper<SceneNode>;
 	GafferBindings::DependencyNodeClass<SceneNode, SceneNodeWrapper>();
 
-	typedef ComputeNodeWrapper<SceneProcessor> SceneProcessorWrapper;
+	using SceneProcessorWrapper = ComputeNodeWrapper<SceneProcessor>;
 	GafferBindings::DependencyNodeClass<SceneProcessor, SceneProcessorWrapper>()
 	.def( init<const std::string &, size_t, size_t>(
 				(

--- a/src/GafferSceneModule/IOBinding.cpp
+++ b/src/GafferSceneModule/IOBinding.cpp
@@ -74,6 +74,6 @@ void GafferSceneModule::bindIO()
 		.staticmethod( "supportedExtensions" )
 	;
 
-	typedef GafferDispatchBindings::TaskNodeWrapper<SceneWriter> SceneWriterWrapper;
+	using SceneWriterWrapper = GafferDispatchBindings::TaskNodeWrapper<SceneWriter>;
 	GafferDispatchBindings::TaskNodeClass<SceneWriter, SceneWriterWrapper>();
 }

--- a/src/GafferSceneModule/TransformBinding.cpp
+++ b/src/GafferSceneModule/TransformBinding.cpp
@@ -55,7 +55,7 @@ using namespace GafferScene;
 void GafferSceneModule::bindTransform()
 {
 
-	typedef ComputeNodeWrapper<FilteredSceneProcessor> Wrapper;
+	using Wrapper = ComputeNodeWrapper<FilteredSceneProcessor>;
 	GafferBindings::DependencyNodeClass<FilteredSceneProcessor, Wrapper>()
 		.def( init<const std::string &, IECore::PathMatcher::Result>(
 				(

--- a/src/GafferSceneUI/AttributeQueryUI.cpp
+++ b/src/GafferSceneUI/AttributeQueryUI.cpp
@@ -127,12 +127,15 @@ private:
 	Gaffer::ConstValuePlugPtr m_plug;
 };
 
-typedef boost::multi_index_container<
+using MenuItemContainer = boost::multi_index_container<
 	MenuItem,
 	boost::multi_index::indexed_by<
 		boost::multi_index::random_access<>,
 		boost::multi_index::ordered_non_unique<
-			boost::multi_index::const_mem_fun< MenuItem, const std::string&, & MenuItem::getName > > > > MenuItemContainer;
+			boost::multi_index::const_mem_fun<MenuItem, const std::string&, & MenuItem::getName>
+		>
+	>
+>;
 
 struct PlugAdder : GafferUI::PlugAdder
 {

--- a/src/GafferSceneUI/CameraVisualiser.cpp
+++ b/src/GafferSceneUI/CameraVisualiser.cpp
@@ -56,7 +56,7 @@ class CameraVisualiser : public ObjectVisualiser
 
 	public :
 
-		typedef IECoreScene::Camera ObjectType;
+		using ObjectType = IECoreScene::Camera;
 
 		CameraVisualiser()
 		{

--- a/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
+++ b/src/GafferSceneUI/ClippingPlaneVisualiser.cpp
@@ -53,7 +53,7 @@ class ClippingPlaneVisualiser : public ObjectVisualiser
 
 	public :
 
-		typedef IECoreScene::ClippingPlane ObjectType;
+		using ObjectType = IECoreScene::ClippingPlane;
 
 		ClippingPlaneVisualiser()
 		{

--- a/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
+++ b/src/GafferSceneUI/CoordinateSystemVisualiser.cpp
@@ -53,7 +53,7 @@ class CoordinateSystemVisualiser : public ObjectVisualiser
 
 	public :
 
-		typedef IECoreScene::CoordinateSystem ObjectType;
+		using ObjectType = IECoreScene::CoordinateSystem;
 
 		CoordinateSystemVisualiser()
 		{

--- a/src/GafferSceneUI/ProceduralVisualiser.cpp
+++ b/src/GafferSceneUI/ProceduralVisualiser.cpp
@@ -124,7 +124,7 @@ class ProceduralVisualiser : public BoundVisualiser
 
 	public :
 
-		typedef IECoreScenePreview::Procedural ObjectType;
+		using ObjectType = IECoreScenePreview::Procedural;
 
 	protected :
 
@@ -139,7 +139,7 @@ class ExternalProceduralVisualiser : public BoundVisualiser
 
 	public :
 
-		typedef IECoreScene::ExternalProcedural ObjectType;
+		using ObjectType = IECoreScene::ExternalProcedural;
 
 	protected :
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -75,7 +75,7 @@ SceneGadget::SceneGadget()
 		m_updateErrored( false ),
 		m_renderRequestPending( false )
 {
-	typedef CompoundObject::ObjectMap::value_type Option;
+	using Option = CompoundObject::ObjectMap::value_type;
 	CompoundObjectPtr openGLOptions = new CompoundObject;
 	openGLOptions->members().insert( {
 		Option( "gl:primitive:wireframeColor", new Color4fData( Color4f( 0.2f, 0.2f, 0.2f, 1.0f ) ) ),

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -394,8 +394,8 @@ class SceneView::ShadingMode : public Signals::Trackable
 			}
 		}
 
-		typedef std::map<std::string, SceneView::ShadingModeCreator> ShadingModeCreatorMap;
-		typedef std::map<std::string, SceneProcessorPtr> ShadingModes;
+		using ShadingModeCreatorMap = std::map<std::string, SceneView::ShadingModeCreator>;
+		using ShadingModes = std::map<std::string, SceneProcessorPtr>;
 
 		static ShadingModeCreatorMap &shadingModeCreators()
 		{

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -72,7 +72,7 @@ using namespace GafferSceneUI;
 namespace
 {
 
-typedef boost::container::flat_map<IECore::InternedString, ShaderView::RendererCreator> Renderers;
+using Renderers = boost::container::flat_map<IECore::InternedString, ShaderView::RendererCreator>;
 Renderers &renderers()
 {
 	// See comment in `sceneCreators()`.
@@ -80,8 +80,8 @@ Renderers &renderers()
 	return *r;
 }
 
-typedef std::pair<std::string, std::string> PrefixAndName;
-typedef boost::container::flat_map<PrefixAndName, ShaderView::SceneCreator> SceneCreators;
+using PrefixAndName = std::pair<std::string, std::string>;
+using SceneCreators = boost::container::flat_map<PrefixAndName, ShaderView::SceneCreator>;
 
 SceneCreators &sceneCreators()
 {
@@ -101,7 +101,7 @@ SceneRegistrationChangedSignal &sceneRegistrationChangedSignal()
 	return s;
 }
 
-typedef Gaffer::Signals::Signal<void ()> RendererRegistrationChangedSignal;
+using RendererRegistrationChangedSignal = Gaffer::Signals::Signal<void ()>;
 RendererRegistrationChangedSignal &rendererRegistrationChangedSignal()
 {
 	static RendererRegistrationChangedSignal s;

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -89,7 +89,7 @@ T parameter( InternedString metadataTarget, const IECore::CompoundData *paramete
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *parameterData = parameters->member<DataType>( parameterName->readable() ) )
 	{
 		return parameterData->readable();

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -597,14 +597,14 @@ class TextureGadget : public GafferUI::Gadget
 		ResizePtr m_resize;
 		std::string m_displayTransform;
 
-		typedef std::unordered_map<std::string, GafferImage::ImageProcessorPtr> DisplayTransformMap;
+		using DisplayTransformMap = std::unordered_map<std::string, GafferImage::ImageProcessorPtr>;
 		DisplayTransformMap m_displayTransforms;
 
 };
 
 IE_CORE_DECLAREPTR( TextureGadget )
 
-typedef FilteredChildIterator<TypePredicate<TextureGadget>> TextureGadgetIterator;
+using TextureGadgetIterator = FilteredChildIterator<TypePredicate<TextureGadget> >;
 
 } // namespace
 

--- a/src/GafferTest/FilteredRecursiveChildIteratorTest.cpp
+++ b/src/GafferTest/FilteredRecursiveChildIteratorTest.cpp
@@ -87,7 +87,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	// predicate specifies that we'll recurse over everything to find them.
 	//////////////////////////////////////////////////////////////////////////
 
-	typedef FilteredRecursiveChildIterator<PlugPredicate<>, TypePredicate<GraphComponent> > DeepRecursivePlugIterator;
+	using DeepRecursivePlugIterator = FilteredRecursiveChildIterator<PlugPredicate<>, TypePredicate<GraphComponent>>;
 	std::vector<PlugPtr> plugs;
 	for( DeepRecursivePlugIterator it( a.get() ); !it.done(); it++ )
 	{
@@ -104,7 +104,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	GAFFERTEST_ASSERT( plugs[6] == g );
 	GAFFERTEST_ASSERT( plugs[7] == h );
 
-	typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, FloatPlug>, TypePredicate<GraphComponent> > DeepRecursiveFloatPlugIterator;
+	using DeepRecursiveFloatPlugIterator = FilteredRecursiveChildIterator<PlugPredicate<Plug::Invalid, FloatPlug>, TypePredicate<GraphComponent>>;
 	plugs.clear();
 	for( DeepRecursiveFloatPlugIterator it( a.get() ); !it.done(); it++ )
 	{
@@ -116,7 +116,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	GAFFERTEST_ASSERT( plugs[1] == g );
 	GAFFERTEST_ASSERT( plugs[2] == h );
 
-	typedef FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, FloatPlug>, TypePredicate<GraphComponent> > DeepRecursiveOutputFloatPlugIterator;
+	using DeepRecursiveOutputFloatPlugIterator = FilteredRecursiveChildIterator<PlugPredicate<Plug::Out, FloatPlug>, TypePredicate<GraphComponent>>;
 	plugs.clear();
 	for( DeepRecursiveOutputFloatPlugIterator it( a.get() ); !it.done(); it++ )
 	{
@@ -131,7 +131,7 @@ void GafferTest::testFilteredRecursiveChildIterator()
 	// recursing to plugs owned by child nodes of the node we're interested in.
 	//////////////////////////////////////////////////////////////////////////
 
-	typedef FilteredRecursiveChildIterator<PlugPredicate<>, PlugPredicate<> > ShallowRecursivePlugIterator;
+	using ShallowRecursivePlugIterator = FilteredRecursiveChildIterator<PlugPredicate<>, PlugPredicate<>>;
 	plugs.clear();
 	for( ShallowRecursivePlugIterator it( a.get() ); !it.done(); it++ )
 	{

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -98,7 +98,7 @@ struct TestLRUCache
 
 	void operator()()
 	{
-		typedef LRUCache<int, int, Policy> Cache;
+		using Cache = LRUCache<int, int, Policy>;
 		Cache cache(
 			[]( int key, size_t &cost, const IECore::Canceller *canceller ) { cost = 1; return key; },
 			m_maxCost
@@ -144,7 +144,7 @@ struct TestLRUCacheRemovalCallback
 	{
 		std::vector<std::pair<int, int>> removed;
 
-		typedef LRUCache<int, int, Policy> Cache;
+		using Cache = LRUCache<int, int, Policy>;
 		Cache cache(
 			// Getter
 			[]( int key, size_t &cost, const IECore::Canceller *canceller ) {
@@ -214,7 +214,7 @@ struct TestLRUCacheContentionForOneItem
 
 	void operator()()
 	{
-		typedef LRUCache<int, int, Policy> Cache;
+		using Cache = LRUCache<int, int, Policy>;
 		Cache cache(
 			[]( int key, size_t &cost, const IECore::Canceller *canceller ) { cost = 1; return key; },
 			100
@@ -256,8 +256,8 @@ struct TestLRUCacheRecursion
 
 	void operator()()
 	{
-		typedef LRUCache<int, int, Policy> Cache;
-		typedef std::unique_ptr<Cache> CachePtr;
+		using Cache = LRUCache<int, int, Policy>;
+		using CachePtr = std::unique_ptr<Cache>;
 
 		CachePtr cache;
 		cache.reset(
@@ -314,8 +314,8 @@ struct TestLRUCacheRecursionOnOneItem
 
 	void operator()()
 	{
-		typedef LRUCache<int, int, Policy> Cache;
-		typedef std::unique_ptr<Cache> CachePtr;
+		using Cache = LRUCache<int, int, Policy>;
+		using CachePtr = std::unique_ptr<Cache>;
 		int recursionDepth = 0;
 
 		CachePtr cache;
@@ -361,8 +361,8 @@ struct TestLRUCacheClearFromGet
 
 	void operator()()
 	{
-		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
-		typedef std::unique_ptr<Cache> CachePtr;
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
+		using CachePtr = std::unique_ptr<Cache>;
 
 		CachePtr cache;
 		cache.reset(
@@ -394,7 +394,7 @@ struct TestLRUCacheExceptions
 	{
 		std::vector<int> calls;
 
-		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
 		Cache cache(
 			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
@@ -556,7 +556,7 @@ struct TestLRUCacheCancellation
 
 		IECore::Canceller canceller;
 
-		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
 		Cache cache(
 			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
@@ -628,7 +628,7 @@ struct TestLRUCacheCancellationOfSecondGet
 
 		std::atomic_int getterCount; getterCount = 0;
 
-		typedef IECorePreview::LRUCache<int, int, Policy> Cache;
+		using Cache = IECorePreview::LRUCache<int, int, Policy>;
 		Cache cache(
 			[&getterCount]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				getterCount++;

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -314,18 +314,18 @@ private:
 
 	struct MemberCompare
 	{
-		typedef bool result_type;
+		using result_type = bool;
 		bool operator()( const Gaffer::Set::Member* const lhs, const Gaffer::Animation::KeyPtr& rhs ) const { return lhs < rhs.get(); }
 		bool operator()( const Gaffer::Animation::KeyPtr& lhs, const Gaffer::Set::Member* const rhs ) const { return lhs.get() < rhs; }
 	};
 
-	typedef boost::multi_index::multi_index_container<
+	using KeyContainer = boost::multi_index::multi_index_container<
 		Gaffer::Animation::KeyPtr,
 		boost::multi_index::indexed_by<
 			boost::multi_index::ordered_unique< boost::multi_index::identity< Gaffer::Animation::KeyPtr > >,
 			boost::multi_index::random_access<>
 		>
-	> KeyContainer;
+	>;
 
 	struct ConnectionData
 	{
@@ -334,9 +334,9 @@ private:
 		unsigned int m_count;
 	};
 
-	typedef std::map<
+	using CurveConnectionMap = std::map<
 		const Gaffer::Animation::CurvePlug*, ConnectionData
-	> CurveConnectionMap;
+	>;
 
 	KeyContainer m_keys;
 	CurveConnectionMap m_connections;

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -145,7 +145,7 @@ ImageGadget::ImageGadget( const std::string &fileName )
 	// we'll load the actual texture later when we're sure a GL context exists,
 	// but we need to find the bounding box now so that bound() will always be correct.
 
-	typedef IECorePreview::LRUCache<std::string, Box3f> ImageBoundCache;
+	using ImageBoundCache = IECorePreview::LRUCache<std::string, Box3f>;
 	static ImageBoundCache g_imageBoundCache( boundGetter, 10000 );
 	m_bound = g_imageBoundCache.get( fileName );
 

--- a/src/GafferUI/NodeGadget.cpp
+++ b/src/GafferUI/NodeGadget.cpp
@@ -62,7 +62,7 @@ using namespace boost;
 namespace
 {
 
-typedef std::map<std::string, NodeGadget::NodeGadgetCreator> TypeCreatorMap;
+using TypeCreatorMap = std::map<std::string, NodeGadget::NodeGadgetCreator>;
 TypeCreatorMap &typeCreators()
 {
 	// We tactically "leak" this map. NodeGadgetCreators are
@@ -73,7 +73,7 @@ TypeCreatorMap &typeCreators()
 	return *c;
 }
 
-typedef std::map<IECore::TypeId, NodeGadget::NodeGadgetCreator> NodeCreatorMap;
+using NodeCreatorMap = std::map<IECore::TypeId, NodeGadget::NodeGadgetCreator>;
 NodeCreatorMap &nodeCreators()
 {
 	// See `typeCreators()` for note on "leak".

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -96,7 +96,7 @@ IECore::InternedString g_compoundNoduleDirectionKey( "compoundNodule:direction" 
 
 // Custom gadget factory
 
-typedef map<string, NoduleLayout::CustomGadgetCreator> CustomGadgetCreatorMap;
+using CustomGadgetCreatorMap = map<string, NoduleLayout::CustomGadgetCreator>;
 CustomGadgetCreatorMap &customGadgetCreators()
 {
 	static CustomGadgetCreatorMap m;
@@ -145,7 +145,7 @@ bool visible( const GraphComponent *parent, const InternedString &gadgetName, IE
 
 // Plug metadata accessors. These affect the layout of individual nodules.
 
-typedef boost::variant<const Gaffer::Plug *, IECore::InternedString> GadgetKey;
+using GadgetKey = boost::variant<const Gaffer::Plug *, IECore::InternedString>;
 
 int layoutIndex( const Plug *plug, int defaultValue )
 {
@@ -552,7 +552,7 @@ void NoduleLayout::nodeMetadataChanged( const Gaffer::Node *node, IECore::Intern
 
 std::vector<NoduleLayout::GadgetKey> NoduleLayout::layoutOrder()
 {
-	typedef pair<int, GadgetKey> SortItem;
+	using SortItem = pair<int, GadgetKey>;
 	vector<SortItem> toSort;
 
 	// Add any plugs which should be visible

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -42,7 +42,7 @@ using namespace GafferUI;
 
 static ConstPointerPtr g_current;
 
-typedef std::map<std::string, ConstPointerPtr> Registry;
+using Registry = std::map<std::string, ConstPointerPtr>;
 static Registry &registry()
 {
 	static Registry r;

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -671,7 +671,7 @@ class LayoutEngine
 		// or on one of the two 45 degree diagonals. We represent such
 		// directions as integer vectors, where the x and y coordinates may
 		// only have values of -1, 0 or +1.
-		typedef V2s Direction;
+		using Direction = V2s;
 
 		Direction direction( const V3f &v )
 		{
@@ -719,24 +719,24 @@ class LayoutEngine
 			Direction idealDirection;
 		};
 
-		typedef boost::adjacency_list<boost::listS, boost::listS, boost::bidirectionalS, Vertex, Edge> Graph;
+		using Graph = boost::adjacency_list<boost::listS, boost::listS, boost::bidirectionalS, Vertex, Edge>;
 
-		typedef Graph::vertex_descriptor VertexDescriptor;
-		typedef Graph::edge_descriptor EdgeDescriptor;
+		using VertexDescriptor = Graph::vertex_descriptor;
+		using EdgeDescriptor = Graph::edge_descriptor;
 
-		typedef Graph::vertex_iterator VertexIterator;
-		typedef std::pair<VertexIterator, VertexIterator> VertexIteratorRange;
+		using VertexIterator = Graph::vertex_iterator;
+		using VertexIteratorRange = std::pair<VertexIterator, VertexIterator>;
 
-		typedef Graph::in_edge_iterator InEdgeIterator;
-		typedef std::pair<InEdgeIterator, InEdgeIterator> InEdgeIteratorRange;
+		using InEdgeIterator = Graph::in_edge_iterator;
+		using InEdgeIteratorRange = std::pair<InEdgeIterator, InEdgeIterator>;
 
-		typedef Graph::out_edge_iterator OutEdgeIterator;
-		typedef std::pair<OutEdgeIterator, OutEdgeIterator> OutEdgeIteratorRange;
+		using OutEdgeIterator = Graph::out_edge_iterator;
+		using OutEdgeIteratorRange = std::pair<OutEdgeIterator, OutEdgeIterator>;
 
-		typedef Graph::edge_iterator EdgeIterator;
-		typedef std::pair<EdgeIterator, EdgeIterator> EdgeIteratorRange;
+		using EdgeIterator = Graph::edge_iterator;
+		using EdgeIteratorRange = std::pair<EdgeIterator, EdgeIterator>;
 
-		typedef std::map<const Node *, VertexDescriptor> NodesToVertices;
+		using NodesToVertices = std::map<const Node *, VertexDescriptor>;
 
 		void addSiblingConstraints( VertexDescriptor vertex, const Direction &edgeDirection )
 		{
@@ -841,7 +841,7 @@ class LayoutEngine
 
 			// find colliding bounds, and add constraints to separate them
 
-			typedef vector<Box2f>::const_iterator BoundIterator;
+			using BoundIterator = vector<Box2f>::const_iterator;
 			vector<BoundIterator> intersectingBounds;
 			for( BoundIterator it = bounds.begin(), eIt = bounds.end(); it != eIt; ++it )
 			{

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -440,7 +440,7 @@ class StandardNodeGadget::ErrorGadget : public Gadget
 			Signals::ScopedConnection parentChangedConnection;
 		};
 
-		typedef std::map<ConstPlugPtr, PlugEntry> PlugErrors;
+		using PlugErrors = std::map<ConstPlugPtr, PlugEntry>;
 		PlugErrors m_errors;
 
 };

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -653,7 +653,7 @@ void StandardStyle::renderWrappedText( TextType textType, const std::string &tex
 
 	V2f cursor( bound.min.x, bound.max.y - coreFont->bound().size().y );
 
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 	boost::char_separator<char> separator( "", " \n\t" );
 	Tokenizer tokenizer( text, separator );
 	Tokenizer::iterator it = tokenizer.begin();

--- a/src/GafferUI/Tool.cpp
+++ b/src/GafferUI/Tool.cpp
@@ -85,8 +85,8 @@ const View *Tool::view() const
 namespace
 {
 
-typedef std::map<std::string, Tool::ToolCreator> NamedCreators;
-typedef std::map<IECore::TypeId, NamedCreators> PerViewCreators;
+using NamedCreators = std::map<std::string, Tool::ToolCreator>;
+using PerViewCreators = std::map<IECore::TypeId, NamedCreators>;
 
 NamedCreators &namedCreators( IECore::TypeId viewType )
 {

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -171,7 +171,7 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS( fullTransformOverloads, fullTransform, 0
 
 void GafferUIModule::bindGadget()
 {
-	typedef GadgetWrapper<Gadget> Wrapper;
+	using Wrapper = GadgetWrapper<Gadget>;
 
 	scope s = GadgetClass<Gadget, Wrapper>()
 		.def( init<>() )

--- a/src/GafferUIModule/NodeGadgetBinding.cpp
+++ b/src/GafferUIModule/NodeGadgetBinding.cpp
@@ -170,7 +170,7 @@ list framed( BackdropNodeGadget &b )
 
 void GafferUIModule::bindNodeGadget()
 {
-	typedef NodeGadgetWrapper<NodeGadget> Wrapper;
+	using Wrapper = NodeGadgetWrapper<NodeGadget>;
 
 	NodeGadgetClass<NodeGadget, Wrapper>()
 		.def( "node", (Gaffer::Node *(NodeGadget::*)())&NodeGadget::node, return_value_policy<CastToIntrusivePtr>() )

--- a/src/GafferVDB/PointsGridToPoints.cpp
+++ b/src/GafferVDB/PointsGridToPoints.cpp
@@ -150,7 +150,7 @@ void convert(Imath::Quatd& dest, const openvdb::math::Quatd& src)
 	dest = Imath::Quatd( src[3], src[0], src[1], src[2]);
 }
 
-typedef openvdb::points::PointDataGrid::TreeType::LeafCIter LeafIter;
+using LeafIter = openvdb::points::PointDataGrid::TreeType::LeafCIter;
 
 template<typename CortexType, typename VDBType, template <typename P> class StorageType = IECore::TypedData>
 void appendData(IECore::Data *destArray, const openvdb::points::AttributeArray& array, LeafIter leafIter)
@@ -179,14 +179,8 @@ IECore::DataPtr createArray( size_t size )
 
 struct Functions
 {
-	typedef std::function<IECore::DataPtr(size_t size)> CreateFn;
-	typedef std::function<
-		void (
-			IECore::Data *,
-			const openvdb::points::AttributeArray&,
-			LeafIter
-		)
-	> AppendFn;
+	using CreateFn = std::function<IECore::DataPtr ( size_t )>;
+	using AppendFn = std::function<void ( IECore::Data *, const openvdb::points::AttributeArray &, LeafIter )>;
 
 	Functions( CreateFn create , AppendFn append ) : m_create(create), m_append(append) {}
 

--- a/src/GafferVDBUI/VDBVisualiser.cpp
+++ b/src/GafferVDBUI/VDBVisualiser.cpp
@@ -274,7 +274,7 @@ class VDBVisualiser : public ObjectVisualiser
 
 	public :
 
-		typedef VDBObject ObjectType;
+		using ObjectType = VDBObject;
 
 		VDBVisualiser()
 		{

--- a/src/IECoreArnold/NodeAlgo.cpp
+++ b/src/IECoreArnold/NodeAlgo.cpp
@@ -58,7 +58,7 @@ struct Converters
 
 };
 
-typedef boost::unordered_map<IECore::TypeId, Converters> Registry;
+using Registry = boost::unordered_map<IECore::TypeId, Converters>;
 
 Registry &registry()
 {

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -220,8 +220,8 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 template<typename T, typename F>
 IECore::DataPtr arrayToDataInternal( AtArray *array, F f )
 {
-	typedef vector<T> VectorType;
-	typedef IECore::TypedData<vector<T> > DataType;
+	using VectorType = vector<T>;
+	using DataType = IECore::TypedData<vector<T> >;
 	typename DataType::Ptr data = new DataType;
 	VectorType &v = data->writable();
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -100,8 +100,8 @@ using namespace IECoreArnold;
 namespace
 {
 
-typedef std::shared_ptr<AtNode> SharedAtNodePtr;
-typedef bool (*NodeDeleter)( AtNode *);
+using SharedAtNodePtr = std::shared_ptr<AtNode>;
+using NodeDeleter = bool (*)( AtNode * );
 
 bool nullNodeDeleter( AtNode *node )
 {
@@ -149,7 +149,7 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *d = reportedCast<const DataType>( it->second.get(), "parameter", name ) )
 	{
 		return d->readable();
@@ -768,7 +768,7 @@ class ShaderCache : public IECore::RefCounted
 		AtUniverse *m_universe;
 		AtNode *m_parentNode;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, ArnoldShaderPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, ArnoldShaderPtr>;
 		Cache m_cache;
 };
 
@@ -1640,7 +1640,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		template<typename T>
 		static T attributeValue( const IECore::InternedString &name, const IECore::CompoundObject *attributes, const T &defaultValue )
 		{
-			typedef IECore::TypedData<T> DataType;
+			using DataType = IECore::TypedData<T>;
 			const DataType *data = attribute<DataType>( name, attributes );
 			return data ? data->readable() : defaultValue;
 		}
@@ -1648,7 +1648,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		template<typename T>
 		static std::optional<T> optionalAttribute( const IECore::InternedString &name, const IECore::CompoundObject *attributes )
 		{
-			typedef IECore::TypedData<T> DataType;
+			using DataType = IECore::TypedData<T>;
 			const DataType *data = attribute<DataType>( name, attributes );
 			return data ? data->readable() : std::optional<T>();
 		}
@@ -2059,7 +2059,7 @@ class InstanceCache : public IECore::RefCounted
 		AtUniverse *m_universe;
 		AtNode *m_parentNode;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, SharedAtNodePtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, SharedAtNodePtr>;
 		Cache m_cache;
 
 };
@@ -2776,7 +2776,7 @@ class ProceduralRenderer final : public ArnoldRendererBase
 
 		IECore::ConstCompoundObjectPtr m_attributesToInherit;
 
-		typedef tbb::spin_mutex NodesCreatedMutex;
+		using NodesCreatedMutex = tbb::spin_mutex;
 		NodesCreatedMutex m_nodesCreatedMutex;
 		vector<AtNode *> m_nodesCreated;
 
@@ -3971,11 +3971,11 @@ class ArnoldGlobals
 		IECore::MessageHandlerPtr m_messageHandler;
 		std::optional<unsigned> m_messageCallbackId;
 
-		typedef std::map<IECore::InternedString, ArnoldOutputPtr> OutputMap;
+		using OutputMap = std::map<IECore::InternedString, ArnoldOutputPtr>;
 		OutputMap m_outputs;
 		int m_interactiveOutput; // Negative if not yet set.
 
-		typedef std::map<IECore::InternedString, ArnoldShaderPtr> AOVShaderMap;
+		using AOVShaderMap = std::map<IECore::InternedString, ArnoldShaderPtr>;
 		AOVShaderMap m_aovShaders;
 
 		ArnoldShaderPtr m_colorManager;
@@ -3984,7 +3984,7 @@ class ArnoldGlobals
 		ArnoldShaderPtr m_imager;
 
 		std::string m_cameraName;
-		typedef tbb::concurrent_unordered_map<std::string, IECoreScene::ConstCameraPtr> CameraMap;
+		using CameraMap = tbb::concurrent_unordered_map<std::string, IECoreScene::ConstCameraPtr>;
 		CameraMap m_cameras;
 		SharedAtNodePtr m_defaultCamera;
 		std::string m_subdivDicingCameraName;

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -72,10 +72,10 @@ const AtString g_nameArnoldString( "name" );
 template<typename Spline>
 void setSplineParameter( AtNode *node, const std::string &name, const Spline &spline )
 {
-	typedef vector<typename Spline::XType> PositionsVector;
-	typedef vector<typename Spline::YType> ValuesVector;
-	typedef TypedData<PositionsVector> PositionsData;
-	typedef TypedData<ValuesVector> ValuesData;
+	using PositionsVector = vector<typename Spline::XType>;
+	using ValuesVector = vector<typename Spline::YType>;
+	using PositionsData = TypedData<PositionsVector>;
+	using ValuesData = TypedData<ValuesVector>;
 
 	typename PositionsData::Ptr positionsData = new PositionsData;
 	typename ValuesData::Ptr valuesData = new ValuesData;
@@ -112,7 +112,7 @@ void setSplineParameter( AtNode *node, const std::string &name, const Spline &sp
 	AiNodeSetStr( node, AtString( ( name + "Basis" ).c_str() ), basis );
 }
 
-typedef boost::unordered_map<ShaderNetwork::Parameter, AtNode *> ShaderMap;
+using ShaderMap = boost::unordered_map<ShaderNetwork::Parameter, AtNode *>;
 
 // Equivalent to Python's `s.partition( c )[0]`.
 InternedString partitionStart( const InternedString &s, char c )

--- a/src/IECoreArnold/UniverseBlock.cpp
+++ b/src/IECoreArnold/UniverseBlock.cpp
@@ -60,7 +60,7 @@ namespace
 
 void loadMetadata( const std::string &pluginPaths )
 {
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
 	#ifdef _WIN32
 		const char *separator = ";";
 	#else

--- a/src/IECoreArnold/VDBAlgo.cpp
+++ b/src/IECoreArnold/VDBAlgo.cpp
@@ -69,8 +69,8 @@ AtString g_volume("volume");
 ///! utility to allow us to stream directly into a UCharVectorData
 struct UCharVectorDataSink
 {
-	typedef char char_type;
-	typedef boost::iostreams::sink_tag category;
+	using char_type = char;
+	using category = boost::iostreams::sink_tag;
 
 	UCharVectorDataSink( IECore::UCharVectorData *storage ) : m_storage( storage->writable() )
 	{


### PR DESCRIPTION
This was done with a combination of `clang-tidy modernize-use-using` and manual work where Clang got confused.

Whether we use `typedef` or `using` isn't particularly important in the grand scheme of things, but it is nice to be consistent, and `using` is the more modern and more flexible of the two. I'm subscribing to the idea that inside C++ is a smaller, better language trying to get out...
