### PR TITLE
ErrorDialogue : Add more informative exception handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - GraphEditor : The focus gadget is now toggled when the button is released rather than when it is pressed. This helps avoid accidental toggling when performing marquee selection.
+- ErrorDialogue : Improved error text for SyntaxError exceptions, and added debug log messages containing Python stack traces.
 
 Fixes
 -----

--- a/python/GafferUI/ErrorDialogue.py
+++ b/python/GafferUI/ErrorDialogue.py
@@ -118,13 +118,25 @@ class ErrorDialogue( GafferUI.Dialogue ) :
 
 			self.__splittingMessageHandler.__enter__()
 
-		def __exit__( self, type, value, traceback ) :
+		def __exit__( self, type, value, tb ) :
 
 			self.__splittingMessageHandler.__exit__( type, value, traceback )
 
 			result = False
 			if type is not None and self.__handleExceptions :
-				self.__capturingMessageHandler.handle( IECore.Msg.Level.Error, self.__kw.get( "title", "Error" ), str( value ) )
+				self.__capturingMessageHandler.handle(
+					IECore.Msg.Level.Error, self.__kw.get( "title", "Error" ),
+					"\n".join( traceback.format_exception_only( type, value ) )
+				)
+				self.__capturingMessageHandler.handle(
+					IECore.Msg.Level.Debug, "Traceback",
+					"\n".join(
+						traceback.format_list(
+							traceback.extract_tb( tb )
+						)
+					)
+				)
+
 				result = True
 
 			if len( self.__capturingMessageHandler.messages ) :


### PR DESCRIPTION
Using `format_exception_only` rather than `str()` gives improved output for SyntaxErrors, such as those that might be raised by ButtonPlugValueWidget. An additional Debug message with the Python traceback provides additional information that might be useful in tracking the error down.
