### PR TITLE
Light Editor error handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Features
 - Edit Menu : Added "Duplicate with Inputs" menu item, with <kbd>Ctrl</kbd>+<kbd>D</kbd> shortcut.
 - StandardAttributes : Added `automaticInstancing` plug to allow instancing to be disabled on selected locations. Currently supported only by the Arnold renderer.
 
+Improvements
+------------
+
+- Light Editor : Added explanation to cell popup when a parameter cannot be edited because there are no editable sources.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Features
 Improvements
 ------------
 
-- Light Editor : Added explanation to cell popup when a parameter cannot be edited because there are no editable sources.
+- Light Editor :
+  - Added explanation to cell popup when a parameter cannot be edited because there are no editable sources.
+  - Added an error icon to a cell with an explanation in the tooltip when there is an error computing its value (#4805).
 
 Fixes
 -----

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -591,5 +591,38 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
 		self.assertEqual( len( cs ), 2 ) # Change affects the result of `inspect().editable()`
 
+	def testUnsupportedSourceNode( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["sceneReader"] = GafferScene.SceneReader()
+		s["sceneReader"]["fileName"].setValue( "${GAFFER_ROOT}/python/GafferSceneTest/usdFiles/sphereLight.usda" )
+
+		s["editScope"] = Gaffer.EditScope()
+		s["editScope"].setup( s["sceneReader"]["out"] )
+		s["editScope"]["in"].setInput( s["sceneReader"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["sceneReader"]["out"], "/SpotLight23", "intensity", None ),
+			source = None,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = False,
+			nonEditableReason = "No editable source found in history."
+		)
+
+		inspection = self.__inspect( s["editScope"]["out"], "/SpotLight23", "intensity", s["editScope"] )
+		edit = inspection.acquireEdit()
+
+		self.assertIsNotNone( edit )
+
+		self.__assertExpectedResult(
+			inspection,
+			source = None,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = edit
+		)
+
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -151,6 +151,13 @@ Inspector::ResultPtr Inspector::inspect() const
 	ResultPtr result = new Result( value, targetEditScope() );
 	inspectHistoryWalk( history.get(), result.get() );
 
+	if( !result->m_value && !result->editable() )
+	{
+		// The property doesn't exist, and there's no
+		// way of making it.
+		return nullptr;
+	}
+
 	if( result->editScope() && !result->m_editScopeInHistory )
 	{
 		result->m_editFunction = boost::str(
@@ -160,11 +167,11 @@ Inspector::ResultPtr Inspector::inspect() const
 		result->m_sourceType = Result::SourceType::Other;
 	}
 
-	if( !result->m_value && !result->editable() )
+	else if( !result->m_source && !result->editable() )
 	{
-		// The property doesn't exist, and there's no
-		// way of making it.
-		return nullptr;
+		// There's no source plug and no way of making
+		// the property.
+		result->m_editFunction = "No editable source found in history.";
 	}
 
 	return result;

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -102,7 +102,18 @@ class LocationNameColumn : public StandardPathColumn
 			Context::EditableScope scope( scenePath->getContext() );
 			scope.setCanceller( canceller );
 
-			ConstCompoundObjectPtr attributes = scenePath->getScene()->fullAttributes( scenePath->names() );
+			ConstCompoundObjectPtr attributes;
+			try
+			{
+				attributes = scenePath->getScene()->fullAttributes( scenePath->names() );
+			}
+			catch( const std::exception &e )
+			{
+				result.icon = new IECore::StringData( "errorSmall.png" );
+				result.toolTip = new IECore::StringData( e.what() );
+				return result;
+			}
+
 			for( const auto &attribute : attributes->members() )
 			{
 				if( attribute.first != "light" && !boost::ends_with( attribute.first.c_str(), ":light" ) )

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -1188,7 +1188,14 @@ class PathModel : public QAbstractItemModel
 						{
 							// Qt doesn't use exceptions for error handling,
 							// so we must suppress them.
-							IECore::msg( IECore::Msg::Warning, "PathListingWidget", e.what() );
+							cellVariants = CellVariants(
+								GafferUI::PathColumn::CellData(
+									nullptr,  // value
+									new IECore::StringData( "errorSmall.png" ),  // icon
+									nullptr,  // background
+									new IECore::StringData( e.what() )  // toolTip
+								)
+							);
 						}
 						catch( ... )
 						{


### PR DESCRIPTION
This improves error handling in the Light Editor for a couple of cases :
- #4805 : previously nothing was shown in the Light Editor, including the name of the light causing the error, which can be known. This adds an error icon and tooltip explaining the error to cells when there is a compute error, and shows the light name in the name column.
- Nodes that do not support editing : This came up after the USDLux support was added in #4800. Trying to change the value of a USD light parameter gave a plug popup window with a warning but no further explanation. The source in this case is a `SceneReader` node. This adds an `editWarning` for unsupported nodes.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
