### PR TITLE
CollectScenes : Don't create empty context variables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Features
 Fixes
 -----
 
+- CollectScenes : An empty `rootNameVariable` value no longer causes the creation of a context variable named `""`. Instead, no context variable is created (but the scenes are still collected).
 - TransformQuery : Removed unnecessary elements from hash.
 
 API
@@ -27,6 +28,7 @@ Breaking Changes
 ----------------
 
 - Arnold : Removed support for Arnold versions prior to 7.1.0.0.
+- CollectScenes : Changed behaviour when `rootNameVariable` is empty.
 - PopupWindow :
   - Removed `sizeMode` and `closeOnLeave` constructor arguments.
   - Removed visibility animation.

--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -487,5 +487,28 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 		collect = GafferScene.CollectScenes()
 		self.assertScenesEqual( collect["out"], GafferScene.ScenePlug() )
 
+	def testNoContextVariable( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		collect = GafferScene.CollectScenes()
+		collect["in"].setInput( sphere["out"] )
+		collect["rootNames"].setValue( IECore.StringVectorData( [ "/sphere1", "/group/sphere2", "/group/sphere3" ] ) )
+		collect["sourceRoot"].setValue( "/sphere" )
+
+		collect["rootNameVariable"].setValue( "" )
+
+		with Gaffer.ContextMonitor( sphere ) as contextMonitor :
+
+			self.assertSceneValid( collect["out"] )
+			for path in collect["rootNames"].getValue() :
+				self.assertPathHashesEqual( collect["out"], path, sphere["out"], "/sphere" )
+				self.assertPathsEqual( collect["out"], path, sphere["out"], "/sphere" )
+
+		self.assertEqual(
+			set( contextMonitor.combinedStatistics().variableNames() ),
+			{ "frame", "framesPerSecond", "scene:path" }
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -187,7 +187,10 @@ class CollectScenes::SourceScope : public Context::EditableScope
 
 		void setRoot( const std::string *root )
 		{
-			set( m_rootVariable, root );
+			if( !m_rootVariable.string().empty() )
+			{
+				set( m_rootVariable, root );
+			}
 		}
 
 	private :


### PR DESCRIPTION
Typically we would expect people to use the (non-empty) default for `rootNameVariable`, or to provide their own (non-empty) name. But it is legitimate to use CollectScenes just to collect identical copies of something, or in the absence of direct support in Group, to use it purely to nest one thing multiple levels deep in the hierarchy. In this case, it natural to want to empty the `rootNameVariable` to remove any additional overhead from the additional context. This commit supports that, by making sure we don't make a bogus variable named `""` in this case.
