### PR TITLE
DotNode : Setup from `plug` input only for input plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 
 - InteractiveArnoldRender : Fixed crash triggered by changing the filter on an ArnoldMeshLight.
 - NodeEditor : Stopped applying "green dot" non-default plug annotations to output plugs.
+- Dot : Fixed a case where adding a Dot node between a `BoxIn` node and a downstream node would reverse the input and output nodules' sides on the Dot.
 
 API
 ---

--- a/python/GafferUITest/DotNodeGadgetTest.py
+++ b/python/GafferUITest/DotNodeGadgetTest.py
@@ -146,5 +146,29 @@ class DotNodeGadgetTest( GafferUITest.TestCase ) :
 		dot1NodeGadget = graphGadget.nodeGadget( s["d1"] )
 		self.assertEqual( dot1NodeGadget.connectionTangent( dot1NodeGadget.nodule( s["d1"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
 
+	def testOutputPassthroughTangents( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+		s["n2"] = GafferTest.AddNode()
+
+		# Match the behavior of a BoxIn node which sets the internal `__in` nodule section to the right.
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "noduleLayout:section", "right" )
+
+		Gaffer.Metadata.registerValue( s["n2"]["sum"], "noduleLayout:section", "right" )
+
+		s["n2"]["sum"].setInput( s["n"]["op1"] )
+
+		s["d"] = Gaffer.Dot()
+
+		g = GafferUI.NodeGadget.create( s["d"] )
+
+		s["d"].setup( s["n2"]["sum"] )
+
+		self.assertEqual( g.connectionTangent( g.nodule( s["d"]["in"] ) ), imath.V3f( -1, 0, 0 ) )
+		self.assertEqual( g.connectionTangent( g.nodule( s["d"]["out"] ) ), imath.V3f( 1, 0, 0 ) )
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Dot.cpp
+++ b/src/Gaffer/Dot.cpp
@@ -67,7 +67,8 @@ void Dot::setup( const Plug *plug )
 {
 	const Plug *originalPlug = plug;
 
-	if( const Plug *inputPlug = plug->getInput() )
+	const Plug *inputPlug = plug->getInput();
+	if( plug->direction() == Gaffer::Plug::In && inputPlug != nullptr )
 	{
 		// We'd prefer to set up based on an input plug if possible - see comments
 		// in DotNodeGadgetTest.testCustomNoduleTangentsPreferInputIfAvailable().


### PR DESCRIPTION
This fixes a bug where adding a `Dot` node between a `BoxIn` node and a downstream node would reverse the input and output nodules' sides on the Dot.

### Dependencies ###

None

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
