### PR TITLE
SConstruct : Remove procedural class stub

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1232,16 +1232,6 @@ libraries = {
 
 	},
 
-	"IECoreScene" : {
-
-		"classStubs" : [
-
-			( "ReadProcedural", "procedurals/read" ),
-
-		],
-
-	},
-
 }
 
 # Add on OpenGL libraries to definitions - these vary from platform to platform


### PR DESCRIPTION
This has been unnecessary ever since we removed `GafferCortex::ProceduralHolder` in `0.42.0.0`.
