### PR TITLE
Improve viewport camera movement

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 -----
 
 - TransformQuery : Removed unnecessary elements from hash.
+- ViewportGadget : Fixed bug which could cause `setCamera()` to emit `cameraChangedSignal()` even when the camera was unchanged.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ API
   - Added `renderer.arnold` plug to control Arnold render settings.
 - RenderController : Added `pathForID()`, `pathsForIDs()`, `idForPath()` and `idsForPaths()` methods. These make it possible to identify an object in the scene from a `uint id` AOV.
 - PlugLayout : Improved activator support. The `layout:activator` and `layout:visibilityActivator` metadata may now take boolean values to control activation directly. This is useful when an activator only applies to one plug, or it applies to several but depends on properties of each plug. String values are treated as before, referring to a predefined activator.
+- ViewportGadget : Added a `CameraFlags` enum, which is used in `cameraChangedSignal()` to specify what aspects of the camera have changed.
 
 Breaking Changes
 ----------------
@@ -31,6 +32,7 @@ Breaking Changes
   - Removed `sizeMode` and `closeOnLeave` constructor arguments.
   - Removed visibility animation.
   - Removed drag&drop positioning.
+- ViewportGadget : Added a `changes` argument to CameraChangedSignal.
 
 0.62.0.0a2 (relative to 0.62.0.0a1)
 ==========

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -45,6 +45,7 @@
 #include "GafferScene/ScenePlug.h"
 
 #include "GafferUI/Gadget.h"
+#include "GafferUI/ViewportGadget.h"
 
 #include "Gaffer/Context.h"
 #include "Gaffer/ParallelAlgo.h"
@@ -198,7 +199,7 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		bool openGLObjectAt( const IECore::LineSegment3f &lineInGadgetSpace, GafferScene::ScenePlug::ScenePath &path, float &depth ) const;
 
 		void updateRenderer();
-		void updateCamera();
+		void updateCamera( GafferUI::ViewportGadget::CameraFlags changes );
 		IECore::PathMatcher convertSelection( IECore::UIntVectorDataPtr ids ) const;
 		void bufferChanged();
 		void visibilityChanged();

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -65,6 +65,7 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 	def testCameraChangedSignal( self ) :
 
 		v = GafferUI.ViewportGadget()
+		v.setPlanarMovement( False )
 
 		cs = GafferTest.CapturingSlot( v.cameraChangedSignal() )
 
@@ -72,14 +73,23 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 0 )
 
 		c = v.getCamera()
-		c.parameters()["perspective:fov"] = IECore.FloatData( 10 )
+		c.setProjection( "perspective" )
+		c.setFocalLengthFromFieldOfView( 10 )
 
 		v.setCamera( c )
 		self.assertEqual( len( cs ), 1 )
-		self.assertEqual( cs[0], ( v, ) )
+		self.assertEqual( cs[0], ( v, GafferUI.ViewportGadget.CameraFlags.Camera ) )
 
 		v.setCamera( v.getCamera() )
 		self.assertEqual( len( cs ), 1 )
+
+		del cs[:]
+		v.frame( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		self.assertEqual(
+			cs, [
+				( v, GafferUI.ViewportGadget.CameraFlags.Transform | GafferUI.ViewportGadget.CameraFlags.CenterOfInterest )
+			]
+		)
 
 	def testChangeResolutionPerspective( self ) :
 

--- a/python/GafferUITest/ViewportGadgetTest.py
+++ b/python/GafferUITest/ViewportGadgetTest.py
@@ -91,6 +91,18 @@ class ViewportGadgetTest( GafferUITest.TestCase ) :
 			]
 		)
 
+		c = IECoreScene.Camera()
+		c.setProjection( "perspective" )
+
+		del cs[:]
+		v.setCamera( c )
+		self.assertEqual( cs, [ ( v, GafferUI.ViewportGadget.CameraFlags.Camera ) ] )
+
+		# Should be a no-op, because it's the same camera as before.
+		del cs[:]
+		v.setCamera( c )
+		self.assertEqual( cs, [] )
+
 	def testChangeResolutionPerspective( self ) :
 
 		v = GafferUI.ViewportGadget()

--- a/src/GafferUIModule/ViewportGadgetBinding.cpp
+++ b/src/GafferUIModule/ViewportGadgetBinding.cpp
@@ -124,13 +124,14 @@ list gadgetsAt2( ViewportGadget &v, const Imath::Box2f &region, Gadget::Layer fi
 	return result;
 }
 
-struct UnarySlotCaller
+struct ViewportGadgetSlotCaller
 {
-	void operator()( boost::python::object slot, ViewportGadgetPtr g )
+	template<typename... Args>
+	void operator()( boost::python::object slot, ViewportGadgetPtr g, Args&&... args )
 	{
 		try
 		{
-			slot( g );
+			slot( g, std::forward<Args>( args )... );
 		}
 		catch( const error_already_set &e )
 		{
@@ -194,12 +195,21 @@ void GafferUIModule::bindViewportGadget()
 		.def( "renderRequestSignal", &ViewportGadget::renderRequestSignal, return_internal_reference<1>() )
 	;
 
+	enum_<ViewportGadget::CameraFlags>( "CameraFlags" )
+		.value( "None_", ViewportGadget::CameraFlags::None )
+		.value( "Camera", ViewportGadget::CameraFlags::Camera )
+		.value( "Transform", ViewportGadget::CameraFlags::Transform )
+		.value( "CenterOfInterest", ViewportGadget::CameraFlags::CenterOfInterest )
+		.value( "All", ViewportGadget::CameraFlags::All )
+	;
+
 	enum_<ViewportGadget::DragTracking>( "DragTracking" )
 		.value( "NoDragTracking", ViewportGadget::NoDragTracking )
 		.value( "XDragTracking", ViewportGadget::XDragTracking )
 		.value( "YDragTracking", ViewportGadget::YDragTracking )
 	;
 
-	SignalClass<ViewportGadget::UnarySignal, DefaultSignalCaller<ViewportGadget::UnarySignal>, UnarySlotCaller>( "UnarySignal" );
+	SignalClass<ViewportGadget::UnarySignal, DefaultSignalCaller<ViewportGadget::UnarySignal>, ViewportGadgetSlotCaller>( "UnarySignal" );
+	SignalClass<ViewportGadget::CameraChangedSignal, DefaultSignalCaller<ViewportGadget::CameraChangedSignal>, ViewportGadgetSlotCaller>( "UnarySignal" );
 
 }


### PR DESCRIPTION
This significantly reduces the overhead of moving the Viewer's camera when using the new Arnold viewport. Previously we were deleting and recreating the Arnold camera on every change, which appeared to trigger expensive whole-scene operations in Arnold (`InitializeNodes` was the top stat, when we would hope it would be something related to raytracing). We now signal changes with finer granularity via `ViewportGadget::cameraChangedSignal()`, and use that to make more minimal edits to the renderer in SceneGadget.