### PR TITLE
EditMenu : Add "Duplicate with Inputs" item

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.x.x (relative to 1.0.3.0)
+=======
+
+Features
+--------
+
+- Edit Menu : Added "Duplicate with Inputs" menu item, with <kbd>Ctrl</kbd>+<kbd>D</kbd> shortcut.
+
 1.0.3.0 (relative to 1.0.2.1)
 =======
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -134,6 +134,7 @@ Action                               | Control or shortcut
 Cut node(s)                          | {kbd}`Ctrl` + {kbd}`X`
 Copy node(s)                         | {kbd}`Ctrl` + {kbd}`C`
 Paste node(s)                        | {kbd}`Ctrl` + {kbd}`V`
+Duplicate node(s) with inputs        | {kbd}`Ctrl` + {kbd}`D`
 Delete node(s)                       | {kbd}`Backspace`<br>or<br>{kbd}`Delete`
 Enable/disable node(s)               | {kbd}`D`
 Rename node(s)                       | {kbd}`F2`

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1241,7 +1241,7 @@ Box3f GraphGadget::renderBound() const
 
 bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
 {
-	if( event.key == "D" )
+	if( event.key == "D" && !event.modifiers )
 	{
 		/// \todo This functionality would be better provided by a config file,
 		/// rather than being hardcoded in here. For that to be done easily we


### PR DESCRIPTION
This adds an Edit Menu command to duplicate node(s) with each new node plug connected to the original node plug input.

### Related issues ###

Related to, but perhaps does not close [#413](https://github.com/GafferHQ/gaffer/issues/413)

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
