### PR TITLE
Arnold ShaderNetworkAlgo : Fix textured mesh lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,11 @@ Improvements
 - ArnoldShader and ArnoldLight : Added activators and sections to the UI.
 - ImageWriter : Options are only displayed for the file format being written. If the extension is unknown, all format options are shown.
 
+Fixes
+-----
+
+- ArnoldMeshLight : Fixed illumination from textured mesh lights. This was broken in 0.61.2.0.
+
 API
 ---
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -427,6 +427,86 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["render"]["state"].setValue( s["render"].State.Stopped )
 
+	def testMeshLightTexture( self ) :
+
+		# Build scene with textures mesh light `/group/sphere1`
+		# on left, illuminating a sphere `/group/sphere2` on right.
+
+		s = Gaffer.ScriptNode()
+
+		s["catalogue"] = GafferImage.Catalogue()
+
+		s["sphere1"] = GafferScene.Sphere()
+		s["sphere1"]["name"].setValue( "sphere1" )
+		s["sphere1"]["radius"].setValue( 10 )
+		s["sphere1"]["transform"]["translate"].setValue( imath.V3f( -10, 0, -2 ) )
+
+		s["sphere2"] = GafferScene.Sphere()
+		s["sphere2"]["name"].setValue( "sphere2" )
+		s["sphere2"]["transform"]["translate"].setValue( imath.V3f( 1, 0, -2 ) )
+
+		s["group"] = GafferScene.Group()
+		s["group"]["in"][0].setInput( s["sphere1"]["out"] )
+		s["group"]["in"][1].setInput( s["sphere2"]["out"] )
+
+		s["sphere1Filter"] = GafferScene.PathFilter()
+		s["sphere1Filter"]["paths"].setValue( IECore.StringVectorData( [ '/group/sphere1' ] ) )
+
+		s["checkerboard"] = GafferArnold.ArnoldShader()
+		s["checkerboard"].loadShader( "checkerboard" )
+
+		s["meshLight"] = GafferArnold.ArnoldMeshLight()
+		s["meshLight"]["in"].setInput( s["group"]["out"] )
+		s["meshLight"]["filter"].setInput( s["sphere1Filter"]["out"] )
+		s["meshLight"]["parameters"]["color"].setInput( s["checkerboard"]["out"] )
+		s["meshLight"]["parameters"]["exposure"].setValue( 11 )
+
+		s["lambert"] = GafferArnold.ArnoldShader()
+		s["lambert"].loadShader( "lambert" )
+
+		s["sphere2Filter"] = GafferScene.PathFilter()
+		s["sphere2Filter"]["paths"].setValue( IECore.StringVectorData( [ '/group/sphere2' ] ) )
+
+		s["shaderAssignment"] = GafferScene.ShaderAssignment()
+		s["shaderAssignment"]["in"].setInput( s["meshLight"]["out"] )
+		s["shaderAssignment"]["filter"].setInput( s["sphere2Filter"]["out"] )
+		s["shaderAssignment"]["shader"].setInput( s["lambert"]["out"] )
+
+		s["outputs"] = GafferScene.Outputs()
+		s["outputs"]["in"].setInput( s["shaderAssignment"]["out"] )
+		s["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ClientDisplayDriver",
+					"displayHost" : "localhost",
+					"displayPort" : str( s['catalogue'].displayDriverServer().portNumber() ),
+					"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+				}
+			)
+		)
+
+		s["options"] = GafferArnold.ArnoldOptions()
+		s["options"]["in"].setInput( s["outputs"]["out"] )
+		s["options"]["options"]["aaSamples"]["enabled"].setValue( True )
+		s["options"]["options"]["aaSamples"]["value"].setValue( 5 )
+
+		s["render"] = self._createInteractiveRender()
+		s["render"]["in"].setInput( s["options"]["out"] )
+
+		# Render, and check `sphere2`` is receiving illumination.
+
+		s["render"]["state"].setValue( s["render"].State.Running )
+		self.uiThreadCallHandler.waitFor( 1.0 )
+
+		litColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.75, 0.5 ) )
+		self.assertGreater( litColor.r, 0.1 )
+		self.assertGreater( litColor.g, 0.1 )
+		self.assertGreater( litColor.b, 0.1 )
+
 	def _createConstantShader( self ) :
 
 		shader = GafferArnold.ArnoldShader()

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -254,7 +254,7 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 			sourceName = partitionEnd( sourceName, '.' );
 		}
 
-		if( parameterName == "color" && ( shader->getName() == "quad_light" || shader->getName() == "skydome_light" ) )
+		if( parameterName == "color" && ( shader->getName() == "quad_light" || shader->getName() == "skydome_light" || shader->getName() == "mesh_light" ) )
 		{
 			// In general, Arnold should be able to form a connection onto a parameter even if the
 			// parameter already has a value.  Something weird happens with the "color" parameter


### PR DESCRIPTION
This was broken in 02a9345704d72b9e35863e72714b0f82dbf2b63a, when we started storing parameter values even when a connection exists. Something about the existence of a value stops Arnold from evaluating the connection correctly. We already fixed the equivalent bug for `skydome_light` and `quad_light` in 77536f0a80049e787354e4648f92c672c1ef599e, and the same fix works for `mesh_light`.
