### PR TITLE
ImageAlgo::sortChannelNames : Use a natural ordering 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ Improvements
 - PresetsPlugValueWidget : The children of compound plugs are now shown when in "Custom" mode.
 - LightEditor/SceneViewInspector : Improved performance when viewing complex scenes, by improving cache usage during history queries.
 - Node menu : Removed unsupported Arnold shaders `ramp_rgb` and `ramp_float`. The OSL `ColorSpline` and `FloatSpline` shaders should be used instead.
+- Image Channel Selectors : Channel names are now shown in "natural order". This means a numerical part of the name is compared numerically, instead of alphabetically (so "channel13" comes after "channel2").
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -80,7 +80,7 @@ API
 - ImageAlgo :
   - Added optional `viewName` arguments to `image()`, `imageHash()` and `tiles()`.
   - Added `viewIsValid()` function.
-  - Added `sortChannelNames()` function.
+  - Added `sortedChannelNames()` function.
 - PlugAlgo : Added optional `value` argument to `canSetValueFromData()`.
 - RenderController :
   - Added Python bindings for optional `callback` argument to `update()` and `updateMatchingPaths()`.

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -109,8 +109,8 @@ bool channelExists( const std::vector<std::string> &channelNames, const std::str
 /// Our sort rules are:
 /// * channels not in a layer come first
 /// * the channels RGBA are sorted in that order, and come before any other channels in the same layer
-/// * otherwise, things are sorted alphabetically
-GAFFERIMAGE_API void sortChannelNames( std::vector< std::string > &channelNames );
+/// * otherwise, things are sorted using a natural ordering
+GAFFERIMAGE_API std::vector<std::string> sortedChannelNames( const std::vector<std::string> &channelNames );
 
 /// Default channel names
 /// ==============================

--- a/python/GafferImageTest/ImageAlgoTest.py
+++ b/python/GafferImageTest/ImageAlgoTest.py
@@ -275,52 +275,52 @@ class ImageAlgoTest( GafferImageTest.ImageTestCase ) :
 			numTilesX * numTilesY * 4
 		)
 
-	def testSortChannelNames( self ):
+	def testSortedChannelNames( self ):
 
 		# Sort RGBA
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( [ "R", "A", "B", "G" ] ), [ "R", "G", "B", "A" ] )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( [ "R", "A", "B", "G" ] ), [ "R", "G", "B", "A" ] )
 
 		# Sort RGBA	before other channels
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( [ "A", "Arc", "Z", "ZSomethingElse", "H", "Bark", "G", "ZBack", "custom", "F", "R", "B" ] ), [ "R", "G", "B", "A", "Arc", "Bark", "F", "H", "Z", "ZBack", "ZSomethingElse", "custom" ] )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( [ "A", "Arc", "Z", "ZSomethingElse", "H", "Bark", "G", "ZBack", "custom", "F", "R", "B" ] ), [ "R", "G", "B", "A", "Arc", "Bark", "F", "H", "Z", "ZBack", "ZSomethingElse", "custom" ] )
 
 		# Sort default layer before named layers
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( [ "A", "G", "A.G", "B.B", "A.R", "B.R", "B", "R", "A.B", "B.G" ] ), [ "R", "G", "B", "A", "A.R", "A.G", "A.B", "B.R", "B.G", "B.B" ] )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( [ "A", "G", "A.G", "B.B", "A.R", "B.R", "B", "R", "A.B", "B.G" ] ), [ "R", "G", "B", "A", "A.R", "A.G", "A.B", "B.R", "B.G", "B.B" ] )
 
 		# Sort hierarchical layers
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( [ "Y.X.Y", "Y.X.X", "Y", "X", "X.X", "X.Y" ] ), [ "X", "Y", "X.X", "X.Y", "Y.X.X", "Y.X.Y" ] )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( [ "Y.X.Y", "Y.X.X", "Y", "X", "X.X", "X.Y" ] ), [ "X", "Y", "X.X", "X.Y", "Y.X.X", "Y.X.Y" ] )
 
 		# Default alphabetical sort puts capital letters before lowercase ( dunno if this is good or not, but
 		# worth documenting )
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( [ "x", "X", "x.x", "X.X", "X.x", "x.X" ] ), ["X", "x", "X.X", "X.x", "x.X", "x.x"] )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( [ "x", "X", "x.x", "X.X", "X.x", "x.X" ] ), ["X", "x", "X.X", "X.x", "x.X", "x.x"] )
 
 		# Test that our natural sort handles numbers
 		self.assertEqual(
-			GafferImage.ImageAlgo.sortChannelNames( [ "12", "4", "1", "14", "2", "3", "13", "99" ] ),
+			GafferImage.ImageAlgo.sortedChannelNames( [ "12", "4", "1", "14", "2", "3", "13", "99" ] ),
 			[ "1", "2", "3", "4", "12", "13", "14", "99" ]
 		)
 
 		self.assertEqual(
-			GafferImage.ImageAlgo.sortChannelNames( [ str( 999 - i ) for i in range( 1000 ) ] ),
+			GafferImage.ImageAlgo.sortedChannelNames( [ str( 999 - i ) for i in range( 1000 ) ] ),
 			[ str( i ) for i in range( 1000 ) ]
 		)
 
 		# And numbers with varying padding
 		self.assertEqual(
-			GafferImage.ImageAlgo.sortChannelNames( [ "03", "00012", "4", "01", "0000014", "2", "00003", "13", "3", "99" ] ),
+			GafferImage.ImageAlgo.sortedChannelNames( [ "03", "00012", "4", "01", "0000014", "2", "00003", "13", "3", "99" ] ),
 			[ "01", "2", "3", "03", "00003", "4", "00012", "13", "0000014", "99" ]
 		)
 
 		# Test large numbers ( larger than the size of an integer )
 		largeNums = [ str( ( i % 9 ) + 1 ) + "0" * i for i in range( 30 ) ]
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( largeNums ), largeNums )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( largeNums ), largeNums )
 
 		# Test something like how we see this being used in production
 		realistic = [ "channel0", "channel1", "channel2", "channel2alt", "channel2alt2", "channel2alt13", "channel04", "channel13" ]
-		self.assertEqual( GafferImage.ImageAlgo.sortChannelNames( realistic ), realistic )
+		self.assertEqual( GafferImage.ImageAlgo.sortedChannelNames( realistic ), realistic )
 
 		# And test every length 4 possibility for alternating letters and digits
 		permutations = [ "".join( i ) for j in [1,2,3,4 ] for i in itertools.product( *["012acC"] * j ) ]
-		permutationsGaffer = GafferImage.ImageAlgo.sortChannelNames( permutations )
+		permutationsGaffer = GafferImage.ImageAlgo.sortedChannelNames( permutations )
 
 
 		# The most debatable order here is between "00C0" and "0C00", which conceptually mean the same thing, and

--- a/python/GafferImageUI/ChannelPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelPlugValueWidget.py
@@ -103,7 +103,7 @@ class ChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 				if channel not in availableChannels :
 					availableChannels.append( channel )
 
-		availableChannels = GafferImage.ImageAlgo.sortChannelNames( availableChannels )
+		availableChannels = GafferImage.ImageAlgo.sortedChannelNames( availableChannels )
 
 		extraChannels = Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:extraChannels" )
 		if extraChannels:

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -114,7 +114,7 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if GafferImage.ImageAlgo.baseName( c ) not in [ "R", "G", "B", "A" ]
 		}
 
-		for channelName in sorted( channelNames, key = GafferImage.ImageAlgo.layerName ) :
+		for channelName in GafferImage.ImageAlgo.sortChannelNames( channelNames ) :
 
 			if GafferImage.ImageAlgo.baseName( channelName ) in [ "R", "G", "B", "A" ] :
 				layerName = GafferImage.ImageAlgo.layerName( channelName )

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -114,7 +114,7 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if GafferImage.ImageAlgo.baseName( c ) not in [ "R", "G", "B", "A" ]
 		}
 
-		for channelName in GafferImage.ImageAlgo.sortChannelNames( channelNames ) :
+		for channelName in GafferImage.ImageAlgo.sortedChannelNames( channelNames ) :
 
 			if GafferImage.ImageAlgo.baseName( channelName ) in [ "R", "G", "B", "A" ] :
 				layerName = GafferImage.ImageAlgo.layerName( channelName )

--- a/src/GafferImage/ImageAlgo.cpp
+++ b/src/GafferImage/ImageAlgo.cpp
@@ -235,10 +235,12 @@ const std::string GafferImage::ImageAlgo::channelNameB( "B" );
 const std::string GafferImage::ImageAlgo::channelNameZ( "Z" );
 const std::string GafferImage::ImageAlgo::channelNameZBack( "ZBack" );
 
-void ImageAlgo::sortChannelNames( std::vector< std::string > &channelNames )
+std::vector<std::string> ImageAlgo::sortedChannelNames( const std::vector<std::string> &channelNames )
 {
+	std::vector<std::string> result = channelNames;
+
 	NaturalOrder s;
-	std::sort( channelNames.begin(), channelNames.end(), [ &s ]( const std::string &a, const std::string &b ){
+	std::sort( result.begin(), result.end(), [ &s ]( const std::string &a, const std::string &b ){
 
 		std::string layerA = layerName( a );
 		std::string layerB = layerName( b );
@@ -272,6 +274,7 @@ void ImageAlgo::sortChannelNames( std::vector< std::string > &channelNames )
 		return s( baseA, baseB );
 	} );
 
+	return result;
 }
 
 IECoreImage::ImagePrimitivePtr GafferImage::ImageAlgo::image( const ImagePlug *imagePlug, const std::string *viewName )

--- a/src/GafferImage/ImageAlgo.cpp
+++ b/src/GafferImage/ImageAlgo.cpp
@@ -41,6 +41,7 @@
 #include "OpenEXR/ImathBox.h"
 
 #include <set>
+#include <regex>
 
 using namespace std;
 using namespace GafferImage;
@@ -118,6 +119,96 @@ int tileIndex( const Imath::V2i &tileOrigin, const Imath::Box2i &tileRange )
 	return offset.y * ( tileRange.size().x + 1 ) + offset.x;
 }
 
+// A comparison functor that tokenizes the string apart into numeric and non-numeric parts, and compares
+// the numeric parts according to the order of integers ( ie.  "x100x" > "x9x" )
+struct NaturalOrder
+{
+	bool operator()( const std::string &l, const std::string &r )
+	{
+		int moreZeros = 0;
+		std::sregex_iterator lit( l.begin(), l.end(), g_naturalSortRegex );
+		std::sregex_iterator rit( r.begin(), r.end(), g_naturalSortRegex );
+		std::sregex_iterator end;
+		for( ; lit != end && rit != end; ++lit, ++rit )
+		{
+			int c = compareToken( *lit, *rit );
+			if( c != 0 )
+			{
+				// We've found a difference in this set of tokens, and can return
+				return c < 0;
+			}
+
+			if( lit->str().size() != rit->str().size() )
+			{
+				// This is a weird special case - the strings have compared equal, but their lengths aren't
+				// the same.  This must be due to one having numbers with different zero padding.  If we
+				// find a significant difference, we'll go by that ( ie "0B" comes after "000A" ), but if
+				// we get to the end without finding a difference, we'll sort the string with more padding
+				// after, just to make sure we do something consistent.
+				moreZeros = lit->str().size() > rit->str().size() ? 1 : -1;
+			}
+		}
+
+		if( lit != end || rit != end )
+		{
+			// One of the strings still has tokens left, the string with more tokens is greater
+			return rit != end;
+		}
+
+		if( moreZeros != 0 )
+		{
+			return moreZeros < 0;
+		}
+
+		return false;
+	}
+
+private:
+
+	int compareToken( const std::smatch &l, const std::smatch &r )
+	{
+		// We only need to do anything special if both tokens are a number - otherwise, the standard
+		// string compare will just put the number before the letters
+		if ( !l[ 1 ].str().empty() && !r[ 1 ].str().empty() )
+		{
+			// We also only need to do something special if the lengths don't match - if the lengths
+			// match, then string comparison is equivalent to numerical comparison
+			if( l.str().size() < r.str().size() )
+			{
+				return -compareLongerNumber( r.str(), l.str() );
+			}
+			else if( l.str().size() > r.str().size() )
+			{
+				return compareLongerNumber( l.str(), r.str() );
+			}
+		}
+
+		return l.str().compare( r.str() );
+	}
+
+	int compareLongerNumber( const std::string &longer, const std::string &shorter )
+	{
+		int diff = longer.size() - shorter.size();
+		// If the longer string has any non-zero digits in the longer portion, it is greater.
+		for( int i = 0; i < diff; i++ )
+		{
+			if( longer[i] != '0' )
+			{
+				return 1;
+			}
+		}
+
+		// If the mismatched portion is all zeros, ignore it, and compare the matching portion
+		return longer.compare( diff, string::npos, shorter );
+	}
+
+	static const std::regex g_naturalSortRegex;
+
+};
+
+const std::regex NaturalOrder::g_naturalSortRegex( R"((\d+)|([^\d]+))" );
+
+
 } // namespace
 
 
@@ -146,13 +237,14 @@ const std::string GafferImage::ImageAlgo::channelNameZBack( "ZBack" );
 
 void ImageAlgo::sortChannelNames( std::vector< std::string > &channelNames )
 {
-	std::sort( channelNames.begin(), channelNames.end(), []( const std::string &a, const std::string &b ){
+	NaturalOrder s;
+	std::sort( channelNames.begin(), channelNames.end(), [ &s ]( const std::string &a, const std::string &b ){
 
 		std::string layerA = layerName( a );
 		std::string layerB = layerName( b );
 		if( layerA != layerB )
 		{
-			return layerA < layerB;
+			return s( layerA, layerB );
 		}
 
 		// The channels are in the same layer, so we need to compare the base names
@@ -177,7 +269,7 @@ void ImageAlgo::sortChannelNames( std::vector< std::string > &channelNames )
 		}
 
 		// Both channels are custom names, so use alphabetical order based on channel name
-		return baseA < baseB;
+		return s( baseA, baseB );
 	} );
 
 }

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1927,7 +1927,7 @@ void ImageWriter::execute() const
 
 		// Sort the channel names so that they get written in a consistent order, with the
 		// basic RGBA channels coming first
-		ImageAlgo::sortChannelNames( channelsToWrite );
+		channelsToWrite = ImageAlgo::sortedChannelNames( channelsToWrite );
 
 		for( const string &i : channelsToWrite )
 		{

--- a/src/GafferImageModule/ImageAlgoBinding.cpp
+++ b/src/GafferImageModule/ImageAlgoBinding.cpp
@@ -100,11 +100,11 @@ inline bool channelExistsWrapper( const GafferImage::ImagePlug *image, const std
 	return GafferImage::ImageAlgo::channelExists( image, channelName );
 }
 
-boost::python::list sortChannelNamesWrapper( object pythonChannelNames )
+boost::python::list sortedChannelNamesWrapper( object pythonChannelNames )
 {
 	vector<string> channelNames;
 	container_utils::extend_container( channelNames, pythonChannelNames );
-	GafferImage::ImageAlgo::sortChannelNames( channelNames );
+	channelNames = GafferImage::ImageAlgo::sortedChannelNames( channelNames );
 	boost::python::list result;
 	for( const auto &it : channelNames )
 	{
@@ -212,7 +212,7 @@ void GafferImageModule::bindImageAlgo()
 	def( "colorIndex", &GafferImage::ImageAlgo::colorIndex );
 	def( "channelExists", &channelExistsWrapper );
 	def( "channelExists", ( bool (*)( const std::vector<std::string> &channelNames, const std::string &channelName ) )&GafferImage::ImageAlgo::channelExists );
-	def( "sortChannelNames", &sortChannelNamesWrapper );
+	def( "sortedChannelNames", &sortedChannelNamesWrapper );
 
 	enum_<ImageAlgo::TileOrder>( "TileOrder" )
 		.value( "Unordered", ImageAlgo::Unordered )


### PR DESCRIPTION
This ends up being a rather over-engineered natural order comparator, but the only short example I found for C++ had a bunch of bugs in it, and making tests thorough enough to catch them turned up more weird corner cases.  The test coverage is now complete enough enough that I'm pretty confident this is reliable now though, and if we ever need a natural order again, we'll have this around.