### PR TITLE
Add USDLayerWriter node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,10 +4,10 @@
 Fixes
 -----
 
-- ShaderQuery : 
+- SceneWriter : Fixed bug which caused sibling locations to be reordered.
+- ShaderQuery :
   - Fix error `ShaderQuery : "outPlug" is missing` when promoting a child plug of a query to a `Spreadsheet`.
   - Adding a child plug of a query to a `Spreadsheet` now uses the default name for the spreadsheet column.
-
 
 0.61.12.0 (relative to 0.61.11.0)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 0.61.x.x (relative to 0.61.12.0)
 ========
 
+Features
+--------
+
+- USDLayerWriter : Added a new node for baking the difference between two Gaffer scenes into a minimal USD layer on disk.
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -1076,6 +1076,26 @@ libraries = {
 
 	"GafferTractorUITest" : {},
 
+	"GafferUSD" : {
+		"envAppends" : {
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX", "sdf", "arch", "tf", "vt" ],
+			# USD includes "at least one deprecated or antiquated header", so we
+			# have to drop our usual strict warning levels.
+			"CXXFLAGS" : [ "-Wno-deprecated"],
+		},
+		"pythonEnvAppends" : {
+			"LIBS" : [ "GafferUSD", "GafferDispatch", "GafferBindings" ],
+		},
+		# USD's Python bindings are intrusive to the main library.
+		"libraryDependsOnPython" : True,
+	},
+
+	"GafferUSDTest" : {},
+
+	"GafferUSDUI" : {},
+
+	"GafferUSDUITest" : {},
+
 	"GafferVDB" : {
 		"envAppends" : {
 			"LIBS" : [ "Gaffer", "GafferScene", "Half", "openvdb$VDB_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
@@ -1187,6 +1207,9 @@ for libraryName, libraryDef in libraries.items() :
 	# environment
 
 	libEnv = baseLibEnv.Clone()
+	if libraryDef.get( "libraryDependsOnPython" ) :
+		libEnv = basePythonEnv.Clone()
+
 	libEnv.Append( CXXFLAGS = "-D{0}_EXPORTS".format( libraryName ) )
 	libEnv.Append( **(libraryDef.get( "envAppends", {} )) )
 	libEnv.Replace( **(libraryDef.get( "envReplacements", {} )) )

--- a/include/GafferUSD/Export.h
+++ b/include/GafferUSD/Export.h
@@ -1,24 +1,22 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
 //  met:
 //
-//      * Redistributions of source code must retain the above
-//        copyright notice, this list of conditions and the following
-//        disclaimer.
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
 //
-//      * Redistributions in binary form must reproduce the above
-//        copyright notice, this list of conditions and the following
-//        disclaimer in the documentation and/or other materials provided with
-//        the distribution.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
 //
-//      * Neither the name of John Haddon nor the names of
-//        any other contributors to this software may be used to endorse or
-//        promote products derived from this software without specific prior
-//        written permission.
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
 //
 //  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 //  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
@@ -34,21 +32,15 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERTEST_TYPEIDS_H
-#define GAFFERTEST_TYPEIDS_H
+#ifndef GAFFERUSD_EXPORT_H
+#define GAFFERUSD_EXPORT_H
 
-namespace GafferTest
-{
+#include "IECore/Export.h"
 
-enum TypeId
-{
+#ifdef GafferUSD_EXPORTS
+	#define GAFFERUSD_API IECORE_EXPORT
+#else
+	#define GAFFERUSD_API IECORE_IMPORT
+#endif
 
-	MultiplyNodeTypeId = 110201,
-
-	LastTypeId = 110224,
-
-};
-
-} // namespace GafferTest
-
-#endif // GAFFERTEST_TYPEIDS_H
+#endif // #ifndef GAFFERUSD_EXPORT_H

--- a/include/GafferUSD/TypeIds.h
+++ b/include/GafferUSD/TypeIds.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,21 +34,21 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERTEST_TYPEIDS_H
-#define GAFFERTEST_TYPEIDS_H
+#ifndef GAFFERUSD_TYPEIDS_H
+#define GAFFERUSD_TYPEIDS_H
 
-namespace GafferTest
+namespace GafferUSD
 {
 
 enum TypeId
 {
 
-	MultiplyNodeTypeId = 110201,
+	USDLayerWriterTypeId = 110225,
 
-	LastTypeId = 110224,
+	LastTypeId = 110250,
 
 };
 
-} // namespace GafferTest
+} // namespace GafferUSD
 
-#endif // GAFFERTEST_TYPEIDS_H
+#endif // GAFFERUSD_TYPEIDS_H

--- a/include/GafferUSD/USDLayerWriter.h
+++ b/include/GafferUSD/USDLayerWriter.h
@@ -15,7 +15,7 @@
 //        disclaimer in the documentation and/or other materials provided with
 //        the distribution.
 //
-//      * Neither the name of Image Engine Design nor the names of
+//      * Neither the name of John Haddon nor the names of
 //        any other contributors to this software may be used to endorse or
 //        promote products derived from this software without specific prior
 //        written permission.
@@ -34,18 +34,65 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERUSD_USDLAYERWRITER_H
+#define GAFFERUSD_USDLAYERWRITER_H
 
-#include "GafferUSD/USDLayerWriter.h"
+#include "GafferUSD/Export.h"
+#include "GafferUSD/TypeIds.h"
 
-#include "GafferDispatchBindings/TaskNodeBinding.h"
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/SceneWriter.h"
 
-using namespace boost::python;
-using namespace GafferUSD;
+#include "GafferDispatch/TaskNode.h"
 
-BOOST_PYTHON_MODULE( _GafferUSD )
+#include "Gaffer/TypedPlug.h"
+#include "Gaffer/StringPlug.h"
+
+namespace GafferUSD
 {
 
-	GafferDispatchBindings::TaskNodeClass<USDLayerWriter>();
+class GAFFERUSD_API USDLayerWriter : public GafferDispatch::TaskNode
+{
 
-}
+	public :
+
+		USDLayerWriter( const std::string &name=defaultName<USDLayerWriter>() );
+		~USDLayerWriter() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferUSD::USDLayerWriter, USDLayerWriterTypeId, GafferDispatch::TaskNode );
+
+		Gaffer::StringPlug *fileNamePlug();
+		const Gaffer::StringPlug *fileNamePlug() const;
+
+		GafferScene::ScenePlug *basePlug();
+		const GafferScene::ScenePlug *basePlug() const;
+
+		GafferScene::ScenePlug *layerPlug();
+		const GafferScene::ScenePlug *layerPlug() const;
+
+		GafferScene::ScenePlug *outPlug();
+		const GafferScene::ScenePlug *outPlug() const;
+
+	protected :
+
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
+		bool requiresSequenceExecution() const override;
+		void execute() const override;
+		void executeSequence( const std::vector<float> &frames ) const override;
+
+	private :
+
+		const GafferScene::SceneWriter *sceneWriter() const;
+
+		static size_t g_firstPlugIndex;
+
+		// Friendship for the bindings
+		friend struct GafferDispatchBindings::Detail::TaskNodeAccessor;
+
+};
+
+IE_CORE_DECLAREPTR( USDLayerWriter )
+
+} // namespace GafferUSD
+
+#endif // GAFFERUSD_USDLAYERWRITER_H

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -392,5 +392,26 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( sceneReader["out"].attributes( "/sphere" ), sceneWriter["in"].attributes( "/sphere" ) )
 
+	def testChildNamesOrder( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( sphere["out"] )
+		duplicate["filter"].setInput( sphereFilter["out"] )
+		duplicate["copies"].setValue( 100 )
+
+		writer = GafferScene.SceneWriter()
+		writer["in"].setInput( duplicate["out"] )
+		writer["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.abc" ) )
+		writer["task"].execute()
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setInput( writer["fileName"] )
+		self.assertScenesEqual( reader["out"], writer["in"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUSD/__init__.py
+++ b/python/GafferUSD/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+__import__( "GafferScene" )
+
+from ._GafferUSD import *
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferUSD" )

--- a/python/GafferUSDTest/ModuleTest.py
+++ b/python/GafferUSDTest/ModuleTest.py
@@ -1,0 +1,47 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferTest
+
+class ModuleTest( GafferTest.TestCase ) :
+
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferUSD" )
+		self.assertModuleDoesNotImportUI( "GafferUSDTest" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDTest/USDLayerWriterTest.py
+++ b/python/GafferUSDTest/USDLayerWriterTest.py
@@ -1,0 +1,183 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import unittest
+
+import pxr.Usd
+
+import IECore
+import IECoreScene
+
+import GafferUSD
+import GafferScene
+import GafferSceneTest
+
+class USDLayerWriterTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		# Make a simple scene, and write it to a USD file.
+		#
+		# - group
+		#   - plane
+		#   - plane1
+		#   - sphere
+		#   - sphere1
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+		sphere["type"].setValue( GafferScene.Sphere.Type.Primitive )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( plane["out"] )
+		group["in"][2].setInput( sphere["out"] )
+		group["in"][3].setInput( sphere["out"] )
+
+		sceneWriter = GafferScene.SceneWriter()
+		sceneWriter["in"].setInput( group["out"] )
+		sceneWriter["fileName"].setValue( os.path.join( self.temporaryDirectory(), "base.usda" ) )
+		sceneWriter["task"].execute()
+
+		# Make downstream modifications to the scene :
+		#
+		#  - Transform `/group/sphere` and assign a shader to it
+		#  - Add a visibility attribute to `/group/plane`
+		#  - Add a new location at `/group/sphere2`
+		#  - Prune `/group/plane1`
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/group/sphere" ] ) )
+
+		transform = GafferScene.Transform()
+		transform["in"].setInput( group["out"] )
+		transform["filter"].setInput( sphereFilter["out"] )
+		transform["transform"]["translate"]["x"].setValue( 10 )
+
+		shaderAssignment = GafferScene.CustomAttributes()
+		shaderAssignment["in"].setInput( transform["out"] )
+		shaderAssignment["filter"].setInput( sphereFilter["out"] )
+		# Assigning shader manually, because IECoreUSD won't round-trip the
+		# blindData that the Shader and ShaderAssignment nodes would add.
+		shaderAssignment["extraAttributes"].setValue( {
+			"surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat" ) }, output = "output" )
+		} )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+
+		attributes = GafferScene.StandardAttributes()
+		attributes["in"].setInput( shaderAssignment["out"] )
+		attributes["filter"].setInput( planeFilter["out"] )
+
+		attributes["attributes"]["visibility"]["enabled"].setValue( True )
+		attributes["attributes"]["visibility"]["value"].setValue( False )
+
+		groupFilter = GafferScene.PathFilter()
+		groupFilter["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( attributes["out"] )
+		parent["filter"].setInput( groupFilter["out"] )
+		parent["children"][0].setInput( sphere["out"] )
+
+		plane1Filter = GafferScene.PathFilter()
+		plane1Filter["paths"].setValue( IECore.StringVectorData( [ "/group/plane1" ] ) )
+
+		prune = GafferScene.Prune()
+		prune["in"].setInput( parent["out"] )
+		prune["filter"].setInput( plane1Filter["out"] )
+
+		# Write the differences to a new USD layer.
+
+		layerWriter = GafferUSD.USDLayerWriter()
+		layerWriter["base"].setInput( group["out"] )
+		layerWriter["layer"].setInput( prune["out"] )
+		layerWriter["fileName"].setValue( os.path.join( self.temporaryDirectory(), "layer.usda" ) )
+		layerWriter["task"].execute()
+
+		# Compose the layer with the original scene using the USD
+		# API, and write the composition to a new file.
+
+		compositionFileName = os.path.join( self.temporaryDirectory(), "composed.usda" )
+		composition = pxr.Usd.Stage.CreateNew( compositionFileName )
+		composition.GetRootLayer().subLayerPaths = [
+			layerWriter["fileName"].getValue(),
+			sceneWriter["fileName"].getValue(),
+		]
+		composition.GetRootLayer().Save()
+
+		# The composed result should be identical to the Gaffer scene.
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( compositionFileName )
+		self.assertScenesEqual( reader["out"], layerWriter["layer"], checks = self.allSceneChecks - { "sets" } )
+
+		# Check that we've actually got a minimal set of opinions in the
+		# layer. We could pass the tests above just by writing
+		# _everything_!
+
+		layer = pxr.Sdf.Layer.OpenAsAnonymous( layerWriter["fileName"].getValue() )
+
+		# We didn't modify `/group/sphere1`, so it shouldn't even be present in the layer.
+		self.assertIsNone( layer.GetPrimAtPath( "/group/sphere1" ) )
+		# We did modify `/group/plane`, but we didn't change its type, so we expect
+		# an "over" in the layer, and a minimal set of authored properties.
+		self.assertEqual( layer.GetPrimAtPath( "/group/plane" ).specifier, pxr.Sdf.SpecifierOver )
+		self.assertEqual( layer.GetPrimAtPath( "/group/plane" ).typeName, "" )
+		self.assertEqual( list( layer.GetPrimAtPath( "/group/plane" ).properties.keys() ), [ "visibility" ] )
+		# Likewise for `/group/sphere`.
+		self.assertEqual( layer.GetPrimAtPath( "/group/sphere" ).specifier, pxr.Sdf.SpecifierOver )
+		self.assertEqual( layer.GetPrimAtPath( "/group/sphere" ).typeName, "" )
+		self.assertEqual( set( layer.GetPrimAtPath( "/group/sphere" ).properties.keys() ), { "material:binding", "xformOp:transform" } )
+		# `/group/sphere2` is newly added, so should be fully defined.
+		self.assertEqual( layer.GetPrimAtPath( "/group/sphere2" ).specifier, pxr.Sdf.SpecifierDef )
+
+	def testCreateDirectories( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		writer = GafferUSD.USDLayerWriter()
+		writer["base"].setInput( sphere["out"] )
+		writer["layer"].setInput( sphere["out"] )
+		writer["fileName"].setValue( os.path.join( self.temporaryDirectory(), "subdir", "test.usda" ) )
+
+		writer["task"].execute()
+		self.assertTrue( os.path.isfile( writer["fileName"].getValue() ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDTest/__init__.py
+++ b/python/GafferUSDTest/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from .ModuleTest import ModuleTest
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()

--- a/python/GafferUSDTest/__init__.py
+++ b/python/GafferUSDTest/__init__.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 from .ModuleTest import ModuleTest
+from .USDLayerWriterTest import USDLayerWriterTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUSDUI/USDLayerWriterUI.py
+++ b/python/GafferUSDUI/USDLayerWriterUI.py
@@ -1,0 +1,120 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferUSD
+
+Gaffer.Metadata.registerNode(
+
+	GafferUSD.USDLayerWriter,
+
+	"description",
+	"""
+	Takes two input scenes and writes a minimal USD file containing the
+	differences between them. This new file can then be layered in a USD
+	composition to transform the first scene into the second. This is useful for
+	baking modifications made in Gaffer into a USD file for consumption in other
+	hosts.
+
+	A typical use case might be to share lookdev authored in Gaffer, with a
+	workflow like the following :
+
+	- A SceneReader brings `model.usd` into Gaffer.
+	- Shaders and attributes are applied in Gaffer, using Gaffer's standard scene
+	  processing nodes.
+	- A USDLayerWriter is used to bake this lookdev into a new `look.usd` layer on
+	  disk, with the SceneReader for `model.usd` connected to the `base` input
+	  and the lookdev connected into the `layer` input.
+	- A new USD file is created that layers `look.usd` over `model.usd`. This is
+	  loaded into Gaffer or another host for lighting.
+
+	> Note : To write a complete USD file (rather than a layer containing differences)
+	> use the standard SceneWriter node.
+	""",
+
+	plugs = {
+
+		"base" : [
+
+			"description",
+			"""
+			The base scene that the `layer` input is compared to.
+			""",
+
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"layer" : [
+
+			"description",
+			"""
+			The scene to be written to `fileName`. This is compared to the
+			`base` scene, and only differences are written to the file.
+			""",
+
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"fileName" : [
+
+			"description",
+			"""
+			The name of the USD file to be written.
+			""",
+
+			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
+			"path:leaf", True,
+			"path:bookmarks", "sceneCache",
+			"fileSystemPath:extensions", "usd usda usdc",
+			"fileSystemPath:extensionsLabel", "Show only USD files",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			A direct pass-through of the `layer` input.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferUSDUI/__init__.py
+++ b/python/GafferUSDUI/__init__.py
@@ -34,4 +34,6 @@
 #
 ##########################################################################
 
+from . import USDLayerWriterUI
+
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferUSDUI" )

--- a/python/GafferUSDUI/__init__.py
+++ b/python/GafferUSDUI/__init__.py
@@ -1,0 +1,37 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferUSDUI" )

--- a/python/GafferUSDUITest/DocumentationTest.py
+++ b/python/GafferUSDUITest/DocumentationTest.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUITest
+import GafferUSD
+import GafferUSDUI
+import GafferScene
+import GafferSceneUI
+
+class DocumentationTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+
+		self.maxDiff = None
+		self.assertNodesAreDocumented(
+			GafferUSD,
+			additionalTerminalPlugTypes = ( GafferScene.ScenePlug, )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDUITest/NodeUITest.py
+++ b/python/GafferUSDUITest/NodeUITest.py
@@ -1,0 +1,50 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferUSD
+import GafferUSDUI
+import GafferUITest
+
+class NodeUITest( GafferUITest.TestCase ) :
+
+	def testLifetimes( self ) :
+
+		self.assertNodeUIsHaveExpectedLifetime( GafferUSD )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDUITest/__init__.py
+++ b/python/GafferUSDUITest/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from .DocumentationTest import DocumentationTest
+from .NodeUITest import NodeUITest
+
+if __name__ == "__main__":
+	unittest.main()

--- a/src/GafferUSD/USDLayerWriter.cpp
+++ b/src/GafferUSD/USDLayerWriter.cpp
@@ -1,0 +1,353 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUSD/USDLayerWriter.h"
+
+#include "GafferScene/SceneAlgo.h"
+
+#include "Gaffer/NameSwitch.h"
+#include "Gaffer/NameValuePlug.h"
+
+#include "IECoreScene/SceneInterface.h"
+
+#include "pxr/usd/sdf/attributeSpec.h"
+#include "pxr/usd/sdf/layer.h"
+#include "pxr/usd/sdf/primSpec.h"
+
+#include "boost/filesystem.hpp"
+
+using namespace std;
+using namespace pxr;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferUSD;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class ScopedDirectory : boost::noncopyable
+{
+
+	public :
+
+		ScopedDirectory( const boost::filesystem::path &p )
+			:	m_path( p )
+		{
+			boost::filesystem::create_directories( m_path );
+		}
+
+		~ScopedDirectory()
+		{
+			boost::filesystem::remove_all( m_path );
+		}
+
+	private :
+
+		boost::filesystem::path m_path;
+
+};
+
+void createDirectories( const std::string &fileName )
+{
+	boost::filesystem::path filePath( fileName );
+	boost::filesystem::path directory = filePath.parent_path();
+	if( !directory.empty() )
+	{
+		boost::filesystem::create_directories( directory );
+	}
+}
+
+// Returns `true` if this prim should be retained, or `false` if it should be
+// removed from its parent.
+bool createDiff( const SdfPrimSpecHandle &prim, SdfLayer &layer, const SdfPrimSpecHandle &basePrim, SdfLayer &baseLayer )
+{
+
+	// Author an inactive prim for any children in `basePrim` that are not in
+	// `prim`. This prunes the child from the composed scene.
+
+	bool keepThisPrim = false;
+
+	const vector<SdfPrimSpecHandle> childPrims = prim->GetNameChildren().values();
+	for( auto &baseChildPrim : basePrim->GetNameChildren().values() )
+	{
+		if( !prim->GetPrimAtPath( SdfPath::ReflexiveRelativePath().AppendChild( baseChildPrim->GetNameToken() ) ) )
+		{
+			SdfPrimSpec::New( prim, baseChildPrim->GetName(), SdfSpecifierOver )->SetActive( false );
+			keepThisPrim = true;
+		}
+	}
+
+	// Recurse to process our children (not including newly-made inactive prims),
+	// and remove any children we no longer need.
+
+	for( const auto &childPrim : childPrims )
+	{
+		if( auto baseChildPrim = basePrim->GetPrimAtPath( SdfPath::ReflexiveRelativePath().AppendChild( childPrim->GetNameToken() ) ) )
+		{
+			if( createDiff( childPrim, layer, baseChildPrim, baseLayer ) )
+			{
+				keepThisPrim = true;
+			}
+			else
+			{
+				prim->RemoveNameChild( childPrim );
+			}
+		}
+		else
+		{
+			keepThisPrim = true;
+		}
+	}
+
+	// Remove any attributes that are identical to those in the base prim.
+
+	for( const auto &property : prim->GetProperties().values() )
+	{
+		bool keepThisProperty = false;
+		SdfPropertySpecHandle baseProperty = basePrim->GetPropertyAtPath( SdfPath::ReflexiveRelativePath().AppendProperty( property->GetNameToken() ) );
+		if( baseProperty )
+		{
+			for( auto &field : property->ListFields() )
+			{
+				if( property->GetField( field ) != baseProperty->GetField( field ) )
+				{
+					keepThisProperty = true;
+					break;
+				}
+			}
+		}
+		else
+		{
+			keepThisProperty = true;
+		}
+
+		if( keepThisProperty )
+		{
+			keepThisPrim = true;
+		}
+		else
+		{
+			prim->RemoveProperty( property );
+		}
+	}
+
+	// Convert to an "over" if we have the same type as the
+	// base prim.
+
+	if( keepThisPrim && prim != layer.GetPseudoRoot() )
+	{
+		if( prim->GetTypeName() == basePrim->GetTypeName() )
+		{
+			prim->SetSpecifier( SdfSpecifierOver );
+			prim->SetTypeName( TfToken() );
+		}
+	}
+
+	return keepThisPrim;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// USDLayerWriter implementation
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_NODE_DEFINE_TYPE( USDLayerWriter );
+
+size_t USDLayerWriter::g_firstPlugIndex = 0;
+
+USDLayerWriter::USDLayerWriter( const std::string &name )
+	: TaskNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ScenePlug( "base", Plug::In ) );
+	addChild( new ScenePlug( "layer", Plug::In ) );
+	addChild( new StringPlug( "fileName" ) );
+	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
+
+	SceneWriterPtr sceneWriter = new SceneWriter( "__sceneWriter" );
+	addChild( sceneWriter );
+
+	NameSwitchPtr sceneSwitch = new NameSwitch( "__sceneSwitch" );
+	sceneSwitch->selectorPlug()->setValue( "${usdLayerWriter:fileName}" );
+	sceneSwitch->setup( basePlug() );
+	sceneSwitch->inPlugs()->getChild<NameValuePlug>( 0 )->valuePlug()->setInput( basePlug() );
+	sceneSwitch->inPlugs()->getChild<NameValuePlug>( 1 )->valuePlug()->setInput( layerPlug() );
+	sceneSwitch->inPlugs()->getChild<NameValuePlug>( 1 )->namePlug()->setValue( "*layer.usdc" );
+
+	addChild( sceneSwitch );
+	sceneWriter->inPlug()->setInput( static_cast<NameValuePlug *>( sceneSwitch->outPlug() )->valuePlug() );
+	sceneWriter->fileNamePlug()->setValue( "${usdLayerWriter:fileName}" );
+
+	outPlug()->setInput( layerPlug() );
+}
+
+USDLayerWriter::~USDLayerWriter()
+{
+}
+
+GafferScene::ScenePlug *USDLayerWriter::basePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const GafferScene::ScenePlug *USDLayerWriter::basePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+GafferScene::ScenePlug *USDLayerWriter::layerPlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
+}
+
+const GafferScene::ScenePlug *USDLayerWriter::layerPlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
+}
+
+StringPlug *USDLayerWriter::fileNamePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+const StringPlug *USDLayerWriter::fileNamePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+GafferScene::ScenePlug *USDLayerWriter::outPlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 3 );
+}
+
+const GafferScene::ScenePlug *USDLayerWriter::outPlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex + 3 );
+}
+
+const GafferScene::SceneWriter *USDLayerWriter::sceneWriter() const
+{
+	return getChild<SceneWriter>( g_firstPlugIndex + 4 );
+}
+
+IECore::MurmurHash USDLayerWriter::hash( const Gaffer::Context *context ) const
+{
+	const std::string fileName = fileNamePlug()->getValue();
+	if( !basePlug()->getInput() || !layerPlug()->getInput() || fileName.empty() )
+	{
+		return IECore::MurmurHash();
+	}
+
+	IECore::MurmurHash h = TaskNode::hash( context );
+	h.append( fileName );
+	h.append( context->hash() );
+
+	return h;
+}
+
+bool USDLayerWriter::requiresSequenceExecution() const
+{
+	return true;
+}
+
+void USDLayerWriter::execute() const
+{
+	std::vector<float> frame( 1, Context::current()->getFrame() );
+	executeSequence( frame );
+}
+
+void USDLayerWriter::executeSequence( const std::vector<float> &frames ) const
+{
+	if( !basePlug()->getInput() )
+	{
+		throw IECore::Exception( "No `base` input" );
+	}
+
+	if( !layerPlug()->getInput() )
+	{
+		throw IECore::Exception( "No `layer` input" );
+	}
+
+	const std::string outputFileName = fileNamePlug()->getValue();
+	if( outputFileName.empty() )
+	{
+		return;
+	}
+
+	// Write the complete base and layer inputs into temporary USD files. We use
+	// a ScopedDirectory so that the files are cleaned up no matter how we exit
+	// this function.
+	/// \todo Should we add an interface to allow IECoreUSD to write to a
+	/// stage in memory? And can we use DeleteObject to avoid writing objects
+	/// which are identical in both scenes, to avoid the overhead of writing
+	/// them only to discard them in `createDiff()`?
+
+	const boost::filesystem::path tempDirectory = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+	ScopedDirectory scopedTempDirectory( tempDirectory );
+
+	const string baseFileName = ( tempDirectory / "base.usdc" ).string();
+	const string layerFileName = ( tempDirectory / "layer.usdc" ).string();
+
+	Context::EditableScope context( Context::current() );
+	for( const auto &fileName : { baseFileName, layerFileName } )
+	{
+		/// \todo Stop this context variable leaking out into the scene
+		/// evaluation. There is some talk of giving NameSwitch a feature to do
+		/// this for us.
+		context.set( "usdLayerWriter:fileName", &fileName );
+		sceneWriter()->taskPlug()->executeSequence( frames );
+	}
+
+	// Load the temporary USD files, and process `layer` in place so that it
+	// contains only the differences from `baseLayer`. Then write the result
+	// out.
+
+	SdfLayerRefPtr baseLayer = SdfLayer::OpenAsAnonymous( baseFileName );
+	SdfLayerRefPtr layer = SdfLayer::OpenAsAnonymous( layerFileName );
+
+	SdfChangeBlock changeBlock;
+	createDiff( layer->GetPseudoRoot(), *layer, baseLayer->GetPseudoRoot(), *baseLayer );
+
+	createDirectories( outputFileName );
+	layer->Export( outputFileName );
+}

--- a/src/GafferUSDModule/GafferUSDModule.cpp
+++ b/src/GafferUSDModule/GafferUSDModule.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 //        disclaimer in the documentation and/or other materials provided with
 //        the distribution.
 //
-//      * Neither the name of John Haddon nor the names of
+//      * Neither the name of Image Engine Design nor the names of
 //        any other contributors to this software may be used to endorse or
 //        promote products derived from this software without specific prior
 //        written permission.
@@ -34,21 +34,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERTEST_TYPEIDS_H
-#define GAFFERTEST_TYPEIDS_H
+#include "boost/python.hpp"
 
-namespace GafferTest
+using namespace boost::python;
+
+BOOST_PYTHON_MODULE( _GafferUSD )
 {
 
-enum TypeId
-{
-
-	MultiplyNodeTypeId = 110201,
-
-	LastTypeId = 110224,
-
-};
-
-} // namespace GafferTest
-
-#endif // GAFFERTEST_TYPEIDS_H
+}

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -498,6 +498,13 @@ nodeMenu.append( "/VDB/Level Set Offset", GafferVDB.LevelSetOffset, searchText =
 nodeMenu.append( "/VDB/Points Grid To Points", GafferVDB.PointsGridToPoints, searchText = "PointsGridToPoints" )
 nodeMenu.append( "/VDB/Sphere Level Set", GafferVDB.SphereLevelSet, searchText="SphereLevelSet")
 
+# USD nodes
+
+import GafferUSD
+import GafferUSDUI
+
+nodeMenu.append( "/USD/Layer Writer", GafferUSD.USDLayerWriter, searchText = "USDLayerWriter" )
+
 # Dispatch nodes
 
 import GafferDispatch


### PR DESCRIPTION
This bakes the differences between two scenes in Gaffer into a single USD layer. The idea being that you can export arbitrary scene modifications made by Gaffer in a minimal form suitable for import into other USD-savvy hosts. In the example below I've  moved a chair, deleted another chair and assigned a shader to the table, and then written this as a minimal USD layer.

![image](https://user-images.githubusercontent.com/1133871/172863134-546d9b8f-bcba-4227-a5ac-d6053a8ddbdc.png)
