### PR TITLE
Move Image Processing Nodes From ImageGadget to ImageView

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,7 @@ API
 Breaking Changes
 ----------------
 
-- ImageGadget : Removed `setDisplayTransform()` and `getDisplayTransform()`, and `setUseGPU()` and `getUseGPU()`. Use `ViewportGadget::setPostProcessShader()` instead. There is temporarily a `setCPUDisplayTransform()` function for setting up display transforms on the CPU path, but that will be removed shortly.
+- ImageGadget : Removed setters and getters for `DisplayTransform`, `UseGPU`, `Clipping`, `Exposure`, `Gamma`.  Instead use `ViewportGadget::setPostProcessShader()` to set up a GPU color transform, or set the plug values on `ImageView`.
 
 1.0.x.x (relative to 1.0.2.1)
 =======

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -128,21 +128,6 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		void setSoloChannel( int index );
 		int getSoloChannel() const;
 
-		void setClipping( bool clipping );
-		bool getClipping() const;
-
-		void setExposure( float exposure );
-		float getExposure() const;
-
-		void setGamma( float gamma );
-		float getGamma() const;
-
-		// Use for setting a display color transform that is a Gaffer image processing node that
-		// will run on the CPU.  This approach is deprecated, it is better to set a GPU OCIO
-		// transform on the ViewportGadget that contains the ImageGadget.
-		void setCPUDisplayTransform( GafferImage::ImageProcessorPtr displayTransform );
-		GafferImage::ConstImageProcessorPtr getCPUDisplayTransform() const;
-
 		void setLabelsVisible( bool visible );
 		bool getLabelsVisible() const;
 
@@ -192,16 +177,6 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		Channels m_rgbaChannels;
 		int m_soloChannel;
 		ImageGadgetSignal m_channelsChangedSignal;
-
-		bool m_clipping;
-		float m_exposure;
-		float m_gamma;
-
-		GafferImage::DeepStatePtr m_deepStateNode;
-		GafferImage::SaturationPtr m_saturationNode;
-		GafferImage::ClampPtr m_clampNode;
-		GafferImage::GradePtr m_gradeNode;
-		GafferImage::ImageProcessorPtr m_cpuDisplayTransform;
 
 		bool m_labelsVisible;
 		bool m_paused;

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -46,6 +46,7 @@
 #include "Gaffer/BoxPlug.h"
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/NumericPlug.h"
+#include "Gaffer/Switch.h"
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/TypedObjectPlug.h"
 
@@ -186,7 +187,10 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		DisplayTransformMap m_displayTransforms;
 		DisplayTransformEntry *m_displayTransformAndShader;
 
-		IECore::IntDataPtr m_soloChannel;
+		IECore::BoolDataPtr m_clippingParameter;
+		IECore::Color3fDataPtr m_multiplyParameter;
+		IECore::Color3fDataPtr m_powerParameter;
+		IECore::IntDataPtr m_soloChannelParameter;
 		bool m_lutGPU;
 
 		ImageGadgetPtr m_imageGadget;
@@ -194,6 +198,13 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 		class ColorInspector;
 		std::unique_ptr<ColorInspector> m_colorInspector;
+
+		GafferImage::ImagePlugPtr m_imageBeforeColorTransform;
+		Gaffer::FloatPlugPtr m_cpuSaturationPlug;
+		Gaffer::BoolPlugPtr m_cpuClippingPlug;
+		Gaffer::Color4fPlugPtr m_cpuMultiplyPlug;
+		Gaffer::Color4fPlugPtr m_cpuGammaPlug;
+		Gaffer::SwitchPtr m_colorTransformSwitch;
 
 		using DisplayTransformCreatorMap = std::map<std::string, DisplayTransformCreator>;
 		static DisplayTransformCreatorMap &displayTransformCreators();

--- a/include/GafferImageUI/OpenColorIOAlgo.h
+++ b/include/GafferImageUI/OpenColorIOAlgo.h
@@ -53,6 +53,9 @@ namespace OpenColorIOAlgo
 // The shader has a frameBufferTexture uniform so it is appropriate to use with ViewportGadget::setPostProcessShader.
 // There are also additional uniforms:
 //   bool unpremultiply : temporarily unpremultiply while applying the color transform
+//   bool clipping : mark regions outside 0 - 1
+//   color multiply : apply a multiplier before the color transform
+//   color power : apply a power curve before the color transform
 //   bool soloChannel : Set to 0-3 to pick channels RGBA, or -2 for luminance.  Default -1 uses all channels as a color.
 GAFFERIMAGEUI_API IECoreGL::Shader::SetupPtr displayTransformToFramebufferShader( const OCIO_NAMESPACE::Processor *processor );
 


### PR DESCRIPTION
This implements John's suggestion to move the image processing nodes from inside ImageGadget to ImageView.  This matches the GPU color transform now being done by ImageView, and probably makes more sense anyway.

It's just the last 3 commits that are new here - this is on top of #4767.  I won't worry about rebasing to be mergeable until after we get that merged.