### PR TITLE
Signals : Rationalise exception handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,17 @@ API
 - Signals :
   - Added a new Signals namespace with Signal, Connection, ScopedConnection and Trackable classes. This provides significant performance and memory usage improvements over the old `boost::signals` library.
   - Removed usage of `boost::signals::detail::unusable` as a substitute for the `void` return type in the Signal bindings. Custom SlotCallers may now use a standard `void` return type.
+  - The following signals now use a `CatchingCombiner` so that exceptions in one slot will not interfere with calls to other slots :
+    - ApplicationRoot : ClipboardSignal.
+    - GraphComponent : UnarySignal and BinarySignal.
+    - Gadget : VisibilityChangedSignal, EnterLeaveSignal and IdleSignal.
+    - Node : UnaryPlugSignal, BinaryPlugSignal.
+    - ScriptNode : ActionSignal, UndoAddedSignal.
+    - ViewportGadget : UnarySignal.
+  - The following signals now handle exceptions thrown from C++ slots as well as Python slots :
+    - Gadget : ButtonSignal, DragBeginSignal, DragDropSignal, KeySignal.
+  - The following signals no longer suppress exceptions thrown from Python slots :
+    - StandardSet : MemberAcceptanceSignal.
 - Monitor : Subclasses may now override `mightForceMonitoring` and `forceMonitoring` in order to ensure the monitored processes always run, instead of being skipped when they are cached
 - ValuePlug : Added `hashCacheTotalUsage()` function.
 
@@ -28,6 +39,7 @@ Breaking Changes
   - Remove the `Gaffer/CatchingSignalCombiner.h` header file. CatchingSignalCombiner can now be found as `Signals::CatchingCombiner` in `Gaffer/Signals.h`.
   - Moved all Python classes into the `Gaffer.Signals` submodule.
   - Deprecated the default value for the `scoped` argument to `Signal.connect()`. Pass `scoped = True` to maintain the previous behaviour, or consider using an unscoped connection.
+- ViewportGadget : Removed `RenderRequestSignal` type. Use the identical `UnarySignal` instead.
 - Replaced all usage of `boost::optional` with `std::optional`.
 - Random : Renamed `contextEntry` plug to `seedVariable`. Old `.gfr` files will be converted automatically on loading.
 - SceneAlgo : Removed `historyIDContextName()` function. `history()` no longer uses an ID in the context to ensure fresh evaluations, it instead uses `Monitor::forceMonitoring()` to temporarily disable caching.

--- a/include/Gaffer/ApplicationRoot.h
+++ b/include/Gaffer/ApplicationRoot.h
@@ -80,7 +80,7 @@ class GAFFER_API ApplicationRoot : public GraphComponent
 		/// Sets the clipboard contents - a copy of clip is taken.
 		void setClipboardContents( const IECore::Object *clip );
 		/// A signal emitted when the clipboard contents have changed.
-		using ClipboardSignal = Signals::Signal<void (ApplicationRoot *)>;
+		using ClipboardSignal = Signals::Signal<void (ApplicationRoot *), Signals::CatchingCombiner<void>>;
 		ClipboardSignal &clipboardContentsChangedSignal();
 		//@}
 

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -87,8 +87,8 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public Signals::T
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::GraphComponent, GraphComponentTypeId, IECore::RunTimeTyped );
 
-		using UnarySignal = Signals::Signal<void (GraphComponent *)>;
-		using BinarySignal = Signals::Signal<void (GraphComponent *, GraphComponent *)>;
+		using UnarySignal = Signals::Signal<void (GraphComponent *), Signals::CatchingCombiner<void>>;
+		using BinarySignal = Signals::Signal<void (GraphComponent *, GraphComponent *), Signals::CatchingCombiner<void>>;
 		using ChildrenReorderedSignal = Signals::Signal<void (GraphComponent *, const std::vector<size_t> &originalIndices ), Signals::CatchingCombiner<void>>;
 
 		/// @name Naming

--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -74,8 +74,8 @@ class GAFFER_API Node : public GraphComponent
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Node, NodeTypeId, GraphComponent );
 
-		using UnaryPlugSignal = Signals::Signal<void (Plug *)>;
-		using BinaryPlugSignal = Signals::Signal<void (Plug *, Plug *)>;
+		using UnaryPlugSignal = Signals::Signal<void (Plug *), Signals::CatchingCombiner<void>>;
+		using BinaryPlugSignal = Signals::Signal<void (Plug *, Plug *), Signals::CatchingCombiner<void>>;
 
 		/// @name Plug signals
 		/// These signals are emitted on events relating to child Plugs

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -129,8 +129,8 @@ class GAFFER_API ScriptNode : public Node
 		/// be active while those operations are being performed.
 		////////////////////////////////////////////////////////////////////
 		//@{
-		using ActionSignal = Signals::Signal<void ( ScriptNode *, const Action *, Action::Stage stage )>;
-		using UndoAddedSignal = Signals::Signal<void ( ScriptNode * )> ;
+		using ActionSignal = Signals::Signal<void ( ScriptNode *, const Action *, Action::Stage stage ), Signals::CatchingCombiner<void>>;
+		using UndoAddedSignal = Signals::Signal<void ( ScriptNode * ), Signals::CatchingCombiner<void>>;
 		bool undoAvailable() const;
 		void undo();
 		bool redoAvailable() const;

--- a/include/GafferBindings/SignalBinding.inl
+++ b/include/GafferBindings/SignalBinding.inl
@@ -163,13 +163,20 @@ struct DefaultSlotCaller<Gaffer::Signals::Signal<Result( Args... ), Combiner>>
 
 	Result operator()( boost::python::object slot, Args&&... args )
 	{
-		if constexpr( std::is_void_v<Result> )
+		try
 		{
-			slot( std::forward<Args>( args )... );
+			if constexpr( std::is_void_v<Result> )
+			{
+				slot( std::forward<Args>( args )... );
+			}
+			else
+			{
+				return boost::python::extract<Result>( slot( std::forward<Args>( args )... ) )();
+			}
 		}
-		else
+		catch( const boost::python::error_already_set &e )
 		{
-			return boost::python::extract<Result>( slot( std::forward<Args>( args )... ) )();
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 

--- a/include/GafferUI/EventSignalCombiner.inl
+++ b/include/GafferUI/EventSignalCombiner.inl
@@ -37,6 +37,8 @@
 #ifndef GAFFERUI_EVENTSIGNALCOMBINER_INL
 #define GAFFERUI_EVENTSIGNALCOMBINER_INL
 
+#include "IECore/MessageHandler.h"
+
 namespace GafferUI
 {
 
@@ -46,12 +48,23 @@ typename EventSignalCombiner<T>::result_type EventSignalCombiner<T>::operator()(
 {
 	while( first != last )
 	{
-		result_type r = *first;
-		if( r )
+		try
 		{
-			return r;
+			result_type r = *first;
+			if( r )
+			{
+				return r;
+			}
 		}
-		first++;
+		catch( const std::exception &e )
+		{
+			IECore::msg( IECore::Msg::Error, "EventSignalCombiner", e.what() );
+		}
+		catch( ... )
+		{
+			IECore::msg( IECore::Msg::Error, "EventSignalCombiner", "Unknown error" );
+		}
+		++first;
 	}
 	return 0;
 };

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -137,7 +137,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// Returns true if this Gadget and all its parents up to the specified
 		/// ancestor are visible.
 		bool visible( Gadget *relativeTo = nullptr ) const;
-		using VisibilityChangedSignal = Gaffer::Signals::Signal<void ( Gadget * )>;
+		using VisibilityChangedSignal = Gaffer::Signals::Signal<void ( Gadget * ), Gaffer::Signals::CatchingCombiner<void>>;
 		/// Emitted when the result of `Gadget::visible()` changes.
 		VisibilityChangedSignal &visibilityChangedSignal();
 		/// Sets whether or not this Gadget is enabled. Disabled gadgets
@@ -219,7 +219,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// The signal triggered by the mouse wheel.
 		ButtonSignal &wheelSignal();
 
-		using EnterLeaveSignal = Gaffer::Signals::Signal<void ( Gadget *, const ButtonEvent &event )>;
+		using EnterLeaveSignal = Gaffer::Signals::Signal<void ( Gadget *, const ButtonEvent &event ), Gaffer::Signals::CatchingCombiner<void>>;
 		/// The signal triggered when the mouse enters the Gadget.
 		EnterLeaveSignal &enterSignal();
 		/// The signal triggered when the mouse leaves the Gadget.
@@ -260,7 +260,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		/// A signal emitted when the host event loop is idle. Connections
 		/// to this should be limited in duration because idle events consume
 		/// CPU when the program would otherwise be inactive.
-		using IdleSignal = Gaffer::Signals::Signal<void ()>;
+		using IdleSignal = Gaffer::Signals::Signal<void (), Gaffer::Signals::CatchingCombiner<void>>;
 		static IdleSignal &idleSignal();
 		//@}
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -60,7 +60,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 
 	public :
 
-		using UnarySignal = Gaffer::Signals::Signal<void (ViewportGadget *)>;
+		using UnarySignal = Gaffer::Signals::Signal<void (ViewportGadget *), Gaffer::Signals::CatchingCombiner<void>>;
 
 		ViewportGadget( GadgetPtr primaryChild = nullptr );
 		~ViewportGadget() override;
@@ -243,8 +243,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// the viewport or its children.
 		UnarySignal &preRenderSignal();
 
-		using RenderRequestSignal = Gaffer::Signals::Signal<void ( ViewportGadget * )>;
-		RenderRequestSignal &renderRequestSignal();
+		UnarySignal &renderRequestSignal();
 
 	private :
 
@@ -339,7 +338,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		UnarySignal m_viewportChangedSignal;
 		UnarySignal m_cameraChangedSignal;
 		UnarySignal m_preRenderSignal;
-		RenderRequestSignal m_renderRequestSignal;
+		UnarySignal m_renderRequestSignal;
 
 };
 

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -274,6 +274,7 @@ class SceneViewTest( GafferUITest.TestCase ) :
 
 		# Work around "Internal C++ object (PySide.QtWidgets.QWidget) already deleted" error. In an
 		# ideal world we'll fix this, but it's unrelated to what we're testing here.
+		viewer.setNodeSet( Gaffer.StandardSet() )
 		window.removeChild( viewer )
 
 	def testFrame( self ) :

--- a/python/GafferTest/SignalsTest.py
+++ b/python/GafferTest/SignalsTest.py
@@ -37,9 +37,6 @@
 
 import unittest
 import weakref
-import sys
-import six
-import gc
 import functools
 import imath
 
@@ -223,18 +220,16 @@ class SignalsTest( GafferTest.TestCase ) :
 		t = T( s )
 		w = weakref.ref( t )
 
-		realStdErr = sys.stderr
-		sio = six.moves.cStringIO()
-		try :
-			sys.stderr = sio
+		with IECore.CapturingMessageHandler() as mh :
 			s.addChild( Gaffer.Node() )
-		finally :
-			sys.stderr = realStdErr
 
 		del t
 
 		self.assertIsNone( w(), None )
-		self.assertIn( "Exception", sio.getvalue() )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "Emitting signal", IECore.Msg.Level.Error )
+		self.assertIn( "Exception", mh.messages[0].message )
 
 	def test0Arity( self ) :
 

--- a/src/GafferModule/ApplicationRootBinding.cpp
+++ b/src/GafferModule/ApplicationRootBinding.cpp
@@ -122,7 +122,7 @@ struct ClipboardSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };

--- a/src/GafferModule/ContextBinding.cpp
+++ b/src/GafferModule/ContextBinding.cpp
@@ -43,6 +43,7 @@
 
 #include "Gaffer/Context.h"
 
+#include "IECorePython/ExceptionAlgo.h"
 #include "IECorePython/RefCountedBinding.h"
 
 using namespace boost::python;
@@ -138,7 +139,7 @@ struct ChangedSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -263,7 +263,7 @@ struct UnarySlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -279,7 +279,7 @@ struct BinarySlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };

--- a/src/GafferModule/NodeBinding.cpp
+++ b/src/GafferModule/NodeBinding.cpp
@@ -68,7 +68,7 @@ struct UnaryPlugSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -84,7 +84,7 @@ struct BinaryPlugSlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -496,7 +496,7 @@ struct ActionSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 
@@ -513,7 +513,7 @@ struct UndoAddedSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 

--- a/src/GafferModule/SetBinding.cpp
+++ b/src/GafferModule/SetBinding.cpp
@@ -152,7 +152,7 @@ struct MemberAcceptanceSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 		return false;
 	}

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1163,7 +1163,7 @@ ViewportGadget::UnarySignal &ViewportGadget::preRenderSignal()
 	return m_preRenderSignal;
 }
 
-ViewportGadget::RenderRequestSignal &ViewportGadget::renderRequestSignal()
+ViewportGadget::UnarySignal &ViewportGadget::renderRequestSignal()
 {
 	return m_renderRequestSignal;
 }

--- a/src/GafferUIModule/GadgetBinding.cpp
+++ b/src/GafferUIModule/GadgetBinding.cpp
@@ -60,7 +60,14 @@ struct VisibilityChangedSlotCaller
 {
 	void operator()( boost::python::object slot, GadgetPtr g )
 	{
-		slot( g );
+		try
+		{
+			slot( g );
+		}
+		catch( const boost::python::error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
 	}
 };
 
@@ -74,8 +81,7 @@ struct ButtonSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // also clears the python error status
-			return false;
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -90,7 +96,7 @@ struct EnterLeaveSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // also clears the python error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -105,8 +111,7 @@ struct DragBeginSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // also clears the python error status
-			return nullptr;
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -121,8 +126,7 @@ struct DragDropSlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // also clears the python error status
-			return false;
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };
@@ -137,8 +141,7 @@ struct KeySlotCaller
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // also clears the python error status
-			return false;
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -128,7 +128,7 @@ struct UnarySlotCaller
 		}
 		catch( const error_already_set &e )
 		{
-			PyErr_PrintEx( 0 ); // clears the error status
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 };


### PR DESCRIPTION
This has been on my todo-list for a while. One of my long-shot explanations for a tricky bug we're currently hunting is that an exception in a badly-behaved slot could be preventing a well-behaved slot from doing its stuff, so I thought now was a good time to finally do it.

1. Translate Python exceptions in all slots to C++, and leave it up to the combiner to handle them, rather than treat Python exceptions differently.
2. Use CatchingCombiner for all signals that are for publishing information only. A badly-behaving observer shouldn't prevent other observers from being updated.
3. Continue to allow exceptions to stop iteration in EventSignalCombiner. In this case, we don't know if the slot would have returned `true` or `false`, so don't know if we should call the other slots or not. Combined with 1, this does represent a change in behaviour, since before we suppressed exceptions from Python slots.

