### PR TITLE
Cycles : Remove trailing space and apply clang-tidy

### DIFF
--- a/include/GafferCycles/IECoreCyclesPreview/ObjectAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ObjectAlgo.h
@@ -63,10 +63,10 @@ IECORECYCLES_API ccl::Object *convert( const IECore::Object *object, const std::
 IECORECYCLES_API ccl::Object *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene = nullptr );
 
 /// Signature of a function which can convert into a Cycles Object.
-typedef ccl::Object * (*Converter)( const IECore::Object *, const std::string &nodeName, ccl::Scene *scene );
+using Converter = ccl::Object *(*)( const IECore::Object *, const std::string &, ccl::Scene * );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Cycles object.
-typedef ccl::Object * (*MotionConverter)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene );
+using MotionConverter = ccl::Object *(*)( const std::vector<const IECore::Object *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -82,8 +82,8 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		typedef ccl::Object *(*Converter)( const T *, const std::string&, ccl::Scene* );
-		typedef ccl::Object *(*MotionConverter)( const std::vector<const T *> &, const std::vector<float> &, const int, const std::string&, ccl::Scene* );
+		using Converter = ccl::Object *(*)( const T *, const std::string &, ccl::Scene * );
+		using MotionConverter = ccl::Object *(*)( const std::vector<const T *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
@@ -57,16 +57,16 @@ IECORECYCLES_API ccl::ShaderInput  *input( ccl::ShaderNode *node, IECore::Intern
 IECORECYCLES_API ccl::ShaderOutput *output( ccl::ShaderNode *node, IECore::InternedString name );
 
 
-IECORECYCLES_API ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader, 
+IECORECYCLES_API ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
                                                  const IECoreScene::ShaderNetwork *displacementShader,
-                                                 const IECoreScene::ShaderNetwork *volumeShader,  
-                                                 ccl::ShaderManager *shaderManager, 
+                                                 const IECoreScene::ShaderNetwork *volumeShader,
+                                                 ccl::ShaderManager *shaderManager,
                                                  const std::string &namePrefix = "" );
 
-IECORECYCLES_API ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader, 
+IECORECYCLES_API ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader,
                                        const IECoreScene::ShaderNetwork *displacementShader,
-                                       const IECoreScene::ShaderNetwork *volumeShader,  
-                                       ccl::ShaderManager *shaderManager, 
+                                       const IECoreScene::ShaderNetwork *volumeShader,
+                                       ccl::ShaderManager *shaderManager,
                                        const std::string &namePrefix = "" );
 IECORECYCLES_API ccl::Light  *convert( const IECoreScene::ShaderNetwork *shaderNetwork );
 IECORECYCLES_API void convertAOV( const IECoreScene::ShaderNetwork *shaderNetwork, ccl::ShaderGraph *graph, ccl::ShaderManager *shaderManager, const std::string &namePrefix = "" );

--- a/python/GafferCyclesUI/CyclesAttributesUI.py
+++ b/python/GafferCyclesUI/CyclesAttributesUI.py
@@ -320,7 +320,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Value under which voxels are considered empty space to 
+			Value under which voxels are considered empty space to
 			optimize rendering.
 			""",
 
@@ -332,7 +332,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Distance between volume samples. When zero it is automatically 
+			Distance between volume samples. When zero it is automatically
 			estimated based on the voxel size.
 			""",
 
@@ -344,8 +344,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Specify volume density and step size in object or world space. 
-			By default object space is used, so that the volume opacity and 
+			Specify volume density and step size in object or world space.
+			By default object space is used, so that the volume opacity and
 			detail remains the same regardless of object scale.
 			""",
 
@@ -383,7 +383,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Use transparent shadows for this material if it contains a Transparent BSDF, 
+			Use transparent shadows for this material if it contains a Transparent BSDF,
 			disabling will render faster but not give accurate shadows.
 			""",
 
@@ -395,7 +395,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Disabling this when using volume rendering, assume volume has the same density 
+			Disabling this when using volume rendering, assume volume has the same density
 			everywhere (not using any textures), for faster rendering.
 			""",
 

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -374,16 +374,16 @@ def __devicesPreset() :
 		elif device["type"] == "METAL" :
 			index = metalIndex
 			metalIndex += 1
-		Gaffer.Metadata.registerValue( 
-			GafferCycles.CyclesOptions, 
-			"options.device.value", 
-			"preset:%s:%02i - %s" % ( device["type"], index, device["description"] ), 
+		Gaffer.Metadata.registerValue(
+			GafferCycles.CyclesOptions,
+			"options.device.value",
+			"preset:%s:%02i - %s" % ( device["type"], index, device["description"] ),
 			"%s:%02i" % ( device["type"], index )
 			)
-		Gaffer.Metadata.registerValue( 
-			GafferCycles.CyclesOptions, 
-			"options.device.value", 
-			"preset:CPU and %s:%02i - %s" % ( device["type"], index, device["description"] ), 
+		Gaffer.Metadata.registerValue(
+			GafferCycles.CyclesOptions,
+			"options.device.value",
+			"preset:CPU and %s:%02i - %s" % ( device["type"], index, device["description"] ),
 			"CPU %s:%02i" % ( device["type"], index )
 			)
 
@@ -470,7 +470,7 @@ Gaffer.Metadata.registerNode(
 			Feature set to use for rendering.
 			- Supported : Only use finished and supported features
 			- Experimental : Use experimental and incomplete features
-								that might be broken or change in the 
+								that might be broken or change in the
 								future.
 			""",
 
@@ -723,7 +723,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Number of samples to render for each pixel. This is for the
-			path integrator, use the other sampling parameters for the 
+			path integrator, use the other sampling parameters for the
 			branched-path integrator.
 			""",
 
@@ -771,7 +771,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Noise level step to stop sampling at, lower values reduce noise the cost of render time. 
+			Noise level step to stop sampling at, lower values reduce noise the cost of render time.
 			Zero for automatic setting based on number of AA samples.
 			""",
 
@@ -783,7 +783,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Minimum AA samples for adaptive sampling, to discover noisy features before stopping sampling. 
+			Minimum AA samples for adaptive sampling, to discover noisy features before stopping sampling.
 			Zero for automatic setting based on number of AA samples.
 			""",
 
@@ -1020,7 +1020,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Use reflective caustics, resulting in a brighter image 
+			Use reflective caustics, resulting in a brighter image
 			(more noise but added realism).
 			""",
 
@@ -1033,7 +1033,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Use refractive caustics, resulting in a brighter image 
+			Use refractive caustics, resulting in a brighter image
 			(more noise but added realism).
 			""",
 
@@ -1093,9 +1093,9 @@ Gaffer.Metadata.registerNode(
 
 		#	"description",
 		#	"""
-		#	Multiplier for dicing rate of geometry outside of the camera view. 
-		#	The dicing rate of objects is gradually increased the further they 
-		#	are outside the camera view. Lower values provide higher quality 
+		#	Multiplier for dicing rate of geometry outside of the camera view.
+		#	The dicing rate of objects is gradually increased the further they
+		#	are outside the camera view. Lower values provide higher quality
 		#	reflections and shadows for off screen objects, while higher values
 		#	use less memory.
 		#	""",
@@ -1506,7 +1506,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Automatically convert textures to .tx files for optimal texture 
+			Automatically convert textures to .tx files for optimal texture
 			cache performance.
 			""",
 
@@ -1517,8 +1517,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Texture cached rendering without mip mapping is very expensive. 
-			Uncheck to prevent Cycles from using textures that are not mip 
+			Texture cached rendering without mip mapping is very expensive.
+			Uncheck to prevent Cycles from using textures that are not mip
 			mapped.
 			""",
 
@@ -1529,7 +1529,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Texture cached rendering without tiled textures is very expensive. 
+			Texture cached rendering without tiled textures is very expensive.
 			Uncheck to prevent Cycles from using textures that are not tiled.
 			""",
 
@@ -1540,7 +1540,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			On the fly creation of tiled versions of textures that are not 
+			On the fly creation of tiled versions of textures that are not
 			tiled. This can increase render time but helps reduce memory usage.
 			""",
 
@@ -1551,8 +1551,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			On the fly creation of mip maps of textures that are not mip 
-			mapped. This can increase render time but helps reduce memory 
+			On the fly creation of mip maps of textures that are not mip
+			mapped. This can increase render time but helps reduce memory
 			usage.
 			""",
 

--- a/python/GafferCyclesUI/CyclesShaderUI.py
+++ b/python/GafferCyclesUI/CyclesShaderUI.py
@@ -192,9 +192,9 @@ for nodeType in ( GafferCycles.CyclesShader, GafferCycles.CyclesLight ) :
 Gaffer.Metadata.registerValue( GafferCycles.CyclesShader, "attributeSuffix", "plugValueWidget:type", "GafferUI.StringPlugValueWidget" )
 Gaffer.Metadata.registerValue( GafferCycles.CyclesShader, "attributeSuffix", "layout:visibilityActivator", "suffixActivator" )
 
-Gaffer.Metadata.registerNode( 
+Gaffer.Metadata.registerNode(
 
-	GafferCycles.CyclesShader, 
+	GafferCycles.CyclesShader,
 
 	plugs = {
 

--- a/src/GafferCycles/CyclesLight.cpp
+++ b/src/GafferCycles/CyclesLight.cpp
@@ -116,7 +116,7 @@ IECoreScene::ShaderNetworkPtr CyclesLight::computeLight( const Gaffer::Context *
 	}
 	else if( ( shaderName == "quad_light" )
 	      || ( shaderName == "disk_light" )
-	      || ( shaderName == "portal" ) )	
+	      || ( shaderName == "portal" ) )
 	{
 		lightShader->parameters()["light_type"] = new StringData( "area" );
 	}

--- a/src/GafferCycles/CyclesShader.cpp
+++ b/src/GafferCycles/CyclesShader.cpp
@@ -71,7 +71,7 @@ namespace {
 
 #if GAFFER_MAJOR_VERSION > 58
 // This is to allow Cycles Shaders to be connected to OSL Shaders
-static bool g_oslRegistration = OSLShader::registerCompatibleShader( "ccl:surface" );
+bool g_oslRegistration = OSLShader::registerCompatibleShader( "ccl:surface" );
 #endif
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
@@ -98,7 +98,7 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 	const Imath::V2f &clippingPlanes = camera->getClippingPlanes();
 	ccam->set_nearclip( clippingPlanes.x );
 	ccam->set_farclip( clippingPlanes.y );
-	
+
 	// Crop window
 	if ( camera->hasCropWindow() )
 	{
@@ -108,7 +108,7 @@ ccl::Camera *convertCommon( const IECoreScene::Camera *camera, const std::string
 		ccam->set_border_top( cropWindow.max.y );
 		ccam->set_border_bottom( cropWindow.min.y );
 	}
-	
+
 	// Shutter TODO: Need to see if this is correct or not, cycles also has a shutter curve...
 	const Imath::V2f &shutter = camera->getShutter();
 	ccam->set_shuttertime( abs(shutter.x) + abs(shutter.y) );

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -92,7 +92,7 @@ ccl::Hair *convertCommon( const IECoreScene::CurvesPrimitive *curve )
 		float constantWidth = 1.0f;
 
 		if( const FloatData *cw = curve->variableData<FloatData>( "width", PrimitiveVariable::Constant ) )
-		{	
+		{
 			constantWidth = cw->readable();
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
@@ -47,9 +47,9 @@ namespace
 {
 
 // Version
-static std::string cyclesVersion = CYCLES_VERSION_STRING;
+std::string cyclesVersion = CYCLES_VERSION_STRING;
 // Store devices once
-static std::vector<ccl::DeviceInfo> cyclesDevices;
+std::vector<ccl::DeviceInfo> cyclesDevices;
 
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -123,7 +123,7 @@ struct MikkUserData {
 	float *tangent_sign;
 };
 
-static int mikk_get_num_faces( const SMikkTSpaceContext *context )
+int mikk_get_num_faces( const SMikkTSpaceContext *context )
 {
 	const MikkUserData *userdata = (const MikkUserData *)context->m_pUserData;
 	if( userdata->mesh->get_num_subd_faces() )
@@ -136,7 +136,7 @@ static int mikk_get_num_faces( const SMikkTSpaceContext *context )
 	}
 }
 
-static int mikk_get_num_verts_of_face( const SMikkTSpaceContext *context, const int face_num )
+int mikk_get_num_verts_of_face( const SMikkTSpaceContext *context, const int face_num )
 {
 	const MikkUserData *userdata = (const MikkUserData *)context->m_pUserData;
 	if( userdata->mesh->get_num_subd_faces() )
@@ -150,7 +150,7 @@ static int mikk_get_num_verts_of_face( const SMikkTSpaceContext *context, const 
 	}
 }
 
-static int mikk_vertex_index( const ccl::Mesh *mesh, const int face_num, const int vert_num )
+int mikk_vertex_index( const ccl::Mesh *mesh, const int face_num, const int vert_num )
 {
 	if( mesh->get_num_subd_faces() )
 	{
@@ -163,7 +163,7 @@ static int mikk_vertex_index( const ccl::Mesh *mesh, const int face_num, const i
 	}
 }
 
-static int mikk_corner_index( const ccl::Mesh *mesh, const int face_num, const int vert_num )
+int mikk_corner_index( const ccl::Mesh *mesh, const int face_num, const int vert_num )
 {
 	if( mesh->get_num_subd_faces() )
 	{
@@ -176,7 +176,7 @@ static int mikk_corner_index( const ccl::Mesh *mesh, const int face_num, const i
 	}
 }
 
-static void mikk_get_position( const SMikkTSpaceContext *context,
+void mikk_get_position( const SMikkTSpaceContext *context,
 							   float P[3],
 							   const int face_num,
 							   const int vert_num )
@@ -190,7 +190,7 @@ static void mikk_get_position( const SMikkTSpaceContext *context,
 	P[2] = vP.z;
 }
 
-static void mikk_get_texture_coordinate( const SMikkTSpaceContext *context,
+void mikk_get_texture_coordinate( const SMikkTSpaceContext *context,
 										 float uv[2],
 										 const int face_num,
 										 const int vert_num )
@@ -222,7 +222,7 @@ static void mikk_get_texture_coordinate( const SMikkTSpaceContext *context,
 	}
 }
 
-static void mikk_get_normal( const SMikkTSpaceContext *context,
+void mikk_get_normal( const SMikkTSpaceContext *context,
 							 float N[3],
 							 const int face_num,
 							 const int vert_num)
@@ -269,7 +269,7 @@ static void mikk_get_normal( const SMikkTSpaceContext *context,
 	N[2] = vN.z;
 }
 
-static void mikk_set_tangent_space(const SMikkTSpaceContext *context,
+void mikk_set_tangent_space(const SMikkTSpaceContext *context,
 								   const float T[],
 								   const float sign,
 								   const int face_num,
@@ -285,7 +285,7 @@ static void mikk_set_tangent_space(const SMikkTSpaceContext *context,
 	}
 }
 
-static void mikk_compute_tangents( const char *layer_name, ccl::Mesh *mesh, bool need_sign, bool active_render )
+void mikk_compute_tangents( const char *layer_name, ccl::Mesh *mesh, bool need_sign, bool active_render )
 {
 	/* Create tangent attributes. */
 	ccl::AttributeSet &attributes = ( mesh->get_num_subd_faces() ) ? mesh->subd_attributes : mesh->attributes;

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -69,7 +69,7 @@ struct MikkUserData {
 				  ccl::Mesh *mesh,
 				  ccl::float3 *tangent,
 				  float *tangent_sign )
-		: mesh( mesh ), texface( NULL ), tangent( tangent ), tangent_sign( tangent_sign )
+		: mesh( mesh ), texface( nullptr ), tangent( tangent ), tangent_sign( tangent_sign )
 	{
 		const ccl::AttributeSet &attributes = (mesh->get_num_subd_faces()) ? mesh->subd_attributes :
 																		  mesh->attributes;
@@ -104,7 +104,7 @@ struct MikkUserData {
 #endif
 
 		ccl::Attribute *attr_uv = attributes.find( ccl::ustring( layer_name ) );
-		if( attr_uv != NULL )
+		if( attr_uv != nullptr )
 		{
 			texface = attr_uv->data_float2();
 		}
@@ -197,14 +197,14 @@ static void mikk_get_texture_coordinate( const SMikkTSpaceContext *context,
 {
 	const MikkUserData *userdata = (const MikkUserData *)context->m_pUserData;
 	const ccl::Mesh *mesh = userdata->mesh;
-	if( userdata->texface != NULL )
+	if( userdata->texface != nullptr )
 	{
 		const int corner_index = mikk_corner_index( mesh, face_num, vert_num );
 		ccl::float2 tfuv = userdata->texface[corner_index];
 		uv[0] = tfuv.x;
 		uv[1] = tfuv.y;
 	}
-	else if (userdata->orco != NULL)
+	else if (userdata->orco != nullptr)
 	{
 		const int vertex_index = mikk_vertex_index(mesh, face_num, vert_num);
 		const ccl::float3 orco_loc = userdata->orco_loc;
@@ -279,7 +279,7 @@ static void mikk_set_tangent_space(const SMikkTSpaceContext *context,
 	const ccl::Mesh *mesh = userdata->mesh;
 	const int corner_index = mikk_corner_index( mesh, face_num, vert_num );
 	userdata->tangent[corner_index] = ccl::make_float3( T[0], T[1], T[2] );
-	if (userdata->tangent_sign != NULL)
+	if (userdata->tangent_sign != nullptr)
 	{
 		userdata->tangent_sign[corner_index] = sign;
 	}
@@ -292,7 +292,7 @@ static void mikk_compute_tangents( const char *layer_name, ccl::Mesh *mesh, bool
 	ccl::Attribute *attr;
 	ccl::ustring name;
 
-	if (layer_name != NULL)
+	if (layer_name != nullptr)
 	{
 		name = ccl::ustring( ( std::string( layer_name ) + ".tangent" ).c_str() );
 	}
@@ -311,13 +311,13 @@ static void mikk_compute_tangents( const char *layer_name, ccl::Mesh *mesh, bool
 	}
 	ccl::float3 *tangent = attr->data_float3();
 	/* Create bitangent sign attribute. */
-	float *tangent_sign = NULL;
+	float *tangent_sign = nullptr;
 	if( need_sign )
 	{
 		ccl::Attribute *attr_sign;
 		ccl::ustring name_sign;
 
-		if (layer_name != NULL)
+		if (layer_name != nullptr)
 		{
 			name_sign = ccl::ustring( ( std::string( layer_name ) + ".tangent_sign" ).c_str() );
 		}

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -542,7 +542,7 @@ void convertN( const IECoreScene::MeshPrimitive *mesh, const V3fVectorData *norm
 			}
 		}
 	}
-	
+
 }
 
 void convertUVSet( const string &uvSet, const IECoreScene::PrimitiveVariable &uvVariable, const IECoreScene::MeshPrimitive *mesh, ccl::AttributeSet &attributes, bool subdivision_uvs, bool defaultUV )//, ccl::Mesh *cmesh )
@@ -707,7 +707,7 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh )
 		int indexOffset = 0;
 		for( size_t i = 0; i < vertsPerFace.size(); i++ )
 		{
-			cmesh->add_subd_face( const_cast<int*>(&vertexIds[indexOffset]), vertsPerFace[i], 
+			cmesh->add_subd_face( const_cast<int*>(&vertexIds[indexOffset]), vertsPerFace[i],
 				f ? f->readable()[i] : 0, s ? s->readable()[i] : smooth ); // Last two args are shader sets and smooth
 			indexOffset += vertsPerFace[i];
 		}
@@ -769,7 +769,7 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh )
 
 			int faceOffset = 0;
 			for( size_t i = 0; i < triVertexIds.size(); i+= 3, ++faceOffset )
-				cmesh->add_triangle( triVertexIds[i], triVertexIds[i+1], triVertexIds[i+2], 
+				cmesh->add_triangle( triVertexIds[i], triVertexIds[i+1], triVertexIds[i+2],
 					f ? f->readable()[faceOffset] : 0, s ? s->readable()[faceOffset] : smooth ); // Last two args are shader sets and smooth
 		}
 		else
@@ -788,7 +788,7 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh )
 
 			int faceOffset = 0;
 			for( size_t i = 0; i < vertexIds.size(); i+= 3, ++faceOffset )
-				cmesh->add_triangle( vertexIds[i], vertexIds[i+1], vertexIds[i+2], 
+				cmesh->add_triangle( vertexIds[i], vertexIds[i+1], vertexIds[i+2],
 					f ? f->readable()[faceOffset] : 0, s ? s->readable()[faceOffset] : smooth ); // Last two args are shader sets and smooth
 		}
 	}

--- a/src/GafferCycles/IECoreCyclesPreview/Mikktspace/mikktspace.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Mikktspace/mikktspace.cpp
@@ -130,7 +130,7 @@ typedef struct {
 	tbool bOrientPreservering;
 } SGroup;
 
-// 
+//
 #define MARK_DEGENERATE				1
 #define QUAD_ONE_DEGEN_TRI			2
 #define GROUP_WITH_ANY				4
@@ -141,7 +141,7 @@ typedef struct {
 typedef struct {
 	int FaceNeighbors[3];
 	SGroup * AssignedGroup[3];
-	
+
 	// normalized first order face derivatives
 	SVec3 vOs, vOt;
 	float fMagS, fMagT;	// original magnitudes
@@ -301,13 +301,13 @@ tbool genTangSpace(const SMikkTSpaceContext * pContext, const float fAngularThre
 	// put the degenerate triangles last.
 	DegenPrologue(pTriInfos, piTriListIn, iNrTrianglesIn, iTotTris);
 
-	
+
 	// evaluate triangle level attributes and neighbor list
 	//printf("gen neighbors list begin\n");
 	InitTriInfo(pTriInfos, piTriListIn, pContext, iNrTrianglesIn);
 	//printf("gen neighbors list end\n");
 
-	
+
 	// based on the 4 rules, identify groups based on connectivity
 	iNrMaxGroups = iNrTrianglesIn*3;
 	pGroups = (SGroup *) malloc(sizeof(SGroup)*iNrMaxGroups);
@@ -349,7 +349,7 @@ tbool genTangSpace(const SMikkTSpaceContext * pContext, const float fAngularThre
 	//printf("gen tspaces begin\n");
 	bRes = GenerateTSpaces(psTspace, pTriInfos, pGroups, iNrActiveGroups, piTriListIn, fThresCos, pContext);
 	//printf("gen tspaces end\n");
-	
+
 	// clean up
 	free(pGroups);
 	free(piGroupTrianglesBuffer);
@@ -375,7 +375,7 @@ tbool genTangSpace(const SMikkTSpaceContext * pContext, const float fAngularThre
 	{
 		const int verts = pContext->m_pInterface->m_getNumVerticesOfFace(pContext, f);
 		if (verts!=3 && verts!=4) continue;
-		
+
 
 		// I've decided to let degenerate triangles and group-with-anythings
 		// vary between left/right hand coordinate systems at the vertices.
@@ -415,7 +415,7 @@ tbool genTangSpace(const SMikkTSpaceContext * pContext, const float fAngularThre
 
 	free(psTspace);
 
-	
+
 	return TTRUE;
 }
 
@@ -542,7 +542,7 @@ static void GenerateSharedVerticesIndexList(int piTriList_in_and_out[], const SM
 		if (iMaxCount<piHashCount[k])
 			iMaxCount=piHashCount[k];
 	pTmpVert = (STmpVert *) malloc(sizeof(STmpVert)*iMaxCount);
-	
+
 
 	// complete the merge
 	for (k=0; k<g_iCells; k++)
@@ -628,7 +628,7 @@ static void MergeVertsFast(int piTriList_in_and_out[], STmpVert pTmpVert[], cons
 				else
 					++l2;
 			}
-			
+
 			// merge if previously found
 			if (!bNotFound)
 				piTriList_in_and_out[i] = piTriList_in_and_out[i2rec];
@@ -711,7 +711,7 @@ static void MergeVertsSlow(int piTriList_in_and_out[], const SMikkTSpaceContext 
 			else
 				++e2;
 		}
-		
+
 		// merge if previously found
 		if (!bNotFound)
 			piTriList_in_and_out[i] = piTriList_in_and_out[i2rec];
@@ -743,7 +743,7 @@ static void GenerateSharedVerticesIndexListSlow(int piTriList_in_and_out[], cons
 					const SVec3 vP2 = GetPosition(pContext, index2);
 					const SVec3 vN2 = GetNormal(pContext, index2);
 					const SVec3 vT2 = GetTexCoord(pContext, index2);
-					
+
 					if (veq(vP,vP2) && veq(vN,vN2) && veq(vT,vT2))
 						bFound = TTRUE;
 					else
@@ -1007,7 +1007,7 @@ static void InitTriInfo(STriInfo pTriInfos[], const int piTriListIn[], const SMi
 		{
 			const tbool bIsDeg_a = (pTriInfos[t].iFlag&MARK_DEGENERATE)!=0 ? TTRUE : TFALSE;
 			const tbool bIsDeg_b = (pTriInfos[t+1].iFlag&MARK_DEGENERATE)!=0 ? TTRUE : TFALSE;
-			
+
 			// bad triangles should already have been removed by
 			// DegenPrologue(), but just in case check bIsDeg_a and bIsDeg_a are false
 			if ((bIsDeg_a||bIsDeg_b)==TFALSE)
@@ -1037,7 +1037,7 @@ static void InitTriInfo(STriInfo pTriInfos[], const int piTriListIn[], const SMi
 		else
 			++t;
 	}
-	
+
 	// match up edge pairs
 	{
 		SEdge * pEdges = (SEdge *) malloc(sizeof(SEdge)*iNrTrianglesIn*3);
@@ -1046,7 +1046,7 @@ static void InitTriInfo(STriInfo pTriInfos[], const int piTriListIn[], const SMi
 		else
 		{
 			BuildNeighborsFast(pTriInfos, pEdges, piTriListIn, iNrTrianglesIn);
-	
+
 			free(pEdges);
 		}
 	}
@@ -1091,7 +1091,7 @@ static int Build4RuleGroups(STriInfo pTriInfos[], SGroup pGroups[], int piGroupT
 					const tbool bAnswer =
 						AssignRecur(piTriListIn, pTriInfos, neigh_indexL,
 									pTriInfos[f].AssignedGroup[i] );
-					
+
 					const tbool bOrPre2 = (pTriInfos[neigh_indexL].iFlag&ORIENT_PRESERVING)!=0 ? TTRUE : TFALSE;
 					const tbool bDiff = bOrPre!=bOrPre2 ? TTRUE : TFALSE;
 					assert(bAnswer || bDiff);
@@ -1237,7 +1237,7 @@ static tbool GenerateTSpaces(STSpace psTspace[], const STriInfo pTriInfos[], con
 
 			// is normalized already
 			n = GetNormal(pContext, iVertIndex);
-			
+
 			// project
 			vOs = vsub(pTriInfos[f].vOs, vscale(vdot(n,pTriInfos[f].vOs), n));
 			vOt = vsub(pTriInfos[f].vOt, vscale(vdot(n,pTriInfos[f].vOt), n));
@@ -1246,7 +1246,7 @@ static tbool GenerateTSpaces(STSpace psTspace[], const STriInfo pTriInfos[], con
 
 			// original face number
 			iOF_1 = pTriInfos[f].iOrgFaceNumber;
-			
+
 			iMembers = 0;
 			for (j=0; j<pGroup->iNrFaces; j++)
 			{
@@ -1290,7 +1290,7 @@ static tbool GenerateTSpaces(STSpace psTspace[], const STriInfo pTriInfos[], con
 				bFound = CompareSubGroups(&tmp_group, &pUniSubGroups[l]);
 				if (!bFound) ++l;
 			}
-			
+
 			// assign tangent space index
 			assert(bFound || l==iUniqueSubGroups);
 			//piTempTangIndices[f*3+index] = iUniqueTspaces+l;
@@ -1618,7 +1618,7 @@ static void BuildNeighborsSlow(STriInfo pTriInfos[], const int piTriListIn[], co
 								++j;
 						}
 					}
-					
+
 					if (!bFound) ++t;
 				}
 
@@ -1694,7 +1694,7 @@ static void QuickSortEdges(SEdge * pSortBuffer, int iLeft, int iRight, const int
 static void GetEdge(int * i0_out, int * i1_out, int * edgenum_out, const int indices[], const int i0_in, const int i1_in)
 {
 	*edgenum_out = -1;
-	
+
 	// test if first index is on the edge
 	if (indices[0]==i0_in || indices[0]==i1_in)
 	{
@@ -1842,7 +1842,7 @@ static void DegenEpilogue(STSpace psTspace[], STriInfo pTriInfos[], int piTriLis
 					const int iSrcOffs=pTriInfos[iTri].iTSpacesOffs;
 					const int iDstVert=pTriInfos[t].vert_num[i];
 					const int iDstOffs=pTriInfos[t].iTSpacesOffs;
-					
+
 					// copy tspace
 					psTspace[iDstOffs+iDstVert] = psTspace[iSrcOffs+iSrcVert];
 				}

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -113,13 +113,13 @@ ccl::PointCloud *convertCommon( const IECoreScene::PointsPrimitive *points )
 		float width = 1.0f;
 
 		if( const FloatData *w = points->variableData<FloatData>( "width", PrimitiveVariable::Constant ) )
-		{	
+		{
 			width = w->readable() * 0.5f;
 			variablesToConvert.erase( "width" );
 		}
 
 		if( const FloatData *w = points->variableData<FloatData>( "radius", PrimitiveVariable::Constant ) )
-		{	
+		{
 			width = w->readable();
 			variablesToConvert.erase( "radius" );
 		}

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -128,22 +128,22 @@ namespace
 {
 
 //typedef std::unique_ptr<ccl::Camera> CCameraPtr;
-typedef std::unique_ptr<ccl::Integrator> CIntegratorPtr;
-typedef std::unique_ptr<ccl::Background> CBackgroundPtr;
-typedef std::unique_ptr<ccl::Film> CFilmPtr;
-typedef std::unique_ptr<ccl::Light> CLightPtr;
-typedef std::shared_ptr<ccl::Camera> SharedCCameraPtr;
-typedef std::shared_ptr<ccl::Object> SharedCObjectPtr;
-typedef std::shared_ptr<ccl::Light> SharedCLightPtr;
-typedef std::shared_ptr<ccl::Geometry> SharedCGeometryPtr;
-typedef std::shared_ptr<ccl::ParticleSystem> SharedCParticleSystemPtr;
+using CIntegratorPtr = std::unique_ptr<ccl::Integrator>;
+using CBackgroundPtr = std::unique_ptr<ccl::Background>;
+using CFilmPtr = std::unique_ptr<ccl::Film>;
+using CLightPtr = std::unique_ptr<ccl::Light>;
+using SharedCCameraPtr = std::shared_ptr<ccl::Camera>;
+using SharedCObjectPtr = std::shared_ptr<ccl::Object>;
+using SharedCLightPtr = std::shared_ptr<ccl::Light>;
+using SharedCGeometryPtr = std::shared_ptr<ccl::Geometry>;
+using SharedCParticleSystemPtr = std::shared_ptr<ccl::ParticleSystem>;
 // Need to defer shader assignments to the scene lock
 typedef std::pair<ccl::Node*, ccl::array<ccl::Node*>> ShaderAssignPair;
 // Defer adding the created nodes to the scene lock
-typedef tbb::concurrent_vector<ccl::Node *> NodesCreated;
+using NodesCreated = tbb::concurrent_vector<ccl::Node *>;
 
 // The shared pointer never deletes, we leave that up to Cycles to do the final delete
-typedef bool (*NodeDeleter)(ccl::Node *);
+using NodeDeleter = bool (*)( ccl::Node * );
 bool nullNodeDeleter( ccl::Node *node )
 {
 	return false;
@@ -192,7 +192,7 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 		return defaultValue;
 	}
 
-	typedef IECore::TypedData<T> DataType;
+	using DataType = IECore::TypedData<T>;
 	if( const DataType *d = reportedCast<const DataType>( it->second.get(), "parameter", name ) )
 	{
 		return d->readable();
@@ -857,7 +857,7 @@ class ShaderCache : public IECore::RefCounted
 		Cache m_cache;
 		CyclesShaderPtr m_defaultSurface;
 		// Need to assign shaders in a deferred manner
-		typedef tbb::concurrent_vector<ShaderAssignPair> ShaderAssignVector;
+		using ShaderAssignVector = tbb::concurrent_vector<ShaderAssignPair>;
 		ShaderAssignVector m_shaderAssignPairs;
 
 };
@@ -1287,7 +1287,7 @@ class CyclesAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		template<typename T>
 		static T attributeValue( const IECore::InternedString &name, const IECore::CompoundObject *attributes, const T &defaultValue )
 		{
-			typedef IECore::TypedData<T> DataType;
+			using DataType = IECore::TypedData<T>;
 			const DataType *data = attribute<DataType>( name, attributes );
 			return data ? data->readable() : defaultValue;
 		}
@@ -1295,7 +1295,7 @@ class CyclesAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		template<typename T>
 		static boost::optional<T> optionalAttribute( const IECore::InternedString &name, const IECore::CompoundObject *attributes )
 		{
-			typedef IECore::TypedData<T> DataType;
+			using DataType = IECore::TypedData<T>;
 			const DataType *data = attribute<DataType>( name, attributes );
 			return data ? data->readable() : boost::optional<T>();
 		}
@@ -2126,14 +2126,14 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 		ccl::Scene *m_scene;
-		typedef tbb::concurrent_vector<SharedCObjectPtr> Objects;
+		using Objects = tbb::concurrent_vector<SharedCObjectPtr>;
 		Objects m_objects;
 		typedef tbb::concurrent_hash_map<IECore::MurmurHash, SharedCGeometryPtr> Geometry;
 		Geometry m_geometry;
-		typedef tbb::concurrent_vector<SharedCGeometryPtr> UniqueGeometry;
+		using UniqueGeometry = tbb::concurrent_vector<SharedCGeometryPtr>;
 		UniqueGeometry m_uniqueGeometry;
 		ParticleSystemsCachePtr m_particleSystemsCache;
-		typedef tbb::spin_mutex ParticlesMutex;
+		using ParticlesMutex = tbb::spin_mutex;
 		ParticlesMutex m_particlesMutex;
 
 
@@ -2228,7 +2228,7 @@ class LightCache : public IECore::RefCounted
 		}
 
 		ccl::Scene *m_scene;
-		typedef tbb::concurrent_vector<SharedCLightPtr> Lights;
+		using Lights = tbb::concurrent_vector<SharedCLightPtr>;
 		Lights m_lights;
 
 };

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -518,7 +518,7 @@ class ShaderCache : public IECore::RefCounted
 			m_defaultSurface = new CyclesShader( m_scene );
 		}
 
-		~ShaderCache()
+		~ShaderCache() override
 		{
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -434,9 +434,9 @@ class CyclesShader : public IECore::RefCounted
 					  const IECoreScene::ShaderNetwork *displacementShader,
 					  const IECoreScene::ShaderNetwork *volumeShader,
 					  ccl::Scene *scene,
-					  const std::string &name, 
+					  const std::string &name,
 					  const IECore::MurmurHash &h,
-					  const bool singleSided, 
+					  const bool singleSided,
 					  const IECore::InternedString displacementMethod,
 					  vector<const IECoreScene::ShaderNetwork *> &aovShaders )
 			:	m_hash( h )
@@ -538,7 +538,7 @@ class ShaderCache : public IECore::RefCounted
 		CyclesShaderPtr get( const IECoreScene::ShaderNetwork *surfaceShader,
 							 const IECoreScene::ShaderNetwork *displacementShader,
 							 const IECoreScene::ShaderNetwork *volumeShader,
-							 const IECore::CompoundObject *attributes, 
+							 const IECore::CompoundObject *attributes,
 							 IECore::MurmurHash &h )
 		{
 			IECore::MurmurHash hSubst;
@@ -1042,7 +1042,7 @@ class CyclesAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 							// In Blender a shader->set_graph(graph); is called which handles the hashing similar to the code above. In GafferCycles
 							// we re-create a fresh shader which is easier to manage, however it misses this call to set need_update_mesh to false.
 							// We set false here, but we also need to make sure all the attribute requests are the same to prevent the flag to be set
-							// to true in another place of the code inside of Cycles. If we have made it this far in this area, we are just updating 
+							// to true in another place of the code inside of Cycles. If we have made it this far in this area, we are just updating
 							// the same shader so this should be safe.
 							shader->attributes = prevShader->attributes;
 							//m_shader->need_update_uvs = false;
@@ -1855,10 +1855,10 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 		// Can be called concurrently with other get() calls.
-		Instance get( const std::vector<const IECore::Object *> &samples, 
-					  const std::vector<float> &times, 
-					  const int frameIdx, 
-					  const IECoreScenePreview::Renderer::AttributesInterface *attributes, 
+		Instance get( const std::vector<const IECore::Object *> &samples,
+					  const std::vector<float> &times,
+					  const int frameIdx,
+					  const IECoreScenePreview::Renderer::AttributesInterface *attributes,
 					  const std::string &nodeName )
 		{
 			const CyclesAttributes *cyclesAttributes = static_cast<const CyclesAttributes *>( attributes );
@@ -1986,10 +1986,10 @@ class InstanceCache : public IECore::RefCounted
 
 	private :
 
-		SharedCObjectPtr convert( const IECore::Object *object, 
-								  const CyclesAttributes *attributes, 
-								  const std::string &nodeName, 
-								  SharedCParticleSystemPtr &cpsysPtr, 
+		SharedCObjectPtr convert( const IECore::Object *object,
+								  const CyclesAttributes *attributes,
+								  const std::string &nodeName,
+								  SharedCParticleSystemPtr &cpsysPtr,
 								  ccl::Geometry *cgeo = nullptr )
 		{
 			ccl::Object *cobject = nullptr;
@@ -2024,12 +2024,12 @@ class InstanceCache : public IECore::RefCounted
 			return SharedCObjectPtr( cobject, nullNodeDeleter );
 		}
 
-		SharedCObjectPtr convert( const std::vector<const IECore::Object *> &samples, 
-								  const std::vector<float> &times, 
-								  const int frame, 
-								  const CyclesAttributes *attributes, 
-								  const std::string &nodeName, 
-								  SharedCParticleSystemPtr &cpsysPtr, 
+		SharedCObjectPtr convert( const std::vector<const IECore::Object *> &samples,
+								  const std::vector<float> &times,
+								  const int frame,
+								  const CyclesAttributes *attributes,
+								  const std::string &nodeName,
+								  SharedCParticleSystemPtr &cpsysPtr,
 								  ccl::Geometry *cgeo = nullptr )
 		{
 			ccl::Object *cobject = nullptr;
@@ -3624,7 +3624,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			ccl::DeviceInfo deviceFallback;
 
 			bool deviceAvailable = false;
-			for( const ccl::DeviceInfo& device : IECoreCycles::devices() ) 
+			for( const ccl::DeviceInfo& device : IECoreCycles::devices() )
 			{
 				if( deviceTypeFallback == device.type )
 				{
@@ -3646,9 +3646,9 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 			else
 			{
-				for( const ccl::DeviceInfo& device : IECoreCycles::devices() ) 
+				for( const ccl::DeviceInfo& device : IECoreCycles::devices() )
 				{
-					if( m_deviceName ==  device.id ) 
+					if( m_deviceName ==  device.id )
 					{
 						m_sessionParams.device = device;
 						deviceAvailable = true;
@@ -3834,12 +3834,12 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			if( !m_outputsChanged )
 				return;
 
-			Box2i displayWindow( 
+			Box2i displayWindow(
 				V2i( 0, 0 ),
 				V2i( width - 1, height - 1 )
 				);
 			Box2i dataWindow(
-				V2i( (int)(camera->get_border_left()   * (float)width ), 
+				V2i( (int)(camera->get_border_left()   * (float)width ),
 					 (int)(camera->get_border_bottom() * (float)height ) ),
 				V2i( (int)(camera->get_border_right()  * (float)width ) - 1,
 					 (int)(camera->get_border_top()    * (float)height - 1 ) )
@@ -4159,7 +4159,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				}
 			}
 
-			// Not sure what the best way is to inform that an interactive render has stopped other than this. 
+			// Not sure what the best way is to inform that an interactive render has stopped other than this.
 			// No way that I know of to inform Gaffer that the render has stopped either.
 			if( m_lastStatus == "Finished" )
 			{
@@ -4173,7 +4173,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			int indexHIP = 0;
 			int indexOptiX = 0;
 			int indexMetal = 0;
-			for( const ccl::DeviceInfo &device : IECoreCycles::devices() ) 
+			for( const ccl::DeviceInfo &device : IECoreCycles::devices() )
 			{
 				if( device.type == ccl::DEVICE_CPU )
 				{

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -538,10 +538,10 @@ ccl::ShaderOutput *output( ccl::ShaderNode *node, IECore::InternedString name )
 	return nullptr;
 }
 
-ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader, 
-								const IECoreScene::ShaderNetwork *displacementShader, 
-								const IECoreScene::ShaderNetwork *volumeShader, 
-								ccl::ShaderManager *shaderManager, 
+ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
+								const IECoreScene::ShaderNetwork *displacementShader,
+								const IECoreScene::ShaderNetwork *volumeShader,
+								ccl::ShaderManager *shaderManager,
 								const std::string &namePrefix )
 {
 	ccl::ShaderGraph *graph = new ccl::ShaderGraph();
@@ -598,10 +598,10 @@ ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
 	return graph;
 }
 
-ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader, 
-					  const IECoreScene::ShaderNetwork *displacementShader, 
-					  const IECoreScene::ShaderNetwork *volumeShader, 
-					  ccl::ShaderManager *shaderManager, 
+ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader,
+					  const IECoreScene::ShaderNetwork *displacementShader,
+					  const IECoreScene::ShaderNetwork *volumeShader,
+					  ccl::ShaderManager *shaderManager,
 					  const std::string &namePrefix )
 {
 	string shaderName(
@@ -686,7 +686,7 @@ void setSingleSided( ccl::ShaderGraph *graph )
 	if( ccl::ShaderOutput *shaderOutput = ShaderNetworkAlgo::output( geometry, "backfacing" ) )
 		if( ccl::ShaderInput *shaderInput = ShaderNetworkAlgo::input( mixClosure, "fac" ) )
 			graph->connect( shaderOutput, shaderInput );
-	
+
 	if( ccl::ShaderOutput *shaderOutput = ShaderNetworkAlgo::output( transparentBSDF, "BSDF" ) )
 		if( ccl::ShaderInput *shaderInput = ShaderNetworkAlgo::input( mixClosure, "closure2" ) )
 			graph->connect( shaderOutput, shaderInput );
@@ -720,11 +720,11 @@ ccl::Shader *createDefaultShader()
 	ccl::GeometryNode *geo = cgraph->create_node<ccl::GeometryNode>();
 	ccl::ShaderNode *vecMathNode = cgraph->add( (ccl::ShaderNode*)vecMath );
 	ccl::ShaderNode *geoNode = cgraph->add( (ccl::ShaderNode*)geo );
-	cgraph->connect( ShaderNetworkAlgo::output( geoNode, "normal" ), 
+	cgraph->connect( ShaderNetworkAlgo::output( geoNode, "normal" ),
 						ShaderNetworkAlgo::input( vecMathNode, "vector1" ) );
-	cgraph->connect( ShaderNetworkAlgo::output( geoNode, "incoming" ), 
+	cgraph->connect( ShaderNetworkAlgo::output( geoNode, "incoming" ),
 						ShaderNetworkAlgo::input( vecMathNode, "vector2" ) );
-	cgraph->connect( ShaderNetworkAlgo::output( vecMathNode, "value" ), 
+	cgraph->connect( ShaderNetworkAlgo::output( vecMathNode, "value" ),
 						ShaderNetworkAlgo::input( outputNode, "surface" ) );
 	cshader->set_graph( cgraph );
 

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -209,10 +209,10 @@ ccl::SocketType::Type getSocketType( const std::string &name )
 template<typename Spline>
 void setSplineParameter( ccl::ShaderNode *node, const std::string &name, const Spline &spline )
 {
-	typedef vector<typename Spline::XType> PositionsVector;
-	typedef vector<typename Spline::YType> ValuesVector;
-	typedef TypedData<PositionsVector> PositionsData;
-	typedef TypedData<ValuesVector> ValuesData;
+	using PositionsVector = vector<typename Spline::XType>;
+	using ValuesVector = vector<typename Spline::YType>;
+	using PositionsData = TypedData<PositionsVector>;
+	using ValuesData = TypedData<ValuesVector>;
 
 	typename PositionsData::Ptr positionsData = new PositionsData;
 	typename ValuesData::Ptr valuesData = new ValuesData;

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -194,7 +194,7 @@ Imath::Quatf getQuaternion( const ccl::float4 quat )
 
 Imath::M44f getTransform( const ccl::Transform transform )
 {
-	return Imath::M44f( 
+	return Imath::M44f(
 		transform.x.x, transform.y.x, transform.z.x, 0.0f,
 		transform.x.y, transform.y.y, transform.z.y, 0.0f,
 		transform.x.z, transform.y.z, transform.z.z, 0.0f,

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -75,8 +75,8 @@ void dataToArray( ccl::Node *node, const ccl::SocketType *socket, const IECore::
 template<typename T, typename U>
 IECore::DataPtr arrayToData( const ccl::array<U>& array )
 {
-	typedef vector<T> VectorType;
-	typedef IECore::TypedData<vector<T> > DataType;
+	using VectorType = vector<T>;
+	using DataType = IECore::TypedData<vector<T>>;
 	typename DataType::Ptr data = new DataType;
 	VectorType &v = data->writable();
 	v.reserve( array.size() );
@@ -92,8 +92,8 @@ IECore::DataPtr arrayToData( const ccl::array<U>& array )
 template<typename T>
 IECore::DataPtr arrayToData( const ccl::array<ccl::float3>& array )
 {
-	typedef vector<T> VectorType;
-	typedef IECore::TypedData<vector<T> > DataType;
+	using VectorType = vector<T>;
+	using DataType = IECore::TypedData<vector<T>>;
 	typename DataType::Ptr data = new DataType;
 	VectorType &v = data->writable();
 	v.reserve( array.size() );

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -65,7 +65,7 @@ class GafferVolumeLoader : public ccl::VDBImageLoader
 		{
 		}
 
-		~GafferVolumeLoader()
+		~GafferVolumeLoader() override
 		{
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.h
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.h
@@ -50,7 +50,7 @@ class IEDisplayOutputDriver : public ccl::OutputDriver
 	public:
 
 		IEDisplayOutputDriver( const Imath::Box2i &displayWindow, const Imath::Box2i &dataWindow, IECore::ConstCompoundDataPtr parameters );
-		virtual ~IEDisplayOutputDriver();
+		~IEDisplayOutputDriver() override;
 
 		void write_render_tile( const Tile &tile ) override;
 		bool update_render_tile( const Tile &tile ) override;

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.h
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.h
@@ -64,7 +64,7 @@ class IEDisplayOutputDriver : public ccl::OutputDriver
 		};
 
 		IECoreImage::DisplayDriverPtr m_displayDriver;
-		typedef std::vector<Layer> Layers;
+		using Layers = std::vector<Layer>;
 		Layers m_layers;
 		int m_numChannels;
 };

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
@@ -53,7 +53,7 @@ class OIIOOutputDriver : public ccl::OutputDriver
 	public:
 
 		OIIOOutputDriver( const Imath::Box2i &displayWindow, const Imath::Box2i &dataWindow, IECore::ConstCompoundDataPtr parameters );
-		virtual ~OIIOOutputDriver();
+		~OIIOOutputDriver() override;
 
 		void write_render_tile( const Tile &tile ) override;
 

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
@@ -71,7 +71,7 @@ class OIIOOutputDriver : public ccl::OutputDriver
 
 		Imath::Box2i m_displayWindow;
 		Imath::Box2i m_dataWindow;
-		typedef std::vector<Layer> Layers;
+		using Layers = std::vector<Layer>;
 		Layers m_layers;
 };
 

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -74,7 +74,7 @@ namespace
 template<typename PlugType>
 Gaffer::Plug *setupNumericPlug( const ccl::NodeType *nodeType, const ccl::SocketType socketType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction )
 {
-	typedef typename PlugType::ValueType ValueType;
+	using ValueType = typename PlugType::ValueType;
 
 	ValueType defaultValue(0);
 	ValueType minValue = Imath::limits<ValueType>::min();
@@ -182,8 +182,8 @@ Gaffer::Plug *setupTypedPlug( const ccl::NodeType *nodeType, const ccl::SocketTy
 template<typename PlugType>
 Gaffer::Plug *setupColorPlug( const ccl::NodeType *nodeType, const ccl::SocketType socketType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction )
 {
-	typedef typename PlugType::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
+	using ValueType = typename PlugType::ValueType;
+	using BaseType = typename ValueType::BaseType;
 
 	ValueType defaultValue( 1 );
 	ccl::float3 *defaultCValue = (ccl::float3*)socketType.default_value;

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -66,7 +66,7 @@ using namespace GafferCycles;
 namespace
 {
 
-static py::list getDevices()
+py::list getDevices()
 {
 	py::scope().attr( "hasOptixDenoise" ) = false;
 
@@ -98,7 +98,7 @@ static py::list getDevices()
 	return result;
 }
 
-static py::dict getSockets( const ccl::NodeType *nodeType, const bool output )
+py::dict getSockets( const ccl::NodeType *nodeType, const bool output )
 {
 	py::dict result;
 
@@ -157,7 +157,7 @@ static py::dict getSockets( const ccl::NodeType *nodeType, const bool output )
 	return result;
 }
 
-static py::dict getNodes()
+py::dict getNodes()
 {
 	py::dict result;
 
@@ -183,7 +183,7 @@ static py::dict getNodes()
 	return result;
 }
 
-static py::dict getShaders()
+py::dict getShaders()
 {
 	py::dict result;
 
@@ -343,7 +343,7 @@ static py::dict getShaders()
 	return result;
 }
 
-static py::dict getLights()
+py::dict getLights()
 {
 	py::dict result;
 
@@ -422,7 +422,7 @@ static py::dict getLights()
 	return result;
 }
 
-static py::dict getPasses()
+py::dict getPasses()
 {
 	py::dict result;
 


### PR DESCRIPTION
Just some minor automated code cleanup, in line with the cleanup already applied historically on the `main` branch.
