### PR TITLE
ShaderNetworkAlgo : check that the user var does not exist before declare

### DIFF
--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -333,6 +333,15 @@ void resetNode( AtNode *node )
 		AiNodeResetParameter( node, name );
 	}
 	AiParamIteratorDestroy( it );
+
+	AtUserParamIterator *itUser = AiNodeGetUserParamIterator( node );
+	while ( !AiUserParamIteratorFinished( itUser ) )
+	{
+		const AtUserParamEntry *param = AiUserParamIteratorGetNext( itUser );
+		const char *name = AiUserParamGetName( param );
+		AiNodeResetParameter( node, name );
+	}
+	AiUserParamIteratorDestroy( itUser );
 }
 
 } // namespace


### PR DESCRIPTION
This adds a check before declaring user parameter in `ShaderNetworkAlgo::convertWalk`

PS : wanted to use `IECoreArnold::ParameterAlgo::setParameter` but this requires to create an `IECore::Data *`

### Related issues ###

- Arnold warning during IPR when scene is updated when light shaders has input with specific names e.g. `tex` and `out`.
`WARNING | cannot declare constant STRING output on light:/quadLight:OSLCode:tex - name already in use`
`WARNING | cannot declare constant STRING output on light:/quadLight:OSLCode:out - name already in use`

### Steps to reproduce ###

- Copy paste [gist ](https://gist.github.com/ppipelin/7268f50a810295aa0febdc4a9be44545) in Gaffer (plane + cam + quad_light which `Color` is set by an OSLCode with output `tex`)
- Launch interactive render
- Edit a parameter of `quad_light`'s node (`parameters.exposure` 5 --> 5.1)
- Can also be done by using an OSLCode output named `out` instead of `tex`


### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
