### PR TITLE
Rename hotkey

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - Light Editor : Added keyboard shortcuts for selected light.
   - <kbd>Alt+E</kbd> : Edit source node.
   - <kbd>Shift+Alt+E</kbd> : Edit tweaks node.
+- Edit Menu : Added item to rename one or more selected nodes, with accompanying keyboard shortcut (#4286).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - <kbd>Alt+E</kbd> : Edit source node.
   - <kbd>Shift+Alt+E</kbd> : Edit tweaks node.
 - Edit Menu : Added item to rename one or more selected nodes, with accompanying keyboard shortcut (#4286).
+- Box : Rename plug dialogue now ensures names are valid as they are typed.
 
 Fixes
 -----

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -388,6 +388,16 @@ GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = Fa
 def __renamePlug( menu, plug ) :
 
 	d = GafferUI.TextInputDialogue( initialText = plug.getName(), title = "Enter name", confirmLabel = "Rename" )
+
+	# Hack to borrow the input validation from NameWidget so we can prevent the
+	# user entering an invalid name.
+	# \todo : This could be improved with some combination of a public validator
+	# API, sanitising node names in `GraphComponent::setName` and relaxing
+	# `GraphComponent` name contraints.
+	from GafferUI.NameWidget import _Validator
+	textWidget = d._getWidget()._qtWidget()
+	textWidget.setValidator( _Validator( textWidget ) )
+
 	name = d.waitForText( parentWindow = menu.ancestor( GafferUI.Window ) )
 
 	if not name :


### PR DESCRIPTION
This adds a rename dialog box for renaming nodes. It is accessible from the `Edit` menu and the `F2` keyboard shortcut.

The second commit, where I added a validator to the `TextInputDialogue`, is probably not acceptable in its current form, but I'm including it as an idea for making name input a little more fool-proof. As a counter-example, giving an invalid name to a `Box` plug via the context menu outputs an error to the console as the attempted name change fails.

### Related issues ###

- #4286

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
