### PR TITLE
Arnold Renderer : Handle cancellation of procedural expansion

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ Fixes
   - Fixed loss of selection when switching from OpenGL to Arnold renderer. [^1]
   - Fixed `cannot declare constant UINT cortex:id` errors. [^1]
   - Fixed crashes when edits made by the TransformTools affected additional objects in the scene (either through constraints or edits to an ancestor of the selection). [^1]
+  - Fixed crashes when making interactive edits to the contents of capsules. [^1]
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
 - Viewer :
   - Fixed loss of selection when switching from OpenGL to Arnold renderer. [^1]
   - Fixed `cannot declare constant UINT cortex:id` errors. [^1]
+  - Fixed crashes when edits made by the TransformTools affected additional objects in the scene (either through constraints or edits to an ancestor of the selection). [^1]
 
 API
 ---

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3087,6 +3087,74 @@ class RendererTest( GafferTest.TestCase ) :
 			color = imath.Color3f( image["R"][centreIndex], image["G"][centreIndex], image["B"][centreIndex] )
 			self.assertEqual( color, imath.Color3f( 1 ) )
 
+	def testProceduralCancellation( self ) :
+
+		class CancellingProcedural( GafferScene.Private.IECoreScenePreview.Procedural ) :
+
+			def __init__( self, cancel ) :
+
+				GafferScene.Private.IECoreScenePreview.Procedural.__init__( self )
+
+				self.__cancel = cancel
+
+			def render( self, renderer ) :
+
+				renderer.object(
+					"/sphere1",
+					IECoreScene.SpherePrimitive( 1 ),
+					renderer.attributes( IECore.CompoundObject() ),
+				)
+
+				if self.__cancel :
+					raise IECore.Cancelled()
+
+				renderer.object(
+					"/sphere2",
+					IECoreScene.SpherePrimitive( 1 ),
+					renderer.attributes( IECore.CompoundObject() ),
+				)
+
+		IECore.registerRunTimeTyped( CancellingProcedural )
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		# Render a procedural that will throw part-way through expansion.
+		# We expect everything to be cleaned up so that there are no stray
+		# shape nodes in the scene.
+
+		with self.assertRaises( IECore.Cancelled ) :
+			renderer.object(
+				"/procedural",
+				CancellingProcedural( cancel = True ),
+				renderer.attributes( IECore.CompoundObject() )
+			)
+
+		universe = ctypes.cast( renderer.command( "ai:queryUniverse", {} ), ctypes.POINTER( arnold.AtUniverse ) )
+		self.assertEqual( self.__allNodes( universe, type = arnold.AI_NODE_SHAPE ), [] )
+
+		# Render the same procedural without throwing. We expect two shapes
+		# now - one for the procedural and one for the `ginstance`. The sphere
+		# nodes are children of the procedural and there doesn't appear to be
+		# any Arnold API to query them.
+
+		o = renderer.object(
+			"/procedural",
+			CancellingProcedural( cancel = False ),
+			renderer.attributes( IECore.CompoundObject() )
+		)
+
+		self.assertEqual( len( self.__allNodes( universe, type = arnold.AI_NODE_SHAPE ) ), 2 )
+
+		instance = arnold.AiNodeLookUpByName( universe, "/procedural" )
+		self.assertTrue( arnold.AiNodeIs( instance, "ginstance" ) )
+		procedural = arnold.AiNodeGetPtr( instance, "node" )
+		self.assertTrue( arnold.AiNodeIs( procedural, "procedural" ) )
+
+		del o
+
 	@staticmethod
 	def __aovShaders( universe ) :
 

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -224,30 +224,40 @@ class ProceduralWrapper : public IECorePython::RunTimeTypedWrapper<IECoreScenePr
 		Imath::Box3f bound() const final
 		{
 			IECorePython::ScopedGILLock gilLock;
-			boost::python::object f = this->methodOverride( "bound" );
-			if( f )
+			try
 			{
-				return extract<Imath::Box3f>( f() );
+				boost::python::object f = this->methodOverride( "bound" );
+				if( f )
+				{
+					return extract<Imath::Box3f>( f() );
+				}
 			}
-			else
+			catch( const boost::python::error_already_set &e )
 			{
-				throw IECore::Exception( "No bound method defined" );
+				IECorePython::ExceptionAlgo::translatePythonException();
 			}
+
+			throw IECore::Exception( "No bound method defined" );
 		}
 
 		void render( IECoreScenePreview::Renderer *renderer ) const final
 		{
 			IECorePython::ScopedGILLock gilLock;
-			boost::python::object f = this->methodOverride( "render" );
-			if( f )
+			try
 			{
-				f( IECoreScenePreview::RendererPtr( renderer ) );
-				return;
+				boost::python::object f = this->methodOverride( "render" );
+				if( f )
+				{
+					f( IECoreScenePreview::RendererPtr( renderer ) );
+					return;
+				}
 			}
-			else
+			catch( const boost::python::error_already_set &e )
 			{
-				throw IECore::Exception( "No render method defined" );
+				IECorePython::ExceptionAlgo::translatePythonException();
 			}
+
+			throw IECore::Exception( "No render method defined" );
 		}
 
 };

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2019,7 +2019,18 @@ class InstanceCache : public IECore::RefCounted
 				Cache::accessor writeAccessor;
 				if( m_cache.insert( writeAccessor, h ) )
 				{
-					writeAccessor->second = convert( object, arnoldAttributes, "instance:" + h.toString() );
+					try
+					{
+						writeAccessor->second = convert( object, arnoldAttributes, "instance:" + h.toString() );
+					}
+					catch( const IECore::Cancelled & )
+					{
+						// Procedural expansion was cancelled. Erase `nullptr`
+						// result from the cache so that we redo the expansion
+						// if given the same procedural another time.
+						m_cache.erase( writeAccessor );
+						throw;
+					}
 				}
 				node = writeAccessor->second;
 				writeAccessor.release();
@@ -2060,7 +2071,14 @@ class InstanceCache : public IECore::RefCounted
 				Cache::accessor writeAccessor;
 				if( m_cache.insert( writeAccessor, h ) )
 				{
-					writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString() );
+					try
+					{
+						writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString() );
+					}
+					catch( const IECore::Cancelled & )
+					{
+						m_cache.erase( writeAccessor );
+					}
 				}
 				node = writeAccessor->second;
 				writeAccessor.release();
@@ -2941,11 +2959,17 @@ int procFunc( AtProceduralNodeMethods *methods )
 
 AtNode *convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, const ArnoldAttributes *attributes, AtUniverse *universe, const std::string &nodeName, AtNode *parentNode )
 {
-	AtNode *node = AiNode( universe, g_proceduralArnoldString, AtString( nodeName.c_str() ), parentNode );
+	// Hold via unique_pointer so that we destroy the node if
+	// `procedural->render()` throws.
+	using UniqueAtNodePtr = std::unique_ptr<AtNode, NodeDeleter>;
+	UniqueAtNodePtr node(
+		AiNode( universe, g_proceduralArnoldString, AtString( nodeName.c_str() ), parentNode ),
+		AiNodeDestroy
+	);
 
-	AiNodeSetPtr( node, g_funcPtrArnoldString, (void *)procFunc );
+	AiNodeSetPtr( node.get(), g_funcPtrArnoldString, (void *)procFunc );
 
-	ProceduralRendererPtr renderer = new ProceduralRenderer( node, attributes->allAttributes() );
+	ProceduralRendererPtr renderer = new ProceduralRenderer( node.get(), attributes->allAttributes() );
 	tbb::this_task_arena::isolate(
 		// Isolate in case procedural spawns TBB tasks, because
 		// `convertProcedural()` is called behind a lock in
@@ -2957,9 +2981,9 @@ AtNode *convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, co
 
 	ProceduralData *data = new ProceduralData;
 	renderer->nodesCreated( data->nodesCreated );
-	AiNodeSetPtr( node, g_userPtrArnoldString, data );
+	AiNodeSetPtr( node.get(), g_userPtrArnoldString, data );
 
-	return node;
+	return node.release();
 }
 
 bool isConvertedProcedural( const AtNode *node )


### PR DESCRIPTION
This is necessary now scene translation is being performed in the background by the raytraced viewport. 