### PR TITLE
TweakPlug : Hide `modeToString()`

### DIFF
--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -134,13 +134,15 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 
 		std::pair<const Shader *, const Gaffer::Plug *> shaderOutput() const;
 
-		void modifyData(
+		void applyNumericTweak(
 			const IECore::Data *sourceData,
 			const IECore::Data *tweakData,
 			IECore::Data *destData,
 			TweakPlug::Mode mode,
 			const std::string &tweakName
 		) const;
+
+		static const char *modeToString( GafferScene::TweakPlug::Mode mode );
 
 };
 

--- a/include/GafferScene/TweakPlug.inl
+++ b/include/GafferScene/TweakPlug.inl
@@ -42,30 +42,6 @@
 namespace GafferScene
 {
 
-namespace Detail
-{
-
-inline const char *modeToString( GafferScene::TweakPlug::Mode mode )
-{
-	switch( mode )
-	{
-		case GafferScene::TweakPlug::Replace :
-			return "Replace";
-		case GafferScene::TweakPlug::Add :
-			return "Add";
-		case GafferScene::TweakPlug::Subtract :
-			return "Subtract";
-		case GafferScene::TweakPlug::Multiply :
-			return "Multiply";
-		case GafferScene::TweakPlug::Remove :
-			return "Remove";
-		default :
-			return "Invalid";
-	}
-}
-
-}  // namespace Detail
-
 template<typename T>
 T *TweakPlug::valuePlug()
 {
@@ -126,7 +102,7 @@ bool TweakPlug::applyTweak(
 		}
 		else if( !( mode == GafferScene::TweakPlug::Replace && missingMode == GafferScene::TweakPlug::MissingMode::IgnoreOrReplace) )
 		{
-			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % Detail::modeToString( mode ) % name ) );
+			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % modeToString( mode ) % name ) );
 		}
 	}
 
@@ -136,7 +112,7 @@ bool TweakPlug::applyTweak(
 		mode == GafferScene::TweakPlug::Multiply
 	)
 	{
-		modifyData( currentValue, newData.get(), newData.get(), mode, name );
+		applyNumericTweak( currentValue, newData.get(), newData.get(), mode, name );
 	}
 
 	setDataFunctor( name, newData );


### PR DESCRIPTION
This was originally implemented in the `.cpp` file, but got moved into a header as part of the functor-based `applyTweaks()` improvement. We still need access to it from the header, so it is now a private static method.

NumericTweak wouldn't have had access to such a private method, but now we require C++17 we can replace it with an inline lambda that does have access. This also removes some boilerplate and makes `applyNumericTweak()` a little easier to follow.

@ericmehl, this is the small tweak I mentioned in our previous discussion - hopefully it makes sense. It's only on `main` because of the requirement for C++17. I'm wondering if now you've done all the hard work, we shouldn't follow through and move TweakPlug to Gaffer? Any thoughts?