### PR TITLE
Plug : Remove child outputs in `removeOutputs()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,14 @@ Features
 
 - Viewer : Added FPS counter option to Gadget menu.
 
+Fixes
+-----
+
+- Plug :
+  - The `removeOutputs()` method now also removes any outputs from child plugs. This is consistent with the `setInput()` method, which has always managed child plug inputs.
+  - Fixed bug which meant that child output connections were not removed when a plug was removed from a node.
+- Expression : Fixed error when updating an expression which was previously connected to a deleted spreadsheet row (#4614).
+
 Breaking Changes
 ----------------
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1494,7 +1494,48 @@ class ExpressionTest( GafferTest.TestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferTest.parallelGetValue( s["n"]["user"]["p"], 100 )
 
+	def testRemoveDrivenSpreadsheetRow( self ) :
 
+		s = Gaffer.ScriptNode()
+
+		# Expression drives column "b" from column "a"
+
+		s["spreadsheet"] = Gaffer.Spreadsheet()
+		s["spreadsheet"]["rows"].addColumn( Gaffer.FloatPlug( "a", defaultValue = 1 ) )
+		s["spreadsheet"]["rows"].addColumn( Gaffer.FloatPlug( "b" ) )
+		row = s["spreadsheet"]["rows"].addRow()
+
+		s["expression"] = Gaffer.Expression()
+		s["expression"].setExpression(
+			inspect.cleandoc(
+				"""
+				import imath
+				a = parent["spreadsheet"]["rows"]["row1"]["cells"]["a"]["value"]
+				parent["spreadsheet"]["rows"]["row1"]["cells"]["b"]["value"] = a * 2
+				"""
+			)
+		)
+
+		self.assertEqual( row["cells"]["b"]["value"].getValue(), 2 )
+
+		# Remove row that is connected to expression. The expression
+		# should be updated to show that the plugs have been disconnected.
+
+		s["spreadsheet"]["rows"].removeRow( row )
+
+		self.assertIsNone( row["cells"]["b"]["value"].getInput() )
+		self.assertEqual( row["cells"]["a"]["value"].outputs(), () )
+
+		self.assertEqual(
+			s["expression"].getExpression()[0],
+			inspect.cleandoc(
+				"""
+				import imath
+				a = 1.0
+				__disconnected = a * 2
+				"""
+			)
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugTest.py
+++ b/python/GafferTest/PlugTest.py
@@ -1071,5 +1071,29 @@ class PlugTest( GafferTest.TestCase ) :
 			set( Gaffer.Plug.RecursiveRange( node1 ) ) | set( Gaffer.Plug.RecursiveRange( node2 ) )
 		)
 
+	def testRemoveOutputsRemovesChildOutputs( self ) :
+
+		p1 = Gaffer.V2iPlug()
+		p2 = Gaffer.V2iPlug()
+
+		p2["x"].setInput( p1["x"] )
+		self.assertEqual( p2["x"].getInput(), p1["x"] )
+
+		p1.removeOutputs()
+		self.assertIsNone( p2["x"].getInput() )
+
+	def testRemovePlugRemovesChildOutputs( self ) :
+
+		n = Gaffer.Node()
+		n["p1"] = Gaffer.V2iPlug()
+		n["p2"] = Gaffer.V2iPlug()
+
+		n["p2"]["x"].setInput( n["p1"]["x"] )
+		self.assertEqual( n["p2"]["x"].getInput(), n["p1"]["x"] )
+
+		p1 = n["p1"] # Keep alive, so destruction of `p1` doesn't remove outputs.
+		del n["p1"]  # Removal alone should be enough to do that.
+		self.assertIsNone( n["p2"]["x"].getInput() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -1203,5 +1203,20 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 			}
 		} )
 
+	def testRemoveRowRemovesConnections( self ) :
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["rows"].addColumn( Gaffer.FloatPlug( "a" ) )
+		spreadsheet["rows"].addColumn( Gaffer.FloatPlug( "b" ) )
+		row = spreadsheet["rows"].addRow()
+
+		add = GafferTest.AddNode()
+		add["op1"].setInput( row["cells"]["a"]["value"] )
+		row["cells"]["b"]["value"].setInput( add["sum"] )
+
+		spreadsheet["rows"].removeRow( row )
+		self.assertIsNone( row["cells"]["b"]["value"].getInput() )
+		self.assertIsNone( add["op1"].getInput() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -545,6 +545,10 @@ void Plug::removeOutputs()
 		Plug *p = *it++;
 		p->setInput( nullptr );
 	}
+	for( auto &child : Range( *this ) )
+	{
+		child->removeOutputs();
+	}
 }
 
 const Plug::OutputContainer &Plug::outputs() const

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -977,11 +977,29 @@ void Catalogue::imageRemoved( GraphComponent *graphComponent )
 		return;
 	}
 
-	Image *image = static_cast<Image *>( graphComponent );
-	// This causes the image to disconnect from
-	// the switch automatically.
-	removeChild( imageNode( image ) );
-	// So now we go through and shuffle everything down
+	// Remove the InternalImage corresponding to the external Image
+	// plug that was removed. We can't call `imageNode()` to find this
+	// for us, because the connections will have been removed along
+	// with the plug. So we search for an internal image which has
+	// no input connection.
+	bool removed = false;
+	for( auto &c : children() )
+	{
+		if( auto *internalImage = dynamic_cast<InternalImage *>( c.get() ) )
+		{
+			if( !internalImage->fileNamePlug()->getInput() )
+			{
+				assert( !removed );
+				// This causes the image to disconnect from
+				// the switch automatically.
+				removeChild( internalImage );
+				removed = true;
+			}
+		}
+	}
+	assert( removed ); (void)removed;
+
+	// Now we go through and shuffle everything down
 	// to fill the hole in the switch inputs.
 	/// \todo Should there be an ArrayPlug method to do this for us?
 	ArrayPlug *plug = imageSwitch()->inPlugs();

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -982,7 +982,10 @@ void Catalogue::imageRemoved( GraphComponent *graphComponent )
 	// for us, because the connections will have been removed along
 	// with the plug. So we search for an internal image which has
 	// no input connection.
-	bool removed = false;
+
+	// `maybe_unused` keeps the compiler happy when release builds omit the
+	// `assert()`.
+	[[maybe_unused]] bool removed = false;
 	for( auto &c : children() )
 	{
 		if( auto *internalImage = dynamic_cast<InternalImage *>( c.get() ) )
@@ -997,7 +1000,7 @@ void Catalogue::imageRemoved( GraphComponent *graphComponent )
 			}
 		}
 	}
-	assert( removed ); (void)removed;
+	assert( removed );
 
 	// Now we go through and shuffle everything down
 	// to fill the hole in the switch inputs.


### PR DESCRIPTION
In #4616 I fixed a bug which had meant that output connections from child plugs were left hanging around after the parent plug was deleted, as reported in #4614. GitHub gave us the big-green-safe-to-merge button and I merged. But subsequently it became apparent that the CI had not actually run at all, and the fix triggered a failure in CatalogueTest. Worse, the failure had knock-on effects to completely unrelated tests that also failed, because the Catalogue was throwing an exception during the emission of `childRemovedSignal` and this left Gaffer in a bad state. So I reverted in https://github.com/GafferHQ/gaffer/commit/bdda910ed9bd3451f9beae0a33e0d1d443d33b43, but still had the heebie-jeebies.

This PR reintroduces the fix along with a fix for the Catalogue problem. But this time I'm targeting `main`, where we have much better handling of exceptions thrown during signal emission, and where we'll have more time to discover any other problems before it hits general usage.

@lucienfostier, I believe this delaying of the fix for #4614 is OK for you because you already have a workaround, correct?

