### PR TITLE
Node : Use `CatchingCombiner` in `ErrorSignal`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,7 +36,7 @@ API
     - ApplicationRoot : ClipboardSignal.
     - GraphComponent : UnarySignal and BinarySignal.
     - Gadget : VisibilityChangedSignal, EnterLeaveSignal and IdleSignal.
-    - Node : UnaryPlugSignal, BinaryPlugSignal.
+    - Node : UnaryPlugSignal, BinaryPlugSignal, ErrorSignal.
     - ScriptNode : ActionSignal, UndoAddedSignal.
     - ViewportGadget : UnarySignal.
   - The following signals now handle exceptions thrown from C++ slots as well as Python slots :

--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -143,7 +143,10 @@ class GAFFER_API Node : public GraphComponent
 		/// specifies the original source of the error, since it may be being
 		/// propagated downstream from an original upstream error. The error
 		/// argument is a description of the problem.
-		using ErrorSignal = Signals::Signal<void ( const Plug *plug, const Plug *source, const std::string &error )>;
+		using ErrorSignal = Signals::Signal<
+			void ( const Plug *plug, const Plug *source, const std::string &error ),
+			Signals::CatchingCombiner<void>
+		>;
 		/// Signal emitted when an error occurs while processing this node.
 		/// This is intended to allow UI elements to display errors that occur
 		/// during processing triggered by other parts of the UI.


### PR DESCRIPTION
This should have been done as part of 58a7cc910ee01d97ca3939e156e8c0949d347b1d.

I'm seeing some "interesting" behaviour in Gaffer 0.61, where the ExpressionUI has a bad slot connected to `errorSignal()`. This is the proper long-term mitigation against all such bad slots, but is an ABI break so only suitable for 0.62. I'll open a separate PR for Gaffer 0.61 that fixes the slot itself.