### PR TITLE
SConstruct : Fix stale file substitutions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1519,11 +1519,11 @@ for libraryName, libraryDef in libraries.items() :
 	# header install
 
 	fileSubstitutions = {
-		"!GAFFER_MILESTONE_VERSION!" : "$GAFFER_MILESTONE_VERSION",
-		"!GAFFER_MAJOR_VERSION!" : "$GAFFER_MAJOR_VERSION",
-		"!GAFFER_MINOR_VERSION!" : "$GAFFER_MINOR_VERSION",
-		"!GAFFER_PATCH_VERSION!" : "$GAFFER_PATCH_VERSION",
-		"!GAFFER_VERSION_SUFFIX!" : "$GAFFER_VERSION_SUFFIX",
+		"!GAFFER_MILESTONE_VERSION!" : libEnv.subst( "$GAFFER_MILESTONE_VERSION" ),
+		"!GAFFER_MAJOR_VERSION!" : libEnv.subst( "$GAFFER_MAJOR_VERSION" ),
+		"!GAFFER_MINOR_VERSION!" : libEnv.subst( "$GAFFER_MINOR_VERSION" ),
+		"!GAFFER_PATCH_VERSION!" : libEnv.subst( "$GAFFER_PATCH_VERSION" ),
+		"!GAFFER_VERSION_SUFFIX!" : libEnv.subst( "$GAFFER_VERSION_SUFFIX" ),
 	}
 
 	def processHeaders( env, libraryName ) :


### PR DESCRIPTION
SCons wasn't noticing changes to the file substitutions, presumably because of the extra level of indirection through the variable substitutions. This led to stale version numbers being baked into headers and the `About` module, which in turn put the wrong version number in the Gaffer title. Performing the substitution ourselves beforehand fixes this.

