### PR TITLE
NamePlugValueWidget : Don't connect `name` on drop

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,12 @@
-0.61.x.x ( relative to 0.61.7.0 )
+
+0.61.x.x (relative to 0.61.7.0)
 ========
 
 Fixes
 -----
 
 - ArnoldRender : Fixed volume motion rendering by setting options.reference_time ( requires Arnold 7.1 to function correctly )
+- NameValuePlug : Fixed bug where making a connection by drag and drop would connect the `name` plug as well as `enabled` and `value`. This caused confusion because making connections like `overscanLeft -> overscanRight` on the StandardOptions node meant that _both_ plugs ended up specifying the left overscan option.
 
 0.61.7.0 (relative to 0.61.6.0)
 ========


### PR DESCRIPTION
This was creating a very confusing experience :

1. Make StandardOptions node.
2. Drag `overscanTop` onto `overscanBottom`, `overscanLeft` and `overscanRight`, with the intention of driving all four values from the one plug.
3. Only `render:overscanTop` appears in the SceneInspector, because all four plugs are now setting the same option. This is because the `name` plugs have been linked as well as the `value` and `enabled` plugs.

We do still make connections to the `name` plug when it is being displayed as an editable StringPlugValueWidget, as in that case it is clear what is happening. This, for instance, allows a connection from a StandardOptions plug to a CustomOptions plug where `name` is driven too, and is visible in the UI.

