### PR TITLE
lightEditor : Ignore Appleseed import errors

### DIFF
--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -42,12 +42,14 @@ import GafferSceneUI
 
 if os.environ.get( "GAFFERAPPLESEED_HIDE_UI", "" ) != "1" :
 
-	# Register Light Editor sections for Appleseed before the generic "Visualisation" section
-	import GafferAppleseedUI
+	with IECore.IgnoredExceptions( ImportError ) :
 
-	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Appleseed", "as:light" )
-	# Default to showing Appleseed lights, since that is the renderer we ship with.
-	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "as:light" )
+		# Register Light Editor sections for Appleseed before the generic "Visualisation" section
+		import GafferAppleseedUI
+
+		Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Appleseed", "as:light" )
+		# Default to showing Appleseed lights, since that is the renderer we ship with.
+		Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "as:light" )
 
 with IECore.IgnoredExceptions( ImportError ) :
 


### PR DESCRIPTION
We were seeing this type of error when launching gaffer 0.61.13.0 at IE:

```
ERROR : IECore.loadConfig : Error executing file "/home/ivani/apps/gaffer/0.61.13.0dev/cent7.x86_64/cortex/10.3/gaffer/py2/startup/gui/lightEditor.py" - "libappleseed.so: cannot open shared object file: No such file or directory".
 Traceback (most recent call last):
  File "/software/apps/cortex/10.3.6.1/cent7.x86_64/base/python/2.7/gcc/6.3.1/IECore/ConfigLoader.py", line 79, in loadConfig
    fileContextDict, fileContextDict
  File "/software/apps/six/1.16.0/six.py", line 735, in exec_
    exec("""exec _code_ in _globs_, _locs_""")
  File "<string>", line 1, in <module>
  File "/home/ivani/apps/gaffer/0.61.13.0dev/cent7.x86_64/cortex/10.3/gaffer/py2/startup/gui/lightEditor.py", line 46, in <module>
    import GafferAppleseedUI
  File "/home/ivani/apps/gaffer/0.61.13.0dev/cent7.x86_64/cortex/10.3/gaffer/py2/python/GafferAppleseedUI/__init__.py", line 37, in <module>
    from . import AppleseedAttributesUI
  File "/home/ivani/apps/gaffer/0.61.13.0dev/cent7.x86_64/cortex/10.3/gaffer/py2/python/GafferAppleseedUI/AppleseedAttributesUI.py", line 41, in <module>
    import GafferAppleseed
  File "/home/ivani/apps/gaffer/0.61.13.0dev/cent7.x86_64/cortex/10.3/gaffer/py2/python/GafferAppleseed/__init__.py", line 39, in <module>
    from ._GafferAppleseed import *
ImportError: libappleseed.so: cannot open shared object file: No such file or directory
```

I noticed that there was an option to hide the GafferAppleseed UI, but it seemed to me that ignoring import exceptions, like all the other renderer-specific code in that file, was a better solution.

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
