### PR TITLE
ParameterHandler : Fix potential array overrun

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 -----
 
 - ArnoldMeshLight : Fixed bug which caused `ai:autobump_visibility` attributes to be inadvertently modified.
+- ArnoldShader/ArnoldLight : Fixed potential buffer overrun when loading color parameters with `gaffer.plugType` metadata.
 - Plug :
   - The `removeOutputs()` method now also removes any outputs from child plugs. This is consistent with the `setInput()` method, which has always managed child plug inputs.
   - Fixed bug which meant that child output connections were not removed when a plug was removed from a node.

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -529,9 +529,7 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( n["parameters"]["start_channel"].defaultValue(), 42 )
 		self.assertAlmostEqual( n["parameters"]["sscale"].defaultValue(), 42.42, places = 5 )
 		self.assertEqual( n["parameters"]["multiply"].defaultValue(), imath.Color3f( 1.2, 3.4, 5.6 ) )
-		# RGBA metadata support added in Arnold 5.3.  Need to wait until we standardise on that
-		# to add this declaration to the test metadata
-		#self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 1.2, 3.4, 5.6, 7.8 ) )
+		self.assertEqual( n["parameters"]["missing_texture_color"].defaultValue(), imath.Color4f( 1.2, 3.4, 5.6, 7.8 ) )
 		self.assertEqual( n["parameters"]["uvcoords"].defaultValue(), imath.V2f( 1.2, 3.4 ) )
 		self.assertEqual( n["parameters"]["filename"].defaultValue(), "overrideDefault" )
 		self.assertEqual( n["parameters"]["filter"].defaultValue(), "closest" )

--- a/python/GafferArnoldTest/metadata/overrideDefaults.mtd
+++ b/python/GafferArnoldTest/metadata/overrideDefaults.mtd
@@ -44,10 +44,8 @@
 		gaffer.default       FLOAT  42.42
 	[attr multiply]
 		gaffer.default       RGB  1.2 3.4 5.6
-	# Until we get onto Arnold 5.3 and this is supported, declaring this breaks metadata parsing
-	# in general
-	#[attr missing_texture_color]
-	#	gaffer.default       RGBA  1.2 3.4 5.6 7.8
+	[attr missing_texture_color]
+		gaffer.default       RGBA  1.2 3.4 5.6 7.8
 	[attr uvcoords]
 		gaffer.default       VECTOR2  1.2 3.4
 	[attr filename]


### PR DESCRIPTION
As discussed in https://github.com/GafferHQ/gaffer/pull/4649, GCC 11 highlighted a potential array overrun in `setupColorPlug()`. We were assuming that RGBA parameters would always be used to create a Color4fPlug, but that is not the case if the plug type has been overridden to Color3fPlug with `gaffer.plugType` metadata. In that case, we could be writing past the end of a Color3f default value, using the alpha from the RGBA parameter default.

I've also refactored the code for getting overrides for the default from the metadata. Although there was no overrun in this part of the code, it was assuming that the metadata size should match the plug size, which is not necessarily the case if one user provides a metadata default and another overrides the plug type. Refactoring allows us to deal with all potential size mismatches in a single well documented call to `copy_n()`.
