### PR TITLE
Gaffer : Expose GafferSceneUI::SelectionTool::sceneGadget() function

### DIFF
--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -60,11 +60,14 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::SelectionTool, SelectionToolTypeId, GafferUI::Tool );
 
+	protected :
+
+		SceneGadget *sceneGadget();
+		const SceneGadget *sceneGadget() const;
+
 	private :
 
 		static ToolDescription<SelectionTool, SceneView> g_toolDescription;
-
-		SceneGadget *sceneGadget();
 
 		class DragOverlay;
 		DragOverlay *dragOverlay();

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -175,7 +175,13 @@ SelectionTool::~SelectionTool()
 
 SceneGadget *SelectionTool::sceneGadget()
 {
-	return runTimeCast<SceneGadget>( view()->viewportGadget()->getPrimaryChild() );
+	return const_cast<SceneGadget *>(
+		static_cast<const SelectionTool *>( this )->sceneGadget() );
+}
+
+const SceneGadget *SelectionTool::sceneGadget() const
+{
+	return runTimeCast<SceneGadget const>( view()->viewportGadget()->getPrimaryChild() );
 }
 
 SelectionTool::DragOverlay *SelectionTool::dragOverlay()

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -1017,8 +1017,7 @@ void TransformTool::plugDirtied( const Gaffer::Plug *plug )
 		{
 			m_preRenderConnection.disconnect();
 			m_handles->setVisible( false );
-			SceneGadget *sceneGadget = static_cast<SceneGadget *>( view()->viewportGadget()->getPrimaryChild() );
-			sceneGadget->setPriorityPaths( IECore::PathMatcher() );
+			sceneGadget()->setPriorityPaths( IECore::PathMatcher() );
 		}
 	}
 }
@@ -1192,14 +1191,14 @@ void TransformTool::preRender()
 		if( m_priorityPathsDirty )
 		{
 			m_priorityPathsDirty = false;
-			SceneGadget *sceneGadget = static_cast<SceneGadget *>( view()->viewportGadget()->getPrimaryChild() );
+			SceneGadget *sg = sceneGadget();
 			if( selection().size() )
 			{
-				sceneGadget->setPriorityPaths( ContextAlgo::getSelectedPaths( view()->getContext() ) );
+				sg->setPriorityPaths( ContextAlgo::getSelectedPaths( view()->getContext() ) );
 			}
 			else
 			{
-				sceneGadget->setPriorityPaths( IECore::PathMatcher() );
+				sg->setPriorityPaths( IECore::PathMatcher() );
 			}
 		}
 	}


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Accesssing the SceneGadget is a common requirement in derived Tool classes so making the `SelectionTool::sceneGadget` function `protected` instead of `private` will avoid duplicated code in derived Tool class implementations. I don't think this change breaks ABI but I may be wrong.

### Related issues ###

None

### Dependencies ###

None

### Breaking changes ###

None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
