### PR TITLE
AttributeInspector : Guard against testing for existence of an attribute on a non-existent scene location.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - SelectionTool : Fixed bug where the drawing mode overrides (Wireframe, Solid and Points) were ignored when selecting objects. This could cause a wireframe (or invisible) object to be selected instead of the visible object behind it.
+- AttributeInspector : Fixed bug where a non-existent child scene location's parameters were being inspected. This fixes `Error on out.attributes : Invalid child name...` resulting from the `SceneViewInspector` attempting to inspect a location that no longer exists, for example during focus changes.
 
 0.61.13.0 (relative to 0.61.12.0)
 =========

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -550,6 +550,11 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		light = GafferSceneTest.TestLight()
 		self.assertIsNone( self.__inspect( light["out"], "/nothingHere", "exposure" ) )
 
+		group = GafferScene.Group()
+		group["in"][0].setInput( light["out"] )
+
+		self.assertIsNone( self.__inspect( group["out"], "/group/nothingHere", "exposure" ) )
+
 	def testNonExistentAttribute( self ) :
 
 		light = GafferSceneTest.TestLight()

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -220,7 +220,7 @@ m_attribute( attribute )
 
 GafferScene::SceneAlgo::History::ConstPtr AttributeInspector::history() const
 {
-	if( !m_scene->exists() )
+	if( !m_scene->existsPlug()->getValue() )
 	{
 		return nullptr;
 	}
@@ -400,7 +400,6 @@ bool AttributeInspector::attributeExists() const
 	}
 
 	ConstCompoundObjectPtr attributes = m_scene->attributesPlug()->getValue();
-	auto m = attributes->members();
-	return m.find( m_attribute ) != m.end();
+	return attributes->member<Object>( m_attribute );
 
 }

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -394,6 +394,11 @@ void AttributeInspector::nodeMetadataChanged( IECore::InternedString key, const 
 bool AttributeInspector::attributeExists() const
 {
 
+	if( !m_scene->existsPlug()->getValue() )
+	{
+		return false;
+	}
+
 	ConstCompoundObjectPtr attributes = m_scene->attributesPlug()->getValue();
 	auto m = attributes->members();
 	return m.find( m_attribute ) != m.end();


### PR DESCRIPTION
This fixes an error that could come up, possibly often, when testing for existence of an attribute from a `ParameterInspector`. The bug was introduced in 6716fc3f21c3cfd01c59f3fb731cdfebbe34af65.

The reproduction steps with the script below illustrates the error :

1. Focus on the group below the cube.
2. Expand the group to show the cube location.
3. Select the cube location.
4. Switch focus to the group below the sphere node.

🚨 `Error on out.attributes : Invalid child name "cube"`

It seems that at some point in the focus change to the sphere group, `ParameterInspector::history()` is being called, looking for the old cube's history.

Here's a stack trace up to the point where it disappears in Boost and Python :

```
libGafferSceneUI.so!GafferSceneUI::Private::AttributeInspector::attributeExists(const GafferSceneUI::Private::AttributeInspector * const this) (/home/HYPOTHETICAL/eric/wkspaces/gaffer/src/GafferSceneUI/AttributeInspector.cpp:399)
libGafferSceneUI.so!GafferSceneUI::Private::ParameterInspector::history(const GafferSceneUI::Private::ParameterInspector * const this) (/home/HYPOTHETICAL/eric/wkspaces/gaffer/src/GafferSceneUI/ParameterInspector.cpp:71)
libGafferSceneUI.so!GafferSceneUI::Private::Inspector::inspect(const GafferSceneUI::Private::Inspector * const this) (/home/HYPOTHETICAL/eric/wkspaces/gaffer/src/GafferSceneUI/Inspector.cpp:134)
_GafferSceneUI.so!(anonymous namespace)::inspectWrapper(const GafferSceneUI::Private::Inspector & inspector) (/home/HYPOTHETICAL/eric/wkspaces/gaffer/src/GafferSceneUIModule/InspectorBinding.cpp:64)
_GafferSceneUI.so!boost::python::detail::invoke<boost::python::to_python_value<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> const&>, boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*)(GafferSceneUI::Private::Inspector const&), boost::python::arg_from_python<GafferSceneUI::Private::Inspector const&> >(const boost::python::to_python_value<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> const&> & rc, boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*&)(const GafferSceneUI::Private::Inspector &) f, boost::python::arg_from_python<GafferSceneUI::Private::Inspector const&> & ac0) (/home/HYPOTHETICAL/eric/build/gaffer-0.61/include/boost/python/detail/invoke.hpp:73)
_GafferSceneUI.so!boost::python::detail::caller_arity<1u>::impl<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*)(GafferSceneUI::Private::Inspector const&), boost::python::default_call_policies, boost::mpl::vector2<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result>, GafferSceneUI::Private::Inspector const&> >::operator()(boost::python::detail::caller_arity<1>::impl<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*)(GafferSceneUI::Private::Inspector const&), boost::python::default_call_policies, boost::mpl::vector2<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result>, GafferSceneUI::Private::Inspector const&> > * const this, PyObject * args_) (/home/HYPOTHETICAL/eric/build/gaffer-0.61/include/boost/python/detail/caller.hpp:216)
_GafferSceneUI.so!boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*)(GafferSceneUI::Private::Inspector const&), boost::python::default_call_policies, boost::mpl::vector2<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result>, GafferSceneUI::Private::Inspector const&> > >::operator()(boost::python::objects::caller_py_function_impl<boost::python::detail::caller<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result> (*)(GafferSceneUI::Private::Inspector const&), boost::python::default_call_policies, boost::mpl::vector2<boost::intrusive_ptr<GafferSceneUI::Private::Inspector::Result>, GafferSceneUI::Private::Inspector const&> > > * const this, PyObject * args, PyObject * kw) (/home/HYPOTHETICAL/eric/build/gaffer-0.61/include/boost/python/object/py_function.hpp:38)

```

<details>

```
import Gaffer
import GafferScene
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 62, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Cube"] = GafferScene.Cube( "Cube" )
parent.addChild( __children["Cube"] )
__children["Cube"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Sphere"] = GafferScene.Sphere( "Sphere" )
parent.addChild( __children["Sphere"] )
__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"] = GafferScene.Group( "Group" )
parent.addChild( __children["Group"] )
__children["Group"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"] = GafferScene.Group( "Group1" )
parent.addChild( __children["Group1"] )
__children["Group1"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Group1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Cube"]["__uiPosition"].setValue( imath.V2f( -2.75000024, 3.14999986 ) )
__children["Sphere"]["__uiPosition"].setValue( imath.V2f( 10.25, 3.15000057 ) )
__children["Group"]["in"][0].setInput( __children["Cube"]["out"] )
__children["Group"]["name"].setValue( 'cubeg' )
__children["Group"]["__uiPosition"].setValue( imath.V2f( -1.25000024, -5.01406288 ) )
__children["Group1"]["in"][0].setInput( __children["Sphere"]["out"] )
__children["Group1"]["name"].setValue( 'sphereg' )
__children["Group1"]["__uiPosition"].setValue( imath.V2f( 11.7508364, -5.01406193 ) )


del __children
```
</details>

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
