### PR TITLE
CyclesOptions : Remove featureSet plug

### DIFF
--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -47,12 +47,6 @@ def __sessionSummary( plug ) :
 	if plug["device"]["enabled"].getValue() :
 		info.append( "Device(s) {}".format( plug["device"]["value"].getValue() ) )
 
-	if plug["featureSet"]["enabled"].getValue() :
-		if plug["featureSet"]["value"].getValue() :
-			info.append( "Experimental Features" )
-		else :
-			info.append( "Standard Features" )
-
 	if plug["shadingSystem"]["enabled"].getValue() :
 		info.append( "Shading System {}".format( plug["shadingSystem"]["value"].getValue() ) )
 
@@ -460,30 +454,6 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Session",
 			"label", "Device(s)",
-
-		],
-
-		"options.featureSet" : [
-
-			"description",
-			"""
-			Feature set to use for rendering.
-			- Supported : Only use finished and supported features
-			- Experimental : Use experimental and incomplete features
-								that might be broken or change in the
-								future.
-			""",
-
-			"layout:section", "Session",
-
-		],
-
-		"options.featureSet.value" : [
-
-			"preset:Supported", False,
-			"preset:Experimental", True,
-
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -62,7 +62,6 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "ccl:shadingsystem", new IECore::StringData( "OSL" ), false, "shadingSystem" ) );
 
 	// Session/Render
-	options->addChild( new Gaffer::NameValuePlug( "ccl:session:experimental", new IECore::BoolData( false ), false, "featureSet" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:session:samples", new IECore::IntData( 1024 ), false, "samples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:session:pixel_size", new IECore::IntData( 1 ), false, "pixelSize" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ccl:session:threads", new IECore::IntData( 0 ), false, "numThreads" ) );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2795,7 +2795,7 @@ IECore::InternedString g_squareSamplesOptionName( "ccl:square_samples" );
 IECore::InternedString g_logLevelOptionName( "ccl:log_level" );
 IECore::InternedString g_progressLevelOptionName( "ccl:progress_level" );
 // Session
-IECore::InternedString g_featureSetOptionName( "ccl:session:experimental" );
+IECore::InternedString g_experimentalOptionName( "ccl:session:experimental" );
 IECore::InternedString g_samplesOptionName( "ccl:session:samples" );
 IECore::InternedString g_pixelSizeOptionName( "ccl:session:pixel_size" );
 IECore::InternedString g_threadsOptionName( "ccl:session:threads" );
@@ -3214,7 +3214,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 			else if( boost::starts_with( name.string(), "ccl:session:" ) )
 			{
-				OPTION(bool,  m_sessionParams, g_featureSetOptionName,   experimental);
+				OPTION(bool,  m_sessionParams, g_experimentalOptionName,   experimental);
 				OPTION(int,   m_sessionParams, g_samplesOptionName,      samples);
 				OPTION(int,   m_sessionParams, g_pixelSizeOptionName,    pixel_size);
 				OPTION(float, m_sessionParams, g_timeLimitOptionName,    time_limit);


### PR DESCRIPTION
The `experimental` flag appears to do nothing at all in Cycles at present, so there is no point exposing it. We're also tending to think that we don't want to expose it directly anyway, as we don't want to be on the hook for supporting unsupported features. If in future someone needs to turn this on, they can use CustomOptions.