### PR TITLE
Light editor attribute tweaks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ Fixes
   - Fixed error `ShaderQuery : "outPlug" is missing` when promoting a child plug of a query to a `Spreadsheet`.
   - Adding a child plug of a query to a `Spreadsheet` now uses the default name for the spreadsheet column.
 
+API
+---
+
+- SceneAlgo : `attributeHistory` now calculates the correct history of an attribute passing through an `AttributeTweaks` node with `localise` enabled.
+
 0.61.12.0 (relative to 0.61.11.0)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - USDLayerWriter : Added a new node for baking the difference between two Gaffer scenes into a minimal USD layer on disk.
 
+Improvements
+------------
+
+- Light Editor : Added support for editing visualisation attributes of lights.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 - ShaderQuery :
   - Fixed error `ShaderQuery : "outPlug" is missing` when promoting a child plug of a query to a `Spreadsheet`.
   - Adding a child plug of a query to a `Spreadsheet` now uses the default name for the spreadsheet column.
+- Spreadsheet : Fixed missing `Remove` TweakPlug mode presets.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ API
 ---
 
 - SceneAlgo : `attributeHistory` now calculates the correct history of an attribute passing through an `AttributeTweaks` node with `localise` enabled.
+- EditScopeAlgo : Added support for editing attributes.
 
 0.61.12.0 (relative to 0.61.11.0)
 =========

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -111,6 +111,16 @@ GAFFERSCENE_API TweakPlug *acquireParameterEdit( Gaffer::EditScope *scope, const
 GAFFERSCENE_API void removeParameterEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
 GAFFERSCENE_API const Gaffer::GraphComponent *parameterEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter );
 
+// Attributes
+// ==========
+//
+// These methods edit attributes for a particular location.
+
+GAFFERSCENE_API bool hasAttributeEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute );
+GAFFERSCENE_API TweakPlug *acquireAttributeEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, bool createIfNecessary = true );
+GAFFERSCENE_API void removeAttributeEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute );
+GAFFERSCENE_API const Gaffer::GraphComponent *attributeEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute );
+
 } // namespace EditScopeAlgo
 
 } // namespace GafferScene

--- a/include/GafferScene/TweakPlug.h
+++ b/include/GafferScene/TweakPlug.h
@@ -62,7 +62,8 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 			Add,
 			Subtract,
 			Multiply,
-			Remove
+			Remove,
+			Create
 		};
 
 		TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, Mode mode = Replace, bool enabled = true );
@@ -100,8 +101,7 @@ class GAFFERSCENE_API TweakPlug : public Gaffer::ValuePlug
 			/// Legacy mode used by CameraTweaks. Same as
 			/// Ignore mode except when `Mode == Replace`, in
 			/// which case a new parameter is created.
-			/// \deprecated Do not use in new code. If you find
-			/// yourself wanting to, add Mode::Create instead.
+			/// \deprecated Do not use in new code.
 			IgnoreOrReplace,
 		};
 

--- a/include/GafferScene/TweakPlug.inl
+++ b/include/GafferScene/TweakPlug.inl
@@ -103,7 +103,6 @@ bool TweakPlug::applyTweak(
 		return setDataFunctor( name,  nullptr );
 	}
 
-	const IECore::Data *currentValue = getDataFunctor( name );
 	IECore::DataPtr newData = Gaffer::PlugAlgo::getValueAsData( valuePlug() );
 	if( !newData )
 	{
@@ -111,32 +110,42 @@ bool TweakPlug::applyTweak(
 			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value plug has unsupported type \"%s\"" ) % name % valuePlug()->typeName() )
 		);
 	}
-	if( currentValue && currentValue->typeId() != newData->typeId() )
-	{
-		throw IECore::Exception(
-			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value of type \"%s\" does not match parameter of type \"%s\"" ) % name % currentValue->typeName() % newData->typeName() )
-		);
-	}
-
-	if( !currentValue )
-	{
-		if( missingMode == GafferScene::TweakPlug::MissingMode::Ignore )
-		{
-			return false;
-		}
-		else if( !( mode == GafferScene::TweakPlug::Replace && missingMode == GafferScene::TweakPlug::MissingMode::IgnoreOrReplace) )
-		{
-			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % Detail::modeToString( mode ) % name ) );
-		}
-	}
 
 	if(
+		mode == GafferScene::TweakPlug::Replace ||
 		mode == GafferScene::TweakPlug::Add ||
 		mode == GafferScene::TweakPlug::Subtract ||
 		mode == GafferScene::TweakPlug::Multiply
 	)
 	{
-		modifyData( currentValue, newData.get(), newData.get(), mode, name );
+		const IECore::Data *currentValue = getDataFunctor( name );
+		if( currentValue && currentValue->typeId() != newData->typeId() )
+		{
+			throw IECore::Exception(
+				boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value of type \"%s\" does not match parameter of type \"%s\"" ) % name % currentValue->typeName() % newData->typeName() )
+			);
+		}
+
+		if( !currentValue )
+		{
+			if( missingMode == GafferScene::TweakPlug::MissingMode::Ignore )
+			{
+				return false;
+			}
+			else if( !( mode == GafferScene::TweakPlug::Replace && missingMode == GafferScene::TweakPlug::MissingMode::IgnoreOrReplace) )
+			{
+				throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % Detail::modeToString( mode ) % name ) );
+			}
+		}
+
+		if(
+			mode == GafferScene::TweakPlug::Add ||
+			mode == GafferScene::TweakPlug::Subtract ||
+			mode == GafferScene::TweakPlug::Multiply
+		)
+		{
+			modifyData( currentValue, newData.get(), newData.get(), mode, name );
+		}
 	}
 
 	setDataFunctor( name, newData );

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,14 +34,12 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERSCENEUI_PARAMETERINSPECTOR_H
-#define GAFFERSCENEUI_PARAMETERINSPECTOR_H
+#ifndef GAFFERSCENEUI_ATTRIBUTEINSPECTOR_H
+#define GAFFERSCENEUI_ATTRIBUTEINSPECTOR_H
 
 #include "GafferSceneUI/Export.h"
 
-#include "GafferSceneUI/Private/AttributeInspector.h"
-
-#include "IECoreScene/ShaderNetwork.h"
+#include "GafferSceneUI/Private/Inspector.h"
 
 namespace GafferSceneUI
 {
@@ -49,32 +47,43 @@ namespace GafferSceneUI
 namespace Private
 {
 
-class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
+class GAFFERSCENEUI_API AttributeInspector : public Inspector
 {
 
 	public :
 
-		ParameterInspector(
-			const GafferScene::ScenePlugPtr &scene, const Gaffer::PlugPtr &editScope,
-			IECore::InternedString attribute, const IECoreScene::ShaderNetwork::Parameter &parameter
+		AttributeInspector(
+			const GafferScene::ScenePlugPtr &scene,
+			const Gaffer::PlugPtr &editScope,
+			IECore::InternedString attribute,
+			const std::string &name = "",
+			const std::string &type = "attribute"
 		);
 
-		IE_CORE_DECLAREMEMBERPTR( ParameterInspector );
+		IE_CORE_DECLAREMEMBERPTR( AttributeInspector );
+
+	protected :
+
+		GafferScene::SceneAlgo::History::ConstPtr history() const override;
+		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
+		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
+		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history) const override;
 
 	private :
 
-		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
-		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
-		EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
+		void plugDirtied( Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
 
-		const IECoreScene::ShaderNetwork::Parameter m_parameter;
+		const GafferScene::ScenePlugPtr m_scene;
+		const IECore::InternedString m_attribute;
 
 };
 
-IE_CORE_DECLAREPTR( ParameterInspector )
+IE_CORE_DECLAREPTR( AttributeInspector )
 
-} // namespace Private
+}  // namespace Private
 
-} // namespace GafferSceneUI
+}  // namespace GafferSceneUI
 
-#endif // GAFFERSCENEUI_PARAMETERINSPECTOR_H
+#endif // GAFFERSCENEUI_ATTRIBUTEINSPECTOR_H

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -69,6 +69,8 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history) const override;
 
+		bool attributeExists() const;
+
 	private :
 
 		void plugDirtied( Gaffer::Plug *plug );

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -132,6 +132,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public boost::sig
 		/// `editWarning` may be assigned a warning that will be shown to the
 		/// user when editing this plug. Called with `history->context` as the
 		/// current context. Default implementation returns null.
+		/// \todo Perhaps this should also be available directly from the
+		/// history class?
 		virtual Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const;
 
 		using EditFunction = std::function<Gaffer::ValuePlugPtr ()>;

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -86,6 +86,9 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public boost::sig
 		IE_CORE_DECLAREMEMBERPTR( Inspector );
 		IE_CORE_FORWARDDECLARE( Result );
 
+		/// The type of property being inspected (for instance "attribute" or "parameter").
+		const std::string &type() const;
+
 		/// The name of the property being inspected, as it is referred to in
 		/// the API. It is the UI's responsibility to format this appropriately
 		/// (for example, by converting from "camelCase" or "snake_case").
@@ -103,7 +106,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public boost::sig
 
 		/// Protected constructor for use by derived classes. The `name` argument
 		/// will be returned verbatim by the `name()` method.
-		Inspector( const std::string &name, const Gaffer::PlugPtr &editScope );
+		Inspector( const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
 
 		/// Methods to be implemented in derived classes
 		/// ============================================
@@ -153,6 +156,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public boost::sig
 		void inspectHistoryWalk( const GafferScene::SceneAlgo::History *history, Result *result ) const;
 		void editScopeInputChanged( const Gaffer::Plug *plug );
 
+		const std::string m_type;
 		const std::string m_name;
 		const Gaffer::PlugPtr m_editScope;
 		InspectorSignal m_dirtiedSignal;

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -61,6 +61,10 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 
 		IE_CORE_DECLAREMEMBERPTR( ParameterInspector );
 
+	protected :
+
+		GafferScene::SceneAlgo::History::ConstPtr history() const override;
+
 	private :
 
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;

--- a/python/GafferSceneTest/AttributeTweaksTest.py
+++ b/python/GafferSceneTest/AttributeTweaksTest.py
@@ -184,6 +184,25 @@ class AttributeTweaksTest( GafferSceneTest.SceneTestCase ) :
 		segmentsTweak["enabled"].setValue( False )
 		self.assertNotIn( "gaffer:transformBlurSegments", tweaks["out"].attributes( "/group/plane" ) )
 
+	def testCreateMode( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		tweaks = GafferScene.AttributeTweaks()
+		tweaks["in"].setInput( plane["out"] )
+		tweaks["filter"].setInput( planeFilter["out"] )
+
+		self.assertNotIn( "test:attribute", tweaks["out"].attributes( "/plane" ) )
+
+		testTweak = GafferScene.TweakPlug( "test:attribute", 2 )
+		testTweak["mode"].setValue( GafferScene.TweakPlug.Mode.Create )
+		tweaks["tweaks"].addChild( testTweak )
+
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["test:attribute"], IECore.IntData( 2 ) )
+
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneTest/CameraTweaksTest.py
+++ b/python/GafferSceneTest/CameraTweaksTest.py
@@ -134,6 +134,8 @@ class CameraTweaksTest( GafferSceneTest.SceneTestCase ) :
 						ref = orig * value
 					elif mode == GafferScene.TweakPlug.Mode.Subtract:
 						ref = orig - value
+					elif mode == GafferScene.TweakPlug.Mode.Create:
+						ref = value
 
 					if name == "fieldOfView":
 						modified = tweaks["out"].object( "/camera" ).calculateFieldOfView()[0]

--- a/python/GafferSceneTest/EditScopeAlgoTest.py
+++ b/python/GafferSceneTest/EditScopeAlgoTest.py
@@ -657,7 +657,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		)
 		self.assertIsInstance( edit, GafferScene.TweakPlug )
 		self.assertIsInstance( edit["value"], Gaffer.FloatPlug )
-		self.assertEqual( edit["mode"].getValue(), GafferScene.TweakPlug.Mode.Replace )
+		self.assertEqual( edit["mode"].getValue(), GafferScene.TweakPlug.Mode.Create )
 		self.assertEqual( edit["value"].getValue(), 1.0 )
 		self.assertEqual( edit["enabled"].getValue(), False )
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -1259,6 +1259,166 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "c" ) )
 
+	def testAttributeHistoryWithAttributeTweaks( self ) :
+
+		# Graph
+		# -----
+		#
+		#        plane
+		#          |
+		#    planeAttributes
+		#          |
+		#      innerGroup
+		#          |
+		#      outerGroup
+		#          |
+		#    innerAttributes
+		#          |
+		#    outerAttributes
+		#
+		# Hierarchy and attributes
+		# ------------------------
+		#
+		#  /outer         a b c
+		#    /inner       a b
+		#       /plane    a
+		#
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		planeAttributes = GafferScene.CustomAttributes()
+		planeAttributes["in"].setInput( plane["out"] )
+		planeAttributes["filter"].setInput( planeFilter["out"] )
+		planeAttributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "planeA" ) )
+
+		innerGroup = GafferScene.Group()
+		innerGroup["in"][0].setInput( planeAttributes["out"] )
+		innerGroup["name"].setValue( "inner" )
+
+		outerGroup = GafferScene.Group()
+		outerGroup["in"][0].setInput( innerGroup["out"] )
+		outerGroup["name"].setValue( "outer" )
+
+		innerFilter = GafferScene.PathFilter()
+		innerFilter["paths"].setValue( IECore.StringVectorData( [ "/outer/inner" ] ) )
+
+		innerAttributes = GafferScene.CustomAttributes()
+		innerAttributes["in"].setInput( outerGroup["out"] )
+		innerAttributes["filter"].setInput( innerFilter["out"] )
+		innerAttributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "innerA" ) )
+		innerAttributes["attributes"].addChild( Gaffer.NameValuePlug( "b", "innerB" ) )
+
+		outerFilter = GafferScene.PathFilter()
+		outerFilter["paths"].setValue( IECore.StringVectorData( [ "/outer" ] ) )
+
+		outerAttributes = GafferScene.CustomAttributes()
+		outerAttributes["in"].setInput( innerAttributes["out"] )
+		outerAttributes["filter"].setInput( outerFilter["out"] )
+		outerAttributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "outerA" ) )
+		outerAttributes["attributes"].addChild( Gaffer.NameValuePlug( "b", "outerB" ) )
+		outerAttributes["attributes"].addChild( Gaffer.NameValuePlug( "c", "outerC" ) )
+
+		tweaksFilter = GafferScene.PathFilter()
+		tweaksFilter["paths"].setValue( IECore.StringVectorData( [ "/outer/inner/plane" ] ) )
+
+		tweaks = GafferScene.AttributeTweaks()
+		tweaks["in"].setInput( outerAttributes["out"] )
+		tweaks["filter"].setInput( tweaksFilter["out"] )
+
+		# No tweaks yet
+
+		history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/outer/inner/plane" )
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "a" )
+
+		self.__assertAttributeHistory( attributeHistory, [], tweaks["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0 ], tweaks["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], outerAttributes["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0 ], outerAttributes["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0 ], innerAttributes["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0 ], innerAttributes["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0 ], outerGroup["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0 ], outerGroup["in"][0], "/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0 ], innerGroup["out"], "/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ], innerGroup["in"][0], "/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], planeAttributes["out"], "/plane", "a", IECore.StringData( "planeA" ), 0 )
+
+		# Without localisation, "b" and "c" have no history
+
+		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "b" ) )
+		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "c" ) )
+
+		# Add tweak on plane attribute
+
+		tweakA = GafferScene.TweakPlug( "a", "tweakA" )
+		tweaks["tweaks"].addChild( tweakA )
+
+		history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/outer/inner/plane" )
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "a" )
+
+		self.__assertAttributeHistory( attributeHistory, [], tweaks["out"], "/outer/inner/plane", "a", IECore.StringData( "tweakA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0 ], tweaks["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], outerAttributes["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0 ], outerAttributes["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0 ], innerAttributes["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0 ], innerAttributes["in"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0 ], outerGroup["out"], "/outer/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0 ], outerGroup["in"][0], "/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0 ], innerGroup["out"], "/inner/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0, 0 ], innerGroup["in"][0], "/plane", "a", IECore.StringData( "planeA" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], planeAttributes["out"], "/plane", "a", IECore.StringData( "planeA" ), 0 )
+
+		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "b" ) )
+		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "c" ) )
+
+		# Add tweaks to inherited attributes
+
+		tweakB = GafferScene.TweakPlug( "b", "tweakB" )
+		tweakC = GafferScene.TweakPlug( "c", "tweakC" )
+
+		tweaks["tweaks"].addChild( tweakB )
+		tweaks["tweaks"].addChild( tweakC )
+
+		# Fail while `localise` and `ignoreMissing` are off
+
+		with six.assertRaisesRegex( self, RuntimeError, "Cannot apply tweak with mode Replace to \"b\" : This parameter does not exist" ) :
+			history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/outer/inner/plane" )
+			GafferScene.SceneAlgo.attributeHistory( history, "b" )
+
+		# Localise will get the attributes from parent locations
+
+		tweaks["localise"].setValue( True )
+
+		# Test attribute "b"
+
+		history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/outer/inner/plane" )
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "b" )
+
+		self.__assertAttributeHistory( attributeHistory, [], tweaks["out"], "/outer/inner/plane", "b", IECore.StringData( "tweakB" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0 ], tweaks["in"], "/outer/inner", "b", IECore.StringData( "innerB" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], outerAttributes["out"], "/outer/inner", "b", IECore.StringData( "innerB" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0 ], outerAttributes["in"], "/outer/inner", "b", IECore.StringData( "innerB" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0, 0, 0 ], innerAttributes["out"], "/outer/inner", "b", IECore.StringData( "innerB" ), 0 )
+
+		# Test attribute "c"
+
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "c" )
+
+		self.__assertAttributeHistory( attributeHistory, [], tweaks["out"], "/outer/inner/plane", "c", IECore.StringData( "tweakC" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0 ], tweaks["in"], "/outer", "c", IECore.StringData( "outerC" ), 1 )
+		self.__assertAttributeHistory( attributeHistory, [ 0, 0 ], outerAttributes["out"], "/outer", "c", IECore.StringData( "outerC" ), 0 )
+
+		# Localise is on, remove parent attribute tweak "b"
+
+		tweaks["tweaks"].removeChild( tweakB )
+
+		history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/outer/inner/plane" )
+		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "b" )
+
+		self.assertIsNone( GafferScene.SceneAlgo.attributeHistory( history, "b" ) )
+
 	def testAttributeHistoryWithMissingAttribute( self ) :
 
 		# Attribute doesn't exist, so we return None.

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -94,7 +94,13 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 
-		]
+		],
+
+		"tweaks.*" : [
+
+			"tweakPlugValueWidget:allowCreate", True,
+
+		],
 
 	}
 )

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -91,6 +91,7 @@ Gaffer.Metadata.registerNode(
 		"tweaks.*" : [
 
 			"tweakPlugValueWidget:allowRemove", True,
+			"tweakPlugValueWidget:allowCreate", True,
 
 		],
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -127,8 +127,11 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 
 		return self.__plug
 
+	# Registers a parameter to be available for editing. `rendererKey` is a pattern
+	# that will be matched against `self.__settingsNode["attribute"]` to determine if
+	# the column should be shown.
 	@classmethod
-	def registerParameter( cls, attribute, parameter, section = None ) :
+	def registerParameter( cls, rendererKey, parameter, section = None ) :
 
 		# We use `tuple` to store `ShaderNetwork.Parameter`, because
 		# the latter isn't hashable and we need to use it as a dict key.
@@ -138,11 +141,40 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			assert( isinstance( parameter, IECoreScene.ShaderNetwork.Parameter ) )
 			parameter = ( parameter.shader, parameter.name )
 
-		sections = cls.__columnRegistry.setdefault( attribute, collections.OrderedDict() )
-		section = sections.setdefault( section, collections.OrderedDict() )
-		section[parameter] = lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
-			GafferSceneUI.Private.ParameterInspector( scene, editScope, attribute, parameter )
+		GafferSceneUI.LightEditor.registerColumn(
+			rendererKey,
+			parameter,
+			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
+				GafferSceneUI.Private.ParameterInspector( scene, editScope, rendererKey, parameter )
+			),
+			section
 		)
+
+	@classmethod
+	def registerAttribute( cls, rendererKey, attributeName, section = None ) :
+
+		displayName = attributeName.split( ':' )[-1]
+		GafferSceneUI.LightEditor.registerColumn(
+			rendererKey,
+			attributeName,
+			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
+				GafferSceneUI.Private.AttributeInspector( scene, editScope, attributeName ),
+				displayName
+			),
+			section
+		)
+
+	# Registers a column in the Light Editor.
+	# `inspectorFunction` is a callable object of the form
+	# `inspectorFunction( scene, editScope )` returning a
+	# `GafferSceneUI._LightEditorInspectorColumn` object.
+	@classmethod
+	def registerColumn( cls, rendererKey, columnKey, inspectorFunction, section = None ) :
+
+		sections = cls.__columnRegistry.setdefault( rendererKey, collections.OrderedDict() )
+		section = sections.setdefault( section, collections.OrderedDict() )
+
+		section[columnKey] = inspectorFunction
 
 	def __repr__( self ) :
 
@@ -192,9 +224,15 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 	@GafferUI.LazyMethod()
 	def __updateColumns( self ) :
 
-		sections = self.__columnRegistry[self.__settingsNode["attribute"].getValue()]
-		section = sections[self.__settingsNode["section"].getValue() or None]
-		sectionColumns = [ c( self.__settingsNode["in"], self.__settingsNode["editScope"] ) for c in section.values() ]
+		attribute = self.__settingsNode["attribute"].getValue()
+		currentSection = self.__settingsNode["section"].getValue()
+
+		sectionColumns = []
+
+		for rendererKey, sections in self.__columnRegistry.items() :
+			if IECore.StringAlgo.match( attribute, rendererKey ) :
+				section = sections.get( currentSection or None, {} )
+				sectionColumns += [ c( self.__settingsNode["in"], self.__settingsNode["editScope"] ) for c in section.values() ]
 
 		nameColumn = self.__pathListing.getColumns()[0]
 		self.__pathListing.setColumns( [ nameColumn ] + sectionColumns )
@@ -382,10 +420,13 @@ class _SectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__ignoreCurrentChanged = True
 			while self._qtWidget().count() :
 				self._qtWidget().removeTab( 0 )
+
 			attribute = self.getPlug().node()["attribute"].getValue()
-			if attribute in LightEditor._LightEditor__columnRegistry :
-				for section in LightEditor._LightEditor__columnRegistry[attribute].keys() :
-					self._qtWidget().addTab( section or "Main" )
+
+			for rendererKey, sections in LightEditor._LightEditor__columnRegistry.items() :
+				if IECore.StringAlgo.match( attribute, rendererKey ) :
+					for section in sections.keys() :
+						self._qtWidget().addTab( section or "Main" )
 		finally :
 			self.__ignoreCurrentChanged = False
 

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -49,7 +49,8 @@ from Qt import QtWidgets
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
 # a target parameter name, an enabled plug, and a mode.  The mode can be "Replace",
 # or "Add"/"Subtract"/"Multiply" if the plug is numeric,
-# or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set
+# or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set,
+# or "Create" if the metadata "tweakPlugValueWidget:allowCreate" is set.
 class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plugs ) :
@@ -165,7 +166,11 @@ Gaffer.Metadata.registerValue(
 
 def __validModes( plug ) :
 
-	result = [ GafferScene.TweakPlug.Mode.Replace ]
+	result = []
+	if Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:allowCreate" ) :
+		result += [ GafferScene.TweakPlug.Mode.Create ]
+
+	result += [ GafferScene.TweakPlug.Mode.Replace ]
 	if hasattr( plug.parent()["value"], "hasMinValue" ) :
 		result += [
 			GafferScene.TweakPlug.Mode.Add,

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -668,6 +668,43 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			edit = light["visualiserAttributes"]["scale"]
 		)
 
+	def testRegisteredAttribute( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( light["out"] )
+		editScope["in"].setInput( light["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "/light", "gl:visualiser:scale", None ),
+			source = light["visualiserAttributes"]["scale"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = light["visualiserAttributes"]["scale"]
+		)
+
+		inspection = self.__inspect( editScope["out"], "/light", "gl:visualiser:scale", editScope )
+		edit = inspection.acquireEdit()
+		self.assertEqual(
+			edit,
+			GafferScene.EditScopeAlgo.acquireAttributeEdit(
+				editScope, "/light", "gl:visualiser:scale", createIfNecessary = False
+			)
+		)
+
+		edit["enabled"].setValue( True )
+
+		# With the tweak in place in `editScope`, force the history to be checked again
+		# to make sure we get the right source back.
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "/light", "gl:visualiser:scale", editScope ),
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -572,7 +572,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 	def testNonExistentAttribute( self ) :
 
 		light = GafferSceneTest.TestLight()
-		self.assertIsNone( self.__inspect( light["out"], "/light", "gl:visualiser:scale" ) )
+		self.assertIsNone( self.__inspect( light["out"], "/light", "bad:attribute" ) )
 
 	def testReadOnlyMetadataSignalling( self ) :
 
@@ -640,6 +640,32 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			editable = True,
 			edit = customAttributes["attributes"]["testPlug"],
 			editWarning = "Edits to \"test:attr\" may affect other locations in the scene."
+		)
+
+	def testDisabledAttribute( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( light["out"] )
+
+		# The value of the attribute isn't editable in this case, but the `enabled`
+		# plug is, so it is considered editable.
+		self.__assertExpectedResult(
+			self.__inspect( light["out"], "/light", "gl:visualiser:scale", None ),
+			source = light["visualiserAttributes"]["scale"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = light["visualiserAttributes"]["scale"]
+		)
+
+		# Values should be inherited from predecessors in the history.
+		self.__assertExpectedResult(
+			self.__inspect( group["out"], "/group/light", "gl:visualiser:scale", None ),
+			source = light["visualiserAttributes"]["scale"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = light["visualiserAttributes"]["scale"]
 		)
 
 

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -1,0 +1,619 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUITest
+import GafferScene
+import GafferSceneTest
+import GafferSceneUI
+
+class AttributeInspectorTest( GafferUITest.TestCase ) :
+
+	def testName( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		inspector = GafferSceneUI.Private.AttributeInspector( light["out"], None, "gl:visualiser:scale" )
+		self.assertEqual( inspector.name(), "gl:visualiser:scale" )
+
+	@staticmethod
+	def __inspect( scene, path, attribute, editScope=None ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.AttributeInspector( scene, editScopePlug, attribute )
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( path.split( "/" )[1:] )
+			return inspector.inspect()
+
+	def __assertExpectedResult(
+		self,
+		result,
+		source,
+		sourceType,
+		editable,
+		nonEditableReason = "",
+		edit = None,
+		editWarning = ""
+	) :
+
+		self.assertEqual( result.source(), source )
+		self.assertEqual( result.sourceType(), sourceType )
+		self.assertEqual( result.editable(), editable )
+
+		if editable :
+			self.assertEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), "" )
+
+			acquiredEdit = result.acquireEdit()
+			self.assertIsNotNone( acquiredEdit )
+			if result.editScope() :
+				self.assertTrue( result.editScope().isAncestorOf( acquiredEdit ) )
+
+			if edit is not None :
+				self.assertEqual(
+					acquiredEdit.fullName() if acquiredEdit is not None else "",
+					edit.fullName() if edit is not None else ""
+				)
+
+			self.assertEqual( result.editWarning(), editWarning )
+
+		else :
+			self.assertIsNone( edit )
+			self.assertEqual( editWarning, "" )
+			self.assertEqual( result.editWarning(), "" )
+			self.assertNotEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), nonEditableReason )
+			self.assertRaises( RuntimeError, result.acquireEdit )
+
+	def testValue( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		light["visualiserAttributes"]["scale"]["value"].setValue( 2.0 )
+
+		self.assertEqual(
+			self.__inspect( light["out"], "/light", "gl:visualiser:scale" ).value(),
+			IECore.FloatData( 2.0 )
+		)
+
+	def testSourceAndEdits( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["light"] = GafferSceneTest.TestLight()
+		s["light"]["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		s["group"] = GafferScene.Group()
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope2"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["light"]["out"] )
+
+		s["editScope1"].setup( s["group"]["out"] )
+		s["editScope1"]["in"].setInput( s["group"]["out"] )
+
+		s["editScope2"].setup( s["editScope1"]["out"] )
+		s["editScope2"]["in"].setInput( s["editScope1"]["out"] )
+
+		# Should be able to edit light directly.
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "/group/light", "gl:visualiser:scale", None ),
+			source = s["light"]["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["light"]["visualiserAttributes"]["scale"]
+		)
+
+		# Even if there is an edit scope in the way
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", None),
+			source = s["light"]["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["light"]["visualiserAttributes"]["scale"]
+		)
+
+		# We shouldn't be able to edit it if we've been told to use and EditScope and it isn't in the history
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] ),
+			source = s["light"]["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable=False,
+			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+		)
+
+		# If it is in the history though, and we're told to use it, then we will.
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
+
+		self.assertIsNone(
+			GafferScene.EditScopeAlgo.acquireAttributeEdit(
+				s["editScope2"], "/group/light", "gl:visualiser:scale", createIfNecessary = False
+			)
+		)
+
+		self.__assertExpectedResult(
+			inspection,
+			source=s["light"]["visualiserAttributes"]["scale"],
+			sourceType=SourceType.Upstream,
+			editable = True
+		)
+
+		lightEditScope2Edit = inspection.acquireEdit()
+		self.assertIsNotNone( lightEditScope2Edit )
+		self.assertEqual(
+			lightEditScope2Edit,
+			GafferScene.EditScopeAlgo.acquireAttributeEdit(
+				s["editScope2"], "/group/light", "gl:visualiser:scale", createIfNecessary = False
+			)
+		)
+
+		# If there's an edit downstream of the EditScope we're asked to use,
+		# then we're allowed to be editable still
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] )
+		self.assertTrue( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "" )
+		lightEditScope1Edit = inspection.acquireEdit()
+		self.assertIsNotNone( lightEditScope1Edit )
+		self.assertEqual(
+			lightEditScope1Edit,
+			GafferScene.EditScopeAlgo.acquireAttributeEdit(
+				s["editScope1"], "/group/light", "gl:visualiser:scale", createIfNecessary = False
+			)
+		)
+		self.assertEqual( inspection.editWarning(), "" )
+
+		# If there is a source node inside an edit scope, make sure we use that
+
+		s["editScope1"]["light2"] = GafferSceneTest.TestLight()
+		s["editScope1"]["light2"]["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		s["editScope1"]["light2"]["visualiserAttributes"]["scale"]["value"].setValue( 0.5 )
+		s["editScope1"]["light2"]["name"].setValue( "light2" )
+		s["editScope1"]["parentLight2"] = GafferScene.Parent()
+		s["editScope1"]["parentLight2"]["parent"].setValue( "/" )
+		s["editScope1"]["parentLight2"]["children"][0].setInput( s["editScope1"]["light2"]["out"] )
+		s["editScope1"]["parentLight2"]["in"].setInput( s["editScope1"]["BoxIn"]["out"] )
+		s["editScope1"]["AttributeEdits"]["in"].setInput( s["editScope1"]["parentLight2"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/light2", "gl:visualiser:scale", s["editScope1"] ),
+			source = s["editScope1"]["light2"]["visualiserAttributes"]["scale"],
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = s["editScope1"]["light2"]["visualiserAttributes"]["scale"]
+		)
+
+		# If there is a tweak in the scope's processor, make sure we use that
+
+		light2Edit = GafferScene.EditScopeAlgo.acquireAttributeEdit(
+			s["editScope1"], "/light2", "gl:visualiser:scale", createIfNecessary = True
+		)
+		light2Edit["enabled"].setValue( True )
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/light2", "gl:visualiser:scale", s["editScope1"] ),
+			source = light2Edit,
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = light2Edit
+		)
+
+		# If there is a manual tweak downstream of the scope's scene processor, make sure we use that
+
+		s["editScope1"]["tweakLight2"] = GafferScene.AttributeTweaks()
+		s["editScope1"]["tweakLight2"]["in"].setInput( s["editScope1"]["AttributeEdits"]["out"] )
+		s["editScope1"]["tweakLight2Filter"] = GafferScene.PathFilter()
+		s["editScope1"]["tweakLight2Filter"]["paths"].setValue( IECore.StringVectorData( [ "/light2" ] ) )
+		s["editScope1"]["tweakLight2"]["filter"].setInput( s["editScope1"]["tweakLight2Filter"]["out"] )
+		s["editScope1"]["BoxOut"]["in"].setInput( s["editScope1"]["tweakLight2"]["out"] )
+
+		editScopeAttributeTweak = GafferScene.TweakPlug( "gl:visualiser:scale", 4.0 )
+		s["editScope1"]["tweakLight2"]["tweaks"].addChild( editScopeAttributeTweak )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/light2", "gl:visualiser:scale", s["editScope1"] ),
+			source = editScopeAttributeTweak,
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = editScopeAttributeTweak
+		)
+
+		# If there is a manual tweak outside of an edit scope, make sure we use that with no scope
+		s["independentAttributeTweak"] = GafferScene.AttributeTweaks()
+		s["independentAttributeTweak"]["in"].setInput( s["editScope2"]["out"] )
+
+		s["independentAttributeTweakFilter"] = GafferScene.PathFilter()
+		s["independentAttributeTweakFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/light" ] ) )
+		s["independentAttributeTweak"]["filter"].setInput( s["independentAttributeTweakFilter"]["out"] )
+
+		independentAttributeTweakPlug = GafferScene.TweakPlug( "gl:visualiser:scale", 8.0 )
+		independentAttributeTweakPlug["enabled"].setValue( True )
+		s["independentAttributeTweak"]["tweaks"].addChild( independentAttributeTweakPlug )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/group/light", "gl:visualiser:scale", None ),
+			source = independentAttributeTweakPlug,
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = independentAttributeTweakPlug
+		)
+
+		# Check we show the last input plug if the source plug is an output
+
+		scaleCurve = Gaffer.Animation.acquire( s["light"]["visualiserAttributes"]["scale"]["value"] )
+		scaleCurve.addKey( Gaffer.Animation.Key( time = 1, value = 2 ) )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "/group/light", "gl:visualiser:scale", None ),
+			source = s["light"]["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["light"]["visualiserAttributes"]["scale"]
+		)
+
+		# Check editWarnings and nonEditableReasons
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] ),
+			source = independentAttributeTweakPlug,
+			sourceType = SourceType.Downstream,
+			editable = True,
+			edit = lightEditScope2Edit,
+			editWarning = "Attribute has edits downstream in independentAttributeTweak."
+		)
+
+		s["editScope2"]["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] ),
+			source = independentAttributeTweakPlug,
+			sourceType = SourceType.Downstream,
+			editable = False,
+			nonEditableReason = "The target EditScope (editScope2) is disabled."
+		)
+
+		s["editScope2"]["enabled"].setValue( True )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/light2", "gl:visualiser:scale", s["editScope2"] ),
+			source = editScopeAttributeTweak,
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2 is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], False )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["AttributeEdits"]["edits"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/light2", "gl:visualiser:scale", s["editScope2"] ),
+			source = editScopeAttributeTweak,
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.AttributeEdits.edits is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["AttributeEdits"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentAttributeTweak"]["out"], "/light2", "gl:visualiser:scale", s["editScope2"] ),
+			source = editScopeAttributeTweak,
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.AttributeEdits is locked."
+		)
+
+	def testEditScopeNotInHistory( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		lightFilter = GafferScene.PathFilter()
+		lightFilter["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		attributeTweaks = GafferScene.AttributeTweaks()
+		attributeTweaks["in"].setInput( light["out"] )
+		attributeTweaks["filter"].setInput( lightFilter["out"] )
+		attributeTweaks["tweaks"].addChild( GafferScene.TweakPlug( "gl:visualiser:scale", 2.0 ) )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( light["out"] )
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( light["out"], "/light", "gl:visualiser:scale", editScope ),
+			source = light["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable = False,
+			nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+		)
+
+		self.__assertExpectedResult(
+			self.__inspect( attributeTweaks["out"], "/light", "gl:visualiser:scale" ),
+			source = attributeTweaks["tweaks"][0],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = attributeTweaks["tweaks"][0]
+		)
+
+		self.__assertExpectedResult(
+			self.__inspect( attributeTweaks["out"], "/light", "gl:visualiser:scale", editScope ),
+			source = attributeTweaks["tweaks"][0],
+			sourceType = SourceType.Other,
+			editable = False,
+			nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+		)
+
+	def testDisabledTweaks( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		lightFilter = GafferScene.PathFilter()
+		lightFilter["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		attributeTweaks = GafferScene.AttributeTweaks()
+		attributeTweaks["in"].setInput( light["out"] )
+		attributeTweaks["filter"].setInput( lightFilter["out"] )
+		scaleTweak = GafferScene.TweakPlug( "gl:visualiser:scale", 2.0 )
+		attributeTweaks["tweaks"].addChild( scaleTweak )
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( attributeTweaks["out"], "/light", "gl:visualiser:scale" ),
+			source = scaleTweak,
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = scaleTweak
+		)
+
+		scaleTweak["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( attributeTweaks["out"], "/light", "gl:visualiser:scale" ),
+			source = light["visualiserAttributes"]["scale"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = light["visualiserAttributes"]["scale"]
+		)
+
+	def testEditScopeNesting( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		editScope1 = Gaffer.EditScope( "EditScope1" )
+		editScope1.setup( light["out"] )
+		editScope1["in"].setInput( light["out"] )
+
+		i = self.__inspect( editScope1["out"], "/light", "gl:visualiser:scale", editScope1 )
+		scope1Edit = i.acquireEdit()
+		scope1Edit["enabled"].setValue( True )
+		self.assertEqual( scope1Edit.ancestor( Gaffer.EditScope ), editScope1 )
+
+		editScope2 = Gaffer.EditScope()
+		editScope2.setup( light["out"] )
+		editScope1.addChild( editScope2 )
+		editScope2["in"].setInput( scope1Edit.ancestor( GafferScene.SceneProcessor )["out"] )
+		editScope1["BoxOut"]["in"].setInput( editScope2["out"] )
+
+		i = self.__inspect( editScope1["out"], "/light", "gl:visualiser:scale", editScope2 )
+		scope2Edit = i.acquireEdit()
+		scope2Edit["enabled"].setValue( True )
+		self.assertEqual( scope2Edit.ancestor( Gaffer.EditScope ), editScope2 )
+
+		# Check we still fin the edit in scope 1
+
+		i = self.__inspect( editScope1["out"], "/light", "gl:visualiser:scale", editScope1 )
+		self.assertEqual( i.acquireEdit()[0].ancestor( Gaffer.EditScope ), editScope1 )
+
+	def testDownstreamSourceType( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( light["out"] )
+		editScope["in"].setInput( light["out"] )
+
+		lightFilter = GafferScene.PathFilter()
+		lightFilter["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		attributeTweaks = GafferScene.AttributeTweaks()
+		attributeTweaks["in"].setInput( editScope["out"] )
+		attributeTweaks["filter"].setInput( lightFilter["out"] )
+		scaleTweak = GafferScene.TweakPlug( "gl:visualiser:scale", 2.0 )
+		attributeTweaks["tweaks"].addChild( scaleTweak )
+
+		self.__assertExpectedResult(
+			self.__inspect( attributeTweaks["out"], "/light", "gl:visualiser:scale", editScope ),
+			source = scaleTweak,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Downstream,
+			editable = True,
+			edit = None,
+			editWarning = "Attribute has edits downstream in AttributeTweaks."
+		)
+
+	def testLightInsideBox( self ) :
+
+		box = Gaffer.Box()
+		box["light"] = GafferSceneTest.TestLight()
+		box["light"]["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		Gaffer.PlugAlgo.promote( box["light"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( box["out"], "/light", "gl:visualiser:scale" ),
+			source = box["light"]["visualiserAttributes"]["scale"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = box["light"]["visualiserAttributes"]["scale"]
+		)
+
+	def testDirtiedSignal( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		editScope1 = Gaffer.EditScope()
+		editScope1.setup( light["out"] )
+		editScope1["in"].setInput( light["out"] )
+
+		editScope2 = Gaffer.EditScope()
+		editScope2.setup( editScope1["out"] )
+		editScope2["in"].setInput( editScope1["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.AttributeInspector(
+			editScope2["out"], settings["editScope"], "gl:visualiser:scale"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		# Tweaking an attribute should dirty the inspector
+		light["visualiserAttributes"]["scale"]["value"].setValue( 2.0 )
+		self.assertEqual( len( cs ) , 1 )
+
+		# But tweaking the transform should not.
+		light["transform"]["translate"]["x"].setValue( 10 )
+		self.assertEqual( len( cs ), 1 )
+
+		# Changing EditScope should also dirty the inspector
+		settings["editScope"].setInput( editScope1["enabled"] )
+		self.assertEqual( len( cs ), 2 )
+		settings["editScope"].setInput( editScope2["enabled"] )
+		self.assertEqual( len( cs ), 3 )
+		settings["editScope"].setInput( None )
+		self.assertEqual( len( cs ), 4 )
+
+	def testNonExistentLocation( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		self.assertIsNone( self.__inspect( light["out"], "/nothingHere", "gl:visualiser:scale" ) )
+
+	def testNonExistentAttribute( self ) :
+
+		light = GafferSceneTest.TestLight()
+		self.assertIsNone( self.__inspect( light["out"], "/light", "gl:visualiser:scale" ) )
+
+	def testReadOnlyMetadataSignalling( self ) :
+
+		light = GafferSceneTest.TestLight()
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( light["out"] )
+		editScope["in"].setInput( light["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.AttributeInspector(
+			editScope["out"], settings["editScope"], "gl:visualiser:scale"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, False )
+		self.assertEqual( len( cs ), 0 ) # Changes not relevant because we're not using the EditScope.
+
+		settings["editScope"].setInput( editScope["enabled"] )
+		self.assertEqual( len( cs ), 1 )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		self.assertEqual( len( cs ), 2 ) # Change affects the result of `inspect().editable()`
+
+	def testCameraAttribute( self ) :
+
+		camera = GafferScene.Camera()
+		camera["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		self.__assertExpectedResult(
+			self.__inspect( camera["out"], "/camera", "gl:visualiser:scale", None ),
+			source = camera["visualiserAttributes"]["scale"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = camera["visualiserAttributes"]["scale"]
+		)
+
+	def testAttributes( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( sphere["out"] )
+		customAttributes["filter"].setInput( sphereFilter["out"] )
+		customAttributes["attributes"].addChild(
+			Gaffer.NameValuePlug(
+				"test:attr",
+				IECore.FloatData( 1.0 ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testPlug"
+			)
+		)
+
+		self.__assertExpectedResult(
+			self.__inspect( customAttributes["out"], "/sphere", "test:attr", None ),
+			source = customAttributes["attributes"]["testPlug"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = customAttributes["attributes"]["testPlug"],
+			editWarning = "Edits to \"test:attr\" may affect other locations in the scene."
+		)
+
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -349,6 +349,34 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			nonEditableReason = "editScope2.AttributeEdits is locked."
 		)
 
+	def testAttributesWarning( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( sphere["out"] )
+		customAttributes["filter"].setInput( sphereFilter["out"] )
+		customAttributes["attributes"].addChild(
+			Gaffer.NameValuePlug(
+				"test:attr",
+				IECore.FloatData( 1.0 ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testPlug"
+			)
+		)
+
+		self.__assertExpectedResult(
+			self.__inspect( customAttributes["out"], "/sphere", "test:attr", None ),
+			source = customAttributes["attributes"]["testPlug"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = customAttributes["attributes"]["testPlug"],
+			editWarning = "Edits to \"test:attr\" may affect other locations in the scene."
+		)
+
 	def testEditScopeNotInHistory( self ) :
 
 		light = GafferSceneTest.TestLight()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -53,6 +53,7 @@ from .TransformToolTest import TransformToolTest
 from .CropWindowToolTest import CropWindowToolTest
 from .NodeUITest import NodeUITest
 from .ParameterInspectorTest import ParameterInspectorTest
+from .AttributeInspectorTest import AttributeInspectorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -240,7 +240,9 @@ for key in [
 	"presetsPlugValueWidget:allowCustom",
 	"ui:scene:acceptsSetName",
 	"ui:scene:acceptsSetNames",
-	"ui:scene:acceptsSetExpression"
+	"ui:scene:acceptsSetExpression",
+	"tweakPlugValueWidget:allowRemove",
+	"tweakPlugValueWidget:allowCreate",
 ] :
 
 	Gaffer.Metadata.registerValue(

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -55,6 +55,7 @@
 
 #include "OpenEXR/ImathMatrixAlgo.h"
 
+#include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/container/flat_map.hpp"
 #include "boost/tokenizer.hpp"
@@ -784,6 +785,13 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireAttributeEdit( Gaffer::EditScope *
 	attributeTweaks->tweaksPlug()->addChild( tweakPlug );
 
 	size_t columnIndex = rows->addColumn( tweakPlug.get(), columnName, /* adoptEnabledPlug */ true );
+	MetadataAlgo::copyIf(
+		tweakPlug.get(), rows->defaultRow()->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug(),
+		[] ( const GraphComponent *from, const GraphComponent *to, const std::string &name ) {
+			return boost::starts_with( name, "tweakPlugValueWidget:" );
+		}
+	);
+
 	tweakPlug->setInput( processor->getChild<Spreadsheet>( "Spreadsheet" )->outPlug()->getChild<Plug>( columnIndex ) );
 
 	return row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug<TweakPlug>();

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -36,6 +36,7 @@
 
 #include "GafferScene/EditScopeAlgo.h"
 
+#include "GafferScene/AttributeTweaks.h"
 #include "GafferScene/Prune.h"
 #include "GafferScene/PathFilter.h"
 #include "GafferScene/SceneProcessor.h"
@@ -409,7 +410,7 @@ SceneProcessor *acquireParameterProcessor( EditScope *editScope, const std::stri
 	return editScope->acquireProcessor<SceneProcessor>( inserted.first->second, createIfNecessary );
 }
 
-ConstDataPtr parameterValue( const ScenePlug *scene, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
+ConstObjectPtr attributeValue( const ScenePlug *scene, const ScenePlug::ScenePath &path, const std::string &attribute )
 {
 	if( !scene->exists( path ) )
 	{
@@ -418,10 +419,25 @@ ConstDataPtr parameterValue( const ScenePlug *scene, const ScenePlug::ScenePath 
 	}
 
 	auto attributes = scene->fullAttributes( path );
-	auto shaderNetwork = attributes->member<IECoreScene::ShaderNetwork>( attribute );
+
+	ConstObjectPtr result = attributes->members()[attribute];
+
+	if( !result )
+	{
+		throw IECore::Exception( boost::str( boost::format( "Attribute \"%s\" does not exist" ) % attribute ) );
+	}
+
+	return result;
+}
+
+ConstDataPtr parameterValue( const ScenePlug *scene, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	auto attributeShader = attributeValue( scene, path, attribute );
+
+	auto shaderNetwork = runTimeCast<const IECoreScene::ShaderNetwork>( attributeShader.get() );
 	if( !shaderNetwork )
 	{
-		throw IECore::Exception( boost::str( boost::format( "Attribute \"%1%\" does not exist" ) % attribute ) );
+		throw IECore::Exception( boost::str( boost::format( "Attribute \"%1%\" is not a shader" ) % attribute ) );
 	}
 
 	const IECoreScene::Shader *shader;
@@ -588,6 +604,208 @@ const GraphComponent *GafferScene::EditScopeAlgo::parameterEditReadOnlyReason( c
 		tweakName = parameter.shader.string() + "." + tweakName;
 	}
 	string columnName = boost::replace_all_copy( tweakName, ".", "_" );
+	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
+	{
+		if( MetadataAlgo::getReadOnly( cell ) )
+		{
+			return cell;
+		}
+
+		for( const auto &plug : Plug::RecursiveRange( *cell ) )
+		{
+			if( MetadataAlgo::getReadOnly( plug.get() ) )
+			{
+				return plug.get();
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+// Attributes
+// ==========
+
+namespace
+{
+
+const std::string g_attributeProcessorName = "AttributeEdits";
+
+SceneProcessorPtr attributeProcessor( const std::string &name )
+{
+	SceneProcessorPtr result = new SceneProcessor( name );
+
+	SpreadsheetPtr spreadsheet = new Spreadsheet;
+	result->addChild( spreadsheet );
+	spreadsheet->selectorPlug()->setValue( "${scene:path}" );
+
+	PathFilterPtr pathFilter = new PathFilter;
+	result->addChild( pathFilter );
+	pathFilter->pathsPlug()->setInput( spreadsheet->activeRowNamesPlug() );
+
+	AttributeTweaksPtr attributeTweaks = new AttributeTweaks;
+	result->addChild( attributeTweaks );
+	attributeTweaks->inPlug()->setInput( result->inPlug() );
+	attributeTweaks->filterPlug()->setInput( pathFilter->outPlug() );
+	attributeTweaks->enabledPlug()->setValue( result->enabledPlug() );
+	attributeTweaks->localisePlug()->setValue( true );
+	attributeTweaks->ignoreMissingPlug()->setValue( true );
+
+	auto rowsPlug = static_cast<Spreadsheet::RowsPlug *>(
+		PlugAlgo::promoteWithName( spreadsheet->rowsPlug(), "edits" )
+	);
+	Metadata::registerValue( rowsPlug, "spreadsheet:defaultRowVisible", new BoolData( false ) );
+	Metadata::registerValue( rowsPlug->defaultRow(), "spreadsheet:rowNameWidth", new IntData( 300 ) );
+
+	result->outPlug()->setInput( attributeTweaks->outPlug() );
+
+	return result;
+}
+
+SceneProcessor *acquireAttributeProcessor( EditScope *editScope, bool createIfNecessary )
+{
+	static bool isRegistered = false;
+	if( !isRegistered )
+	{
+		EditScope::registerProcessor(
+			g_attributeProcessorName,
+			[]() {
+				return attributeProcessor( g_attributeProcessorName );
+			}
+		);
+
+		isRegistered = true;
+	}
+
+	return editScope->acquireProcessor<SceneProcessor>( g_attributeProcessorName, createIfNecessary );
+}
+
+}  // namespace
+
+
+bool GafferScene::EditScopeAlgo::hasAttributeEdit( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	return acquireAttributeEdit( const_cast<EditScope *>( scope ), path, attribute, /* createIfNecessary = */ false );
+}
+
+TweakPlug *GafferScene::EditScopeAlgo::acquireAttributeEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute, bool createIfNecessary )
+{
+	const std::string pathString = ScenePlug::pathToString( path );
+
+	// If we need to create an edit, we'll need to do a compute to figure our the attribute
+	// type and value. But we don't want to do that if we already have an edit. And since the
+	// compute could error, we need to get the attribute value before making _any_ changes, so we
+	// don't leave things in a partial state. We use `ensureAttributeValue()` to get the value
+	// lazily at the first point we know it will be needed.
+	ConstDataPtr attributeValue;
+	auto ensureAttributeValue = [&] {
+		if( !attributeValue )
+		{
+			attributeValue = runTimeCast<const Data>(
+				::attributeValue( scope->outPlug<ScenePlug>(), path, attribute )
+			);
+			if( !attributeValue )
+			{
+				throw IECore::Exception( boost::str( boost::format( "Attribute \"%s\" cannot be tweaked" ) % attribute ) );
+			}
+		}
+	};
+
+	// Find processor, and row for `path`.
+
+	auto *processor = acquireAttributeProcessor( scope, /* createIfNecessary */ false );
+	if( !processor )
+	{
+		if( !createIfNecessary )
+		{
+			return nullptr;
+		}
+		else
+		{
+			ensureAttributeValue();
+			processor = acquireAttributeProcessor( scope, /* createIfNecessary */ true );
+		}
+	}
+
+	auto *rows = processor->getChild<Spreadsheet::RowsPlug>( "edits" );
+	Spreadsheet::RowPlug *row = rows->row( pathString );
+	if( !row )
+	{
+		if( !createIfNecessary )
+		{
+			return nullptr;
+		}
+		ensureAttributeValue();
+		row = rows->addRow();
+		row->namePlug()->setValue( pathString );
+	}
+
+	// Find cell for attribute
+
+	std::string columnName = boost::replace_all_copy( attribute, ":", "_" );
+	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
+	{
+		return cell->valuePlug<TweakPlug>();
+	}
+
+	if( !createIfNecessary )
+	{
+		return nullptr;
+	}
+
+	// No tweak for the attribute yet. Create it.
+
+	ensureAttributeValue();
+
+	ValuePlugPtr valuePlug = PlugAlgo::createPlugFromData( "value", Plug::In, Plug::Default, attributeValue.get() );
+
+	TweakPlugPtr tweakPlug = new TweakPlug( attribute, valuePlug, TweakPlug::Replace, false );
+
+	auto *attributeTweaks = processor->getChild<AttributeTweaks>( "AttributeTweaks" );
+	attributeTweaks->tweaksPlug()->addChild( tweakPlug );
+
+	size_t columnIndex = rows->addColumn( tweakPlug.get(), columnName, /* adoptEnabledPlug */ true );
+	tweakPlug->setInput( processor->getChild<Spreadsheet>( "Spreadsheet" )->outPlug()->getChild<Plug>( columnIndex ) );
+
+	return row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug<TweakPlug>();
+}
+
+void GafferScene::EditScopeAlgo::removeAttributeEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	TweakPlug *edit = acquireAttributeEdit( scope, path, attribute, /* createIfNecessary */ false );
+	if( !edit )
+	{
+		return;
+	}
+	// We're unlikely to be able to delete the row or column,
+	// because that would affect other edits, so we simply disable
+	// the edit instead.
+	edit->enabledPlug()->setValue( false );
+}
+
+const Gaffer::GraphComponent *GafferScene::EditScopeAlgo::attributeEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	auto *processor = acquireAttributeProcessor( const_cast<EditScope *>( scope ), /*createIfNecessary */ false );
+	if( !processor )
+	{
+		return MetadataAlgo::readOnlyReason( scope );
+	}
+
+	const std::string pathString = ScenePlug::pathToString( path );
+
+	auto *rows = processor->getChild<Spreadsheet::RowsPlug>( "edits" );
+	Spreadsheet::RowPlug *row = rows->row( pathString );
+	if( !row )
+	{
+		return MetadataAlgo::readOnlyReason( rows );
+	}
+
+	if( const auto reason = MetadataAlgo::readOnlyReason( row->cellsPlug() ) )
+	{
+		return reason;
+	}
+
+	std::string columnName = boost::replace_all_copy( attribute, ":", "_" );
 	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
 	{
 		if( MetadataAlgo::getReadOnly( cell ) )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -36,6 +36,7 @@
 
 #include "GafferScene/SceneAlgo.h"
 
+#include "GafferScene/AttributeTweaks.h"
 #include "GafferScene/CameraTweaks.h"
 #include "GafferScene/CopyAttributes.h"
 #include "GafferScene/Filter.h"
@@ -588,7 +589,7 @@ void addShuffleAttributesPredecessors( const ShuffleAttributes *shuffleAttribute
 	destination->predecessors.push_back( SceneAlgo::attributeHistory( source[0].get(), sourceAttributeName ) );
 }
 
-void addLocaliseAttributesPredecessors( const LocaliseAttributes *localiseAttributes, const SceneAlgo::History::Predecessors &source, SceneAlgo::AttributeHistory *destination )
+void addLocaliseAttributesPredecessors( const SceneAlgo::History::Predecessors &source, SceneAlgo::AttributeHistory *destination )
 {
 	// No need to check if the node is filtered to this location.
 	// Filtered or unfiltered, it's all the same : the predecessor
@@ -759,13 +760,17 @@ SceneAlgo::AttributeHistory::Ptr SceneAlgo::attributeHistory( const SceneAlgo::H
 		{
 			addShuffleAttributesPredecessors( shuffleAttributes, attributesHistory->predecessors, result.get() );
 		}
-		else if( auto localiseAttributes = runTimeCast<const LocaliseAttributes>( node ) )
+		else if( runTimeCast<const LocaliseAttributes>( node ) )
 		{
-			addLocaliseAttributesPredecessors( localiseAttributes, attributesHistory->predecessors, result.get() );
+			addLocaliseAttributesPredecessors( attributesHistory->predecessors, result.get() );
 		}
 		else if( auto mergeScenes = runTimeCast<const MergeScenes>( node ) )
 		{
 			addMergeScenesPredecessors( mergeScenes, attributesHistory->predecessors, result.get() );
+		}
+		else if( runTimeCast<const AttributeTweaks>( node ) )
+		{
+			addLocaliseAttributesPredecessors( attributesHistory->predecessors, result.get() );
 		}
 		else
 		{

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -612,7 +612,11 @@ void addLocaliseAttributesPredecessors( const SceneAlgo::History::Predecessors &
 		}
 	}
 
-	assert( predecessor );
+	if( !predecessor )
+	{
+		return;
+	}
+
 	destination->predecessors.push_back( predecessor );
 }
 

--- a/src/GafferScene/TweakPlug.cpp
+++ b/src/GafferScene/TweakPlug.cpp
@@ -81,7 +81,7 @@ TweakPlug::TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name, D
 {
 	addChild( new StringPlug( "name", direction ) );
 	addChild( new BoolPlug( "enabled", direction, true ) );
-	addChild( new IntPlug( "mode", direction, Replace, Replace, Remove ) );
+	addChild( new IntPlug( "mode", direction, Replace, Replace, Create ) );
 
 	if( valuePlug )
 	{
@@ -242,8 +242,9 @@ public:
 				break;
 			case TweakPlug::Replace :
 			case TweakPlug::Remove :
-				// These cases are unused - we handle replace and remove mode outside of numericTweak.
-				// But the compiler gets unhappy if we don't handle some cases
+			case TweakPlug::Create :
+				// These cases are unused - we handle replace, remove and create mode outside
+				// of numericTweak. But the compiler gets unhappy if we don't handle some cases
 				break;
 		}
 	}

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -124,6 +124,10 @@ Imath::M44f matrixWrapper( EditScopeAlgo::TransformEdit &e )
 	return e.matrix();
 }
 
+
+// Shaders
+// =======
+
 bool hasParameterEditWrapper( const Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
 {
 	return EditScopeAlgo::hasParameterEdit( &scope, path, attribute, parameter );
@@ -144,6 +148,32 @@ void removeParameterEditWrapper( Gaffer::EditScope &scope, const ScenePlug::Scen
 GraphComponentPtr parameterEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, const IECoreScene::ShaderNetwork::Parameter &parameter )
 {
 	return const_cast<GraphComponent *>( EditScopeAlgo::parameterEditReadOnlyReason( &scope, path, attribute, parameter ) );
+}
+
+
+// Attributes
+// ==========
+
+bool hasAttributeEditWrapper( const Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	return EditScopeAlgo::hasAttributeEdit( &scope, path, attribute );
+}
+
+TweakPlugPtr acquireAttributeEditWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute, bool createIfNecessary )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::acquireAttributeEdit( &scope, path, attribute, createIfNecessary );
+}
+
+void removeAttributeEditWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::removeAttributeEdit( &scope, path, attribute );
+}
+
+GraphComponentPtr attributeEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &attribute )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::attributeEditReadOnlyReason( &scope, path, attribute ) );
 }
 
 } // namespace
@@ -182,6 +212,11 @@ void bindEditScopeAlgo()
 	def( "hasParameterEdit", &hasParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
 	def( "removeParameterEdit", &removeParameterEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
 	def( "parameterEditReadOnlyReason", &parameterEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "parameter" ) ) );
+
+	def( "acquireAttributeEdit", &acquireAttributeEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ), arg( "createIfNecessary" ) = true ) );
+	def( "hasAttributeEdit", &hasAttributeEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
+	def( "removeAttributeEdit", &removeAttributeEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
+	def( "attributeEditReadOnlyReason", &attributeEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
 
 }
 

--- a/src/GafferSceneModule/TweaksBinding.cpp
+++ b/src/GafferSceneModule/TweaksBinding.cpp
@@ -125,6 +125,7 @@ void GafferSceneModule::bindTweaks()
 			.value( "Subtract", TweakPlug::Subtract )
 			.value( "Multiply", TweakPlug::Multiply )
 			.value( "Remove", TweakPlug::Remove )
+			.value( "Create", TweakPlug::Create )
 		;
 
 		enum_<TweakPlug::MissingMode>( "MissingMode" )

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -266,6 +266,13 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 				plug->enabledPlug()->getValue()
 			)
 			{
+				/// \todo This is overly conservative. We should test to see if there is more than
+				/// one filter match (but make sure to early-out once two are found, rather than test
+				/// the rest of the scene).
+				editWarning = boost::str(
+					boost::format( "Edits to \"%s\" may affect other locations in the scene." )
+						% m_attribute.string()
+				);
 				return plug;
 			}
 		}

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -1,0 +1,377 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/AttributeInspector.h"
+
+#include "GafferScene/Attributes.h"
+#include "GafferScene/AttributeTweaks.h"
+#include "GafferScene/Camera.h"
+#include "GafferScene/EditScopeAlgo.h"
+#include "GafferScene/Light.h"
+#include "GafferScene/SceneAlgo.h"
+#include "GafferScene/SceneNode.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/NameValuePlug.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/ParallelAlgo.h"
+#include "Gaffer/ValuePlug.h"
+
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+//////////////////////////////////////////////////////////////////////////
+// History cache
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// This uses the same strategy that ValuePlug uses for the hash cache,
+// using `plug->dirtyCount()` to invalidate previous cache entries when
+// a plug is dirtied.
+struct HistoryCacheKey
+{
+	HistoryCacheKey() {};
+	HistoryCacheKey( const ValuePlug *plug )
+		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
+	{
+	}
+
+	bool operator==( const HistoryCacheKey &rhs ) const
+	{
+		return
+			plug == rhs.plug &&
+			contextHash == rhs.contextHash &&
+			dirtyCount == rhs.dirtyCount
+		;
+	}
+
+	const ValuePlug *plug;
+	IECore::MurmurHash contextHash;
+	uint64_t dirtyCount;
+};
+
+size_t hash_value( const HistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, key.plug );
+	boost::hash_combine( result, key.contextHash );
+	boost::hash_combine( result, key.dirtyCount );
+	return result;
+}
+
+using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+HistoryCache g_historyCache(
+	// Getter
+	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		return SceneAlgo::history(
+			key.plug, Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName )
+		);
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// Histories contain PlugPtrs, which could potentially be the sole
+		// owners. Destroying plugs can trigger dirty propagation, so as a
+		// precaution we destroy the history on the UI thread, where this would
+		// be OK.
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+struct AttributeHistoryCacheKey : public HistoryCacheKey
+{
+	AttributeHistoryCacheKey() {};
+	AttributeHistoryCacheKey( const ScenePlug *plug, IECore::InternedString attribute )
+		:	HistoryCacheKey( plug->attributesPlug() ), attribute( attribute )
+	{
+	}
+
+	bool operator==( const AttributeHistoryCacheKey &rhs ) const
+	{
+		return HistoryCacheKey::operator==( rhs ) && attribute == rhs.attribute;
+	}
+
+	IECore::InternedString attribute;
+};
+
+size_t hash_value( const AttributeHistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, static_cast<const HistoryCacheKey &>( key ) );
+	boost::hash_combine( result, key.attribute.c_str() );
+	return result;
+}
+
+using AttributeHistoryCache = IECorePreview::LRUCache<AttributeHistoryCacheKey, SceneAlgo::AttributeHistory::ConstPtr>;
+
+AttributeHistoryCache g_attributeHistoryCache(
+	// Getter
+	[] ( const AttributeHistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		SceneAlgo::History::ConstPtr attributesHistory = g_historyCache.get( key, canceller );
+		return SceneAlgo::attributeHistory( attributesHistory.get(), key.attribute );
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const AttributeHistoryCacheKey &key, const SceneAlgo::AttributeHistory::ConstPtr &history ) {
+		// See comment in g_historyCache
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+Gaffer::ValuePlugPtr attributePlug( const Gaffer::CompoundDataPlug *parentPlug, const std::string &attributeName )
+{
+	for( const auto &plug : Gaffer::NameValuePlug::Range( *parentPlug ) )
+	{
+		if(plug->namePlug()->getValue() == attributeName )
+		{
+			return plug;
+		}
+	}
+	return nullptr;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// AttributeInspector
+//////////////////////////////////////////////////////////////////////////
+
+AttributeInspector::AttributeInspector(
+	const GafferScene::ScenePlugPtr &scene,
+	const Gaffer::PlugPtr &editScope,
+	IECore::InternedString attribute,
+	const std::string &name,
+	const std::string &type
+) :
+Inspector( type, name == "" ? attribute.string() : name, editScope ),
+m_scene( scene ),
+m_attribute( attribute )
+{
+	m_scene->node()->plugDirtiedSignal().connect(
+		boost::bind( &AttributeInspector::plugDirtied, this, ::_1 )
+	);
+
+	Metadata::plugValueChangedSignal().connect( boost::bind( &AttributeInspector::plugMetadataChanged, this, ::_3, ::_4 ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &AttributeInspector::nodeMetadataChanged, this, ::_2, ::_3 ) );
+}
+
+GafferScene::SceneAlgo::History::ConstPtr AttributeInspector::history() const
+{
+	if( !m_scene->exists() )
+	{
+		return nullptr;
+	}
+
+	ConstCompoundObjectPtr attributes = m_scene->attributesPlug()->getValue();
+	auto m = attributes->members();
+	if( m.find( m_attribute ) == m.end() )
+	{
+		// Computing histories is expensive, and there's no point doing it
+		// if the specific attribute we want doesn't exist.
+		return nullptr;
+	}
+
+	return g_attributeHistoryCache.get( AttributeHistoryCacheKey( m_scene.get(), m_attribute ), Context::current()->canceller() );
+}
+
+IECore::ConstObjectPtr AttributeInspector::value( const GafferScene::SceneAlgo::History *history ) const
+{
+	auto attributeHistory = static_cast<const SceneAlgo::AttributeHistory *>( history );
+
+	return attributeHistory->attributeValue;
+}
+
+Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
+{
+	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );
+	if( !sceneNode || history->scene != sceneNode->outPlug() )
+	{
+		return nullptr;
+	}
+
+	if( auto light = runTimeCast<Light>( sceneNode ) )
+	{
+		return attributePlug( light->visualiserAttributesPlug(), m_attribute );
+	}
+
+	else if( auto camera = runTimeCast<GafferScene::Camera>( sceneNode ) )
+	{
+		return attributePlug( camera->visualiserAttributesPlug(), m_attribute );
+	}
+
+	else if( auto attributes = runTimeCast<GafferScene::Attributes>( sceneNode ) )
+	{
+		if( !(attributes->filterPlug()->match( attributes->inPlug() ) & PathMatcher::ExactMatch ) )
+		{
+			return nullptr;
+		}
+
+		for( const auto &plug : NameValuePlug::Range( *attributes->attributesPlug() ) )
+		{
+			if(
+				plug->namePlug()->getValue() == m_attribute.string() &&
+				plug->enabledPlug()->getValue()
+			)
+			{
+				return plug;
+			}
+		}
+	}
+
+	else if( auto attributeTweaks = runTimeCast<AttributeTweaks>( sceneNode ) )
+	{
+		if( !( attributeTweaks->filterPlug()->match( attributeTweaks->inPlug() ) & PathMatcher::ExactMatch ) )
+		{
+			return nullptr;
+		}
+
+		for( const auto &tweak : TweakPlug::Range( *attributeTweaks->tweaksPlug() ) )
+		{
+			if(
+				tweak->namePlug()->getValue() == m_attribute.string() &&
+				tweak->enabledPlug()->getValue()
+			)
+			{
+				return tweak;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+Inspector::EditFunctionOrFailure AttributeInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+{
+	auto attributeHistory = static_cast<const SceneAlgo::AttributeHistory *>( history );
+
+	const GraphComponent *readOnlyReason = EditScopeAlgo::attributeEditReadOnlyReason(
+		editScope,
+		history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ),
+		attributeHistory->attributeName
+	);
+
+	if( readOnlyReason )
+	{
+		// If we don't have an edit and the scope is locked, we error,
+		// as we can't add an edit. Other cases where we already _have_
+		// an edit will have been found by `source()`.
+		return boost::str(
+			boost::format( "%s is locked." ) % readOnlyReason->relativeName( readOnlyReason->ancestor<ScriptNode>() )
+		);
+	}
+	else
+	{
+		return [
+			editScope = EditScopePtr( editScope ),
+			attributeName = attributeHistory->attributeName,
+			context = attributeHistory->context
+		] () {
+			Context::Scope scope( context.get() );
+			return EditScopeAlgo::acquireAttributeEdit(
+				editScope.get(),
+				context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ),
+				attributeName
+			);
+		};
+	}
+}
+
+void AttributeInspector::plugDirtied( Gaffer::Plug *plug )
+{
+	if( plug == m_scene->attributesPlug() )
+	{
+		dirtiedSignal()( this );
+	}
+}
+
+void AttributeInspector::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug )
+{
+	if( !plug )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+	nodeMetadataChanged( key, plug->node() );
+}
+
+void AttributeInspector::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node )
+{
+	if( !node )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+
+	EditScope *scope = targetEditScope();
+	if( !scope )
+	{
+		return;
+	}
+
+	if(
+		MetadataAlgo::readOnlyAffectedByChange( scope, node, key ) ||
+		( MetadataAlgo::readOnlyAffectedByChange( key ) && scope->isAncestorOf( node ) )
+	)
+	{
+		// Might affect `EditScopeAlgo::attributeEditReadOnlyReason()`
+		// which we call in `editFunction()`.
+		/// \todo Can we ditch the signal processing and call `attributeEditReadOnlyReason()`
+		/// just-in-time from `editable()`? In the past that wasn't possible
+		/// because editability changed the appearance of the UI, but it isn't
+		/// doing that currently.
+		dirtiedSignal()( this );
+	}
+}

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -108,8 +108,8 @@ Gaffer::Plug *spreadsheetAwareSource( Gaffer::Plug *plug )
 // Inspector
 //////////////////////////////////////////////////////////////////////////
 
-Inspector::Inspector( const std::string &name, const Gaffer::PlugPtr &editScope )
-	:	m_name( name ), m_editScope( editScope )
+Inspector::Inspector( const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope )
+	:	m_type( type ), m_name( name ), m_editScope( editScope )
 {
 	if( editScope && editScope->node() )
 	{
@@ -117,6 +117,11 @@ Inspector::Inspector( const std::string &name, const Gaffer::PlugPtr &editScope 
 			boost::bind( &Inspector::editScopeInputChanged, this, ::_1 )
 		);
 	}
+}
+
+const std::string &Inspector::type() const
+{
+	return m_type;
 }
 
 const std::string &Inspector::name() const
@@ -236,7 +241,8 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 					const auto *downstreamEditScope = downstreamNode->ancestor<EditScope>();
 					downstreamNode = downstreamEditScope ? downstreamEditScope : downstreamNode;
 					result->m_editWarning = boost::str(
-						boost::format( "Parameter has edits downstream in %1%." )
+						boost::format( "%1% has edits downstream in %2%." )
+							% ( std::string( 1, std::toupper( type()[0] ) ) + type().substr( 1 ) )
 							% downstreamNode->relativeName( downstreamNode->scriptNode() )
 					);
 				}

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -138,10 +138,6 @@ Inspector::ResultPtr Inspector::inspect() const
 	}
 
 	ConstObjectPtr value = this->value( history.get() );
-	if( !value )
-	{
-		return nullptr;
-	}
 
 	ResultPtr result = new Result( value, targetEditScope() );
 	inspectHistoryWalk( history.get(), result.get() );
@@ -153,6 +149,13 @@ Inspector::ResultPtr Inspector::inspect() const
 				% result->editScope()->relativeName( result->editScope()->scriptNode() )
 		);
 		result->m_sourceType = Result::SourceType::Other;
+	}
+
+	if( !result->m_value && !result->editable() )
+	{
+		// The property doesn't exist, and there's no
+		// way of making it.
+		return nullptr;
 	}
 
 	return result;
@@ -329,7 +332,7 @@ Inspector::Result::SourceType Inspector::Result::sourceType() const
 
 bool Inspector::Result::editable() const
 {
-	return m_editFunction.which() == 0;
+	return m_editFunction.which() == 0 && boost::get<EditFunction>( m_editFunction ) != nullptr;
 }
 
 std::string Inspector::Result::nonEditableReason() const

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -64,6 +64,18 @@ ParameterInspector::ParameterInspector(
 
 }
 
+GafferScene::SceneAlgo::History::ConstPtr ParameterInspector::history() const
+{
+	// Computing histories is expensive, and there's no point doing it
+	// if the specific attribute we want doesn't exist.
+	if( !attributeExists() )
+	{
+		return nullptr;
+	}
+
+	return AttributeInspector::history();
+}
+
 IECore::ConstObjectPtr ParameterInspector::value( const GafferScene::SceneAlgo::History *history ) const
 {
 	auto attribute = AttributeInspector::value( history );

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -36,16 +36,14 @@
 
 #include "GafferSceneUI/Private/ParameterInspector.h"
 
+#include "GafferSceneUI/Private/AttributeInspector.h"
+
 #include "GafferScene/EditScopeAlgo.h"
 #include "GafferScene/Light.h"
 #include "GafferScene/LightFilter.h"
 #include "GafferScene/ShaderAssignment.h"
 #include "GafferScene/ShaderTweaks.h"
 
-#include "Gaffer/Metadata.h"
-#include "Gaffer/MetadataAlgo.h"
-#include "Gaffer/ParallelAlgo.h"
-#include "Gaffer/Private/IECorePreview/LRUCache.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Switch.h"
 
@@ -57,161 +55,19 @@ using namespace Gaffer;
 using namespace GafferScene;
 using namespace GafferSceneUI::Private;
 
-//////////////////////////////////////////////////////////////////////////
-// History cache
-//////////////////////////////////////////////////////////////////////////
-
-namespace
-{
-
-// This uses the same strategy that ValuePlug uses for the hash cache,
-// using `plug->dirtyCount()` to invalidate previous cache entries when
-// a plug is dirtied.
-struct HistoryCacheKey
-{
-	HistoryCacheKey() {};
-	HistoryCacheKey( const ValuePlug *plug )
-		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
-	{
-	}
-
-	bool operator==( const HistoryCacheKey &rhs ) const
-	{
-		return
-			plug == rhs.plug &&
-			contextHash == rhs.contextHash &&
-			dirtyCount == rhs.dirtyCount
-		;
-	}
-
-	const ValuePlug *plug;
-	IECore::MurmurHash contextHash;
-	uint64_t dirtyCount;
-};
-
-size_t hash_value( const HistoryCacheKey &key )
-{
-	size_t result = 0;
-	boost::hash_combine( result, key.plug );
-	boost::hash_combine( result, key.contextHash );
-	boost::hash_combine( result, key.dirtyCount );
-	return result;
-}
-
-using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
-
-HistoryCache g_historyCache(
-	// Getter
-	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
-		assert( canceller == Context::current()->canceller() );
-		cost = 1;
-		return SceneAlgo::history(
-			key.plug, Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName )
-		);
-	},
-	// Max cost
-	1000,
-	// Removal callback
-	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
-		// Histories contain PlugPtrs, which could potentially be the sole
-		// owners. Destroying plugs can trigger dirty propagation, so as a
-		// precaution we destroy the history on the UI thread, where this would
-		// be OK.
-		ParallelAlgo::callOnUIThread(
-			[history] () {}
-		);
-	}
-
-);
-
-struct AttributeHistoryCacheKey : public HistoryCacheKey
-{
-	AttributeHistoryCacheKey() {};
-	AttributeHistoryCacheKey( const ScenePlug *plug, IECore::InternedString attribute )
-		:	HistoryCacheKey( plug->attributesPlug() ), attribute( attribute )
-	{
-	}
-
-	bool operator==( const AttributeHistoryCacheKey &rhs ) const
-	{
-		return HistoryCacheKey::operator==( rhs ) && attribute == rhs.attribute;
-	}
-
-	IECore::InternedString attribute;
-};
-
-size_t hash_value( const AttributeHistoryCacheKey &key )
-{
-	size_t result = 0;
-	boost::hash_combine( result, static_cast<const HistoryCacheKey &>( key ) );
-	boost::hash_combine( result, key.attribute.c_str() );
-	return result;
-}
-
-using AttributeHistoryCache = IECorePreview::LRUCache<AttributeHistoryCacheKey, SceneAlgo::AttributeHistory::ConstPtr>;
-
-AttributeHistoryCache g_attributeHistoryCache(
-	// Getter
-	[] ( const AttributeHistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
-		assert( canceller == Context::current()->canceller() );
-		cost = 1;
-		SceneAlgo::History::ConstPtr attributesHistory = g_historyCache.get( key, canceller );
-		return SceneAlgo::attributeHistory( attributesHistory.get(), key.attribute );
-	},
-	// Max cost
-	1000,
-	// Removal callback
-	[] ( const AttributeHistoryCacheKey &key, const SceneAlgo::AttributeHistory::ConstPtr &history ) {
-		// See comment in g_historyCache
-		ParallelAlgo::callOnUIThread(
-			[history] () {}
-		);
-	}
-
-);
-
-} // namespace
-
-//////////////////////////////////////////////////////////////////////////
-// ParameterInspector
-//////////////////////////////////////////////////////////////////////////
-
 ParameterInspector::ParameterInspector(
 	const GafferScene::ScenePlugPtr &scene, const Gaffer::PlugPtr &editScope,
 	IECore::InternedString attribute, const IECoreScene::ShaderNetwork::Parameter &parameter
 )
-	: Inspector( parameter.name.string(), editScope ), m_scene( scene ), m_attribute( attribute ), m_parameter( parameter )
+	: AttributeInspector( scene, editScope, attribute, parameter.name.string(), "parameter" ), m_parameter( parameter )
 {
-	m_scene->node()->plugDirtiedSignal().connect(
-		boost::bind( &ParameterInspector::plugDirtied, this, ::_1 )
-	);
 
-	Metadata::plugValueChangedSignal().connect( boost::bind( &ParameterInspector::plugMetadataChanged, this, ::_3, ::_4 ) );
-	Metadata::nodeValueChangedSignal().connect( boost::bind( &ParameterInspector::nodeMetadataChanged, this, ::_2, ::_3 ) );
-}
-
-GafferScene::SceneAlgo::History::ConstPtr ParameterInspector::history() const
-{
-	if( !m_scene->exists() )
-	{
-		return nullptr;
-	}
-
-	ConstCompoundObjectPtr attributes = m_scene->attributesPlug()->getValue();
-	if( attributes->members().find( m_attribute ) == attributes->members().end() )
-	{
-		// Computing histories is expensive, and there's no point doing it
-		// if the specific attribute we want doesn't exist.
-		return nullptr;
-	}
-
-	return g_attributeHistoryCache.get( AttributeHistoryCacheKey( m_scene.get(), m_attribute ), Context::current()->canceller() );
 }
 
 IECore::ConstObjectPtr ParameterInspector::value( const GafferScene::SceneAlgo::History *history ) const
 {
-	auto attributeHistory = static_cast<const SceneAlgo::AttributeHistory *>( history );
-	auto shaderNetwork = runTimeCast<const ShaderNetwork>( attributeHistory->attributeValue.get() );
+	auto attribute = AttributeInspector::value( history );
+	auto shaderNetwork = runTimeCast<const ShaderNetwork>( attribute.get() );
 	if( !shaderNetwork )
 	{
 		return nullptr;
@@ -329,52 +185,5 @@ Inspector::EditFunctionOrFailure ParameterInspector::editFunction( Gaffer::EditS
 					parameter
 				);
 		};
-	}
-}
-
-void ParameterInspector::plugDirtied( Gaffer::Plug *plug )
-{
-	if( plug == m_scene->attributesPlug() )
-	{
-		dirtiedSignal()( this );
-	}
-}
-
-void ParameterInspector::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug )
-{
-	if( !plug )
-	{
-		// Assume readOnly metadata is only registered on instances.
-		return;
-	}
-	nodeMetadataChanged( key, plug->node() );
-}
-
-void ParameterInspector::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node )
-{
-	if( !node )
-	{
-		// Assume readOnly metadata is only registered on instances.
-		return;
-	}
-
-	EditScope *scope = targetEditScope();
-	if( !scope )
-	{
-		return;
-	}
-
-	if(
-		MetadataAlgo::readOnlyAffectedByChange( scope, node, key ) ||
-		( MetadataAlgo::readOnlyAffectedByChange( key ) && scope->isAncestorOf( node ) )
-	)
-	{
-		// Might affect `EditScopeAlgo::parameterEditReadOnlyReason()`
-		// which we call in `editFunction()`.
-		/// \todo Can we ditch the signal processing and call `parameterEditReadOnlyReason()`
-		/// just-in-time from `editable()`? In the past that wasn't possible
-		/// because editability changed the appearance of the UI, but it isn't
-		/// doing that currently.
-		dirtiedSignal()( this );
 	}
 }

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -39,6 +39,7 @@
 #include "InspectorBinding.h"
 
 #include "GafferSceneUI/Private/Inspector.h"
+#include "GafferSceneUI/Private/AttributeInspector.h"
 #include "GafferSceneUI/Private/ParameterInspector.h"
 
 #include "GafferBindings/SignalBinding.h"
@@ -131,6 +132,14 @@ void GafferSceneUIModule::bindInspector()
 		.def(
 			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString, const ShaderNetwork::Parameter &>(
 				( arg( "scene" ), arg( "attribute" ), arg( "parameter" ) )
+			)
+		)
+	;
+
+	RefCountedClass<AttributeInspector, Inspector>( "AttributeInspector" )
+		.def(
+			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString, const std::string &>(
+				( arg( "scene" ), arg( "editScope" ), arg( "attribute" ), arg( "name" ) = "" )
 			)
 		)
 	;

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -149,8 +149,8 @@ class InspectorColumn : public PathColumn
 
 		IE_CORE_DECLAREMEMBERPTR( InspectorColumn )
 
-		InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector )
-			:	m_inspector( inspector ), m_headerValue( headerValue( inspector->name() ) )
+		InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector, const std::string &columnName )
+			:	m_inspector( inspector ), m_headerValue( headerValue( columnName != "" ? columnName : inspector->name() ) )
 		{
 			m_inspector->dirtiedSignal().connect( boost::bind( &InspectorColumn::inspectorDirtied, this ) );
 		}
@@ -235,7 +235,12 @@ void GafferSceneUIModule::bindLightEditor()
 	;
 
 	IECorePython::RefCountedClass<InspectorColumn, GafferUI::PathColumn>( "_LightEditorInspectorColumn" )
-		.def( init<GafferSceneUI::Private::InspectorPtr>() )
+		.def( init<GafferSceneUI::Private::InspectorPtr, const std::string &>(
+			(
+				arg_( "inspector" ),
+				arg_( "columName" ) = ""
+			)
+		) )
 		.def( "inspector", &InspectorColumn::inspector, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 	;
 

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -42,6 +42,9 @@ import GafferSceneUI
 
 if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
+	# Register Light Editor sections for Appleseed before the generic "Visualisation" section
+	import GafferAppleseedUI
+
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Appleseed", "as:light" )
 	# Default to showing Appleseed lights, since that is the renderer we ship with.
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "as:light" )
@@ -75,7 +78,19 @@ with IECore.IgnoredExceptions( ImportError ) :
 with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
+	# Register Light Editor sections for Arnold before the generic "Visualisation" section
+	import GafferArnoldUI
 
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Arnold", "ai:light" )
 	# If Arnold is available, then assume it is the renderer of choice.
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "ai:light" )
+
+# Register generic light attributes
+for attributeName in [
+	"gl:visualiser:scale",
+	"gl:visualiser:maxTextureResolution",
+	"gl:visualiser:frustum",
+	"gl:light:frustumScale",
+	"gl:light:drawingMode",
+] :
+	GafferSceneUI.LightEditor.registerAttribute( "*", attributeName, "Visualisation" )


### PR DESCRIPTION
This adds the ability to edit visualisation attributes of lights in the Light Editor.

There are a couple of outstanding issues I know of at the moment that need to be addressed :

1. The "Visualisation" tab in the light editor shows up first, which is not ideal. I believe that's because it is registered before Arnold and Appleseed register their columns, but I'm not sure what the best way to move it to the right side of the list is.
2. When editing an attribute in the Light Editor (via double clicking the value) and while using an Edit Scope, the tweak `mode` presets don't know about `Create`. A way of getting that preset added is needed.

### Breaking changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
