### PR TITLE
FileSystemPath : Improve Windows UNC path handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,9 @@ Fixes
 -----
 
 - Plug : Fixed bug that could prevent `plugDirtiedSignal()` from ever being emitted again if an exception was thrown during parenting. This could cause the UI to stop updating.
+- FileSystemPath (Windows only) :
+  - `.` characters are now excluded from the path entries. These were being inserted in some cases even when the user did not input one.
+  - Fix browsing UNC paths in file browsers.
 
 API
 ---
@@ -17,6 +20,7 @@ API
 - FileSystemPath :
   - Added support for Windows paths.
   - Added `nativeString()` function to return the path as an OS-specific string.
+  - (Windows only) Paths beginning with a single `/` or `\` not followed by a drive letter are interpreted as UNC paths.
 - WidgetAlgo : Improved `joinEdges()` to support a wider range of widget types.
 
 Breaking Changes

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -215,16 +215,51 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		self.assertFalse( p.isEmpty() )
 		self.assertFalse( p.isValid() )
 
+		p = Gaffer.FileSystemPath( r"/this.server/share/does/not/exist.ext" )
+		if os.name == "nt" :
+			self.assertEqual( list( p ), [ "share", "does", "not", "exist.ext" ] )
+			self.assertEqual( p.root(), "//this.server/" )
+			self.assertEqual( str( p ), "//this.server/share/does/not/exist.ext" )
+			self.assertEqual( p.nativeString(), r"\\this.server\share\does\not\exist.ext")
+		else :
+			self.assertEqual( list( p ), [ "this.server", "share", "does", "not", "exist.ext" ] )
+			self.assertEqual( p.root(), "/" )
+			self.assertEqual( str( p ), "/this.server/share/does/not/exist.ext" )
+			self.assertEqual( p.nativeString(), "/this.server/share/does/not/exist.ext" )
+
+		f = Gaffer.FileSystemPath( "/" )
+		b = Gaffer.FileSystemPath( "\\" )
+		if os.name == "nt" :
+			self.assertEqual( list( f ), [] )
+			self.assertEqual( list( b ), [] )
+			self.assertEqual( f.root(), "//" )
+			self.assertEqual( b.root(), "//" )
+			self.assertEqual( str( f ), "//" )
+			self.assertEqual( str( b ), "//" )
+			self.assertEqual( f.nativeString(), r"\\" )
+			self.assertEqual( b.nativeString(), r"\\" )
+		else :
+			self.assertEqual( list( f ), [] )
+			self.assertEqual( list( b ), [ "\\" ] )
+			self.assertEqual( f.root(), "/" )
+			self.assertEqual( b.root(), "" )
+			self.assertEqual( str( f ), "/" )
+			self.assertEqual( str( b ), "\\" )
+			self.assertEqual( f.nativeString(), "/" )
+			self.assertEqual( b.nativeString(), "\\" )
+
 	def testPosixPath( self ) :
 		p = Gaffer.FileSystemPath( "/this/path/does/not/exist.ext" )
 
-		self.assertEqual( p.root(), "/")
-		self.assertEqual( str( p ), "/this/path/does/not/exist.ext" )
-		self.assertEqual( list( p ), [ "this", "path", "does", "not", "exist.ext" ] )
-
 		if os.name == "nt" :
-			self.assertEqual( p.nativeString(), r"\this\path\does\not\exist.ext" )
+			self.assertEqual( list( p ), [ "path", "does", "not", "exist.ext" ] )
+			self.assertEqual( p.root(), "//this/")
+			self.assertEqual( str( p ), "//this/path/does/not/exist.ext" )
+			self.assertEqual( p.nativeString(), r"\\this\path\does\not\exist.ext" )
 		else :
+			self.assertEqual( list( p ), [ "this", "path", "does", "not", "exist.ext" ] )
+			self.assertEqual( p.root(), "/")
+			self.assertEqual( str( p ), "/this/path/does/not/exist.ext" )
 			self.assertEqual( p.nativeString(), "/this/path/does/not/exist.ext")
 
 		self.assertFalse( p.isEmpty() )


### PR DESCRIPTION
This fixes a few things on Windows related to UNC paths :
- Browsing UNC paths in the file browser was not working previously - files never registered as valid and therefore could not be selected. This was caused by `PathListingWidget` using `PathMatcher` which always starts a path with a single `/`. The inability to have a `PathMatcher` start with a double `/` requires us to settle on an interpretation of single `/` as either being followed by a drive letter or is the start of a UNC path.
- After the above change, Gaffer would crash when trying to browse a UNC path. Windows will allow a directory listing starting with a single or double slash, which it takes to mean the root directory of the current drive. But we are forcing such paths to be considered UNC paths, which leads to a state where `PathListingWidget` had multiple children with roots but no `names()`. This caused a crash when trying to get `(*it)->names().back()` with `(*it)->names().size() == 0`. 
- Boost would insert `.` characters into path iterators in certain circumstances. While this does not cause errors, it seems unusual so we suppress them.

### Breaking changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
