### PR TITLE
GraphComponent : Use DirtyPropagationScope for parent changes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.x.x.x
+=======
+
+API
+---
+
+- Signals : Added `Trackable::disconnectTrackedConnections()` method.
+
 1.0.2.1 (relative to 1.0.2.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.x.x.x
 =======
 
+Fixes
+-----
+
+- Plug : Fixed bug that could prevent `plugDirtiedSignal()` from ever being emitted again if an exception was thrown during parenting. This could cause the UI to stop updating.
+
 API
 ---
 

--- a/include/Gaffer/Private/SlotBase.h
+++ b/include/Gaffer/Private/SlotBase.h
@@ -165,4 +165,13 @@ inline void intrusive_ptr_release( SlotBase *r )
 
 } // namespace Gaffer::Signals::Private
 
+// Forward declaration to allow friendship with the Python bindings.
+
+namespace GafferModule
+{
+
+void bindSignals();
+
+};
+
 #endif // GAFFER_SLOTBASE_H

--- a/include/Gaffer/Signals.h
+++ b/include/Gaffer/Signals.h
@@ -246,7 +246,13 @@ class Trackable : boost::noncopyable
 
 		virtual ~Trackable();
 
+	protected :
+
+		void disconnectTrackedConnections();
+
 	private :
+
+		friend void GafferModule::bindSignals();
 
 		template<typename Signature, typename Combiner>
 		friend class Signal;

--- a/include/Gaffer/Signals.h
+++ b/include/Gaffer/Signals.h
@@ -236,7 +236,9 @@ struct CatchingCombiner;
 ///
 /// \todo Perhaps we should add a protected `track( const Connection &connection )`
 /// method that could be used to track any sort of connection? Then we could replace
-/// our usage of `boost::bind()` with `std::bind()`.
+/// our usage of `boost::bind()` with `std::bind()`. Or perhaps `Signal::connect()`
+/// should take multiple arguments and do the binding for you, so it naturally gets
+/// to introspect the arguments looking for Trackables?
 class Trackable : boost::noncopyable
 {
 

--- a/include/Gaffer/Signals.inl
+++ b/include/Gaffer/Signals.inl
@@ -452,13 +452,7 @@ struct CatchingCombiner
 
 inline Trackable::~Trackable()
 {
-	if( m_connections )
-	{
-		for( auto &c : *m_connections )
-		{
-			c.disconnect();
-		}
-	}
+	disconnectTrackedConnections();
 }
 
 struct Trackable::TrackableVisitor
@@ -507,6 +501,17 @@ void Trackable::trackConnection( const SlotFunctor &slotFunctor, const Connectio
 		slotFunctor,
 		0
 	);
+}
+
+inline void Trackable::disconnectTrackedConnections()
+{
+	if( m_connections )
+	{
+		for( auto &c : *m_connections )
+		{
+			c.disconnect();
+		}
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/include/GafferUI/Tool.h
+++ b/include/GafferUI/Tool.h
@@ -129,6 +129,8 @@ class GAFFERUI_API Tool : public Gaffer::Node
 			}
 		};
 
+		void parentChanged( GraphComponent *oldParent ) override;
+
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferTest/SignalsTest.py
+++ b/python/GafferTest/SignalsTest.py
@@ -437,12 +437,23 @@ class SignalsTest( GafferTest.TestCase ) :
 
 		c = s.connect( Gaffer.WeakMethod( t.f ), scoped = False )
 
+		# Deleting `t` should automatically disconnect the slots that refer to
+		# it.
+
 		self.assertTrue( c.connected() )
 		del t
 		self.assertIsNone( w() )
 		self.assertFalse( c.connected() )
 
 		s() # Would throw if an expired WeakMethod remained connected
+
+		# Slots can also be manually disconnected with `_disconnectTrackedConnections()`.
+
+		t = TrackableTest()
+		c = s.connect( Gaffer.WeakMethod( t.f ), scoped = False )
+		self.assertTrue( c.connected() )
+		t._disconnectTrackedConnections()
+		self.assertFalse( c.connected() )
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testConstructionPerformance( self ) :

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -387,6 +387,7 @@ void GraphComponent::throwIfChildRejected( const GraphComponent *potentialChild 
 
 void GraphComponent::addChildInternal( GraphComponentPtr child, size_t index )
 {
+	DirtyPropagationScope dirtyPropagationScope;
 	child->parentChanging( this );
 	GraphComponent *previousParent = child->m_parent;
 	if( previousParent )
@@ -435,6 +436,7 @@ void GraphComponent::removeChild( GraphComponentPtr child )
 
 void GraphComponent::removeChildInternal( GraphComponentPtr child, bool emitParentChanged )
 {
+	DirtyPropagationScope dirtyPropagationScope;
 	if( emitParentChanged )
 	{
 		child->parentChanging( nullptr );

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -568,15 +568,13 @@ PlugPtr Plug::createCounterpart( const std::string &name, Direction direction ) 
 
 void Plug::parentChanging( Gaffer::GraphComponent *newParent )
 {
-	// When a plug is removed from a node, we need to propagate
-	// dirtiness based on that. We must call `DependencyNode::affects()`
-	// now, while the plug is still a child of the node, but we push
-	// scope so that the emission of `plugDirtiedSignal()` is deferred
-	// until `parentChanged()` when the operation is complete. It is
-	// essential that exceptions don't prevent us getting to `parentChanged()`
-	// where we pop scope, so propateDirtiness() takes care of handling
-	// exceptions thrown by `DependencyNode::affects()`.
-	pushDirtyPropagationScope();
+	// When a plug is removed from a node, we need to propagate dirtiness for
+	// it. We must call `DependencyNode::affects()` now, while the plug is still
+	// a child of the node.
+	//
+	// Before calling `parentChanging()`, GraphComponent has scoped a
+	// DirtyPropagationScope so that the emission of `plugDirtiedSignal()` is
+	// deferred until after `parentChanged()`, when the operation is complete.
 	if( node() )
 	{
 		propagateDirtinessForParentChange( this );
@@ -668,8 +666,6 @@ void Plug::parentChanged( Gaffer::GraphComponent *oldParent )
 		// propagate dirtiness.
 		propagateDirtinessForParentChange( this );
 	}
-	// Pop the scope pushed in `parentChanging()`.
-	popDirtyPropagationScope();
 }
 
 void Plug::childrenReordered( const std::vector<size_t> &oldIndices )

--- a/src/GafferModule/SignalsBinding.cpp
+++ b/src/GafferModule/SignalsBinding.cpp
@@ -186,7 +186,9 @@ void GafferModule::bindSignals()
 		.def( init<const Connection &>() )
 	;
 
-	class_<Gaffer::Signals::Trackable, boost::noncopyable>( "Trackable" );
+	class_<Gaffer::Signals::Trackable, boost::noncopyable>( "Trackable" )
+		.def( "_disconnectTrackedConnections", &Trackable::disconnectTrackedConnections )
+	;
 
 	using Signal0 = Gaffer::Signals::Signal<object (), PythonResultCombiner>;
 	using Signal1 = Gaffer::Signals::Signal<object ( object ), PythonResultCombiner>;

--- a/src/GafferUI/Tool.cpp
+++ b/src/GafferUI/Tool.cpp
@@ -162,6 +162,18 @@ void Tool::registeredTools( IECore::TypeId viewType, std::vector<std::string> &t
 	} while( viewType != (IECore::TypeId)NodeTypeId && viewType != IECore::InvalidTypeId );
 }
 
+void Tool::parentChanged( GraphComponent *oldParent )
+{
+	if( oldParent != nullptr )
+	{
+		// Tools are bound to a particular ToolContainer, and can't be reparented.  If we already
+		// had a parent, and it's changing, that can only mean we're being destroyed.
+		// Disable signals while we're being destroyed, so that Tools don't have to handle
+		// plugDirtiedSignal while their parent is invalid.
+		disconnectTrackedConnections();
+	}
+}
+
 //////////////////////////////////////////////////////////////////////////
 // ToolContainer
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a core thing that I don't know all the details of, so you definite may want to change up some of the details.  But I have got a nice simple test that demonstrates that misuse of undo scopes can currently trigger an exception that results in a mismatched DirtyPropagationScope.

I also observed that you have now added a DirtyPropagationScope to `~GraphComponent`.  Since you suggested the original reason for not doing this around parentChanging/parentChanged in GraphComponent was so that GraphComponent wouldn't know about dirty propagation, the fact that it now does this in one place strongly suggests that GraphComponent should always take care of it.

My naive fix does seem to address the issue.  Some questions about it, that you would probably know more than I would about:
* should we release the DirtyPropagationScope before `MemberSignals::emitLazily( ..., parentChangedSignal )`?  Not sure what makes more sense, but in this naive version, I've implicitly changed the order from what it was before
* should we avoid creating a DirtyPropagationScope when emitParentChanged == False?  Again, not sure what makes sense, but that's the way it was before