### PR TITLE
HistoryPath and browser

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
 
 - Qt : Added missing QtUiTools module.
 - SceneReader : Fixed shader type for UsdLux lights. It was `surface` and is now `light`.
+- Fixed a bug in `SceneAlgo::attributeHistory` that would return a branching history from a `ShaderTweaks` node with `inherit` enabled.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 1.0.x.x (relative to 1.0.2.1)
 =======
 
+Features
+--------
+
+- Light Editor : Added a non-modal dialog to view the history of a parameter. It can be accessed by right-clicking a parameter in the Light Editor and selecting `Show History...`. Within the dialogue :
+  - Double clicking a node name will open a Node Editor popup.
+  - Dragging a node name into the Graph Editor will zoom to the node.
+  - Double clicking, pressing <kbd>Return</kbd> or <kbd>Enter</kbd> on a parameter value or operation will open a plug popup to edit the value.
+
 Improvements
 ------------
 

--- a/include/GafferSceneUI/TypeIds.h
+++ b/include/GafferSceneUI/TypeIds.h
@@ -55,6 +55,7 @@ enum TypeId
 	CameraToolTypeId = 110661,
 	UVViewTypeId = 110662,
 	UVSceneTypeId = 110663,
+	HistoryPathTypeId = 110664,
 
 	LastTypeId = 110700
 };

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -48,6 +48,7 @@ import GafferScene
 import GafferSceneUI
 
 from GafferUI.PlugValueWidget import sole
+from GafferSceneUI._HistoryWindow import _HistoryWindow
 
 from . import ContextAlgo
 from . import _GafferSceneUI
@@ -117,6 +118,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			)
 			self.__pathListing.buttonDoubleClickSignal().connectFront( Gaffer.WeakMethod( self.__buttonDoubleClick ), scoped = False )
 			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+			self.__pathListing.buttonPressSignal().connectFront( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
 
 		self.__settingsNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__settingsPlugSet ), scoped = False )
 
@@ -351,6 +353,67 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Label( "<h4>{}</h4>".format( nonEditable[0].nonEditableReason() ) )
 
 			self.__popup.popup()
+
+	def __buttonPress( self, pathListing, event ) :
+
+		if event.button != event.Buttons.Right or event.modifiers != event.Modifiers.None_ :
+			return False
+
+		selection = pathListing.getSelection()
+
+		columns = pathListing.getColumns()
+		cellColumn = pathListing.columnAt( event.line.p0 )
+		columnIndex = -1
+		for i in range( 0, len( columns ) ) :
+			if cellColumn == columns[i] :
+				columnIndex = i
+
+		if columnIndex == -1 :
+			return False
+
+		cellPath = pathListing.pathAt( event.line.p0 )
+
+		if not selection[columnIndex].match( str( cellPath ) ) & IECore.PathMatcher.Result.ExactMatch :
+			for p in selection :
+				p.clear()
+			selection[columnIndex].addPath( str( cellPath ) )
+			pathListing.setSelection( selection )
+
+		menuDefinition = IECore.MenuDefinition()
+
+		menuDefinition.append(
+			"Show History...",
+			{
+				"command" : Gaffer.WeakMethod( self.__showHistory ),
+				"active" : any( not i.isEmpty() for i in selection )
+			}
+		)
+
+		self.__contextMenu = GafferUI.Menu( menuDefinition )
+		self.__contextMenu.popup( pathListing )
+
+		return True
+
+	def __showHistory( self, *unused ) :
+
+		selection = self.__pathListing.getSelection()
+		columns = self.__pathListing.getColumns()
+
+		for i in range( 0, len( columns ) ) :
+			column = columns[ i ]
+			if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+				continue
+
+			for path in selection[i].paths() :
+				window = _HistoryWindow(
+					column.inspector(),
+					path,
+					self.getContext(),
+					self.ancestor( GafferUI.ScriptWindow ).scriptNode(),
+					"History : {} : {}".format( path, column.headerData().value )
+				)
+				self.ancestor( GafferUI.Window ).addChildWindow( window, removeOnClose = True )
+				window.setVisible( True )
 
 
 GafferUI.Editor.registerType( "LightEditor", LightEditor )

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -1,0 +1,265 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferSceneUI
+
+class _OperationIconColumn( GafferUI.PathColumn ) :
+
+	def __init__( self, title, property ) :
+
+		GafferUI.PathColumn.__init__( self )
+
+		self.__title = title
+		self.__property = property
+
+	def cellData( self, path, canceller = None ) :
+
+		cellValue = path.property( self.__property )
+
+		data = self.CellData()
+
+		data.icon = {
+			Gaffer.TweakPlug.Mode.Replace : "replaceSmall.png",
+			Gaffer.TweakPlug.Mode.Add : "plusSmall.png",
+			Gaffer.TweakPlug.Mode.Subtract : "minusSmall.png",
+			Gaffer.TweakPlug.Mode.Multiply : "multiplySmall.png",
+			Gaffer.TweakPlug.Mode.Remove : "removeSmall.png",
+			Gaffer.TweakPlug.Mode.Create : "createSmall.png",
+			Gaffer.TweakPlug.Mode.Min : "lessThanSmall.png",
+			Gaffer.TweakPlug.Mode.Max : "greaterThanSmall.png",
+			Gaffer.TweakPlug.Mode.ListAppend : "listAppendSmall.png",
+			Gaffer.TweakPlug.Mode.ListPrepend : "listPrependSmall.png",
+			Gaffer.TweakPlug.Mode.ListRemove : "listRemoveSmall.png",
+		}.get( cellValue, "errorSmall.png" )
+
+		return data
+
+	def headerData( self, canceller = None ) :
+
+		return self.CellData( self.__title )
+
+class _NodeNameColumn( GafferUI.PathColumn ) :
+
+	def __init__( self, title, property, scriptNode ) :
+
+		GafferUI.PathColumn.__init__( self )
+
+		self.__title = title
+		self.__property = property
+		self.__scriptNode = scriptNode
+
+	def cellData( self, path, canceller = None ) :
+
+		cellValue = path.property( self.__property )
+
+		data = self.CellData( cellValue.relativeName( self.__scriptNode ) )
+
+		return data
+
+	def headerData( self, canceller = None ) :
+
+		return self.CellData( self.__title )
+
+class _HistoryWindow( GafferUI.Window ) :
+
+	def __init__( self, inspector, scenePath, context, scriptNode, title=None, **kw ) :
+
+		assert( isinstance( scriptNode, Gaffer.ScriptNode ) )
+
+		if title is None :
+			title = "History"
+
+		GafferUI.Window.__init__( self, title, **kw )
+
+		self.__inspector = inspector
+		self.__scenePath = scenePath
+		self.__scriptNode = scriptNode
+
+		with self :
+			self.__pathListingWidget = GafferUI.PathListingWidget(
+				Gaffer.DictPath( {}, "/" ),
+				columns = (
+					_NodeNameColumn( "Node", "history:node", self.__scriptNode ),
+					GafferUI.PathListingWidget.StandardColumn( "Value", "history:value" ),
+					_OperationIconColumn( "Operation", "history:operation" ),
+				),
+				sortable = False,
+				horizontalScrollMode = GafferUI.ScrollMode.Automatic,
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Cell
+			)
+
+		self.__pathListingWidget.setDragPointer( "values" )
+
+		self.__nameColumnIndex = 0
+		self.__valueColumnIndex = 1
+		self.__operationColumnIndex = 2
+
+		self.__pathListingWidget.buttonDoubleClickSignal().connectFront( Gaffer.WeakMethod( self.__buttonDoubleClick ), scoped = False )
+		self.__pathListingWidget.keyPressSignal().connectFront( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+		self.__pathListingWidget.dragBeginSignal().connectFront( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
+		self.__pathListingWidget.updateFinishedSignal().connectFront( Gaffer.WeakMethod( self.__updateFinished ), scoped = False )
+
+		inspector.dirtiedSignal().connect( Gaffer.WeakMethod( self.__inspectorDirtied ), scoped = False )
+
+		context.changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = False )
+
+		self.__updatePath( context )
+
+	def __updatePath( self, newContext ) :
+
+		with Gaffer.Context( newContext ) as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( self.__scenePath )
+			self.__path = self.__inspector.historyPath()
+			self.__pathChangedConnection = self.__path.pathChangedSignal().connect( Gaffer.WeakMethod( self.__pathChanged ), scoped = True )
+
+		self.__pathListingWidget.setPath( self.__path )
+
+	def __pathChanged( self, path ) :
+
+		if len( path.children() ) == 0 :
+			self.close()
+
+	def __buttonDoubleClick( self, pathListing, event ) :
+
+		if pathListing.pathAt( event.line.p0 ) is None :
+			return False
+
+		if event.buttons == event.Buttons.Left :
+			self.__editSelectedCell( pathListing )
+
+			return True
+
+		return False
+
+	def __keyPress( self, pathListing, event ) :
+
+		if event.key == "Return" or event.key == "Enter" :
+			self.__editSelectedCell( pathListing )
+
+			return True
+
+		return False
+
+	def __editSelectedCell( self, pathListing ) :
+
+		selection = pathListing.getSelection()
+
+		selectedPath, selectedColumn = self.__selectionData( selection )
+
+		if selectedColumn == self.__nameColumnIndex :
+			GafferUI.NodeEditor.acquire(
+				selectedPath.property( "history:node" ),
+				floating = True
+			)
+		elif selectedColumn == self.__valueColumnIndex or selectedColumn == self.__operationColumnIndex :
+			editPlug = selectedPath.property( "history:source" )
+			self.__popup = GafferUI.PlugPopup(
+				[ editPlug ], warning = selectedPath.property( "history:editWarning" )
+			)
+			if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
+				self.__popup.plugValueWidget().setNameVisible( False )
+
+			self.__popup.popup()
+
+	def __dragBegin( self, pathListing, event ) :
+
+		selection = pathListing.getSelection()
+
+		selectedPath, selectedColumn = self.__selectionData( selection )
+
+		if selectedColumn == self.__nameColumnIndex :
+			GafferUI.Pointer.setCurrent( "nodes" )
+
+			return selectedPath.property( "history:node" )
+
+		elif selectedColumn == self.__operationColumnIndex :
+			GafferUI.Pointer.setCurrent( "values" )
+
+			return selectedPath.property( "history:operation" )
+
+		# Value column works by default
+
+	def __selectionData( self, selection ) :
+
+		# Return a tuple of (selectedPath, selectedColumnIndex )
+
+		columnIndex = None
+
+		for i in range( 0, len( selection ) ) :
+			if selection[i].size() > 0 :
+				selectedPathString = selection[i].paths()[0]
+				columnIndex = i
+
+		for path in self.__path.children() :
+			if str( path ) == selectedPathString :
+				return (path, columnIndex )
+
+		return None
+
+	def __inspectorDirtied( self, inspector ) :
+
+		self.__path._emitPathChanged()
+
+	def __contextChanged( self, context, key ) :
+
+		self.__updatePath( context )
+
+	def __updateFinished( self, pathListing ) :
+
+		self.__nodeNameChangedSignals = []
+
+		for path in self.__path.children() :
+			node = path.property( "history:node" )
+
+			# The node and all of its parents up to the script node
+			# contribute to the path name.
+
+			while node is not self.__scriptNode and node is not None :
+				self.__nodeNameChangedSignals.append(
+					node.nameChangedSignal().connect(
+						Gaffer.WeakMethod( self.__nodeNameChanged ),
+						scoped = True
+					)
+				)
+
+				node = node.parent()
+
+	def __nodeNameChanged( self, node ) :
+
+		self.__path._emitPathChanged()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -1,0 +1,359 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import threading
+import imath
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneUI
+import GafferSceneTest
+
+class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
+
+	@staticmethod
+	def __inspector( scene, parameter, editScope=None, attribute="light" ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.ParameterInspector(
+			scene, editScopePlug, attribute, ( "", parameter )
+		)
+
+		return inspector
+
+	def test( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		s["lightFilter"] = GafferScene.PathFilter()
+		s["lightFilter"]["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		s["tweaks"] = GafferScene.ShaderTweaks()
+		s["tweaks"]["in"].setInput( s["testLight"]["out"] )
+		s["tweaks"]["filter"].setInput( s["lightFilter"]["out"] )
+		s["tweaks"]["shader"].setValue( "light" )
+
+		exposureTweak = Gaffer.TweakPlug( "exposure", 2.0 )
+		s["tweaks"]["tweaks"].addChild( exposureTweak )
+
+		s["editScope"] = Gaffer.EditScope()
+		s["editScope"].setup( s["tweaks"]["out"] )
+		s["editScope"]["in"].setInput( s["tweaks"]["out"] )
+
+		# Just the light
+		inspector = self.__inspector( s["testLight"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertIsInstance( historyPath, Gaffer.Path )
+
+		self.assertFalse( historyPath.isLeaf() )
+		self.assertTrue( historyPath.isValid() )
+		self.assertEqual( len( historyPath ), 0 )
+
+		c = historyPath.children()
+		self.assertEqual( len( c ), 1 )
+		self.assertTrue( c[0].isLeaf() )
+		self.assertTrue( c[0].isValid() )
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+
+		# Add tweaks
+		inspector = self.__inspector( s["tweaks"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertFalse( historyPath.isLeaf() )
+		self.assertTrue( historyPath.isValid() )
+		self.assertEqual( len( historyPath ), 0 )
+
+		c = historyPath.children()
+		self.assertEqual( len(c ), 2 )
+		self.assertTrue( c[0].isLeaf() )
+		self.assertTrue( c[0].isValid() )
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertTrue( c[1].isLeaf() )
+		self.assertTrue( c[1].isValid() )
+		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
+
+		# Add an edit to the EditScope
+		inspector = self.__inspector( s["editScope"]["out"], "exposure", s["editScope"] )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			edit = inspector.inspect().acquireEdit()
+			edit["enabled"].setValue( True )
+			edit["value"].setValue( 4.0 )
+			historyPath = inspector.historyPath()
+
+		self.assertFalse( historyPath.isLeaf() )
+		self.assertTrue( historyPath.isValid() )
+		self.assertEqual( len( historyPath ), 0 )
+
+		c = historyPath.children()
+		self.assertEqual( len( c ), 3 )
+		self.assertTrue( c[0].isLeaf() )
+		self.assertTrue( c[0].isValid() )
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertTrue( c[1].isLeaf() )
+		self.assertTrue( c[1].isValid() )
+		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
+		self.assertTrue( c[2].isLeaf() )
+		self.assertTrue( c[2].isValid() )
+		self.assertEqual( c[2].property( "name" ), str( c[2][-1] ) )
+
+		# Add a node + plug at the end of the graph that isn't parented to the script
+		orphanNode = Gaffer.Node()
+		orphanNode.addChild( GafferScene.ScenePlug( "orphanPlug", Gaffer.Plug.Direction.Out ) )
+		orphanNode["orphanPlug"].setInput( s["editScope"]["out"])
+
+		inspector = self.__inspector( orphanNode["orphanPlug"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertFalse( historyPath.isLeaf() )
+		self.assertTrue( historyPath.isValid() )
+		self.assertEqual( len( historyPath ), 0 )
+
+		c = historyPath.children()
+		self.assertEqual( len( c ), 3 )
+		self.assertTrue( c[0].isLeaf() )
+		self.assertTrue( c[0].isValid() )
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertTrue( c[1].isLeaf() )
+		self.assertTrue( c[1].isValid() )
+		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
+		self.assertTrue( c[2].isLeaf() )
+		self.assertTrue( c[2].isValid() )
+		self.assertEqual( c[2].property( "name" ), str( c[2][-1] ) )
+
+	def testPropertyNames( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		inspector = self.__inspector( s["testLight"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertEqual(
+			sorted( historyPath.propertyNames() ),
+			sorted(
+				[
+					"fullName",
+					"name",
+				]
+			)
+		)
+
+		self.assertEqual(
+			sorted( historyPath.children()[0].propertyNames() ),
+			sorted(
+				[
+					"fullName",
+					"name",
+					"history:value",
+					"history:operation",
+					"history:source",
+					"history:editWarning",
+					"history:node"
+				]
+			)
+		)
+
+	def testProperties( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		s["lightFilter"] = GafferScene.PathFilter()
+		s["lightFilter"]["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		s["tweaks"] = GafferScene.ShaderTweaks()
+		s["tweaks"]["in"].setInput( s["testLight"]["out"] )
+		s["tweaks"]["filter"].setInput( s["lightFilter"]["out"] )
+		s["tweaks"]["shader"].setValue( "light" )
+
+		exposureTweak = Gaffer.TweakPlug( "exposure", 2.0 )
+		exposureTweak["mode"].setValue( Gaffer.TweakPlug.Mode.Add )
+		s["tweaks"]["tweaks"].addChild( exposureTweak )
+
+		s["editScope"] = Gaffer.EditScope()
+		s["editScope"].setup( s["tweaks"]["out"] )
+		s["editScope"]["in"].setInput( s["tweaks"]["out"] )
+
+		inspector1 = self.__inspector( s["editScope"]["out"], "exposure", s["editScope"] )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+
+			edit = inspector1.inspect().acquireEdit()
+			edit["enabled"].setValue( True )
+			edit["value"].setValue( 3.0 )
+
+			historyPath = inspector1.historyPath()
+
+		c = historyPath.children()
+
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertEqual( c[0].property( "history:node" ), s["testLight"] )
+		self.assertEqual( c[0].property( "history:value" ), 0.0 )
+		self.assertEqual( c[0].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( c[0].property( "history:source" ), s["testLight"]["parameters"]["exposure"] )
+		self.assertEqual( c[0].property( "history:editWarning" ), "" )
+
+		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
+		self.assertEqual( c[1].property( "history:node" ), s["tweaks"] )
+		self.assertEqual( c[1].property( "history:value" ), 2.0 )
+		self.assertEqual( c[1].property( "history:operation" ), Gaffer.TweakPlug.Mode.Add )
+		self.assertEqual( c[1].property( "history:source" ), exposureTweak )
+		self.assertEqual( c[1].property( "history:editWarning" ), "" )
+
+		self.assertEqual( c[2].property( "name" ), str( c[2][-1] ) )
+		self.assertEqual( c[2].property( "history:node" ), s["editScope"]["LightEdits"]["ShaderTweaks"] )
+		self.assertEqual( c[2].property( "history:value" ), 3.0 )
+		self.assertEqual( c[2].property( "history:operation" ), Gaffer.TweakPlug.Mode.Replace )
+		self.assertEqual( c[2].property( "history:source" ), edit )
+		self.assertEqual( c[2].property( "history:editWarning" ), "" )
+
+	def testCopy( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+		s["testLight"]["parameters"]["exposure"].setValue( 3.0 )
+
+		inspector = self.__inspector( s["testLight"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertEqual( historyPath.children()[0].property( "history:value" ), 3.0 )
+
+		rootCopy = historyPath.copy()
+		self.assertEqual( rootCopy.children()[0].property( "history:value" ), 3.0 )
+
+		leafCopy = rootCopy.children()[0].copy()
+		self.assertEqual( leafCopy.property( "history:node" ), s["testLight"] )
+		self.assertEqual( leafCopy.property( "history:value" ), 3.0 )
+
+	def testInvalidPath( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		inspector = self.__inspector( s["testLight"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		historyPath.setFromString( "/missingNode" )
+		self.assertFalse( historyPath.isValid() )
+
+	def testPlugClashing( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		s["lightFilter"] = GafferScene.PathFilter()
+		s["lightFilter"]["paths"].setValue( IECore.StringVectorData( ["light"] ) )
+
+		s["loop"] = Gaffer.Loop()
+		s["loop"].setup( s["testLight"]["out"] )
+		s["loop"]["in"].setInput( s["testLight"]["out"] )
+
+		s["tweaks"] = GafferScene.ShaderTweaks()
+		s["tweaks"]["in"].setInput( s["loop"]["previous"] )
+		s["tweaks"]["filter"].setInput( s["lightFilter"]["out"] )
+		s["tweaks"]["shader"].setValue( "light" )
+
+		exposureTweak = Gaffer.TweakPlug( "exposure", 1.0 )
+		exposureTweak["mode"].setValue( Gaffer.TweakPlug.Mode.Add )
+		s["tweaks"]["tweaks"].addChild( exposureTweak )
+
+		s["loop"]["next"].setInput( s["tweaks"]["out"] )
+
+		inspector = self.__inspector( s["loop"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertEqual( len( historyPath.children() ), s["loop"]["iterations"].getValue() + 1 )
+		self.assertEqual( historyPath.children()[0].property( "history:node" ), s["testLight"] )
+		self.assertEqual( historyPath.children()[0].property( "history:value" ), 0 )
+		for i in range( 1, s["loop"]["iterations"].getValue() + 1 ) :
+			self.assertEqual( historyPath.children()[i].property( "history:node" ), s["tweaks"] )
+			self.assertEqual( historyPath.children()[i].property( "history:value" ), i )
+
+	def testEmptyHistory( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+		s["testLight"]["enabled"].setValue( False )
+
+		inspector = self.__inspector( s["testLight"]["out"], "exposure" )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( ["light"] )
+			historyPath = inspector.historyPath()
+
+		self.assertEqual( len( historyPath.children() ), 0 )
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -54,6 +54,7 @@ from .CropWindowToolTest import CropWindowToolTest
 from .NodeUITest import NodeUITest
 from .ParameterInspectorTest import ParameterInspectorTest
 from .AttributeInspectorTest import AttributeInspectorTest
+from .HistoryPathTest import HistoryPathTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -130,11 +130,13 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		self._qtWidget().model().selectionChanged.connect( Gaffer.WeakMethod( self.__selectionChanged ) )
 		self._qtWidget().model().expansionChanged.connect( Gaffer.WeakMethod( self.__expansionChanged ) )
+		self._qtWidget().model().updateFinished.connect( Gaffer.WeakMethod( self.__updateFinished ) )
 
 		self.__pathSelectedSignal = GafferUI.WidgetSignal()
 		self.__selectionChangedSignal = GafferUI.WidgetSignal()
 		self.__displayModeChangedSignal = GafferUI.WidgetSignal()
 		self.__expansionChangedSignal = GafferUI.WidgetSignal()
+		self.__updateFinishedSignal = GafferUI.WidgetSignal()
 
 		# Connections for implementing selection and drag and drop.
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
@@ -247,6 +249,10 @@ class PathListingWidget( GafferUI.Widget ) :
 	def expansionChangedSignal( self ) :
 
 		return self.__expansionChangedSignal
+
+	def updateFinishedSignal( self ) :
+
+		return self.__updateFinishedSignal
 
 	def getDisplayMode( self ) :
 
@@ -513,6 +519,10 @@ class PathListingWidget( GafferUI.Widget ) :
 	def __expansionChanged( self ) :
 
 		self.__expansionChangedSignal( self )
+
+	def __updateFinished( self ) :
+
+		self.__updateFinishedSignal( self )
 
 	def __keyPress( self, widget, event ) :
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -314,6 +314,28 @@
 			]
 		},
 
+		"tweakModes" : {
+
+			"options" : {
+				"requiredWidth" : 14,
+				"requiredHeight" : 14,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"plusSmall",
+				"minusSmall",
+				"multiplySmall",
+				"replaceSmall",
+				"createSmall",
+				"lessThanSmall",
+				"greaterThanSmall",
+				"listAppendSmall",
+				"listPrependSmall",
+				"listRemoveSmall",
+			]
+		}
+
 	},
 
 	"ids" : [

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -15,13 +15,133 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
    sodipodi:docname="graphics.svg"
    enable-background="new">
   <title
      id="title2005">Gaffer Icons</title>
   <defs
      id="defs4">
+    <linearGradient
+       id="linearGradient3356"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3354" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3326"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3324" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3316"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3314" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3310"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3308" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3304"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3302" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3298"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3296" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3292"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3290" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3286"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3284" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3280"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3278" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3274"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3272" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3268"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3266" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3262"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3260" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3254"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3252" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3248"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3246" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3240"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f4f4f4;stop-opacity:1;"
+         offset="0"
+         id="stop3238" />
+    </linearGradient>
     <linearGradient
        id="linearGradient1896"
        osb:paint="solid">
@@ -232,6 +352,165 @@
          id="path2605-7"
          inkscape:label="#path3910" />
     </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3244"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3328"
+       x1="35"
+       y1="2671.3623"
+       x2="49"
+       y2="2671.3623"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3332"
+       x1="53"
+       y1="2671.3623"
+       x2="67"
+       y2="2671.3623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.39999867,0,1602.8208)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3334"
+       x1="167"
+       y1="2674.3623"
+       x2="175"
+       y2="2674.3623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.5,0.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3336"
+       x1="160.98029"
+       y1="2666.8621"
+       x2="166"
+       y2="2666.8621"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.48029,-0.4999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3338"
+       x1="161"
+       y1="2673.8623"
+       x2="166"
+       y2="2673.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.5,-1.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3342"
+       x1="178.99014"
+       y1="2668.8623"
+       x2="184.00986"
+       y2="2668.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.49014,1.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3344"
+       x1="179.00986"
+       y1="2675.8623"
+       x2="184.00986"
+       y2="2675.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.50986,0.4999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3348"
+       x1="196.99014"
+       y1="2666.8623"
+       x2="202.00986"
+       y2="2666.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.50986,-0.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3350"
+       x1="197"
+       y1="2675.8623"
+       x2="202"
+       y2="2675.8623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.5,0.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3352"
+       x1="89.471245"
+       y1="2671.2668"
+       x2="102.52876"
+       y2="2671.2668"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(1.076923,0,0,0.40000024,49.384612,1600.8166)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3332-3"
+       x1="53"
+       y1="2671.3623"
+       x2="67"
+       y2="2671.3623"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(1.076923,0,0,0.39999684,49.384612,1604.8258)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3332-5"
+       x1="53"
+       y1="2671.3623"
+       x2="67"
+       y2="2671.3623"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="rotate(45,60,2714.818)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3328-1"
+       x1="35"
+       y1="2671.3623"
+       x2="49"
+       y2="2671.3623"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3334-0"
+       x1="167"
+       y1="2674.3623"
+       x2="175"
+       y2="2674.3623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(18.5,-7.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3334-0-6"
+       x1="167"
+       y1="2674.3623"
+       x2="175"
+       y2="2674.3623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="rotate(45,193.93199,2717.068)" />
+    <linearGradient
+       gradientTransform="matrix(-1,0,0,1,282,0)"
+       inkscape:collect="always"
+       xlink:href="#foreground"
+       id="linearGradient3244-2"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
      id="base"
@@ -242,21 +521,21 @@
      inkscape:pageshadow="2"
      inkscape:document-units="px"
      inkscape:object-nodes="true"
-     showguides="false"
+     showguides="true"
      inkscape:guide-bbox="true"
      inkscape:object-paths="false"
      inkscape:bbox-paths="false"
      inkscape:bbox-nodes="true"
      showgrid="true"
-     inkscape:zoom="2.3228534"
-     inkscape:cx="424.89855"
-     inkscape:cy="-309.88184"
-     inkscape:window-width="2681"
-     inkscape:window-height="1668"
-     inkscape:window-x="204"
-     inkscape:window-y="123"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g2711"
+     inkscape:zoom="9.2914136"
+     inkscape:cx="112.79795"
+     inkscape:cy="-1589.5006"
+     inkscape:window-width="2516"
+     inkscape:window-height="1409"
+     inkscape:window-x="44"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g6742"
      inkscape:snap-bbox="true">
     <inkscape:grid
        type="xygrid"
@@ -491,6 +770,56 @@
        inkscape:locked="false"
        inkscape:label="colorInspector icons - 12 - lower bound"
        inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="6,-1612"
+       orientation="0,1"
+       id="guide6826"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="6.5,-1626"
+       orientation="0,1"
+       id="guide6828"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="89,-1612"
+       orientation="1,0"
+       id="guide6832"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="103,-1615.8937"
+       orientation="1,0"
+       id="guide6834"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="179,-1610.5"
+       orientation="1,0"
+       id="guide6845"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="193,-1612"
+       orientation="1,0"
+       id="guide6847"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="197,-1616.5"
+       orientation="1,0"
+       id="guide6861"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="211,-1617"
+       orientation="1,0"
+       id="guide6863"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="107,-1612"
+       orientation="1,0"
+       id="guide2066"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="121,-1613"
+       orientation="1,0"
+       id="guide2068"
+       inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -1357,13 +1686,13 @@
            width="343.75" /></flowRegion><flowPara
          id="flowPara1886"
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">PlugValueWidgets</flowPara></flowRoot>    <path
-       transform="translate(0,-52.362183)"
        style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M -6,2589.3622 H 743.99999"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc"
        inkscape:label="hr1"
-       id="path1868" />
+       id="path1868"
+       transform="translate(0,-52.362183)" />
     <flowRoot
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
@@ -1379,12 +1708,35 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect1870" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
-         id="flowPara1874">LightEditor</flowPara></flowRoot>  </g>
+         id="flowPara1874">LightEditor</flowPara></flowRoot>    <path
+       id="path1211"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,2602.4617 H 743.99999"
+       style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot1219"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,1.0000138,288.10156,1591.3091)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1215"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"><rect
+           id="rect1213"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara1217"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">TweakModes</flowPara></flowRoot>  </g>
   <g
      inkscape:groupmode="layer"
      id="layer4"
      inkscape:label="ExportAreas"
-     style="display:inline">
+     style="display:inline"
+     sodipodi:insensitive="true">
     <g
        id="g2711"
        inkscape:label="pointers">
@@ -2308,6 +2660,98 @@
        height="25"
        x="50"
        y="2427.9998" />
+    <rect
+       id="rect1221"
+       y="2612"
+       x="10"
+       height="14"
+       width="14"
+       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       inkscape:label="sizeGuide" />
+    <g
+       id="g6806"
+       inkscape:label="tweakModes">
+      <rect
+         id="plusSmall"
+         y="2612"
+         x="35"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="plusSmall" />
+      <rect
+         inkscape:label="minusSmall"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="14"
+         height="14"
+         x="53"
+         y="2612"
+         id="minusSmall" />
+      <rect
+         id="multiplySmall"
+         y="2612"
+         x="71"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="multiplySmall" />
+      <rect
+         inkscape:label="replaceSmall"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="14"
+         height="14"
+         x="89"
+         y="2612"
+         id="replaceSmall" />
+      <rect
+         id="createSmall"
+         y="2612"
+         x="107"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="createSmall" />
+      <rect
+         inkscape:label="lessThanSmall"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="14"
+         height="14"
+         x="125"
+         y="2612"
+         id="lessThanSmall" />
+      <rect
+         id="greaterThanSmall"
+         y="2612"
+         x="143"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="greaterThanSmall" />
+      <rect
+         inkscape:label="listAppendSmall"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="14"
+         height="14"
+         x="161"
+         y="2612"
+         id="listAppendSmall" />
+      <rect
+         id="listPrependSmall"
+         y="2612"
+         x="179"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="listPrependSmall" />
+      <rect
+         inkscape:label="listRemoveSmall"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="14"
+         height="14"
+         x="197"
+         y="2612"
+         id="listRemoveSmall" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
@@ -7286,5 +7730,127 @@
        d="m 632,1351.3622 v 4 h 14 v -4 z"
        id="path4294"
        inkscape:connector-curvature="0" />
+    <rect
+       style="display:inline;fill:none;stroke:none"
+       id="minus-6"
+       width="16"
+       height="17"
+       x="53"
+       y="2691.3623"
+       inkscape:label="#rect3043" />
+    <g
+       id="g6742"
+       inkscape:label="tweakModes"
+       transform="translate(0,-1.7e-5)">
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path5"
+         d="m 41,2664.3622 h 2 v 6 h 6 v 2 h -6 v 6 h -2 v -6 h -6 v -2 h 6 z"
+         style="fill:url(#linearGradient3328);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         inkscape:label="plusSmall" />
+      <path
+         style="display:inline;fill:url(#linearGradient3244);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-opacity:1"
+         d="m 139,2664.3622 v 3 l -8,4 8,4 v 3 l -14,-7 z"
+         id="path4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:label="lessThanSmall" />
+      <path
+         style="fill:url(#linearGradient3332);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 67,2670.3622 v 2 H 53 v -2 z"
+         id="path6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         inkscape:label="minusSmall" />
+      <path
+         style="fill:url(#linearGradient3334);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 171,2672.3622 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z"
+         id="path6671"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path6673"
+         d="m 165.01971,2664.3622 v 4 H 161 v -4 z"
+         style="fill:url(#linearGradient3336);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#linearGradient3338);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 165,2670.3622 v 4 h -4 v -4 z"
+         id="path6679"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient3342);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 183.01972,2668.3622 v 4 H 179 v -4 z"
+         id="path6853"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path6855"
+         d="m 183,2674.3622 v 4 h -4 v -4 z"
+         style="fill:url(#linearGradient3344);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path6869"
+         d="m 201,2664.3622 v 4 h -4.01972 v -4 z"
+         style="fill:url(#linearGradient3348);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:url(#linearGradient3350);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 201,2674.3622 v 4 h -4 v -4 z"
+         id="path6873"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         id="path6937"
+         style="opacity:1;vector-effect:none;fill:url(#linearGradient3352);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+         d="m 94,2671.3622 h -3.5 l 5.5,6 5.5,-6 H 98 v -6.5001 h -4 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient3332-3);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 119,2668.3622 v 2 h -10 v -2 z"
+         id="path6-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         inkscape:label="minusSmall" />
+      <path
+         style="display:inline;fill:url(#linearGradient3332-5);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 119,2672.3622 v 2 h -10 v -2 z"
+         id="path6-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         inkscape:label="minusSmall" />
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path5-7"
+         d="m 82.242641,2665.7053 1.414213,1.4143 -4.24264,4.2426 4.24264,4.2426 -1.414213,1.4143 L 78,2672.7764 l -4.242641,4.2427 -1.414213,-1.4143 4.24264,-4.2426 -4.24264,-4.2426 1.414213,-1.4143 L 78,2669.948 Z"
+         style="display:inline;fill:url(#linearGradient3328-1);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         inkscape:label="plusSmall" />
+      <path
+         style="display:inline;fill:url(#linearGradient3334-0);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 189,2664.3622 h 2 v 2 h 2 v 2 h -2 v 2 h -2 v -2 h -2 v -2 h 2 z"
+         id="path6671-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient3334-0-6);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 209.32842,2668.5338 1.41422,1.4142 -1.41422,1.4142 1.41422,1.4142 -1.41422,1.4142 -1.41421,-1.4142 -1.41421,1.4142 -1.41422,-1.4142 1.41422,-1.4142 -1.41422,-1.4142 1.41422,-1.4142 1.41421,1.4142 z"
+         id="path6671-3-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <path
+         style="display:inline;fill:url(#linearGradient3244-2);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-opacity:1"
+         d="m 143,2664.3622 v 3 l 8,4 -8,4 v 3 l 14,-7 z"
+         id="path4-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:label="lessThanSmall" />
+    </g>
   </g>
 </svg>

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -787,6 +787,10 @@ SceneAlgo::AttributeHistory::Ptr SceneAlgo::attributeHistory( const SceneAlgo::H
 		{
 			addLocaliseAttributesPredecessors( attributesHistory->predecessors, result.get() );
 		}
+		else if( runTimeCast<const ShaderTweaks>( node ) )
+		{
+			addLocaliseAttributesPredecessors( attributesHistory->predecessors, result.get() );
+		}
 		else
 		{
 			addGenericAttributePredecessors( attributesHistory->predecessors, result.get() );

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -42,6 +42,7 @@
 #include "GafferSceneUI/Private/AttributeInspector.h"
 #include "GafferSceneUI/Private/ParameterInspector.h"
 
+#include "GafferBindings/PathBinding.h"
 #include "GafferBindings/SignalBinding.h"
 
 #include "IECorePython/ExceptionAlgo.h"
@@ -104,9 +105,12 @@ void GafferSceneUIModule::bindInspector()
 			.def( "name", &Inspector::name, return_value_policy<copy_const_reference>() )
 			.def( "inspect", &inspectWrapper )
 			.def( "dirtiedSignal", &Inspector::dirtiedSignal, return_internal_reference<1>() )
+			.def( "historyPath", &Inspector::historyPath )
 		;
 
 		SignalClass<Inspector::InspectorSignal, DefaultSignalCaller<Inspector::InspectorSignal>, DirtiedSlotCaller>( "ChangedSignal" );
+
+		PathClass<Inspector::HistoryPath>();
 
 		scope resultScope = RefCountedClass<Inspector::Result, IECore::RefCounted>( "Result" )
 			.def( "value", &valueWrapper )

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -221,6 +221,12 @@ class InspectorColumn : public PathColumn
 
 };
 
+PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Canceller *canceller )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return pathColumn.headerData( canceller );
+}
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -242,6 +248,7 @@ void GafferSceneUIModule::bindLightEditor()
 			)
 		) )
 		.def( "inspector", &InspectorColumn::inspector, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "headerData", &headerDataWrapper, ( arg_( "canceller" ) = object() ) )
 	;
 
 }


### PR DESCRIPTION
This adds `HistoryPath`, a `Path`-derived class to store a chain of `History` objects. It also adds a non-modal dialogue box for interacting with a `HistoryPath`, which can be opened by right clicking on one or more parameters in the Light Editor.

Note that there is currently a bug related to the `dirtiedSignal()` connection that `HistoryPath` creates in its constructor. I haven't sorted out a reproduction in tests, but it's fairly easy to reproduce in the UI :
1. Create a scene with at least two lights.
2. Open the Light Editor and select parameters on at least two lights, in the same column.
3. Right click and choose "Show History".
4. Uh oh...
```
gaffer: include/Gaffer/Private/SlotBase.h:116: virtual void Gaffer::Signals::Private::SlotBase::disconnect(): Assertion `previousRef == this' failed.
ERROR   | signal caught: SIGABRT -- Abnormal process abort
Aborted (core dumped)
```

Sometimes it takes a few selections of "Show History" for it to error, but it happens eventually.

The main clue I got from trying to fix it that might shed some light is that commenting out `dialogue.setVisible( True )` prevents the crash. So the dialog is created but has a very short lifetime, until the end of the loop iteration. It suggests that reusing the same `Inspector` in multiple `HistoryPath` / dialogues (each column returns the same `Inspector`) is part of the problem.

If nothing obviously wrong comes up as part of the review, I'll dig back in and see what I can discover.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
