### PR TITLE
VectorDataWidget : Add color swatch column

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 - SceneWriter : Added support for Alembic visibility attributes.
 - ColorPlugValueWidget : Hid the color chooser button (sliders) for output plugs.
 - Arnold : Added metadata for new `standard_volume` shader parameters introduced in Arnold 7.1.3.0.
+- VectorDataWidget : Added a color swatch column for `Color3f` and `Color4f` elements. These are currently included in the `RandomChoice` node when `choices` is set to a list of colors, and for color primitive variables in the Primitive Inspector.
 
 Fixes
 -----

--- a/python/GafferUI/ColorSwatch.py
+++ b/python/GafferUI/ColorSwatch.py
@@ -166,41 +166,67 @@ class _Checker( QtWidgets.QWidget ) :
 
 	def paintEvent( self, event ) :
 
-		painter = QtGui.QPainter( self )
-		rect = event.rect()
+		_Checker._paintRectangle(
+			QtGui.QPainter( self ),
+			event.rect(),
+			self.color0,
+			self.color1,
+			self.borderColor,
+			self.__borderTop,
+			self.__borderBottom,
+			self.width(),
+			self.height()
+		)
 
-		if self.color0 != self.color1 :
+	@staticmethod
+	def _paintRectangle(
+		painter,
+		rect,
+		color0,
+		color1,
+		borderColor = None,
+		borderTop = False,
+		borderBottom = False,
+		borderWidth = 0,
+		borderHeight = 0
+	) :
+
+		if color0 != color1 :
 
 			# draw checkerboard if colours differ
 			checkSize = 6
 
-			min = imath.V2i( rect.x() / checkSize, rect.y() / checkSize )
-			max = imath.V2i( 1 + (rect.x() + rect.width()) / checkSize, 1 + (rect.y() + rect.height()) / checkSize )
+			gridSize = imath.V2i( rect.width() / checkSize + 1, rect.height() / checkSize + 1 )
 
-			for x in range( min.x, max.x ) :
-				for y in range( min.y, max.y ) :
-					if ( x + y ) % 2 :
-						painter.fillRect( QtCore.QRectF( x * checkSize, y * checkSize, checkSize, checkSize ), self.color0 )
+			for i in range( 0, gridSize.x ) :
+				for j in range( 0, gridSize.y ) :
+					offset = imath.V2i( i * checkSize, j * checkSize )
+					square = QtCore.QRectF(
+						rect.x() + offset.x,
+						rect.y() + offset.y,
+						min( rect.width() - offset.x, checkSize ),
+						min( rect.height() - offset.y, checkSize )
+					)
+					if ( i + j ) % 2 :
+						painter.fillRect( square, color0 )
 					else :
-						painter.fillRect( QtCore.QRectF( x * checkSize, y * checkSize, checkSize, checkSize ), self.color1 )
+						painter.fillRect( square, color1 )
 
 		else :
 
 			# otherwise just draw a flat colour cos it'll be quicker
-			painter.fillRect( QtCore.QRectF( rect.x(), rect.y(), rect.x() + rect.width(), rect.y() + rect.height() ), self.color0 )
+			painter.fillRect( QtCore.QRectF( rect.x(), rect.y(), rect.width(), rect.height() ), color0 )
 
-		if self.borderColor is not None :
-			w = self.width()
-			h = self.height()
-			pen = QtGui.QPen( self.borderColor )
+		if borderColor is not None :
+			pen = QtGui.QPen( borderColor )
 			lines = [
-				QtCore.QLine( 0, 0, 0, h ),
-				QtCore.QLine( w, 0, w, h ),
+				QtCore.QLine( 0, 0, 0, borderHeight ),
+				QtCore.QLine( borderWidth, 0, borderWidth, borderHeight ),
 			]
-			if self.__borderTop :
-				lines.append( QtCore.QLine( 0, 0, w, 0 ) )
-			if self.__borderBottom :
-				lines.append( QtCore.QLine( 0, h, w, h ) )
+			if borderTop :
+				lines.append( QtCore.QLine( 0, 0, borderWidth, 0 ) )
+			if borderBottom :
+				lines.append( QtCore.QLine( 0, borderHeight, borderWidth, borderHeight ) )
 			pen.setWidth( 4 )
 			painter.setPen( pen )
 			painter.drawLines( lines )

--- a/python/GafferUITest/VectorDataWidgetTest.py
+++ b/python/GafferUITest/VectorDataWidgetTest.py
@@ -61,25 +61,27 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( w.columnToDataIndex( 1 ), ( 1, 0 ) )
 		self.assertEqual( w.columnToDataIndex( 2 ), ( 1, 1 ) )
 		self.assertEqual( w.columnToDataIndex( 3 ), ( 1, 2 ) )
-		self.assertEqual( w.columnToDataIndex( 4 ), ( 2, -1 ) )
-		self.assertEqual( w.columnToDataIndex( 5 ), ( 3, -1 ) )
-		self.assertEqual( w.columnToDataIndex( 6 ), ( 4, 0 ) )
-		self.assertEqual( w.columnToDataIndex( 7 ), ( 4, 1 ) )
-		self.assertEqual( w.columnToDataIndex( 8 ), ( 4, 2 ) )
+		self.assertEqual( w.columnToDataIndex( 4 ), ( 1, 3 ) )
+		self.assertEqual( w.columnToDataIndex( 5 ), ( 2, -1 ) )
+		self.assertEqual( w.columnToDataIndex( 6 ), ( 3, -1 ) )
+		self.assertEqual( w.columnToDataIndex( 7 ), ( 4, 0 ) )
+		self.assertEqual( w.columnToDataIndex( 8 ), ( 4, 1 ) )
+		self.assertEqual( w.columnToDataIndex( 9 ), ( 4, 2 ) )
 
-		self.assertRaises( IndexError, w.columnToDataIndex, 9 )
+		self.assertRaises( IndexError, w.columnToDataIndex, 10 )
 
 		self.assertEqual( w.dataToColumnIndex( 0, -1 ), 0 )
 		self.assertEqual( w.dataToColumnIndex( 1, 0 ), 1 )
 		self.assertEqual( w.dataToColumnIndex( 1, 1 ), 2 )
 		self.assertEqual( w.dataToColumnIndex( 1, 2 ), 3 )
-		self.assertEqual( w.dataToColumnIndex( 2, -1 ), 4 )
-		self.assertEqual( w.dataToColumnIndex( 3, -1 ), 5 )
-		self.assertEqual( w.dataToColumnIndex( 4, 0 ), 6 )
-		self.assertEqual( w.dataToColumnIndex( 4, 1 ), 7 )
-		self.assertEqual( w.dataToColumnIndex( 4, 2 ), 8 )
+		self.assertEqual( w.dataToColumnIndex( 1, 3 ), 4 )
+		self.assertEqual( w.dataToColumnIndex( 2, -1 ), 5 )
+		self.assertEqual( w.dataToColumnIndex( 3, -1 ), 6 )
+		self.assertEqual( w.dataToColumnIndex( 4, 0 ), 7 )
+		self.assertEqual( w.dataToColumnIndex( 4, 1 ), 8 )
+		self.assertEqual( w.dataToColumnIndex( 4, 2 ), 9 )
 
-		self.assertRaises( IndexError, w.dataToColumnIndex, 5, 0 )
+		self.assertRaises( IndexError, w.dataToColumnIndex, 6, 0 )
 
 	def testColumnEditability( self ) :
 
@@ -91,10 +93,10 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 
 		w = GafferUI.VectorDataWidget( data )
 
-		for i in range( 0, 5 ) :
+		for i in range( 0, 6 ) :
 			self.assertEqual( w.getColumnEditable( i ), True )
 
-		self.assertRaises( IndexError, w.getColumnEditable, 5 )
+		self.assertRaises( IndexError, w.getColumnEditable, 7 )
 		self.assertRaises( IndexError, w.getColumnEditable, -1 )
 
 		w.setColumnEditable( 1, False )
@@ -103,7 +105,7 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 		data[0][0] += 1.0
 		w.setData( data )
 
-		for i in range( 0, 5 ) :
+		for i in range( 0, 6 ) :
 			self.assertEqual( w.getColumnEditable( i ), i != 1 )
 
 		cs = GafferTest.CapturingSlot( w.dataChangedSignal() )
@@ -114,6 +116,37 @@ class VectorDataWidgetTest( GafferUITest.TestCase ) :
 
 		# changing editability shouldn't emit dataChangedSignal.
 		self.assertEqual( len( cs ), 0 )
+
+	def testColorColumn( self ) :
+
+		data = [
+			IECore.Color3fVectorData( [ imath.Color3f( x ) for x in range( 0, 3 ) ] ),
+			IECore.Color4fVectorData( [ imath.Color4f( x ) for x in range( 0, 3 ) ] ),
+		]
+
+		w = GafferUI.VectorDataWidget( data )
+		self.assertEqual( w.columnToDataIndex( 0 ), ( 0, 0 ) )
+		self.assertEqual( w.columnToDataIndex( 1 ), ( 0, 1 ) )
+		self.assertEqual( w.columnToDataIndex( 2 ), ( 0, 2 ) )
+		self.assertEqual( w.columnToDataIndex( 3 ), ( 0, 3 ) )
+
+		self.assertEqual( w.columnToDataIndex( 4 ), ( 1, 0 ) )
+		self.assertEqual( w.columnToDataIndex( 5 ), ( 1, 1 ) )
+		self.assertEqual( w.columnToDataIndex( 6 ), ( 1, 2 ) )
+		self.assertEqual( w.columnToDataIndex( 7 ), ( 1, 3 ) )
+		self.assertEqual( w.columnToDataIndex( 8 ), ( 1, 4 ) )
+
+		for i in range( 0, 3 ) :
+			self.assertEqual( w.getData()[0][i][0], i )
+			self.assertEqual( w.getData()[0][i][1], i )
+			self.assertEqual( w.getData()[0][i][2], i )
+			self.assertEqual( w.getData()[0][i], imath.Color3f( i, i, i ) )
+
+			self.assertEqual( w.getData()[1][i][0], i )
+			self.assertEqual( w.getData()[1][i][1], i )
+			self.assertEqual( w.getData()[1][i][2], i )
+			self.assertEqual( w.getData()[1][i][3], i )
+			self.assertEqual( w.getData()[1][i], imath.Color4f( i, i, i, i ) )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds an additional column showing the color of `Color3f` and `Color4f` data in a `VectorDataWidget`.

I still need to add selection highlighting to the color swatches when they are selected, but I think it's usable enough now to get feedback.

I'm also currently handling alpha in a `Colorf4f` swatch as actual alpha instead of the split checkerboard / color scheme that color swatches use. Is there a way to reuse the color swatch directly? I think no because the `QStyledItemDelegate` wants to handle painting. Is it worth duplicating or moving the checkerboard swatch internals somewhere they can be reused by `_ColorDelegate`?

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
