### PR TITLE
Work Around MessageWidget triggering UI Refresh During Compute

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - GraphEditor : Fixed active-branch-highlighting bug, where newly created GraphEditors wouldn't update correctly until the focus node was set again.
 - Spreadsheet : Fixed attempts to edit non-editable plugs when double-clicking on a boolean cell.
+- MessageWidget : Modified so that we no longer trigger UI updates while handling messages. This fixes some weird behaviour in rare cases when UI elements were evaluated in the wrong context.
 
 API
 ---
@@ -20,6 +21,7 @@ API
   - Added Python binding for `setDimmed()`.
   - Added missing `getDimmed()` accessor.
 - Pointer : Added `add` and `remove` pointers for use with `setCurrent()`.
+- MessageWidget : We no longer update the UI immediately when a message is emitted on the UI thread. If you have a slow process that you want to receive messages from interactively, you should run it on a background thread (perhaps using BackgroundTaskDialogue). If you have old code that runs something slow on the UI thread, it will still run, but you will only see messages from it once it finishes.
 
 0.61.5.0 (relative to 0.61.4.0)
 ========


### PR DESCRIPTION
Currently the MessageWidget message handler calls processEvents.  In certain obscure cases, this can result in a message being logged during a compute triggering a UI update within that compute.  This seems extremely dangerous, though the only actually visible side effect currently is that ValuePlug.settable() will return false if called within a compute, resulting in disabled UI.

John suggested the BlockedIdleExecution scope.  I've implemented that naively, and it does fix my production repro.

We're now piling up a lot of hacks now, and I'm really wondering if we couldn't just get rid of some of this complexity.  It appears the purpose of the weird processEvents in the message handler is so that a message log UI can update while a long process runs on the foreground thread.

Do we actually need this anywhere?

It seems like if we actually want to have a slow computation with a running progress report, the correct solution is to run the slow computation on a background thread?