### PR TITLE
SceneWriter : Write attributes after objects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.4.0/cortex-10.3.4.0-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.6.0/cortex-10.3.6.0-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.4.0/cortex-10.3.4.0-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.6.0/cortex-10.3.6.0-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:1.2.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.4.0/cortex-10.3.4.0-linux-python3.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.6.0/cortex-10.3.6.0-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.4.0/cortex-10.3.4.0-macos-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.3.6.0/cortex-10.3.6.0-macos-python2.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,17 @@
+0.61.x.x (relative to 0.61.8.0)
+========
+
+Improvements
+------------
+
+- USD :
+  - Added support for reading `.usdz` files.
+  - Added support for `doubleSided` attribute.
+
+Build
+-----
+
+- Cortex : Updated to version 10.3.6.0.
 
 0.61.8.0 (relative to 0.61.7.0)
 ========

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -373,5 +373,24 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( sceneReader["out"].object( "/plane" )["test"].data.value, 10 )
 		self.assertEqual( sceneReader["out"].attributes( "/plane" ), IECore.CompoundObject() )
 
+	def testUSDDoubleSidedAttribute( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["in"].setInput( sphere["out"] )
+		attributes["attributes"]["doubleSided"]["enabled"].setValue( True )
+		attributes["attributes"]["doubleSided"]["value"].setValue( True )
+
+		sceneWriter = GafferScene.SceneWriter()
+		sceneWriter["in"].setInput( attributes["out"] )
+		sceneWriter["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.usda" ) )
+		sceneWriter["task"].execute()
+
+		sceneReader = GafferScene.SceneReader()
+		sceneReader["fileName"].setInput( sceneWriter["fileName"] )
+
+		self.assertEqual( sceneReader["out"].attributes( "/sphere" ), sceneWriter["in"].attributes( "/sphere" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -121,16 +121,6 @@ struct LocationWriter
 			m_output = m_output->child( scenePath.back(), SceneInterface::CreateIfMissing );
 		}
 
-		for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; it++ )
-		{
-			m_output->writeAttribute( it->first, it->second.get(), m_time );
-		}
-
-		if( globals && !globals->members().empty() )
-		{
-			m_output->writeAttribute( "gaffer:globals", globals.get(), m_time );
-		}
-
 		if( object->typeId() != IECore::NullObjectTypeId && scenePath.size() > 0 )
 		{
 			m_output->writeObject( object.get(), m_time );
@@ -141,6 +131,16 @@ struct LocationWriter
 		if( transformData )
 		{
 			m_output->writeTransform( transformData.get(), m_time );
+		}
+
+		for( CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; it++ )
+		{
+			m_output->writeAttribute( it->first, it->second.get(), m_time );
+		}
+
+		if( globals && !globals->members().empty() )
+		{
+			m_output->writeAttribute( "gaffer:globals", globals.get(), m_time );
 		}
 
 		if( !locationSets.empty() )


### PR DESCRIPTION
This is required to allow USD's `doubleSided` attribute to be written - see https://github.com/ImageEngine/cortex/pull/1260 for details. The CI won't succeed until we publish an updated dependencies package after merging the Cortex PR.
