### PR TITLE
RenderController : Fix crash changing ArnoldMeshLight filtering

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 Fixes
 -----
 
+- InteractiveArnoldRender : Fixed crash triggered by changing the filter on an ArnoldMeshLight.
 - ArnoldRender : Fixed volume motion rendering by setting `options.reference_time`. This had been broken by changes in Arnold `7.0.0.3`, but Arnold `7.1.0.0` or later is required for the fix to work.
 - NameValuePlug : Fixed bug where making a connection by drag and drop would connect the `name` plug as well as `enabled` and `value`. This caused confusion because making connections like `overscanLeft -> overscanRight` on the StandardOptions node meant that _both_ plugs ended up specifying the left overscan option.
 

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -84,6 +84,9 @@ class IECORESCENE_API CapturingRenderer : public Renderer
 
 				CapturedAttributes( const IECore::ConstCompoundObjectPtr &attributes );
 
+				int uneditableAttributeValue() const;
+				bool unrenderableAttributeValue() const;
+
 				friend class CapturingRenderer;
 
 				IECore::ConstCompoundObjectPtr m_attributes;

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -59,7 +59,7 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		coreAttributes = IECore.CompoundObject( { "x" : IECore.IntData( 10 ) } )
 		attributes = renderer.attributes( coreAttributes )
 		self.assertIsInstance( attributes, renderer.CapturedAttributes )
-		self.assertTrue( attributes.attributes().isSame( coreAttributes ) )
+		self.assertEqual( attributes.attributes(), coreAttributes )
 
 	def testCapturedObject( self ) :
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -408,7 +408,10 @@ class RenderController::SceneGraph
 						}
 					}
 				}
+			}
 
+			if( m_objectInterface )
+			{
 				// If the transform has changed, or we have an entirely new object,
 				// the apply the transform.
 				if( m_changedComponents & ( ObjectComponent | TransformComponent ) )


### PR DESCRIPTION
ArnoldMeshLight has a separate bug whereby it inadvertently edits autobump visibility attributes. That will be dealt with in another PR. Here we deal with a bug that those attribute edits exposed in the RenderController.

Autobump attributes cause edit failures in `ArnoldObjectInterface::attributes()` because they need to be applied to the `polymesh` rather than the `ginstance`. This causes the RenderController to drop the current ObjectInterface and create a new one via `RenderController::updateObject()`. But in this case, the object has also switched type from `SceneGraph::LightType` to `SceneGraph::ObjectType`, so `updateObject()` nullifies `m_objectInterface`. This then triggered crashes when we tried to update the transform on the null interface.

The solution is simple : repeat the `if( m_objectInterface )` check after calling `updateObject()` again.

