### PR TITLE
ID AOVs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ API
 
 - ImageAlgo : Added `sortChannelNames()` function.
 - NodeAlgo : Added support for presets on compound plugs. If all child plugs have a particular preset then the parent plug is considered to have it too, and calling `applyPreset( parent, preset )` will apply it to all the children.
+- RenderController : Added `pathForID()`, `pathsForIDs()`, `idForPath()` and `idsForPaths()` methods. These make it possible to identify an object in the scene from a `uint id` AOV.
 
 Breaking Changes
 ----------------

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -119,6 +119,8 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				int numAttributeEdits() const;
 				int numLinkEdits( const IECore::InternedString &type ) const;
 
+				uint32_t id() const;
+
 				/// Renderer interface
 				/// ==================
 
@@ -126,6 +128,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
 				bool attributes( const AttributesInterface *attributes ) override;
 				void link( const IECore::InternedString &type, const ConstObjectSetPtr &objects ) override;
+				void assignID( uint32_t id ) override;
 
 			private :
 
@@ -142,6 +145,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				ConstCapturedAttributesPtr m_capturedAttributes;
 				int m_numAttributeEdits;
 				std::unordered_map<IECore::InternedString, std::pair<ConstObjectSetPtr, int>> m_capturedLinks;
+				uint32_t m_id;
 
 		};
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -203,6 +203,9 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 				/// - "lightFilters" : specifies the set of light filters that should
 				///   be applied to a light.
 				virtual void link( const IECore::InternedString &type, const ConstObjectSetPtr &objects ) = 0;
+				/// Assigns an integer ID that should be made available via a `uint id`
+				/// AOV that can be referenced via `output()`.
+				virtual void assignID( uint32_t id ) = 0;
 
 			protected :
 

--- a/include/GafferScene/RenderController.h
+++ b/include/GafferScene/RenderController.h
@@ -63,6 +63,9 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		RenderController( const ConstScenePlugPtr &scene, const Gaffer::ConstContextPtr &context, const IECoreScenePreview::RendererPtr &renderer );
 		~RenderController();
 
+		// Renderer, scene and expansion
+		// =============================
+
 		IECoreScenePreview::Renderer *renderer();
 
 		void setScene( const ConstScenePlugPtr &scene );
@@ -77,6 +80,9 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		void setMinimumExpansionDepth( size_t depth );
 		size_t getMinimumExpansionDepth() const;
 
+		// Update
+		// ======
+
 		using UpdateRequiredSignal = Gaffer::Signals::Signal<void ( RenderController & )>;
 		UpdateRequiredSignal &updateRequiredSignal();
 
@@ -88,6 +94,20 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		std::shared_ptr<Gaffer::BackgroundTask> updateInBackground( const ProgressCallback &callback = ProgressCallback(), const IECore::PathMatcher &priorityPaths = IECore::PathMatcher()  );
 
 		void updateMatchingPaths( const IECore::PathMatcher &pathsToUpdate, const ProgressCallback &callback = ProgressCallback() );
+
+		// ID queries
+		// ==========
+		//
+		// These allow IDs acquired from a standard `uint id` AOV to be mapped
+		// back to the scene paths they came from.
+
+		std::optional<ScenePlug::ScenePath> pathForID( uint32_t id ) const;
+		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids ) const;
+
+		// Returns the ID associated with the specified path, or `0` if that
+		// path has not been rendered.
+		uint32_t idForPath( const ScenePlug::ScenePath &path ) const;
+		std::vector<uint32_t> idsForPaths( const IECore::PathMatcher &paths ) const;
 
 	private :
 
@@ -123,10 +143,12 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 
 		class SceneGraph;
 		class SceneGraphUpdateTask;
+		class IDMap;
 
 		ConstScenePlugPtr m_scene;
 		Gaffer::ConstContextPtr m_context;
 		IECoreScenePreview::RendererPtr m_renderer;
+		std::unique_ptr<IDMap> m_idMap;
 
 		IECore::PathMatcher m_expandedPaths;
 		size_t m_minimumExpansionDepth;

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -79,10 +79,14 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		self.assertEqual( o.capturedLinks( "lights" ), None )
 		self.assertEqual( o.numAttributeEdits(), 1 )
 		self.assertEqual( o.numLinkEdits( "lights" ), 0 )
+		self.assertEqual( o.id(), 0 )
 
 		o.attributes( attributes2 )
 		self.assertEqual( o.capturedAttributes(), attributes2 )
 		self.assertEqual( o.numAttributeEdits(), 2 )
+
+		o.assignID( 10 )
+		self.assertEqual( o.id(), 10 )
 
 		l1 = renderer.light( "l1", IECore.NullObject(), attributes1 )
 		l2 = renderer.light( "l2", IECore.NullObject(), attributes1 )

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
@@ -70,6 +70,12 @@ class CompoundRendererTest( GafferTest.TestCase ) :
 			self.assertEqual( o.capturedSamples(), [ IECoreScene.SpherePrimitive() ] )
 			self.assertEqual( o.capturedSampleTimes(), [] )
 			self.assertEqual( o.capturedAttributes().attributes(), coreAttributes1 )
+			self.assertEqual( o.id(), 0 )
+
+		compoundObject.assignID( 1 )
+		for r in renderers :
+			o = r.capturedObject( "o" )
+			self.assertEqual( o.id(), 1 )
 
 		# Attribute edits
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3616,6 +3616,32 @@ class RendererTest( GafferTest.TestCase ) :
 		# Must delete objects before the renderer.
 		del light
 
+	def testIDAOV( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+		)
+
+		fileName = os.path.join( self.temporaryDirectory(), "testID.exr" )
+		r.output( "testID", IECoreScene.Output( fileName, "exr", "uint id", { "filter" : "closest" } ) )
+
+		o = r.object(
+			"/sphere",
+				IECoreScene.SpherePrimitive(),
+				r.attributes( IECore.CompoundObject() )
+		)
+		o.transform( imath.M44f().translate( imath.V3f( 0, 0, -2 ) ) )
+		o.assignID( 101 )
+		del o
+
+		r.render()
+
+		imageReader = IECoreImage.ImageReader( fileName )
+		data = imageReader.readChannel( "Y", raw = True )
+		self.assertIsInstance( data, IECore.UIntVectorData )
+		self.assertEqual( data[len(data)//2], 101 )
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -296,6 +296,12 @@ class AppleseedEntity : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
+		void assignID( uint32_t id ) override
+		{
+			// Not implemented. We don't anticipate using Appleseed in scenarios
+			// where IDs are useful.
+		}
+
 	protected :
 
 		AppleseedEntity( asr::Project &project, const string &name, bool interactiveRender )

--- a/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
+++ b/src/GafferDelight/IECoreDelightPreview/Renderer.cpp
@@ -956,6 +956,11 @@ class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
+		void assignID( uint32_t id ) override
+		{
+			/// \todo Implement
+		}
+
 	private :
 
 		const DelightHandle m_transformHandle;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -445,6 +445,16 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 		{
 		}
 
+		void assignID( uint32_t id ) override
+		{
+			// The GL renderer provides a more lightweight ID mechanism where
+			// IDs are just the index in the object list, and don't need
+			// assigning. This is exposed via the `gl:querySelection` command.
+			// So we don't implement `assignID()` for now.
+			/// \todo Evaluate overhead of the more general ID mechanism, and
+			/// consider dropping the custom OpenGL one.
+		}
+
 		Box3f transformedBound() const
 		{
 			Box3f b;

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -223,7 +223,7 @@ bool CapturingRenderer::CapturedAttributes::unrenderableAttributeValue() const
 //////////////////////////////////////////////////////////////////////////
 
 CapturingRenderer::CapturedObject::CapturedObject( CapturingRenderer *renderer, const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times )
-	:	m_renderer( renderer ), m_name( name ), m_capturedSamples( samples.begin(), samples.end() ), m_capturedSampleTimes( times ), m_numAttributeEdits( 0 )
+	:	m_renderer( renderer ), m_name( name ), m_capturedSamples( samples.begin(), samples.end() ), m_capturedSampleTimes( times ), m_numAttributeEdits( 0 ), m_id( 0 )
 {
 }
 
@@ -288,6 +288,11 @@ int CapturingRenderer::CapturedObject::numLinkEdits( const IECore::InternedStrin
 	return it->second.second;
 }
 
+uint32_t CapturingRenderer::CapturedObject::id() const
+{
+	return m_id;
+}
+
 void CapturingRenderer::CapturedObject::transform( const Imath::M44f &transform )
 {
 	m_renderer->checkPaused();
@@ -329,4 +334,9 @@ void CapturingRenderer::CapturedObject::link( const IECore::InternedString &type
 	auto &p = m_capturedLinks[type];
 	p.first = objects;
 	p.second++;
+}
+
+void CapturingRenderer::CapturedObject::assignID( uint32_t id )
+{
+	m_id = id;
 }

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -131,6 +131,17 @@ struct CompoundObjectInterface : public IECoreScenePreview::Renderer::ObjectInte
 		}
 	}
 
+	void assignID( uint32_t id ) override
+	{
+		for( auto &o : objects )
+		{
+			if( o )
+			{
+				o->assignID( id );
+			}
+		}
+	}
+
 	/// See comment for CompoundAttributesInterface::attributes.
 	std::array<IECoreScenePreview::Renderer::ObjectInterfacePtr, 2> objects;
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -51,6 +51,9 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"
 #include "boost/container/flat_set.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/ordered_index.hpp"
+#include "boost/multi_index_container.hpp"
 
 #include "tbb/task.h"
 
@@ -218,6 +221,70 @@ struct ObjectInterfaceHandle : public boost::noncopyable
 //////////////////////////////////////////////////////////////////////////
 // Internal implementation details
 //////////////////////////////////////////////////////////////////////////
+
+// Maps between scene locations and integer IDs.
+class RenderController::IDMap
+{
+
+	public :
+
+		// Creates an ID if no ID has been created yet.
+		uint32_t acquireID( const ScenePlug::ScenePath &path )
+		{
+			Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+			auto it = m_map.find( path );
+			if( it != m_map.end() )
+			{
+				return it->second;
+			}
+
+			lock.upgrade_to_writer();
+			return m_map.insert( PathAndID( path, m_map.size() + 1 ) ).first->second;
+		}
+
+		uint32_t idForPath( const ScenePlug::ScenePath &path ) const
+		{
+			Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+			auto it = m_map.find( path );
+			if( it != m_map.end() )
+			{
+				return it->second;
+			}
+			return 0;
+		}
+
+		std::optional<ScenePlug::ScenePath> pathForID( uint32_t id ) const
+		{
+			Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+			auto &index = m_map.get<1>();
+			auto it = index.find( id );
+			if( it != index.end() )
+			{
+				return it->first;
+			}
+			return std::nullopt;
+		}
+
+	private :
+
+		using PathAndID = std::pair<ScenePlug::ScenePath, uint32_t>;
+		using Map = boost::multi_index::multi_index_container<
+			PathAndID,
+			boost::multi_index::indexed_by<
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<PathAndID, ScenePlug::ScenePath, &PathAndID::first>
+				>,
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<PathAndID, uint32_t, &PathAndID::second>
+				>
+			>
+		>;
+		using Mutex = tbb::spin_rw_mutex;
+
+		Map m_map;
+		mutable Mutex m_mutex;
+
+};
 
 // Represents a location in the Gaffer scene as specified to the
 // renderer. We use this to build up a persistent representation of
@@ -426,6 +493,18 @@ class RenderController::SceneGraph
 					else
 					{
 						m_objectInterface->transform( m_fullTransform, *m_transformTimesOutput );
+					}
+				}
+
+				// Assign an ID
+				if( m_changedComponents & ObjectComponent )
+				{
+					// We don't assign IDs for OpenGL renders, because the OpenGL renderer
+					// assigns its own lightweight IDs.
+					/// \todo Measure overhead and consider using same IDs everywhere.
+					if( controller->m_renderer->name() != g_openGLRendererName )
+					{
+						m_objectInterface->assignID( controller->m_idMap->acquireID( path ) );
 					}
 				}
 
@@ -1213,6 +1292,7 @@ class RenderController::SceneGraphUpdateTask : public tbb::task
 
 RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer::ConstContextPtr &context, const IECoreScenePreview::RendererPtr &renderer )
 	:	m_renderer( renderer ),
+		m_idMap( std::make_unique<IDMap>() ),
 		m_minimumExpansionDepth( 0 ),
 		m_updateRequired( false ),
 		m_updateRequested( false ),
@@ -1666,4 +1746,40 @@ void RenderController::cancelBackgroundTask()
 		m_backgroundTask->cancelAndWait();
 		m_backgroundTask.reset();
 	}
+}
+
+std::optional<ScenePlug::ScenePath> RenderController::pathForID( uint32_t id ) const
+{
+	return m_idMap->pathForID( id );
+}
+
+IECore::PathMatcher RenderController::pathsForIDs( const std::vector<uint32_t> &ids ) const
+{
+	IECore::PathMatcher result;
+	for( auto id : ids )
+	{
+		if( auto path = m_idMap->pathForID( id ) )
+		{
+			result.addPath( *path );
+		}
+	}
+	return result;
+}
+
+uint32_t RenderController::idForPath( const ScenePlug::ScenePath &path ) const
+{
+	return m_idMap->idForPath( path );
+}
+
+std::vector<uint32_t> RenderController::idsForPaths( const IECore::PathMatcher &paths ) const
+{
+	std::vector<uint32_t> result;
+	for( PathMatcher::Iterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
+	{
+		if( auto id = idForPath( *it ) )
+		{
+			result.push_back( id );
+		}
+	}
+	return result;
 }

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -426,6 +426,7 @@ void GafferSceneModule::bindRender()
 				.def( "transform", objectInterfaceTransform2 )
 				.def( "attributes", &Renderer::ObjectInterface::attributes )
 				.def( "link", &objectInterfaceLink )
+				.def( "assignID", &Renderer::ObjectInterface::assignID )
 			;
 		}
 
@@ -509,6 +510,7 @@ void GafferSceneModule::bindRender()
 			.def( "capturedLinks", &capturedObjectCapturedLinks )
 			.def( "numAttributeEdits", &CapturingRenderer::CapturedObject::numAttributeEdits )
 			.def( "numLinkEdits", &CapturingRenderer::CapturedObject::numLinkEdits )
+			.def( "id", &CapturingRenderer::CapturedObject::id )
 		;
 	}
 

--- a/src/GafferSceneModule/RenderControllerBinding.cpp
+++ b/src/GafferSceneModule/RenderControllerBinding.cpp
@@ -103,6 +103,20 @@ void updateMatchingPaths( RenderController &r, const IECore::PathMatcher &pathsT
 	r.updateMatchingPaths( pathsToUpdate );
 }
 
+object pathForID( RenderController &r, uint32_t id )
+{
+	if( auto path = r.pathForID( id ) )
+	{
+		return object( ScenePlug::pathToString( *path ) );
+	}
+	return object();
+}
+
+IECore::UIntVectorDataPtr idsForPaths( RenderController &r, const IECore::PathMatcher &paths )
+{
+	return new IECore::UIntVectorData( r.idsForPaths( paths ) );
+}
+
 } // namespace
 
 void GafferSceneModule::bindRenderController()
@@ -122,6 +136,10 @@ void GafferSceneModule::bindRenderController()
 		.def( "updateRequiredSignal", &RenderController::updateRequiredSignal, return_internal_reference<1>() )
 		.def( "update", &update )
 		.def( "updateMatchingPaths", &updateMatchingPaths )
+		.def( "pathForID", &pathForID )
+		.def( "pathsForIDs", &RenderController::pathsForIDs )
+		.def( "idForPath", &RenderController::idForPath )
+		.def( "idsForPaths", &idsForPaths )
 	;
 
 	SignalClass<RenderController::UpdateRequiredSignal>( "UpdateRequiredSignal" );


### PR DESCRIPTION
This adds minimal changes to Renderer and RenderController to allow an integer ID AOV to be used to identify objects in rendered images. This lays the foundations for supporting arbitrary renders in `GafferSceneUI::SceneGadget`, which is currently limited to OpenGL.