### PR TITLE
AttributeTweaks node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Features
 --------
 
 - Tools Menu : Added item to populate the Arnold GPU cache, which may improve startup times for GPU renders.
+- AttributeTweaks : Added node to tweak scene location attributes.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ API
 
 - ArnoldShader : Added support for `gaffer.layout.activator` and `gaffer.layout.visibilityActivator` in `.mtd` files.
 - PlugLayout : User interface sections are now hidden if all plugs in that section are hidden.
+- TweakPlug : Added functor-based variation of `applyTweak` allowing greater control of how users get and set the data being tweaked. `TweaksPlug::applyTweaks` now uses that method and can be used as a reference implementation.
 
 0.61.9.0 (relative to 0.61.8.0)
 ========

--- a/include/GafferScene/AttributeTweaks.h
+++ b/include/GafferScene/AttributeTweaks.h
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_ATTRIBUTETWEAKS_H
+#define GAFFERSCENE_ATTRIBUTETWEAKS_H
+
+#include "GafferScene/AttributeProcessor.h"
+#include "GafferScene/Export.h"
+#include "GafferScene/TweakPlug.h"
+#include "GafferScene/TypeIds.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API AttributeTweaks : public AttributeProcessor
+{
+
+	public :
+
+		AttributeTweaks( const std::string &name=defaultName<AttributeTweaks>() );
+		~AttributeTweaks() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::AttributeTweaks, AttributeTweaksTypeId, AttributeProcessor );
+
+		Gaffer::BoolPlug *localisePlug();
+		const Gaffer::BoolPlug *localisePlug() const;
+
+		Gaffer::BoolPlug *ignoreMissingPlug();
+		const Gaffer::BoolPlug *ignoreMissingPlug() const;
+
+		GafferScene::TweaksPlug *tweaksPlug();
+		const GafferScene::TweaksPlug *tweaksPlug() const;
+
+	protected :
+
+		bool affectsProcessedAttributes( const Gaffer::Plug *input) const override;
+		void hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const override;
+
+		static size_t g_firstPlugIndex;
+};
+
+IE_CORE_DECLAREPTR( AttributeTweaks )
+
+}  // namespace GafferScene
+
+#endif // GAFFERSCENE_ATTRIBUTETWEAKS_H

--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -107,6 +107,23 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 
 		/// \deprecated. Use `TweaksPlug::applyTweaks()` instead.
 		bool applyTweak( IECore::CompoundData *parameters, MissingMode missingMode = MissingMode::Error ) const;
+
+		/// Applies the tweak using functors to get and set the data.
+		/// \returns true if any tweaks were applied
+		template<class GetDataFunctor, class SetDataFunctor>
+		bool applyTweak(
+			/// Signature : const IECore::Data *functor( const std::string &valueName ).
+			/// \returns `nullptr` if `valueName` is invalid.
+			GetDataFunctor &&getDataFunctor,
+			/// Signature : bool functor( const std::string &valueName, IECore::DataPtr newData).
+			/// Passing `nullptr` in `newData` removes the entry for `valueName`.
+			/// \returns true if the value was set or erased, false if erasure failed.
+			SetDataFunctor &&setDataFunctor,
+			MissingMode missingMode = MissingMode::Error
+		) const;
+
+		/// \deprecated
+		/// \todo Remove when `ShaderTweaks::applyTweaks` has been refactored.
 		/// \returns true if any tweaks were applied
 		static bool applyTweaks( const Plug *tweaksPlug, IECoreScene::ShaderNetwork *shaderNetwork, MissingMode missingMode = MissingMode::Error );
 
@@ -116,6 +133,14 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 		const Gaffer::ValuePlug *valuePlugInternal() const;
 
 		std::pair<const Shader *, const Gaffer::Plug *> shaderOutput() const;
+
+		void modifyData(
+			const IECore::Data *sourceData,
+			const IECore::Data *tweakData,
+			IECore::Data *destData,
+			TweakPlug::Mode mode,
+			const std::string &tweakName
+		) const;
 
 };
 
@@ -143,8 +168,23 @@ class GAFFERSCENE_API TweaksPlug : public Gaffer::ValuePlug
 		/// Functions return true if any tweaks were applied.
 
 		bool applyTweaks( IECore::CompoundData *parameters, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
+		/// \deprecated
+		/// \todo Refactor into `ShaderTweaks` and move `TweakPlug` to `Gaffer` module.
 		bool applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error ) const;
 
+		/// Applies the tweak using functors to get and set the data.
+		/// \returns true if any tweaks were applied
+		template<class GetDataFunctor, class SetDataFunctor>
+		bool applyTweaks(
+			/// Signature : const IECore::Data *functor( const std::string &valueName ).
+			/// \returns `nullptr` if `valueName` is invalid.
+			GetDataFunctor &&getDataFunctor,
+			/// Signature : bool functor( const std::string &valueName, IECore::DataPtr newData ).
+			/// Passing `nullptr` in `newData` removes the entry for `valueName`.
+			/// \returns true if the value was set or erased, false if erasure failed.
+			SetDataFunctor &&setDataFunctor,
+			TweakPlug::MissingMode missingMode = TweakPlug::MissingMode::Error
+		) const;
 };
 
 } // namespace GafferScene

--- a/include/GafferScene/TweakPlug.inl
+++ b/include/GafferScene/TweakPlug.inl
@@ -37,8 +37,34 @@
 #ifndef GAFFERSCENE_TWEAKPLUG_INL
 #define GAFFERSCENE_TWEAKPLUG_INL
 
+#include "Gaffer/PlugAlgo.h"
+
 namespace GafferScene
 {
+
+namespace Detail
+{
+
+inline const char *modeToString( GafferScene::TweakPlug::Mode mode )
+{
+	switch( mode )
+	{
+		case GafferScene::TweakPlug::Replace :
+			return "Replace";
+		case GafferScene::TweakPlug::Add :
+			return "Add";
+		case GafferScene::TweakPlug::Subtract :
+			return "Subtract";
+		case GafferScene::TweakPlug::Multiply :
+			return "Multiply";
+		case GafferScene::TweakPlug::Remove :
+			return "Remove";
+		default :
+			return "Invalid";
+	}
+}
+
+}  // namespace Detail
 
 template<typename T>
 T *TweakPlug::valuePlug()
@@ -50,6 +76,92 @@ template<typename T>
 const T *TweakPlug::valuePlug() const
 {
 	return IECore::runTimeCast<const T>( valuePlugInternal() );
+}
+
+template<class GetDataFunctor, class SetDataFunctor>
+bool TweakPlug::applyTweak(
+	GetDataFunctor &&getDataFunctor,
+	SetDataFunctor &&setDataFunctor,
+	MissingMode missingMode
+) const
+{
+	if( !enabledPlug()->getValue() )
+	{
+		return false;
+	}
+
+	const std::string name = namePlug()->getValue();
+	if( name.empty() )
+	{
+		return false;
+	}
+
+	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
+
+	if( mode == GafferScene::TweakPlug::Remove )
+	{
+		return setDataFunctor( name,  nullptr );
+	}
+
+	const IECore::Data *currentValue = getDataFunctor( name );
+	IECore::DataPtr newData = Gaffer::PlugAlgo::getValueAsData( valuePlug() );
+	if( !newData )
+	{
+		throw IECore::Exception(
+			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value plug has unsupported type \"%s\"" ) % name % valuePlug()->typeName() )
+		);
+	}
+	if( currentValue && currentValue->typeId() != newData->typeId() )
+	{
+		throw IECore::Exception(
+			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value of type \"%s\" does not match parameter of type \"%s\"" ) % name % currentValue->typeName() % newData->typeName() )
+		);
+	}
+
+	if( !currentValue )
+	{
+		if( missingMode == GafferScene::TweakPlug::MissingMode::Ignore )
+		{
+			return false;
+		}
+		else if( !( mode == GafferScene::TweakPlug::Replace && missingMode == GafferScene::TweakPlug::MissingMode::IgnoreOrReplace) )
+		{
+			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % Detail::modeToString( mode ) % name ) );
+		}
+	}
+
+	if(
+		mode == GafferScene::TweakPlug::Add ||
+		mode == GafferScene::TweakPlug::Subtract ||
+		mode == GafferScene::TweakPlug::Multiply
+	)
+	{
+		modifyData( currentValue, newData.get(), newData.get(), mode, name );
+	}
+
+	setDataFunctor( name, newData );
+
+	return true;
+}
+
+template<class GetDataFunctor, class SetDataFunctor>
+bool TweaksPlug::applyTweaks(
+	GetDataFunctor &&getDataFunctor,
+	SetDataFunctor &&setDataFunctor,
+	TweakPlug::MissingMode missingMode
+) const
+{
+	bool tweakApplied = false;
+
+	for( auto &tweakPlug : TweakPlug::Range( *this ) )
+	{
+		if( tweakPlug->applyTweak( getDataFunctor, setDataFunctor, missingMode ) )
+		{
+			tweakApplied = true;
+		}
+	}
+
+	return tweakApplied;
 }
 
 } // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -167,6 +167,7 @@ enum TypeId
 	UVSamplerTypeId = 110622,
 	CryptomatteTypeId = 110623,
 	ShaderQueryTypeId = 110624,
+	AttributeTweaksTypeId = 110625,
 
 	PreviewGeometryTypeId = 110648,
 	PreviewProceduralTypeId = 110649,

--- a/python/GafferSceneTest/AttributeTweaksTest.py
+++ b/python/GafferSceneTest/AttributeTweaksTest.py
@@ -1,0 +1,189 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import unittest
+import six
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class AttributeTweaksTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		l = GafferSceneTest.TestLight()
+		l["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["scale"]["value"].setValue( 5 )
+
+		t = GafferScene.AttributeTweaks()
+		t["in"].setInput( l["out"] )
+
+		self.assertSceneValid( t["out"] )
+		self.assertScenesEqual( t["out"], l["out"] )
+		self.assertSceneHashesEqual( t["out"], l["out"] )
+		self.assertEqual( l["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 5.0 ) )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		t["filter"].setInput( f["out"] )
+
+		self.assertSceneValid( t["out"] )
+		self.assertScenesEqual( t["out"], l["out"] )
+		self.assertSceneHashesEqual( t["out"], l["out"] )
+
+		scaleTweak = GafferScene.TweakPlug( "gl:visualiser:scale", 10.0 )
+		t["tweaks"].addChild( scaleTweak )
+
+		self.assertSceneValid( t["out"] )
+
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 10.0 ) )
+
+		scaleTweak["value"].setValue( 20 )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 20.0 ) )
+
+		scaleTweak["enabled"].setValue( False )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 5.0 ) )
+
+		scaleTweak["enabled"].setValue( True )
+		scaleTweak["mode"].setValue( scaleTweak.Mode.Add )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 25.0 ) )
+
+		scaleTweak["mode"].setValue( scaleTweak.Mode.Subtract )
+		scaleTweak["value"].setValue( 1 )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 4.0 ) )
+
+		scaleTweak["mode"].setValue( scaleTweak.Mode.Multiply )
+		scaleTweak["value"].setValue( 3 )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 15.0 ) )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["t"] = GafferScene.AttributeTweaks()
+		s["t"]["tweaks"].addChild( GafferScene.TweakPlug( "test", 1.0 ) )
+		s["t"]["tweaks"].addChild( GafferScene.TweakPlug( "test", imath.Color3f( 1, 2, 3 ) ) )
+
+		ss = Gaffer.ScriptNode()
+		ss.execute( s.serialise() )
+
+		for i in range( 0, len( s["t"]["tweaks"] ) ) :
+			for n in s["t"]["tweaks"][i].keys() :
+				self.assertEqual( ss["t"]["tweaks"][i][n].getValue(), s["t"]["tweaks"][i][n].getValue() )
+
+	def testIgnoreMissing( self ) :
+
+		l = GafferSceneTest.TestLight()
+		l["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		l["visualiserAttributes"]["scale"]["value"].setValue( 5.0 )
+
+		f = GafferScene.PathFilter()
+		f["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		t = GafferScene.AttributeTweaks()
+		t["in"].setInput( l["out"] )
+		t["filter"].setInput( f["out"] )
+
+		tweak = GafferScene.TweakPlug( "badAttribute", 1.0 )
+		t["tweaks"].addChild( tweak )
+
+		with six.assertRaisesRegex( self, RuntimeError, "Cannot apply tweak with mode Replace to \"badAttribute\" : This parameter does not exist" ) :
+			t["out"].attributes( "/light" )
+
+		t["ignoreMissing"].setValue( True )
+		self.assertEqual( t["out"].attributes( "/light" ), t["in"].attributes( "/light" ) )
+
+		tweak["name"].setValue( "gl:visualiser:scale" )
+		self.assertIn( "gl:visualiser:scale", t["out"].attributes( "/light" ) )
+		self.assertEqual( t["out"].attributes( "/light" )["gl:visualiser:scale"], IECore.FloatData( 1.0 ) )
+
+		tweak["name"].setValue( "badAttribute.p" )
+		self.assertEqual( t["out"].attributes( "/light" ), t["in"].attributes( "/light" ) )
+
+	def testLocalise( self ) :
+
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["attributes"]["transformBlurSegments"]["enabled"].setValue( True )
+		attributes["attributes"]["transformBlurSegments"]["value"].setValue( 5 )
+
+		groupFilter = GafferScene.PathFilter()
+		groupFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		attributes["in"].setInput( group["out"] )
+		attributes["filter"].setInput( groupFilter["out"] )
+
+		self.assertIn( "gaffer:transformBlurSegments", attributes["out"].attributes( "/group" ) )
+		self.assertNotIn( "gaffer:transformBlurSegments", attributes["out"].attributes( "/group/plane" ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+
+		tweaks = GafferScene.AttributeTweaks()
+		tweaks["in"].setInput( attributes["out"] )
+		tweaks["filter"].setInput( planeFilter["out"] )
+
+		segmentsTweak = GafferScene.TweakPlug( "gaffer:transformBlurSegments", 2 )
+		tweaks["tweaks"].addChild( segmentsTweak )
+
+		self.assertEqual( tweaks["localise"].getValue(), False )
+		with six.assertRaisesRegex( self, RuntimeError, "Cannot apply tweak with mode Replace to \"gaffer:transformBlurSegments\" : This parameter does not exist" ) :
+			tweaks["out"].attributes( "/group/plane" )
+
+		tweaks["localise"].setValue( True )
+
+		groupAttr = tweaks["out"].attributes( "/group" )
+		self.assertEqual( groupAttr["gaffer:transformBlurSegments"], IECore.IntData( 5 ) )
+
+		planeAttr = tweaks["out"].attributes( "/group/plane" )
+		self.assertIn( "gaffer:transformBlurSegments", planeAttr )
+		self.assertEqual( planeAttr["gaffer:transformBlurSegments"], IECore.IntData( 2 ) )
+
+		# Test disabling tweak results in no localisation
+
+		segmentsTweak["enabled"].setValue( False )
+		self.assertNotIn( "gaffer:transformBlurSegments", tweaks["out"].attributes( "/group/plane" ) )
+
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -160,6 +160,7 @@ from .AttributeQueryTest import AttributeQueryTest
 from .NameSwitchTest import NameSwitchTest
 from .CryptomatteTest import CryptomatteTest
 from .ShaderQueryTest import ShaderQueryTest
+from .AttributeTweaksTest import AttributeTweaksTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -1,0 +1,284 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import six
+import functools
+import collections
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferSceneUI
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.AttributeTweaks,
+
+	"description",
+	"""
+	Makes modifications to attributes.
+	""",
+
+	plugs = {
+
+		"localise" : [
+
+			"description",
+			"""
+			Turn on to allow location-specific tweaks to be made to inherited
+			attributes. Attributes will be localised to locations matching the
+			node's filter prior to tweaking. The original inherited attributes
+			will remain untouched.
+			"""
+
+		],
+
+		"ignoreMissing" : [
+
+			"description",
+			"""
+			Ignores tweaks targeting missing attributes. When off, missing attributes
+			cause the node to error.
+			"""
+
+		],
+
+		"tweaks" : [
+
+			"description",
+			"""
+			The tweaks to be made to the attributes. Arbitrary numbers of user defined
+			tweaks may be added as children of this plug via the user interface, or
+			using the AttributeTweaks API via python.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:customWidget:footer:widgetType", "GafferSceneUI.AttributeTweaksUI._TweaksFooter",
+			"layout:customWidget:footer:index", -1,
+
+			"nodule:type", "",
+
+		]
+
+	}
+)
+
+##########################################################################
+# Internal utilities
+##########################################################################
+
+def _attributeTweaksNode( plugValueWidget ) :
+
+	# The plug may not belong to an AttributeTweaks node
+	# directly. Instead it may have been promoted
+	# elsewhere and be driving a target plug on an
+	# AttributeTweaks node.
+
+	def walkOutputs( plug ) :
+
+		if isinstance( plug.node(), GafferScene.AttributeTweaks ) :
+			return plug.node()
+
+		for output in plug.outputs() :
+			node = walkOutputs( output )
+			if node is not None :
+				return node
+
+	return walkOutputs( plugValueWidget.getPlug() )
+
+def _pathsFromAffected( plugValueWidget ) :
+
+	node = _attributeTweaksNode( plugValueWidget )
+	if node is None :
+		return []
+
+	pathMatcher = IECore.PathMatcher()
+	with plugValueWidget.getContext() :
+		GafferScene.SceneAlgo.matchingPaths( node["filter"], node["in"], pathMatcher )
+
+	return pathMatcher.paths()
+
+def _pathsFromSelection( plugValueWidget ) :
+
+	node = _attributeTweaksNode( plugValueWidget )
+	if node is None :
+		return []
+
+	paths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.getContext() )
+	paths = paths.paths() if paths else []
+
+	with plugValueWidget.getContext() :
+		paths = [ p for p in paths if node["in"].exists( p ) ]
+
+	return paths
+
+
+##########################################################################
+# _TweaksFooter
+##########################################################################
+
+class _TweaksFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.MenuButton(
+					image = "plus.png",
+					hasFrame = False,
+					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
+				)
+
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		result.append(
+			"/From Affected",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromAffectedMenuDefinition )
+			}
+		)
+
+		result.append(
+			"/From Selection",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromSelectedMenuDefinition )
+			}
+		)
+
+		result.append( "/FromPathsDivider", { "divider" : True } )
+
+		# TODO - would be nice to share these default options with other users of TweakPlug
+		for item in [
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			"NumericDivider",
+			Gaffer.StringPlug,
+			"StringDivider",
+			Gaffer.V2iPlug,
+			Gaffer.V3iPlug,
+			Gaffer.V2fPlug,
+			Gaffer.V3fPlug,
+			"VectorDivider",
+			Gaffer.Color3fPlug,
+			Gaffer.Color4fPlug
+		] :
+
+			if isinstance( item, six.string_types ) :
+				result.append( "/" + item, { "divider" : True } )
+			else :
+				result.append(
+					"/" + item.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__addTweak ), "", item ),
+					}
+				)
+
+		return result
+
+	def __addFromAffectedMenuDefinition( self ) :
+
+		return self.__addFromPathsMenuDefinition( _pathsFromAffected( self ) )
+
+	def __addFromSelectedMenuDefinition( self ) :
+
+		return self.__addFromPathsMenuDefinition( _pathsFromSelection( self ) )
+
+	def __addFromPathsMenuDefinition( self, paths ) :
+
+		result = IECore.MenuDefinition()
+
+		node = _attributeTweaksNode( self )
+		attributes = {}
+
+		if node is not None :
+			with self.getContext() :
+				useFullAttr = node["localise"].getValue()
+				for path in paths :
+					attr = node["in"].fullAttributes( path ) if useFullAttr else node["in"].attributes( path )
+					attributes.update( attr )
+
+		attributes = collections.OrderedDict( sorted( attributes.items() ) )
+
+		for key, value in [ ( k, v ) for k, v in attributes.items() if k.replace( ':', '_' ) not in node["tweaks"] ] :
+			result.append(
+				"/" + key,
+				{
+					"command" : functools.partial(
+						Gaffer.WeakMethod( self.__addTweak ),
+						key,
+						value
+					)
+				}
+			)
+
+		if not len( result.items() ) :
+			result.append(
+				"/No Attributes Found", { "active" : False }
+			)
+			return result
+
+		return result
+
+	def __addTweak( self, name, plugTypeOrValue ) :
+
+		if isinstance( plugTypeOrValue, IECore.Data ) :
+			plug = GafferScene.TweakPlug( name, plugTypeOrValue )
+		else :
+			plug = GafferScene.TweakPlug( name, plugTypeOrValue() )
+
+		if name :
+			plug.setName( name.replace( ':', '_' ) )
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addChild( plug )

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -174,6 +174,7 @@ from . import AttributeQueryUI
 from . import UVSamplerUI
 from . import CryptomatteUI
 from . import ShaderQueryUI
+from . import AttributeTweaksUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/AttributeTweaks.cpp
+++ b/src/GafferScene/AttributeTweaks.cpp
@@ -1,0 +1,167 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/AttributeTweaks.h"
+#include "GafferScene/TweakPlug.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+
+GAFFER_NODE_DEFINE_TYPE( AttributeTweaks );
+
+size_t AttributeTweaks::g_firstPlugIndex = 0;
+
+AttributeTweaks::AttributeTweaks( const std::string &name ) : AttributeProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new BoolPlug( "localise", Plug::In, false ) );
+	addChild( new BoolPlug( "ignoreMissing", Plug::In, false ) );
+	addChild( new TweaksPlug( "tweaks" ) );
+}
+
+AttributeTweaks::~AttributeTweaks()
+{
+
+}
+
+Gaffer::BoolPlug *AttributeTweaks::localisePlug()
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::BoolPlug *AttributeTweaks::localisePlug() const
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
+Gaffer::BoolPlug *AttributeTweaks::ignoreMissingPlug()
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::BoolPlug *AttributeTweaks::ignoreMissingPlug() const
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+GafferScene::TweaksPlug *AttributeTweaks::tweaksPlug()
+{
+	return getChild<GafferScene::TweaksPlug>( g_firstPlugIndex + 2 );
+}
+
+const GafferScene::TweaksPlug *AttributeTweaks::tweaksPlug() const
+{
+	return getChild<GafferScene::TweaksPlug>( g_firstPlugIndex + 2 );
+}
+
+bool AttributeTweaks::affectsProcessedAttributes( const Gaffer::Plug *input) const
+{
+	return
+		AttributeProcessor::affectsProcessedAttributes( input ) ||
+		tweaksPlug()->isAncestorOf( input ) ||
+		input == localisePlug() ||
+		input == ignoreMissingPlug()
+	;
+}
+
+void AttributeTweaks::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if( tweaksPlug()->children().empty() )
+	{
+		h = inPlug()->attributesPlug()->hash();
+	}
+	else
+	{
+		AttributeProcessor::hashProcessedAttributes( path, context, h );
+		localisePlug()->hash( h );
+
+		if( localisePlug()->getValue() )
+		{
+			h.append( inPlug()->fullAttributesHash( path ) );
+		}
+
+		ignoreMissingPlug()->hash( h );
+		tweaksPlug()->hash( h );
+	}
+}
+
+IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
+{
+	const TweaksPlug *tweaksPlug = this->tweaksPlug();
+	if( tweaksPlug->children().empty() )
+	{
+		return inputAttributes;
+	}
+
+	const bool ignoreMissing = ignoreMissingPlug()->getValue();
+
+	CompoundObjectPtr result = new CompoundObject();
+	result->members() = inputAttributes->members();
+
+	// We switch our source attributes depending on whether we are
+	// localising inherted attributes or just using the ones at the location
+
+	const CompoundObject *source = inputAttributes;
+
+	ConstCompoundObjectPtr fullAttributes;
+	if( localisePlug()->getValue() )
+	{
+		fullAttributes = inPlug()->fullAttributes( path );
+		source = fullAttributes.get();
+	}
+
+	tweaksPlug->applyTweaks(
+		[&source]( const std::string &valueName )
+		{
+			return source->member<Data>( valueName );
+		},
+		[&result]( const std::string &valueName, DataPtr newData )
+		{
+			if( newData == nullptr )
+			{
+				return result->members().erase( valueName ) > 0;
+			}
+			result->members()[valueName] = newData;
+			return true;
+		},
+		ignoreMissing ? TweakPlug::MissingMode::Ignore : TweakPlug::MissingMode::Error
+	);
+
+	return result;
+}

--- a/src/GafferSceneModule/TweaksBinding.cpp
+++ b/src/GafferSceneModule/TweaksBinding.cpp
@@ -39,6 +39,7 @@
 
 #include "TweaksBinding.h"
 
+#include "GafferScene/AttributeTweaks.h"
 #include "GafferScene/ShaderTweaks.h"
 #include "GafferScene/CameraTweaks.h"
 #include "GafferScene/TweakPlug.h"
@@ -111,6 +112,7 @@ void GafferSceneModule::bindTweaks()
 {
 	DependencyNodeClass<ShaderTweaks>();
 	DependencyNodeClass<CameraTweaks>();
+	DependencyNodeClass<AttributeTweaks>();
 
 	PlugClass<TweakPlug> tweakPlugClass;
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -322,6 +322,7 @@ nodeMenu.append( "/Scene/Attributes/Delete Attributes", GafferScene.DeleteAttrib
 nodeMenu.append( "/Scene/Attributes/Shuffle Attributes", GafferScene.ShuffleAttributes, searchText = "ShuffleAttributes" )
 nodeMenu.append( "/Scene/Attributes/Localise Attributes", GafferScene.LocaliseAttributes, searchText = "LocaliseAttributes" )
 nodeMenu.append( "/Scene/Attributes/Attribute Visualiser", GafferScene.AttributeVisualiser, searchText = "AttributeVisualiser" )
+nodeMenu.append( "/Scene/Attributes/Attribute Tweaks", GafferScene.AttributeTweaks, searchText = "AttributeTweaks" )
 nodeMenu.append( "/Scene/Attributes/Copy Attributes", GafferScene.CopyAttributes, searchText = "CopyAttributes" )
 nodeMenu.append( "/Scene/Attributes/Collect Transforms", GafferScene.CollectTransforms, searchText = "CollectTransforms" )
 nodeMenu.append( "/Scene/Filters/Set Filter", GafferScene.SetFilter, searchText = "SetFilter" )


### PR DESCRIPTION
This adds a node for tweaking attributes attached to scene locations.

It also adds a functor-based variation of `TweakPlug::applyTweak`, allowing clients of `TweakPlug` to define their own method of getting and setting tweak data.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
