### PR TITLE
Arnold metadata : Update `standard_volume` parameters for Arnold 7.1.3.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Added loading of `treatAsPoint` and `treatAsLine` parameters from UsdLux lights.
 - SceneWriter : Added support for Alembic visibility attributes.
 - ColorPlugValueWidget : Hid the color chooser button (sliders) for output plugs.
+- Arnold : Added metadata for new `standard_volume` shader parameters introduced in Arnold 7.1.3.0.
 
 Fixes
 -----

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -2650,6 +2650,7 @@
 	gaffer.nodeMenu.category STRING "Volume"
 	gaffer.graphEditorLayout.defaultVisibility BOOL false
 
+	gaffer.layout.activator.secondaryAnisotropyEnabled STRING "parameters['scatter_secondary_anisotropy_mix'].getValue() > 0.0"
 	gaffer.layout.activator.emissionModeCommon STRING "parameters['emission_mode'].getValue() != 'none'"
 	gaffer.layout.activator.emissionModeBlackbody STRING "parameters['emission_mode'].getValue() == 'blackbody'"
 
@@ -2669,6 +2670,13 @@
 		page STRING "Scatter"
 	[attr scatter_anisotropy]
 		page STRING "Scatter"
+	[attr scatter_secondary_anisotropy]
+		page STRING "Scatter"
+		label STRING "Secondary Anisotropy"
+		gaffer.layout.activator STRING "secondaryAnisotropyEnabled"
+	[attr scatter_secondary_anisotropy_mix]
+		page STRING "Scatter"
+		label STRING "Secondary Anisotropy Mix"
 
 	[attr transparent]
 		page STRING "Transparent"
@@ -2679,6 +2687,9 @@
 
 	[attr emission_mode]
 		page STRING "Emission"
+	[attr emission_scaling]
+		page STRING "Emission"
+		gaffer.layout.activator STRING "emissionModeCommon"
 	[attr emission]
 		gaffer.graphEditorLayout.visible BOOL true
 		page STRING "Emission"
@@ -2703,7 +2714,9 @@
 	[attr blackbody_intensity]
 		page STRING "Emission"
 		gaffer.layout.activator STRING "emissionModeBlackbody"
-
+	[attr blackbody_contrast]
+		page STRING "Emission"
+		gaffer.layout.activator STRING "emissionModeBlackbody"
 	[attr displacement]
 		gaffer.graphEditorLayout.visible BOOL true
 		page STRING "Sampling"


### PR DESCRIPTION
Arnold 7.1.3.0 introduced additional `standard_volume` parameters to control secondary anisotropy as well as emission scaling and contrast. This adds metadata to put them in the right sections of the Node Editor, and an activator for secondary anisotropy.

https://docs.arnoldrenderer.com/display/A5ARP/7.1.3.0

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
