### PR TITLE
Arnold output improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - ContextQuery : Added node to access a context variable value directly without needing to use an expression.
 
+Improvements
+------------
+
+- Outputs : Added support for `layerName` string parameter, which can be used to customise the naming of channels in EXR outputs. Currently only supported for Arnold renders.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,9 @@ Features
 Improvements
 ------------
 
-- Outputs : Added support for `layerName` string parameter, which can be used to customise the naming of channels in EXR outputs. Currently only supported for Arnold renders.
+- Outputs :
+  - Added support for `layerName` string parameter, which can be used to customise the naming of channels in EXR outputs. Currently only supported for Arnold renders.
+  - Added support for `layerPerLightGroup` boolean parameter, which automatically splits the outputs into separate layers, one for each light group.
 
 API
 ---

--- a/python/IECoreArnoldTest/OutputDriverTest.py
+++ b/python/IECoreArnoldTest/OutputDriverTest.py
@@ -88,5 +88,21 @@ class OutputDriverTest( unittest.TestCase ) :
 		self.assertTrue( "N.G" in channelNames )
 		self.assertTrue( "N.B" in channelNames )
 
+	def testLayerName( self ) :
+
+		server = IECoreImage.DisplayDriverServer( 1559 )
+		time.sleep( 2 )
+
+		subprocess.check_call( [
+			"kick", "-v", "0", "-dw", "-dp",
+			os.path.join( os.path.dirname( __file__ ), "assFiles", "outputWithLayerName.ass" )
+		] )
+
+		image = IECoreImage.ImageDisplayDriver.removeStoredImage( "layerNameImage" )
+		self.assertEqual(
+			set( image.keys() ),
+			{ "diffuseLayer.{}".format( c ) for c in "RGBA" }
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3641,6 +3641,47 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertIsInstance( data, IECore.UIntVectorData )
 		self.assertEqual( data[len(data)//2], 101 )
 
+	def testOutputLayerNames( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+		)
+
+		beautyFileName = os.path.join( self.temporaryDirectory(), "beauty.exr" )
+		r.output(
+			"whatABeauty", IECoreScene.Output(
+				beautyFileName, "exr", "rgba",
+				{
+					"layerName" : "beauty",
+				}
+			)
+		)
+
+		diffuseFileName = os.path.join( self.temporaryDirectory(), "diffuse.exr" )
+		r.output(
+			"diffuseLPE", IECoreScene.Output(
+				diffuseFileName, "exr", "lpe C<RD>.*",
+				{
+					"layerName" : "diffuse",
+				}
+			)
+		)
+
+		r.render()
+
+		beautyImage = IECore.Reader.create( beautyFileName ).read()
+		self.assertEqual(
+			set( beautyImage.keys() ),
+			{ "beauty.{}".format( c ) for c in "RGBA" }
+		)
+
+		diffuseImage = IECore.Reader.create( diffuseFileName ).read()
+		self.assertEqual(
+			set( diffuseImage.keys() ),
+			{ "diffuse.{}".format( c ) for c in "RGB" }
+		)
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/python/IECoreArnoldTest/assFiles/outputWithLayerName.ass
+++ b/python/IECoreArnoldTest/assFiles/outputWithLayerName.ass
@@ -1,0 +1,43 @@
+options
+{
+	name options
+	outputs 1 1 STRING
+		"diffuse RGBA filter display diffuseLayer"
+	xres 640
+	yres 480
+	camera camera
+}
+
+gaussian_filter
+{
+	name filter
+}
+
+ieDisplay
+{
+	name display
+	driverType "ClientDisplayDriver"
+	declare displayHost CONSTANT STRING
+	displayHost "localhost"
+	declare displayPort CONSTANT STRING
+	displayPort "1559"
+	declare remoteDisplayType CONSTANT STRING
+	remoteDisplayType "ImageDisplayDriver"
+	declare handle CONSTANT STRING
+	handle "layerNameImage"
+}
+
+persp_camera
+{
+	name camera
+}
+
+sphere
+{
+	name lovelySphere
+	matrix
+	1 0 0 0
+	0 1 0 0
+	0 0 1 0
+	0 0 -3 1
+}

--- a/src/GafferArnoldPlugin/OutputDriver.cpp
+++ b/src/GafferArnoldPlugin/OutputDriver.cpp
@@ -159,10 +159,10 @@ void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displa
 			namePrefix = std::string( name ) + ".";
 		}
 
-		const StringData *layerName = parameters->member< StringData >( "layerName" );
-		if( layerName && layerName->readable() != "" )
+		const AtString layerName = AiOutputIteratorGetLayerName( iterator );
+		if( layerName.length() )
 		{
-			namePrefix = layerName->readable() + ".";
+			namePrefix = std::string( layerName.c_str() ) + ".";
 		}
 
 		switch( pixelType )

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -642,6 +642,35 @@ class ArnoldOutput : public IECore::RefCounted
 				}
 			}
 
+			if( parameter<bool>( output->parameters(), "layerPerLightGroup", false ) )
+			{
+				// This is Arnold's special syntax for requesting multiple light groups.
+				// We present it as a `layerPerLightGroup` parameter as it is a little
+				// easier to discover/use, and it should be easier to generalise to other
+				// renderers.
+				m_data += "_*";
+				if( m_layerName.size() )
+				{
+					// Work around Arnold bug #12282. If a layer name is specified, then Arnold
+					// will fail to apply the light group suffix to it. This causes the EXR driver
+					// to write duplicate channels with the same name, resulting in errors and/or
+					// crashes.
+					m_layerName = "";
+					if( m_lpeName.empty() )
+					{
+						IECore::msg( IECore::Msg::Warning, "ArnoldRenderer",
+							boost::format( "Cannot use `layerName` with `layerPerLightGroup` for non-LPE output \"%1%\", due to Arnold bug #12882" ) % name
+						);
+					}
+					else
+					{
+						// Although we've had to clear the layer name, we'll actually still
+						// get what we want, because the layer name is used as the name of the
+						// LPE.
+					}
+				}
+			}
+
 			// Decide if this render should be updated at interactive rates or
 			// not. We update all beauty outputs interactively by default, and
 			// allow others to be overridden using a parameter.

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -85,6 +85,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	import GafferArnold
 
 	for aov in [
+		"beauty",
 		"direct",
 		"indirect",
 		"emission",
@@ -114,15 +115,11 @@ with IECore.IgnoredExceptions( ImportError ) :
 		"volume_direct",
 		"volume_indirect",
 		"volume_albedo",
-		"light_groups",
 		"motionvector",
 	] :
 
 		label = aov.replace( "_", " " ).title().replace( " ", "_" )
-
-		data = aov
-		if data == "light_groups":
-			data = "RGBA_*"
+		data = "color " + aov if aov != "beauty" else "rgba"
 
 		if aov == "motionvector" :
 			parameters = {
@@ -130,6 +127,9 @@ with IECore.IgnoredExceptions( ImportError ) :
 			}
 		else :
 			parameters = {}
+
+		if aov not in { "motionvector", "emission", "background" } :
+			parameters["layerPerLightGroup"] = False
 
 		interactiveParameters = parameters.copy()
 		interactiveParameters.update(
@@ -146,7 +146,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 			IECoreScene.Output(
 				aov,
 				"ieDisplay",
-				"color " + data,
+				data,
 				interactiveParameters
 			)
 		)
@@ -156,7 +156,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 			IECoreScene.Output(
 				"${project:rootDirectory}/renders/${script:name}/%s/%s.####.exr" % ( aov, aov ),
 				"exr",
-				"color " + data,
+				data,
 				parameters,
 			)
 		)


### PR DESCRIPTION
This improves Arnold output handling, so that we can specify custom channel names via a new `layerName` parameter, and control per-light-group AOVs using a new `layerPerLightGroup` parameter. The latter replaces the old practice of using an Arnold-specific `_*` syntax, which didn't work with LPE outputs. The latter should mean that we can rely on Arnold's auto-light-group outputs in all cases, rather than rolling our own.