### PR TITLE
LabelPlugValueWidget/PlugLayout : Don't apply "green dot" to output plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 -----
 
 - InteractiveArnoldRender : Fixed crash triggered by changing the filter on an ArnoldMeshLight.
+- NodeEditor : Stopped applying "green dot" non-default plug annotations to output plugs.
 
 API
 ---

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -300,9 +300,8 @@ Gaffer.Metadata.registerNode(
 			"layout:section", "Settings.Outputs",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-
 			"noduleLayout:section", "right",
-			"noduleLayout:spacing", 0.2,
+			"noduleLayout:spacing", 0.4,
 
 		],
 
@@ -318,9 +317,7 @@ Gaffer.Metadata.registerNode(
 			"plugValueWidget:type", "GafferSceneUI.ShaderQueryUI._OutputWidget",
 
 			"nodule:type", "GafferUI::CompoundNodule",
-
 			"noduleLayout:section", "right",
-			"noduleLayout:spacing", 0.2,
 
 		],
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -129,13 +129,17 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# with proper support for child plug connections/defaults) at the next API break.
 
 		def valueChanged( plug ) :
-			changed = plug.getInput() is not None
-			if not changed and isinstance( plug, Gaffer.ValuePlug ) :
-				if Gaffer.NodeAlgo.hasUserDefault( plug ) :
-					changed = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
-				else :
-					changed = not plug.isSetToDefault()
-			return changed
+
+			if plug.direction() == Gaffer.Plug.Direction.Out :
+				return False
+			elif plug.getInput() is not None :
+				return True
+			elif not isinstance( plug, Gaffer.ValuePlug ) :
+				return False
+			elif Gaffer.NodeAlgo.hasUserDefault( plug ) :
+				return not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+			else :
+				return not plug.isSetToDefault()
 
 		anyValueChanged = any( [ valueChanged( plug ) for plug in self.getPlugs() ] )
 		self.__setValueChanged( anyValueChanged )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -397,13 +397,16 @@ class PlugLayout( GafferUI.Widget ) :
 		## \todo This mirrors LabelPlugValueWidget. This doesn't handle child plug defaults/connections
 		# properly. We need to improve NodeAlgo when we have the next API break.
 
-		valueChanged = plug.getInput() is not None
-		if not valueChanged and isinstance( plug, Gaffer.ValuePlug ) :
-			if Gaffer.NodeAlgo.hasUserDefault( plug ) :
-				valueChanged = not Gaffer.NodeAlgo.isSetToUserDefault( plug )
-			else :
-				valueChanged = not plug.isSetToDefault()
-		return valueChanged
+		if plug.direction() == Gaffer.Plug.Direction.Out :
+			return False
+		elif plug.getInput() is not None :
+			return True
+		elif not isinstance( plug, Gaffer.ValuePlug ) :
+			return False
+		elif Gaffer.NodeAlgo.hasUserDefault( plug ) :
+			return not Gaffer.NodeAlgo.isSetToUserDefault( plug )
+		else :
+			return not plug.isSetToDefault()
 
 	def __import( self, path ) :
 


### PR DESCRIPTION
There's no useful concept of an output plug being at a default value, and the dots are messing up the nice output layout for the new ShaderQuery node.

I've also included https://github.com/GafferHQ/gaffer/commit/a3944d8a358eb700e110c065f739a9d0a1198bc5 which groups the outputs of the ShaderQuery in the GraphEditor. I'm not as convinced by this as I was before trying it, so if you don't think it's helpful @ericmehl, I can drop that commit.