### PR TITLE
CyclesShaderUI : Fix `suffixActivator` warning

### DIFF
--- a/python/GafferCyclesUI/CyclesShaderUI.py
+++ b/python/GafferCyclesUI/CyclesShaderUI.py
@@ -189,9 +189,6 @@ for nodeType in ( GafferCycles.CyclesShader, GafferCycles.CyclesLight ) :
 
 	Gaffer.Metadata.registerValue( nodeType, "description", __nodeDescription )
 
-Gaffer.Metadata.registerValue( GafferCycles.CyclesShader, "attributeSuffix", "plugValueWidget:type", "GafferUI.StringPlugValueWidget" )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesShader, "attributeSuffix", "layout:visibilityActivator", "suffixActivator" )
-
 Gaffer.Metadata.registerNode(
 
 	GafferCycles.CyclesShader,


### PR DESCRIPTION
We were trying to use an activator called `suffixActivator` for the `attributeSuffix` plug, but since no such activator exists, were getting this error :

```
WARNING : PlugLayout : Activator metadata `layout:activator:suffixActivator` not registered
```

The `attributeSuffix` plug is intended for use when multiple shader assignments might be made, and we don't want them to conflict. For instance, we want to be able to assign multiple Arnold lights filters, so use a `barndoor` suffix for one and a `decay` suffix for another.

As far as I know, we don't need this concept in GafferCycles at present, so can just rely on the base Shader metadata for `attributeSuffix`, which hides it.
