### PR TITLE
AnimationEditor : fix bug when parent node of editable curve removed

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - AnimationGadget : Fixed bug that prevented signals from being disconnected when key deleted.
 - Animation Editor :
   - Fixed glitch when dragging tangent handle with opposite tangent with (+/-) inf slope.
+  - Fixed bug that caused exception to be raised when parent node of editable curve removed.
 
 0.61.14.1 (relative to 0.61.14.0)
 =========

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -250,12 +250,20 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 		editablePlugs = set()
 		for name in self.__curveList.getSelection().paths() :
 			path.setFromString( name )
-			graphComponent = path.property( "graphComponent:graphComponent" )
-			if isinstance( graphComponent, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( graphComponent ) :
-				editablePlugs.add( graphComponent )
-			for child in graphComponent.children() :
-				if isinstance( child, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( child ) :
-					editablePlugs.add( child )
+			try :
+				# NOTE : path.property() will throw a KeyError exception if the parent
+				#        node has been deleted since we last updated in which case we
+				#        dont want to add the curve to the editable set so we pass.
+				# TODO : Could path.property() return None instead of raising an exception?
+				graphComponent = path.property( "graphComponent:graphComponent" )
+			except KeyError :
+				pass
+			else :
+				if isinstance( graphComponent, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( graphComponent ) :
+					editablePlugs.add( graphComponent )
+				for child in graphComponent.children() :
+					if isinstance( child, Gaffer.ValuePlug ) and Gaffer.Animation.isAnimated( child ) :
+						editablePlugs.add( child )
 
 		editable = self.__animationGadget.editablePlugs()
 		curves = set( self.__sourceCurvePlug( plug ) for plug in editablePlugs & visiblePlugs )


### PR DESCRIPTION
Fixes exception that is thrown when undo removes a node with editable animation curve

To reproduce
  - create a sphere
  - key radius
  - open animation editor
  - expand and select radius in curve listing
  - select key in editor
  - undo until sphere removed from scene
  - exception thrown on line 112 of Gaffer/GraphComponentPath.py when
    called via line 255 of GafferUI/AnimationEditor.py

Tried checking that property name is in path.propertyNames() prior to calling path.property but that returns True.

### Related issues ###

ref #4756