### PR TITLE
SConstruct : VFX Platform 2023 uses new ABI with GCC 11.2.1

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -473,7 +473,7 @@ if env["PLATFORM"] != "win32" :
 		if gccVersion >= [ 4, 2 ] :
 			env.Append( CXXFLAGS = [ "-Wno-error=strict-overflow" ] )
 
-		if gccVersion >= [ 5, 1 ] :
+		if gccVersion >= [ 5, 1 ] and gccVersion < [ 11, 2 ] :
 			env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )
 
 		if gccVersion >= [ 9, 2 ] :


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- VFX Platform has decided to use the new ABI (removal of `_GLIBCXX_USE_CXX11_ABI=0`) https://vfxplatform.com/
- To build on eg. Rocky Linux 9 with GCC 11.2.1

### Related issues ###

- Getting early in on VFX platform 2023

### Dependencies ###

- Cortex [#1294](https://github.com/ImageEngine/cortex/pull/1294)

### Breaking changes ###

- Gaffer dependencies compiling on GCC 11.2.x will have to omit `_GLIBCXX_USE_CXX11_ABI=0` if set

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
