### PR TITLE
CI : Update to GafferHQ/dependencies 5.0.0a4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL:  https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a4/gafferDependencies-5.0.0a4-Python2-linux.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -55,7 +55,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a4/gafferDependencies-5.0.0a4-Python2-linux.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -66,7 +66,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-linux-python3.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a4/gafferDependencies-5.0.0a4-Python3-linux.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
@@ -75,7 +75,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.0.0a3/cortex-10.4.0.0a3-macos-python2.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a4/gafferDependencies-5.0.0a4-Python2-osx.tar.gz
             testRunner: bash -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 ------------
 
 - USD : Added basic support for loading UsdLux lights. The data is available in Gaffer, but needs manual conversion to meet the requirements of a specific renderer.
+- ImageReader/ImageWriter : Added support for JPEG 2000 (`.jp2`) images.
 - Spreadsheet : Added `activeRowIndex` plug, which outputs the index of the currently active row.
 - InteractiveArnoldRender : Added support for an `updateInteractively` bool parameter for render outputs. This can be used to request more frequent updates for AOVs other than the beauty image.
 - ChannelPlugValueWidget : Improved the ordering of channel names presented in the menu.
@@ -50,6 +51,13 @@ Breaking Changes
 - Spreadsheet :
   - Renamed `activeRowNames` plug to `enabledRowNames`. Backwards compatibility is provided when loading old `.gfr` files.
   - Renamed `ui:spreadsheet:activeRowNamesConnection` metadata to `ui:spreadsheet:enabledRowNamesConnection`.
+
+Build
+-----
+
+- Qt : Updated to version 5.15.3.
+- LLVM : Updated to version 11.1.0.
+- Subprocess32 : Now packaged as a regular module rather than as a `.egg` package.
 
 0.62.0.0a1
 ==========


### PR DESCRIPTION
As well as the advertised changes, this also provides Cycles, so we can start to build and test the GafferCycles module.
