### PR TITLE
Viewer : Tool hotkeys for non-exclusive tools should work as toggle

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+0.61.x.x (relative to 0.61.9.0)
+========
+
+Features
+--------
+
+- Tool hotkeys now work as toggles for non-exclusive tools.  This is currently noticeable on the Camera Tool - pressing T again will deactivate it.
+
+
 0.61.9.0 (relative to 0.61.8.0)
 ========
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -231,7 +231,13 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 		for t in self.__toolChooser.tools() :
 			if Gaffer.Metadata.value( t, "viewer:shortCut" ) == event.key :
-				t["active"].setValue( True )
+				if not t["active"].getValue():
+					t["active"].setValue( True )
+				else:
+					# If it's already active, and it's a non-exclusive tool, then pressing the key
+					# again should deactivate it
+					if Gaffer.Metadata.value( t, "tool:exclusive" ) == False:
+						t["active"].setValue( False )
 				return True
 
 		return False


### PR DESCRIPTION
As discussed, it makes sense for the hotkeys for non-exclusive tools to work as toggles.  This addresses the user request that the T hotkey for the camera tool work as a toggle.