### PR TITLE
config/ie : Better search for the corresponding registry entry

### DIFF
--- a/config/ie/installAll
+++ b/config/ie/installAll
@@ -1,18 +1,19 @@
 #!/usr/bin/env iePython2.7
 
 import IEEnv
-import os, sys, subprocess
+import sys
+import subprocess
 
 ##########################################################################
 # parse SConstruct file for the gaffer version
 ##########################################################################
 
 ## \todo: this is duplicated from ./options but can we centralize it instead?
-def gafferRegistryVersion() :
+def gafferVersionFromScons() :
 
 	import re
 	sconsFile = "SConstruct"
-	versionVars = ["gafferMilestoneVersion", "gafferMajorVersion"]
+	versionVars = ["gafferMilestoneVersion", "gafferMajorVersion", "gafferMinorVersion", "gafferPatchVersion"]
 	varsToFind = list(versionVars)
 
 	varsFound = {}
@@ -30,9 +31,35 @@ def gafferRegistryVersion() :
 	if varsToFind:
 		raise Exception( "Could not find the gaffer version in the SConstruct file. Please review the parsing rules." )
 
-	return varsFound["gafferMilestoneVersion"] + "." + varsFound["gafferMajorVersion"] + ".0.0"
+	return ".".join( [varsFound[k] for k in versionVars] )
 
-gafferRegVersion = gafferRegistryVersion()
+
+def gafferRegistryVersion( gafferVersion ) :
+
+	# have to do local imports for some reason on the options file
+	import distutils
+	import IEEnv
+
+	gafferCompatibilityVersion = ".".join( gafferVersion.split( "." )[:2] )
+	looseGafferVersion = distutils.version.LooseVersion( gafferVersion )
+	registryVersions = list( IEEnv.registry["apps"]["gaffer"].keys() )
+	# only keep entries that have the expected elements
+	registryVersions = [x for x in registryVersions if len( x.split( "." ) ) == 4]
+	# only keep those that are of the same compatibility version
+	registryVersions = [x for x in registryVersions if x.startswith( gafferCompatibilityVersion + "." )]
+	# only keep those that are the same or older than the one we are installing
+	registryVersions = [x for x in registryVersions if looseGafferVersion >= distutils.version.LooseVersion( x )]
+	# sort the remaining entries by LooseVersion, and pick the first one
+	registryVersions.sort( key=distutils.version.LooseVersion, reverse=True )
+
+	if not registryVersions:
+		raise Exception( "Could not find a matching registry entry for {}".format( gafferVersion ) )
+
+	registryVersion = registryVersions[0]
+	return registryVersion
+
+
+gafferRegVersion = gafferRegistryVersion( gafferVersionFromScons() )
 gafferReg = IEEnv.registry["apps"]["gaffer"][gafferRegVersion][IEEnv.platform()]
 variantReg = gafferReg.get( "variants", {} )
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -59,11 +59,12 @@ def getOption( name, default ) :
 # parse SConstruct file for the gafferVersion
 ##########################################################################
 
-def gafferRegistryVersion() :
+## \todo: this is duplicated from ./installAll but can we centralize it instead?
+def gafferVersionFromScons() :
 
 	import re
 	sconsFile = "SConstruct"
-	versionVars = ["gafferMilestoneVersion", "gafferMajorVersion"]
+	versionVars = ["gafferMilestoneVersion", "gafferMajorVersion", "gafferMinorVersion", "gafferPatchVersion"]
 	varsToFind = list(versionVars)
 
 	varsFound = {}
@@ -81,7 +82,32 @@ def gafferRegistryVersion() :
 	if varsToFind:
 		raise Exception( "Could not find the gaffer version in the SConstruct file. Please review the parsing rules." )
 
-	return varsFound["gafferMilestoneVersion"] + "." + varsFound["gafferMajorVersion"] + ".0.0"
+	return ".".join( [varsFound[k] for k in versionVars] )
+
+
+def gafferRegistryVersion( gafferVersion ) :
+
+	# have to do local imports for some reason on the options file
+	import distutils
+	import IEEnv
+
+	gafferCompatibilityVersion = ".".join( gafferVersion.split( "." )[:2] )
+	looseGafferVersion = distutils.version.LooseVersion( gafferVersion )
+	registryVersions = list( IEEnv.registry["apps"]["gaffer"].keys() )
+	# only keep entries that have the expected elements
+	registryVersions = [x for x in registryVersions if len( x.split( "." ) ) == 4]
+	# only keep those that are of the same compatibility version
+	registryVersions = [x for x in registryVersions if x.startswith( gafferCompatibilityVersion + "." )]
+	# only keep those that are the same or older than the one we are installing
+	registryVersions = [x for x in registryVersions if looseGafferVersion >= distutils.version.LooseVersion( x )]
+	# sort the remaining entries by LooseVersion, and pick the first one
+	registryVersions.sort( key=distutils.version.LooseVersion, reverse=True )
+
+	if not registryVersions:
+		raise Exception( "Could not find a matching registry entry for {}".format( gafferVersion ) )
+
+	registryVersion = registryVersions[0]
+	return registryVersion
 
 
 cortexVersion = getOption( "CORTEX_VERSION", os.environ["CORTEX_VERSION"] )
@@ -94,11 +120,12 @@ targetApp = getOption( "APP", None )
 targetAppVersion = None
 
 if int( getOption( "IE_STOMP_VERSION", "0" ) ):
-	registryVersion = os.environ["GAFFER_COMPATIBILITY_VERSION"] + ".0.0"
+	gafferVersion = os.environ["GAFFER_VERSION"]
 	GAFFER_MILESTONE_VERSION, GAFFER_MAJOR_VERSION, GAFFER_MINOR_VERSION, GAFFER_PATH_VERSION = os.environ["GAFFER_VERSION"].rstrip( "dev" ).split( "." )
 else:
-	registryVersion = gafferRegistryVersion()
+	gafferVersion = gafferVersionFromScons()
 
+registryVersion = gafferRegistryVersion( gafferVersion )
 gafferReg = IEEnv.registry["apps"]["gaffer"][registryVersion][IEEnv.platform()]
 gafferBuildVariant = getOption( "GAFFER_BUILD_VARIANT", "py2" )
 qtVersion = gafferReg["qtVersion"]


### PR DESCRIPTION
Build
---

- config/ie : Better search for the corresponding gaffer registry entry

------

The previous logic would fail if we ever needed a new entry for the same
compatibility version, which happens to be the case for 0.61, where
support for Arnold 7.1.1.0 was added by the minor version 0.61.3.0.

The new algorithm should get the best valid match that is guaranteed to
be of the same compatibility version, but also the most recent version
that is the same or older than the one being installed.

This PR doesn't yet solve the code duplication issue between `installAll`
and `options`.

------

@johnhaddon, I'm not sure if this kind of change that affects only IE should go into the `Changes.md` file or not, so I didn't include that.

But let me know if you think it should be included, and I'll take care of adding it.


