### PR TITLE
GafferImage::Text : Don't insert useless vertical space before long w…

### DIFF
--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -113,6 +113,36 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( text["out"], reader["out"], ignoreMetadata = True, maxDifference = 0.001 )
 
+	def testArea( self ) :
+
+		text = GafferImage.Text()
+		text["text"].setValue( "a a a a a a a a" )
+		text["size"].setValue( imath.V2i( 20 ) )
+		text["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ) )
+
+		self.assertEqual( text["out"].dataWindow(), imath.Box2i( imath.V2i( 1, 58 ), imath.V2i( 83, 92 ) ) )
+
+		text["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 200 ) ) )
+		self.assertEqual( text["out"].dataWindow(), imath.Box2i( imath.V2i( 1, 181 ), imath.V2i( 137, 192 ) ) )
+
+		text["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 5, 200 ) ) )
+		self.assertEqual( text["out"].dataWindow(), imath.Box2i( imath.V2i( 1, 20 ), imath.V2i( 11, 192 ) ) )
+
+		text["text"].setValue( "longWord\nlongWord\nlongWord" )
+		text["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 100 ) ) )
+
+		self.assertEqual( text["out"].dataWindow(), imath.Box2i( imath.V2i( 1, 31 ), imath.V2i( 95, 96 ) ) )
+
+		# If the text box is too short horizontally to fit a single word in, this doesn't affect anything,
+		# since we don't wrap individual words ( this test ensures that we don't add vertical space in
+		# this case, which wouldn't help fit the text in
+		shortText = GafferImage.Text()
+		shortText["text"].setValue( "longWord\nlongWord\nlongWord" )
+		shortText["size"].setValue( imath.V2i( 20 ) )
+		shortText["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 5, 100 ) ) )
+		shortText["text"].setValue( "longWord\nlongWord\nlongWord" )
+		self.assertImagesEqual( text["out"], shortText["out"], ignoreMetadata = True, maxDifference = 0.001 )
+
 	def testHorizontalAlignment( self ) :
 
 		text = GafferImage.Text()

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -427,7 +427,7 @@ IECore::ConstCompoundObjectPtr Text::computeLayout( const Gaffer::Context *conte
 		{
 			const u32string word = fromUTF8( *it );
 			int width = ::width( word, face.get() );
-			if( pen.x + width > area.max.x )
+			if( pen.x + width > area.max.x && pen.x > area.min.x )
 			{
 				pen.x = area.min.x;
 


### PR DESCRIPTION
…ords

( I know I'm supposed to keep my commit messages under 70 characters, but the formatting just seemed too perfect in this case )

Because we don't split words when wrapping to fit in the area, if a word is longer than the target area, it will just stick out.  Before this commit however, as well as sticking out horizontally, it would also get an extra newline inserted vertically ( because we were trying to wrap it, not realizing it couldn't be split ).

( This isn't critical at all, it just confused me, so I thought I might sneak it in since I'm working up to tackling viewer wipes on a Monday after a long weekend ).
