### PR TITLE
IECoreArnold::Renderer : Set reference time for correct volume motion

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x ( relative to 0.61.7.0 )
+========
+
+Fixes
+-----
+
+- ArnoldRender : Fixed volume motion rendering by setting options.reference_time ( requires Arnold 7.1 to function correctly )
+
 0.61.7.0 (relative to 0.61.6.0)
 ========
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -325,6 +325,7 @@ const AtString g_pluginSearchPathArnoldString( "plugin_searchpath" );
 const AtString g_polymeshArnoldString("polymesh");
 const AtString g_rasterArnoldString( "raster" );
 const AtString g_receiveShadowsArnoldString( "receive_shadows" );
+const AtString g_referenceTimeString( "reference_time" );
 const AtString g_regionMinXArnoldString( "region_min_x" );
 const AtString g_regionMaxXArnoldString( "region_max_x" );
 const AtString g_regionMinYArnoldString( "region_min_y" );
@@ -3538,6 +3539,12 @@ class ArnoldGlobals
 			AiNodeSetInt(
 				options, g_aaSeedArnoldString,
 				m_aaSeed.get_value_or( m_frame.get_value_or( 1 ) )
+			);
+
+			// Set the reference time, so that volume motion will use the correct reference
+			AiNodeSetFlt(
+				options, g_referenceTimeString,
+				m_frame.value_or( 1 )
 			);
 
 			AtNode *dicingCamera = nullptr;


### PR DESCRIPTION
This seems adequate to keep Murray's test case from exploding in Arnold 7.1
