### PR TITLE
ShaderUI : Fix error when clicking "Input" column

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - TweakPlug : Fixed loading of files saved from Gaffer 1.0.0.0 and above.
+- ShaderQuery and ShaderTweaks : Fixed error `TypeError: object of type 'NoneType' has no len()` when clicking "Input" column of a shader row.
 
 0.61.14.0 (relative to 0.61.13.1)
 =========

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -732,6 +732,9 @@ class _ShaderParameterDialogue( GafferUI.Dialogue ) :
 			inputRootPath = path.parent().parent()
 			inputs = path.property( "shader:inputs" )
 
+			if inputs is None :
+				return False
+
 			if len( inputs ) == 0 :
 				return False
 


### PR DESCRIPTION
This fixes an error output to the terminal if the `Input` column of a shader (not a shader parameter) was clicked. It didn't cause any functional problems, but the error to the terminal may sound more serious than it is to users.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
