### PR TITLE
Github Workflows : Update Windows worker to windows-2019

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
             sconsCacheMegabytes: 400
 
           - name: windows-python3
-            os: windows-2016
+            os: windows-2019
             buildType: RELEASE
             variant: windows-python3
             publish: false


### PR DESCRIPTION
This should have been on 2019 when I first added Windows to the CI, but it seems we're officially kicked off 2016 so it's required now.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
