### PR TITLE
ie/options : Avoid moc wrapper =

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -491,5 +491,12 @@ os.environ["GAFFER_JEMALLOC"] = "0"
 os.environ["QT_VERSION"] = qtVersion
 os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = os.path.join( IEEnv.Environment.rootPath(), "apps", "qt", qtVersion, IEEnv.platform(), compiler, compilerVersion, "plugins" )
 
+# also prepend the qt bin path to the search path so that we get `moc` directly from it, instead of the wrapper
+# this is so that the moc file creation creates a proper dependency to the qt version being used
+# via the moc binary path
+os.environ["PATH"] = os.path.join( IEEnv.Environment.rootPath(), "apps", "qt", qtVersion, IEEnv.platform(), compiler, compilerVersion, "bin" ) + ":" + os.environ["PATH"]
+# Required to run `moc` without the wrapper
+LOCATE_DEPENDENCY_LIBPATH.append( os.path.join( IEEnv.Environment.rootPath(), "apps", compiler, compilerVersion, IEEnv.platform(), "lib64" ) )
+
 # speed up the build a bit hopefully.
 BUILD_CACHEDIR = os.environ["IEBUILD_CACHEDIR"]


### PR DESCRIPTION
This is a small change to the `SConstruct` so that Qt's `moc` files are always built.

### Related issues ###

The reason for the change is that when building for more than one Qt version, `moc` files generated during a previous build can be incompatible with the current build.

More specifically, it seems that when the `moc` file was generated for Qt 5.15 it's not usable by Qt 5.12.

At IE, gaffer 0.62 is built using Qt 5.15 for everything except for Nuke, which requires 5.12, which is making the process fail.

There are a number of ways this could be addressed, and the one proposed here is the simplest, by always assuming that the `moc` file is out of date and rebuilding it. Since the cost is very low (as far as I can tell, only 1 `moc` file needs to be generated), this seemed like a good approach.

Another approach I tried was writing out a file which contains the Qt version being used during a build, and then making that file a dependency of the `moc` file. I've included that at the end of this PR description, for reference.

Even though that seemed like a more "proper" solution, since we are letting scons know about the dependency, I decided against it because the creation of the auxiliary file annoyed me a bit, specially for a single `moc` file's sake. But I am glad to go for that approach if you feel it's better.


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.


### Alternative Implementation ###

<details>
<summary>Click to Expand</summary><p>

```
Index: SConstruct
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/SConstruct b/SConstruct
--- a/SConstruct	(revision 859a20531ae012b952d0fd005247037e4298b346)
+++ b/SConstruct	(date 1654302805897)
@@ -608,8 +608,8 @@
 
 	int main()
 	{
-#ifdef QT_VERSION_MAJOR
-		std::cout << QT_VERSION_MAJOR;
+#ifdef QT_VERSION_STR
+		std::cout << QT_VERSION_STR;
 #else
 		std::cout << 4;
 #endif
@@ -619,7 +619,8 @@
 
 	result = context.TryRun( program, ".cpp" )
 	if result[0] :
-		context.sconf.env["QT_VERSION"] = result[1]
+		context.sconf.env["QT_VERSION_STR"] = result[1]
+		context.sconf.env["QT_VERSION"] = result[1].split( "." )[0]
 
 	context.Result( result[0] )
 	return result[0]
@@ -683,6 +684,9 @@
 
 commandEnv["ENV"]["PYTHONPATH"] = commandEnv.subst( os.path.pathsep.join( split( commandEnv["LOCATE_DEPENDENCY_PYTHONPATH"] ) ) )
 
+# write out qt version as a file, so we can use it as a dependency to moc files
+qtVersionFile = commandEnv.Textfile( ".qtVersion.tmp", ["$QT_VERSION_STR"] )
+
 # SIP on MacOS prevents DYLD_LIBRARY_PATH being passed down so we make sure
 # we also pass through to gaffer the other base vars it uses to populate paths
 # for third-party support.
@@ -1489,12 +1493,10 @@
 
 	for sourceFile in libraryDef.get( "mocSourceFiles", [] ) :
 		mocOutput = commandEnv.Command( os.path.splitext( sourceFile )[0] + ".moc", sourceFile, "moc $SOURCE -o $TARGET" )
+		env.Depends( mocOutput, qtVersionFile )
 		# Somehow the above leads to a circular dependency between `mocOutput` and itself.
 		# Tell SCons not to worry. The official SCons tool does the same.
 		env.Ignore( mocOutput, mocOutput )
 
 	# python component of python module
 

```
</p>
</details>
