### PR TITLE
TaskNodes : Make virtual overrides protected

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 Breaking Changes
 ----------------
 
+- ImageWriter/SceneWriter : The overrides for TaskNode virtual methods are now `protected` rather than `public`. Use the `TaskPlug` API instead.
 - ShaderQuery : `addQuery()` now creates `query` and `out` plugs with numeric suffixes starting at 0 (rather than 1).
 
 0.62.0.0a3 (relative to 0.62.0.0a2)

--- a/include/GafferCortex/ExecutableOpHolder.h
+++ b/include/GafferCortex/ExecutableOpHolder.h
@@ -69,8 +69,15 @@ class GAFFERCORTEX_API ExecutableOpHolder : public ParameterisedHolderTaskNode
 		IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr );
 		const IECore::Op *getOp( std::string *className = nullptr, int *classVersion = nullptr ) const;
 
+	protected :
+
 		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 		void execute() const override;
+
+	private :
+
+		// Friendship for the bindings
+		friend struct GafferDispatchBindings::Detail::TaskNodeAccessor;
 
 };
 

--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -101,10 +101,6 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 		Gaffer::ValuePlug *fileFormatSettingsPlug( const std::string &fileFormat );
 		const Gaffer::ValuePlug *fileFormatSettingsPlug( const std::string &fileFormat ) const;
 
-		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
-
-		void execute() const override;
-
 		const std::string currentFileFormat() const;
 
 		/// Note that this is intentionally identical to the ImageReader's DefaultColorSpaceFunction
@@ -112,6 +108,11 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 		using DefaultColorSpaceFunction = std::function<const std::string ( const std::string &fileName, const std::string &fileFormat, const std::string &dataType, const IECore::CompoundData *metadata )>;
 		static void setDefaultColorSpaceFunction( DefaultColorSpaceFunction f );
 		static DefaultColorSpaceFunction getDefaultColorSpaceFunction();
+
+	protected :
+
+		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
+		void execute() const override;
 
 	private :
 
@@ -128,6 +129,10 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 		static size_t g_firstPlugIndex;
 
 		static DefaultColorSpaceFunction &defaultColorSpaceFunction();
+
+		// Friendship for the bindings
+		friend struct GafferDispatchBindings::Detail::TaskNodeAccessor;
+
 };
 
 IE_CORE_DECLAREPTR( ImageWriter )

--- a/include/GafferScene/SceneWriter.h
+++ b/include/GafferScene/SceneWriter.h
@@ -71,6 +71,8 @@ class GAFFERSCENE_API SceneWriter : public GafferDispatch::TaskNode
 
 		IECore::MurmurHash hash( const Gaffer::Context *context ) const override;
 
+	protected :
+
 		void execute() const override;
 
 		/// Re-implemented to open the file for writing, then iterate through the
@@ -87,6 +89,10 @@ class GAFFERSCENE_API SceneWriter : public GafferDispatch::TaskNode
 		static size_t g_firstPlugIndex;
 
 		static const double g_frameRate;
+
+		// Friendship for the bindings
+		friend struct GafferDispatchBindings::Detail::TaskNodeAccessor;
+
 };
 
 IE_CORE_DECLAREPTR( SceneWriter )


### PR DESCRIPTION
Just as the implementation of all ComputeNode overrides is protected, so should be the implementation of all TaskNode overrides. The general design principle is that Nodes provide internal implementation, and Plugs provide public interfaces.

These methods are protected on the TaskNode base class already, and remain exposed to Python as before, so in practice I don't think this change will affect anyone. A bigger change that we should probably consider at some point is to change the Python bindings to prefix the protected methods with `_`. That would make it much clearer that the TaskPlug API is the one that people should be interacting with.
