### PR TITLE
 GafferCycles : Fix linking on MacOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1235,6 +1235,7 @@ libraries = {
 				( "CCL_NAMESPACE_END", "}" ),
 				( "WITH_OSL", "1" ),
 			],
+			"FRAMEWORKS" : [ "Foundation", "Metal" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBPATH" : [ "$CYCLES_ROOT/lib" ],

--- a/include/GafferCycles/IECoreCyclesPreview/AttributeAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/AttributeAlgo.h
@@ -40,7 +40,9 @@
 #include "IECoreScene/Primitive.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/attribute.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/CameraAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/CameraAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/camera.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/CurvesAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/CurvesAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
+++ b/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
@@ -38,7 +38,9 @@
 #include "GafferCycles/IECoreCyclesPreview/Export.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "device/device.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>
 

--- a/include/GafferCycles/IECoreCyclesPreview/MeshAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/MeshAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/ObjectAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ObjectAlgo.h
@@ -42,9 +42,11 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
 // Currently only VDBs need scene to get to the image manager
 #include "scene/scene.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/ParticleAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ParticleAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/particles.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/PointsAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/PointsAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
@@ -42,10 +42,12 @@
 #include "IECoreScene/ShaderNetwork.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/shader_graph.h"
 #include "scene/light.h"
 #include "scene/shader.h"
 #include "scene/scene.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/SocketAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/SocketAlgo.h
@@ -43,9 +43,11 @@
 #include "IECore/Spline.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "graph/node.h"
 #include "graph/node_type.h"
 #include "util/transform.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/SphereAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/SphereAlgo.h
@@ -42,7 +42,9 @@
 #include <vector>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/IECoreCyclesPreview/VDBAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/VDBAlgo.h
@@ -37,10 +37,14 @@
 
 #include "GafferCycles/IECoreCyclesPreview/Export.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "IECoreVDB/VDBObject.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/object.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/include/GafferCycles/SocketHandler.h
+++ b/include/GafferCycles/SocketHandler.h
@@ -40,7 +40,9 @@
 #include "Gaffer/Plug.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "graph/node.h"
+IECORE_POP_DEFAULT_VISIBILITY
 #undef fmix // OpenImageIO's farmhash inteferes with IECore::MurmurHash
 
 namespace GafferCycles

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -38,7 +38,9 @@
 #include "boost/algorithm/string.hpp"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "device/device.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace Imath;
 using namespace GafferCycles;

--- a/src/GafferCycles/IECoreCyclesPreview/ObjectAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ObjectAlgo.cpp
@@ -32,15 +32,17 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-// Cycles (for ustring)
-#include "util/param.h"
-#undef fmix // OpenImageIO's farmhash inteferes with IECore::MurmurHash
-
 #include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
 
 #include "IECore/MessageHandler.h"
 
 #include "IECoreScene/PrimitiveVariable.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+// Cycles (for ustring)
+#include "util/param.h"
+#undef fmix // OpenImageIO's farmhash inteferes with IECore::MurmurHash
+IECORE_POP_DEFAULT_VISIBILITY
 
 #include <unordered_map>
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -82,6 +82,7 @@
 #include <unordered_map>
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "bvh/params.h"
 #include "device/device.h"
 #include "graph/node.h"
@@ -111,6 +112,7 @@
 #include "util/path.h"
 #include "util/time.h"
 #include "util/vector.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -56,9 +56,11 @@
 #include "boost/unordered_map.hpp"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/shader_nodes.h"
 #include "scene/osl.h"
 #include "util/path.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace IECore;

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -38,10 +38,12 @@
 #include "IECore/VectorTypedData.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "kernel/types.h" // for RAMP_TABLE_SIZE
 #include "util/transform.h"
 #include "util/types.h"
 #include "util/vector.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -45,8 +45,10 @@
 #include "IECore/SimpleTypedData.h"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/geometry.h"
 #include "scene/pointcloud.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -37,15 +37,19 @@
 #include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "openvdb/openvdb.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "kernel/types.h"
 #include "scene/image.h"
 #include "scene/image_vdb.h"
 #include "scene/volume.h"
 #include "util/param.h"
 #include "util/types.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/IEDisplayOutputDriver.cpp
@@ -36,9 +36,11 @@
 
 #include "IEDisplayOutputDriver.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/pass.h"
 #include "util/murmurhash.h"
 #include "util/string.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.cpp
@@ -36,15 +36,19 @@
 
 #include "OIIOOutputDriver.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/pass.h"
 #include "util/murmurhash.h"
 #include "util/string.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenImageIO/imageio.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace
 {

--- a/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
+++ b/src/GafferCycles/IECoreCyclesPreview/outputDriver/OIIOOutputDriver.h
@@ -34,16 +34,22 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "IECore/Export.h"
+
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "kernel/types.h"
 #include "session/output_driver.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 // Cortex
 #include "IECore/CompoundData.h"
 #include "IECore/InternedString.h"
 
 // OIIO
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenImageIO/typedesc.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreCycles
 {

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -55,10 +55,12 @@
 #include "boost/container/flat_set.hpp"
 
 // Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "kernel/types.h"
 #include "util/transform.h"
 #include "util/types_float2.h"
 #include "util/types_float3.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;
 using namespace Imath;


### PR DESCRIPTION
We need to link to Foundation and Metal, because Cycles depends on them. And we need to push and pop visibility when including Cycles headers to avoid reams and reams of linking errors like the following :

```
ld: warning: direct access in function '___cxx_global_var_init.30' from file 'src/GafferCycles/SocketHandler.os' to global weak symbol 'guard variable for fmt::v7::detail::basic_data<void>::dragonbox_pow10_significands_128' from file '/Users/john/dev/build/gaffer/cycles/lib/libcycles_scene.a(background.cpp.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```

This is a bit unsatisfactory, and I think should really be resolved by improvements to Cycle's own packaging. I did experiment with this, building a `libcycles.dylib` from the various `libcycles_*.a` static libraries like so :

```
clang++ -shared -Wl,-all_load *.a -Wl,-noall_load -framework Foundation -framework Metal -o libcycles.dylib -L/Users/john/dev/build/gaffer/lib -lembree3 -lAlembic -lOpenImageIO -lOpenImageIO_Util -lImath -lopenvdb -ltbb -loslexec -lOpenColorIO -losdCPU
```

This did in fact work, and meant that we could link solely to `libcycles` with none of the code changes here being necessary. But Alex has concerns about this not working on Windows, and I have a limited appetite for the amount of post-processing we do on a Cycles build. Really I think Cycles should provide a configuration option to allow it to build and ship as a single shared library, just like every other renderer does. The big benefit of this to us would be that we could work on Cycles and run new builds in Gaffer just by pointing it at a new CYCLES_ROOT, rather than having to rebuild GafferCycles to pick up changes to the static libs. To be revisited...

