### PR TITLE
Add tweak plug modes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,16 @@
+1.0.x.x (relative to 1.0.0.0)
+=======
+
+Improvements
+------------
+
+- TweakPlug : Added new tweak modes.
+  - Min : Resulting value will be the lesser of the existing value and the tweak value. For values with multiple components, such as `Color3f`, each component is compared individually.
+  - Max : Same as `Min` except the resulting value is the greater of the existing value and the tweak value.
+  - ListAppend : Values in the tweak list are added to the end of the existing list. If a value is in both the existing list and the tweak list, it is removed from the existing list before being added.
+  - ListPrepend : Same as `ListAppend` except the tweak list is added to the beginning of the existing list.
+  - ListRemove : Values in the tweak list are removed from the existing list.
+
 1.0.0.0 (relative to 0.61.x.x)
 =======
 

--- a/include/Gaffer/TweakPlug.h
+++ b/include/Gaffer/TweakPlug.h
@@ -64,7 +64,15 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 			Subtract,
 			Multiply,
 			Remove,
-			Create
+			Create,
+			Min,
+			Max,
+			ListAppend,
+			ListPrepend,
+			ListRemove,
+
+			First = Replace,
+			Last = ListRemove,
 		};
 
 		TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, Mode mode = Replace, bool enabled = true );
@@ -125,6 +133,14 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 		const Gaffer::ValuePlug *valuePlugInternal() const;
 
 		void applyNumericTweak(
+			const IECore::Data *sourceData,
+			const IECore::Data *tweakData,
+			IECore::Data *destData,
+			TweakPlug::Mode mode,
+			const std::string &tweakName
+		) const;
+
+		void applyListTweak(
 			const IECore::Data *sourceData,
 			const IECore::Data *tweakData,
 			IECore::Data *destData,

--- a/python/GafferSceneTest/CameraTweaksTest.py
+++ b/python/GafferSceneTest/CameraTweaksTest.py
@@ -87,8 +87,13 @@ class CameraTweaksTest( GafferSceneTest.SceneTestCase ) :
 
 			self.assertEqual( c["out"].object( "/camera" ), tweaks["out"].object( "/camera" ) )
 
-			for mode in Gaffer.TweakPlug.Mode.names.values():
-			#for mode in [ Gaffer.TweakPlug.Mode.Replace ]:
+			for mode in [
+				m for m in Gaffer.TweakPlug.Mode.names.values() if m not in [
+					Gaffer.TweakPlug.Mode.ListAppend,
+					Gaffer.TweakPlug.Mode.ListPrepend,
+					Gaffer.TweakPlug.Mode.ListRemove
+				]
+			] :
 				for name, value in [
 						("projection", "orthographic" ),
 						( "aperture", imath.V2f( 10, 20 ) ),
@@ -105,7 +110,13 @@ class CameraTweaksTest( GafferSceneTest.SceneTestCase ) :
 						( "apertureAspectRatio", 0.15 ),
 					]:
 
-					if type( value ) in [ str ] and mode in [ Gaffer.TweakPlug.Mode.Add, Gaffer.TweakPlug.Mode.Subtract, Gaffer.TweakPlug.Mode.Multiply ] :
+					if type( value ) in [ str ] and mode in [
+						Gaffer.TweakPlug.Mode.Add,
+						Gaffer.TweakPlug.Mode.Subtract,
+						Gaffer.TweakPlug.Mode.Multiply,
+						Gaffer.TweakPlug.Mode.Min,
+						Gaffer.TweakPlug.Mode.Max
+					] :
 						continue
 
 					tweaks["tweaks"].clearChildren()
@@ -136,6 +147,16 @@ class CameraTweaksTest( GafferSceneTest.SceneTestCase ) :
 						ref = orig - value
 					elif mode == Gaffer.TweakPlug.Mode.Create:
 						ref = value
+					elif mode == GafferScene.TweakPlug.Mode.Min:
+						if type( value ) == imath.V2f:
+							ref = imath.V2f( min( orig[0], value[0] ), min( orig[1], value[1] ) )
+						else:
+							ref = min( orig, value )
+					elif mode == GafferScene.TweakPlug.Mode.Max:
+						if type( value ) == imath.V2f:
+							ref = imath.V2f( max( orig[0], value[0] ), max( orig[1], value[1] ) )
+						else:
+							ref = max( orig, value )
 
 					if name == "fieldOfView":
 						modified = tweaks["out"].object( "/camera" ).calculateFieldOfView()[0]

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -47,7 +47,8 @@ from Qt import QtWidgets
 # Widget for TweakPlug, which is used to build tweak nodes such as ShaderTweaks
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
 # a target parameter name, an enabled plug, and a mode.  The mode can be "Replace",
-# or "Add"/"Subtract"/"Multiply" if the plug is numeric,
+# or "Add"/"Subtract"/"Multiply"/"Min"/"Max" if the plug is numeric,
+# or "ListAppend"/"ListPrepend"/"ListRemove" if the plug is a list,
 # or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set,
 # or "Create" if the metadata "tweakPlugValueWidget:allowCreate" is set.
 class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
@@ -179,6 +180,24 @@ def __validModes( plug ) :
 			Gaffer.TweakPlug.Mode.Multiply
 		]
 
+	if type( plug.parent()["value"] ) in [
+		Gaffer.BoolVectorDataPlug,
+		Gaffer.IntVectorDataPlug,
+		Gaffer.FloatVectorDataPlug,
+		Gaffer.StringVectorDataPlug,
+		Gaffer.InternedStringVectorDataPlug,
+		Gaffer.V2iVectorDataPlug,
+		Gaffer.V3fVectorDataPlug,
+		Gaffer.Color3fVectorDataPlug,
+		Gaffer.M44fVectorDataPlug,
+		Gaffer.M33fVectorDataPlug,
+	] :
+		result += [
+			Gaffer.TweakPlug.Mode.ListAppend,
+			Gaffer.TweakPlug.Mode.ListPrepend,
+			Gaffer.TweakPlug.Mode.ListRemove
+		]
+
 	if Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:allowRemove" ) :
 		result += [ Gaffer.TweakPlug.Mode.Remove ]
 
@@ -186,7 +205,7 @@ def __validModes( plug ) :
 
 Gaffer.Metadata.registerValue(
 	Gaffer.TweakPlug, "mode",
-	"presetNames", lambda plug : IECore.StringVectorData( [ str( x ) for x in __validModes( plug ) ] )
+	"presetNames", lambda plug : IECore.StringVectorData( [ IECore.CamelCase.toSpaced( str( x ) ) for x in __validModes( plug ) ] )
 )
 
 Gaffer.Metadata.registerValue(

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -288,9 +288,10 @@ const char *TweakPlug::modeToString( Gaffer::TweakPlug::Mode mode )
 			return "Multiply";
 		case Gaffer::TweakPlug::Remove :
 			return "Remove";
-		default :
-			return "Invalid";
+		case Gaffer::TweakPlug::Create : 
+			return  "Create";
 	}
+	return  "Invalid";
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -65,6 +65,42 @@ template< typename T > struct IsColorTypedData : boost::mpl::and_< TypeTraits::I
 // SupportsArithmeticData
 template< typename T > struct SupportsArithData : boost::mpl::or_<  TypeTraits::IsNumericSimpleTypedData<T>, TypeTraits::IsVecTypedData<T>, IsColorTypedData<T>> {};
 
+template<typename T>
+T vectorAwareMin( const T &v1, const T &v2 )
+{
+	if constexpr( TypeTraits::IsVec<T>::value || TypeTraits::IsColor<T>::value )
+	{
+		T result;
+		for( size_t i = 0; i < T::dimensions(); ++i )
+		{
+			result[i] = std::min( v1[i], v2[i] );
+		}
+		return result;
+	}
+	else
+	{
+		return std::min( v1, v2 );
+	}
+}
+
+template<typename T>
+T vectorAwareMax( const T &v1, const T &v2 )
+{
+	if constexpr( TypeTraits::IsVec<T>::value || TypeTraits::IsColor<T>::value )
+	{
+		T result;
+		for( size_t i = 0; i < T::dimensions(); ++i )
+		{
+			result[i] = std::max( v1[i], v2[i] );
+		}
+		return result;
+	}
+	else
+	{
+		return std::max( v1, v2 );
+	}
+}
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -91,7 +127,7 @@ TweakPlug::TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name, D
 {
 	addChild( new StringPlug( "name", direction ) );
 	addChild( new BoolPlug( "enabled", direction, true ) );
-	addChild( new IntPlug( "mode", direction, Replace, Replace, Create ) );
+	addChild( new IntPlug( "mode", direction, Replace, First, Last ) );
 
 	if( valuePlug )
 	{
@@ -250,10 +286,19 @@ void TweakPlug::applyNumericTweak(
 					case TweakPlug::Multiply :
 						data->writable() = sourceDataCast->readable() * tweakDataCast->readable();
 						break;
+					case TweakPlug::Min :
+						data->writable() = vectorAwareMin( sourceDataCast->readable(), tweakDataCast->readable() );
+						break;
+					case TweakPlug::Max :
+						data->writable() = vectorAwareMax( sourceDataCast->readable(), tweakDataCast->readable() );
+						break;
+					case TweakPlug::ListAppend :
+					case TweakPlug::ListPrepend :
+					case TweakPlug::ListRemove :
 					case TweakPlug::Replace :
 					case TweakPlug::Remove :
 					case TweakPlug::Create :
-						// These cases are unused - we handle replace and remove mode outside of numericTweak.
+						// These cases are unused - we handle them outside of numericTweak.
 						// But the compiler gets unhappy if we don't handle some cases.
 						assert( false );
 						break;
@@ -270,7 +315,60 @@ void TweakPlug::applyNumericTweak(
 				);
 			}
 		}
+	);
+}
 
+void TweakPlug::applyListTweak(
+	const IECore::Data *sourceData,
+	const IECore::Data *tweakData,
+	IECore::Data *destData,
+	TweakPlug::Mode mode,
+	const std::string &tweakName
+) const
+{
+	dispatch(
+
+		destData,
+
+		[&] ( auto data ) {
+
+			using DataType = typename std::remove_pointer<decltype( data )>::type;
+
+			if constexpr( TypeTraits::IsVectorTypedData<DataType>::value )
+			{
+				const DataType *sourceDataCast = runTimeCast<const DataType>( sourceData );
+				const DataType *tweakDataCast = runTimeCast<const DataType>( tweakData );
+
+				const auto &currentElements = sourceDataCast->readable();
+				const auto &newElements = tweakDataCast->readable();
+
+				data->writable() = typename DataType::ValueType( currentElements );
+				data->writable().erase(
+					std::remove_if(
+						data->writable().begin(),
+						data->writable().end(),
+						[&newElements]( const auto &elem )
+						{
+							return std::find(
+								newElements.begin(),
+								newElements.end(),
+								elem
+							) != newElements.end();
+						}
+					),
+					data->writable().end()
+				);
+
+				if( mode == TweakPlug::ListAppend )
+				{
+					data->writable().insert( data->writable().end(), newElements.begin(), newElements.end() );
+				}
+				else if( mode == TweakPlug::ListPrepend )
+				{
+					data->writable().insert( data->writable().begin(), newElements.begin(), newElements.end() );
+				}
+			}
+		}
 	);
 }
 
@@ -288,8 +386,18 @@ const char *TweakPlug::modeToString( Gaffer::TweakPlug::Mode mode )
 			return "Multiply";
 		case Gaffer::TweakPlug::Remove :
 			return "Remove";
-		case Gaffer::TweakPlug::Create : 
+		case Gaffer::TweakPlug::Create :
 			return  "Create";
+		case Gaffer::TweakPlug::Min :
+			return "Min";
+		case Gaffer::TweakPlug::Max :
+			return "Max";
+		case Gaffer::TweakPlug::ListAppend :
+			return "ListAppend";
+		case Gaffer::TweakPlug::ListPrepend :
+			return "ListPrepend";
+		case Gaffer::TweakPlug::ListRemove :
+			return "ListRemove";
 	}
 	return  "Invalid";
 }

--- a/src/GafferModule/TweakPlugBinding.cpp
+++ b/src/GafferModule/TweakPlugBinding.cpp
@@ -112,6 +112,11 @@ void GafferModule::bindTweakPlugs()
 			.value( "Multiply", TweakPlug::Multiply )
 			.value( "Remove", TweakPlug::Remove )
 			.value( "Create", TweakPlug::Create )
+			.value( "Min", TweakPlug::Min )
+			.value( "Max", TweakPlug::Max )
+			.value( "ListAppend", TweakPlug::ListAppend )
+			.value( "ListPrepend", TweakPlug::ListPrepend )
+			.value( "ListRemove", TweakPlug::ListRemove )
 		;
 
 		enum_<TweakPlug::MissingMode>( "MissingMode" )


### PR DESCRIPTION
This adds new tweak modes including `Min`, `Max`, `ListAppend`, `ListPrepend` and `ListRemove`. List handling is intended to match the [USD list specification](https://graphics.pixar.com/usd/release/glossary.html#list-editing).

It will need some care when merging into `main` in the future because `TweakPlug` has been moved into the `Gaffer` module on `main`. It should be mostly replacing `GafferScene` with `Gaffer`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
