### PR TITLE
PlugLayout : Fix visibility of collapsible layouts with nesting

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,8 +4,8 @@
 Fixes
 -----
 
+- PlugLayout : Fixed visibility of collapsible layouts with nesting (#4694).
 - Image Node Mix : Fixed incorrect results outside mask data window, and incorrect results when changing inputs.
-
 
 0.61.11.0 (relative to 0.61.10.0)
 =========

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -761,7 +761,10 @@ class _CollapsibleLayout( _Layout ) :
 
 			collapsible.getChild().update( subsection )
 
-			collapsible.setVisible( any ( [ w.getVisible() for w in subsection.widgets ] ) )
+			collapsible.setVisible(
+				any( [ w.getVisible() for w in subsection.widgets ] ) or
+				any( [ w.getVisible() for w in collapsible.getChild().__collapsibles.values() ] )
+			)
 
 			collapsible.getCornerWidget().setText(
 				"<small>" + "&nbsp;( " + subsection.summary + " )</small>" if subsection.summary else ""


### PR DESCRIPTION
We were hiding collapsibles if all their child widgets were hidden, but failing to account for nested collapsibles which might have held still-visible widgets.

Fixes #4694.
