### PR TITLE
OCIO 2 Support (round 3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.2.1/cortex-10.3.2.1-linux-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.2.1/cortex-10.3.2.1-linux-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.2.1/cortex-10.3.2.1-linux-python3.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.2.1/cortex-10.3.2.1-macos-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -56,6 +56,16 @@ Build
 
 - Moved minimum required C++ standard to C++17.
 - Updated to GCC 9.3.1 for Linux builds.
+- Updated to GafferHQ/dependencies 5.0.0 :
+  - Boost : Updated to version 1.76.0.
+  - Alembic : Updated to version 1.8.3.
+  - TBB : Updated to version 2020.3.
+  - USD : Updated to version 21.11.
+  - OpenImageIO : Updated to version 2.3.11.0.
+  - OpenShadingLanguage : Updated to version 1.11.17.0.
+  - OpenVDB : Updated to version 9.0.0.
+  - OpenColorIO : Updated to version 2.1.1.
+  - Cortex : Updated to version 10.4.0.0.
 
 0.61.4.0 (relative to 0.61.3.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- Viewer : Improved accuracy of OpenColorIO display transforms when applied using the GPU.
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes, by improving cache usage during history queries.
 - Node menu : Removed unsupported Arnold shaders `ramp_rgb` and `ramp_float`. The OSL `ColorSpline` and `FloatSpline` shaders should be used instead.
 

--- a/SConstruct
+++ b/SConstruct
@@ -673,7 +673,10 @@ if env["PLATFORM"] == "win32" :
 	commandEnv["ENV"]["PATH"] = commandEnv.subst( "$BUILD_DIR/lib" + os.path.pathsep ) + commandEnv["ENV"]["PATH"]
 
 if commandEnv["PLATFORM"]=="darwin" :
-	commandEnv["ENV"]["DYLD_LIBRARY_PATH"] = commandEnv.subst( ":".join( [ "$BUILD_DIR/lib" ] + split( commandEnv["LOCATE_DEPENDENCY_LIBPATH"] ) ) )
+	commandEnv["ENV"]["DYLD_LIBRARY_PATH"] = commandEnv.subst( ":".join(
+		[ "/System/Library/Frameworks/ImageIO.framework/Resources", "$BUILD_DIR/lib" ] +
+		split( commandEnv["LOCATE_DEPENDENCY_LIBPATH"] )
+	) )
 elif commandEnv["PLATFORM"] == "win32" :
 	commandEnv["ENV"]["PATH"] = commandEnv.subst( ";".join( [ "$BUILD_DIR/lib" ] + split( commandEnv[ "LOCATE_DEPENDENCY_LIBPATH" ] ) + [ commandEnv["ENV"]["PATH"] ] ) )
 else:

--- a/SConstruct
+++ b/SConstruct
@@ -995,7 +995,7 @@ libraries = {
 	"GafferImage" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$BUILD_DIR/include/freetype2" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferImage", "GafferDispatch", "IECoreImage$CORTEX_LIB_SUFFIX", ],
@@ -1074,7 +1074,7 @@ libraries = {
 	"GafferArnoldUI" : {
 		"envAppends" : {
 			"LIBPATH" : [ "$ARNOLD_ROOT/bin" ] if env["PLATFORM"] != "win32" else [ "$ARNOLD_ROOT/bin", "$ARNOLD_ROOT/lib" ],
-			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI", "ai" ],
+			"LIBS" : [ "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "Gaffer", "GafferScene", "GafferOSL", "GafferSceneUI", "ai" ],
 			"CXXFLAGS" : [ "-DAI_ENABLE_DEPRECATION_WARNINGS" ],
 			"CPPPATH" : [ "$ARNOLD_ROOT/include" ],
 		},
@@ -1109,7 +1109,7 @@ libraries = {
 	"GafferOSL" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],
-			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],
@@ -1157,7 +1157,7 @@ libraries = {
 		"envAppends" : {
 			"CXXFLAGS" : [ systemIncludeArgument, "$APPLESEED_ROOT/include", "-DAPPLESEED_ENABLE_IMATH_INTEROP", "-DAPPLESEED_USE_SSE" ],
 			"LIBPATH" : [ "$APPLESEED_ROOT/lib" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"CXXFLAGS" : [ systemIncludeArgument, "$APPLESEED_ROOT/include", "-DAPPLESEED_ENABLE_IMATH_INTEROP", "-DAPPLESEED_USE_SSE" ],

--- a/contrib/openColorIOPandemonium/generatePandemonium.py
+++ b/contrib/openColorIOPandemonium/generatePandemonium.py
@@ -1,0 +1,70 @@
+import os
+import random
+import math
+
+directory = os.path.dirname( os.path.realpath( __file__ ) )
+
+
+smallSize = 100
+largeSize = 8000
+colorSize = 5000
+
+bigLUTSize = 9
+smallLUTSize = 5
+
+random.seed( 42 )
+
+f = open( os.path.join( directory, "pandemoniumSmall1D.spi1d" ), "w" )
+f.write( """
+Version 1
+From -0.125 1.125
+Length %i
+Components 1
+{
+""" % smallSize )
+for i in range( smallSize ):
+	f.write( "\t%f\n" % random.random() )
+f.write( "}" )
+f.close()
+
+f = open( os.path.join( directory, "pandemoniumLarge1D.spi1d" ), "w" )
+f.write( """
+Version 1
+From -0.125 1.125
+Length %i
+Components 1
+{
+""" % largeSize )
+for i in range( largeSize ):
+	t = i / ( largeSize / math.pi )
+	# Can't have too many high frequency transforms where every element is random, or else we magnify floating
+	# point inaccuracy too much, so use a sine instead for some transforms
+	f.write( "\t%f\n" % math.sin( t ) )
+f.write( "}" )
+f.close()
+
+f = open( os.path.join( directory, "pandemoniumColor1D.spi1d" ), "w" )
+f.write( """
+Version 1
+From -0.125 1.125
+Length %i
+Components 3
+{
+""" % colorSize )
+for i in range( colorSize ):
+	t = i / ( largeSize / math.pi )
+	f.write( "\t%f %f %f\n" % ( math.sin( t ), math.sin( t * 2 ) * 0.5 + 0.5, math.sin( t * 3 ) * 0.5 + 0.5  ) )
+f.write( "}" )
+f.close()
+
+f = open( os.path.join( directory, "pandemoniumBig.cube" ), "w" )
+f.write( "LUT_3D_SIZE %i\n" % bigLUTSize )
+for i in range( bigLUTSize * bigLUTSize * bigLUTSize ):
+	f.write( "\t%f %f %f\n" % ( random.random(), random.random(), random.random() ) )
+f.close()
+
+f = open( os.path.join( directory, "pandemoniumSmall.cube" ), "w" )
+f.write( "LUT_3D_SIZE %i\n" % smallLUTSize )
+for i in range( smallLUTSize * smallLUTSize * smallLUTSize ):
+	f.write( "\t%f %f %f\n" % ( random.random(), random.random(), random.random() ) )
+f.close()

--- a/contrib/openColorIOPandemonium/pandemonium.ocio
+++ b/contrib/openColorIOPandemonium/pandemonium.ocio
@@ -1,0 +1,68 @@
+ocio_profile_version: 1
+
+search_path: luts
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  color_picking: linear
+  color_timing: linear
+  compositing_log: linear
+  data: raw
+  default: raw
+  matte_paint: linear
+  reference: linear
+  scene_linear: linear
+  texture_paint: linear
+
+displays:
+  default:
+    - !<View> {name: pandemonium, colorspace: pandemonium}
+    - !<View> {name: linear, colorspace: linear}
+
+active_displays: [default]
+active_views: [sRGB]
+
+colorspaces:
+  - !<ColorSpace>
+    name: linear
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Scene-linear, high dynamic range. Used for rendering and compositing.
+    isdata: false
+    allocation: lg2
+    allocationvars: [-15, 6]
+
+  # I wasn't sure how to make sure that a range of possible ColorSpace's would all be handled correctly
+  # by our GPU path, so I made a single "worst possible ColorSpace".  It contains a sequence of a bunch of
+  # 1D luts, 3D luts, matrices, CDL, and gamma adjustments, several of which contain unreasonably high
+  # frequency variation, which will exaggerate any errors.
+  #
+  # With the new OCIO2 GPU path, it is now possible to get a perfect match to the CPU path, if you make 2
+  # modifications:
+  #  * switch ImageGadget to use INTENSITY32F instead of INTENSITY16F for image tiles
+  #  * switch pandemoniumBig.cube to use tetrahedral interpolation.  OCIO itself has a loss of precision when
+  #    using linear interpolation of 3D luts on the GPU, because it uses the default GPU 3D texture filter,
+  #    which is approximate
+  - !<ColorSpace>
+    name: pandemonium
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Test OCIO to the max with transform that aggressively does everything
+    isdata: false
+    allocation: uniform
+    allocationvars: [-0.125, 1.125]
+    from_reference: !<GroupTransform>
+     children:
+       - !<FileTransform> { src: "pandemoniumLarge1D.spi1d", interpolation: linear }
+       - !<CDLTransform> {power: [1, 0.8, 1]}
+       - !<FileTransform> { src: "pandemoniumSmall.cube", interpolation: tetrahedral }
+       - !<FileTransform> { src: "pandemoniumMatrix.spimtx" }
+       - !<FileTransform> { src: "pandemoniumColor1D.spi1d", interpolation: best }
+       - !<ExponentTransform> {value: [1, 1.8, 1, 1]}
+       - !<FileTransform> { src: "pandemoniumBig.cube", interpolation: linear }
+       - !<FileTransform> { src: "pandemoniumSmall1D.spi1d", interpolation: linear }

--- a/include/GafferImage/CDL.h
+++ b/include/GafferImage/CDL.h
@@ -74,7 +74,7 @@ class GAFFERIMAGE_API CDL : public OpenColorIOTransform
 
 		bool affectsTransform( const Gaffer::Plug *input ) const override;
 		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		OpenColorIO::ConstTransformRcPtr transform() const override;
+		OCIO_NAMESPACE::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/ColorSpace.h
+++ b/include/GafferImage/ColorSpace.h
@@ -70,7 +70,7 @@ class GAFFERIMAGE_API ColorSpace : public OpenColorIOTransform
 
 		bool affectsTransform( const Gaffer::Plug *input ) const override;
 		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		OpenColorIO::ConstTransformRcPtr transform() const override;
+		OCIO_NAMESPACE::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/DisplayTransform.h
+++ b/include/GafferImage/DisplayTransform.h
@@ -72,7 +72,7 @@ class GAFFERIMAGE_API DisplayTransform : public OpenColorIOTransform
 
 		bool affectsTransform( const Gaffer::Plug *input ) const override;
 		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		OpenColorIO::ConstTransformRcPtr transform() const override;
+		OCIO_NAMESPACE::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/LUT.h
+++ b/include/GafferImage/LUT.h
@@ -92,7 +92,7 @@ class GAFFERIMAGE_API LUT : public OpenColorIOTransform
 
 		bool affectsTransform( const Gaffer::Plug *input ) const override;
 		void hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		OpenColorIO::ConstTransformRcPtr transform() const override;
+		OCIO_NAMESPACE::ConstTransformRcPtr transform() const override;
 
 	private :
 

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -71,7 +71,7 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 		/// Returns the OCIO processor for this node, taking into account
 		/// the current Gaffer context and the OCIO context specified by
 		/// `contextPlug()`. Returns nullptr if this node is a no-op.
-		OpenColorIO::ConstProcessorRcPtr processor() const;
+		OCIO_NAMESPACE::ConstProcessorRcPtr processor() const;
 		/// Returns a hash that uniquely represents the result of calling
 		/// `processor()` in the current context.
 		IECore::MurmurHash processorHash() const;
@@ -107,11 +107,11 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 		/// Derived classes must implement this to return a valid OpenColorIO
 		/// Transform which can be used by an OpenColorIO Processor or a null
 		/// pointer if no processing should take place.
-		virtual OpenColorIO::ConstTransformRcPtr transform() const = 0;
+		virtual OCIO_NAMESPACE::ConstTransformRcPtr transform() const = 0;
 
 	private :
 
-		OpenColorIO::ConstContextRcPtr ocioContext( OpenColorIO::ConstConfigRcPtr config ) const;
+		OCIO_NAMESPACE::ConstContextRcPtr ocioContext( OCIO_NAMESPACE::ConstConfigRcPtr config ) const;
 
 		static size_t g_firstPlugIndex;
 		bool m_hasContextPlug;

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -483,6 +483,19 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			for key in overrideMetadata :
 				expectedMetadata[key] = overrideMetadata[key]
 
+			if removeAlpha:
+				# If we're not writing alpha, we can't expect to see OIIO's automatically added alpha type
+				# metadata get read in.  This should be compatible with both current OIIO, and also in the
+				# future once we upgrade to OIIO 2.3.12, and it gets renamed from tga: to targa:
+				try:
+					del expectedMetadata[ "tga:alpha_type" ]
+				except:
+					pass
+				try:
+					del expectedMetadata["targa:alpha_type" ]
+				except:
+					pass
+
 			self.__addExpectedIPTCMetadata( writerMetadata, expectedMetadata )
 
 			for metaName in expectedMetadata.keys() :

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -38,6 +38,8 @@ import os
 import unittest
 import imath
 
+import PyOpenColorIO
+
 import IECore
 
 import Gaffer
@@ -71,12 +73,6 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), inverse )
 		self.assertNotEqual( forward, inverse )
 
-		o["interpolation"].setValue( GafferImage.LUT.Interpolation.Nearest )
-		tet = GafferImage.ImageAlgo.image( o["out"] )
-		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), tet )
-		self.assertNotEqual( forward, tet )
-		self.assertNotEqual( inverse, tet )
-
 	def testBadFileName( self ) :
 
 		n = GafferImage.ImageReader()
@@ -95,8 +91,29 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		o = GafferImage.LUT()
 		o["in"].setInput( n["out"] )
 		o["fileName"].setValue( self.lut )
-		o["interpolation"].setValue( GafferImage.LUT.Interpolation.Tetrahedral )
-		self.assertRaises( RuntimeError, GafferImage.ImageAlgo.image, o["out"] )
+
+		image = GafferImage.ImageAlgo.image( o["out"] )
+
+		log = []
+		def loggingFunction( message ) :
+			log.append( message )
+
+		try :
+			PyOpenColorIO.SetLoggingFunction( loggingFunction )
+			o["interpolation"].setValue( GafferImage.LUT.Interpolation.Tetrahedral )
+			# Bad interpolations fall back to the default interpolation, but
+			# also emit a warning message.
+			self.assertEqual( GafferImage.ImageAlgo.image( o["out"] ), image )
+		finally :
+			PyOpenColorIO.ResetToDefaultLoggingFunction()
+
+		## \todo Perhaps libGafferImage should permanently install a logging function that
+		# forwards messages to `IECore::MessageHandler`?
+		self.assertEqual( len( log ), 1 )
+		self.assertIn(
+			"Interpolation specified by FileTransform 'tetrahedral' is not allowed with the given file",
+			log[0]
+		)
 
 	def testHashPassThrough( self ) :
 

--- a/python/GafferImageUI/DisplayTransformUI.py
+++ b/python/GafferImageUI/DisplayTransformUI.py
@@ -48,27 +48,27 @@ def __displayPresetNames( plug ) :
 
 	config = PyOpenColorIO.GetCurrentConfig()
 
-	return IECore.StringVectorData( [ "None" ] + config.getDisplays() )
+	return IECore.StringVectorData( [ "None" ] + list( config.getDisplays() ) )
 
 def __displayPresetValues( plug ) :
 
 	config = PyOpenColorIO.GetCurrentConfig()
 
-	return IECore.StringVectorData( [ "" ] + config.getDisplays() )
+	return IECore.StringVectorData( [ "" ] + list( config.getDisplays() ) )
 
 def __viewPresetNames( plug ) :
 
 	config = PyOpenColorIO.GetCurrentConfig()
 	display = plug.parent()["display"].getValue()
 
-	return IECore.StringVectorData( [ "None" ] + config.getViews( display ) )
+	return IECore.StringVectorData( [ "None" ] + list( config.getViews( display ) ) )
 
 def __viewPresetValues( plug ) :
 
 	config = PyOpenColorIO.GetCurrentConfig()
 	display = plug.parent()["display"].getValue()
 
-	return IECore.StringVectorData( [ "" ] + config.getViews( display ) )
+	return IECore.StringVectorData( [ "" ] + list( config.getViews( display ) ) )
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -146,7 +146,6 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Controls whether to use the fast GPU path for applying exposure, gamma, and displayTransform.
-			Much faster, but may suffer loss of accuracy in some corner cases.
 			""",
 
 			"plugValueWidget:type", "GafferImageUI.ImageViewUI._LutGPUPlugValueWidget",
@@ -845,9 +844,9 @@ class _LutGPUPlugValueWidget( GafferUI.PlugValueWidget ) :
 		text = "# LUT Mode\n\n"
 		if self.__button.getEnabled():
 			if self.getPlug().getValue():
-				text += "Running LUT on GPU ( fast mode )."
+				text += "Running LUT on GPU."
 			else:
-				text += "Running LUT on CPU ( slow but accurate mode )."
+				text += "Running LUT on CPU."
 			text += "\n\nAlt+G to toggle"
 		else:
 			text += "GPU not supported by current DisplayTransform"
@@ -879,8 +878,8 @@ class _LutGPUPlugValueWidget( GafferUI.PlugValueWidget ) :
 		gpuSupported = isinstance( GafferImageUI.ImageView.createDisplayTransform( n ), GafferImage.OpenColorIOTransform )
 		m = IECore.MenuDefinition()
 		for name, value in [
-			( "GPU (fast)", True ),
-			( "CPU (accurate)", False )
+			( "GPU", True ),
+			( "CPU", False )
 		] :
 			m.append(
 				"/" + name,

--- a/python/GafferImageUI/LUTUI.py
+++ b/python/GafferImageUI/LUTUI.py
@@ -77,7 +77,6 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"preset:Best", GafferImage.LUT.Interpolation.Best,
-			"preset:Nearest", GafferImage.LUT.Interpolation.Nearest,
 			"preset:Linear", GafferImage.LUT.Interpolation.Linear,
 			"preset:Tetrahedral", GafferImage.LUT.Interpolation.Tetrahedral,
 

--- a/src/GafferImage/CDL.cpp
+++ b/src/GafferImage/CDL.cpp
@@ -58,9 +58,9 @@ CDL::CDL( const std::string &name )
 
 	addChild( new IntPlug(
 		"direction", Plug::In,
-		OpenColorIO::TRANSFORM_DIR_FORWARD,
-		OpenColorIO::TRANSFORM_DIR_FORWARD,
-		OpenColorIO::TRANSFORM_DIR_INVERSE
+		OCIO_NAMESPACE::TRANSFORM_DIR_FORWARD,
+		OCIO_NAMESPACE::TRANSFORM_DIR_FORWARD,
+		OCIO_NAMESPACE::TRANSFORM_DIR_INVERSE
 	) );
 }
 
@@ -149,14 +149,16 @@ void CDL::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h )
 	directionPlug()->hash( h );
 }
 
-OpenColorIO::ConstTransformRcPtr CDL::transform() const
+OCIO_NAMESPACE::ConstTransformRcPtr CDL::transform() const
 {
-	OpenColorIO::CDLTransformRcPtr result = OpenColorIO::CDLTransform::Create();
-	result->setSlope( &slopePlug()->getValue()[0] );
-	result->setOffset( &offsetPlug()->getValue()[0] );
-	result->setPower( &powerPlug()->getValue()[0] );
+	OCIO_NAMESPACE::CDLTransformRcPtr result = OCIO_NAMESPACE::CDLTransform::Create();
+
+	using Color3d = Imath::Color3<double>;
+	result->setSlope( Color3d( slopePlug()->getValue() ).getValue() );
+	result->setOffset( Color3d( offsetPlug()->getValue() ).getValue() );
+	result->setPower( Color3d( powerPlug()->getValue() ).getValue() );
 	result->setSat( saturationPlug()->getValue() );
-	result->setDirection( (OpenColorIO::TransformDirection)directionPlug()->getValue() );
+	result->setDirection( (OCIO_NAMESPACE::TransformDirection)directionPlug()->getValue() );
 
 	return result;
 }

--- a/src/GafferImage/ColorSpace.cpp
+++ b/src/GafferImage/ColorSpace.cpp
@@ -104,7 +104,7 @@ void ColorSpace::hashTransform( const Gaffer::Context *context, IECore::MurmurHa
 	outputSpacePlug()->hash( h );
 }
 
-OpenColorIO::ConstTransformRcPtr ColorSpace::transform() const
+OCIO_NAMESPACE::ConstTransformRcPtr ColorSpace::transform() const
 {
 	string inputSpace( inputSpacePlug()->getValue() );
 	string outputSpace( outputSpacePlug()->getValue() );
@@ -113,10 +113,10 @@ OpenColorIO::ConstTransformRcPtr ColorSpace::transform() const
 	// actually changing the color space.
 	if( ( inputSpace == outputSpace ) || inputSpace.empty() || outputSpace.empty() )
 	{
-		return OpenColorIO::ColorSpaceTransformRcPtr();
+		return OCIO_NAMESPACE::ColorSpaceTransformRcPtr();
 	}
 
-	OpenColorIO::ColorSpaceTransformRcPtr result = OpenColorIO::ColorSpaceTransform::Create();
+	OCIO_NAMESPACE::ColorSpaceTransformRcPtr result = OCIO_NAMESPACE::ColorSpaceTransform::Create();
 	result->setSrc( inputSpace.c_str() );
 	result->setDst( outputSpace.c_str() );
 

--- a/src/GafferImage/DisplayTransform.cpp
+++ b/src/GafferImage/DisplayTransform.cpp
@@ -112,7 +112,7 @@ void DisplayTransform::hashTransform( const Gaffer::Context *context, IECore::Mu
 	h.append( view );
 }
 
-OpenColorIO::ConstTransformRcPtr DisplayTransform::transform() const
+OCIO_NAMESPACE::ConstTransformRcPtr DisplayTransform::transform() const
 {
 	std::string colorSpace = inputColorSpacePlug()->getValue();
 	std::string display = displayPlug()->getValue();
@@ -122,11 +122,11 @@ OpenColorIO::ConstTransformRcPtr DisplayTransform::transform() const
 	// have valid inputs
 	if( colorSpace.empty() || display.empty() || view.empty() )
 	{
-		return OpenColorIO::DisplayTransformRcPtr();
+		return OCIO_NAMESPACE::ConstTransformRcPtr();
 	}
 
-	OpenColorIO::DisplayTransformRcPtr result = OpenColorIO::DisplayTransform::Create();
-	result->setInputColorSpaceName( colorSpace.c_str() );
+	OCIO_NAMESPACE::DisplayViewTransformRcPtr result = OCIO_NAMESPACE::DisplayViewTransform::Create();
+	result->setSrc( colorSpace.c_str() );
 	result->setDisplay( display.c_str() );
 	result->setView( view.c_str() );
 

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -157,8 +157,8 @@ ImageReader::ImageReader( const std::string &name )
 	addChild( colorSpace );
 	colorSpace->inPlug()->setInput( oiioReader->outPlug() );
 	colorSpace->inputSpacePlug()->setInput( intermediateColorSpacePlug() );
-	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
-	colorSpace->outputSpacePlug()->setValue( config->getColorSpace( OpenColorIO::ROLE_SCENE_LINEAR )->getName() );
+	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
+	colorSpace->outputSpacePlug()->setValue( config->getColorSpace( OCIO_NAMESPACE::ROLE_SCENE_LINEAR )->getName() );
 	colorSpace->processUnpremultipliedPlug()->setValue( true );
 	intermediateImagePlug()->setInput( colorSpace->outPlug() );
 }

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1310,12 +1310,12 @@ ImageWriter::ImageWriter( const std::string &name )
 	ColorSpacePtr colorSpaceChild = new ColorSpace( "__colorSpace" );
 	addChild( colorSpaceChild );
 
-	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
-	colorSpaceUnpremultedChild->inputSpacePlug()->setValue( config->getColorSpace( OpenColorIO::ROLE_SCENE_LINEAR )->getName() );
+	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
+	colorSpaceUnpremultedChild->inputSpacePlug()->setValue( config->getColorSpace( OCIO_NAMESPACE::ROLE_SCENE_LINEAR )->getName() );
 	colorSpaceUnpremultedChild->inPlug()->setInput( inPlug() );
 	colorSpaceUnpremultedChild->outputSpacePlug()->setValue( "${__imageWriter:colorSpace}" );
 
-	colorSpaceChild->inputSpacePlug()->setValue( config->getColorSpace( OpenColorIO::ROLE_SCENE_LINEAR )->getName() );
+	colorSpaceChild->inputSpacePlug()->setValue( config->getColorSpace( OCIO_NAMESPACE::ROLE_SCENE_LINEAR )->getName() );
 	colorSpaceChild->inPlug()->setInput( inPlug() );
 
 	colorSpaceChild->outputSpacePlug()->setValue( "${__imageWriter:colorSpace}" );

--- a/src/GafferImage/LUT.cpp
+++ b/src/GafferImage/LUT.cpp
@@ -105,10 +105,10 @@ const Gaffer::IntPlug *LUT::directionPlug() const
 
 size_t LUT::supportedExtensions( std::vector<std::string> &extensions )
 {
-	extensions.reserve( OpenColorIO::FileTransform::getNumFormats() );
-	for( int i = 0; i < OpenColorIO::FileTransform::getNumFormats(); ++i )
+	extensions.reserve( OCIO_NAMESPACE::FileTransform::GetNumFormats() );
+	for( int i = 0; i < OCIO_NAMESPACE::FileTransform::GetNumFormats(); ++i )
 	{
-		extensions.push_back( OpenColorIO::FileTransform::getFormatExtensionByIndex( i ) );
+		extensions.push_back( OCIO_NAMESPACE::FileTransform::GetFormatExtensionByIndex( i ) );
 	}
 
 	return extensions.size();
@@ -132,7 +132,7 @@ void LUT::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h )
 	interpolationPlug()->hash( h );
 }
 
-OpenColorIO::ConstTransformRcPtr LUT::transform() const
+OCIO_NAMESPACE::ConstTransformRcPtr LUT::transform() const
 {
 	std::string fileName = fileNamePlug()->getValue();
 
@@ -140,22 +140,22 @@ OpenColorIO::ConstTransformRcPtr LUT::transform() const
 	// have a valid LUT file.
 	if( fileName.empty() )
 	{
-		return OpenColorIO::FileTransformRcPtr();
+		return OCIO_NAMESPACE::FileTransformRcPtr();
 	}
 
-	OpenColorIO::FileTransformRcPtr result = OpenColorIO::FileTransform::Create();
+	OCIO_NAMESPACE::FileTransformRcPtr result = OCIO_NAMESPACE::FileTransform::Create();
 	result->setSrc( fileName.c_str() );
 
 	switch( (Direction)directionPlug()->getValue() )
 	{
 		case Forward :
 		{
-			result->setDirection( OpenColorIO::TRANSFORM_DIR_FORWARD );
+			result->setDirection( OCIO_NAMESPACE::TRANSFORM_DIR_FORWARD );
 			break;
 		}
 		case Inverse :
 		{
-			result->setDirection( OpenColorIO::TRANSFORM_DIR_INVERSE );
+			result->setDirection( OCIO_NAMESPACE::TRANSFORM_DIR_INVERSE );
 			break;
 		}
 	}
@@ -164,22 +164,22 @@ OpenColorIO::ConstTransformRcPtr LUT::transform() const
 	{
 		case Best :
 		{
-			result->setInterpolation( OpenColorIO::INTERP_BEST );
+			result->setInterpolation( OCIO_NAMESPACE::INTERP_BEST );
 			break;
 		}
 		case Nearest :
 		{
-			result->setInterpolation( OpenColorIO::INTERP_NEAREST );
+			result->setInterpolation( OCIO_NAMESPACE::INTERP_NEAREST );
 			break;
 		}
 		case Linear :
 		{
-			result->setInterpolation( OpenColorIO::INTERP_LINEAR );
+			result->setInterpolation( OCIO_NAMESPACE::INTERP_LINEAR );
 			break;
 		}
 		case Tetrahedral :
 		{
-			result->setInterpolation( OpenColorIO::INTERP_TETRAHEDRAL );
+			result->setInterpolation( OCIO_NAMESPACE::INTERP_TETRAHEDRAL );
 			break;
 		}
 	}

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -123,22 +123,22 @@ const Gaffer::CompoundDataPlug *OpenColorIOTransform::contextPlug() const
 	return getChild<CompoundDataPlug>( g_firstPlugIndex );
 }
 
-OpenColorIO::ConstProcessorRcPtr OpenColorIOTransform::processor() const
+OCIO_NAMESPACE::ConstProcessorRcPtr OpenColorIOTransform::processor() const
 {
 	// Process is necessary to trigger substitutions for plugs
 	// pulled on by `transform()` and `ocioContext()`.
 	ProcessorProcess process( ProcessorProcess::processorProcessType, this );
 
-	OpenColorIO::ConstTransformRcPtr colorTransform = transform();
+	OCIO_NAMESPACE::ConstTransformRcPtr colorTransform = transform();
 	if( !colorTransform )
 	{
-		return OpenColorIO::ConstProcessorRcPtr();
+		return OCIO_NAMESPACE::ConstProcessorRcPtr();
 	}
 
 	OCIOMutex::scoped_lock lock( g_ocioMutex );
-	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
-	OpenColorIO::ConstContextRcPtr context = ocioContext( config );
-	return config->getProcessor( context, colorTransform, OpenColorIO::TRANSFORM_DIR_FORWARD );
+	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
+	OCIO_NAMESPACE::ConstContextRcPtr context = ocioContext( config );
+	return config->getProcessor( context, colorTransform, OCIO_NAMESPACE::TRANSFORM_DIR_FORWARD );
 }
 
 IECore::MurmurHash OpenColorIOTransform::processorHash() const
@@ -192,10 +192,10 @@ void OpenColorIOTransform::hashColorData( const Gaffer::Context *context, IECore
 	h.append( processorHash() );
 }
 
-OpenColorIO::ConstContextRcPtr OpenColorIOTransform::ocioContext(OpenColorIO::ConstConfigRcPtr config) const
+OCIO_NAMESPACE::ConstContextRcPtr OpenColorIOTransform::ocioContext( OCIO_NAMESPACE::ConstConfigRcPtr config ) const
 {
 
-	OpenColorIO::ConstContextRcPtr context = config->getCurrentContext();
+	OCIO_NAMESPACE::ConstContextRcPtr context = config->getCurrentContext();
 	const CompoundDataPlug *p = contextPlug();
 	if( !p )
 	{
@@ -207,7 +207,7 @@ OpenColorIO::ConstContextRcPtr OpenColorIOTransform::ocioContext(OpenColorIO::Co
 		return context;
 	}
 
-	OpenColorIO::ContextRcPtr mutableContext;
+	OCIO_NAMESPACE::ContextRcPtr mutableContext;
 	std::string name;
 	std::string value;
 
@@ -242,7 +242,7 @@ OpenColorIO::ConstContextRcPtr OpenColorIOTransform::ocioContext(OpenColorIO::Co
 
 void OpenColorIOTransform::processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const
 {
-	OpenColorIO::ConstProcessorRcPtr processor;
+	OCIO_NAMESPACE::ConstProcessorRcPtr processor;
 	{
 		ImagePlug::GlobalScope c( context );
 		processor = this->processor();
@@ -253,7 +253,7 @@ void OpenColorIOTransform::processColorData( const Gaffer::Context *context, IEC
 		return;
 	}
 
-	OpenColorIO::PlanarImageDesc image(
+	OCIO_NAMESPACE::PlanarImageDesc image(
 		r->baseWritable(),
 		g->baseWritable(),
 		b->baseWritable(),
@@ -262,12 +262,13 @@ void OpenColorIOTransform::processColorData( const Gaffer::Context *context, IEC
 		1 // height
 	);
 
-	processor->apply( image );
+	OCIO_NAMESPACE::ConstCPUProcessorRcPtr cpuProcessor = processor->getDefaultCPUProcessor();
+	cpuProcessor->apply( image );
 }
 
 void OpenColorIOTransform::availableColorSpaces( std::vector<std::string> &colorSpaces )
 {
-	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
+	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
 
 	colorSpaces.clear();
 	colorSpaces.reserve( config->getNumColorSpaces() );
@@ -280,7 +281,7 @@ void OpenColorIOTransform::availableColorSpaces( std::vector<std::string> &color
 
 void OpenColorIOTransform::availableRoles( std::vector<std::string> &roles )
 {
-	OpenColorIO::ConstConfigRcPtr config = OpenColorIO::GetCurrentConfig();
+	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
 
 	roles.clear();
 	roles.reserve( config->getNumRoles() );

--- a/startup/GafferImage/defaultColorSpace.py
+++ b/startup/GafferImage/defaultColorSpace.py
@@ -1,3 +1,5 @@
+import six
+
 import PyOpenColorIO
 
 import GafferImage
@@ -6,9 +8,9 @@ def defaultColorSpace( fileName, fileFormat, dataType, metadata ) :
 
 	config = PyOpenColorIO.GetCurrentConfig()
 
-	linear = config.getColorSpace(PyOpenColorIO.Constants.ROLE_SCENE_LINEAR).getName()
-	log = config.getColorSpace(PyOpenColorIO.Constants.ROLE_COMPOSITING_LOG).getName()
-	display = config.getColorSpace(PyOpenColorIO.Constants.ROLE_COLOR_PICKING).getName()
+	linear = config.getColorSpace( PyOpenColorIO.ROLE_SCENE_LINEAR ).getName()
+	log = config.getColorSpace( PyOpenColorIO.ROLE_COMPOSITING_LOG ).getName()
+	display = config.getColorSpace( PyOpenColorIO.ROLE_COLOR_PICKING ).getName()
 
 	colorSpaces = {
 
@@ -57,7 +59,7 @@ def defaultColorSpace( fileName, fileFormat, dataType, metadata ) :
 	}
 
 	s = colorSpaces[fileFormat]
-	if isinstance( s, str ) :
+	if isinstance( s, six.string_types ) :
 		return s
 	else :
 		return s[dataType]


### PR DESCRIPTION
This is #4579, hopefully with the Mac linking errors fixed, and the following additional changes :

- Updated `LUTTest.testBadInterpolation` to keep the test. Not sure how worthwhile this is, but it does give us some coverage, and a thought for future work.
- Made minor tweaks to the UI : https://github.com/GafferHQ/gaffer/commit/2881ec632ea3a6317fd99825ee0be54685b13a84.
- Moved pandemonium LUT to `/contrib`, since it doesn't actually do anything in `GafferImageTest`, and omitted the LUTs since they take space in the repo and can be recreated with `generatePandemonium.py` anyway.

The ImageGadget stuff, which was the meat of #4579, remains completely unchanged.

I suspect this will still fail CI on Mac, because the PyOpenColorIO module seems to have wandered off `sys.path`. I'm looking into that now...