### PR TITLE
PathListingWidget fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - SceneReader : Fixed shader type for UsdLux lights. It was `surface` and is now `light`.
 - Fixed a bug in `SceneAlgo::attributeHistory` that would return a branching history from a `ShaderTweaks` node with `inherit` enabled.
 - Arnold : Fixed errors when making interactive render edits to lights with component-level connections between OSL shaders.
+- PathListingWidget : Fixed bug where one more rows at the bottom of the list could not be selected.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -32,7 +32,9 @@ Fixes
 - SceneReader : Fixed shader type for UsdLux lights. It was `surface` and is now `light`.
 - Fixed a bug in `SceneAlgo::attributeHistory` that would return a branching history from a `ShaderTweaks` node with `inherit` enabled.
 - Arnold : Fixed errors when making interactive render edits to lights with component-level connections between OSL shaders.
-- PathListingWidget : Fixed bug where one more rows at the bottom of the list could not be selected.
+- PathListingWidget :
+  - Fixed bug where one more rows at the bottom of the list could not be selected.
+  - Fixed error when dragging from shader browser name columns, shader browser input columns and Catalogue columns.
 
 API
 ---

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -93,7 +93,7 @@ class Column( GafferUI.PathColumn ) :
 		return self.__title.value
 
 	## Calls `_imageCellData()`.
-	def cellData( self, path, canceller ) :
+	def cellData( self, path, canceller = None ) :
 
 		image = path.property( "catalogue:image" )
 		catalogue = path.property( "catalogue" )
@@ -126,7 +126,7 @@ class Column( GafferUI.PathColumn ) :
 
 		return self.CellData()
 
-	def headerData( self, canceller ) :
+	def headerData( self, canceller = None ) :
 
 		return self.CellData( value = self.__title )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -383,7 +383,7 @@ class _DuplicateIconColumn ( GafferUI.PathColumn ) :
 		self.__title = title
 		self.__property = property
 
-	def cellData( self, path, canceller ) :
+	def cellData( self, path, canceller = None ) :
 
 		cellValue = path.property( self.__property )
 		# \todo : Remove this check when Arnold lights don't use `__shader`
@@ -403,7 +403,7 @@ class _DuplicateIconColumn ( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller ) :
+	def headerData( self, canceller = None ) :
 
 		return self.CellData( self.__title )
 
@@ -415,7 +415,7 @@ class _ShaderInputColumn ( GafferUI.PathColumn ) :
 
 		self.__title = title
 
-	def cellData( self, path, canceller ) :
+	def cellData( self, path, canceller = None ) :
 
 		data = self.CellData()
 
@@ -439,7 +439,7 @@ class _ShaderInputColumn ( GafferUI.PathColumn ) :
 
 		return data
 
-	def headerData( self, canceller ) :
+	def headerData( self, canceller = None ) :
 
 		return self.CellData( self.__title )
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -633,11 +633,11 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		if not pathSelected :
 			self.__singleSelect( index )
-
-		# The item is selected, Return True so that we have the option of
-		# starting a drag if we want. If a drag doesn't follow, we'll adjust
-		# selection in `__buttonRelease`.
-		self.__updateSelectionInButtonRelease = True
+		else :
+			# The item is selected, Return True so that we have the option of
+			# starting a drag if we want. If a drag doesn't follow, we'll adjust
+			# selection in `__buttonRelease`.
+			self.__updateSelectionInButtonRelease = True
 
 		return True
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -700,16 +700,16 @@ class PathListingWidget( GafferUI.Widget ) :
 
 	def __indexAt( self, position ) :
 
-		# A small corner area below the vertical scroll bar may pass through
-		# to us, causing odd selection behavior. Check that we're within the
-		# scroll area.
-		if position.x > self._qtWidget().viewport().size().width() or position.y > self._qtWidget().viewport().size().height() :
-			return None
-
 		point = self._qtWidget().viewport().mapFrom(
 			self._qtWidget(),
 			QtCore.QPoint( position.x, position.y )
 		)
+
+		# A small corner area below the vertical scroll bar may pass through
+		# to us, causing odd selection behavior. Check that we're within the
+		# scroll area.
+		if point.x() > self._qtWidget().viewport().size().width() or point.y() > self._qtWidget().viewport().size().height() :
+			return None
 
 		index = self._qtWidget().indexAt( point )
 		if not index.isValid() :

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -1080,7 +1080,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 				GafferUI.PathColumn.__init__( self )
 
-			def cellData( self, path, canceller ) :
+			def cellData( self, path, canceller = None ) :
 
 				SleepingColumn.cellDataCalled = True
 
@@ -1088,7 +1088,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 					time.sleep( 0.01 )
 					IECore.Canceller.check( canceller )
 
-			def headerData( self, canceller ) :
+			def headerData( self, canceller = None ) :
 
 				return self.CellData( value = "Title" )
 


### PR DESCRIPTION
This fixes a few bugs found in the `PathListingWidget` :

1. The bottom row (or two) could not be selected because of a mismatch in the coordinate systems used for bounds checking.
2. After fixing the above, selecting a half visible row would scroll and select the row below it.
3. Some columns were raising errors when dragging from them.

I think the solution for 2. is valid, but I don't recall if we were selecting twice on purpose. I can explore other solutions if that breaks something.

### Breaking changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
