### PR TITLE
Plug : Remove child outputs in `removeOutputs()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,10 @@ Fixes
 - GraphEditor : Fixed active-branch-highlighting bug, where newly created GraphEditors wouldn't update correctly until the focus node was set again.
 - Spreadsheet : Fixed attempts to edit non-editable plugs when double-clicking on a boolean cell.
 - MessageWidget : Modified so that we no longer trigger UI updates while handling messages. This fixes some weird behaviour in rare cases when UI elements were evaluated in the wrong context.
+- Plug :
+  - The `removeOutputs()` method now also removes any outputs from child plugs. This is consistent with the `setInput()` method, which has always managed child plug inputs.
+  - Fixed bug which meant that child output connections were not removed when a plug was removed from a node.
+- Expression : Fixed error when updating an expression which was previously connected to a deleted spreadsheet row (#4614).
 
 API
 ---

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1494,7 +1494,48 @@ class ExpressionTest( GafferTest.TestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferTest.parallelGetValue( s["n"]["user"]["p"], 100 )
 
+	def testRemoveDrivenSpreadsheetRow( self ) :
 
+		s = Gaffer.ScriptNode()
+
+		# Expression drives column "b" from column "a"
+
+		s["spreadsheet"] = Gaffer.Spreadsheet()
+		s["spreadsheet"]["rows"].addColumn( Gaffer.FloatPlug( "a", defaultValue = 1 ) )
+		s["spreadsheet"]["rows"].addColumn( Gaffer.FloatPlug( "b" ) )
+		row = s["spreadsheet"]["rows"].addRow()
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression(
+			inspect.cleandoc(
+				"""
+				import imath
+				a = parent["spreadsheet"]["rows"]["row1"]["cells"]["a"]["value"]
+				parent["spreadsheet"]["rows"]["row1"]["cells"]["b"]["value"] = a * 2
+				"""
+			)
+		)
+
+		self.assertEqual( row["cells"]["b"]["value"].getValue(), 2 )
+
+		# Remove row that is connected to expression. The expression
+		# should be updated to show that the plugs have been disconnected.
+
+		s["spreadsheet"]["rows"].removeRow( row )
+
+		self.assertIsNone( row["cells"]["b"]["value"].getInput() )
+		self.assertEqual( row["cells"]["a"]["value"].outputs(), () )
+
+		self.assertEqual(
+			s["expression"].getExpression()[0],
+			inspect.cleandoc(
+				"""
+				import imath
+				a = 1.0
+				__disconnected = a * 2
+				"""
+			)
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -1071,5 +1071,29 @@ class PlugTest( GafferTest.TestCase ) :
 			set( Gaffer.Plug.RecursiveRange( node1 ) ) | set( Gaffer.Plug.RecursiveRange( node2 ) )
 		)
 
+	def testRemoveOutputsRemovesChildOutputs( self ) :
+
+		p1 = Gaffer.V2iPlug()
+		p2 = Gaffer.V2iPlug()
+
+		p2["x"].setInput( p1["x"] )
+		self.assertEqual( p2["x"].getInput(), p1["x"] )
+
+		p1.removeOutputs()
+		self.assertIsNone( p2["x"].getInput() )
+
+	def testRemovePlugRemovesChildOutputs( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.V2iPlug()
+		n["p2"] = Gaffer.V2iPlug()
+
+		n["p2"]["x"].setInput( n["p1"]["x"] )
+		self.assertEqual( n["p2"]["x"].getInput(), n["p1"]["x"] )
+
+		p1 = n["p1"] # Keep alive, so destruction of `p1` doesn't remove outputs.
+		del n["p1"]  # Removal alone should be enough to do that.
+		self.assertIsNone( n["p2"]["x"].getInput() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -1203,5 +1203,20 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 			}
 		} )
 
+	def testRemoveRowRemovesConnections( self ) :
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["rows"].addColumn( Gaffer.FloatPlug( "a" ) )
+		spreadsheet["rows"].addColumn( Gaffer.FloatPlug( "b" ) )
+		row = spreadsheet["rows"].addRow()
+
+		add = GafferTest.AddNode()
+		add["op1"].setInput( row["cells"]["a"]["value"] )
+		row["cells"]["b"]["value"].setInput( add["sum"] )
+
+		spreadsheet["rows"].removeRow( row )
+		self.assertIsNone( row["cells"]["b"]["value"].getInput() )
+		self.assertIsNone( add["op1"].getInput() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -545,6 +545,10 @@ void Plug::removeOutputs()
 		Plug *p = *it++;
 		p->setInput( nullptr );
 	}
+	for( auto &child : Range( *this ) )
+	{
+		child->removeOutputs();
+	}
 }
 
 const Plug::OutputContainer &Plug::outputs() const


### PR DESCRIPTION
This fixes #4614, where an unexpected remaining connection broke the updating of expressions when the parent of an input plug was removed. Our intention is that when a plug is removed, all its connections are also removed, so that it has no links to the remaining node graph. We were doing this correctly for input connections (including into children), but not for output connections from children.

This could have been fixed more locally by placing the child recursion in `parentChanging()` rather than in the public `removeOutputs()` method. In some ways its riskier to do it in `removeOutputs()`, but I believe it is the correct behaviour given that `setInput()` already recurses. This is backed up by examining the current uses of `removeOutputs()` in Gaffer - there are only two, and in both cases the removal of child outputs is desired.
