### PR TITLE
ArnoldMeshLight : Don't modify `ai:autobump_visibility` attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 Fixes
 -----
 
+- ArnoldMeshLight : Fixed bug which caused `ai:autobump_visibility` attributes to be inadvertently modified.
 - Plug :
   - The `removeOutputs()` method now also removes any outputs from child plugs. This is consistent with the `setInput()` method, which has always managed child plug inputs.
   - Fixed bug which meant that child output connections were not removed when a plug was removed from a node.
@@ -37,6 +38,7 @@ Breaking Changes
 - ImageReader : Changed the default interpretation of channel names in multi-part OpenEXR files. Set the `channelInterpretation` plug to `Legacy` to preserve the old behaviour.
 - ImageWriter : Multi-part OpenEXR files are now written by default. Set the `layout` plug to `Single Part` to write a single-part file instead.
 - OSLShader : Removed `prepareSplineCVsForOSL()` method. Use `IECoreScene::ShaderNetworkAlgo::expandSplineParameters()` instead.
+- ArnoldMeshLight : The `ai:autobump_visibility` attributes are no longer modified. Use a separate ArnoldAttributes node if necessary.
 
 0.62.0.0a1
 ==========

--- a/python/GafferArnoldTest/ArnoldMeshLightTest.py
+++ b/python/GafferArnoldTest/ArnoldMeshLightTest.py
@@ -64,10 +64,16 @@ class ArnoldMeshLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( l["out"].attributes( "/group/sphere" )["ai:light"].outputShader().name, "mesh_light" )
 		self.assertTrue( "ai:light" not in l["out"].attributes( "/group/plane" ) )
 
+		# Make sure we set the visibility attributes we expect.
 		for v in ( "shadow", "diffuse_transmit", "specular_transmit", "volume", "diffuse_reflect", "specular_reflect", "subsurface" ) :
 			v = "ai:visibility:" + v
 			self.assertEqual( l["out"].attributes( "/group/sphere" )[v].value, False )
 			self.assertTrue( v not in l["out"].attributes( "/group/plane" ) )
+
+		# Make sure that we don't set any unexpected attributes.
+		for k in l["out"].attributes( "/group/sphere" ).keys() :
+			self.assertFalse( k.startswith( "ai:autobump" ) )
+		self.assertEqual( len( l["out"].attributes( "/group/sphere" ) ), 8 )
 
 		self.assertEqual( set( l["out"].set( "__lights" ).value.paths() ), { "/group/sphere" } )
 

--- a/src/GafferArnold/ArnoldMeshLight.cpp
+++ b/src/GafferArnold/ArnoldMeshLight.cpp
@@ -69,7 +69,11 @@ ArnoldMeshLight::ArnoldMeshLight( const std::string &name )
 	attributes->filterPlug()->setInput( filterPlug() );
 	for( NameValuePlug::Iterator it( attributes->attributesPlug() ); !it.done(); ++it )
 	{
-		if( boost::ends_with( (*it)->getName().string(), "Visibility" ) && (*it)->getName() != "cameraVisibility" )
+		if(
+			boost::ends_with( (*it)->getName().string(), "Visibility" ) &&
+			(*it)->getName().string().find( "AutoBump" ) == std::string::npos &&
+			(*it)->getName() != "cameraVisibility"
+		)
 		{
 			(*it)->enabledPlug()->setValue( true );
 			(*it)->valuePlug<BoolPlug>()->setValue( false );


### PR DESCRIPTION
The original code was written before the autobump visibility attributes were added in 0.60.4.0. It was inadvertently turning these attributes off because their names end in "Visibility".

I considered replacing the `ends_with( attribute, "Visibility" )` test with a hardcoded whitelist, but the original approach does have the slight benefit that it'll adapt automatically if Arnold introduces any more visibility flags. And the newly added tests will prevent us from setting any more unrelated attributes inadvertently in future, so the old approach is now safe.
