### PR TITLE
Various GCC 11.2 fixes (Ubuntu 22.04 default compiler)

### DIFF
--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -41,6 +41,8 @@
 #include "boost/noncopyable.hpp"
 #include "boost/variant.hpp"
 
+#include <optional>
+
 namespace IECorePreview
 {
 

--- a/include/Gaffer/Private/IECorePreview/TaskMutex.h
+++ b/include/Gaffer/Private/IECorePreview/TaskMutex.h
@@ -53,6 +53,7 @@
 #include "tbb/task_scheduler_observer.h"
 
 #include <iostream>
+#include <optional>
 #include <thread>
 
 namespace IECorePreview

--- a/include/Gaffer/Signals.inl
+++ b/include/Gaffer/Signals.inl
@@ -43,6 +43,9 @@
 #include "boost/iterator/iterator_facade.hpp"
 #include "boost/visit_each.hpp"
 
+#include <optional>
+
+
 namespace Gaffer::Signals
 {
 
@@ -532,7 +535,7 @@ inline ScopedConnection &ScopedConnection::operator=( const Connection &connecti
 //////////////////////////////////////////////////////////////////////////
 
 inline BlockedConnection::BlockedConnection( Signals::Connection &connection, bool block )
-	:	m_connection( nullptr )
+	:	m_connection( nullptr ), m_previouslyBlocked( false )
 {
 	if( block && connection.connected() )
 	{

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -2883,7 +2883,7 @@ class AppleseedRenderer final : public AppleseedRendererBase
 				}
 				else
 				{
-					msg( Msg::Warning, "AppleseedRenderer::output", boost::format( "Unknown AOV \"%s\"." ) % aov->get_name() );
+					msg( Msg::Warning, "AppleseedRenderer::output", boost::format( "Unknown AOV \"%s\"." ) % output->getData() );
 					return;
 				}
 			}

--- a/src/GafferOSLUI/OSLImageUI.cpp
+++ b/src/GafferOSLUI/OSLImageUI.cpp
@@ -284,7 +284,7 @@ class OSLImagePlugAdder : public PlugAdder
 
 			std::sort( result.begin(), result.end() );
 			vector<std::string> customSortResult;
-			for( const std::string &i : { "RGB", "RGBA", "R", "G", "B", "A" } )
+			for( const char *i : { "RGB", "RGBA", "R", "G", "B", "A" } )
 			{
 				if( std::find( result.begin(), result.end(), i ) != result.end() )
 				{

--- a/src/GafferScene/AimConstraint.cpp
+++ b/src/GafferScene/AimConstraint.cpp
@@ -92,7 +92,7 @@ void AimConstraint::hashConstraint( const Gaffer::Context *context, IECore::Murm
 Imath::M44f AimConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
 	// decompose into scale, shear, rotate and translate
-	V3f s, h, r, t;
+	V3f s( 1 ), h( 0 ), r( 0 ), t( 0 );
 	extractSHRT( fullInputTransform, s, h, r, t );
 
 	// figure out the aim matrix


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Various GCC 11.2 fixes (Ubuntu 22.04 default compiler)
- `std::optional needs #include <optional>` in various sources which use it
- `src/GafferScene/AimConstraint.cpp` - V3f t uninitialized error, ignore pragma fix (maybe a better way?)
- `src/GafferArnold/ParameterHandler.cpp` - array bounds error for some ValueType plugs eg. Color3f, ignore pragma fix (maybe a better way?)
- `src/GafferOSLUI/OSLImageUI.cpp:287:49: error: loop variable 'i' of type 'const string&' {aka 'const std::basic_string<char>&'} binds to a temporary constructed from type 'const char* const' [-Werror=range-loop-construct]` - used an array in an anon namespace instead (maybe just a `#pragma` ignore would be fine?)
- `src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp` - invalid use of aov, it would be nullptr
- `include/Gaffer/Signals.inl` - Uninitialised member `m_previouslyBlocked`

### Related issues ###

- None

### Dependencies ###

- None

### Breaking changes ###

- None, compiler fixes

### Checklist ###
- [*] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [*] I have updated the documentation, if applicable.
- [*] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [*] My code follows the Gaffer project's prevailing coding style and conventions.
