### PR TITLE
Catalogue : Hash all views when deciding on image filename

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 - Fixed errors in Light Editor :
   - Error when pressing <kbd>Return</kbd> or <kbd>Enter</kbd> with no cells selected.
   - Error when double-clicking the `Name` column.
+- Fix issue with CatalogueUI that prevented saving of images.  Also improved support for multi-view images in the catalog
 
 1.0.0.0 (relative to 0.61.x.x)
 =======

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -1052,25 +1052,28 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __pathListingDrop( self, widget, event ) :
 
-		image = self.__dropImage( event.data )
-		if image is None :
-			return False
+		try:
+			image = self.__dropImage( event.data )
+			if image is None :
+				return False
 
-		with self.getContext() :
-			fileName = self.__catalogue().generateFileName( image )
-			imageWriter = GafferImage.ImageWriter()
-			imageWriter["in"].setInput( image )
-			imageWriter["fileName"].setValue( fileName )
-			imageWriter["task"].execute()
+			with self.getContext() :
+				fileName = self.__catalogue().generateFileName( image )
+				imageWriter = GafferImage.ImageWriter()
+				imageWriter["in"].setInput( image )
+				imageWriter["fileName"].setValue( fileName )
+				imageWriter["task"].execute()
 
-		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			loadedImage = GafferImage.Catalogue.Image.load( fileName )
-			loadedImage.setName( image.node().getName() )
-			self.__images().addChild( loadedImage )
-			self.getPlug().setValue( len( self.__images() ) - 1 )
+			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+				loadedImage = GafferImage.Catalogue.Image.load( fileName )
+				loadedImage.setName( image.node().getName() )
+				self.__images().addChild( loadedImage )
+				self.getPlug().setValue( len( self.__images() ) - 1 )
 
-		self.__pathListing.setHighlighted( False )
-		GafferUI.Pointer.setCurrent( None )
+			self.__pathListing.setHighlighted( False )
+			GafferUI.Pointer.setCurrent( None )
+		except Exception as e:
+			IECore.msg( IECore.Msg.Level.Warning, "CatalogueUI", 'Failed to add image during drag, exception: ' + str( e ) )
 
 		return True
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -107,6 +107,14 @@ class Column( GafferUI.PathColumn ) :
 			# to output the image of interest.
 			with Gaffer.Context( catalogue.scriptNode().context() ) as context :
 				context["catalogue:imageName"] = image.getName()
+
+				# Our cells can only display data from one view, so we need to pick one.
+				# If the "default" view is present use that, otherwise use the first view
+				viewNames = catalogue["out"].viewNames()
+				if not len( viewNames ):
+					raise Exception( "Catalogue : Image has no views, no data to display" )
+				context["image:viewName"] = "default" if "default" in viewNames else viewNames[0]
+
 				try :
 					return self._imageCellData( image, catalogue )
 				except NotImplementedError :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -197,7 +197,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 			else :
 				# We want to present the options above as a simple "Show Name" checkbox, and haven't yet
 				# decided how to present other combinations of allowable gadgets.
-				IECore.msg( IECore.msg.Warning, "UIEditor", 'Unknown combination of "uiEditor:nodeGadgetTypes"' )
+				IECore.msg( IECore.Msg.Level.Warning, "UIEditor", 'Unknown combination of "uiEditor:nodeGadgetTypes"' )
 
 	@classmethod
 	def appendNodeEditorToolMenuDefinitions( cls, nodeEditor, node, menuDefinition ) :

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -962,7 +962,14 @@ std::string Catalogue::generateFileName( const ImagePlug *image ) const
 	}
 
 	boost::filesystem::path result( directory );
-	result /= ImageAlgo::imageHash( image ).toString();
+
+	// Hash all views of the image
+	IECore::MurmurHash h;
+	for( const std::string &v : image->viewNames()->readable() )
+	{
+		h.append( ImageAlgo::imageHash( image, &v ) );
+	}
+	result /= h.toString();
 	result.replace_extension( "exr" );
 
 	return result.string();


### PR DESCRIPTION
This avoids a dependency on the default view name which caused generateFileName to fail when outside of a script context.

The most concerning part of this is probably that the tests didn't catch it.  This appears to be due to a difference in how the tests handle setting the default view name ( ImageTestCase.setUp scopes a Context with the default view set ), vs how the UI handles setting the default view name ( a script variable ).  This means that in UI, if you're running something which doesn't inherit the script variables ( like apparently Catalogue::imageReceived ), it doesn't have the default view set, but in the tests, it will have it set, so we missed this bug.

We do seem to be encountering a bunch of these sorts of issues ( I think Ivan has been talking to you about some of the things he's found at IE ).  I do kind of wonder whether there could have been a better way of making sure this got set that wasn't dependent on the UI, but I guess at this point we've probably caught most of the edge cases.

The fix for this specific piece of code goes a little beyond just setting the default view - I hash all views, which would be correct even in the possible future where we start using the catalog with multi-view images.