### PR TITLE
SceneGadget : Fix error handling bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ Fixes
   - Fixed `cannot declare constant UINT cortex:id` errors. [^1]
   - Fixed crashes when edits made by the TransformTools affected additional objects in the scene (either through constraints or edits to an ancestor of the selection). [^1]
   - Fixed crashes when making interactive edits to the contents of capsules. [^1]
+  - Fixed bug which prevented the viewer from updating after an error had occurred, even when the error was subsequently fixed in the node graph. [^1]
 
 API
 ---

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -754,17 +754,17 @@ void SceneGadget::renderLayer( Layer layer, const GafferUI::Style *style, Render
 		return;
 	}
 
-	if( m_updateErrored )
-	{
-		return;
-	}
-
 	if( isSelectionRender( reason ) )
 	{
 		return;
 	}
 
 	const_cast<SceneGadget *>( this )->updateRenderer();
+	if( m_updateErrored )
+	{
+		return;
+	}
+
 	if( m_outputBuffer )
 	{
 		m_outputBuffer->render();


### PR DESCRIPTION
The `m_updateErrored` flag tells us if the previous render controller update ended in error. It is needed so we can avoid displaying partial results from the OutputBuffer and the GL Renderer's scene graph. It is _not_ a flag that tells us we shouldn't try to update again - whether or not we need to update is determined entirely by `RenderController::updateRequired()`. In 3feea6a1f7cbb91a85f71ffb18f8efb71e819064 I made the mistake of thinking it was the latter, putting the check _before_ `updateRenderer()` instead of after it. This meant that the SceneGadget would never update again after an initial error.
