### PR TITLE
NameWidget : Don't allow names to start with double underscore

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - ColorPlugValueWidget : Hid the color chooser button (sliders) for output plugs.
 - Arnold : Added metadata for new `standard_volume` shader parameters introduced in Arnold 7.1.3.0.
 - VectorDataWidget : Added a color swatch column for `Color3f` and `Color4f` elements. These are currently included in the `RandomChoice` node when `choices` is set to a list of colors, and for color primitive variables in the Primitive Inspector.
+- NameWidget : Added a check to prevent users from setting a node or plug name to a value starting with a double underscore.
 
 Fixes
 -----

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -133,7 +133,7 @@ class _Validator( QtGui.QValidator ) :
 
 		input = input.replace( " ", "_" )
 		if len( input ) :
-			if re.match( "^[A-Za-z_]+[A-Za-z_0-9]*$", input ) :
+			if re.match( "^(?!__)[A-Za-z_]+[A-Za-z_0-9]*$", input ) :
 				result = QtGui.QValidator.Acceptable
 			else :
 				result = QtGui.QValidator.Invalid


### PR DESCRIPTION
Starting a plug name with a double underscore will cause it to be hidden in the UI, which can be confusing for users not expecting that behavior. This change applies only to names input by the user, existing rules for node names overall are not changed.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
