### PR TITLE
SceneNode : Warn for sets containing `/`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ Breaking Changes
 
 - ImageReader : Changed the default interpretation of channel names in multi-part OpenEXR files. Set the `channelInterpretation` plug to `Legacy` to preserve the old behaviour.
 - ImageWriter : Multi-part OpenEXR files are now written by default. Set the `layout` plug to `Single Part` to write a single-part file instead.
+- SubTree : Removed the `/` root location from generated sets, because root membership is unsupported elsewhere in Gaffer.
 - OSLShader : Removed `prepareSplineCVsForOSL()` method. Use `IECoreScene::ShaderNetworkAlgo::expandSplineParameters()` instead.
 - ArnoldMeshLight : The `ai:autobump_visibility` attributes are no longer modified. Use a separate ArnoldAttributes node if necessary.
 

--- a/python/GafferSceneTest/SubTreeTest.py
+++ b/python/GafferSceneTest/SubTreeTest.py
@@ -351,7 +351,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 				self.assertEqual( s["out"].attributes( "/" ), IECore.CompoundObject() )
 				self.assertEqual( s["out"].transform( "/" ), imath.M44f() )
 
-	def testIncludeRootWithRootObjectInSet( self ) :
+	def testRootPathNeverInSet( self ) :
 
 		sphere = GafferScene.Sphere()
 		sphere["sets"].setValue( "setA" )
@@ -360,8 +360,10 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 		subTree["in"].setInput( sphere["out"] )
 		subTree["root"].setValue( "/sphere" )
 		subTree["includeRoot"].setValue( True )
-
 		self.assertEqual( subTree["out"].set( "setA" ).value, IECore.PathMatcher( [ "/sphere" ] ) )
+
+		subTree["includeRoot"].setValue( False )
+		self.assertEqual( subTree["out"].set( "setA" ).value, IECore.PathMatcher() )
 
 	def testTranformInheritance( self ) :
 
@@ -509,7 +511,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 		subTree["in"].setInput( setB["out"] )
 		subTree["root"].setValue( "/groupA" )
 		self.assertSceneValid( subTree["out"] )
-		self.assertEqual( subTree["out"].set( "setA" ).value, IECore.PathMatcher( [ "/" ] ) )
+		self.assertEqual( subTree["out"].set( "setA" ).value, IECore.PathMatcher() )
 		self.assertEqual( subTree["out"].set( "setB" ).value, IECore.PathMatcher( [ "/groupB", "/groupB/sphere" ] ) )
 
 		subTree["includeRoot"].setValue( True )


### PR DESCRIPTION
This is a follow-on PR from #4625, where I realised that the SubTree node would output a set containing `/` in certain circumstances. I prevented that from happening in the new `inheritSetMemberships` mode but wanted to keep the old behaviour in `0.61` for the original modes, for exact backwards compatibility. For `0.62` though, I think it's best to start cleaning this up, because having `/` in a set is confusing :

- The SceneInspector allows you to click on a set to select its contents, and the Viewer will show everything in the scene as selected (by inheritance).
- But nodes don't operate on the root location, so feeding such a set into a SetFilter will have no such effect.
- Nodes such as Parent and Group don't support `/` in child sets, so the membership disappears.

I wasn't sure how far to go with this. Initially I just added https://github.com/GafferHQ/gaffer/pull/4626/commits/246ecc785bbc58649c21c8df36d4047e3d8bcb55 to clear up the SubTree behaviour, but it seemed that this would ideally be dealt with more centrally. So I've also added a SceneNode warning (which is treated as an error in the unit tests) for any sets which are found to contain `/`. This threw up two uses of `/...` in a Set node in the tests, so it'll be interesting to see what it throws up in the real world. I suspect there may be a few unwise uses of `/...` there, hence why I've gone for a warning rather than a hard error at this stage.

The first two commits are from #4625 and just included here to avoid merge conflicts later - no need to review them again for this PR.