### PR TITLE
IECoreGL Renderer : Respect primitive drawing options during selection

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.x.x (relative to 0.61.13.0)
+========
+
+Fixes
+-----
+
+- SelectionTool : Fixed bug where the drawing mode overrides (Wireframe, Solid and Points) were ignored when selecting objects. This could cause a wireframe (or invisible) object to be selected instead of the visible object behind it.
+
 0.61.13.0 (relative to 0.61.12.0)
 =========
 

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -911,6 +911,10 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 					/// \todo Change IECoreGL::Selector so it provides a partial state object
 					/// containing only the things it needs to change.
 					IECoreGL::StatePtr shapeState = new IECoreGL::State( /* complete = */ false );
+					shapeState->add( state->get<IECoreGL::Primitive::DrawWireframe>() );
+					shapeState->add( state->get<IECoreGL::Primitive::DrawSolid>() );
+					shapeState->add( state->get<IECoreGL::Primitive::DrawOutline>() );
+					shapeState->add( state->get<IECoreGL::Primitive::DrawPoints>() );
 					shapeState->add( state->get<IECoreGL::PointsPrimitive::UseGLPoints>() );
 					shapeState->add( state->get<IECoreGL::PointsPrimitive::GLPointWidth>() );
 					shapeState->add( state->get<IECoreGL::CurvesPrimitive::UseGLLines>() );


### PR DESCRIPTION
We were doing selection drawing using the default solid mode, due to unwanted overrides made by the `IECoreGL::Selector::baseState()`. This meant that `SceneGadget::objectAt()` could return a closer object than the visible one, which in turn caused unwanted selections in the SelectionTool.

This can be tested using the script below. View the group, expand all, turn off Solid drawing mode in the viewer, and then click to select the cube. The sphere was getting selected instead!

![image](https://user-images.githubusercontent.com/1133871/174781717-397adfcc-447c-4c40-b8de-1d0242cccbe6.png)

<details>

```
import Gaffer
import GafferImage
import GafferScene
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 61, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 13, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
parent.addChild( __children["defaultFormat"] )
__children["Sphere"] = GafferScene.Sphere( "Sphere" )
parent.addChild( __children["Sphere"] )
__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Cube"] = GafferScene.Cube( "Cube" )
parent.addChild( __children["Cube"] )
__children["Cube"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"] = GafferScene.Group( "Group" )
parent.addChild( __children["Group"] )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["OpenGLAttributes"] = GafferScene.OpenGLAttributes( "OpenGLAttributes" )
parent.addChild( __children["OpenGLAttributes"] )
__children["OpenGLAttributes"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
parent["variables"]["imageCataloguePort"]["value"].setValue( 44588 )
Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
__children["Sphere"]["__uiPosition"].setValue( imath.V2f( 4.5998745, 5.45112467 ) )
__children["Cube"]["__uiPosition"].setValue( imath.V2f( -8.4001255, 5.44943857 ) )
__children["Group"]["in"][0].setInput( __children["OpenGLAttributes"]["out"] )
__children["Group"]["in"][1].setInput( __children["Sphere"]["out"] )
__children["Group"]["__uiPosition"].setValue( imath.V2f( -0.600125551, -12.7810631 ) )
__children["OpenGLAttributes"]["in"].setInput( __children["Cube"]["out"] )
__children["OpenGLAttributes"]["attributes"]["primitiveSolid"]["enabled"].setValue( True )
__children["OpenGLAttributes"]["attributes"]["primitiveWireframe"]["value"].setValue( False )
__children["OpenGLAttributes"]["attributes"]["primitiveWireframe"]["enabled"].setValue( True )
__children["OpenGLAttributes"]["__uiPosition"].setValue( imath.V2f( -8.4001255, -2.71462393 ) )


del __children

```
</details>