### PR TITLE
GafferArnold : Drop support for Arnold versions prior to 7.1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
         import sys
         import os
 
-        for arnoldVersion in [ "6.2.0.1", "7.0.0.3", "7.1.1.0" ] :
+        for arnoldVersion in [ "7.1.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
           os.environ["ARNOLD_ROOT"] =  arnoldRoot
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,17 @@
 0.62.x.x (relative to 0.62.0.0a2)
 ========
 
+> Note : This release requires Arnold version 7.1.0.0 or newer.
+
 API
 ---
 
 - RenderController : Added `pathForID()`, `pathsForIDs()`, `idForPath()` and `idsForPaths()` methods. These make it possible to identify an object in the scene from a `uint id` AOV.
+
+Breaking Changes
+----------------
+
+- Arnold : Removed support for Arnold versions prior to 7.1.0.0.
 
 0.62.0.0a2 (relative to 0.62.0.0a1)
 ==========

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -301,7 +301,7 @@ texinfo_documents = [
 
 # Variables for string replacement functions
 
-arnold_version = '5.1.1.1'
+arnold_version = '7.1.1.1'
 arnold_path_linux = '/opt/solidangle/arnold-{0}'.format( arnold_version )
 arnold_path_osx = '/opt/solidangle/arnold-{0}'.format( arnold_version )
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -695,14 +695,10 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		for t in threads :
 			t.join()
 
-		if [ int( v ) for v in arnold.AiGetVersion()[:3] ] >= [ 7, 0, 0 ] :
-			with Gaffer.Context() as c :
-				for i in range( 0, 2 ) :
-					c.setFrame( i )
-					self.assertTrue( os.path.exists( c.substitute( render["fileName"].getValue() ) ) )
-		else :
-			self.assertEqual( len( errors ), 1 )
-			self.assertTrue( "Arnold is already in use" in errors[0] )
+		with Gaffer.Context() as c :
+			for i in range( 0, 2 ) :
+				c.setFrame( i )
+				self.assertTrue( os.path.exists( c.substitute( render["fileName"].getValue() ) ) )
 
 	def testTraceSets( self ) :
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -109,32 +109,11 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["r2"] = self._createInteractiveRender( failOnError = False )
 		s["r2"]["in"].setInput( s["o2"]["out"] )
 
-		if [ int( v ) for v in arnold.AiGetVersion()[:3] ] >= [ 7, 0, 0 ] :
+		s["r2"]["state"].setValue( s["r"].State.Running )
+		time.sleep( 0.5 )
 
-			s["r2"]["state"].setValue( s["r"].State.Running )
-			time.sleep( 0.5 )
-
-			image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere2" )
-			self.assertTrue( isinstance( image, IECoreImage.ImagePrimitive ) )
-
-		else :
-
-			# Only one universe available, so second render will fail.
-
-			try :
-				defaultHandler = IECore.MessageHandler.getDefaultHandler()
-				messageHandler = IECore.CapturingMessageHandler()
-				IECore.MessageHandler.setDefaultHandler( messageHandler )
-				s["r2"]["state"].setValue( s["r"].State.Running )
-			finally :
-				IECore.MessageHandler.setDefaultHandler( defaultHandler )
-
-			messages = s["r2"]["messages"].getValue().value
-			self.assertEqual( len( messages ), 1 )
-			self.assertEqual( messages[0].message, "Arnold is already in use" )
-
-			self.assertEqual( len( messageHandler.messages ), 1 )
-			self.assertEqual( messageHandler.messages[0].message, "Arnold is already in use" )
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere2" )
+		self.assertTrue( isinstance( image, IECoreImage.ImagePrimitive ) )
 
 	def testEditSubdivisionAttributes( self ) :
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -2740,7 +2740,6 @@ class RendererTest( GafferTest.TestCase ) :
 
 				self.assertEqual( [ m.message for m in fallbackHandler.messages ], [], msg=str(renderType) )
 
-	@unittest.skipIf( [ int( v ) for v in arnold.AiGetVersion()[:3] ] < [ 7, 0, 0 ], "Two renders not supported" )
 	# Arnold's message handling is broken. The errors from `AiNodeSetInt()` are sent
 	# to the render session for the default universe instead of the render session for
 	# the universe the node is in.

--- a/python/IECoreArnoldTest/UniverseBlockTest.py
+++ b/python/IECoreArnoldTest/UniverseBlockTest.py
@@ -47,36 +47,13 @@ import IECoreArnold
 
 class UniverseBlockTest( unittest.TestCase ) :
 
-	__usingMultipleUniverses = [ int( v ) for v in arnold.AiGetVersion()[:3] ] >= [ 7, 0, 0 ]
-
-	def test( self ) :
-
-		if not self.__usingMultipleUniverses :
-			self.assertFalse( arnold.AiUniverseIsActive() )
-
-		with IECoreArnold.UniverseBlock( writable = False ) :
-
-			if not self.__usingMultipleUniverses :
-				self.assertTrue( arnold.AiUniverseIsActive() )
-
-			with IECoreArnold.UniverseBlock( writable = False ) :
-
-				if not self.__usingMultipleUniverses :
-					self.assertTrue( arnold.AiUniverseIsActive() )
-
-			if not self.__usingMultipleUniverses :
-				self.assertTrue( arnold.AiUniverseIsActive() )
-
 	def testWritable( self ) :
 
 		def createBlock( writable, expectedUniverse = None ) :
 
 			with IECoreArnold.UniverseBlock( writable ) as universe :
 
-				if not self.__usingMultipleUniverses :
-					self.assertTrue( arnold.AiUniverseIsActive() )
-				else :
-					self.assertIsNotNone( universe )
+				self.assertIsNotNone( universe )
 
 				if expectedUniverse is not None :
 					self.assertEqual(
@@ -86,21 +63,12 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			if not self.__usingMultipleUniverses :
-				self.assertTrue( arnold.AiUniverseIsActive() )
-			else :
-				self.assertIsNotNone( universe )
-
+			self.assertIsNotNone( universe )
 			createBlock( False )
-			if not self.__usingMultipleUniverses :
-				six.assertRaisesRegex( self, RuntimeError, "Arnold is already in use", createBlock, True )
 
 		with IECoreArnold.UniverseBlock( writable = False ) as universe :
 
-			if not self.__usingMultipleUniverses :
-				self.assertTrue( arnold.AiUniverseIsActive() )
-			else :
-				self.assertIsNotNone( universe )
+			self.assertIsNotNone( universe )
 
 			createBlock( True )
 			createBlock( False, expectedUniverse = universe )
@@ -145,18 +113,6 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 				arnold.AiMetaDataGetInt( e, "AA_samples", "cortex.testInt", i )
 				self.assertEqual( i.value, 12 )
-
-	@unittest.skipIf( __usingMultipleUniverses, "Not relevant" )
-	def testReadOnlyUniverseDoesntPreventWritableUniverseCleanup( self ) :
-
-		with IECoreArnold.UniverseBlock( writable = False ) :
-
-			with IECoreArnold.UniverseBlock( writable = True ) :
-
-				node = arnold.AiNode( "polymesh" )
-				arnold.AiNodeSetStr( node, "name", "test" )
-
-			self.assertEqual( arnold.AiNodeLookUpByName( "test" ), None )
 
 	def testKickNodes( self ) :
 

--- a/src/GafferArnoldPlugin/OutputDriver.cpp
+++ b/src/GafferArnoldPlugin/OutputDriver.cpp
@@ -106,21 +106,13 @@ void driverParameters( AtList *params, AtNodeEntry *nentry )
 	AiMetaDataSetStr( nentry, nullptr, "maya.translator", "ie" );
 }
 
-#if ARNOLD_VERSION_NUM < 70100
-void driverInitialize( AtNode *node )
-#else
 void driverInitialize( AtRenderSession *session, AtNode *node )
-#endif
 {
 	AiDriverInitialize( node, true );
 	AiNodeSetLocalData( node, new LocalData );
 }
 
-#if ARNOLD_VERSION_NUM < 70100
-void driverUpdate( AtNode *node )
-#else
 void driverUpdate( AtRenderSession *session, AtNode *node )
-#endif
 {
 }
 
@@ -157,11 +149,7 @@ void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displa
 	CompoundDataPtr parameters = new CompoundData();
 	ParameterAlgo::getParameters( node, parameters->writable() );
 
-#if ARNOLD_VERSION_NUM >= 70000
 	AtString name;
-#else
-	const char *name;
-#endif
 	int pixelType = 0;
 	while( AiOutputIteratorGetNext( iterator, &name, &pixelType, nullptr ) )
 	{
@@ -194,11 +182,7 @@ void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displa
 			case AI_TYPE_FLOAT :
 			case AI_TYPE_UINT :
 				// no need for prefix because it's not a compound type
-#if ARNOLD_VERSION_NUM >= 70000
 				channelNames.push_back( name.c_str() );
-#else
-				channelNames.push_back( name );
-#endif
 				break;
 		}
 		localData->numOutputs += 1;

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -234,37 +234,6 @@ IECore::DataPtr arrayToDataInternal( AtArray *array, F f )
 	return data;
 }
 
-#if ARNOLD_VERSION_NUM < 70000
-
-// Prior to Arnold 7, `AiArrayGet*` is implemented using macros.
-// Replace them with function equivalent to the ones in Arnold 7.
-
-#undef AiArrayGetBool
-bool AiArrayGetBool( const AtArray *a, uint32_t i )
-{
-	return AiArrayGetBoolFunc( a, i, __AI_FILE__, __AI_LINE__ );
-}
-
-#undef AiArrayGetInt
-int AiArrayGetInt( const AtArray *a, uint32_t i )
-{
-	return AiArrayGetIntFunc( a, i, __AI_FILE__, __AI_LINE__ );
-}
-
-#undef AiArrayGetUInt
-uint32_t AiArrayGetUInt( const AtArray *a, uint32_t i )
-{
-	return AiArrayGetUIntFunc( a, i, __AI_FILE__, __AI_LINE__ );
-}
-
-#undef AiArrayGetFlt
-float AiArrayGetFlt( const AtArray *a, uint32_t i )
-{
-	return AiArrayGetFltFunc( a, i, __AI_FILE__, __AI_LINE__ );
-}
-
-#endif
-
 const char* getStrWrapper( const AtArray* a, uint32_t i )
 {
 	return AiArrayGetStr( a, i ).c_str();

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2973,74 +2973,6 @@ void throwError( int errorCode )
 	}
 }
 
-#if ARNOLD_VERSION_NUM < 70000
-
-// Arnold 6 doesn't have AtRenderSession, so we define forwards-compatibility wrappers
-// that let us write code to the new API only, rather than sprinkle `#ifdefs` throughout.
-
-class AtRenderSession;
-
-AtRenderSession *AiRenderSession( AtUniverse *universe, AtSessionMode mode )
-{
-	return nullptr;
-}
-
-AtRenderErrorCode AiRenderBegin( AtRenderSession *renderSession, AtRenderMode mode = AI_RENDER_MODE_CAMERA, AtRenderUpdateCallback callback = nullptr, void *callbackData = nullptr )
-{
-	return ::AiRenderBegin( mode, callback, callbackData );
-}
-
-void AiRenderInterrupt( AtRenderSession *renderSession, AtBlockingCall blocking )
-{
-	return ::AiRenderInterrupt( blocking );
-}
-
-void AiRenderRestart( AtRenderSession *renderSession )
-{
-	return ::AiRenderRestart();
-}
-
-AtRenderErrorCode AiRenderEnd( AtRenderSession *renderSession )
-{
-	return ::AiRenderEnd();
-}
-
-bool AiRenderSetHintInt( AtRenderSession *renderSession, AtString hint, int32_t value )
-{
-	return AiRenderSetHintInt( hint, value );
-}
-
-bool AiRenderSetHintBool( AtRenderSession *renderSession, AtString hint, bool value )
-{
-	return AiRenderSetHintBool( hint, value );
-}
-
-void AiRenderAddInteractiveOutput( AtRenderSession *renderSession, uint32_t outputIndex )
-{
-	::AiRenderAddInteractiveOutput( outputIndex );
-}
-
-void AiRenderRemoveAllInteractiveOutputs( AtRenderSession *renderSession )
-{
-	::AiRenderRemoveAllInteractiveOutputs();
-}
-
-void AiRenderSessionDestroy( AtRenderSession *renderSession )
-{
-}
-
-void AiMsgSetConsoleFlags( const AtRenderSession *renderSession, int flags )
-{
-	::AiMsgSetConsoleFlags( flags );
-}
-
-void AiMsgSetLogFileFlags( const AtRenderSession *renderSession, int flags )
-{
-	::AiMsgSetLogFileFlags( flags );
-}
-
-#endif
-
 // Arnold's `AiRender()` function does exactly what you want for a batch render :
 // starts a render and returns when it is complete. But it is deprecated. Here we
 // jump through hoops to re-implement the behaviour using non-deprecated API.
@@ -3151,26 +3083,14 @@ class ArnoldGlobals
 			if( m_messageHandler )
 			{
 				m_messageCallbackId = AiMsgRegisterCallback( &messageCallback, m_consoleFlags, this );
-#if ARNOLD_VERSION_NUM < 70100
-				AiMsgSetConsoleFlags( m_renderSession.get(), AI_LOG_NONE );
-#else
 				AiMsgSetConsoleFlags( m_universeBlock->universe(), AI_LOG_NONE );
-#endif
 			}
 			else
 			{
-#if ARNOLD_VERSION_NUM < 70100
-				AiMsgSetConsoleFlags( m_renderSession.get(), m_consoleFlags );
-#else
 				AiMsgSetConsoleFlags( m_universeBlock->universe(), m_consoleFlags );
-#endif
 			}
 
-#if ARNOLD_VERSION_NUM < 70100
-			AiMsgSetLogFileFlags( m_renderSession.get(), m_logFileFlags );
-#else
 			AiMsgSetLogFileFlags( m_universeBlock->universe(), m_logFileFlags );
-#endif
 			// Get OSL shaders onto the shader searchpath.
 			option( g_pluginSearchPathOptionName, new IECore::StringData( "" ) );
 		}
@@ -3811,20 +3731,12 @@ class ArnoldGlobals
 				}
 				else
 				{
-#if ARNOLD_VERSION_NUM < 70100
-					AiMsgSetConsoleFlags( m_renderSession.get(), flags );
-#else
 					AiMsgSetConsoleFlags( m_universeBlock->universe(), flags );
-#endif
 				}
 			}
 			else
 			{
-#if ARNOLD_VERSION_NUM < 70100
-				AiMsgSetLogFileFlags( m_renderSession.get(), flags );
-#else
 				AiMsgSetLogFileFlags( m_universeBlock->universe(), flags );
-#endif
 			}
 
 			return true;
@@ -4004,7 +3916,6 @@ class ArnoldGlobals
 		{
 			const ArnoldGlobals *that = static_cast<ArnoldGlobals *>( userPtr );
 
-#if ARNOLD_VERSION_NUM >= 70100
 			// We get given messages from all render sessions, but can filter them based on the `universe` metadata.
 			void *universe = nullptr;
 			if( AiParamValueMapGetPtr( metadata, g_universeArnoldString, &universe ) )
@@ -4014,18 +3925,6 @@ class ArnoldGlobals
 					return;
 				}
 			}
-#elif ARNOLD_VERSION_NUM >= 70000
-			// We get given messages from all render sessions, but can filter them based on the
-			// `render_session` metadata.
-			void *renderSession = nullptr;
-			if( AiParamValueMapGetPtr( metadata, g_renderSessionArnoldString, &renderSession ) )
-			{
-				if( renderSession != that->m_renderSession.get() )
-				{
-					return;
-				}
-			}
-#endif
 
 			const IECore::Msg::Level level = \
 				( mask == AI_LOG_DEBUG ) ? IECore::Msg::Level::Debug : g_ieMsgLevels[ min( severity, 3 ) ];

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2973,88 +2973,6 @@ void throwError( int errorCode )
 	}
 }
 
-// Arnold's `AiRender()` function does exactly what you want for a batch render :
-// starts a render and returns when it is complete. But it is deprecated. Here we
-// jump through hoops to re-implement the behaviour using non-deprecated API.
-void renderAndWait( AtRenderSession *renderSession )
-{
-
-	// Updated by `callback` to notify this thread when the render has
-	// completed.
-	struct Status {
-		std::mutex mutex;
-		std::condition_variable conditionVariable;
-		AtRenderStatus value = AI_RENDER_STATUS_NOT_STARTED;
-	} status;
-
-	// Called from one of the Arnold render threads to notify us of progress.
-	auto callback = []( void *voidStatus, AtRenderUpdateType updateType, const AtRenderUpdateInfo *updateInfo ) {
-
-		// We are required to return a new status for the render,
-		// following a table of values in `ai_render.h`.
-		AtRenderStatus newStatus = AI_RENDER_STATUS_FAILED;
-		switch( updateType )
-		{
-			case AI_RENDER_UPDATE_INTERRUPT :
-				newStatus = AI_RENDER_STATUS_PAUSED;
-				break;
-			case AI_RENDER_UPDATE_BEFORE_PASS :
-				newStatus = AI_RENDER_STATUS_RENDERING;
-				break;
-			case AI_RENDER_UPDATE_DURING_PASS :
-				newStatus = AI_RENDER_STATUS_RENDERING;
-				break;
-			case AI_RENDER_UPDATE_AFTER_PASS :
-				newStatus = AI_RENDER_STATUS_RENDERING;
-				break;
-			case AI_RENDER_UPDATE_IMAGERS :
-				// Documentation doesn't state the appropriate
-				// return value, so this is a guess.
-				newStatus = AI_RENDER_STATUS_RENDERING;
-				break;
-			case AI_RENDER_UPDATE_FINISHED :
-				newStatus = AI_RENDER_STATUS_FINISHED;
-				break;
-			case AI_RENDER_UPDATE_ERROR :
-				newStatus = AI_RENDER_STATUS_FAILED;
-				break;
-			// No `default` clause so that the compiler will warn us
-			// when new AtRenderUpdateType values are added.
-		}
-
-		if( newStatus == AI_RENDER_STATUS_FINISHED || newStatus == AI_RENDER_STATUS_FAILED )
-		{
-			// Notify the waiting thread that we're done.
-			Status *status = static_cast<Status *>( voidStatus );
-			{
-				std::lock_guard<std::mutex> lock( status->mutex );
-				status->value = newStatus;
-			}
-			status->conditionVariable.notify_one();
-		}
-
-		return newStatus;
-	};
-
-	// Start the render. `AiRenderBegin()` returns immediately.
-	AtRenderErrorCode result = AiRenderBegin( renderSession, AI_RENDER_MODE_CAMERA, callback, &status );
-	if( result != AI_SUCCESS )
-	{
-		throwError( result );
-	}
-
-	// Wait to be notified that the render has finished. We're using the
-	// condition variable approach to avoid busy-waiting on `AiRenderGetStatus()`.
-	std::unique_lock<std::mutex> lock( status.mutex );
-	status.conditionVariable.wait( lock, [&status]{ return status.value != AI_RENDER_STATUS_NOT_STARTED; } );
-
-	result = AiRenderEnd( renderSession );
-	if( result != AI_SUCCESS )
-	{
-		throwError( result );
-	}
-}
-
 class ArnoldGlobals
 {
 
@@ -3565,7 +3483,7 @@ class ArnoldGlobals
 					for( const auto &cameraOverride : cameraOverrides )
 					{
 						updateCamera( cameraOverride.size() ? cameraOverride : m_cameraName );
-						renderAndWait( m_renderSession.get() );
+						throwError( AiRender( m_renderSession.get() ) );
 					}
 					break;
 				}


### PR DESCRIPTION
In 0.62 we plan to introduce features that lean on Arnold 7's multiple universe support, so we are dropping support for prior Arnold versions. And since 7.0 was such a short-lived version (and has at least one important bug not fixed until 7.1), it seems reasonable to require 7.1 as a minimum.