### PR TITLE
SubTree : Add plugs to control inheritance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.61.x.x (relative to 0.61.6.0)
 ========
 
+Improvements
+------------
+
+- SubTree : Added `inheritTransform`, `inheritAttributes` and `inheritSetMembership` plugs.
+
 Fixes
 -----
 

--- a/include/GafferScene/SubTree.h
+++ b/include/GafferScene/SubTree.h
@@ -65,6 +65,15 @@ class GAFFERSCENE_API SubTree : public SceneProcessor
 		Gaffer::BoolPlug *includeRootPlug();
 		const Gaffer::BoolPlug *includeRootPlug() const;
 
+		Gaffer::BoolPlug *inheritTransformPlug();
+		const Gaffer::BoolPlug *inheritTransformPlug() const;
+
+		Gaffer::BoolPlug *inheritAttributesPlug();
+		const Gaffer::BoolPlug *inheritAttributesPlug() const;
+
+		Gaffer::BoolPlug *inheritSetMembershipPlug();
+		const Gaffer::BoolPlug *inheritSetMembershipPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -68,24 +68,24 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The list of paths to the locations to be matched by the filter.
-			A path is formed by a sequence of names separated by '/', and
+			A path is formed by a sequence of names separated by `/`, and
 			specifies the hierarchical position of a location within the scene.
 			Paths may use Gaffer's standard wildcard characters to match
 			multiple locations.
 
-			The '*' wildcard matches any sequence of characters within
+			The `*` wildcard matches any sequence of characters within
 			an individual name, but never matches across names separated
-			by a '/'.
+			by a `/`.
 
-			 - /robot/*Arm matches /robot/leftArm, /robot/rightArm and
-			   /robot/Arm. But does not match /robot/limbs/leftArm or
-			   /robot/arm.
+			 - `/robot/*Arm` matches `/robot/leftArm`, `/robot/rightArm` and
+			   `/robot/Arm`. But does not match `/robot/limbs/leftArm` or
+			   `/robot/arm`.
 
-			The "..." wildcard matches any sequence of names, and can be
+			The `...` wildcard matches any sequence of names, and can be
 			used to match locations no matter where they are parented in
 			the hierarchy.
 
-			 - /.../house matches /house, /street/house and /city/street/house.
+			 - `/.../house` matches `/house`, `/street/house` and `/city/street/house`.
 			""",
 
 			"nodule:type", "",

--- a/python/GafferSceneUI/SubTreeUI.py
+++ b/python/GafferSceneUI/SubTreeUI.py
@@ -79,7 +79,39 @@ Gaffer.Metadata.registerNode(
 			/street/house instead.
 			""",
 
-		]
+		],
+
+		"inheritTransform" : [
+
+			"description",
+			"""
+			Maintains the subtree's world-space position by applying the `root`
+			location's full transform to the subtree's children.
+			"""
+
+		],
+
+		"inheritAttributes" : [
+
+			"description",
+			"""
+			Maintains the subtree's attributes (including shader assignments) by
+			applying the `root` location's full attributes to the subtree's
+			children.
+			"""
+
+		],
+
+		"inheritSetMembership" : [
+
+			"description",
+			"""
+			Maintains the subtree's membership in sets by transferring the
+			`root` location's memberships to the subtree's children.
+			"""
+
+
+		],
 
 	}
 

--- a/python/GafferSceneUI/SubTreeUI.py
+++ b/python/GafferSceneUI/SubTreeUI.py
@@ -70,13 +70,12 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Causes the root location to also be kept in the
-			output scene, in addition to its children. For
-			instance, if the scene contains only
-			/city/street/house and the root is set to /city/street,
-			then the new scene will by default contain only /house -
-			but the includeRoot setting will cause it to contain
-			/street/house instead.
+			Causes the root location to also be kept in the output scene, in
+			addition to its children. For instance, if the scene contains only
+			`/city/street/house` and the root is set to `/city/street`, then the
+			new scene will by default contain only `/house` - but the
+			`includeRoot` setting will cause it to contain `/street/house`
+			instead.
 			""",
 
 		],


### PR DESCRIPTION
These allow the subtree to maintain it's world transform, full attributes and set memberships as inherited from the subtree root.
