### PR TITLE
Light editor source node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,9 @@ Improvements
 - Viewer : Tool hotkeys now work as toggles for non-exclusive tools. This is currently noticeable on the Camera Tool - pressing <kbd>T</kbd> again will deactivate it.
 - ArnoldShader and ArnoldLight : Added activators and sections to the UI.
 - ImageWriter : Options are only displayed for the file format being written. If the extension is unknown, all format options are shown.
+- Light Editor : Added keyboard shortcuts for selected light.
+  - <kbd>Alt+E</kbd> : Edit source node.
+  - <kbd>Shift+Alt+E</kbd> : Edit tweaks node.
 
 API
 ---

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -394,6 +394,8 @@ Draw new region anywhere              :kbd:`Shift` + click and drag
 Action                               Control or shorcut
 ==================================== ================================================
 Copy selected paths                  :kbd:`Ctrl` + :kbd:`C`
+Edit source node of selection        :kbd:`Alt` + :kbd:`E`
+Edit tweaks node for selection       :kbd:`Alt` + :kbd:`Shift` + :kbd:`E`
 ==================================== ================================================
 ```
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -511,3 +511,14 @@ Move keyboard focus                                :kbd:`Ctrl` + :kbd:`Up`, :kbd
 Toggle selection state of cell with keyboard focus :kbd:`Space`
 ================================================== ================================================================
 ```
+
+## Light Editor ##
+
+```eval_rst
+====================================================== =====================================
+Action                                                 Control or shortcut
+====================================================== =====================================
+Edit source node of selection                          :kbd:`Alt` + :kbd:`E`
+Edit tweaks node for selection                         :kbd:`Alt` + :kbd:`Shift` + :kbd:`E`
+====================================================== =====================================
+```

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -123,6 +123,10 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 
 	__columnRegistry = collections.OrderedDict()
 
+	def scene( self ) :
+
+		return self.__plug
+
 	@classmethod
 	def registerParameter( cls, attribute, parameter, section = None ) :
 

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -65,7 +65,7 @@ def connectToEditor( editor ) :
 
 	if isinstance( editor, GafferUI.Viewer ) :
 		editor.keyPressSignal().connect( __viewerKeyPress, scoped = False )
-	elif isinstance( editor, GafferSceneUI.HierarchyView ) :
+	elif isinstance( editor, GafferSceneUI.HierarchyView ) or isinstance( editor, GafferSceneUI.LightEditor ) :
 		editor.keyPressSignal().connect( __hierarchyViewKeyPress, scoped = False )
 	elif isinstance( editor, GafferUI.Editor ) :
 		editor.keyPressSignal().connect( __nodeEditorKeyPress, scoped = False )


### PR DESCRIPTION
This adds shortcut keys the `HierarchyView` and `Viewer` have for bringing up the relevant node or tweaks for the selected light :
- Alt+E : Edit source node
- Shift+Alt+E : Edit tweaks node

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
