### PR TITLE
TweakPlug : Handle non-existent lists.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.x.x (relative to 1.0.1.0)
+=======
+
+Improvements
+------------
+
+- TweakPlug : Using the modes `listAppend` and `listPrepend` to modify a list that does not exist now results in a list with the new values. Using the mode `listRemove` to modify a non-existent list results in a non-existent list. All other modes retain their current `missingMode` behavior.
+
 1.0.1.0 (relative to 1.0.0.0)
 =======
 

--- a/include/Gaffer/TweakPlug.inl
+++ b/include/Gaffer/TweakPlug.inl
@@ -102,7 +102,12 @@ bool TweakPlug::applyTweak(
 
 	if( !currentValue )
 	{
-		if( missingMode == Gaffer::TweakPlug::MissingMode::Ignore )
+		if( mode == Gaffer::TweakPlug::ListAppend || mode == Gaffer::TweakPlug::ListPrepend )
+		{
+			setDataFunctor( name, newData );
+			return true;
+		}
+		else if( missingMode == Gaffer::TweakPlug::MissingMode::Ignore || mode == Gaffer::TweakPlug::ListRemove )
 		{
 			return false;
 		}


### PR DESCRIPTION
This modifies the behavior of `TweakPlug` when using the `ListAppend`, `ListPrepend` and `ListRemove` modes on non-existent lists.
- `ListAppend` and `ListPrepend` will create the list and set it to the new list values, regardless of the value of `missingMode`.
- `ListRemove` will always behave as though `missingMode` is set to `ignore`.

This is motivated by the desire to reduce graph complexity for the common case where list tweaks are applied at a graph location where the value may or may not already exist. It avoids the need for additional graph logic to check for the existence of the value and change the tweak to `Create` when needed.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
