### PR TITLE
Container : Fix symbol exports

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Improvements
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes, by improving cache usage during history queries.
 - Node menu : Removed unsupported Arnold shaders `ramp_rgb` and `ramp_float`. The OSL `ColorSpline` and `FloatSpline` shaders should be used instead.
 
+Fixes
+-----
+
+- ScriptContainer : Fixed `typeName()`, which was omitting the `Gaffer::` prefix.
+
 API
 ---
 
@@ -26,6 +31,7 @@ API
     - StandardSet : MemberAcceptanceSignal.
 - Monitor : Subclasses may now override `mightForceMonitoring` and `forceMonitoring` in order to ensure the monitored processes always run, instead of being skipped when they are cached
 - ValuePlug : Added `hashCacheTotalUsage()` function.
+- ScriptContainer : Added Python binding.
 
 Breaking Changes
 ----------------

--- a/include/Gaffer/Container.h
+++ b/include/Gaffer/Container.h
@@ -43,7 +43,7 @@ namespace Gaffer
 {
 
 template<typename Base, typename T>
-class Container : public Base
+class IECORE_EXPORT Container : public Base
 {
 
 	public :
@@ -92,7 +92,5 @@ class Container : public Base
 
 
 } // namespace Gaffer
-
-#include "Gaffer/Container.inl"
 
 #endif // GAFFER_CONTAINER_H

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -136,6 +136,11 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 		self.assertEqual( len( d ), 2 )
 		self.assertEqual( a.getClipboardContents(), IECore.IntData( 20 ) )
 
+	def testScriptContainer( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		self.assertIsInstance( a["scripts"], Gaffer.ScriptContainer )
+
 	def tearDown( self ) :
 
 		for f in [

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -72,7 +72,7 @@ using namespace Gaffer;
 namespace Gaffer
 {
 
-GAFFER_DECLARECONTAINERSPECIALISATIONS( ScriptContainer, ScriptContainerTypeId )
+GAFFER_DECLARECONTAINERSPECIALISATIONS( Gaffer::ScriptContainer, ScriptContainerTypeId )
 template class Container<GraphComponent, ScriptNode>;
 
 }

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -41,6 +41,7 @@
 #include "Gaffer/ApplicationRoot.h"
 #include "Gaffer/BackgroundTask.h"
 #include "Gaffer/CompoundDataPlug.h"
+#include "Gaffer/Container.inl"
 #include "Gaffer/Context.h"
 #include "Gaffer/DependencyNode.h"
 #include "Gaffer/MetadataAlgo.h"
@@ -72,6 +73,7 @@ namespace Gaffer
 {
 
 GAFFER_DECLARECONTAINERSPECIALISATIONS( ScriptContainer, ScriptContainerTypeId )
+template class Container<GraphComponent, ScriptNode>;
 
 }
 

--- a/src/GafferModule/ScriptNodeBinding.cpp
+++ b/src/GafferModule/ScriptNodeBinding.cpp
@@ -541,6 +541,9 @@ struct FocusChangedSlotCaller
 
 void GafferModule::bindScriptNode()
 {
+
+	GraphComponentClass<ScriptContainer>();
+
 	boost::python::scope s = NodeClass<ScriptNode, ScriptNodeWrapper>()
 		.def( "applicationRoot", &applicationRoot )
 		.def( "selection", &selection )


### PR DESCRIPTION
This is a quick followup to https://github.com/GafferHQ/gaffer/pull/4574, which had some unintended side effects on Container symbol visibility that went undetected because I failed to bind ScriptContainer to Python a long long time ago.

@ericmehl, would be great if you could check that this doesn't re-break your Windows build. Sorry for the delay in getting back to #4570 - I was off on holiday all last week, and am still playing catch up...