### PR TITLE
ShaderQueryUI fix greedy delete menu item

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - SetFilter : Fixed missing set names in `setExpression` context menu. Sets were being listed for nodes directly connected to the filter, but not for nodes downstream of an intermediate filter such as a UnionFilter (#2678).
+- Fixed `NameValue` plugs having a `delete` menu item in their popup menu when they shouldn't. This was broken in 0.61.9.0.
 
 0.61.10.0 (relative to 0.61.9.0)
 =========

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -600,7 +600,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	readOnlyUI = plugValueWidget.getReadOnly()
 	plug = plugValueWidget.getPlug().ancestor( Gaffer.NameValuePlug )
 
-	if plug is not None :
+	if plug is not None and isinstance( plug.node(), GafferScene.ShaderQuery ) :
 
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/DeleteDivider", { "divider" : True } )


### PR DESCRIPTION
This fixes a bug introduced by `ShaderQuery` in 0.61.9.0 causing `NameValuePlugs` to have a `Delete` item in their popup menus when they shouldn't.

### Breaking changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
