### PR TITLE
GafferImage config : Add color space config for signed TIFF images

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,11 @@
-0.61.x.x (relative to 0.61.14.2)
+0.61.14.x (relative to 0.61.14.2)
 =========
 
 Fixes
 -----
 
 - CurvesAlgo : fix Arnold rendering error for non-linear curves with Vertex interpolation Quatf primitive variable.
+- ImageReader : Fixed reading of signed integer TIFF files, which were failing due to a missing colorspace configuration. Signed integer files are now assumed to contain linear data (#4772).
 
 0.61.14.2 (relative to 0.61.14.1)
 =========

--- a/startup/GafferImage/defaultColorSpace.py
+++ b/startup/GafferImage/defaultColorSpace.py
@@ -50,6 +50,9 @@ def defaultColorSpace( fileName, fileFormat, dataType, metadata ) :
 			"uint16" : display,
 			"uint32" : linear,
 			"float"  : linear,
+			"int8"  : linear,
+			"int16"  : linear,
+			"int"  : linear,
 		},
 
 		"zfile" : linear,


### PR DESCRIPTION
I can't think of a likely reason for wanting negative values for colour data, so it seems reasonable to assume that such images are data that should be treated as linear (normals perhaps).

@MrPetru, can you confirm this works for you?