### PR TITLE
ShaderQueryUI : Fix errors related to a non-existent location.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,13 @@
+0.61.x.x (relative to 0.61.13.1)
+=========
+
+Fixes
+-----
+
+- ShaderQuery :
+  - Fixed bug when attempting to browse shader parameters for a non-existent location.
+  - Fixed bug when attempting to use the context menu to set the name of the shader to query for a non-existent location.
+
 0.61.13.1 (relative to 0.61.13.0)
 =========
 


### PR DESCRIPTION
This fixes an error that would be generated while trying to browse shader parameters for a non-existent location. It also fixes an error that would be generated when using the context menu to select the shader to query using a non-existent location.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
