### PR TITLE
Cross platform `FileSystemPath`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,8 @@ jobs:
             publish: false
             containerImage:
             dependenciesURL: https://github.com/hypothetical-inc/gafferDependencies/releases/download/6.1.0/gafferDependencies-6.1.0-Python3-windows.zip
+            testRunner: Invoke-Expression
+            testArguments: GafferTest.FileSystemPathTest
 
     runs-on: ${{ matrix.os }}
 
@@ -166,9 +168,8 @@ jobs:
       timeout-minutes: 60
       run: |
         echo "::add-matcher::./.github/workflows/main/problemMatchers/unittest.json"
-        ${{ matrix.testRunner }} "${{ env.GAFFER_BUILD_DIR }}/bin/gaffer test"
+        ${{ matrix.testRunner }} "${{ env.GAFFER_BUILD_DIR }}/bin/gaffer test ${{ matrix.testArguments }}"
         echo "::remove-matcher owner=unittest::"
-      if: runner.os == 'macOS' || runner.os == 'Linux'
 
     - name: Build and test Arnold extension
       run: |

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,10 @@ API
 - ViewportGadget : Added `setPostProcessShader()`.  This allows the main layer to be rendered to a framebuffer, and processed by a shader before being displayed.  Useful for applying color transforms on the GPU after rendering.
 - GafferImageUI : Added `OpenColorIOAlgo::displayTransformToFramebufferShader()`.  Converts an OCIO processor to a shader suitable for use with `setPostProcessShader()`.
 - ImageView : ImageView now uses a color transform on the viewport instead of ImageGadget.  Should not impact user visible behaviour, but paves the way for future work.
+- Path : Added virtual `rootAndNames()` method. This can be overridden to modify the `root` and `names` values as set by `setFromString()`.
+- FileSystemPath :
+  - Added support for Windows paths.
+  - Added `nativeString()` function to return the path as an OS-specific string.
 
 Breaking Changes
 ----------------

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -45,6 +45,15 @@
 namespace Gaffer
 {
 
+/// The FileSystemPath class provides cross-platform file path functions.
+/// Paths can be a native formatted path - elements are separated by "/"
+/// on Linux and MacOS and "\" on Windows - or by the Gaffer standard
+/// path separator "/" on all platforms.
+///
+/// The root of a FileSystemPath will be "" for relative paths. On Linux and
+/// MacOS, an absolute path root will be "/".
+/// On Windows, an absolute path root will be either "<driveLetter>:/" for
+/// drive-letter paths, or "//<serverName>/" for UNC paths.
 class GAFFER_API FileSystemPath : public Path
 {
 
@@ -82,6 +91,9 @@ class GAFFER_API FileSystemPath : public Path
 		// a FileSequence.
 		IECore::FileSequencePtr fileSequence() const;
 
+		// Returns the path converted to the OS native format
+		std::string nativeString() const;
+
 		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "", bool includeSequenceFilter = false );
 
 	protected :
@@ -89,6 +101,13 @@ class GAFFER_API FileSystemPath : public Path
 		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const override;
 
 	private :
+
+#ifdef _MSC_VER
+
+		/// Sets the path root and names in generic format from an OS native path string
+		void rootAndNames( const std::string &string, IECore::InternedString &root, Names &names ) const override;
+
+#endif
 
 		bool m_includeSequences;
 

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -219,6 +219,8 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 
 	private :
 
+		virtual void rootAndNames( const std::string &s, IECore::InternedString &root, Names &names ) const;
+
 		void filterChanged();
 		void checkName( const IECore::InternedString &name ) const;
 

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -39,7 +39,8 @@ import unittest
 import time
 import datetime
 import os
-if os.name is not "nt" :
+if os.name !="nt" :
+
 	import pwd
 	import grp
 else :
@@ -518,7 +519,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def getFileOwner( self, filePath ):
 
-		if os.name is not "nt" :
+		if os.name != "nt" :
 			return pwd.getpwuid( os.stat( filePath ).st_uid ).pw_name
 		else :
 			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )
@@ -527,7 +528,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def getFileGroup( self, filePath ) :
 
-		if os.name is not "nt" :
+		if os.name != "nt" :
 			return grp.getgrgid( os.stat( filePath ).st_gid ).gr_name
 		else :
 			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -42,6 +42,8 @@ import os
 if os.name is not "nt" :
 	import pwd
 	import grp
+else :
+	from . import _WindowsUtils
 
 import IECore
 
@@ -515,17 +517,23 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		GafferTest.TestCase.tearDown( self )
 
-	def getFileOwner( self, filepath ):
+	def getFileOwner( self, filePath ):
 
-		# Windows Python does not have a reliable native method to get the owner
-		# without installing the Win32 package. Since the files being tested
-		# are created within the test process, assume the current user is
-		# an acceptable standin for the file owner
 		if os.name is not "nt" :
-			return pwd.getpwuid( os.stat( filepath ).st_uid ).pw_name
+			return pwd.getpwuid( os.stat( filePath ).st_uid ).pw_name
 		else :
-			return os.environ["USERNAME"]
+			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )
+			owner, domain = securityDescriptor.owner()
+			return owner
 
+	def getFileGroup( self, filePath ) :
+
+		if os.name is not "nt" :
+			return grp.getgrgid( os.stat( filePath ).st_gid ).gr_name
+		else :
+			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )
+			group, domain = securityDescriptor.group()
+			return group
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -360,7 +360,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		g = p.property( "fileSystem:group" )
 		self.assertTrue( isinstance( g, str ) )
-		self.assertEqual( g, grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
+		self.assertEqual( g, self.getFileGroup( p.nativeString() ) )
 
 	def testPropertyNames( self ) :
 
@@ -416,8 +416,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 				self.assertTrue( x.isLeaf() )
 
 			self.assertEqual( x.property( "fileSystem:owner" ), self.getFileOwner( p.nativeString() ) )
-			if os.name is not "nt" :
-				self.assertEqual( x.property( "fileSystem:group" ), grp.getgrgid( os.stat( str( p ) ).st_gid ).gr_name )
+			self.assertEqual( x.property( "fileSystem:group" ), self.getFileGroup( p.nativeString() ) )
 			self.assertLess( (datetime.datetime.utcnow() - x.property( "fileSystem:modificationTime" )).total_seconds(), 2 )
 			if "###" not in str( x ) :
 				self.assertFalse( x.isFileSequence() )

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -77,6 +77,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		p = Gaffer.FileSystemPath( __file__, filter = f )
 		self.assertTrue( p.getFilter().isSame( f ) )
 
+	@unittest.skipIf( os.name == "nt", "Windows does not support symbolic links." )
 	def testBrokenSymbolicLinks( self ) :
 
 		os.symlink( self.temporaryDirectory() + "/nonExistent", self.temporaryDirectory() + "/broken" )
@@ -98,6 +99,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		# since we said it was valid, it ought to have some info
 		self.assertIsNotNone( l.info() )
 
+	@unittest.skipIf( os.name == "nt", "Windows does not support symbolic links." )
 	def testSymLinkInfo( self ) :
 
 		with open( self.temporaryDirectory() + "/a", "w" ) as f :

--- a/python/GafferTest/_WindowsUtils.py
+++ b/python/GafferTest/_WindowsUtils.py
@@ -1,0 +1,120 @@
+import ctypes as ctypes
+from ctypes import wintypes as wintypes
+from enum import Enum
+
+# Adapted from https://stackoverflow.com/questions/8086412/howto-determine-file-owner-on-windows-using-python-without-pywin32
+
+kernel32 = ctypes.WinDLL( 'kernel32', use_last_error = True )
+advapi32 = ctypes.WinDLL( 'advapi32', use_last_error = True )
+
+SE_FILE_OBJECT = 1
+OWNER_SECURITY_INFORMATION = 0x00000001
+GROUP_SECURITY_INFORMATION = 0x00000002
+DACL_SECURITY_INFORMATION = 0x00000004
+SACL_SECURITY_INFORMATION = 0x00000008
+LABEL_SECURITY_INFORMATION = 0x00000010
+
+class SID_NAME_USE( wintypes.DWORD ) :
+
+	SidTypeUser = 1
+	SidTypeGroup = 2
+	SidTypeDomain = 3
+	SidTypeAlias = 4
+	SidTypeWellKnownGroup = 5
+	SidTypeDeletedAccount = 6
+	SidTypeInvalid = 7
+	SidTypeUnknown = 8
+	SidTypeComputer = 9
+	SidTypeLabel = 10
+	SidTypeLogonSession = 11
+
+PSID_NAME_USE = ctypes.POINTER( SID_NAME_USE )
+
+class PLOCAL( wintypes.LPVOID ) :
+
+	__needsFree = False
+
+	def __init__( self, value = None, needsFree = False ) :
+		super( PLOCAL, self ).__init__( value )
+		self.__needsFree = needsFree
+
+	def __del__( self ):
+		if self and self.__needsFree :
+			kernel32.LocalFree( self )
+			self.__needsFree = False
+
+PACL = PLOCAL
+
+class PSID( PLOCAL ) :
+
+	def __init__( self, value = None, needsFree = False ) :
+		super( PSID, self ).__init__( value, needsFree )
+
+	def __str__( self ) :
+		if not self:
+			raise ValueError( "NULL pointer access" )
+		sid = wintypes.LPWSTR()
+		advapi32.ConvertSidToStringSidW( self, ctypes.byref( sid ) )
+		try:
+			return sid.value
+		finally:
+			if sid:
+				kernel32.LocalFree( sid )
+
+class PSECURITY_DESCRIPTOR( PLOCAL ) :
+	def __init__( self, value = None, needsFree = False ) :
+		super( PSECURITY_DESCRIPTOR, self ).__init__( value, needsFree )
+		self.pOwner = PSID()
+		self.pGroup = PSID()
+		self.pDacl = PACL()
+		self.pSacl = PACL()
+
+	def owner( self ) :
+		if not self or not self.pOwner :
+			raise ValueError( "\"pOwner\" not set." )
+		return lookupAccountSid( self.pOwner )
+
+	def group( self ) :
+		if not self or not self.pGroup :
+			raise ValueError( "\"pGroup\" not set." )
+		return lookupAccountSid( self.pGroup )
+
+def lookupAccountSid( sid ) :
+	SIZE = 256
+	name = ctypes.create_unicode_buffer( SIZE )
+	domain = ctypes.create_unicode_buffer( SIZE )
+	cch_name = wintypes.DWORD( SIZE )
+	cch_domain = wintypes.DWORD( SIZE )
+	sid_type = SID_NAME_USE()
+	advapi32.LookupAccountSidW(
+		None,  # In : System Name
+		sid,  # In : SID
+		name,  # Out : Name
+		ctypes.byref( cch_name ),  # In / Out : cchName
+		domain,  # Out : Domain
+		ctypes.byref( cch_domain ),  # In / Out : cchDomain
+		ctypes.byref( sid_type )  # Out : Use
+	)
+	return name.value, domain.value
+
+def getFileSecurity(
+	fileName,
+	request = (
+		OWNER_SECURITY_INFORMATION |
+		GROUP_SECURITY_INFORMATION
+	)
+):
+	pSD = PSECURITY_DESCRIPTOR( needsFree = True )
+	error = advapi32.GetNamedSecurityInfoW(
+		fileName,  # In : File name
+		SE_FILE_OBJECT,  # In : Object Type
+		request,  # In : Security Info
+		ctypes.byref( pSD.pOwner ),  # Out : Owner
+		ctypes.byref( pSD.pGroup ),  # Out : Group
+		ctypes.byref( pSD.pDacl ),  # Out : DACL (Discretionary access control list)
+		ctypes.byref( pSD.pSacl ),  # Out : SACL (System access control list)
+		ctypes.byref( pSD )  # Out : Security Descriptor
+	)
+	if error != 0:
+		raise ctypes.WinError( error )
+	return pSD

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -222,14 +222,10 @@ void Path::setFromPath( const Path *path )
 
 void Path::setFromString( const std::string &string )
 {
-	Names newNames;
-	StringAlgo::tokenize<InternedString>( string, '/', back_inserter( newNames ) );
-
 	InternedString newRoot;
-	if( string.size() && string[0] == '/' )
-	{
-		newRoot = "/";
-	}
+	Names newNames;
+
+	rootAndNames( string, newRoot, newNames );
 
 	if( newRoot == m_root && newNames == m_names )
 	{
@@ -240,6 +236,16 @@ void Path::setFromString( const std::string &string )
 	m_root = newRoot;
 
 	emitPathChanged();
+}
+
+void Path::rootAndNames( const std::string &string, InternedString &root, Names &names ) const
+{
+	StringAlgo::tokenize<InternedString>( string, '/', back_inserter( names ) );
+
+	if( string.size() && string[0] == '/' )
+	{
+		root = "/";
+	}
 }
 
 PathPtr Path::copy() const

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -532,6 +532,7 @@ void GafferModule::bindPath()
 				arg( "includeSequenceFilter" ) = false
 			)
 		)
+		.def( "nativeString", &FileSystemPath::nativeString )
 		.staticmethod( "createStandardFilter" )
 	;
 

--- a/startup/gui/bookmarks.py
+++ b/startup/gui/bookmarks.py
@@ -43,6 +43,17 @@ bookmarks.setDefault( os.getcwd() )
 bookmarks.add( "Home", os.path.expandvars( "$HOME" ) )
 bookmarks.add( "Desktop", os.path.expandvars( "$HOME/Desktop" ) )
 
+if os.name == "nt" :
+	import string
+	from ctypes import windll
+
+	driveMask = windll.kernel32.GetLogicalDrives()
+	for letter in string.ascii_uppercase :
+		if driveMask & 1 :
+			bookmarks.add( "Drives/" + letter + ":", letter + ":/" )
+
+		driveMask >>= 1
+
 fontBookmarks = GafferUI.Bookmarks.acquire( application, category="font" )
 fontBookmarks.add( "Gaffer Fonts", os.path.expandvars( "$GAFFER_ROOT/fonts" ) )
 


### PR DESCRIPTION
This adds support for Windows to `FileSystemPath`. Some background is in #2695 and #2727. Those were largely about a potential `FileSystemPathPlug`, which this does not address. Instead it addresses the need for a Gaffer-native file system path representation common to all platforms.

The representation I've settled on here is to use UNIX style paths internally in Gaffer. That leaves existing behavior unchanged, and Windows-specific behavior is introduced when setting and getting paths at the earliest and latest point, respectively.

To summarize the specification of Windows paths this addresses :

1. Paths can start with a single letter + `:`, and any number of path elements separated by `\`. I'm calling these paths "drive letter paths". For example `C:\production\assets\platypus.tx`. Their `root` is the letter + `:` combination, for example `C:` and the `names` are the following paths.
2. Paths can start with a `\\` (literal), a server name, a `\`, a share name and any number of path elements separated by `\`. For example `\\my.cool.server\production\ProjectA\assets\platypus.tx`. Windows calls these UNC paths. Their root is the server name _and_ share name. If you keep popping directories off the back and go all the way to the server name, it won't return a list of shares as expected, instead it will be empty.
3. To allow us to distinguish a Gaffer-native UNIX path and a Gaffer-native UNC path, special handling is introduced to add `//` to the UNC Gaffer-native path, allowing us to format it correctly when returning the native Windows string.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
