### PR TITLE
GraphGadget : Remove redundant `callOnUIThread()`

### DIFF
--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1045,11 +1045,7 @@ void GraphGadget::updateActive()
 
 	if( !focusPlugs.size() )
 	{
-		Gaffer::ParallelAlgo::callOnUIThread(
-			[this] {
-				this->applyActive( nullptr, nullptr );
-			}
-		);
+		applyActive( nullptr, nullptr );
 		return;
 	}
 


### PR DESCRIPTION
We are already guaranteed to be on the UI thread in `updateActive()` since it is only called from `renderLayer()`. I don't think this was causing actual problems (the call was still made immediately because we're on the UI thread), but it made for a more confusing stack trace when I was hunting down a separate issue.
