### PR TITLE
ShaderQuery : Fix type qualifiers for return type

### DIFF
--- a/src/GafferScene/ShaderQuery.cpp
+++ b/src/GafferScene/ShaderQuery.cpp
@@ -105,7 +105,7 @@ void addChildPlugsToAffectedOutputs( const Gaffer::Plug* plug, Gaffer::Dependenc
 /// Returns the index into the child vector of `parentPlug` that is
 /// either the `childPlug` itself or an ancestor of childPlug.
 /// Throws an Exception if the `childPlug` is not a descendant of `parentPlug`.
-const size_t getChildIndex( const Gaffer::Plug *parentPlug, const Gaffer::ValuePlug *descendantPlug )
+size_t getChildIndex( const Gaffer::Plug *parentPlug, const Gaffer::ValuePlug *descendantPlug )
 {
 	const GraphComponent *p = descendantPlug;
 	while( p )


### PR DESCRIPTION
Gaffer 0.61.9.0 fails to built at IE for houdini because of more strict compiler flags.

The changes in this PR addresses those warnings.

@johnhaddon, I'm not sure which flag exactly triggers the warning, but here is the warning message (which is treated as an error):

```
2022-05-12T18:59:38.2857648Z src/GafferScene/ShaderQuery.cpp:108:101: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
2022-05-12T18:59:38.2862978Z  const size_t getChildIndex( const Gaffer::Plug *parentPlug, const Gaffer::ValuePlug *descendantPlug )
```

And here is the compiler flags we use when building for houdini:

```
"-D_GLIBCXX_USE_CXX11_ABI=0", "-D_GNU_SOURCE", "-DLINUX", "-DAMD64", "-m64", "-fPIC",
"-DSIZEOF_VOID_P=8",
"-DFBX_ENABLED=1", "-DOPENCL_ENABLED=1", "-DOPENVDB_ENABLED=1", "-DSESI_LITTLE_ENDIAN",
"-DENABLE_THREADS",
"-DUSE_PTHREADS", "-D_REENTRANT", "-D_FILE_OFFSET_BITS=64", "-c", "-DGCC4", "-DGCC3",
"-Wno-deprecated",
"-Wall", "-W", "-Wno-parentheses", "-Wno-sign-compare", "-Wno-reorder", "-Wno-uninitialized",
"-Wunused", "-Wno-unused-parameter", "-Wno-unused-local-typedefs", "-fno-strict-aliasing",
```

Do you think we should make the regular compiler flags more strict so that errors like this one don't get past the CI?
Or do you think that the houdini flags being used at IE are too strict?
