### PR TITLE
SpreadsheetUI : Hide "add column" button if columns not serialisable

### DIFF
--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -167,6 +167,13 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# Likewise, we don't support the addition of new columns at all.
 				self.__addColumnButton.setVisible( False )
 
+			if Gaffer.Metadata.value( plug, "spreadsheet:columnsNeedSerialisation" ) == False :
+				# This metadata is set by custom nodes which create their
+				# columns in a constructor. If users were to add their own
+				# columns, they wouldn't be serialised correctly, so we hide the
+				# button.
+				self.__addColumnButton.setVisible( False )
+
 			self.__statusLabel = GafferUI.Label(
 				"",
 				parenting = {


### PR DESCRIPTION
This was made visible by 3f436965c50bca6035c5fd984e5e2015a0f0f93b, but that was a bit overzealous. We do want it to be visible for promoted plugs on Boxes, but not necessarily for plugs on all custom nodes.
