### PR TITLE
Apply clang-tidy readability-static-definition-in-anonymous-namespace

### DIFF
--- a/src/GafferDelight/IECoreDelightPreview/CurvesAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/CurvesAlgo.cpp
@@ -49,8 +49,8 @@ using namespace IECoreDelight;
 namespace
 {
 
-static const char *g_catmullRom = "catmull-rom";
-static const char *g_bSpline = "b-spline";
+const char *g_catmullRom = "catmull-rom";
+const char *g_bSpline = "b-spline";
 
 void staticParameters( const IECoreScene::CurvesPrimitive *object, ParameterList &parameters )
 {

--- a/src/GafferDelight/IECoreDelightPreview/PointsAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/PointsAlgo.cpp
@@ -47,7 +47,7 @@ using namespace IECoreDelight;
 namespace
 {
 
-static float g_one = 1.0f;
+float g_one = 1.0f;
 
 void staticParameters( const IECoreScene::PointsPrimitive *object, ParameterList &parameters )
 {

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -254,13 +254,13 @@ IECore::FrameListPtr frameRange( Dispatcher &n, const ScriptNode &script, const 
 	return n.Dispatcher::frameRange( &script, &context );
 }
 
-static void registerDispatcher( std::string type, object creator, object setupPlugsFn )
+void registerDispatcher( std::string type, object creator, object setupPlugsFn )
 {
 	DispatcherHelper helper( creator, setupPlugsFn );
 	Dispatcher::registerDispatcher( type, helper, helper );
 }
 
-static tuple registeredDispatchersWrapper()
+tuple registeredDispatchersWrapper()
 {
 	std::vector<std::string> types;
 	Dispatcher::registeredDispatchers( types );
@@ -272,7 +272,7 @@ static tuple registeredDispatchersWrapper()
 	return boost::python::tuple( result );
 }
 
-static list createMatching( std::string pattern )
+list createMatching( std::string pattern )
 {
 	std::vector<DispatcherPtr> dispatchers = Dispatcher::createMatching( pattern );
 	list result;

--- a/src/GafferImage/DeepState.cpp
+++ b/src/GafferImage/DeepState.cpp
@@ -51,13 +51,13 @@ GAFFER_NODE_DEFINE_TYPE( DeepState );
 namespace
 {
 
-const static IECore::InternedString g_AName = "A";
-const static IECore::InternedString g_ZName = "Z";
-const static IECore::InternedString g_ZBackName = "ZBack";
-const static IECore::InternedString g_sampleOffsetsName = "sampleOffsets";
-const static IECore::InternedString g_contributionIdsName = "contributionIds";
-const static IECore::InternedString g_contributionWeightsName = "contributionWeights";
-const static IECore::InternedString g_contributionOffsetsName = "contributionOffsets";
+const IECore::InternedString g_AName = "A";
+const IECore::InternedString g_ZName = "Z";
+const IECore::InternedString g_ZBackName = "ZBack";
+const IECore::InternedString g_sampleOffsetsName = "sampleOffsets";
+const IECore::InternedString g_contributionIdsName = "contributionIds";
+const IECore::InternedString g_contributionWeightsName = "contributionWeights";
+const IECore::InternedString g_contributionOffsetsName = "contributionOffsets";
 
 // This class stores all information about how samples are merged together.
 // It is initialized just based on the sorted Z and ZBack channels ( and the sampleOffsets that

--- a/src/GafferImage/OpenColorIOTransform.cpp
+++ b/src/GafferImage/OpenColorIOTransform.cpp
@@ -65,7 +65,7 @@ using OCIOMutex = tbb::mutex;
 using OCIOMutex = tbb::null_mutex;
 #endif
 
-static OCIOMutex g_ocioMutex;
+OCIOMutex g_ocioMutex;
 
 struct ProcessorProcess : public Process
 {

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -53,9 +53,9 @@ using namespace GafferImage;
 
 namespace
 {
-	static IECore::InternedString g_tileInputBoundName( "tileInputBound"  );
-	static IECore::InternedString g_pixelInputPositionsName( "pixelInputPositions"  );
-	static IECore::InternedString g_pixelInputDerivativesName( "pixelInputDerivatives"  );
+	IECore::InternedString g_tileInputBoundName( "tileInputBound"  );
+	IECore::InternedString g_pixelInputPositionsName( "pixelInputPositions"  );
+	IECore::InternedString g_pixelInputDerivativesName( "pixelInputDerivatives"  );
 
 	const CompoundObject *sampleRegionsEmptyTile()
 	{

--- a/src/GafferModule/ExpressionBinding.cpp
+++ b/src/GafferModule/ExpressionBinding.cpp
@@ -340,7 +340,7 @@ class EngineWrapper : public IECorePython::RefCountedWrapper<Expression::Engine>
 
 ValuePlug::CachePolicy EngineWrapper::g_cachePolicy( defaultExecuteCachePolicy() );
 
-static tuple languages()
+tuple languages()
 {
 	std::vector<std::string> languages;
 	Expression::languages( languages );

--- a/src/GafferScene/MotionPath.cpp
+++ b/src/GafferScene/MotionPath.cpp
@@ -54,9 +54,9 @@ using namespace GafferScene;
 namespace
 {
 
-static InternedString g_lightsSetName( "__lights" );
-static InternedString g_defaultLightsSetName( "defaultLights" );
-static InternedString g_camerasSetName( "__cameras" );
+InternedString g_lightsSetName( "__lights" );
+InternedString g_defaultLightsSetName( "defaultLights" );
+InternedString g_camerasSetName( "__cameras" );
 
 } // namespace
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -82,10 +82,10 @@ using namespace GafferScene;
 namespace
 {
 
-static InternedString g_transformBlurAttributeName( "gaffer:transformBlur" );
-static InternedString g_transformBlurSegmentsAttributeName( "gaffer:transformBlurSegments" );
-static InternedString g_deformationBlurAttributeName( "gaffer:deformationBlur" );
-static InternedString g_deformationBlurSegmentsAttributeName( "gaffer:deformationBlurSegments" );
+InternedString g_transformBlurAttributeName( "gaffer:transformBlur" );
+InternedString g_transformBlurSegmentsAttributeName( "gaffer:transformBlurSegments" );
+InternedString g_deformationBlurAttributeName( "gaffer:deformationBlur" );
+InternedString g_deformationBlurSegmentsAttributeName( "gaffer:deformationBlurSegments" );
 
 } // namespace
 
@@ -958,8 +958,8 @@ const InternedString g_transformBlurOptionName( "option:render:transformBlur" );
 const InternedString g_deformationBlurOptionName( "option:render:deformationBlur" );
 const InternedString g_shutterOptionName( "option:render:shutter" );
 
-static InternedString g_setsAttributeName( "sets" );
-static InternedString g_visibleAttributeName( "scene:visible" );
+InternedString g_setsAttributeName( "sets" );
+InternedString g_visibleAttributeName( "scene:visible" );
 
 IECore::InternedString optionName( const IECore::InternedString &globalsName )
 {

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -875,8 +875,8 @@ ScenePlug *SceneAlgo::sourceScene( GafferImage::ImagePlug *image )
 namespace
 {
 
-static InternedString g_lights( "__lights" );
-static InternedString g_linkedLights( "linkedLights" );
+InternedString g_lights( "__lights" );
+InternedString g_linkedLights( "linkedLights" );
 
 template<typename AttributesPredicate>
 struct AttributesFinder

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -116,7 +116,7 @@ Color3f colorForSetName( const InternedString &name, const std::vector<Override>
 // We're limited in our target GLSL version to fixed size shader array params
 size_t g_maxShaderColors = 9;
 
-static const StringDataPtr fragmentSource()
+const StringDataPtr fragmentSource()
 {
 	static StringDataPtr g_fragmentSource = new IECore::StringData(
 		"#if __VERSION__ <= 120\n"

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -135,7 +135,7 @@ class LocationNameColumn : public StandardPathColumn
 
 };
 
-static const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = {
+const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = {
 	{ (int)Inspector::Result::SourceType::Upstream, nullptr },
 	{ (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
 	{ (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },

--- a/src/GafferUI/CompoundNumericNodule.cpp
+++ b/src/GafferUI/CompoundNumericNodule.cpp
@@ -142,7 +142,7 @@ struct TypeDescription
 	}
 };
 
-static TypeDescription g_typeDescription;
+TypeDescription g_typeDescription;
 
 } // namespace
 

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -66,7 +66,7 @@ using namespace GafferUI;
 namespace
 {
 
-static IECoreGL::Texture *texture( Style::State state )
+IECoreGL::Texture *texture( Style::State state )
 {
 	static IECoreGL::TexturePtr normalTexture;
 	static IECoreGL::TexturePtr highlightedTexture;

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -78,8 +78,8 @@ using namespace GafferUI;
 
 namespace {
 
-static const float g_borderWidth = 0.5f;
-static const float g_maxFocusWidth = 2.0f;
+const float g_borderWidth = 0.5f;
+const float g_maxFocusWidth = 2.0f;
 
 IECoreGL::Texture *focusIconTexture( bool focus, bool hover )
 {

--- a/src/GafferUIModule/NoduleBinding.cpp
+++ b/src/GafferUIModule/NoduleBinding.cpp
@@ -80,7 +80,7 @@ struct NoduleCreator
 
 };
 
-static void registerNodule( const std::string &noduleTypeName, object creator, IECore::TypeId plugType )
+void registerNodule( const std::string &noduleTypeName, object creator, IECore::TypeId plugType )
 {
 	Nodule::registerNodule( noduleTypeName, NoduleCreator( creator ), plugType );
 }

--- a/src/GafferVDB/LevelSetToMesh.cpp
+++ b/src/GafferVDB/LevelSetToMesh.cpp
@@ -79,7 +79,7 @@ struct MesherDispatch
 	openvdb::tools::VolumeToMesh &m_mesher;
 };
 
-static std::map<std::string, std::function<void( MesherDispatch& dispatch )> > meshers =
+std::map<std::string, std::function<void( MesherDispatch& dispatch )> > meshers =
 {
 	{ openvdb::typeNameAsString<bool>(), []( MesherDispatch& dispatch ) { dispatch.execute<openvdb::BoolGrid>(); } },
 	{ openvdb::typeNameAsString<double>(), []( MesherDispatch& dispatch ) { dispatch.execute<openvdb::DoubleGrid>(); } },

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2076,8 +2076,8 @@ IE_CORE_DECLAREPTR( InstanceCache )
 namespace
 {
 
-static IECore::InternedString g_surfaceAttributeName( "surface" );
-static IECore::InternedString g_aiSurfaceAttributeName( "ai:surface" );
+IECore::InternedString g_surfaceAttributeName( "surface" );
+IECore::InternedString g_aiSurfaceAttributeName( "ai:surface" );
 
 IE_CORE_FORWARDDECLARE( ArnoldLight )
 


### PR DESCRIPTION
This was done with the following command :

```
run-clang-tidy.py -header-filter='.*' -checks='-*,readability-static-definition-in-anonymous-namespace' -fix
```
