### PR TITLE
StandardNodeGadget : Toggle focus on release, not press

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x (relative to 0.61.3.0)
+========
+
+Improvements
+------------
+
+- GraphEditor : The focus gadget is now toggled when the button is released rather than when it is pressed. This helps avoid accidental toggling when performing marquee selection.
+
 0.61.3.0 (relative to 0.61.2.0)
 ========
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -117,6 +117,7 @@ class FocusGadget : public Gadget
 				m_mouseOver( false )
 		{
 			buttonPressSignal().connect( boost::bind( &FocusGadget::buttonPressed, this, ::_1,  ::_2 ) );
+			buttonReleaseSignal().connect( boost::bind( &FocusGadget::buttonRelease, this, ::_1,  ::_2 ) );
 			enterSignal().connect( boost::bind( &FocusGadget::mouseEntered, this, ::_1,  ::_2 ) );
 			leaveSignal().connect( boost::bind( &FocusGadget::mouseLeft, this, ::_1,  ::_2 ) );
 			buttonDoubleClickSignal().connect( boost::bind( &FocusGadget::buttonDoubleClick, this, ::_1,  ::_2 ) );
@@ -174,7 +175,12 @@ class FocusGadget : public Gadget
 
 		bool buttonPressed( GadgetPtr gadget, const ButtonEvent &event )
 		{
-			if( event.buttons==ButtonEvent::Left )
+			return true;
+		}
+
+		bool buttonRelease( GadgetPtr gadget, const ButtonEvent &event )
+		{
+			if( m_mouseOver && event.button == ButtonEvent::Left )
 			{
 				toggleFocus();
 			}


### PR DESCRIPTION
This follows the behaviour of a regular Qt button, and makes it much harder to accidentally toggle focus when intending to perform a marquee selection.

@murrays-ie, might be worth taking this for a spin to check it works as hoped.