### PR TITLE
Add "..." to menu items that open shader browsers.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.61.x.x (relative to 0.61.10.0)
 ========
 
+Improvements
+------------
+
+- ShaderQuery and ShaderTweaks : Improved labels of menu items that open shader browsers by adding "..." to the item name.
+
 Fixes
 -----
 

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -451,7 +451,7 @@ class _ShaderQueryFooter( GafferUI.PlugValueWidget ) :
 		result = IECore.MenuDefinition()
 
 		result.append(
-			"/From Location",
+			"/From Location...",
 			{
 				"command" : Gaffer.WeakMethod( self.__browseLocationShaders )
 			}

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -237,14 +237,14 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		result = IECore.MenuDefinition()
 
 		result.append(
-			"/From Affected",
+			"/From Affected...",
 			{
 				"command" : Gaffer.WeakMethod( self.__browseAffectedShaders )
 			}
 		)
 
 		result.append(
-			"/From Selection",
+			"/From Selection...",
 			{
 				"command" : Gaffer.WeakMethod( self.__browseSelectedShaders )
 			}


### PR DESCRIPTION
This improves the UI for `ShaderQuery` and `ShaderTweaks` by adding an ellipsis at the end of menu item names that open shader browser dialog boxes.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
