### PR TITLE
Light editor multi edit

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ API
   - Deprecated `allowMultipleSelection` constructor argument. Use `selectionMode` argument instead.
   - Added modes to `selectionMode` allowing single and multiple cell selections.
   - `setSelection` and `getSelection` now accept and return different types depending on the `selectionMode`. For `Row` and `Rows` modes, a single `PathMatcher` object represents the selection for all columns, maintaining backwards compatiblity. For `Cell` and `Cells` modes, a list of `PatchMatcher` objects, one per column, represents the selection.
+- PlugValueWidget : Added new exception types `MultipleWidgetCreatorsError` and `MultiplePlugTypesError`.
 
 0.61.13.1 (relative to 0.61.13.0)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -55,6 +55,7 @@ API
 - EditScopeAlgo : Added support for editing attributes.
 - TweakPlug : Added `Create` mode.
 - VectorDataWidget : Added `dataMenuSignal` for constructing the context menu. Classes can add their own slots to this signal to modify the context menu. Derived classes should use it in favor of `_contextMenuDefinition()`.
+- PathListingWidget : Deprecated `allowMultipleSelection` constructor argument. Use `selectionMode` argument instead.
 
 0.61.12.0 (relative to 0.61.11.0)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 0.61.x.x (relative to 0.61.13.1)
 =========
 
+Improvements
+------------
+
+- Light Editor :
+  - Added the ability to edit multiple values at one time. With multiple cells selected, pressing <kbd>Return</kbd> or <kbd>Enter</kbd> will open a popup to edit the values for all cells.
+  - Added the ability to drag from a cell and drop that cell's value on an appropriate target.
+  - Added the ability to select individual cells with the mouse and keyboard. Cells can be selected by clicking or using the up <kbd>&uarr;</kbd>, down <kbd>&darr;</kbd>, left <kbd>&larr;</kbd> and right <kbd>&rarr;</kbd> keys. For both the keyboard and mouse, holding <kbd>Control</kbd> toggles the next selection. Holding <kbd>Shift</kbd> range-selects the next selection.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,14 @@ Fixes
   - Fixed bug when attempting to browse shader parameters for a non-existent location.
   - Fixed bug when attempting to use the context menu to set the name of the shader to query for a non-existent location.
 
+API
+---
+
+- PathListingWidget :
+  - Deprecated `allowMultipleSelection` constructor argument. Use `selectionMode` argument instead.
+  - Added modes to `selectionMode` allowing single and multiple cell selections.
+  - `setSelection` and `getSelection` now accept and return different types depending on the `selectionMode`. For `Row` and `Rows` modes, a single `PathMatcher` object represents the selection for all columns, maintaining backwards compatiblity. For `Cell` and `Cells` modes, a list of `PatchMatcher` objects, one per column, represents the selection.
+
 0.61.13.1 (relative to 0.61.13.0)
 =========
 
@@ -55,7 +63,6 @@ API
 - EditScopeAlgo : Added support for editing attributes.
 - TweakPlug : Added `Create` mode.
 - VectorDataWidget : Added `dataMenuSignal` for constructing the context menu. Classes can add their own slots to this signal to modify the context menu. Derived classes should use it in favor of `_contextMenuDefinition()`.
-- PathListingWidget : Deprecated `allowMultipleSelection` constructor argument. Use `selectionMode` argument instead.
 
 0.61.12.0 (relative to 0.61.11.0)
 =========

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -218,7 +218,7 @@ class _LocalJobsWindow( GafferUI.Window ) :
 						GafferUI.PathListingWidget.StandardColumn( "CPU", "localDispatcher:cpu" ),
 						GafferUI.PathListingWidget.StandardColumn( "Memory", "localDispatcher:memory" ),
 					),
-					allowMultipleSelection=True
+					selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
 				)
 				self.__jobListingWidget._qtWidget().header().setSortIndicator( 1, QtCore.Qt.AscendingOrder )
 				self.__jobListingWidget.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__jobSelectionChanged ), scoped = False )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -651,7 +651,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 			self.__pathListing = GafferUI.PathListingWidget(
 				_ImagesPath( self.__images(), [] ),
 				columns = self.__listingColumns(),
-				allowMultipleSelection = True,
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
 				sortable = False,
 				horizontalScrollMode = GafferUI.ScrollMode.Automatic
 			)

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -75,7 +75,7 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 			self.__pathListing = GafferUI.PathListingWidget(
 				Gaffer.DictPath( {}, "/" ), # temp till we make a ScenePath
 				columns = [ GafferUI.PathListingWidget.defaultNameColumn ],
-				allowMultipleSelection = True,
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 			)
 			self.__pathListing.setDragPointer( "objects" )

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -104,7 +104,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			self.__pathListing = GafferUI.PathListingWidget(
 				Gaffer.DictPath( {}, "/" ), # Temp till we make a ScenePath
 				columns = [ _GafferSceneUI._LightEditorLocationNameColumn() ],
-				allowMultipleSelection = True,
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 			)
 			self.__pathListing.setDragPointer( "objects" )

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -47,6 +47,8 @@ import GafferUI
 import GafferScene
 import GafferSceneUI
 
+from GafferUI.PlugValueWidget import sole
+
 from . import ContextAlgo
 from . import _GafferSceneUI
 
@@ -104,7 +106,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			self.__pathListing = GafferUI.PathListingWidget(
 				Gaffer.DictPath( {}, "/" ), # Temp till we make a ScenePath
 				columns = [ _GafferSceneUI._LightEditorLocationNameColumn() ],
-				selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 			)
 			self.__pathListing.setDragPointer( "objects" )
@@ -113,6 +115,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 				Gaffer.WeakMethod( self.__selectionChanged )
 			)
 			self.__pathListing.buttonDoubleClickSignal().connect( 0, Gaffer.WeakMethod( self.__buttonDoubleClick ), scoped = False )
+			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
 
 		self.__settingsNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__settingsPlugSet ), scoped = False )
 
@@ -269,40 +272,64 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		assert( pathListing is self.__pathListing )
 
 		with Gaffer.BlockedConnection( self._contextChangedConnection() ) :
-			ContextAlgo.setSelectedPaths( self.getContext(), pathListing.getSelection() )
+			ContextAlgo.setSelectedPaths( self.getContext(), pathListing.getSelection()[0] )
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferSelectionFromContext( self ) :
 
-		selection = ContextAlgo.getSelectedPaths( self.getContext() )
+		selectedPaths = ContextAlgo.getSelectedPaths( self.getContext() )
 		with Gaffer.BlockedConnection( self.__selectionChangedConnection ) :
+			selection = [selectedPaths] + ( [IECore.PathMatcher()] * ( len( self.__pathListing.getColumns() ) - 1 ) )
 			self.__pathListing.setSelection( selection, scrollToFirst=True, expandNonLeaf=False )
 
 	def __buttonDoubleClick( self, pathListing, event ) :
 
-		if event.button != event.Buttons.Left :
-			return False
+		if event.button == event.Buttons.Left :
+			self.__editSelectedCells( pathListing )
 
-		path = pathListing.pathAt( event.line.p0 )
-		if path is None :
-			return False
+			return True
 
-		column = pathListing.columnAt( event.line.p0 )
-		if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
-			return False
+		return False
+
+	def __keyPress( self, pathListing, event ) :
+
+		if event.key == "Return" or event.key == "Enter" :
+			self.__editSelectedCells( pathListing )
+
+			return True
+
+		return False
+
+	def __editSelectedCells( self, pathListing ) :
+
+		selection = pathListing.getSelection()
+		columns = pathListing.getColumns()
+
+		inspections = []
 
 		with Gaffer.Context( self.getContext() ) as context :
-			context["scene:path"] = IECore.InternedStringVectorData( path[:] )
-			inspection = column.inspector().inspect()
+			for i in range( 0, len( columns ) ) :
+				column = columns[ i ]
+				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+					continue
+				for path in selection[i].paths() :
+					context["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
+					inspection = column.inspector().inspect()
 
-		if inspection is None :
-			return False
+					if inspection is not None :
+						inspections.append( inspection )
 
-		if inspection.editable() :
+		nonEditable = [ i for i in inspections if not i.editable() ]
 
-			self.__popup = GafferUI.PlugPopup( [ inspection.acquireEdit() ], warning = inspection.editWarning() )
+		if len( nonEditable ) == 0 :
+			edits = [ i.acquireEdit() for i in inspections ]
+			warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
+
+			self.__popup = GafferUI.PlugPopup( edits, warning = warnings )
+
 			if isinstance( self.__popup.plugValueWidget(), GafferSceneUI.TweakPlugValueWidget ) :
 				self.__popup.plugValueWidget().setNameVisible( False )
+
 			self.__popup.popup()
 
 		else :
@@ -313,11 +340,10 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			with PopupWindow() as self.__popup :
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 					GafferUI.Image( "warningSmall.png" )
-					GafferUI.Label( "<h4>{}</h4>".format( inspection.nonEditableReason() ) )
+					GafferUI.Label( "<h4>{}</h4>".format( nonEditable[0].nonEditableReason() ) )
 
 			self.__popup.popup()
 
-		return True
 
 GafferUI.Editor.registerType( "LightEditor", LightEditor )
 

--- a/python/GafferSceneUI/TweakPlugValueWidget.py
+++ b/python/GafferSceneUI/TweakPlugValueWidget.py
@@ -55,6 +55,8 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plugs ) :
 
+		valueWidget = GafferUI.PlugValueWidget.create( self.__childPlugs( plugs, "value" ) )
+
 		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__row, plugs )
@@ -79,7 +81,7 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 		modeWidget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
 		self.__row.append( modeWidget, verticalAlignment = GafferUI.Label.VerticalAlignment.Top )
 
-		self.__row.append( GafferUI.PlugValueWidget.create( self.__childPlugs( plugs, "value" ) ), expand = True )
+		self.__row.append( valueWidget, expand = True )
 
 		self._updateFromPlugs()
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -140,7 +140,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 			Gaffer.DictPath( {}, "/" ), # placeholder, updated in `_updateFromSet()`.
 			columns = ( GafferUI.PathListingWidget.defaultNameColumn, ),
 			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
-			allowMultipleSelection=True
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
 		)
 
 		self.__curveList._qtWidget().setMinimumSize( 160, 0 )

--- a/python/GafferUI/PathChooserWidget.py
+++ b/python/GafferUI/PathChooserWidget.py
@@ -97,7 +97,10 @@ class PathChooserWidget( GafferUI.Widget ) :
 					parenting = { "expand" : True }
 				) as splitContainer :
 
-					self.__directoryListing = GafferUI.PathListingWidget( tmpPath, allowMultipleSelection=allowMultipleSelection )
+					self.__directoryListing = GafferUI.PathListingWidget(
+						tmpPath,
+						selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows if allowMultipleSelection else GafferUI.PathListingWidget.SelectionMode.Row
+					)
 					self.__directoryListing.displayModeChangedSignal().connect( Gaffer.WeakMethod( self.__displayModeChanged ), scoped = False )
 					if len( previewTypes ) :
 						self.__previewWidget = GafferUI.CompoundPathPreview( tmpPath, childTypes=previewTypes )

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -142,10 +142,9 @@ class PlugPopup( _PopupWindow ) :
 					warningBadge.setToolTip( warning )
 
 				# PlugValueWidget, or label explaining why we can't show one
-
-				if sole( p.__class__ for p in plugs ) :
+				try :
 					self.__plugValueWidget = GafferUI.PlugValueWidget.create( plugs )
-				else :
+				except :
 					self.__plugValueWidget = None
 					GafferUI.Label( "Unable to edit plugs with mixed types" )
 

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -144,9 +144,13 @@ class PlugPopup( _PopupWindow ) :
 				# PlugValueWidget, or label explaining why we can't show one
 				try :
 					self.__plugValueWidget = GafferUI.PlugValueWidget.create( plugs )
-				except :
+				except (
+					GafferUI.PlugValueWidget.MultipleWidgetCreatorsError,
+					GafferUI.PlugValueWidget.MultiplePlugTypesError
+				) as e :
 					self.__plugValueWidget = None
 					GafferUI.Label( "Unable to edit plugs with mixed types" )
+					e.__traceback__ = None
 
 		# If we have a ColorPlugValueWidget, expand it to show the chooser.
 		colorPlugValueWidget = self.__colorPlugValueWidget( self.__plugValueWidget )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -61,6 +61,8 @@ import GafferUI
 class PlugValueWidget( GafferUI.Widget ) :
 
 	class MultiplePlugsError( ValueError ) : pass
+	class MultipleWidgetCreatorsError( ValueError ) : pass
+	class MultiplePlugTypesError( ValueError ) : pass
 
 	def __init__( self, topLevelWidget, plugs, **kw ) :
 
@@ -249,7 +251,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 				plugs = next( iter( plugs ) )
 
 		if len( creators ) > 1 :
-			raise Exception( "Multiple widget creators" )
+			raise cls.MultipleWidgetCreatorsError()
 
 		creator = next( iter( creators ) )
 		if creator is not None :
@@ -490,7 +492,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		assert( isinstance( plugs, set ) )
 		if len( plugs ) and sole( p.__class__ for p in plugs ) is None :
-			raise ValueError( "Plugs have different types" )
+			raise self.MultiplePlugTypesError()
 
 		nodes = set()
 		scriptNodes = set()

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -235,7 +235,11 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		p = Gaffer.DictPath( d, "/" )
 
-		w = GafferUI.PathListingWidget( p, allowMultipleSelection = True, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
 		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertTrue( w.getSelection().isEmpty() )
@@ -278,7 +282,11 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		p = Gaffer.DictPath( d, "/" )
 
-		w = GafferUI.PathListingWidget( p, allowMultipleSelection = True, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
 		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertTrue( w.getSelection().isEmpty() )
@@ -307,7 +315,11 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		p = Gaffer.DictPath( d, "/" )
 
-		w = GafferUI.PathListingWidget( p, allowMultipleSelection = True, displayMode = GafferUI.PathListingWidget.DisplayMode.Tree )
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
 		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		self.assertTrue( w.getSelection().isEmpty() )
@@ -331,7 +343,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		}
 
 		p = Gaffer.DictPath( d, "/" )
-		w = GafferUI.PathListingWidget( p, allowMultipleSelection=True )
+		w = GafferUI.PathListingWidget( p, selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows )
 		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
 
 		c = GafferTest.CapturingSlot( w.selectionChangedSignal() )

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -224,7 +224,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setExpandedPaths( e )
 		self.assertEqual( len( c ), 4 )
 
-	def testSelection( self ) :
+	def testRowSelection( self ) :
 
 		d = {}
 		for i in range( 0, 10 ) :
@@ -271,7 +271,62 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setSelection( s2 )
 		self.assertEqual( w.getSelection(), s2 )
 
-	def testSelectionScrolling( self ) :
+	def testCellsSelection( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
+
+		self.assertEqual( w.getColumns(), list( w.defaultFileSystemColumns ) )
+
+		c = [ w.defaultNameColumn, w.StandardColumn( "h", "a" ) ]
+
+		w.setColumns( c )
+		self.assertEqual( w.getColumns(), c )
+
+		self.assertEqual( len( w.getSelection() ), 2 )
+
+		# Set selection. This should be immediately reflected in
+		# the `selectionChangedSignal` and the result of `getSelection()`.
+
+		cs = GafferTest.CapturingSlot( w.selectionChangedSignal() )
+		s11 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5", "/3/1" ] )
+		s12 = IECore.PathMatcher( [ "/1", "/3", "/9", "/2/5", "/4/6" ] )
+
+		w.setSelection( [ s11, s12 ] )
+		self.assertEqual( w.getSelection(), [ s11, s12 ] )
+		self.assertEqual( len( cs ), 1 )
+
+		# Delete a path that was selected.
+		d2 = d["2"]
+		del d["2"]
+		self.__emitPathChanged( w )
+		# We don't expect this to affect the result of `getSelection()` because
+		# the selection state is independent of the model contents.
+		self.assertEqual( w.getSelection(), [ s11, s12 ] )
+
+		# Now try to set selection twice in succession, so the model doesn't have
+		# chance to finish one update before starting the next.
+
+		s21 = IECore.PathMatcher( [ "/9", "/9/10", "/8/6" ] )
+		s31 = IECore.PathMatcher( [ "/9", "/9/9", "/5/6", "3" ] )
+		w.setSelection( [ s21, s12 ] )
+		w.setSelection( [ s31, s12 ] )
+		self.assertEqual( w.getSelection(), [ s31, s12 ] )
+
+	def testRowSelectionScrolling( self ) :
 
 		d = {}
 		for i in range( 0, 10 ) :
@@ -304,7 +359,53 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3" ] ) )
 
-	def testSelectionExpansion( self ) :
+	def testCellSelectionScrolling( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
+
+		# The default widget has multiple columns preset for file browsing,
+		# just use two to simply testing.
+		c = [ w.defaultNameColumn, w.StandardColumn( "h", "a" ) ]
+		w.setColumns( c )
+		self.assertEqual( w.getColumns(), c )
+
+		self.assertEqual( w.getSelection(), [IECore.PathMatcher()] * 2 )
+		self.assertTrue( w.getExpansion().isEmpty() )
+
+		s1 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
+		s2 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
+		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = False )
+		self.assertEqual( w.getSelection(), [ s1, s2 ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( w.getExpansion().isEmpty() )
+
+		s1.addPath( "/3/5" )
+		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = True )
+		self.assertEqual( w.getSelection(), [ s1, s2 ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3" ] ) )
+
+		s2.addPath( "/4/6" )
+		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = True )
+		self.assertEqual( w.getSelection(), [ s1, s2 ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3", "/4" ] ) )
+
+	def testRowSelectionExpansion( self ) :
 
 		d = {}
 		for i in range( 0, 10 ) :
@@ -331,6 +432,40 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/1", "/2", "/9" ] ) )
 
+	def testCellSelectionExpansion( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			p,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
+
+		# The default widget has multiple columns preset for file browsing,
+		# just use two to simply testing.
+		c = [ w.defaultNameColumn, w.StandardColumn( "h", "a" ) ]
+		w.setColumns( c )
+		self.assertEqual( w.getColumns(), c )
+
+		self.assertEqual( w.getSelection(), [IECore.PathMatcher()] * 2 )
+		self.assertTrue( w.getExpansion().isEmpty() )
+
+		s1 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
+		s2 = IECore.PathMatcher( [ "/1", "/3", "/4", "/9", "/4/6" ] )
+		w.setSelection( [ s1, s2 ], expandNonLeaf = True, scrollToFirst = False )
+		self.assertEqual( w.getSelection(), [ s1, s2 ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/1", "/2", "/3", "/4", "/9" ] ) )
+
 	def testSelectionSignalFrequency( self ) :
 
 		d = {
@@ -354,7 +489,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( len( c ), 1 )
 
-	def testChangingDirectoryClearsSelection( self ) :
+	def testChangingDirectoryClearsRowSelection( self ) :
 
 		path = Gaffer.DictPath( { "a" : { "b" : { "c" : 10 } } }, "/" )
 		widget = GafferUI.PathListingWidget( path )
@@ -364,6 +499,42 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		path.append( "a" )
 		self.assertEqual( widget.getSelection(), IECore.PathMatcher() )
+
+	def testChangingDirectoryClearsCellSelection( self ) :
+
+		path = Gaffer.DictPath( { "a" : { "b" : { "c" : 10 } } }, "/" )
+		widget = GafferUI.PathListingWidget(
+			path,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells
+		)
+		# The default widget has multiple columns preset for file browsing,
+		# just use two to simply testing.
+		c = [ widget.defaultNameColumn, widget.StandardColumn( "h", "a" ) ]
+		widget.setColumns( c )
+		self.assertEqual( widget.getColumns(), c )
+
+		widget.setSelection(
+			[
+				IECore.PathMatcher( [ "/a" ] ),
+				IECore.PathMatcher( [ "/a/b" ] ),
+			]
+		)
+		self.assertEqual(
+			widget.getSelection(),
+			[
+				IECore.PathMatcher( [ "/a" ] ),
+				IECore.PathMatcher( [ "/a/b" ] ),
+			]
+		)
+
+		path.append( "a" )
+		self.assertEqual(
+			widget.getSelection(),
+			[
+				IECore.PathMatcher(),
+				IECore.PathMatcher(),
+			]
+		)
 
 	def testExpandedPathsWhenPathChanges( self ) :
 

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -109,11 +109,11 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["p1"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["user"]["p2"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 
-		with six.assertRaisesRegex( self, ValueError, "Plugs have different types" ) :
+		with self.assertRaises( GafferUI.PlugValueWidget.MultiplePlugTypesError ) :
 			GafferUI.NumericPlugValueWidget( n["user"].children() )
 
 		w = GafferUI.NumericPlugValueWidget( n["user"]["p1"] )
-		with six.assertRaisesRegex( self, ValueError, "Plugs have different types" ) :
+		with self.assertRaises( GafferUI.PlugValueWidget.MultiplePlugTypesError ) :
 			w.setPlugs( n["user"].children() )
 
 	def testCreateReleasesReferenceWithMismatchedPlugs( self ) :
@@ -148,7 +148,7 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		Gaffer.Metadata.registerValue( n["user"]["p1"], "plugValueWidget:type", "GafferUI.ConnectionPlugValueWidget" )
 
-		with six.assertRaisesRegex( self, Exception, "Multiple widget creators" ) :
+		with self.assertRaises( GafferUI.PlugValueWidget.MultipleWidgetCreatorsError ) :
 			GafferUI.PlugValueWidget.create( n["user"].children() )
 
 	def testCreateSupportsLegacyWidgetsWithSinglePlugs( self ) :

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -37,6 +37,7 @@
 
 import unittest
 import six
+import weakref
 
 import IECore
 
@@ -114,6 +115,21 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		w = GafferUI.NumericPlugValueWidget( n["user"]["p1"] )
 		with six.assertRaisesRegex( self, ValueError, "Plugs have different types" ) :
 			w.setPlugs( n["user"].children() )
+
+	def testCreateReleasesReferenceWithMismatchedPlugs( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["p1"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["p2"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		p = GafferUI.PlugPopup( s["n"]["user"].children() )
+
+		w = weakref.ref( p )
+
+		del p
+
+		self.assertEqual( w(), None )
 
 	def testGetPlugWithMultiplePlugs( self ) :
 

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -156,6 +156,12 @@ void cellDataSetToolTip( PathColumn::CellData &cellData, const ConstDataPtr &dat
 	cellData.toolTip = data;
 }
 
+PathColumn::CellData cellDataWrapper( PathColumn &pathColumn, const Path &path, const Canceller *canceller )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return pathColumn.cellData( path, canceller );
+}
+
 struct ChangedSignalSlotCaller
 {
 	boost::signals::detail::unusable operator()( boost::python::object slot, PathColumnPtr c )
@@ -180,6 +186,7 @@ void GafferUIModule::bindPathColumn()
 		scope s = IECorePython::RefCountedClass<PathColumn, IECore::RefCounted, PathColumnWrapper>( "PathColumn" )
 			.def( init<>() )
 			.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
+			.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
 		;
 
 		class_<PathColumn::CellData>( "CellData" )

--- a/startup/GafferUI/pathListingWidgetCompatibility.py
+++ b/startup/GafferUI/pathListingWidgetCompatibility.py
@@ -1,0 +1,55 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferUI
+
+def __initWrapper( originalInit ) :
+
+	def init( self, *args, **kw ) :
+
+		if len( args ) >= 3 :
+			if isinstance( args[2], bool ) :
+				args[2] = self.SelectionMode.Rows if args[2] else self.SelectionMode.Row
+		elif "allowMultipleSelection" in kw :
+			kw = kw.copy()
+			kw["selectionMode"] = self.SelectionMode.Rows if kw["allowMultipleSelection"] else self.SelectionMode.Row
+			del kw["allowMultipleSelection"]
+
+		originalInit( self, *args, **kw )
+
+	return init
+
+GafferUI.PathListingWidget.__init__ = __initWrapper( GafferUI.PathListingWidget.__init__ )


### PR DESCRIPTION
This adds the ability to select and edit multiple cells in one interaction. To accomplish this, it also replaces `allowMultipleSelection` with `selectionMode` in the `PathListingWidget`, with options for `Cell` and `Cells` in addition to the backwards compatible `Row` and `Rows`.

This is a re-PR of https://github.com/GafferHQ/gaffer/pull/4726 which was closed when I re-forked my personal repository onto HQ.

From that PR, I made the change to the `ScopedGILRelease` in `setSelection` which fixed the problem with using `extend_container`. And hopefully the crash that popped up in the CI tests.

I also looked again at what I thought was a problem with selection expansion. I think that the test I had been using wasn't quite correct. I had been setting the selection to include `/4/9` and expecting `/4` to be expanded which I believe is not the intended behavior. The test is changed to reflect the expected behavior and is now passing.

Ready for reviewing of the code and all the key and click combinations we can think of to try and find a hole in the implementation.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
