### PR TITLE
ValuePlug : Fix subtle cache key problem

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,12 @@ Fixes
 -----
 
 - SelectionTool : Fixed bug where the drawing mode overrides (Wireframe, Solid and Points) were ignored when selecting objects. This could cause a wireframe (or invisible) object to be selected instead of the visible object behind it.
+- StringPlug : Fixed crashes caused by incoming connections from StringVectorDataPlugs.
+
+API
+---
+
+- StringPlug : Deprecated `precomputedHash` argument to `getValue()` method.
 
 0.61.13.0 (relative to 0.61.12.0)
 =========

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -109,9 +109,9 @@ class GAFFER_API StringPlug : public ValuePlug
 
 		/// \undoable
 		void setValue( const std::string &value );
-		/// Returns the value. See comments in TypedObjectPlug::getValue()
-		/// for details of the optional precomputedHash argument - and use
-		/// with care!
+		/// Returns the value. The `precomputedHash` argument is deprecated, and
+		/// will be removed in a future release.
+		/// \todo Remove `precomputedHash` argument.
 		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
 		void setFrom( const ValuePlug *other ) override;

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -248,8 +248,11 @@ class GAFFER_API ValuePlug : public Plug
 		/// and then have been immediately removed by another thread.
 		///
 		/// If a precomputed hash is available it may be passed to avoid computing
-		/// it again unnecessarily. Passing an incorrect hash has dire consequences, so
-		/// use with care.
+		/// it again unnecessarily.
+		///
+		/// > Caution : Passing an incorrect `precomputedHash` has dire consequences,
+		/// so use with care. The hash must be the direct result of `ValuePlug::hash()`,
+		/// so this feature is not suitable for use in classes that override that method.
 		template<typename T = IECore::Object>
 		boost::intrusive_ptr<const T> getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		/// Should be called by derived classes when they wish to set the plug

--- a/python/GafferSceneTest/SetTest.py
+++ b/python/GafferSceneTest/SetTest.py
@@ -446,7 +446,6 @@ class SetTest( GafferSceneTest.SceneTestCase ) :
 		setNode = GafferScene.Set()
 		setNode["in"].setInput( group["out"] )
 		setNode["filter"].setInput( pathFilter["out"] )
-		setNode["name"].setValue( "round square" )
 		setNode["setVariable"].setValue( "set" )
 
 		spreadsheet = Gaffer.Spreadsheet()
@@ -458,6 +457,7 @@ class SetTest( GafferSceneTest.SceneTestCase ) :
 		spreadsheet["rows"][2]["name"].setValue( "square" )
 		spreadsheet["rows"][2]["cells"]["paths"]["value"].setValue( IECore.StringVectorData( [ "/group/cube" ] ) )
 
+		setNode["name"].setInput( spreadsheet["enabledRowNames"] )
 		pathFilter["paths"].setInput( spreadsheet["out"]["paths"] )
 
 		self.assertEqual( { str( x ) for x in setNode["out"].setNames() }, { "round", "square" } )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -511,7 +511,13 @@ struct ComputeProcessKey
 	{
 		if( m_hash == g_nullHash )
 		{
-			m_hash = plug->hash();
+			// Note : We call `plug->ValuePlug::hash()` rather than
+			// `plug->hash()` because we only want to represent the result of
+			// the private `getValueInternal()` method. Overrides such as
+			// `StringPlug::hash()` account for additional processing (such as
+			// substitutions) performed in public `getValue()` methods _after_
+			// calling `getValueInternal()`.
+			m_hash = plug->ValuePlug::hash();
 		}
 		return m_hash;
 	}


### PR DESCRIPTION
This fixes a crash introduced by the StringVectorDataPlug->StringPlug connections added in 2e22984398c643ceeead771790a8ad09650f9670. The crashes were the result of infinite recursion between `StringPlug::hash()` and `StringPlug::getObjectValue()`. This is exposed initially by the addition of a StringVectorDataPlug->StringPlug connection in `SetTest.testSetVariable()`, which is where I encountered the problem in the real world.

The underlying issue is that we have been using `ValuePlug::hash()` for two subtley different purposes :

- In ComputeProcessKey, as a key into the cache where we store `IECore::Object` values for plugs.
- In the public API as a hash representing the result of `ValuePlug::getValue()` calls.

For most plugs, these two things are one and the same, because `getValue()` returns an object from the cache directly and the default `ValuePlug::hash()` is sufficient for both. But for StringPlugs, they are different, because `StringPlug::getValue()` performs additional context-based substitutions on top of the cached value. Therefore `StringPlug::hash()` overrides `ValuePlug::hash()` to provide a hash that exactly corresponds to the subsituted value.

Where the StringVectorDataPlug->StringPlug connections come in is that `ValuePlug::hash()` has dedicated logic to account for the conversion :

```
// Get the hash from
// the input and add a little extra something to represent the
// conversion that m_resultPlug->setFrom( input ) will perform,
// to break apart the cache entries.
IECore::MurmurHash h = input->hash();
h.append( input->typeId() );
h.append( plug->typeId() );
return h;
```

This is the cache key we want to store the result of the conversion in the cache. But the `StringPlug::hash()` override skips all of that logic, and instead calls `getObjectValue()`. In turn, `getObjectValue()` tried to retrieve the value from the cache, which meant computing the cache key, which meant calling `StringPlug::hash()`. Which caused infinite recursion and a crash.

This is fixed by recognising that `StringPlug::hash()` is _not_ the appropriate cache key and using the base `ValuePlug::hash()` instead. In future we should perhaps consider changes to the API so that the two concepts are explicitly separated, but it's not immediately clear how, and that would be a breaking change anyway.

I've also deprecated the `precomputedHash` argument to `StringPlug::getValue()`, because it's far too much to expect client code to understand this subtley and to pass the right flavour of hash. In practice, this isn't used anyway so will easily removed in future.

The final detail is why `StringPlugTest.testStringVectorDataInput()` didn't catch this problem in the first place. The reason is that the cache policy for the conversion is chosen by calling `ComputeNode::computeCachePolicy()`, and because there was no ComputeNode in the test, we fell back to using an uncached conversion, where the hash is never needed. Perhaps there is some debate to be had about whether we ever want to cache conversions, but I want to get the existing behaviour _correct_ before considering changes that need measuring for performance.
