### PR TITLE
TweakPlug fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,11 @@ Features
 - OptionTweaks : Added node for tweaking options in a scene.
 - OptionQuery : Added node for querying options from a scene.
 
+Improvements
+------------
+
+- TweakPlug : Added the ability to set `InternedStringData` from `StringData`.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 
 - CyclesOptions : Fixed errors in section summaries.
 - NoduleLayout : Fixed shutdown crashes triggered by custom gadgets implemented in Python.
+- ShaderTweaks : Fixed error when attempting to use a `:` in a parameter name.
 
 1.0.3.0 (relative to 1.0.2.1)
 =======

--- a/include/Gaffer/TweakPlug.inl
+++ b/include/Gaffer/TweakPlug.inl
@@ -93,6 +93,15 @@ bool TweakPlug::applyTweak(
 	}
 
 	const IECore::Data *currentValue = getDataFunctor( name );
+
+	if( IECore::runTimeCast<const IECore::InternedStringData>( currentValue ) )
+	{
+		if( const IECore::StringData *s = IECore::runTimeCast<const IECore::StringData>( newData.get() ) )
+		{
+			newData = new IECore::InternedStringData( s->readable() );
+		}
+	}
+
 	if( currentValue && currentValue->typeId() != newData->typeId() )
 	{
 		throw IECore::Exception(

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -324,7 +324,9 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 			plug = Gaffer.TweakPlug( name, plugTypeOrValue() )
 
 		if name :
-			plug.setName( name.replace( ".", "_" ) )
+			for i in ( ".", ":", ) :
+				name = name.replace( i, "_" )
+			plug.setName( name )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )

--- a/python/GafferTest/TweakPlugTest.py
+++ b/python/GafferTest/TweakPlugTest.py
@@ -339,6 +339,21 @@ class TweakPlugTest( GafferTest.TestCase ) :
 		self.assertFalse( tweaks.applyTweaks( parameters ) )
 		self.assertNotIn( "f", parameters )
 
+	def testTweakInternedString( self ) :
+
+		data = IECore.CompoundData(
+			{
+				"a" : IECore.InternedStringData( "testInternedString" ),
+			}
+		)
+		self.assertEqual( data["a"], IECore.InternedStringData( "testInternedString" ) )
+
+		tweak = Gaffer.TweakPlug( "a", "stringValue" )
+
+		result = tweak.applyTweak( data )
+		self.assertTrue( result )
+		self.assertEqual( data["a"], IECore.InternedStringData( "stringValue" ) )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -57,6 +57,7 @@
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
+#include "boost/range/algorithm/replace_copy_if.hpp"
 #include "boost/container/flat_map.hpp"
 #include "boost/tokenizer.hpp"
 
@@ -551,7 +552,8 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireParameterEdit( Gaffer::EditScope *
 		tweakName = parameter.shader.string() + "." + tweakName;
 	}
 
-	string columnName = boost::replace_all_copy( tweakName, ".", "_" );
+	string columnName;
+	boost::replace_copy_if( tweakName, std::back_inserter( columnName ), boost::is_any_of( ".:" ), '_' );
 	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
 	{
 		return cell->valuePlug<TweakPlug>();
@@ -623,7 +625,8 @@ const GraphComponent *GafferScene::EditScopeAlgo::parameterEditReadOnlyReason( c
 	{
 		tweakName = parameter.shader.string() + "." + tweakName;
 	}
-	string columnName = boost::replace_all_copy( tweakName, ".", "_" );
+	string columnName;
+	boost::replace_copy_if( tweakName, std::back_inserter( columnName ), boost::is_any_of( ".:" ), '_' );
 	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
 	{
 		if( MetadataAlgo::getReadOnly( cell ) )


### PR DESCRIPTION
This fixes a bug and improves existing functionality in `TweakPlug` that came to our attention after adding support for USDLux in #4800.

- USD uses colons to delimit some parameter names, which caused a error when trying to create a plug name directly from the parameter name.
- Some USD attributes are converted to `IECore::InternedStringData` which would be converted to `StringData` by `TweakPlug`. This adds compatibility between `InternedStringData` and `StringData`, maintaining the input data type.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
