### PR TITLE
CI : Update to Cortex 10.4a3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
+            dependenciesURL:  https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-osx.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-macos-python2.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Features
 Improvements
 ------------
 
+- USD : Added basic support for loading UsdLux lights. The data is available in Gaffer, but needs manual conversion to meet the requirements of a specific renderer.
 - ChannelPlugValueWidget : Improved the ordering of channel names presented in the menu.
 - PresetsPlugValueWidget : The children of compound plugs are now shown when in "Custom" mode.
 


### PR DESCRIPTION
This puts us in a position to make another 0.62 alpha release to coincide with the next 0.61 release.