### PR TITLE
Extra warnings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ API
 
 - RenderController : Added `pathForID()`, `pathsForIDs()`, `idForPath()` and `idsForPaths()` methods. These make it possible to identify an object in the scene from a `uint id` AOV.
 
+Fixes
+-----
+
+- TransformQuery : Removed unnecessary elements from hash.
+
 Breaking Changes
 ----------------
 

--- a/SConstruct
+++ b/SConstruct
@@ -88,7 +88,10 @@ options.Add(
 options.Add(
 	"CXXFLAGS",
 	"The extra flags to pass to the C++ compiler during compilation.",
-	[ "-pipe", "-Wall" ] if Environment()["PLATFORM"] != "win32" else [],
+	# We want `-Wextra` because some of its warnings are useful, and further useful
+	# warnings may be added in future. But it does introduce warnings we find unhelpful - see
+	# the compiler sections below where we turn them back off again.
+	[ "-pipe", "-Wall", "-Wextra" ] if Environment()["PLATFORM"] != "win32" else [],
 )
 
 options.Add(
@@ -429,6 +432,9 @@ if env["PLATFORM"] != "win32" :
 			CXXFLAGS = [ "-Wno-unused-local-typedef" ]
 		)
 
+		# Turn off the parts of `-Wextra` that we don't like.
+		env.Append( CXXFLAGS = [ "-Wno-unused-parameter" ] )
+
 	elif "g++" in os.path.basename( env["CXX"] ) :
 
 		# Get GCC version.
@@ -450,6 +456,9 @@ if env["PLATFORM"] != "win32" :
 
 		if gccVersion >= [ 9, 2 ] :
 			env.Append( CXXFLAGS = [ "-Wsuggest-override" ] )
+
+		# Turn off the parts of `-Wextra` that we don't like.
+		env.Append( CXXFLAGS = [ "-Wno-cast-function-type", "-Wno-unused-parameter" ] )
 
 		env.Append(
 			CXXFLAGS = [ "-pthread" ],

--- a/SConstruct
+++ b/SConstruct
@@ -432,22 +432,11 @@ if env["PLATFORM"] != "win32" :
 				gccVersion = subprocess.check_output( [ env["CXX"], "-dumpfullversion" ], env=env["ENV"], universal_newlines=True ).strip()
 			gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
 
-			# GCC 4.1.2 in conjunction with boost::flat_map produces crashes when
-			# using the -fstrict-aliasing optimisation (which defaults to on with -O2),
-			# so we turn the optimisation off here, only for that specific GCC version.
-			if gccVersion == [ 4, 1, 2 ] :
-				env.Append( CXXFLAGS = [ "-fno-strict-aliasing" ] )
-
 			# GCC emits spurious "assuming signed overflow does not occur"
 			# warnings, typically triggered by the comparisons in Box3f::isEmpty().
 			# Downgrade these back to warning status.
 			if gccVersion >= [ 4, 2 ] :
 				env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
-
-			# Old GCC emits spurious "maybe uninitialized" warnings when using
-			# boost::optional
-			if gccVersion < [ 5, 1 ] :
-				env.Append( CXXFLAGS = [ "-Wno-error=maybe-uninitialized" ] )
 
 			if gccVersion >= [ 5, 1 ] :
 				env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -93,7 +93,10 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 				/// `plug->execute()` in the specified context.
 				/// A copy of the context is stored.
 				Task( ConstTaskPlugPtr plug, const Gaffer::Context *context );
-				Task( const Task &t );
+				Task( const Task &t ) = default;
+				~Task() = default;
+				Task & operator = ( const Task &rhs ) = default;
+
 				/// Returns the TaskPlug component of the task.
 				const TaskPlug *plug() const;
 				/// Returns the Context component of the task.

--- a/src/GafferDelight/IECoreDelightPreview/CurvesAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/CurvesAlgo.cpp
@@ -77,7 +77,8 @@ void staticParameters( const IECoreScene::CurvesPrimitive *object, ParameterList
 			basis,
 			NSITypeString,
 			0,
-			1
+			1,
+			0
 		} );
 	}
 

--- a/src/GafferDelight/IECoreDelightPreview/GeometryAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/GeometryAlgo.cpp
@@ -63,7 +63,7 @@ bool convert( const IECoreScenePreview::Geometry *geometry, NSIContext_t context
 	{
 		const double angle = angleData->readable();
 		ParameterList parameters;
-		parameters.add( { "angle", &angle, NSITypeDouble, 0, 1 } );
+		parameters.add( { "angle", &angle, NSITypeDouble, 0, 1, 0 } );
 		NSISetAttribute( context, handle, parameters.size(), parameters.data() );
 	}
 

--- a/src/GafferDelight/IECoreDelightPreview/MeshAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/MeshAlgo.cpp
@@ -60,7 +60,8 @@ void staticParameters( const IECoreScene::MeshPrimitive *mesh, ParameterList &pa
 			&g_catmullClark,
 			NSITypeString,
 			0,
-			1
+			1,
+			0
 		} );
 	}
 }

--- a/src/GafferDelight/IECoreDelightPreview/PointsAlgo.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/PointsAlgo.cpp
@@ -59,7 +59,8 @@ void staticParameters( const IECoreScene::PointsPrimitive *object, ParameterList
 			&g_one,
 			NSITypeFloat,
 			0,
-			1
+			1,
+			0
 		} );
 	}
 }

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -258,8 +258,8 @@ class DelightOutput : public IECore::RefCounted
 			const char *namePtr = output->getName().c_str();
 
 			ParameterList driverParams( output->parameters() );
-			driverParams.add( { "drivername", &typePtr, NSITypeString, 0, 1 } );
-			driverParams.add( { "imagefilename", &namePtr, NSITypeString, 0, 1 } );
+			driverParams.add( { "drivername", &typePtr, NSITypeString, 0, 1, 0 } );
+			driverParams.add( { "imagefilename", &namePtr, NSITypeString, 0, 1, 0 } );
 
 			m_driverHandle = DelightHandle( context, "outputDriver:" + name, ownership, "outputdriver", driverParams );
 
@@ -325,7 +325,7 @@ class DelightOutput : public IECore::RefCounted
 			layerParams.add( "variablesource", variableSource );
 			layerParams.add( "layertype", layerType );
 			layerParams.add( "layername", layerName );
-			layerParams.add( { "withalpha", &withAlpha, NSITypeInteger, 0, 1 } );
+			layerParams.add( { "withalpha", &withAlpha, NSITypeInteger, 0, 1, 0 } );
 
 			const string scalarFormat = this->scalarFormat( output );
 			const string colorProfile = scalarFormat == "float" ? "linear" : "sRGB";
@@ -1007,8 +1007,8 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			if( renderType == SceneDescription )
 			{
 				params = {
-					{ "type", &apistream, NSITypeString, 0, 1 },
-					{ "streamfilename", &fileNamePtr, NSITypeString , 0, 1 }//,
+					{ "type", &apistream, NSITypeString, 0, 1, 0 },
+					{ "streamfilename", &fileNamePtr, NSITypeString , 0, 1, 0 }
 				};
 			}
 
@@ -1016,8 +1016,8 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			{
 				void *handler = reinterpret_cast<void *>( &DelightRenderer::nsiErrorHandler );
 				void *data = this;
-				params.push_back( { "errorhandler",	&handler, NSITypePointer, 0, 1 } );
-				params.push_back( { "errorhandlerdata",	&data, NSITypePointer, 0, 1 } );
+				params.push_back( { "errorhandler",	&handler, NSITypePointer, 0, 1, 0 } );
+				params.push_back( { "errorhandlerdata",	&data, NSITypePointer, 0, 1, 0 } );
 			}
 
 			m_context = NSIBegin( params.size(), params.data() );
@@ -1259,7 +1259,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			{
 				const char *synchronize = "synchronize";
 				vector<NSIParam_t> params = {
-					{ "action", &synchronize, NSITypeString, 0, 1 }
+					{ "action", &synchronize, NSITypeString, 0, 1, 0 }
 				};
 				NSIRenderControl(
 					m_context,
@@ -1273,13 +1273,13 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			const int one = 1;
 			const char *start = "start";
 			vector<NSIParam_t> params = {
-				{ "action", &start, NSITypeString, 0, 1 },
-				{ "frame", &m_frame, NSITypeInteger, 0, 1 }
+				{ "action", &start, NSITypeString, 0, 1, 0 },
+				{ "frame", &m_frame, NSITypeInteger, 0, 1, 0 }
 			};
 
 			if( m_renderType == Interactive )
 			{
-				params.push_back( { "interactive", &one, NSITypeInteger, 0, 1 } );
+				params.push_back( { "interactive", &one, NSITypeInteger, 0, 1, 0 } );
 			}
 
 			NSIRenderControl(
@@ -1296,7 +1296,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 			const char *wait = "wait";
 			params = {
-				{ "action", &wait, NSITypeString, 0, 1 }
+				{ "action", &wait, NSITypeString, 0, 1, 0 }
 			};
 
 			NSIRenderControl(
@@ -1331,7 +1331,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 			const char *stop = "stop";
 			ParameterList params = {
-				{ "action", &stop, NSITypeString, 0, 1 }
+				{ "action", &stop, NSITypeString, 0, 1, 0 }
 			};
 
 			NSIRenderControl(
@@ -1412,7 +1412,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			// Update the screen
 
 			ParameterList screeenParameters = {
-				{ "oversampling", &m_oversampling, NSITypeInteger, 0, 1 }
+				{ "oversampling", &m_oversampling, NSITypeInteger, 0, 1, 0 }
 			};
 
 			const V2i &resolution = camera->getResolution();

--- a/src/GafferDispatch/TaskNode.cpp
+++ b/src/GafferDispatch/TaskNode.cpp
@@ -58,10 +58,6 @@ TaskNode::Task::Task( ConstTaskPlugPtr plug, const Gaffer::Context *context )
 {
 }
 
-TaskNode::Task::Task( const Task &t ) : m_plug( t.m_plug ), m_context( t.m_context )
-{
-}
-
 TaskNode::Task::Task( TaskNodePtr n, const Context *c ) : m_plug( n->taskPlug() ), m_context( new Context( *c ) )
 {
 }

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -744,7 +744,7 @@ void BranchCreator::hashObject( const ScenePath &path, const Gaffer::Context *co
 				hashBranchObject( path, branchPath, context, h );
 				break;
 			}
-			// Fall through
+			[[fallthrough]];
 		case Ancestor :
 		case PassThrough :
 			h = inPlug()->objectPlug()->hash();
@@ -778,7 +778,7 @@ IECore::ConstObjectPtr BranchCreator::computeObject( const ScenePath &path, cons
 				}
 				return computeBranchObject( path, branchPath, context );
 			}
-			// Fall through
+			[[fallthrough]];
 		case Ancestor :
 		case PassThrough :
 			return inPlug()->objectPlug()->getValue();
@@ -815,7 +815,7 @@ void BranchCreator::hashChildNames( const ScenePath &path, const Gaffer::Context
 				newChildNames->hash( h );
 				return;
 			}
-			// Fall through
+			[[fallthrough]];
 		case PassThrough :
 		default :
 			h = inPlug()->childNamesPlug()->hash();
@@ -850,7 +850,7 @@ IECore::ConstInternedStringVectorDataPtr BranchCreator::computeChildNames( const
 				);
 				return combinedNames;
 			}
-			// Fall through
+			[[fallthrough]];
 		case PassThrough :
 		default :
 			return inPlug()->childNamesPlug()->getValue();

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -115,8 +115,10 @@ uint32_t MurmurHash3_x86_32( const void *key, size_t len, uint32_t seed )
 	{
 	case 3:
 		k1 ^= tail[2] << 16;
+		[[fallthrough]];
 	case 2:
 		k1 ^= tail[1] << 8;
+		[[fallthrough]];
 	case 1:
 		k1 ^= tail[0];
 		k1 *= c1;

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -591,6 +591,7 @@ void MergeScenes::hashAttributes( const ScenePath &path, const Gaffer::Context *
 				case InputType::First :
 					// Initialise hash and fall through
 					SceneProcessor::hashAttributes( path, context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input hash
 					scene->attributesPlug()->hash( h );
@@ -619,6 +620,7 @@ IECore::ConstCompoundObjectPtr MergeScenes::computeAttributes( const ScenePath &
 					// fall through.
 					merged = new CompoundObject();
 					result = merged;
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input attributes into result.
 					ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
@@ -649,6 +651,7 @@ void MergeScenes::hashObject( const ScenePath &path, const Gaffer::Context *cont
 				case InputType::First :
 					// Initialise hash and fall through.
 					SceneProcessor::hashObject( path, context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input hash.
 					scene->objectPlug()->hash( h );
@@ -696,6 +699,7 @@ void MergeScenes::hashChildNames( const ScenePath &path, const Gaffer::Context *
 					break;
 				case InputType::First :
 					SceneProcessor::hashChildNames( path, context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					scene->childNamesPlug()->hash( h );
 			}
@@ -760,6 +764,7 @@ void MergeScenes::hashGlobals( const Gaffer::Context *context, const ScenePlug *
 				case InputType::First :
 					// Initialise hash and fall through.
 					SceneProcessor::hashGlobals( context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input hash.
 					scene->globalsPlug()->hash( h );
@@ -788,6 +793,7 @@ IECore::ConstCompoundObjectPtr MergeScenes::computeGlobals( const Gaffer::Contex
 					// fall through.
 					merged = new CompoundObject();
 					result = merged;
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input globals into result.
 					ConstCompoundObjectPtr globals = scene->globalsPlug()->getValue();
@@ -818,6 +824,7 @@ void MergeScenes::hashSetNames( const Gaffer::Context *context, const ScenePlug 
 				case InputType::First :
 					// Initialise hash and fall through.
 					SceneProcessor::hashSetNames( context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input hash.
 					scene->setNamesPlug()->hash( h );
@@ -845,6 +852,7 @@ IECore::ConstInternedStringVectorDataPtr MergeScenes::computeSetNames( const Gaf
 					// fall through.
 					merged = new InternedStringVectorData();
 					result = merged;
+					[[fallthrough]];
 				case InputType::Other :
 					// This naive approach to merging set names preserves the order of the incoming names,
 					// but at the expense of using linear search. We assume that the number of sets is small
@@ -879,6 +887,7 @@ void MergeScenes::hashSet( const IECore::InternedString &setName, const Gaffer::
 				case InputType::First :
 					// Initialise hash and fall through.
 					SceneProcessor::hashSet( setName, context, parent, h );
+					[[fallthrough]];
 				case InputType::Other :
 					// Merge input hash.
 					scene->setPlug()->hash( h );
@@ -906,6 +915,7 @@ IECore::ConstPathMatcherDataPtr MergeScenes::computeSet( const IECore::InternedS
 					// fall through.
 					merged = new PathMatcherData();
 					result = merged;
+					[[fallthrough]];
 				case InputType::Other :
 					ConstPathMatcherDataPtr paths = scene->setPlug()->getValue();
 					merged->writable().addPaths( paths->readable() );

--- a/src/GafferScene/Set.cpp
+++ b/src/GafferScene/Set.cpp
@@ -371,6 +371,7 @@ IECore::ConstPathMatcherDataPtr Set::computeSet( const IECore::InternedString &s
 				return result;
 			}
 			// Input set empty - fall through to create mode.
+			[[fallthrough]];
 		}
 		case Create : {
 			return pathMatcher;

--- a/src/GafferScene/TransformQuery.cpp
+++ b/src/GafferScene/TransformQuery.cpp
@@ -267,6 +267,7 @@ void TransformQuery::hash( Gaffer::ValuePlug const* const output, Gaffer::Contex
 					{
 						h.append( splug->fullTransformHash( path ) );
 						h.append( invertPlug()->hash() );
+						break;
 					}
 					case Space::Relative:
 					{

--- a/src/IECoreArnold/ShapeAlgo.cpp
+++ b/src/IECoreArnold/ShapeAlgo.cpp
@@ -228,6 +228,7 @@ void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const Pr
 			}
 			// "indexed" data only makes sense for meshes - fall
 			// through to Vertex case,
+			[[fallthrough]];
 		case PrimitiveVariable::Vertex :
 			// Arnold doesn't appear to have vertex storage, but
 			// fortunately for many primitives it is equivalent to varying.


### PR DESCRIPTION
 This turns on `-Wextra` and deals with the consequences, so we're less likely to have a mismatch with IE's compiler options as in #4661. This turned up one legitimate (but pretty harmless) bug in TransformQuery, but was otherwise pretty uneventful.