### PR TITLE
PlugAlgo : Support NameValuePlug in `extractDataFromPlug()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,12 +1,18 @@
 0.61.x.x (relative to 0.61.4.0)
 ========
 
+Fixes
+-----
+
+- Spreadsheet : Fixed errors computing `resolvedRows` when the Spreadsheet contains a NameValuePlug (#4583).
+
 API
 ---
 
 - Tool : Added support for subclassing in Python.
 - View : Added `tools()` method which returns a container of all connected Tools.
 - Container : Added constructor with a `name` argument.
+- PlugAlgo : Added support for NameValuePlug in `extractDataFromPlug()`.
 
 0.61.4.0 (relative to 0.61.3.0)
 ========

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -619,5 +619,20 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		self.assertIsNone( Gaffer.Metadata.value( p, "b:promotable" ) )
 		self.assertNotIn( "c:promotable", Gaffer.Metadata.registeredValues( p ) )
 
+	def testExtractDataFromNameValuePlug( self ) :
+
+		withEnabled = Gaffer.NameValuePlug( "test", 10, defaultEnabled = True )
+		withoutEnabled = Gaffer.NameValuePlug( "test", 20 )
+
+		self.assertEqual(
+			Gaffer.PlugAlgo.extractDataFromPlug( withEnabled ),
+			IECore.CompoundData( { "name" : "test", "value" : 10, "enabled" : True } )
+		)
+
+		self.assertEqual(
+			Gaffer.PlugAlgo.extractDataFromPlug( withoutEnabled ),
+			IECore.CompoundData( { "name" : "test", "value" : 20 } )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -467,6 +467,14 @@ IECore::DataPtr extractDataFromPlug( const ValuePlug *plug )
 			return new M44fData( static_cast<const M44fPlug *>( plug )->getValue() );
 		case M33fPlugTypeId :
 			return new M33fData( static_cast<const M33fPlug *>( plug )->getValue() );
+		case NameValuePlugTypeId : {
+			CompoundDataPtr result = new CompoundData;
+			for( auto &childPlug : ValuePlug::Range( *plug ) )
+			{
+				result->writable()[childPlug->getName()] = extractDataFromPlug( childPlug.get() );
+			}
+			return result;
+		}
 		default :
 			throw IECore::Exception(
 				boost::str( boost::format( "Plug \"%s\" has unsupported type \"%s\"" ) % plug->getName().string() % plug->typeName() )


### PR DESCRIPTION
This fixes #4583, where `Spreadsheet.resolvedRows` was failing to compute if the Spreadsheet contained a NameValuePlug.

I did consider adding the new CompoundData fallback for all unknown plug types that had children, but decided against it. It's not 100% clear that such plugs wouldn't have a better dedicated conversion of their own. Adding the conversion we want later will be easier if we don't add an unwanted conversion now (it could become a compatibility hazard).
