### PR TITLE
TransformTool : Fix depth buffering

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x (relative to 0.61.6.0)
+========
+
+Fixes
+-----
+
+- TransformTool : Fixed glitch that could cause a more distant handle to be drawn on top of a closer one.
+
 0.61.6.0 (relative to 0.61.5.0)
 ========
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -150,6 +150,17 @@ class HandlesGadget : public Gadget
 
 	protected :
 
+		Imath::Box3f renderBound() const override
+		{
+			// We need `renderLayer()` to be called any time it will
+			// be called for one of our children. Our children claim
+			// infinite bounds to account for their raster scale, so
+			// we must too.
+			Box3f b;
+			b.makeInfinite();
+			return b;
+		}
+
 		void renderLayer( Layer layer, const Style *style, RenderReason reason ) const override
 		{
 			if( layer != Layer::MidFront )


### PR DESCRIPTION
Because `renderBound()` was empty, `renderLayer()` wasn't getting called, and we weren't setting up the depth buffering appropriately for the child handles.
