### PR TITLE
ColorSwatchPlugValueWidget : Fix dialogue for Tool plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - PlugLayout : Fixed visibility of collapsible layouts with nesting (#4694).
 - Image Node Mix : Fixed incorrect results outside mask data window, and incorrect results when changing inputs.
+- ColorSwatchPlugValueWidget : Fixed popup dialogue for plugs belonging to Tools.
 
 0.61.11.0 (relative to 0.61.10.0)
 =========

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -165,6 +165,14 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 		plug = next( iter( plugs ) )
 
 		script = plug.node().scriptNode()
+		if script is None :
+			# Plug might be part of the UI rather than the node graph (e.g. a
+			# Tool or View setting). Find the script.
+			view = plug.ancestor( GafferUI.View )
+			if view is not None :
+				script = view["in"].getInput().node().scriptNode()
+
+		assert( script is not None )
 		scriptWindow = GafferUI.ScriptWindow.acquire( script )
 
 		for window in scriptWindow.childWindows() :


### PR DESCRIPTION
I'm not sure if this is the right long-term fix or not, but it works for our immediate needs (a custom Tool subclass with a ColorPlug). It wouldn't work for, say, a plug in the LightEditor settings, where there's no way of finding the script from the parent-less settings node. As discussed in #50, it might be ideal if the entire UI hierarchy was specified via Nodes/Plugs, and then this approach could work for the LightEditor and everything else too.

An alternative approach would be to pass a `forWidget` argument to `acquire()` and then find a suitable parent window for the dialogue from that. But that is a bit harder to use, and also means we could end up with multiple colour dialogues (under different windows) for the same plug, which is what we're trying to avoid.
