### PR TITLE
ShaderQuery : Fix various small bugs.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,14 @@
+0.61.x.x (relative to 0.61.12.0)
+========
+
+Fixes
+-----
+
+- ShaderQuery : 
+  - Fix error `ShaderQuery : "outPlug" is missing` when promoting a child plug of a query to a `Spreadsheet`.
+  - Adding a child plug of a query to a `Spreadsheet` now uses the default name for the spreadsheet column.
+
+
 0.61.12.0 (relative to 0.61.11.0)
 =========
 

--- a/python/GafferSceneTest/ShaderQueryTest.py
+++ b/python/GafferSceneTest/ShaderQueryTest.py
@@ -84,7 +84,6 @@ class ShaderQueryTest( GafferSceneTest.SceneTestCase ):
 		n1 = q.addQuery( Gaffer.IntPlug() )
 		n2 = q.addQuery( Gaffer.Color3fPlug() )
 		n3 = q.addQuery( Gaffer.Box2iPlug() )
-		n4 = q.addQuery( Gaffer.IntPlug() )
 		badPlug = Gaffer.NameValuePlug( "missing", Gaffer.Color3fPlug(), "badPlug" )
 
 		self.assertEqual( q.outPlugFromQuery( n1 ), q["out"][0] )
@@ -106,15 +105,6 @@ class ShaderQueryTest( GafferSceneTest.SceneTestCase ):
 		self.assertEqual( q.queryPlug( q["out"][2]["value"]["min"] ), n3 )
 		self.assertEqual( q.queryPlug( q["out"][2]["value"]["min"]["x"] ), n3 )
 		self.assertRaises( IECore.Exception, q.queryPlug, badPlug )
-
-		q["out"][3].removeChild( q["out"][3]["exists"] )
-		q["out"][3].removeChild( q["out"][3]["value"] )
-
-		self.assertIsNone( q.existsPlugFromQuery( n4 ) )
-		self.assertIsNone( q.valuePlugFromQuery( n4 ) )
-
-		q["out"][3].addChild( Gaffer.FloatPlug( "exists", Gaffer.Plug.Direction.Out ) )
-		self.assertIsNone( q.existsPlugFromQuery( n4 ) )
 
 	def testAddRemoveQuery( self ) :
 

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -266,8 +266,6 @@ Gaffer.Metadata.registerNode(
 			The default value to output if the parameter does not exist.
 			""",
 
-			"spreadsheet:columnName", functools.partial( __getLabel, parentPlug = "queries", sanitise = True ),
-
 		],
 
 		"queries.*.name" : [
@@ -303,6 +301,7 @@ Gaffer.Metadata.registerNode(
 			"nodule:type", "GafferUI::CompoundNodule",
 			"noduleLayout:section", "right",
 			"noduleLayout:spacing", 0.4,
+			"noduleLayout:customGadget:addButton:gadgetType", "",
 
 		],
 

--- a/src/GafferScene/ShaderQuery.cpp
+++ b/src/GafferScene/ShaderQuery.cpp
@@ -143,9 +143,9 @@ ShaderQuery::ShaderQuery( const std::string &name ) : Gaffer::ComputeNode( name 
 	addChild( new StringPlug( "location" ) );
 	addChild( new StringPlug( "shader" ) );
 	addChild( new BoolPlug( "inherit", Plug::In, false ) );
-	addChild( new ArrayPlug( "queries" ) );
+	addChild( new ArrayPlug( "queries", Plug::Direction::In, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 
-	addChild( new ArrayPlug( "out", Plug::Direction::Out ) );
+	addChild( new ArrayPlug( "out", Plug::Direction::Out, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 
 	AttributeQueryPtr attributeQuery = new AttributeQuery( "__attributeQuery" );
 	addChild( attributeQuery );
@@ -487,7 +487,7 @@ const Gaffer::ValuePlug *ShaderQuery::outPlugFromQuery( const Gaffer::NameValueP
 	if( childIndex < outPlug()->children().size() )
 	{
 		const ValuePlug *oPlug = outPlug()->getChild<const ValuePlug>( childIndex );
-		if( oPlug->typeId() != Gaffer::ValuePlug::staticTypeId() )
+		if( oPlug != nullptr && oPlug->typeId() != Gaffer::ValuePlug::staticTypeId() )
 		{
 			throw IECore::Exception( "ShaderQuery : \"outPlug\" must be a `ValuePlug`."  );
 		}


### PR DESCRIPTION
This fixes a few bugs that were discovered as part of @danieldresser work on `ContextQuery`.

I think this along with #4701 covers everything we talked about needing to be done for `ShaderQuery`, anything I'm missing?

- Don't test for `out` plug validity. We generally assume specific plug configurations are not modified in a way that could break functionality. By testing this possibility, it could give the impression such modifications are valid.
- `oPlug` was being checked by its type, but the plug was not found by `getChild` it will be `nullptr` and fail to get the type.
- Fix promoting children of `query` plug to a `Spreadsheet`

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
