### PR TITLE
StringPlug/StringVectorDataPlug : Support interconnection

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,11 @@
 0.61.x.x (relative to 0.61.11.0)
-=========
+========
+
+Improvements
+------------
+
+- StringPlug : Added support for input connections from StringVectorDataPlugs. The string value is formed by joining the string array using spaces.
+- StringVectorDataPlug : Added support for input connections from StringPlugs. The array value is formed by splitting the string on spaces.
 
 Fixes
 -----

--- a/python/GafferTest/StringPlugTest.py
+++ b/python/GafferTest/StringPlugTest.py
@@ -377,5 +377,31 @@ class StringPlugTest( GafferTest.TestCase ) :
 		for i in range( 10, 20 ) :
 			self.assertEqual( hashes[i], hashes[10] )
 
+	def testStringVectorDataInput( self ) :
+
+		node = Gaffer.Node()
+		node["user"]["string"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		node["user"]["stringVector"] = Gaffer.StringVectorDataPlug( defaultValue = IECore.StringVectorData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		self.assertTrue( node["user"]["string"].acceptsInput( node["user"]["stringVector"] ) )
+		node["user"]["string"].setInput( node["user"]["stringVector"] )
+
+		hashes = set()
+		for input, output in [
+			( [], "", ),
+			( [ "test" ], "test" ),
+			( [ "a", "b", "c" ], "a b c" ),
+			( [ "dog", "cat" ], "dog cat" ),
+			( [ "a", "b", "", "c" ], "a b  c" ),
+		] :
+
+			node["user"]["stringVector"].setValue( IECore.StringVectorData( input ) )
+
+			h = node["user"]["string"].hash()
+			self.assertNotIn( h, hashes )
+			hashes.add( h )
+
+			self.assertEqual( node["user"]["string"].getValue(), output )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/TypedObjectPlugTest.py
+++ b/python/GafferTest/TypedObjectPlugTest.py
@@ -335,5 +335,31 @@ class TypedObjectPlugTest( GafferTest.TestCase ) :
 		plug2 = eval( repr( plug ) )
 		self.assertEqual( plug2.defaultValue(), plug.defaultValue() )
 
+	def testStringVectorDataPlugWithStringInput( self ) :
+
+		node = Gaffer.Node()
+		node["user"]["string"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		node["user"]["stringVector"] = Gaffer.StringVectorDataPlug( defaultValue = IECore.StringVectorData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		self.assertTrue( node["user"]["stringVector"].acceptsInput( node["user"]["string"] ) )
+		node["user"]["stringVector"].setInput( node["user"]["string"] )
+
+		hashes = set()
+		for input, output in [
+			( "", [] ),
+			( "test", [ "test" ] ),
+			( "a b c", [ "a", "b", "c" ] ),
+			( "dog cat", [ "dog", "cat" ] ),
+			( "a b  c", [ "a", "b", "", "c" ] )
+		] :
+
+			node["user"]["string"].setValue( input )
+
+			h = node["user"]["stringVector"].hash()
+			self.assertNotIn( h, hashes )
+			hashes.add( h )
+
+			self.assertEqual( node["user"]["stringVector"].getValue(), IECore.StringVectorData( output ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/StringPlug.cpp
+++ b/src/Gaffer/StringPlug.cpp
@@ -39,6 +39,9 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/Process.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+#include "boost/algorithm/string/join.hpp"
 
 using namespace IECore;
 using namespace Gaffer;
@@ -73,7 +76,7 @@ bool StringPlug::acceptsInput( const Plug *input ) const
 	}
 	if( input )
 	{
-		return input->isInstanceOf( staticTypeId() );
+		return input->isInstanceOf( staticTypeId() ) || input->isInstanceOf( StringVectorDataPlug::staticTypeId() );
 	}
 	return true;
 }
@@ -109,10 +112,14 @@ std::string StringPlug::getValue( const IECore::MurmurHash *precomputedHash ) co
 
 void StringPlug::setFrom( const ValuePlug *other )
 {
-	const StringPlug *tOther = IECore::runTimeCast<const StringPlug >( other );
-	if( tOther )
+	if( auto stringPlug = IECore::runTimeCast<const StringPlug >( other ) )
 	{
-		setValue( tOther->getValue() );
+		setValue( stringPlug->getValue() );
+	}
+	else if( auto stringVectorPlug = IECore::runTimeCast<const StringVectorDataPlug >( other ) )
+	{
+		ConstStringVectorDataPtr data = stringVectorPlug->getValue();
+		setValue( boost::algorithm::join( data->readable(), " " ) );
 	}
 	else
 	{


### PR DESCRIPTION
When driving a StringPlug with a StringVectorDataPlug, we join the array using spaces to form the string value. When driving a StringVectorDataPlug with a StringPlug, we split the string on spaces to form the array value. This is handy in a number of scenarios where we'd previously have resorted to a Python expression to perform the conversion, making the graph harder to understand and slower to execute. My favourite example is using `Spreadsheet.enabledRowNames` to drive `Set.name`, to allow arbitrary numbers of sets to be defined with a single spreadsheet.

We've chosen space as the separator because it fits well with existing usage in Gaffer, where StringPlugs often accept a space-separated list. While other separators - like `,` - are a perfectly reasonable choice, there is no precedent for their use in Gaffer, and we're comfortable with hardcoding a choice which favours existing practice. Other conventions can be supported using conversion expressions as before.

I've made no attempt to quote strings containing spaces when converting from StringVectorDataPlug values, because that quoting would not be supported by any of the nodes consuming the StringPlug value. Typically those nodes either split on spaces or they use `StringAlgo::matchMultiple()`, neither which support quoting.
