### PR TITLE
PathFilterUI : Remove manual node positioning

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.14.x (relative to 0.61.14.3)
+=========
+
+Fixes
+-----
+
+- PathFilter : Improved positioning of PathFilters created by dropping paths onto a node.
+
 0.61.14.3 (relative to 0.61.14.2)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Fixes
 -----
 
 - PathFilter : Improved positioning of PathFilters created by dropping paths onto a node.
-- GraphEditor : Improved positioning of pasted nodes, so that they are less likely to overlap with any node they are automatically connected to.
+- GraphEditor :
+  - Improved handling of Backdrops when laying out nodes. Individual nodes are no longer pushed outside backdrops, and backdrops themselves are positioned as a group containing all their child nodes.
+  - Improved positioning of pasted nodes, so that they are less likely to overlap with any node they are automatically connected to.
 
 0.61.14.3 (relative to 0.61.14.2)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - PathFilter : Improved positioning of PathFilters created by dropping paths onto a node.
+- GraphEditor : Improved positioning of pasted nodes, so that they are less likely to overlap with any node they are automatically connected to.
 
 0.61.14.3 (relative to 0.61.14.2)
 =========

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -299,9 +299,6 @@ def __drop( nodeGadget, event ) :
 			nodeGadget.node().parent().addChild( pathFilter )
 			nodeGadget.node()["filter"].setInput( pathFilter["out"] )
 
-			graphGadget = nodeGadget.ancestor( GafferUI.GraphGadget )
-			graphGadget.getLayout().positionNode( graphGadget, pathFilter )
-
 			pathsPlug = pathFilter["paths"]
 
 		pathsPlug.setValue( IECore.StringVectorData( paths ) )

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -97,26 +97,23 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		g.getLayout().connectNode( g, s["compound"], Gaffer.StandardSet( [ s["add2"] ] ) )
 		self.assertEqual( s["compound"]["p"]["f"].getInput(), None )
 
-		Gaffer.Metadata.registerValue( GafferTest.CompoundPlugNode, "p", "nodule:type", "GafferUI::CompoundNodule" )
+		Gaffer.Metadata.registerValue( s["compound"]["p"], "nodule:type", "GafferUI::CompoundNodule" )
 
-		s["compound2"] = GafferTest.CompoundPlugNode()
-		g.getLayout().connectNode( g, s["compound2"], Gaffer.StandardSet( [ s["add2"] ] ) )
-		self.assertTrue( s["compound2"]["p"]["f"].getInput().isSame( s["add2"]["sum"] ) )
+		g.getLayout().connectNode( g, s["compound"], Gaffer.StandardSet( [ s["add2"] ] ) )
+		self.assertTrue( s["compound"]["p"]["f"].getInput().isSame( s["add2"]["sum"] ) )
 
 		# check we can connect from a nested plug, but only provided it is represented
 		# in the node graph by a nodule for that exact plug.
 
 		s["add3"] = GafferTest.AddNode()
 
-		g.getLayout().connectNode( g, s["add3"], Gaffer.StandardSet( [ s["compound2"] ] ) )
+		g.getLayout().connectNode( g, s["add3"], Gaffer.StandardSet( [ s["compound"] ] ) )
 		self.assertEqual( s["add3"]["op1"].getInput(), None )
 
-		Gaffer.Metadata.registerValue( GafferTest.CompoundPlugNode, "o", "nodule:type", "GafferUI::CompoundNodule" )
+		Gaffer.Metadata.registerValue( s["compound"]["o"], "nodule:type", "GafferUI::CompoundNodule" )
 
-		s["compound3"] = GafferTest.CompoundPlugNode()
-
-		g.getLayout().connectNode( g, s["add3"], Gaffer.StandardSet( [ s["compound3"] ] ) )
-		self.assertTrue( s["add3"]["op1"].getInput().isSame( s["compound3"]["o"]["f"] ) )
+		g.getLayout().connectNode( g, s["add3"], Gaffer.StandardSet( [ s["compound"] ] ) )
+		self.assertTrue( s["add3"]["op1"].getInput().isSame( s["compound"]["o"]["f"] ) )
 
 	def testConnectNodes( self ) :
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -444,6 +444,39 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( g.getNodePosition( s["node2"] ).x > g.getNodePosition( s["node1"] ).x )
 		self.assertAlmostEqual( g.getNodePosition( s["node1"] ).y, g.getNodePosition( s["node2"] ).y, 2 )
 
+	def testPositionNodesPutsAllNodesDownstream( self ) :
+
+		# When positioning `b` and `c` relative to `a`, we want to
+		# make sure that both nodes end up to the right of `a`,
+		# even though only `c` has a connection from it.
+		#
+		#  a ------> ---------
+		#            |   c   |
+		#       b -> ---------
+
+		s = Gaffer.ScriptNode()
+
+		s["a"] = self.LayoutNode()
+		s["b"] = self.LayoutNode()
+		s["c"] = self.LayoutNode()
+
+		s["c"]["left0"].setInput( s["a"]["right2"] )
+		s["c"]["left2"].setInput( s["b"]["right0"] )
+
+		g = GafferUI.GraphGadget( s )
+
+		g.setNodePosition( s["a"], imath.V2f( 0, 0 ) )
+		g.setNodePosition( s["b"], imath.V2f( -100, 0 ) )
+		g.setNodePosition( s["c"], imath.V2f( -50, 20 ) )
+
+		bcOffset = g.getNodePosition( s["c"] ) - g.getNodePosition( s["b"] )
+
+		g.getLayout().positionNodes( g, Gaffer.StandardSet( [ s["b"], s["c"] ] ) )
+
+		self.assertEqual( g.getNodePosition( s["a"] ), imath.V2f( 0 ) )
+		self.assertEqual( g.getNodePosition( s["c"] ) - g.getNodePosition( s["b"] ), bcOffset )
+		self.assertGreater( g.getNodePosition( s["b"] ).x, g.getNodePosition( s["a"] ).x )
+
 	def testPositionNodesFallback( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -45,36 +45,36 @@ import GafferUI
 import GafferTest
 import GafferUITest
 
-class LayoutNode( Gaffer.Node ) :
-
-	def __init__( self, name = "LayoutNode" ) :
-
-		Gaffer.Node.__init__( self, name )
-
-		self["top0"] = Gaffer.IntPlug()
-		self["top1"] = Gaffer.IntPlug()
-		self["top2"] = Gaffer.IntPlug()
-
-		self["left0"] = Gaffer.IntPlug()
-		self["left1"] = Gaffer.IntPlug()
-		self["left2"] = Gaffer.IntPlug()
-
-		self["bottom0"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-		self["bottom1"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-		self["bottom2"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-
-		self["right0"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-		self["right1"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-		self["right2"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
-
-IECore.registerRunTimeTyped( LayoutNode )
-
-Gaffer.Metadata.registerValue( LayoutNode, "left*", "noduleLayout:section", "left" )
-Gaffer.Metadata.registerValue( LayoutNode, "right*", "noduleLayout:section", "right" )
-Gaffer.Metadata.registerValue( LayoutNode, "top*", "noduleLayout:section", "top" )
-Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "noduleLayout:section", "bottom" )
-
 class StandardGraphLayoutTest( GafferUITest.TestCase ) :
+
+	class LayoutNode( Gaffer.Node ) :
+
+		def __init__( self, name = "LayoutNode" ) :
+
+			Gaffer.Node.__init__( self, name )
+
+			self["top0"] = Gaffer.IntPlug()
+			self["top1"] = Gaffer.IntPlug()
+			self["top2"] = Gaffer.IntPlug()
+
+			self["left0"] = Gaffer.IntPlug()
+			self["left1"] = Gaffer.IntPlug()
+			self["left2"] = Gaffer.IntPlug()
+
+			self["bottom0"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+			self["bottom1"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+			self["bottom2"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+
+			self["right0"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+			self["right1"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+			self["right2"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+
+	IECore.registerRunTimeTyped( LayoutNode )
+
+	Gaffer.Metadata.registerValue( LayoutNode, "left*", "noduleLayout:section", "left" )
+	Gaffer.Metadata.registerValue( LayoutNode, "right*", "noduleLayout:section", "right" )
+	Gaffer.Metadata.registerValue( LayoutNode, "top*", "noduleLayout:section", "top" )
+	Gaffer.Metadata.registerValue( LayoutNode, "bottom*", "noduleLayout:section", "bottom" )
 
 	def testConnectNode( self ) :
 
@@ -209,8 +209,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 	def testLayoutDirection( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["top"] = LayoutNode()
-		s["bottom"] = LayoutNode()
+		s["top"] = self.LayoutNode()
+		s["bottom"] = self.LayoutNode()
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
@@ -218,8 +218,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		self.assertTrue( g.getNodePosition( s["top"] ).y > g.getNodePosition( s["bottom"] ).y )
 
-		s["left"] = LayoutNode()
-		s["right"] = LayoutNode()
+		s["left"] = self.LayoutNode()
+		s["right"] = self.LayoutNode()
 		s["right"]["left0"].setInput( s["left"]["right0"] )
 
 		g.getLayout().layoutNodes( g )
@@ -230,10 +230,10 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["top0"] = LayoutNode()
-		s["top1"] = LayoutNode()
-		s["top2"] = LayoutNode()
-		s["bottom"] = LayoutNode()
+		s["top0"] = self.LayoutNode()
+		s["top1"] = self.LayoutNode()
+		s["top2"] = self.LayoutNode()
+		s["bottom"] = self.LayoutNode()
 		s["bottom"]["top0"].setInput( s["top0"]["bottom0"] )
 		s["bottom"]["top1"].setInput( s["top1"]["bottom0"] )
 		s["bottom"]["top2"].setInput( s["top2"]["bottom0"] )
@@ -250,10 +250,10 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["left0"] = LayoutNode()
-		s["left1"] = LayoutNode()
-		s["left2"] = LayoutNode()
-		s["right"] = LayoutNode()
+		s["left0"] = self.LayoutNode()
+		s["left1"] = self.LayoutNode()
+		s["left2"] = self.LayoutNode()
+		s["right"] = self.LayoutNode()
 		s["right"]["left0"].setInput( s["left0"]["right0"] )
 		s["right"]["left1"].setInput( s["left1"]["right0"] )
 		s["right"]["left2"].setInput( s["left2"]["right0"] )
@@ -270,8 +270,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["bottom"] = LayoutNode()
-		s["top"] = LayoutNode()
+		s["bottom"] = self.LayoutNode()
+		s["top"] = self.LayoutNode()
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
@@ -287,8 +287,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["bottom"] = LayoutNode()
-		s["top"] = LayoutNode()
+		s["bottom"] = self.LayoutNode()
+		s["top"] = self.LayoutNode()
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
@@ -306,8 +306,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["bottom"] = LayoutNode()
-		s["top"] = LayoutNode()
+		s["bottom"] = self.LayoutNode()
+		s["top"] = self.LayoutNode()
 		s["bottom"]["top0"].setInput( s["top"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
@@ -325,8 +325,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["one"] = LayoutNode()
-		s["two"] = LayoutNode()
+		s["one"] = self.LayoutNode()
+		s["two"] = self.LayoutNode()
 
 		g = GafferUI.GraphGadget( s )
 		g.getLayout().layoutNodes( g )
@@ -337,12 +337,12 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["top1"] = LayoutNode()
-		s["bottom1"] = LayoutNode()
+		s["top1"] = self.LayoutNode()
+		s["bottom1"] = self.LayoutNode()
 		s["bottom1"]["top0"].setInput( s["top1"]["bottom0"] )
 
-		s["top2"] = LayoutNode()
-		s["bottom2"] = LayoutNode()
+		s["top2"] = self.LayoutNode()
+		s["bottom2"] = self.LayoutNode()
 		s["bottom2"]["top0"].setInput( s["top2"]["bottom0"] )
 
 		g = GafferUI.GraphGadget( s )
@@ -354,10 +354,10 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["top"] = LayoutNode()
-		s["middle"] = LayoutNode()
-		s["bottom"] = LayoutNode()
-		s["left"] = LayoutNode()
+		s["top"] = self.LayoutNode()
+		s["middle"] = self.LayoutNode()
+		s["bottom"] = self.LayoutNode()
+		s["left"] = self.LayoutNode()
 
 		s["middle"]["top0"].setInput( s["top"]["bottom0"] )
 		s["bottom"]["top0"].setInput( s["middle"]["bottom0"] )
@@ -375,14 +375,14 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["topLeft"] = LayoutNode()
-		s["topRight"] = LayoutNode()
+		s["topLeft"] = self.LayoutNode()
+		s["topRight"] = self.LayoutNode()
 
 		g = GafferUI.GraphGadget( s )
 		g.setNodePosition( s["topLeft"], imath.V2f( 10, 0 ) )
 		g.setNodePosition( s["topRight"], imath.V2f( 40, 0 ) )
 
-		s["new"] = LayoutNode()
+		s["new"] = self.LayoutNode()
 		s["new"]["top0"].setInput( s["topLeft"]["bottom1"] )
 		s["new"]["top2"].setInput( s["topRight"]["bottom1"] )
 
@@ -400,8 +400,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["node1"] = LayoutNode()
-		s["node2"] = LayoutNode()
+		s["node1"] = self.LayoutNode()
+		s["node2"] = self.LayoutNode()
 
 		g = GafferUI.GraphGadget( s )
 		g.setNodePosition( s["node1"], imath.V2f( 10, 0 ) )
@@ -420,9 +420,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		#       v
 		#       3
 
-		s["node1"] = LayoutNode()
-		s["node2"] = LayoutNode()
-		s["node3"] = LayoutNode()
+		s["node1"] = self.LayoutNode()
+		s["node2"] = self.LayoutNode()
+		s["node3"] = self.LayoutNode()
 
 		s["node2"]["left1"].setInput( s["node1"]["right1"] )
 		s["node3"]["top1"].setInput( s["node2"]["bottom1"] )
@@ -448,8 +448,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["node1"] = LayoutNode()
-		s["node2"] = LayoutNode()
+		s["node1"] = self.LayoutNode()
+		s["node2"] = self.LayoutNode()
 
 		s["node2"]["left0"].setInput( s["node1"]["right0"] )
 
@@ -474,12 +474,12 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["s1"] = LayoutNode()
-		s["s2"] = LayoutNode()
-		s["s3"] = LayoutNode()
+		s["s1"] = self.LayoutNode()
+		s["s2"] = self.LayoutNode()
+		s["s3"] = self.LayoutNode()
 
-		s["o1"] = LayoutNode()
-		s["o2"] = LayoutNode()
+		s["o1"] = self.LayoutNode()
+		s["o2"] = self.LayoutNode()
 
 		s["o1"]["top0"].setInput( s["s1"]["bottom1"] )
 		s["o1"]["top1"].setInput( s["s2"]["bottom1"] )
@@ -504,12 +504,12 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["s1"] = LayoutNode()
-		s["s2"] = LayoutNode()
-		s["s3"] = LayoutNode()
+		s["s1"] = self.LayoutNode()
+		s["s2"] = self.LayoutNode()
+		s["s3"] = self.LayoutNode()
 
-		s["o1"] = LayoutNode()
-		s["o2"] = LayoutNode()
+		s["o1"] = self.LayoutNode()
+		s["o2"] = self.LayoutNode()
 
 		s["o1"]["left0"].setInput( s["s1"]["right1"] )
 		s["o1"]["left1"].setInput( s["s2"]["right1"] )
@@ -534,10 +534,10 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["t"] = LayoutNode()
-		s["b"] = LayoutNode()
-		s["bb"] = LayoutNode()
-		s["bbb"] = LayoutNode()
+		s["t"] = self.LayoutNode()
+		s["b"] = self.LayoutNode()
+		s["bb"] = self.LayoutNode()
+		s["bbb"] = self.LayoutNode()
 
 		s["b"]["top1"].setInput( s["t"]["bottom1"] )
 		s["bb"]["top1"].setInput( s["t"]["bottom1"] )
@@ -560,10 +560,10 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["s"] = LayoutNode()
-		s["t1"] = LayoutNode()
-		s["t2"] = LayoutNode()
-		s["t3"] = LayoutNode()
+		s["s"] = self.LayoutNode()
+		s["t1"] = self.LayoutNode()
+		s["t2"] = self.LayoutNode()
+		s["t3"] = self.LayoutNode()
 
 		s["t1"]["left0"].setInput( s["s"]["bottom1"] )
 		s["t2"]["left0"].setInput( s["s"]["bottom1"] )
@@ -581,8 +581,8 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["i"] = LayoutNode()
-		s["o"] = LayoutNode()
+		s["i"] = self.LayoutNode()
+		s["o"] = self.LayoutNode()
 
 		s["o"]["top1"].setInput( s["i"]["bottom1"] )
 
@@ -606,9 +606,9 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["t1"] = LayoutNode()
-		s["t2"] = LayoutNode()
-		s["b"] = LayoutNode()
+		s["t1"] = self.LayoutNode()
+		s["t2"] = self.LayoutNode()
+		s["b"] = self.LayoutNode()
 
 		s["b"]["top0"].setInput( s["t1"]["bottom1"] )
 		s["b"]["top1"].setInput( s["t2"]["bottom1"] )
@@ -633,11 +633,11 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["t1"] = LayoutNode()
-		s["t2"] = LayoutNode()
-		s["m"] = LayoutNode()
-		s["b1"] = LayoutNode()
-		s["b2"] = LayoutNode()
+		s["t1"] = self.LayoutNode()
+		s["t2"] = self.LayoutNode()
+		s["m"] = self.LayoutNode()
+		s["b1"] = self.LayoutNode()
+		s["b2"] = self.LayoutNode()
 
 		s["m"]["top0"].setInput( s["t1"]["bottom1"] )
 		s["m"]["top1"].setInput( s["t2"]["bottom1"] )
@@ -737,7 +737,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 	def testSimpleAuxiliaryConnectionToNode( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["n"] = LayoutNode()
+		s["n"] = self.LayoutNode()
 		Gaffer.Metadata.registerValue( s["n"]["top0"], "nodule:type", "" )
 
 		s["e"] = Gaffer.Expression()
@@ -759,7 +759,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		# If the expression has an input, we don't want that to affect the
 		# expression's position if it has only one output like in this case.
 
-		s["n2"] = LayoutNode()
+		s["n2"] = self.LayoutNode()
 		g.setNodePosition( s["n2"], g.getNodePosition( s["n"] ) + imath.V2f( 0, 10 ) )
 
 		s["e"].setExpression( "parent['n']['top0'] = parent['n2']['bottom0']" )
@@ -775,7 +775,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		# opposed to top to bottom
 
 		s = Gaffer.ScriptNode()
-		s["n"] = LayoutNode()
+		s["n"] = self.LayoutNode()
 
 		Gaffer.Metadata.registerValue( s["n"]["left0"], "nodule:type", "" )
 
@@ -807,7 +807,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		# The nodule's tangent will determine how the auxiliary node is positioned.
 
 		s = Gaffer.ScriptNode()
-		s["n"] = LayoutNode()
+		s["n"] = self.LayoutNode()
 
 		s["e"] = Gaffer.Expression()
 		s["e"].setExpression( "parent['n']['top1'] = 0" )
@@ -832,7 +832,7 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 	def testMultipleAuxiliaryConnectionsToNode( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["n"] = LayoutNode()
+		s["n"] = self.LayoutNode()
 
 		Gaffer.Metadata.registerValue( s["n"]["left0"], "nodule:type", "" )
 		Gaffer.Metadata.registerValue( s["n"]["left1"], "nodule:type", "" )
@@ -865,13 +865,13 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 
-		s["o"] = LayoutNode()
+		s["o"] = self.LayoutNode()
 		Gaffer.Metadata.registerValue( s["o"]["left0"], "nodule:type", "" )
 
-		s["i1"] = LayoutNode()
+		s["i1"] = self.LayoutNode()
 		Gaffer.Metadata.registerValue( s["i1"]["left0"], "nodule:type", "" )
 
-		s["i2"] = LayoutNode()
+		s["i2"] = self.LayoutNode()
 		Gaffer.Metadata.registerValue( s["i2"]["left0"], "nodule:type", "" )
 
 		s["e"] = Gaffer.Expression()

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -143,12 +143,6 @@ class Constraint
 			LessThanOrEqualTo
 		};
 
-		/// \todo Remove - it's only here so we can call m_constraints.resize()
-		/// to remove the collision constraints.
-		Constraint()
-		{
-		}
-
 		// Enforces p - q ( ==, >=, <= ) d in direction v
 		Constraint( V2f *p, V2f *q, Type type, float d, const V2f &v, float w = 0.5 )
 			:	m_p( p ), m_q( q ), m_type( type ), m_d( d ), m_v( v ), m_w( w )
@@ -608,7 +602,7 @@ class LayoutEngine
 		{
 			VertexIteratorRange v = vertices( m_graph );
 
-			size_t numConstraints = m_constraints.size();
+			const size_t firstCollisionConstraintIndex = m_constraints.size();
 			for( int i = 0; i < m_maxIterations; ++i )
 			{
 				for( VertexIterator it = v.first; it != v.second; ++it )
@@ -624,7 +618,7 @@ class LayoutEngine
 				{
 					addCollisionConstraints();
 					applyConstraints( m_constraintsIterations );
-					m_constraints.resize( numConstraints );
+					m_constraints.erase( m_constraints.begin() + firstCollisionConstraintIndex, m_constraints.end() );
 				}
 
 				float maxMovement = 0;

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -217,15 +217,11 @@ class LayoutEngine
 
 				Box3f bb = nodeGadget->bound();
 
-				bool auxiliary = bool( runTimeCast<const AuxiliaryNodeGadget>( nodeGadget ) );
-
 				VertexDescriptor v = add_vertex( m_graph );
 				m_graph[v].node = node;
 				m_graph[v].position = graphGadget->getNodePosition( node );
 				m_graph[v].bound = Box2f( V2f( bb.min.x, bb.min.y ), V2f( bb.max.x, bb.max.y ) );
-				m_graph[v].pinned = false;
-				m_graph[v].collisionGroup = 0;
-				m_graph[v].auxiliary = auxiliary;
+				m_graph[v].auxiliary = runTimeCast<const AuxiliaryNodeGadget>( nodeGadget );
 				m_nodesToVertices[node] = v;
 			}
 
@@ -351,9 +347,6 @@ class LayoutEngine
 
 			VertexDescriptor groupDescriptor = add_vertex( m_graph );
 			Vertex &group = m_graph[groupDescriptor];
-			group.node = nullptr;
-			group.pinned = false;
-			group.collisionGroup = 0;
 			group.position = bound.center();
 			group.bound = Box2f( bound.min - group.position, bound.max - group.position );
 
@@ -729,22 +722,21 @@ class LayoutEngine
 			// The node this vertex represents.
 			// May be nullptr for vertices introduced
 			// by groupNodes().
-			Node *node;
+			Node *node = nullptr;
 			// Node position within graph.
-			V2f position;
+			V2f position = V2f( 0.0f );
 			// Node bound in local space.
-			Box2f bound;
+			Box2f bound = Box2f( V2f( 0.0f ) );
 			// True if node is not to be moved.
-			bool pinned;
+			bool pinned = false;
 			// Provides finer control over collision avoidance.
-			int collisionGroup;
+			int collisionGroup = 0;
+			// True if node is represented by a (smaller) AuxiliaryNodeGadget
+			bool auxiliary = false;
 
 			// State variables for use in solve().
-			V2f previousPosition;
-			V2f force;
-
-			// True if node is represented by a (smaller) AuxiliaryNodeGadget
-			bool auxiliary;
+			V2f previousPosition = V2f( 0.0f );
+			V2f force = V2f( 0.0f );
 		};
 
 		struct Edge


### PR DESCRIPTION
This predates the automatic positioning performed in `GraphEditor.__preRender`, and does a worse job of it.
