### PR TITLE
SceneGadget : Support alternative renderers

### DIFF
--- a/include/GafferSceneUI/Private/OutputBuffer.h
+++ b/include/GafferSceneUI/Private/OutputBuffer.h
@@ -1,0 +1,117 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_OUTPUTBUFFER_H
+#define GAFFERSCENEUI_OUTPUTBUFFER_H
+
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "Gaffer/Signals.h"
+
+#include "IECoreGL/Shader.h"
+#include "IECoreGL/Texture.h"
+
+#include "IECore/PathMatcher.h"
+
+#include <mutex>
+
+namespace GafferSceneUI
+{
+
+/// Provides OpenGL rendering of beauty, depth and ID outputs from an
+/// `IECoreScenePreview::Renderer`.
+class OutputBuffer
+{
+
+	public :
+
+		/// Calls `renderer->output()` to create outputs that will be sent to
+		/// this buffer.
+		OutputBuffer( IECoreScenePreview::Renderer *renderer );
+		~OutputBuffer();
+
+		/// Renders the output buffers to OpenGL.
+		void render() const;
+
+		/// Specifies a set of objects to be drawn as highlighted.
+		void setSelection( const std::vector<uint32_t> &ids );
+		const std::vector<uint32_t> &getSelection() const;
+
+		/// Returns the ID for the object found at the specified NDC position, filling `depth` with its
+		/// depth from the camera. Returns 0 if no object is found.
+		uint32_t idAt( const Imath::V2f &ndcPosition, float &depth ) const;
+		/// Returns the IDs of all objects found in the specified region of NDC space.
+		std::vector<uint32_t> idsAt( const Imath::Box2f &ndcBox ) const;
+
+		/// Signal emitted when the buffers have changed and `render()`
+		/// should be called.
+		using BufferChangedSignal = Gaffer::Signals::Signal<void()>;
+		BufferChangedSignal &bufferChangedSignal();
+
+	private :
+
+		class DisplayDriver;
+
+		void imageFormat( const Imath::Box2i &displayWindow, const Imath::Box2i &dataWindow );
+		template<typename T>
+		void updateBuffer( const Imath::Box2i &box, const T *data, int numChannels, std::vector<T> &buffer );
+		void dirtyTexture();
+
+		// Used to prevent the buffers being reallocated by an `imageFormat()` call
+		// on a background thread while they are being read from by the foreground
+		// thread. _Not_ used to synchronise reads/writes - see `updateBuffer()`.
+		mutable std::mutex m_bufferReallocationMutex;
+
+		Imath::Box2i m_dataWindow;
+		std::vector<float> m_rgbaBuffer;
+		std::vector<float> m_depthBuffer;
+		std::vector<uint32_t> m_idBuffer;
+		std::vector<uint32_t> m_selectionBuffer;
+		BufferChangedSignal m_bufferChangedSignal;
+
+		mutable std::atomic_bool m_texturesDirty;
+		mutable IECoreGL::TexturePtr m_rgbaTexture;
+		mutable IECoreGL::TexturePtr m_depthTexture;
+		mutable IECoreGL::TexturePtr m_idTexture;
+		class BufferTexture;
+		mutable std::unique_ptr<BufferTexture> m_selectionTexture;
+		mutable IECoreGL::ShaderPtr m_shader;
+		mutable IECoreGL::Shader::SetupPtr m_shaderSetup;
+
+};
+
+} // namespace GafferSceneUI
+
+#endif // GAFFERSCENEUI_OUTPUTBUFFER_H

--- a/python/GafferArnoldUITest/ArnoldSceneGadgetTest.py
+++ b/python/GafferArnoldUITest/ArnoldSceneGadgetTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,12 +34,17 @@
 #
 ##########################################################################
 
-from .DocumentationTest import DocumentationTest
-from .ArnoldShaderUITest import ArnoldShaderUITest
-from .VisualiserAlgoTest import VisualiserAlgoTest
-from .InteractiveArnoldRenderPerformanceTest import InteractiveArnoldRenderPerformanceTest
-from .NodeUITest import NodeUITest
-from .ArnoldSceneGadgetTest import ArnoldSceneGadgetTest
+import unittest
+
+import GafferTest
+import GafferSceneUITest
+
+@unittest.skipIf( GafferTest.inCI(), "Insufficient OpenGL features - need GLSL 330" )
+class ArnoldSceneGadgetTest( GafferSceneUITest.SceneGadgetTest ) :
+
+	# Tests are inherited from base class. We just need to
+	# override the renderer being used.
+	renderer = "Arnold"
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -872,7 +872,12 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 			if( m_renderType == Interactive )
 			{
-				renderInteractive();
+				// We currently don't have any use for interactively rendering
+				// to outputs defined by the `output()` function. To facilitate
+				// interactive use in a CompoundRenderer (where the other
+				// renderer _is_ rendering to the outputs), we instead define a
+				// separate `gl:renderToCurrentContext` command which renders
+				// into a framebuffer managed by the client.
 			}
 			else
 			{
@@ -902,6 +907,11 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 			{
 				return querySelectedObjects( parameters );
 			}
+			else if( name == "gl:renderToCurrentContext" )
+			{
+				renderToCurrentContext();
+				return nullptr;
+			}
 			else if( boost::starts_with( name.string(), "gl:" ) || name.string().find( ":" ) == string::npos )
 			{
 				IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer::command", boost::format( "Unknown command \"%s\"." ) % name.c_str() );
@@ -912,7 +922,7 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 
 	private :
 
-		void renderInteractive()
+		void renderToCurrentContext()
 		{
 			processQueue();
 			removeDeletedObjects();

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -74,6 +74,7 @@ namespace
 {
 
 const InternedString g_openGLRendererName( "OpenGL" );
+const InternedString g_compoundRendererName( "Compound" );
 
 // Copied from RendererAlgo.cpp
 
@@ -1717,10 +1718,12 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 
 void RenderController::updateDefaultCamera()
 {
-	if( m_renderer->name() == g_openGLRendererName )
+	if( m_renderer->name() == g_openGLRendererName || m_renderer->name() == g_compoundRendererName )
 	{
-		// Don't need a default camera for OpenGL, because in interactive mode the
-		// renderer currently expects the camera to be provided externally.
+		// Don't need a default camera for OpenGL, because in interactive mode
+		// the renderer currently expects the camera to be provided externally.
+		// Don't currently need one for compound renderers either, because then
+		// SceneGadget provides a camera.
 		return;
 	}
 

--- a/src/GafferSceneUI/OutputBuffer.cpp
+++ b/src/GafferSceneUI/OutputBuffer.cpp
@@ -1,0 +1,543 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/OutputBuffer.h"
+
+#include "IECoreGL/ShaderLoader.h"
+
+#include "IECoreImage/DisplayDriver.h"
+
+#include "OpenEXR/ImathBoxAlgo.h"
+
+#include "boost/lexical_cast.hpp"
+
+#include <unordered_set>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreGL;
+using namespace GafferScene;
+using namespace GafferSceneUI;
+
+//////////////////////////////////////////////////////////////////////////
+// BufferTexture
+//////////////////////////////////////////////////////////////////////////
+
+// IECoreGL::Texture doesn't support buffer textures, so we roll our own.
+class OutputBuffer::BufferTexture
+{
+	public :
+
+		BufferTexture()
+		{
+			glGenTextures( 1, &m_texture );
+			glGenBuffers( 1, &m_buffer );
+		}
+
+		~BufferTexture()
+		{
+			glDeleteBuffers( 1, &m_buffer );
+			glDeleteTextures( 1, &m_texture );
+		}
+
+		GLuint texture() const
+		{
+			return m_texture;
+		}
+
+		void updateBuffer( const vector<uint32_t> &data )
+		{
+			glBindBuffer( GL_TEXTURE_BUFFER, m_buffer );
+			glBufferData( GL_TEXTURE_BUFFER, sizeof( uint32_t ) * data.size(), data.data(), GL_STREAM_DRAW );
+
+			glBindTexture( GL_TEXTURE_BUFFER, m_texture );
+			glTexBuffer( GL_TEXTURE_BUFFER, GL_R32UI, m_buffer );
+		}
+
+	private :
+
+		GLuint m_texture;
+		GLuint m_buffer;
+
+};
+
+//////////////////////////////////////////////////////////////////////////
+// GLSL source
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+const char *g_vertexSource = R"(
+
+#version 330 compatibility
+
+in vec2 P; // Receives unit quad
+out vec2 texCoords;
+
+void main()
+{
+	vec2 p = P * 2.0 - 1.0;
+	gl_Position = vec4( p.x, p.y, 0, 1 );
+	texCoords = P * vec2( 1, -1 ) + vec2( 0, 1 );
+}
+
+)";
+
+const char *g_fragmentSource = R"(
+
+#version 330 compatibility
+
+#include "IECoreGL/ColorAlgo.h"
+
+// Assumes texture contains sorted values.
+bool contains( usamplerBuffer array, uint value )
+{
+	int high = textureSize( array ) - 1;
+	int low = 0;
+	while( low != high )
+	{
+		int mid = (low + high + 1) / 2;
+		if( texelFetch( array, mid ).r > value )
+		{
+			high = mid - 1;
+		}
+		else
+		{
+			low = mid;
+		}
+	}
+	return texelFetch( array, low ).r == value;
+}
+
+uniform sampler2D rgbaTexture;
+uniform sampler2D depthTexture;
+uniform usampler2D idTexture;
+uniform usamplerBuffer selectionTexture;
+
+in vec2 texCoords;
+layout( location=0 ) out vec4 outColor;
+
+void main()
+{
+	outColor = texture( rgbaTexture, texCoords );
+	if( outColor.a == 0.0 )
+	{
+		discard;
+	}
+
+	/// \todo : Add OCIO support for configurable color space
+	outColor = vec4(
+		outColor.a * ieLinToSRGB( outColor.r / outColor.a ),
+		outColor.a * ieLinToSRGB( outColor.g / outColor.a ),
+		outColor.a * ieLinToSRGB( outColor.b / outColor.a ),
+		outColor.a
+	);
+
+	// Input depth is absolute in camera space (completely
+	// unrelated to clipping planes). Convert to the screen
+	// space that `GL_fragDepth` needs.
+	float depth = texture( depthTexture, texCoords ).r;
+	vec4 Pcamera = vec4( 0.0, 0.0, -depth, 1.0 );
+	vec4 Pclip = gl_ProjectionMatrix * Pcamera;
+	float ndcDepth = Pclip.z / Pclip.w;
+	gl_FragDepth = (ndcDepth + 1.0) / 2.0;
+
+	uint id = texture( idTexture, texCoords ).r;
+	outColor = mix(
+		outColor,
+		vec4( 0.466, 0.612, 0.741, 1.0 ) * outColor.a,
+		0.75 * float( contains( selectionTexture, id ) )
+	);
+}
+
+)";
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// OutputBuffer
+//////////////////////////////////////////////////////////////////////////
+
+OutputBuffer::OutputBuffer( IECoreScenePreview::Renderer *renderer )
+	:	m_texturesDirty( false )
+{
+	IECoreScene::OutputPtr outputTemplate = new IECoreScene::Output( "", "ieDisplay", "" );
+	outputTemplate->parameters()["driverType"] = new IECore::StringData( "OutputBuffer::DisplayDriver" );
+	outputTemplate->parameters()["buffer"] =  new IECore::StringData( std::to_string( (uintptr_t)this ) );
+	outputTemplate->parameters()["updateInteractively"] = new IECore::BoolData( true );
+
+	using OutputDefinition = std::tuple<const char *, const char *, const char *>;
+	for(
+		auto &[name, data, filter] : {
+			OutputDefinition( "beauty", "rgba", "box" ),
+			OutputDefinition( "depth", "float Z", "closest" ),
+			OutputDefinition( "id", "uint id", "closest" ),
+		}
+	)
+	{
+		IECoreScene::OutputPtr output = outputTemplate->copy();
+		output->setName( name );
+		output->setData( data );
+		output->parameters()["filter"] = new IECore::StringData( filter );
+		renderer->output( string( "__outputBuffer:" ) + name, output.get() );
+	}
+}
+
+OutputBuffer::~OutputBuffer()
+{
+}
+
+void OutputBuffer::render() const
+{
+	if( m_dataWindow.isEmpty() )
+	{
+		return;
+	}
+
+	if( !m_rgbaTexture )
+	{
+		GLuint textures[3];
+		glGenTextures( 3, textures );
+		m_rgbaTexture = new Texture( textures[0] );
+		m_depthTexture = new Texture( textures[1] );
+		m_idTexture = new Texture( textures[2] );
+		for( auto &texture : { m_rgbaTexture, m_depthTexture, m_idTexture } )
+		{
+			Texture::ScopedBinding binding( *texture );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+			glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+		}
+		m_selectionTexture = std::make_unique<BufferTexture>();
+	}
+
+	if( m_texturesDirty.exchange( false ) )
+	{
+		std::unique_lock lock( m_bufferReallocationMutex );
+
+		glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
+
+		Texture::ScopedBinding binding( *m_rgbaTexture );
+		glTexImage2D(
+			GL_TEXTURE_2D, 0, GL_RGBA,
+			/* width = */ m_dataWindow.size().x + 1, /* height = */ m_dataWindow.size().y + 1, /* border = */ 0,
+			GL_RGBA, GL_FLOAT, m_rgbaBuffer.data()
+		);
+
+		Texture::ScopedBinding depthBinding( *m_depthTexture );
+		glTexImage2D(
+			GL_TEXTURE_2D, 0, GL_R32F,
+			/* width = */ m_dataWindow.size().x + 1, /* height = */ m_dataWindow.size().y + 1, /* border = */ 0,
+			GL_RED, GL_FLOAT, m_depthBuffer.data()
+		);
+
+		Texture::ScopedBinding idBinding( *m_idTexture );
+		glTexImage2D(
+			GL_TEXTURE_2D, 0, GL_R32UI,
+			/* width = */ m_dataWindow.size().x + 1, /* height = */ m_dataWindow.size().y + 1, /* border = */ 0,
+			GL_RED_INTEGER, GL_UNSIGNED_INT, m_idBuffer.data()
+		);
+
+		m_selectionTexture->updateBuffer( m_selectionBuffer );
+	}
+
+	if( !m_shader )
+	{
+		m_shader = ShaderLoader::defaultShaderLoader()->create( g_vertexSource, "", g_fragmentSource );
+		m_shaderSetup = new IECoreGL::Shader::Setup( m_shader );
+		m_shaderSetup->addUniformParameter( "rgbaTexture", m_rgbaTexture );
+		m_shaderSetup->addUniformParameter( "depthTexture", m_depthTexture );
+		m_shaderSetup->addUniformParameter( "idTexture", m_idTexture );
+		m_shaderSetup->addVertexAttribute(
+			"P", new V2fVectorData( { V2f( 0, 0 ), V2f( 0, 1 ), V2f( 1, 1 ), V2f( 1, 0 ) } )
+		);
+	}
+
+	IECoreGL::Shader::Setup::ScopedBinding shaderBinding( *m_shaderSetup );
+
+	const IECoreGL::Shader::Parameter *selectionParameter = m_shader->uniformParameter( "selectionTexture" );
+	GLuint selectionTextureUnit = selectionParameter->textureUnit;
+	if( !selectionTextureUnit )
+	{
+		// Workaround until IECoreGL assigns units to GL_SAMPLER_BUFFER.
+		selectionTextureUnit = 3;
+	}
+
+	glActiveTexture( GL_TEXTURE0 + selectionTextureUnit );
+	glBindTexture( GL_TEXTURE_BUFFER, m_selectionTexture->texture() );
+	glUniform1i( selectionParameter->location, selectionTextureUnit );
+
+	glPushAttrib( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_ENABLE_BIT );
+
+		glEnable( GL_DEPTH_TEST );
+		glEnable( GL_BLEND );
+		glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
+
+		glDrawArrays( GL_TRIANGLE_FAN, 0, 4 );
+
+	glPopAttrib();
+}
+
+void OutputBuffer::setSelection( const std::vector<uint32_t> &ids )
+{
+	m_selectionBuffer = ids;
+	if( !m_selectionBuffer.size() )
+	{
+		m_selectionBuffer.push_back( 0 );
+	}
+
+	std::sort( m_selectionBuffer.begin(), m_selectionBuffer.end() );
+
+	if( !m_dataWindow.isEmpty() )
+	{
+		// Don't want to dirty texture when data window is empty
+		// because there is nothing to draw anyway, and dirtying
+		// would prevent `bufferChangedSignal()` from being emitted
+		// when the first bucket arrives.
+		dirtyTexture();
+	}
+}
+
+const std::vector<uint32_t> &OutputBuffer::getSelection() const
+{
+	return m_selectionBuffer;
+}
+
+OutputBuffer::BufferChangedSignal &OutputBuffer::bufferChangedSignal()
+{
+	return m_bufferChangedSignal;
+}
+
+uint32_t OutputBuffer::idAt( const V2f &ndcPosition, float &depth ) const
+{
+	std::unique_lock lock( m_bufferReallocationMutex );
+
+	if( m_dataWindow.isEmpty() )
+	{
+		return false;
+	}
+
+	const V2i pixelPosition = ndcPosition * (m_dataWindow.size() + V2i( 1 ));
+	if( !m_dataWindow.intersects( pixelPosition ) )
+	{
+		return false;
+	}
+
+	const size_t pixelIndex = pixelPosition.x + pixelPosition.y * ( m_dataWindow.size().x + 1 );
+	assert( pixelIndex < m_idBuffer.size() );
+	if( uint32_t id = m_idBuffer[pixelIndex] )
+	{
+		depth = m_depthBuffer[pixelIndex];
+		return id;
+	}
+	return 0;
+}
+
+std::vector<uint32_t> OutputBuffer::idsAt( const Box2f &ndcBox ) const
+{
+	std::unique_lock lock( m_bufferReallocationMutex );
+
+	if( m_dataWindow.isEmpty() )
+	{
+		return {};
+	}
+
+	Box2i rasterBox(
+		ndcBox.min * ( m_dataWindow.size() + V2i( 1 ) ),
+		ndcBox.max * ( m_dataWindow.size() + V2i( 1 ) )
+	);
+	rasterBox.min = clip( rasterBox.min, m_dataWindow );
+	rasterBox.max = clip( rasterBox.max, m_dataWindow );
+
+	std::vector<uint32_t> result;
+	for( int y = rasterBox.min.y; y < rasterBox.max.y; ++y )
+	{
+		for( int x = rasterBox.min.x; x < rasterBox.max.x; ++x )
+		{
+			const size_t pixelIndex = x + y * ( m_dataWindow.size().x + 1 );
+			if( uint32_t id = m_idBuffer[pixelIndex] )
+			{
+				result.push_back( id );
+			}
+		}
+	}
+
+	std::sort( result.begin(), result.end() );
+	result.erase(
+		std::unique( result.begin(), result.end() ),
+		result.end()
+	);
+	return result;
+}
+
+// Note : Cortex display drivers use the EXR convention for windows, _not_ the Gaffer
+// one. This means that the size of the image in pixels is `dataWindow.size() + 1`.
+void OutputBuffer::imageFormat( const Imath::Box2i &displayWindow, const Imath::Box2i &dataWindow )
+{
+	if( dataWindow == m_dataWindow )
+	{
+		return;
+	}
+
+	std::unique_lock lock( m_bufferReallocationMutex );
+
+	m_dataWindow = dataWindow;
+	const size_t numPixels = (dataWindow.size().x + 1) * (dataWindow.size().y + 1);
+	m_rgbaBuffer.resize( numPixels * 4, 0 );
+	m_depthBuffer.resize( numPixels, 0 );
+	m_idBuffer.resize( numPixels, 0 );
+
+	lock.unlock();
+	dirtyTexture();
+}
+
+template<typename T>
+void OutputBuffer::updateBuffer( const Imath::Box2i &box, const T *data, int numChannels, vector<T> &buffer )
+{
+	// We deliberately don't worry about synchronising these writes with the
+	// reads from the buffers (such as when transferring to a texture). Worst
+	// case, we get a torn read and then `dirtyTexture()` forces us to redo it
+	// when the write is complete.
+	const int fromStride = ( box.size().x + 1 ) * numChannels;
+	const int toStride = ( m_dataWindow.size().x + 1 ) * numChannels;
+	const T *from = data;
+	T *to = buffer.data() + (box.min.y - m_dataWindow.min.y) * toStride + (box.min.x - m_dataWindow.min.x) * numChannels;
+	for( int y = box.min.y; y <= box.max.y; ++y )
+	{
+		std::copy( from, from + fromStride, to );
+		to += toStride;
+		from += fromStride;
+	}
+	dirtyTexture();
+}
+
+void OutputBuffer::dirtyTexture()
+{
+	if( !m_texturesDirty.exchange( true ) )
+	{
+		bufferChangedSignal()();
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////
+// DisplayDriver
+//////////////////////////////////////////////////////////////////////////
+
+class OutputBuffer::DisplayDriver : public IECoreImage::DisplayDriver
+{
+
+	public :
+
+		// Deliberately "borrowing" DisplayDriverTypeId as we don't need an ID for
+		// a non-public class.
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( OutputBuffer::DisplayDriver, IECoreImage::DisplayDriverTypeId, DisplayDriver );
+
+		enum class Type
+		{
+			RGBA,
+			Depth,
+			ID
+		};
+
+		DisplayDriver( const Imath::Box2i &displayWindow, const Imath::Box2i &dataWindow, const std::vector<std::string> &channelNames, IECore::ConstCompoundDataPtr parameters )
+			:	IECoreImage::DisplayDriver( displayWindow, dataWindow, channelNames, parameters )
+		{
+			auto bufferData = parameters->member<StringData>( "buffer" );
+			assert( bufferData );
+			assert( channelNames.size() == 4 || channelNames.size() == 1 );
+			m_buffer = reinterpret_cast<OutputBuffer *>( boost::lexical_cast<uintptr_t>(bufferData->readable() ) );
+			m_buffer->imageFormat( displayWindow, dataWindow );
+			if( channelNames.size() == 1 )
+			{
+				if( channelNames[0] == "Z" )
+				{
+					m_type = Type::Depth;
+				}
+				else
+				{
+					assert( channelNames[0] == "id" );
+					m_type = Type::ID;
+				}
+			}
+			else
+			{
+				m_type = Type::RGBA;
+			}
+		}
+
+		void imageData( const Imath::Box2i &box, const float *data, size_t dataSize ) override
+		{
+			switch( m_type )
+			{
+				case Type::RGBA :
+					m_buffer->updateBuffer( box, data, 4, m_buffer->m_rgbaBuffer );
+					break;
+				case Type::Depth :
+					m_buffer->updateBuffer( box, data, 1, m_buffer->m_depthBuffer );
+					break;
+				case Type::ID :
+					// Cortex DisplayDrivers technically only support floats, but we send `uint32_t` data through
+					// the API and just do pointer casts at either end.
+					m_buffer->updateBuffer( box, reinterpret_cast<const uint32_t *>( data ), 1, m_buffer->m_idBuffer );
+					break;
+			}
+		}
+
+		void imageClose() override
+		{
+		}
+
+		bool scanLineOrderOnly() const override
+		{
+			return false;
+		}
+
+		bool acceptsRepeatedData() const override
+		{
+			return true;
+		}
+
+	private :
+
+		Type m_type;
+
+		OutputBuffer *m_buffer;
+		static DisplayDriverDescription<DisplayDriver> g_description;
+
+};
+
+IECoreImage::DisplayDriver::DisplayDriverDescription<OutputBuffer::DisplayDriver> OutputBuffer::DisplayDriver::g_description;

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -594,7 +594,7 @@ void SceneGadget::renderScene() const
 	{
 		return;
 	}
-	m_renderer->render();
+	m_renderer->command( "gl:renderToCurrentContext" );
 }
 
 void SceneGadget::visibilityChanged()

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -52,16 +52,18 @@ using namespace GafferSceneUI;
 
 namespace
 {
-	float lineariseDepthBufferSample( float bufferDepth, float *m )
-	{
-		// Heavily optimised extraction that works with our orthogonal clipping planes
-		//   Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix
-		//   http://www.cs.otago.ac.nz/postgrads/alexis/planeExtraction.pdf
-		const float n = - ( m[15] + m[14] ) / ( m[11] + m[10] );
-		const float f = - ( m[15] - m[14] ) / ( m[11] - m[10] );
-		return ( 2.0f * n * f ) / ( f + n - ( bufferDepth * 2.0f - 1.0f ) * ( f - n ) );
-	}
+
+float lineariseDepthBufferSample( float bufferDepth, float *m )
+{
+	// Heavily optimised extraction that works with our orthogonal clipping planes
+	//   Fast Extraction of Viewing Frustum Planes from the WorldView-Projection Matrix
+	//   http://www.cs.otago.ac.nz/postgrads/alexis/planeExtraction.pdf
+	const float n = - ( m[15] + m[14] ) / ( m[11] + m[10] );
+	const float f = - ( m[15] - m[14] ) / ( m[11] - m[10] );
+	return ( 2.0f * n * f ) / ( f + n - ( bufferDepth * 2.0f - 1.0f ) * ( f - n ) );
 }
+
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////
 // SceneGadget implementation

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -136,6 +136,7 @@ IECore::StringVectorDataPtr getSelectionMask( const SceneGadget &g )
 
 IECore::InternedStringVectorDataPtr objectAt( SceneGadget &g, IECore::LineSegment3f &l )
 {
+	ScopedGILRelease gilRelease;
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData;
 	if( g.objectAt( l, result->writable() ) )
 	{
@@ -148,11 +149,34 @@ tuple objectAndIntersectionAt( SceneGadget &g, IECore::LineSegment3f &l )
 {
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData;
 	Imath::V3f hitPos( 0.0f );
-	if( g.objectAt( l, result->writable(), hitPos ) )
+
 	{
-		return boost::python::make_tuple( result, hitPos );
+		ScopedGILRelease gilRelease;
+		if( !g.objectAt( l, result->writable(), hitPos ) )
+		{
+			result = nullptr;
+		}
 	}
-	return boost::python::make_tuple( object(), hitPos );
+
+	return boost::python::make_tuple( result, hitPos );
+}
+
+size_t objectsAt( SceneGadget &g, const Imath::V3f &corner0InGadgetSpace, const Imath::V3f &corner1InGadgetSpace, IECore::PathMatcher &paths )
+{
+	ScopedGILRelease gilRelease;
+	return g.objectsAt( corner0InGadgetSpace, corner1InGadgetSpace, paths );
+}
+
+Imath::Box3f selectionBound( SceneGadget &g )
+{
+	ScopedGILRelease gilRelease;
+	return g.selectionBound();
+}
+
+Imath::Box3f bound( SceneGadget &g, bool selected, const IECore::PathMatcher *omitted )
+{
+	ScopedGILRelease gilRelease;
+	return g.bound( selected, omitted );
 }
 
 } // namespace
@@ -183,13 +207,11 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "getSelectionMask", &getSelectionMask )
 		.def( "objectAt", &objectAt )
 		.def( "objectAndIntersectionAt", &objectAndIntersectionAt )
-		.def( "objectsAt", &SceneGadget::objectsAt )
+		.def( "objectsAt", &objectsAt )
 		.def( "setSelection", &SceneGadget::setSelection )
 		.def( "getSelection", &SceneGadget::getSelection, return_value_policy<copy_const_reference>() )
-		.def( "selectionBound", &SceneGadget::selectionBound )
-		.def( "bound", (Imath::Box3f (SceneGadget::*)(bool,const IECore::PathMatcher*) const)&SceneGadget::bound,
-			( arg( "selected" ), arg( "omitted" ) = object() )
-		)
+		.def( "selectionBound", &selectionBound )
+		.def( "bound", &bound, ( arg( "selected" ), arg( "omitted" ) = object() ) )
 	;
 
 	enum_<SceneGadget::State>( "State" )

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -112,6 +112,17 @@ struct SceneGadgetSlotCaller
 	}
 };
 
+void setRenderer( SceneGadget &g, IECore::InternedString name )
+{
+	ScopedGILRelease gilRelease;
+	g.setRenderer( name );
+}
+
+std::string getRenderer( SceneGadget &g )
+{
+	return g.getRenderer().string();
+}
+
 IECore::CompoundObjectPtr getOpenGLOptions( const SceneGadget &g )
 {
 	return g.getOpenGLOptions()->copy();
@@ -164,6 +175,8 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "state", &SceneGadget::state )
 		.def( "stateChangedSignal", &SceneGadget::stateChangedSignal, return_internal_reference<1>() )
 		.def( "waitForCompletion", &waitForCompletion )
+		.def( "setRenderer", &setRenderer )
+		.def( "getRenderer", &getRenderer )
 		.def( "setOpenGLOptions", &SceneGadget::setOpenGLOptions )
 		.def( "getOpenGLOptions", &getOpenGLOptions )
 		.def( "setSelectionMask", &SceneGadget::setSelectionMask )


### PR DESCRIPTION
The SceneGadget is the primary component in the 3D viewer, responsible for drawing the scene in OpenGL. This adds a `setRenderer()` method to it, providing the option of doing a hybrid render where OpenGL is used for drawing bounds and visualisers and, say, Arnold is used for rendering everything else. Because everything is hidden behind the SceneGadget API, existing tools for selection, snapping etc all continue to work as before.

This PR doesn't expose the feature to users yet - that will come in a followup PR which adds appropriate render settings to the SceneView. But testing is provided by the new ArnoldSceneGadgetTest, which runs all the original OpenGL SceneGadget tests in the new hybrid mode.