### PR TITLE
GraphEditor : Improvements and fixes for read-only graphs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 -----
 
 - GraphEditor : Fixed bugs which allowed new connections to be made in read-only graphs.
+- NodeEditor : Fixed bugs which allowed plugs to be added to read-only tweaks nodes.
 - CyclesOptions : Fixed errors in section summaries.
 - NoduleLayout : Fixed shutdown crashes triggered by custom gadgets implemented in Python.
 - ShaderTweaks : Fixed error when attempting to use a `:` in a parameter name.

--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,7 @@ Improvements
 Fixes
 -----
 
-- GraphEditor : Fixed bug which allowed new connections to be made in read-only graphs.
+- GraphEditor : Fixed bugs which allowed new connections to be made in read-only graphs.
 - CyclesOptions : Fixed errors in section summaries.
 - NoduleLayout : Fixed shutdown crashes triggered by custom gadgets implemented in Python.
 - ShaderTweaks : Fixed error when attempting to use a `:` in a parameter name.

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 ------------
 
 - TweakPlug : Added the ability to set `InternedStringData` from `StringData`.
+- GraphEditor : Added a warning for attempts to open the node creation menu in a read-only graph.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 Fixes
 -----
 
+- GraphEditor : Fixed bug which allowed new connections to be made in read-only graphs.
 - CyclesOptions : Fixed errors in section summaries.
 - NoduleLayout : Fixed shutdown crashes triggered by custom gadgets implemented in Python.
 - ShaderTweaks : Fixed error when attempting to use a `:` in a parameter name.

--- a/include/GafferUI/PlugAdder.h
+++ b/include/GafferUI/PlugAdder.h
@@ -78,6 +78,8 @@ class GAFFERUI_API PlugAdder : public ConnectionCreator
 
 	private :
 
+		bool couldCreateConnection() const;
+
 		void enter( GadgetPtr gadget, const ButtonEvent &event );
 		void leave( GadgetPtr gadget, const ButtonEvent &event );
 		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -171,7 +171,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-				GafferUI.MenuButton(
+				self.__button = GafferUI.MenuButton(
 					image = "plus.png",
 					hasFrame = False,
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -179,9 +179,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
+		self._updateFromPlug()
+
 	def _updateFromPlug( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__button.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -172,7 +172,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-				GafferUI.MenuButton(
+				self.__button = GafferUI.MenuButton(
 					image = "plus.png",
 					hasFrame = False,
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -180,9 +180,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
+		self._updateFromPlug()
+
 	def _updateFromPlug( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__button.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -131,7 +131,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-				GafferUI.MenuButton(
+				self.__button = GafferUI.MenuButton(
 					image = "plus.png",
 					hasFrame = False,
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -139,9 +139,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
+		self._updateFromPlug()
+
 	def _updateFromPlug( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__button.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -222,7 +222,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-				GafferUI.MenuButton(
+				self.__button = GafferUI.MenuButton(
 					image = "plus.png",
 					hasFrame = False,
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -230,9 +230,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
+		self._updateFromPlug()
+
 	def _updateFromPlug( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__button.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/src/GafferOSLUI/OSLImageUI.cpp
+++ b/src/GafferOSLUI/OSLImageUI.cpp
@@ -88,6 +88,16 @@ class OSLImagePlugAdder : public PlugAdder
 
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
+			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_plugsParent.get() ) )
+			{
+				return false;
+			}
+
 			IECore::ConstCompoundDataPtr plugAdderOptions = Metadata::value<IECore::CompoundData>( m_plugsParent->node(), "plugAdderOptions" );
 			return !availableChannels( plugAdderOptions.get(), endpoint ).empty();
 		}
@@ -182,6 +192,11 @@ class OSLImagePlugAdder : public PlugAdder
 
 		bool buttonRelease( const ButtonEvent &event )
 		{
+			if( MetadataAlgo::readOnly( m_plugsParent.get() ) )
+			{
+				return false;
+			}
+
 			IECore::ConstCompoundDataPtr plugAdderOptions = Metadata::value<IECore::CompoundData>( m_plugsParent->node(), "plugAdderOptions" );
 			vector<std::string> origNames = availableChannels( plugAdderOptions.get() );
 			map<std::string, std::string> nameMapping;

--- a/src/GafferOSLUI/OSLObjectUI.cpp
+++ b/src/GafferOSLUI/OSLObjectUI.cpp
@@ -46,6 +46,7 @@
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/UndoScope.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameValuePlug.h"
 #include "Gaffer/PlugAlgo.h"
 
@@ -80,6 +81,16 @@ class OSLObjectPlugAdder : public PlugAdder
 
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
+			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_plugsParent.get() ) )
+			{
+				return false;
+			}
+
 			IECore::ConstCompoundDataPtr plugAdderOptions = Metadata::value<IECore::CompoundData>( m_plugsParent->node(), "plugAdderOptions" );
 			return !availablePrimVars( plugAdderOptions.get(), endpoint ).empty();
 		}
@@ -156,6 +167,11 @@ class OSLObjectPlugAdder : public PlugAdder
 
 		bool buttonRelease( const ButtonEvent &event )
 		{
+			if( MetadataAlgo::readOnly( m_plugsParent.get() ) )
+			{
+				return false;
+			}
+
 			IECore::ConstCompoundDataPtr plugAdderOptions = Metadata::value<IECore::CompoundData>( m_plugsParent->node(), "plugAdderOptions" );
 			vector<std::string> origNames = availablePrimVars( plugAdderOptions.get() );
 			map<std::string, std::string> nameMapping;

--- a/src/GafferUI/ArrayPlugUI.cpp
+++ b/src/GafferUI/ArrayPlugUI.cpp
@@ -40,6 +40,7 @@
 
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -65,6 +66,11 @@ class ArrayPlugAdder : public PlugAdder
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
 			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_plug.get() ) )
 			{
 				return false;
 			}

--- a/src/GafferUI/BoxIONodeGadget.cpp
+++ b/src/GafferUI/BoxIONodeGadget.cpp
@@ -42,6 +42,7 @@
 #include "Gaffer/BoxIO.h"
 #include "Gaffer/BoxOut.h"
 #include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/UndoScope.h"
@@ -79,6 +80,11 @@ class BoxIOPlugAdder : public PlugAdder
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
 			if( !PlugAdder::canCreateConnection( endpoint ) )
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_boxIO.get() ) )
 			{
 				return false;
 			}

--- a/src/GafferUI/BoxUI.cpp
+++ b/src/GafferUI/BoxUI.cpp
@@ -41,6 +41,7 @@
 #include "Gaffer/Box.h"
 #include "Gaffer/BoxIn.h"
 #include "Gaffer/BoxOut.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/UndoScope.h"
 
@@ -73,6 +74,11 @@ class BoxPlugAdder : public PlugAdder
 			}
 
 			if( endpoint->node() == m_box )
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_box.get() ) )
 			{
 				return false;
 			}

--- a/src/GafferUI/ContextProcessorUI.cpp
+++ b/src/GafferUI/ContextProcessorUI.cpp
@@ -38,6 +38,7 @@
 #include "GafferUI/PlugAdder.h"
 
 #include "Gaffer/ContextProcessor.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -62,7 +63,10 @@ class ContextProcessorPlugAdder : public PlugAdder
 			updateVisibility();
 		}
 
-	protected :
+		bool canCreateConnection( const Gaffer::Plug *endpoint ) const override
+		{
+			return PlugAdder::canCreateConnection( endpoint ) && !MetadataAlgo::readOnly( m_node.get() );
+		}
 
 		void createConnection( Plug *endpoint ) override
 		{

--- a/src/GafferUI/EditScopeUI.cpp
+++ b/src/GafferUI/EditScopeUI.cpp
@@ -39,6 +39,7 @@
 #include "GafferUI/StandardNodeGadget.h"
 
 #include "Gaffer/EditScope.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -75,6 +76,11 @@ class EditScopePlugAdder : public PlugAdder
 				endpoint->node() == m_editScope ||
 				m_editScope->inPlug()
 			)
+			{
+				return false;
+			}
+
+			if( MetadataAlgo::readOnly( m_editScope.get() ) )
 			{
 				return false;
 			}

--- a/src/GafferUI/LoopUI.cpp
+++ b/src/GafferUI/LoopUI.cpp
@@ -38,6 +38,7 @@
 #include "GafferUI/PlugAdder.h"
 
 #include "Gaffer/Loop.h"
+#include "Gaffer/MetadataAlgo.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -70,6 +71,12 @@ class LoopPlugAdder : public PlugAdder
 			{
 				return false;
 			}
+
+			if( MetadataAlgo::readOnly( m_node.get() ) )
+			{
+				return false;
+			}
+
 			return runTimeCast<const ValuePlug>( endpoint );
 		}
 

--- a/src/GafferUI/NameSwitchUI.cpp
+++ b/src/GafferUI/NameSwitchUI.cpp
@@ -70,6 +70,11 @@ class NameSwitchPlugAdder : public PlugAdder
 				return false;
 			}
 
+			if( MetadataAlgo::readOnly( m_plug.get() ) )
+			{
+				return false;
+			}
+
 			// Assume that if the first plug wouldn't accept the input,
 			// then neither would the new one that we add.
 

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -122,11 +122,11 @@ bool StandardNodule::canCreateConnection( const Gaffer::Plug *endpoint ) const
 
 	if( localPlug->direction() == Gaffer::Plug::Direction::In )
 	{
-		return localPlug->acceptsInput( endpoint );
+		return localPlug->acceptsInput( endpoint ) && !Gaffer::MetadataAlgo::readOnly( localPlug );
 	}
 	else
 	{
-		return endpoint->acceptsInput( localPlug );
+		return endpoint->acceptsInput( localPlug ) && !Gaffer::MetadataAlgo::readOnly( endpoint );
 	}
 }
 

--- a/src/GafferUI/SwitchUI.cpp
+++ b/src/GafferUI/SwitchUI.cpp
@@ -39,6 +39,7 @@
 #include "GafferUI/PlugAdder.h"
 
 #include "Gaffer/ArrayPlug.h"
+#include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameSwitch.h"
 #include "Gaffer/NameValuePlug.h"
 #include "Gaffer/ScriptNode.h"
@@ -72,7 +73,7 @@ class SwitchPlugAdder : public PlugAdder
 
 		bool canCreateConnection( const Plug *endpoint ) const override
 		{
-			return PlugAdder::canCreateConnection( endpoint );
+			return PlugAdder::canCreateConnection( endpoint ) && !Gaffer::MetadataAlgo::readOnly( m_switch.get() );
 		}
 
 		void createConnection( Plug *endpoint ) override


### PR DESCRIPTION
Couple of small changes to hopefully reduce confusion when folks are presented with a read-only graph.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/1133871/188618173-23d1ee50-14ff-404c-b0e9-e74f6c8638ef.png">
