### PR TITLE
Add new plug `FilePathPlug`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
             containerImage:
             dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.2.1/cortex-10.4.2.1-windows-python3.zip
             testRunner: Invoke-Expression
-            testArguments: GafferTest.FileSystemPathTest
+            testArguments: GafferTest.FileSystemPathTest GafferTest.FilePathPlugTest GafferTest.StringPlugTest
 
     runs-on: ${{ matrix.os }}
 

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ API
   - Values returned by `getValue()` are in Gaffer's internal representation, using forward slashes to separate directory components.
   - `FilePathPlug` is compatible with `StringPlug` - `FilePathPlug` can be used as input for `StringPlug` and `StringPlug` can be used as input for `FilePathPlug`.
   - Converted existing `StringPlug` used for file paths to `FilePathPlug`.
+  - Added `FilePathPlug` to the list of User Plugs.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,10 @@ API
   - (Windows only) Paths beginning with a single `/` or `\` not followed by a drive letter are interpreted as UNC paths.
 - WidgetAlgo : Improved `joinEdges()` to support a wider range of widget types.
 - OpenColorIOTransform : Consolidated the duplicate `Direction` enums from CDL, LookTransform and LUT in to a single `OpenColorIOTransform::Direction` enum.
+- FilePathPlug : Added plug to represent file paths in an OS-friendly way. It behaves identically to `StringPlug` except for the way its value is set.
+  - When setting the value, an OS-native or generic string can be supplied. It will be converted to Gaffer's internal file path representation for storage.
+  - Values returned by `getValue()` are in Gaffer's internal representation, using forward slashes to separate directory components.
+  - `FilePathPlug` is compatible with `StringPlug` - `FilePathPlug` can be used as input for `StringPlug` and `StringPlug` can be used as input for `FilePathPlug`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,7 @@ API
   - `FilePathPlug` is compatible with `StringPlug` - `FilePathPlug` can be used as input for `StringPlug` and `StringPlug` can be used as input for `FilePathPlug`.
   - Converted existing `StringPlug` used for file paths to `FilePathPlug`.
   - Added `FilePathPlug` to the list of User Plugs.
+  - Converted options for 3Delight, Arnold, Appleseed and Cycles using `StringPlug` for file paths to `FilePathPlug`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ API
   - When setting the value, an OS-native or generic string can be supplied. It will be converted to Gaffer's internal file path representation for storage.
   - Values returned by `getValue()` are in Gaffer's internal representation, using forward slashes to separate directory components.
   - `FilePathPlug` is compatible with `StringPlug` - `FilePathPlug` can be used as input for `StringPlug` and `StringPlug` can be used as input for `FilePathPlug`.
+  - Converted existing `StringPlug` used for file paths to `FilePathPlug`.
 
 Breaking Changes
 ----------------

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -3,6 +3,7 @@
 setlocal EnableDelayedExpansion
 
 set GAFFER_ROOT=%~dp0%..
+set "GAFFER_ROOT=%GAFFER_ROOT:\=/%"
 
 set HOME=%USERPROFILE%
 

--- a/include/Gaffer/FilePathPlug.h
+++ b/include/Gaffer/FilePathPlug.h
@@ -48,6 +48,8 @@ namespace Gaffer
 ///
 /// Inherit from StringPlug for string substitution support and backwards
 /// compatibility.
+/// Note that `getValue()` will always return a string using forward slashes.
+/// The Windows API allows paths to be specified with forward slashes.
 
 class GAFFER_API FilePathPlug : public StringPlug
 {
@@ -69,10 +71,6 @@ class GAFFER_API FilePathPlug : public StringPlug
 
 		/// \undoable
 		void setValue( const std::string &value ) override;
-		/// Returns the value in OS-specific format. See comments in
-		/// TypedObjectPlug::getValue() for details of the optional
-		/// precomputedHash argument - and use with care!
-		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const override;
 };
 
 IE_CORE_DECLAREPTR( FilePathPlug );

--- a/include/Gaffer/FilePathPlug.h
+++ b/include/Gaffer/FilePathPlug.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,17 +34,49 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERMODULE_STRINGPLUGBINDING_H
-#define GAFFERMODULE_STRINGPLUGBINDING_H
+#ifndef GAFFER_FILEPATHPLUG_H
+#define GAFFER_FILEPATHPLUG_H
 
-namespace GafferModule
+#include "Gaffer/StringPlug.h"
+
+#include "IECore/StringAlgo.h"
+
+namespace Gaffer
 {
 
-template<typename T>
-void bindStringPlug();
+/// Plug for providing file system path values.
+///
+/// Inherit from StringPlug for string substitution support and backwards
+/// compatibility.
 
-void bindStringPlugs();
+class GAFFER_API FilePathPlug : public StringPlug
+{
 
-} // namespace GafferModule
+	public :
 
-#endif // GAFFERMODULE_STRINGPLUGBINDING_H
+		GAFFER_PLUG_DECLARE_TYPE( Gaffer::FilePathPlug, FilePathPlugTypeId, StringPlug );
+
+		FilePathPlug(
+			const std::string &name = defaultName<FilePathPlug>(),
+			Direction direction=In,
+			const std::string &defaultValue = "",
+			unsigned flags = Default,
+			unsigned substitutions = IECore::StringAlgo::AllSubstitutions
+		);
+		~FilePathPlug() override;
+
+		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+
+		/// \undoable
+		void setValue( const std::string &value ) override;
+		/// Returns the value in OS-specific format. See comments in
+		/// TypedObjectPlug::getValue() for details of the optional
+		/// precomputedHash argument - and use with care!
+		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const override;
+};
+
+IE_CORE_DECLAREPTR( FilePathPlug );
+
+} // namespace Gaffer
+
+#endif // GAFFER_FILEPATHPLUGPLUG_H

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -39,6 +39,7 @@
 #define GAFFER_FILESYSTEMPATH_H
 
 #include "Gaffer/Path.h"
+#include "Gaffer/PathFilter.h"
 
 #include "IECore/FileSequence.h"
 

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -67,7 +67,7 @@ IE_CORE_FORWARDDECLARE( ApplicationRoot );
 IE_CORE_FORWARDDECLARE( Context );
 IE_CORE_FORWARDDECLARE( StandardSet );
 IE_CORE_FORWARDDECLARE( CompoundDataPlug );
-IE_CORE_FORWARDDECLARE( StringPlug );
+IE_CORE_FORWARDDECLARE( FilePathPlug );
 
 using ScriptContainer = Container<GraphComponent, ScriptNode>;
 IE_CORE_DECLAREPTR( ScriptContainer );
@@ -220,8 +220,8 @@ class GAFFER_API ScriptNode : public Node
 		////////////////////////////////////////////////////////////////////
 		/// Returns the plug which specifies the file used in all load and save
 		/// operations.
-		StringPlug *fileNamePlug();
-		const StringPlug *fileNamePlug() const;
+		FilePathPlug *fileNamePlug();
+		const FilePathPlug *fileNamePlug() const;
 		/// Returns a plug which is used to flag when the script has had changes
 		/// made since the last call to save().
 		BoolPlug *unsavedChangesPlug();

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -108,11 +108,11 @@ class GAFFER_API StringPlug : public ValuePlug
 		const std::string &defaultValue() const;
 
 		/// \undoable
-		void setValue( const std::string &value );
+		virtual void setValue( const std::string &value );
 		/// Returns the value. The `precomputedHash` argument is deprecated, and
 		/// will be removed in a future release.
 		/// \todo Remove `precomputedHash` argument.
-		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		virtual std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
 		void setFrom( const ValuePlug *other ) override;
 

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -112,7 +112,7 @@ class GAFFER_API StringPlug : public ValuePlug
 		/// Returns the value. The `precomputedHash` argument is deprecated, and
 		/// will be removed in a future release.
 		/// \todo Remove `precomputedHash` argument.
-		virtual std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
+		std::string getValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 
 		void setFrom( const ValuePlug *other ) override;
 

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -146,6 +146,7 @@ enum TypeId
 	ContextQueryTypeId = 110099,
 	TweakPlugTypeId = 110100,
 	TweaksPlugTypeId = 110101,
+	FilePathPlugTypeId = 110102,
 
 	LastTypeId = 110159,
 

--- a/include/GafferArnold/ArnoldVDB.h
+++ b/include/GafferArnold/ArnoldVDB.h
@@ -42,6 +42,8 @@
 
 #include "GafferScene/ObjectSource.h"
 
+#include "Gaffer/FilePathPlug.h"
+
 namespace GafferArnold
 {
 
@@ -55,8 +57,8 @@ class GAFFERARNOLD_API ArnoldVDB : public GafferScene::ObjectSource
 		ArnoldVDB( const std::string &name=defaultName<ArnoldVDB>() );
 		~ArnoldVDB() override;
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		Gaffer::StringPlug *gridsPlug();
 		const Gaffer::StringPlug *gridsPlug() const;

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -58,6 +58,7 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( FilePathPlug )
 
 } // namespace Gaffer
 
@@ -168,8 +169,8 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		const Gaffer::StringPlug *jobNamePlug() const;
 		/// Returns the plug which specifies the directory used by dispatchers to store temporary
 		/// files on a per-job basis.
-		Gaffer::StringPlug *jobsDirectoryPlug();
-		const Gaffer::StringPlug *jobsDirectoryPlug() const;
+		Gaffer::FilePathPlug *jobsDirectoryPlug();
+		const Gaffer::FilePathPlug *jobsDirectoryPlug() const;
 		/// At the start of dispatch(), a directory is created under jobsDirectoryPlug + jobNamePlug
 		/// which the dispatcher writes temporary files to. This method returns the most recent created directory.
 		const std::string jobDirectory() const;

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -39,6 +39,7 @@
 
 #include "GafferImage/ImageNode.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/Switch.h"
@@ -77,8 +78,8 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 
 				Image( const std::string &name = defaultName<Image>(), Direction direction = In, unsigned flags = Default );
 
-				Gaffer::StringPlug *fileNamePlug();
-				const Gaffer::StringPlug *fileNamePlug() const;
+				Gaffer::FilePathPlug *fileNamePlug();
+				const Gaffer::FilePathPlug *fileNamePlug() const;
 
 				Gaffer::StringPlug *descriptionPlug();
 				const Gaffer::StringPlug *descriptionPlug() const;
@@ -117,8 +118,8 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;
 
-		Gaffer::StringPlug *directoryPlug();
-		const Gaffer::StringPlug *directoryPlug() const;
+		Gaffer::FilePathPlug *directoryPlug();
+		const Gaffer::FilePathPlug *directoryPlug() const;
 
 		/// All Catalogues share a single DisplayDriverServer instance
 		/// to receive rendered images. To send an image to the catalogues,

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -47,6 +47,7 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( FilePathPlug )
 
 } // namespace Gaffer
 
@@ -97,8 +98,8 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 			Specification,
 		};
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		/// Number of times the node has been refreshed.
 		Gaffer::IntPlug *refreshCountPlug();

--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -51,6 +51,7 @@ namespace Gaffer
 	IE_CORE_FORWARDDECLARE( ValuePlug )
 	IE_CORE_FORWARDDECLARE( StringPlug )
 	IE_CORE_FORWARDDECLARE( ContextQuery )
+	IE_CORE_FORWARDDECLARE( FilePathPlug )
 } // namespace Gaffer
 
 namespace GafferImage
@@ -75,8 +76,8 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageWriter, ImageWriterTypeId, TaskNode );
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		GafferImage::ImagePlug *inPlug();
 		const GafferImage::ImagePlug *inPlug() const;

--- a/include/GafferImage/LUT.h
+++ b/include/GafferImage/LUT.h
@@ -44,7 +44,7 @@
 namespace Gaffer
 {
 
-IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( FilePathPlug )
 
 } // namespace Gaffer
 
@@ -69,8 +69,14 @@ class GAFFERIMAGE_API LUT : public OpenColorIOTransform
 			Tetrahedral
 		};
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		enum Direction
+		{
+			Forward = 0,
+			Inverse
+		};
+
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		Gaffer::IntPlug *interpolationPlug();
 		const Gaffer::IntPlug *interpolationPlug() const;

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -46,6 +46,7 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( FilePathPlug )
 
 } // namespace Gaffer
 
@@ -69,8 +70,8 @@ class GAFFERIMAGE_API OpenImageIOReader : public ImageNode
 			Hold,
 		};
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		/// Number of times the node has been refreshed.
 		Gaffer::IntPlug *refreshCountPlug();

--- a/include/GafferImage/Text.h
+++ b/include/GafferImage/Text.h
@@ -40,6 +40,7 @@
 #include "GafferImage/Shape.h"
 
 #include "Gaffer/BoxPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 namespace Gaffer
 {
@@ -79,8 +80,8 @@ class GAFFERIMAGE_API Text : public Shape
 		Gaffer::StringPlug *textPlug();
 		const Gaffer::StringPlug *textPlug() const;
 
-		Gaffer::StringPlug *fontPlug();
-		const Gaffer::StringPlug *fontPlug() const;
+		Gaffer::FilePathPlug *fontPlug();
+		const Gaffer::FilePathPlug *fontPlug() const;
 
 		Gaffer::V2iPlug *sizePlug();
 		const Gaffer::V2iPlug *sizePlug() const;

--- a/include/GafferScene/Cryptomatte.h
+++ b/include/GafferScene/Cryptomatte.h
@@ -41,6 +41,7 @@
 
 #include "GafferImage/FlatImageProcessor.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedObjectPlug.h"
 
@@ -73,11 +74,11 @@ class GAFFERSCENE_API Cryptomatte : public GafferImage::FlatImageProcessor
 		Gaffer::IntPlug *manifestSourcePlug();
 		const Gaffer::IntPlug *manifestSourcePlug() const;
 
-		Gaffer::StringPlug *manifestDirectoryPlug();
-		const Gaffer::StringPlug *manifestDirectoryPlug() const;
+		Gaffer::FilePathPlug *manifestDirectoryPlug();
+		const Gaffer::FilePathPlug *manifestDirectoryPlug() const;
 
-		Gaffer::StringPlug *sidecarFilePlug();
-		const Gaffer::StringPlug *sidecarFilePlug() const;
+		Gaffer::FilePathPlug *sidecarFilePlug();
+		const Gaffer::FilePathPlug *sidecarFilePlug() const;
 
 		Gaffer::StringVectorDataPlug *matteNamesPlug();
 		const Gaffer::StringVectorDataPlug *matteNamesPlug() const;

--- a/include/GafferScene/ExternalProcedural.h
+++ b/include/GafferScene/ExternalProcedural.h
@@ -40,6 +40,7 @@
 #include "GafferScene/ObjectSource.h"
 
 #include "Gaffer/CompoundDataPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 namespace GafferScene
 {
@@ -54,8 +55,8 @@ class GAFFERSCENE_API ExternalProcedural : public ObjectSource
 		ExternalProcedural( const std::string &name=defaultName<ExternalProcedural>() );
 		~ExternalProcedural() override;
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		Gaffer::Box3fPlug *boundPlug();
 		const Gaffer::Box3fPlug *boundPlug() const;

--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -42,6 +42,7 @@
 
 #include "GafferDispatch/TaskNode.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
 
@@ -75,8 +76,8 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		Gaffer::IntPlug *modePlug();
 		const Gaffer::IntPlug *modePlug() const;
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -47,6 +47,7 @@ namespace Gaffer
 {
 
 IE_CORE_FORWARDDECLARE( StringPlug )
+IE_CORE_FORWARDDECLARE( FilePathPlug )
 IE_CORE_FORWARDDECLARE( TransformPlug )
 
 } // namespace Gaffer
@@ -65,8 +66,8 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneReader, SceneReaderTypeId, SceneNode )
 
 		/// Holds the name of the file to be loaded.
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		/// Number of times the node has been refreshed.
 		Gaffer::IntPlug *refreshCountPlug();

--- a/include/GafferScene/SceneWriter.h
+++ b/include/GafferScene/SceneWriter.h
@@ -42,6 +42,7 @@
 
 #include "GafferDispatch/TaskNode.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/TypedPlug.h"
 #include "Gaffer/StringPlug.h"
 
@@ -60,8 +61,8 @@ class GAFFERSCENE_API SceneWriter : public GafferDispatch::TaskNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneWriter, SceneWriterTypeId, GafferDispatch::TaskNode );
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		ScenePlug *inPlug();
 		const ScenePlug *inPlug() const;

--- a/include/GafferScene/Text.h
+++ b/include/GafferScene/Text.h
@@ -37,6 +37,7 @@
 #ifndef GAFFERSCENE_TEXT_H
 #define GAFFERSCENE_TEXT_H
 
+#include "Gaffer/FilePathPlug.h"
 #include "GafferScene/ObjectSource.h"
 
 namespace GafferScene
@@ -55,8 +56,8 @@ class GAFFERSCENE_API Text : public ObjectSource
 		Gaffer::StringPlug *textPlug();
 		const Gaffer::StringPlug *textPlug() const;
 
-		Gaffer::StringPlug *fontPlug();
-		const Gaffer::StringPlug *fontPlug() const;
+		Gaffer::FilePathPlug *fontPlug();
+		const Gaffer::FilePathPlug *fontPlug() const;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 

--- a/include/GafferSceneUI/UVView.h
+++ b/include/GafferSceneUI/UVView.h
@@ -47,6 +47,7 @@
 #include "GafferUI/View.h"
 
 #include "Gaffer/BackgroundTask.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/StringPlug.h"
 
 #include <unordered_set>
@@ -72,8 +73,8 @@ class GAFFERSCENEUI_API UVView : public GafferUI::View
 		Gaffer::StringPlug *uvSetPlug();
 		const Gaffer::StringPlug *uvSetPlug() const;
 
-		Gaffer::StringPlug *textureFileNamePlug();
-		const Gaffer::StringPlug *textureFileNamePlug() const;
+		Gaffer::FilePathPlug *textureFileNamePlug();
+		const Gaffer::FilePathPlug *textureFileNamePlug() const;
 
 		Gaffer::StringPlug *displayTransformPlug();
 		const Gaffer::StringPlug *displayTransformPlug() const;

--- a/include/GafferUSD/USDLayerWriter.h
+++ b/include/GafferUSD/USDLayerWriter.h
@@ -61,8 +61,8 @@ class GAFFERUSD_API USDLayerWriter : public GafferDispatch::TaskNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferUSD::USDLayerWriter, USDLayerWriterTypeId, GafferDispatch::TaskNode );
 
-		Gaffer::StringPlug *fileNamePlug();
-		const Gaffer::StringPlug *fileNamePlug() const;
+		Gaffer::FilePathPlug *fileNamePlug();
+		const Gaffer::FilePathPlug *fileNamePlug() const;
 
 		GafferScene::ScenePlug *basePlug();
 		const GafferScene::ScenePlug *basePlug() const;

--- a/python/GafferAppleseed/AppleseedShaderBall.py
+++ b/python/GafferAppleseed/AppleseedShaderBall.py
@@ -48,7 +48,7 @@ class AppleseedShaderBall( GafferScene.ShaderBall ) :
 
 		GafferScene.ShaderBall.__init__( self, name )
 
-		self["environment"] = Gaffer.StringPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
+		self["environment"] = Gaffer.FilePathPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
 
 		# Appleseed doesn't support primitives spheres
 		self["__sphere"]["type"].setValue( self["__sphere"].Type.Mesh )

--- a/python/GafferAppleseedUI/AppleseedAttributesUI.py
+++ b/python/GafferAppleseedUI/AppleseedAttributesUI.py
@@ -256,7 +256,6 @@ Gaffer.Metadata.registerNode(
 
 		"attributes.alphaMap.value" : [
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "texture",
 

--- a/python/GafferAppleseedUI/AppleseedOptionsUI.py
+++ b/python/GafferAppleseedUI/AppleseedOptionsUI.py
@@ -822,7 +822,6 @@ Gaffer.Metadata.registerNode(
 
 		"options.logFileName.value" : [
 
-		"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 		"pathPlugValueWidget:leaf", True,
 		"fileSystemPath:extensions", "txt log",
 		"fileSystemPath:extensionsLabel", "Show only log files",

--- a/python/GafferAppleseedUI/AppleseedRenderUI.py
+++ b/python/GafferAppleseedUI/AppleseedRenderUI.py
@@ -62,7 +62,6 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "appleseed",
 			"fileSystemPath:extensions", "appleseed",

--- a/python/GafferAppleseedUI/AppleseedShaderBallUI.py
+++ b/python/GafferAppleseedUI/AppleseedShaderBallUI.py
@@ -56,7 +56,6 @@ Gaffer.Metadata.registerNode(
 			format.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "texture",

--- a/python/GafferArnold/ArnoldShaderBall.py
+++ b/python/GafferArnold/ArnoldShaderBall.py
@@ -46,7 +46,7 @@ class ArnoldShaderBall( GafferScene.ShaderBall ) :
 
 		GafferScene.ShaderBall.__init__( self, name )
 
-		self["environment"] = Gaffer.StringPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
+		self["environment"] = Gaffer.FilePathPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
 
 		self["__envMap"] = GafferArnold.ArnoldShader()
 		self["__envMap"].loadShader( "image" )

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -983,7 +983,6 @@ Gaffer.Metadata.registerNode(
 
 		"options.logFileName.value" : [
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"fileSystemPath:extensions", "txt log",
 			"fileSystemPath:extensionsLabel", "Show only log files",

--- a/python/GafferArnoldUI/ArnoldShaderBallUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderBallUI.py
@@ -56,7 +56,6 @@ Gaffer.Metadata.registerNode(
 			format.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "texture",

--- a/python/GafferArnoldUI/ArnoldVDBUI.py
+++ b/python/GafferArnoldUI/ArnoldVDBUI.py
@@ -58,7 +58,6 @@ Gaffer.Metadata.registerNode(
 			The name of the VDB file to be loaded.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "vdb",

--- a/python/GafferCortex/ObjectReader.py
+++ b/python/GafferCortex/ObjectReader.py
@@ -47,7 +47,7 @@ class ObjectReader( Gaffer.ComputeNode ) :
 
 		Gaffer.ComputeNode.__init__( self, name )
 
-		self.addChild( Gaffer.StringPlug( "fileName", Gaffer.Plug.Direction.In ) )
+		self.addChild( Gaffer.FilePathPlug( "fileName", Gaffer.Plug.Direction.In ) )
 		self.addChild( Gaffer.ObjectPlug( "out", Gaffer.Plug.Direction.Out, IECore.NullObject.defaultNullObject() ) )
 
 	def affects( self, input ) :

--- a/python/GafferCortex/ObjectWriter.py
+++ b/python/GafferCortex/ObjectWriter.py
@@ -52,7 +52,7 @@ class ObjectWriter( GafferDispatch.TaskNode ) :
 		inPlug = Gaffer.ObjectPlug( "in", Gaffer.Plug.Direction.In, IECore.NullObject.defaultNullObject() )
 		self.addChild( inPlug )
 
-		fileNamePlug = Gaffer.StringPlug( "fileName", Gaffer.Plug.Direction.In )
+		fileNamePlug = Gaffer.FilePathPlug( "fileName", Gaffer.Plug.Direction.In )
 		self.addChild( fileNamePlug )
 
 		self.addChild( Gaffer.Plug( "parameters" ) )

--- a/python/GafferCortexUI/ObjectReaderUI.py
+++ b/python/GafferCortexUI/ObjectReaderUI.py
@@ -62,7 +62,6 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "cortex",

--- a/python/GafferCortexUI/ObjectWriterUI.py
+++ b/python/GafferCortexUI/ObjectWriterUI.py
@@ -73,7 +73,6 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"nodule:type", "",
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "cortex",
 			"fileSystemPath:extensions", " ".join( IECore.Reader.supportedExtensions() ),

--- a/python/GafferCycles/CyclesShaderBall.py
+++ b/python/GafferCycles/CyclesShaderBall.py
@@ -48,7 +48,7 @@ class CyclesShaderBall( GafferScene.ShaderBall ) :
 
 		GafferScene.ShaderBall.__init__( self, name )
 
-		self["environment"] = Gaffer.StringPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
+		self["environment"] = Gaffer.FilePathPlug( defaultValue = "${GAFFER_ROOT}/resources/hdri/studio.exr" )
 
 		# Cycles doesn't support primitives spheres
 		self["__sphere"]["type"].setValue( self["__sphere"].Type.Mesh )

--- a/python/GafferCyclesUI/CyclesShaderBallUI.py
+++ b/python/GafferCyclesUI/CyclesShaderBallUI.py
@@ -58,7 +58,6 @@ Gaffer.Metadata.registerNode(
 			format.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "texture",

--- a/python/GafferDelightUI/DelightOptionsUI.py
+++ b/python/GafferDelightUI/DelightOptionsUI.py
@@ -308,7 +308,6 @@ Gaffer.Metadata.registerNode(
 
 		"options.networkCacheDirectory.value" : [
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", False,
 
 		],

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -113,7 +113,6 @@ Gaffer.Metadata.registerNode(
 			A directory to store temporary files used by the dispatcher.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", False,
 
 		),

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -396,7 +396,6 @@ Gaffer.Metadata.registerNode(
 			in the catalogue for the next session.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", False,
 
 		],

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -64,7 +64,6 @@ Gaffer.Metadata.registerNode(
 			format is used, then missingFrameMode will be activated.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "image",
 			"fileSystemPath:extensions", " ".join( GafferImage.ImageReader.supportedExtensions() ),

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -116,7 +116,6 @@ Gaffer.Metadata.registerNode(
 			as a placeholder for the frame numbers.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "image",
 			"fileSystemPath:extensions", " ".join( GafferImage.ImageReader.supportedExtensions() ),

--- a/python/GafferImageUI/LUTUI.py
+++ b/python/GafferImageUI/LUTUI.py
@@ -60,7 +60,6 @@ Gaffer.Metadata.registerNode(
 			supported files will function as expected.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "color",
 			"fileSystemPath:extensions", " ".join( GafferImage.LUT.supportedExtensions() ),

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -63,7 +63,6 @@ Gaffer.Metadata.registerNode(
 			format is used, then missingFrameMode will be activated.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "image",
 			"fileSystemPath:extensions", " ".join( GafferImage.OpenImageIOReader.supportedExtensions() ),

--- a/python/GafferImageUI/TextUI.py
+++ b/python/GafferImageUI/TextUI.py
@@ -92,7 +92,6 @@ Gaffer.Metadata.registerNode(
 			environment variable.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:bookmarks", "font",
 			"path:leaf", True,
 			"path:valid", True,

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -223,7 +223,6 @@ Gaffer.Metadata.registerNode(
 			the file at the resulting path.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", False,
 			"layout:visibilityActivator", "metadataManifest",
 		],
@@ -238,7 +237,6 @@ Gaffer.Metadata.registerNode(
 			as a placeholder for the frame numbers.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"fileSystemPath:extensions", "json",
 			"fileSystemPath:extensionsLabel", "Show only JSON files",

--- a/python/GafferSceneUI/ExternalProceduralUI.py
+++ b/python/GafferSceneUI/ExternalProceduralUI.py
@@ -62,7 +62,6 @@ Gaffer.Metadata.registerNode(
 			The path to the external procedural or archive.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "procedurals",
 

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -99,7 +99,6 @@ Gaffer.Metadata.registerNode(
 
 		"outputs.*.fileName" : [
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:bookmarks", "image",
 			"path:leaf", True,
 

--- a/python/GafferSceneUI/RenderUI.py
+++ b/python/GafferSceneUI/RenderUI.py
@@ -94,7 +94,6 @@ Gaffer.Metadata.registerNode(
 			The name of the file to be generated when in scene description mode.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 
 			"layout:activator", "modeIsSceneDescription",

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -68,7 +68,6 @@ Gaffer.Metadata.registerNode(
 			in any of the formats supported by Cortex's SceneInterfaces.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:valid", True,
 			"path:bookmarks", "sceneCache",

--- a/python/GafferSceneUI/SceneWriterUI.py
+++ b/python/GafferSceneUI/SceneWriterUI.py
@@ -64,7 +64,6 @@ Gaffer.Metadata.registerNode(
 			number is generally not necessary.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "sceneCache",
 			"fileSystemPath:extensions", " ".join( IECoreScene.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write ) ),

--- a/python/GafferSceneUI/TextUI.py
+++ b/python/GafferSceneUI/TextUI.py
@@ -75,7 +75,6 @@ Gaffer.Metadata.registerNode(
 			environment variable.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:bookmarks", "font",
 			"path:leaf", True,
 			"path:valid", True,

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -142,7 +142,6 @@ Gaffer.Metadata.registerNode(
 
 		"textureFileName" : [
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "image",
 			"fileSystemPath:extensions", " ".join( GafferImage.ImageReader.supportedExtensions() ),

--- a/python/GafferTest/FilePathInOutNode.py
+++ b/python/GafferTest/FilePathInOutNode.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+import GafferTest
+
+class FilePathInOutNode( GafferTest.StringInOutNode ) :
+
+	def __init__( self, name="FilePathInOutNode", defaultValue="", substitutions = Gaffer.Context.Substitutions.AllSubstitutions ) :
+
+		Gaffer.ComputeNode.__init__( self, name )
+
+		self.addChild( Gaffer.FilePathPlug( "in", Gaffer.Plug.Direction.In, defaultValue, substitutions = substitutions ) )
+		self.addChild( Gaffer.FilePathPlug( "out", Gaffer.Plug.Direction.Out ) )
+
+		self.numHashCalls = 0
+		self.numComputeCalls = 0
+
+IECore.registerRunTimeTyped( FilePathInOutNode, typeName = "GafferTest::FilePathInOutNode" )

--- a/python/GafferTest/FilePathPlugTest.py
+++ b/python/GafferTest/FilePathPlugTest.py
@@ -1,0 +1,128 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import inspect
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class FilePathPlugTest( GafferTest.StringPlugTest ) :
+
+	def inOutNode( self, name="FilePathInOutNode", defaultValue="", substitutions = IECore.StringAlgo.Substitutions.AllSubstitutions ) :
+
+		return GafferTest.FilePathInOutNode( name = name, defaultValue = defaultValue, substitutions = substitutions )
+
+	def testPathExpansion( self ) :
+
+		n = self.inOutNode()
+
+		# nothing should be expanded when we're in a non-computation context
+		n["in"].setValue( "testy/Testy.##.exr" )
+		self.assertEqual( n["in"].getValue(), os.path.join( "testy", "Testy.##.exr" ) )
+
+		n["in"].setValue( "${a}/$b/${a:b}" )
+		self.assertEqual( n["in"].getValue(), os.path.join( "${a}", "$b", "${a:b}" ) )
+
+		# but expansions should happen magically when the compute()
+		# calls getValue().
+		context = Gaffer.Context()
+
+		context["env:dir"] = "a/path"
+		n["in"].setValue( "a/${env:dir}/b" )
+		with context :
+			self.assertEqual( n["out"].getValue(), os.path.join( "a", "a", "path", "b" ) )
+
+		# once again, nothing should be expanded when we're in a
+		# non-computation context
+		n["in"].setValue( "testy/Testy.##.exr" )
+		self.assertEqual( n["in"].getValue(), os.path.join( "testy", "Testy.##.exr" ) )
+
+	def testTildeExpansion( self ) :
+
+		n = self.inOutNode()
+
+		n["in"].setValue( "~" )
+		self.assertEqual( n["out"].getValue(), os.path.expanduser( "~" ) )
+
+		n["in"].setValue( "~/something.tif" )
+		self.assertEqual( n["out"].getValue(), os.path.join( os.path.expanduser( "~" ), "something.tif" ) )
+
+		# ~ shouldn't be expanded unless it's at the front - it would
+		# be meaningless in other cases.
+		n["in"].setValue( "in ~1900" )
+		self.assertEqual( n["out"].getValue(), "in ~1900" )
+
+	def testGenericConversion( self ) :
+
+		n = self.inOutNode()
+
+		n["in"].setValue( os.path.join( "C:", "path", "test.ext" ) )
+
+		self.assertEqual( n["out"].getValue(), os.path.join( "C:", "path", "test.ext" ) )
+
+	def testStringPlugCompatibility( self ):
+
+		s1 = GafferTest.StringPlugTest.inOutNode( self )
+		n = self.inOutNode()
+		s2 = GafferTest.StringPlugTest.inOutNode( self )
+
+		self.assertTrue( isinstance( s1["in"], Gaffer.StringPlug ) )
+		self.assertTrue( isinstance( s1["out"], Gaffer.StringPlug ) )
+		self.assertTrue( isinstance( n["in"], Gaffer.FilePathPlug ) )
+		self.assertTrue( isinstance( n["out"], Gaffer.FilePathPlug ) )
+		self.assertTrue( isinstance( s2["in"], Gaffer.StringPlug ) )
+		self.assertTrue( isinstance( s2["out"], Gaffer.StringPlug ) )
+
+		s1["in"].setValue( "test/string.ext" )
+		n["in"].setInput( s1["out"] )
+		s2["in"].setInput( n["out"] )
+
+		self.assertEqual( s1["out"].getValue(), "test/string.ext" )
+		self.assertEqual( n["out"].getValue(), os.path.join( "test", "string.ext" ) )
+		if os.name == "nt" :
+			# We lose a `\` every time we do a string subsitution with `EscapeSubstitutions`
+			# enabled.
+			self.assertEqual( s2["out"].getValue(), "teststring.ext" )
+		else :
+			self.assertEqual( s2["out"].getValue(), "test/string.ext" )
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -67,7 +67,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 		self.assertEqual( s.getName(), "ScriptNode" )
 
-		self.assertEqual( s["fileName"].typeName(), "Gaffer::StringPlug" )
+		self.assertEqual( s["fileName"].typeName(), "Gaffer::FilePathPlug" )
 
 	def testExecution( self ) :
 

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -167,6 +167,8 @@ from .EditScopeTest import EditScopeTest
 from .RandomChoiceTest import RandomChoiceTest
 from .ContextQueryTest import ContextQueryTest
 from .TweakPlugTest import TweakPlugTest
+from .FilePathInOutNode import FilePathInOutNode
+from .FilePathPlugTest import FilePathPlugTest
 
 from .IECorePreviewTest import *
 

--- a/python/GafferUI/FileSystemPathPlugValueWidget.py
+++ b/python/GafferUI/FileSystemPathPlugValueWidget.py
@@ -130,3 +130,5 @@ class FileSystemPathPlugValueWidget( GafferUI.PathPlugValueWidget ) :
 			v = Gaffer.Metadata.value( self.getPlug(), "fileSystemPathPlugValueWidget:" + name )
 
 		return v
+
+GafferUI.PlugValueWidget.registerType( Gaffer.FilePathPlug, FileSystemPathPlugValueWidget )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -951,6 +951,7 @@ class _PlugListing( GafferUI.Widget ) :
 		m.append( "/Add Plug/NumericDivider", { "divider" : True } )
 
 		m.append( "/Add Plug/String", { "command" : functools.partial( Gaffer.WeakMethod( self.__addPlug ), Gaffer.StringPlug ) } )
+		m.append( "/Add Plug/FilePath", { "command" : functools.partial( Gaffer.WeakMethod( self.__addPlug ), Gaffer.FilePathPlug ) } )
 		m.append( "/Add Plug/StringDivider", { "divider" : True } )
 
 		m.append( "/Add Plug/V2i", { "command" : functools.partial( Gaffer.WeakMethod( self.__addPlug ), Gaffer.V2iPlug ) } )
@@ -1516,6 +1517,10 @@ class _PlugEditor( GafferUI.Widget ) :
 			return
 
 		widgetType = Gaffer.Metadata.value( self.getPlug(), "plugValueWidget:type" ) or ""
+
+		# \todo Can this be generalized by getting the default widget type?
+		if widgetType == "" and isinstance( self.getPlug(), Gaffer.FilePathPlug ) :
+			widgetType = "GafferUI.FileSystemPathPlugValueWidget"
 
 		with self.__widgetSettingsContainer :
 

--- a/python/GafferUI/UserPlugs.py
+++ b/python/GafferUI/UserPlugs.py
@@ -53,6 +53,7 @@ def appendPlugCreationMenuDefinitions( plugParent, menuDefinition, prefix = "" )
 	menuDefinition.append( prefix + "/NumericDivider", { "divider" : True } )
 
 	menuDefinition.append( prefix + "/String", { "command" : functools.partial( __addPlug, plugParent, Gaffer.StringPlug ), "active" : active } )
+	menuDefinition.append( prefix + "/FilePath", { "command" : functools.partial(__addPlug, plugParent, Gaffer.FilePathPlug ), "active" : active } )
 	menuDefinition.append( prefix + "/StringDivider", { "divider" : True } )
 
 	menuDefinition.append( prefix + "/V2i", { "command" : functools.partial( __addPlug, plugParent, Gaffer.V2iPlug ), "active" : active } )

--- a/python/GafferUSDUI/USDLayerWriterUI.py
+++ b/python/GafferUSDUI/USDLayerWriterUI.py
@@ -98,7 +98,6 @@ Gaffer.Metadata.registerNode(
 			The name of the USD file to be written.
 			""",
 
-			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
 			"path:leaf", True,
 			"path:bookmarks", "sceneCache",
 			"fileSystemPath:extensions", "usd usda usdc",

--- a/src/Gaffer/FilePathPlug.cpp
+++ b/src/Gaffer/FilePathPlug.cpp
@@ -52,7 +52,7 @@ FilePathPlug::FilePathPlug(
 	const std::string &defaultValue,
 	unsigned flags,
 	unsigned substitutions
-) : StringPlug( name, direction, defaultValue, flags, substitutions )
+) : StringPlug( name, direction, Gaffer::FileSystemPath( defaultValue ).string(), flags, substitutions )
 {
 }
 
@@ -69,10 +69,4 @@ void FilePathPlug::setValue(const std::string &value)
 {
 	const std::string genericValue = Gaffer::FileSystemPath( value ).string();
 	StringPlug::setValue( genericValue );
-}
-
-std::string FilePathPlug::getValue( const IECore::MurmurHash *precomputedHash ) const
-{
-	const std::string genericValue = StringPlug::getValue( precomputedHash );
-	return Gaffer::FileSystemPath( genericValue ).nativeString();
 }

--- a/src/Gaffer/FilePathPlug.cpp
+++ b/src/Gaffer/FilePathPlug.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2015, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,17 +34,45 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERMODULE_STRINGPLUGBINDING_H
-#define GAFFERMODULE_STRINGPLUGBINDING_H
+#include "Gaffer/FilePathPlug.h"
+#include "Gaffer/FileSystemPath.h"
+#include "Gaffer/PathFilter.h"
 
-namespace GafferModule
+#include "Gaffer/Context.h"
+#include "Gaffer/Process.h"
+
+using namespace IECore;
+using namespace Gaffer;
+
+GAFFER_PLUG_DEFINE_TYPE( FilePathPlug );
+
+FilePathPlug::FilePathPlug(
+	const std::string &name,
+	Direction direction,
+	const std::string &defaultValue,
+	unsigned flags,
+	unsigned substitutions
+) : StringPlug( name, direction, defaultValue, flags, substitutions )
 {
+}
 
-template<typename T>
-void bindStringPlug();
+FilePathPlug::~FilePathPlug()
+{
+}
 
-void bindStringPlugs();
+PlugPtr FilePathPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new FilePathPlug( name, direction, defaultValue(), getFlags(), substitutions() );
+}
 
-} // namespace GafferModule
+void FilePathPlug::setValue(const std::string &value)
+{
+	const std::string genericValue = Gaffer::FileSystemPath( value ).string();
+	StringPlug::setValue( genericValue );
+}
 
-#endif // GAFFERMODULE_STRINGPLUGBINDING_H
+std::string FilePathPlug::getValue( const IECore::MurmurHash *precomputedHash ) const
+{
+	const std::string genericValue = StringPlug::getValue( precomputedHash );
+	return Gaffer::FileSystemPath( genericValue ).nativeString();
+}

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -44,9 +44,9 @@
 #include "Gaffer/Container.inl"
 #include "Gaffer/Context.h"
 #include "Gaffer/DependencyNode.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/StandardSet.h"
-#include "Gaffer/StringPlug.h"
 #include "Gaffer/TypedPlug.h"
 
 #include "IECore/Exception.h"
@@ -356,7 +356,7 @@ ScriptNode::ScriptNode( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "fileName", Plug::In, "", Plug::Default & ~Plug::Serialisable ) );
+	addChild( new FilePathPlug( "fileName", Plug::In, "", Plug::Default & ~Plug::Serialisable ) );
 	addChild( new BoolPlug( "unsavedChanges", Plug::In, false, Plug::Default & ~Plug::Serialisable ) );
 
 	ValuePlugPtr frameRangePlug = new ValuePlug( "frameRange", Plug::In );
@@ -384,14 +384,14 @@ ScriptNode::~ScriptNode()
 {
 }
 
-StringPlug *ScriptNode::fileNamePlug()
+FilePathPlug *ScriptNode::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
-const StringPlug *ScriptNode::fileNamePlug() const
+const FilePathPlug *ScriptNode::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
 BoolPlug *ScriptNode::unsavedChangesPlug()

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -68,10 +68,8 @@ namespace
 /// and avoids the creation of lots of unnecessary cache entries.
 inline const ValuePlug *sourcePlug( const ValuePlug *p )
 {
-	const IECore::TypeId typeId = p->typeId();
-
 	const ValuePlug *in = p->getInput<ValuePlug>();
-	while( in && in->typeId() == typeId )
+	while( in && p->isInstanceOf( in->typeId() ) )
 	{
 		p = in;
 		in = p->getInput<ValuePlug>();

--- a/src/GafferAppleseed/AppleseedAttributes.cpp
+++ b/src/GafferAppleseed/AppleseedAttributes.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferAppleseed/AppleseedAttributes.h"
 
+#include "Gaffer/FilePathPlug.h"
+
 using namespace Imath;
 using namespace Gaffer;
 using namespace GafferAppleseed;
@@ -61,7 +63,7 @@ AppleseedAttributes::AppleseedAttributes( const std::string &name )
 	attributes->addChild( new Gaffer::NameValuePlug( "as:medium_priority", new IECore::IntData( 0 ), false, "mediumPriority" ) );
 
 	// alpha map parameters
-	attributes->addChild( new Gaffer::NameValuePlug( "as:alpha_map", new IECore::StringData(), false, "alphaMap" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "as:alpha_map", new Gaffer::FilePathPlug(), false, "alphaMap" ) );
 
 	// mesh parameters
 	attributes->addChild( new Gaffer::NameValuePlug( "as:smooth_normals", new IECore::BoolData(), false, "smoothNormals" ) );

--- a/src/GafferAppleseed/AppleseedOptions.cpp
+++ b/src/GafferAppleseed/AppleseedOptions.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferAppleseed/AppleseedOptions.h"
 
+#include "Gaffer/FilePathPlug.h"
+
 using namespace Imath;
 using namespace GafferAppleseed;
 
@@ -102,7 +104,7 @@ AppleseedOptions::AppleseedOptions( const std::string &name )
 
 	// logging
 	options->addChild( new Gaffer::NameValuePlug( "as:log:level", new IECore::StringData( "info" ), false, "logLevel" ) );
-	options->addChild( new Gaffer::NameValuePlug( "as:log:filename", new IECore::StringData( "" ), false, "logFileName" ) );
+	options->addChild( new Gaffer::NameValuePlug( "as:log:filename", new Gaffer::FilePathPlug(), false, "logFileName" ) );
 
 	// currently being used by the ShaderBall preview,
 	// not exposed in the options node UI,

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -37,6 +37,8 @@
 
 #include "GafferArnold/ArnoldOptions.h"
 
+#include "Gaffer/FilePathPlug.h"
+
 using namespace Imath;
 using namespace GafferArnold;
 
@@ -129,7 +131,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 
 	// Logging
 
-	options->addChild( new Gaffer::NameValuePlug( "ai:log:filename", new IECore::StringData( "" ), false, "logFileName" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:log:filename", new Gaffer::FilePathPlug(), false, "logFileName" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:log:max_warnings", new IECore::IntData( 100 ), false, "logMaxWarnings" ) );
 
 	options->addChild( new Gaffer::NameValuePlug( "ai:log:info", new IECore::BoolData( true ), false, "logInfo" ) );

--- a/src/GafferArnold/ArnoldVDB.cpp
+++ b/src/GafferArnold/ArnoldVDB.cpp
@@ -106,7 +106,7 @@ ArnoldVDB::ArnoldVDB( const std::string &name )
 	:	ObjectSource( name, "volume" )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new StringPlug( "grids", Plug::In, "density" ) );
 	addChild( new StringPlug( "velocityGrids" ) );
 	addChild( new FloatPlug( "velocityScale", Plug::In, 1.0f ) );
@@ -118,14 +118,14 @@ ArnoldVDB::~ArnoldVDB()
 {
 }
 
-Gaffer::StringPlug *ArnoldVDB::fileNamePlug()
+Gaffer::FilePathPlug *ArnoldVDB::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *ArnoldVDB::fileNamePlug() const
+const Gaffer::FilePathPlug *ArnoldVDB::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
 Gaffer::StringPlug *ArnoldVDB::gridsPlug()

--- a/src/GafferDelight/DelightOptions.cpp
+++ b/src/GafferDelight/DelightOptions.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferDelight/DelightOptions.h"
 
+#include "Gaffer/FilePathPlug.h"
+
 using namespace Imath;
 using namespace GafferDelight;
 
@@ -70,7 +72,7 @@ DelightOptions::DelightOptions( const std::string &name )
 	// Network cache
 
 	options->addChild( new Gaffer::NameValuePlug( "dl:networkcache.size", new IECore::IntData( 15 ), false, "networkCacheSize" ) );
-	options->addChild( new Gaffer::NameValuePlug( "dl:networkcache.directory", new IECore::StringData( "" ), false, "networkCacheDirectory" ) );
+	options->addChild( new Gaffer::NameValuePlug( "dl:networkcache.directory", new Gaffer::FilePathPlug(), false, "networkCacheDirectory" ) );
 
 	// Licensing
 

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextProcessor.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
@@ -131,7 +132,7 @@ Dispatcher::Dispatcher( const std::string &name )
 	addChild( new IntPlug( "framesMode", Plug::In, CurrentFrame, CurrentFrame ) );
 	addChild( new StringPlug( "frameRange", Plug::In, "1-100x10" ) );
 	addChild( new StringPlug( "jobName", Plug::In, "" ) );
-	addChild( new StringPlug( "jobsDirectory", Plug::In, "" ) );
+	addChild( new FilePathPlug( "jobsDirectory", Plug::In, "" ) );
 }
 
 Dispatcher::~Dispatcher()
@@ -168,14 +169,14 @@ const StringPlug *Dispatcher::jobNamePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 2 );
 }
 
-StringPlug *Dispatcher::jobsDirectoryPlug()
+FilePathPlug *Dispatcher::jobsDirectoryPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
-const StringPlug *Dispatcher::jobsDirectoryPlug() const
+const FilePathPlug *Dispatcher::jobsDirectoryPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
 const std::string Dispatcher::jobDirectory() const
@@ -185,7 +186,7 @@ const std::string Dispatcher::jobDirectory() const
 
 void Dispatcher::createJobDirectory( const Gaffer::ScriptNode *script, Gaffer::Context *context ) const
 {
-	boost::filesystem::path jobDirectory( context->substitute( jobsDirectoryPlug()->getValue() ) );
+	boost::filesystem::path jobDirectory( jobsDirectoryPlug()->getValue() );
 	jobDirectory /= context->substitute( jobNamePlug()->getValue() );
 
 	if( jobDirectory == "" )

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/DownstreamIterator.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/ParallelAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
@@ -106,7 +107,7 @@ class Catalogue::InternalImage : public ImageNode
 		{
 			storeIndexOfNextChild( g_firstChildIndex );
 
-			addChild( new StringPlug( "fileName" ) );
+			addChild( new FilePathPlug( "fileName" ) );
 			addChild( new StringPlug( "description" ) );
 
 			// Used to load an image from disk, according to
@@ -166,14 +167,14 @@ class Catalogue::InternalImage : public ImageNode
 			}
 		}
 
-		StringPlug *fileNamePlug()
+		FilePathPlug *fileNamePlug()
 		{
-			return getChild<StringPlug>( g_firstChildIndex );
+			return getChild<FilePathPlug>( g_firstChildIndex );
 		}
 
-		const StringPlug *fileNamePlug() const
+		const FilePathPlug *fileNamePlug() const
 		{
-			return getChild<StringPlug>( g_firstChildIndex );
+			return getChild<FilePathPlug>( g_firstChildIndex );
 		}
 
 		StringPlug *descriptionPlug()
@@ -189,7 +190,7 @@ class Catalogue::InternalImage : public ImageNode
 		void copyFrom( const InternalImage *other )
 		{
 			descriptionPlug()->source<StringPlug>()->setValue( other->descriptionPlug()->getValue() );
-			fileNamePlug()->source<StringPlug>()->setValue( other->fileNamePlug()->getValue() );
+			fileNamePlug()->source<FilePathPlug>()->setValue( other->fileNamePlug()->getValue() );
 			imageSwitch()->indexPlug()->setValue( other->imageSwitch()->indexPlug()->getValue() );
 			text()->enabledPlug()->setValue( other->text()->enabledPlug()->getValue() );
 
@@ -613,7 +614,7 @@ class Catalogue::InternalImage : public ImageNode
 				{
 					// Set up the client to read from the saved image
 					client->text()->enabledPlug()->setValue( false );
-					client->fileNamePlug()->source<StringPlug>()->setValue( m_writer->fileNamePlug()->getValue() );
+					client->fileNamePlug()->source<FilePathPlug>()->setValue( m_writer->fileNamePlug()->getValue() );
 					client->imageSwitch()->indexPlug()->setValue( 0 );
 					// But force hashChannelData and computeChannelData to be called
 					// so that we can reuse the cache entries created by the original
@@ -652,21 +653,21 @@ GAFFER_PLUG_DEFINE_TYPE( Catalogue::Image );
 Catalogue::Image::Image( const std::string &name, Direction direction, unsigned flags )
 	:	Plug( name, direction, flags )
 {
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new StringPlug( "description" ) );
 	addChild( new StringPlug( "__name", Plug::In, name, Plug::Default & ~Plug::Serialisable ) );
 
 	nameChangedSignal().connect( boost::bind( &Image::nameChanged, this ) );
 }
 
-Gaffer::StringPlug *Catalogue::Image::fileNamePlug()
+Gaffer::FilePathPlug *Catalogue::Image::fileNamePlug()
 {
-	return getChild<StringPlug>( 0 );
+	return getChild<FilePathPlug>( 0 );
 }
 
-const Gaffer::StringPlug *Catalogue::Image::fileNamePlug() const
+const Gaffer::FilePathPlug *Catalogue::Image::fileNamePlug() const
 {
-	return getChild<StringPlug>( 0 );
+	return getChild<FilePathPlug>( 0 );
 }
 
 Gaffer::StringPlug *Catalogue::Image::descriptionPlug()
@@ -792,7 +793,7 @@ Catalogue::Catalogue( const std::string &name )
 	addChild( new Plug( "images" ) );
 	addChild( new IntPlug( "imageIndex" ) );
 	addChild( new StringPlug( "name" ) );
-	addChild( new StringPlug( "directory" ) );
+	addChild( new FilePathPlug( "directory" ) );
 	addChild( new IntPlug( "__imageIndex", Plug::Out ) );
 
 	// Switch used to choose which image to output
@@ -856,14 +857,14 @@ const Gaffer::StringPlug *Catalogue::namePlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 2 );
 }
 
-Gaffer::StringPlug *Catalogue::directoryPlug()
+Gaffer::FilePathPlug *Catalogue::directoryPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
-const Gaffer::StringPlug *Catalogue::directoryPlug() const
+const Gaffer::FilePathPlug *Catalogue::directoryPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
 Gaffer::IntPlug *Catalogue::internalImageIndexPlug()

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -39,6 +39,7 @@
 #include "GafferImage/ColorSpace.h"
 #include "GafferImage/OpenImageIOReader.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/StringPlug.h"
 
 #include "OpenEXR/ImathFun.h"
@@ -118,7 +119,7 @@ ImageReader::ImageReader( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstChildIndex );
 	addChild(
-		new StringPlug(
+		new FilePathPlug(
 			"fileName", Plug::In, "",
 			/* flags */ Plug::Default,
 			/* substitutions */ IECore::StringAlgo::AllSubstitutions & ~IECore::StringAlgo::FrameSubstitutions
@@ -170,14 +171,14 @@ ImageReader::~ImageReader()
 {
 }
 
-StringPlug *ImageReader::fileNamePlug()
+FilePathPlug *ImageReader::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstChildIndex );
+	return getChild<FilePathPlug>( g_firstChildIndex );
 }
 
-const StringPlug *ImageReader::fileNamePlug() const
+const FilePathPlug *ImageReader::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstChildIndex );
+	return getChild<FilePathPlug>( g_firstChildIndex );
 }
 
 IntPlug *ImageReader::refreshCountPlug()

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -48,6 +48,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextQuery.h"
 #include "Gaffer/DeleteContextVariables.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
@@ -1514,7 +1515,7 @@ ImageWriter::ImageWriter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ImagePlug( "in" ) );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new StringPlug( "channels", Gaffer::Plug::In, "*" ) );
 	addChild( new StringPlug( "colorSpace" ) );
 	addChild( new ImagePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
@@ -1651,14 +1652,14 @@ const GafferImage::ImagePlug *ImageWriter::inPlug() const
 	return getChild<ImagePlug>( g_firstPlugIndex );
 }
 
-Gaffer::StringPlug *ImageWriter::fileNamePlug()
+Gaffer::FilePathPlug *ImageWriter::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex+1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex+1 );
 }
 
-const Gaffer::StringPlug *ImageWriter::fileNamePlug() const
+const Gaffer::FilePathPlug *ImageWriter::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex+1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex+1 );
 }
 
 Gaffer::StringPlug *ImageWriter::channelsPlug()

--- a/src/GafferImage/LUT.cpp
+++ b/src/GafferImage/LUT.cpp
@@ -36,7 +36,7 @@
 
 #include "GafferImage/LUT.h"
 
-#include "Gaffer/StringPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 using namespace std;
 using namespace IECore;
@@ -51,7 +51,7 @@ LUT::LUT( const std::string &name )
 	:	OpenColorIOTransform( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 
 	addChild( new IntPlug(
 		"interpolation", Plug::In,
@@ -73,14 +73,14 @@ LUT::~LUT()
 {
 }
 
-Gaffer::StringPlug *LUT::fileNamePlug()
+Gaffer::FilePathPlug *LUT::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *LUT::fileNamePlug() const
+const Gaffer::FilePathPlug *LUT::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
 Gaffer::IntPlug *LUT::interpolationPlug()

--- a/src/GafferImage/Text.cpp
+++ b/src/GafferImage/Text.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferImage/BufferAlgo.h"
 
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/Transform2DPlug.h"
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
@@ -217,7 +218,7 @@ Text::Text( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "text", Plug::In, "Hello World" ) );
-	addChild( new StringPlug( "font", Plug::In, "Vera.ttf" ) );
+	addChild( new FilePathPlug( "font", Plug::In, "Vera.ttf" ) );
 	addChild( new V2iPlug( "size", Plug::In, V2i( 50 ), V2i( 0 ) ) );
 	addChild( new Box2iPlug( "area" ) );
 	addChild( new IntPlug( "horizontalAlignment", Plug::In, Left, Left, HorizontalCenter ) );
@@ -240,14 +241,14 @@ const Gaffer::StringPlug *Text::textPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
-Gaffer::StringPlug *Text::fontPlug()
+Gaffer::FilePathPlug *Text::fontPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
-const Gaffer::StringPlug *Text::fontPlug() const
+const Gaffer::FilePathPlug *Text::fontPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
 Gaffer::V2iPlug *Text::sizePlug()

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -208,7 +208,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindValuePlug();
 	bindNumericPlug();
 	bindTypedPlug();
-	bindStringPlug();
+	bindStringPlugs();
 	bindTypedObjectPlug();
 	bindScriptNode();
 	bindApplicationRoot();

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -335,8 +335,8 @@ Cryptomatte::Cryptomatte( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "layer", Gaffer::Plug::In, "" ) );
 	addChild( new IntPlug( "manifestSource", Gaffer::Plug::In, (int)ManifestSource::Metadata, /* min */ (int)ManifestSource::None, /* max */ (int)ManifestSource::Sidecar ) );
-	addChild( new StringPlug( "manifestDirectory", Gaffer::Plug::In, "") );
-	addChild( new StringPlug( "sidecarFile", Gaffer::Plug::In, "") );
+	addChild( new FilePathPlug( "manifestDirectory", Gaffer::Plug::In, "") );
+	addChild( new FilePathPlug( "sidecarFile", Gaffer::Plug::In, "") );
 	addChild( new StringPlug( "outputChannel", Gaffer::Plug::In, "A") );
 	addChild( new StringVectorDataPlug( "matteNames", Gaffer::Plug::In, new StringVectorData() ) );
 	addChild( new FloatVectorDataPlug( "__matteValues", Gaffer::Plug::Out, new FloatVectorData() ) );
@@ -374,24 +374,24 @@ const Gaffer::IntPlug *Cryptomatte::manifestSourcePlug() const
 	return getChild<IntPlug>( g_firstPlugIndex + 1 );
 }
 
-Gaffer::StringPlug *Cryptomatte::manifestDirectoryPlug()
+Gaffer::FilePathPlug *Cryptomatte::manifestDirectoryPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 }
 
-const Gaffer::StringPlug *Cryptomatte::manifestDirectoryPlug() const
+const Gaffer::FilePathPlug *Cryptomatte::manifestDirectoryPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 }
 
-Gaffer::StringPlug *Cryptomatte::sidecarFilePlug()
+Gaffer::FilePathPlug *Cryptomatte::sidecarFilePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
-const Gaffer::StringPlug *Cryptomatte::sidecarFilePlug() const
+const Gaffer::FilePathPlug *Cryptomatte::sidecarFilePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
 Gaffer::StringPlug *Cryptomatte::outputChannelPlug()

--- a/src/GafferScene/ExternalProcedural.cpp
+++ b/src/GafferScene/ExternalProcedural.cpp
@@ -36,7 +36,7 @@
 
 #include "GafferScene/ExternalProcedural.h"
 
-#include "Gaffer/StringPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 #include "IECoreScene/ExternalProcedural.h"
 
@@ -52,7 +52,7 @@ ExternalProcedural::ExternalProcedural( const std::string &name )
 	:	ObjectSource( name, "procedural" )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new Box3fPlug( "bound", Plug::In, Box3f( V3f( -0.5 ), V3f( 0.5 ) ) ) );
 	addChild( new CompoundDataPlug( "parameters" ) );
 }
@@ -61,14 +61,14 @@ ExternalProcedural::~ExternalProcedural()
 {
 }
 
-Gaffer::StringPlug *ExternalProcedural::fileNamePlug()
+Gaffer::FilePathPlug *ExternalProcedural::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *ExternalProcedural::fileNamePlug() const
+const Gaffer::FilePathPlug *ExternalProcedural::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
 Gaffer::Box3fPlug *ExternalProcedural::boundPlug()

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 #include "boost/multi_index/member.hpp"
 #include "boost/multi_index/ordered_index.hpp"
@@ -132,7 +133,7 @@ Gaffer::ValuePlug *Outputs::addOutput( const std::string &name, const IECoreScen
 	activePlug->setFlags( Plug::Dynamic, true );
 	outputPlug->addChild( activePlug );
 
-	StringPlugPtr fileNamePlug = new StringPlug( "fileName" );
+	FilePathPlugPtr fileNamePlug = new FilePathPlug( "fileName" );
 	fileNamePlug->setValue( output->getName() );
 	fileNamePlug->setFlags( Plug::Dynamic, true );
 	outputPlug->addChild( fileNamePlug );

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -109,7 +109,7 @@ Render::Render( const IECore::InternedString &rendererType, const std::string &n
 	addChild( new ScenePlug( "in" ) );
 	addChild( new StringPlug( rendererType.string().empty() ? "renderer" : "__renderer", Plug::In, rendererType.string() ) );
 	addChild( new IntPlug( "mode", Plug::In, RenderMode, RenderMode, SceneDescriptionMode ) );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ScenePlug( "__adaptedIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
@@ -155,14 +155,14 @@ const Gaffer::IntPlug *Render::modePlug() const
 	return getChild<IntPlug>( g_firstPlugIndex + 2 );
 }
 
-Gaffer::StringPlug *Render::fileNamePlug()
+Gaffer::FilePathPlug *Render::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
-const Gaffer::StringPlug *Render::fileNamePlug() const
+const Gaffer::FilePathPlug *Render::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 3 );
 }
 
 ScenePlug *Render::outPlug()

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"
+#include "Gaffer/FilePathPlug.h"
 #include "Gaffer/TransformPlug.h"
 
 #include "IECoreScene/SceneCache.h"
@@ -96,7 +97,7 @@ SceneReader::SceneReader( const std::string &name )
 	:	SceneNode( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new IntPlug( "refreshCount" ) );
 	addChild( new StringPlug( "tags" ) );
 	addChild( new TransformPlug( "transform" ) );
@@ -109,14 +110,14 @@ SceneReader::~SceneReader()
 {
 }
 
-Gaffer::StringPlug *SceneReader::fileNamePlug()
+Gaffer::FilePathPlug *SceneReader::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
-const Gaffer::StringPlug *SceneReader::fileNamePlug() const
+const Gaffer::FilePathPlug *SceneReader::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex );
+	return getChild<FilePathPlug>( g_firstPlugIndex );
 }
 
 Gaffer::IntPlug *SceneReader::refreshCountPlug()

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -39,7 +39,7 @@
 #include "GafferScene/SceneAlgo.h"
 
 #include "Gaffer/Context.h"
-#include "Gaffer/StringPlug.h"
+#include "Gaffer/FilePathPlug.h"
 
 #include "IECoreScene/SceneInterface.h"
 
@@ -177,7 +177,7 @@ SceneWriter::SceneWriter( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ScenePlug( "in", Plug::In ) );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
 	outPlug()->setInput( inPlug() );
 }
@@ -196,14 +196,14 @@ const ScenePlug *SceneWriter::inPlug() const
 	return getChild<ScenePlug>( g_firstPlugIndex );
 }
 
-StringPlug *SceneWriter::fileNamePlug()
+FilePathPlug *SceneWriter::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
-const StringPlug *SceneWriter::fileNamePlug() const
+const FilePathPlug *SceneWriter::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
 ScenePlug *SceneWriter::outPlug()

--- a/src/GafferScene/Text.cpp
+++ b/src/GafferScene/Text.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
+#include "Gaffer/FilePathPlug.h"
 
 #include "IECoreScene/Font.h"
 #include "IECoreScene/MeshPrimitive.h"
@@ -100,7 +101,7 @@ Text::Text( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "text", Plug::In, "Hello World" ) );
-	addChild( new StringPlug( "font", Plug::In, "Vera.ttf" ) );
+	addChild( new FilePathPlug( "font", Plug::In, "Vera.ttf" ) );
 }
 
 Text::~Text()
@@ -117,14 +118,14 @@ const Gaffer::StringPlug *Text::textPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
-Gaffer::StringPlug *Text::fontPlug()
+Gaffer::FilePathPlug *Text::fontPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
-const Gaffer::StringPlug *Text::fontPlug() const
+const Gaffer::FilePathPlug *Text::fontPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
 void Text::affects( const Plug *input, AffectedPlugsContainer &outputs ) const

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -103,7 +103,7 @@ class UVView::UVScene : public SceneProcessor
 
 			addChild( new StringVectorDataPlug( "visiblePaths", Plug::In, new StringVectorData ) );
 			addChild( new StringPlug( "uvSet", Plug::In, "uv" ) );
-			addChild( new StringPlug( "textureFileName", Plug::In, "" ) );
+			addChild( new FilePathPlug( "textureFileName", Plug::In, "" ) );
 			addChild( new CompoundObjectPlug( "textures", Plug::Out, new CompoundObject ) );
 
 			addChild( new StringVectorDataPlug( "__udimQueryPaths", Plug::Out, new StringVectorData ) );
@@ -171,14 +171,14 @@ class UVView::UVScene : public SceneProcessor
 			return getChild<StringPlug>( g_firstPlugIndex + 1 );
 		}
 
-		StringPlug *textureFileNamePlug()
+		FilePathPlug *textureFileNamePlug()
 		{
-			return getChild<StringPlug>( g_firstPlugIndex + 2 );
+			return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 		}
 
-		const StringPlug *textureFileNamePlug() const
+		const FilePathPlug *textureFileNamePlug() const
 		{
-			return getChild<StringPlug>( g_firstPlugIndex + 2 );
+			return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 		}
 
 		CompoundObjectPlug *texturesPlug()
@@ -587,7 +587,7 @@ UVView::UVView( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new StringPlug( "uvSet", Plug::In, "uv" ) );
-	addChild( new StringPlug( "textureFileName" ) );
+	addChild( new FilePathPlug( "textureFileName" ) );
 	addChild( new StringPlug( "displayTransform", Plug::In, "Default" ) );
 	addChild( new CompoundObjectPlug( "__textures", Plug::In, new CompoundObject ) );
 
@@ -656,14 +656,14 @@ const Gaffer::StringPlug *UVView::uvSetPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
-Gaffer::StringPlug *UVView::textureFileNamePlug()
+Gaffer::FilePathPlug *UVView::textureFileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
-const Gaffer::StringPlug *UVView::textureFileNamePlug() const
+const Gaffer::FilePathPlug *UVView::textureFileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 1 );
 }
 
 Gaffer::StringPlug *UVView::displayTransformPlug()

--- a/src/GafferUSD/USDLayerWriter.cpp
+++ b/src/GafferUSD/USDLayerWriter.cpp
@@ -231,7 +231,7 @@ USDLayerWriter::USDLayerWriter( const std::string &name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ScenePlug( "base", Plug::In ) );
 	addChild( new ScenePlug( "layer", Plug::In ) );
-	addChild( new StringPlug( "fileName" ) );
+	addChild( new FilePathPlug( "fileName" ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
 
 	SceneWriterPtr sceneWriter = new SceneWriter( "__sceneWriter" );
@@ -275,14 +275,14 @@ const GafferScene::ScenePlug *USDLayerWriter::layerPlug() const
 	return getChild<ScenePlug>( g_firstPlugIndex + 1 );
 }
 
-StringPlug *USDLayerWriter::fileNamePlug()
+FilePathPlug *USDLayerWriter::fileNamePlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 }
 
-const StringPlug *USDLayerWriter::fileNamePlug() const
+const FilePathPlug *USDLayerWriter::fileNamePlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+	return getChild<FilePathPlug>( g_firstPlugIndex + 2 );
 }
 
 GafferScene::ScenePlug *USDLayerWriter::outPlug()


### PR DESCRIPTION
This adds a new plug specifically for representing file paths. It behaves almost identically to `StringPlug` (from which it is derived) except for the way it gets and sets values :

- Values can be set from either OS-native path strings or generic path strings.
- Values returned by `getValue()` are in OS-native format.

`FilePathPlug` is compatible with `StringPlug`, and users creating their own nodes can continue to use `StringPlug` with `GafferUI.FileSystemPathPlugValueWidget` metadata if they choose.

The main improvement his plug makes is returning paths in a Windows native format (when running on Windows).

### Related issues ###

Closes issue #2727.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
