### PR TITLE
BackdropNodeGadget : Fix threshold for hovering on top edge

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - EditScope : Fixed mislocated plug nodules when connecting a new `EditScope` to a `BoxIn`, `BoxOut` or `Box` node.
+- Backdrop : Fixed bug selecting or moving a backdrop when zoomed out in the GraphEditor, where drag-resizing the top edge was incorrectly being given precedence.
 
 1.0.4.0 (relative to 1.0.3.0)
 =======

--- a/src/GafferUI/BackdropNodeGadget.cpp
+++ b/src/GafferUI/BackdropNodeGadget.cpp
@@ -518,9 +518,6 @@ float BackdropNodeGadget::hoverWidth() const
 
 void BackdropNodeGadget::hoveredEdges( const ButtonEvent &event, int &horizontal, int &vertical ) const
 {
-	const Backdrop *backdrop = static_cast<const Backdrop *>( node() );
-	const float scale = backdrop->scalePlug()->getValue();
-
 	const Box2f b = getBound();
 
 	const V3f &p = event.line.p0;
@@ -541,7 +538,7 @@ void BackdropNodeGadget::hoveredEdges( const ButtonEvent &event, int &horizontal
 	{
 		vertical = -1;
 	}
-	else if( fabs( p.y - b.max.y ) < std::min( width, 0.25f * g_margin * scale ) )
+	else if( fabs( p.y - b.max.y ) < std::min( width, g_titleBarMargin ) )
 	{
 		vertical = 1;
 	}


### PR DESCRIPTION
This should have been changed when the title bar was introduced in 4a833b112fce4be02a9c9670df746ee5211bc0a1. When the backdrop scale was set above `1.0` and the GraphEditor was zoomed out, the threshold was so large that it was impossible to select the title bar.

I don't know if folks might prefer the rules to be tweaked so that select/drag is given greater precedence than resizing somehow, but this at least fixes a legitimate bug and put them both on an even footing.

The script I've been testing with is below - when zoomed out to show all backdrops, it was impossible to backdrops with the larger scale values.

<details>

```
import Gaffer
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 0, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["Backdrop"] = Gaffer.Backdrop( "Backdrop" )
parent.addChild( __children["Backdrop"] )
__children["Backdrop"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop1"] = Gaffer.Backdrop( "Backdrop1" )
parent.addChild( __children["Backdrop1"] )
__children["Backdrop1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop1"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop2"] = Gaffer.Backdrop( "Backdrop2" )
parent.addChild( __children["Backdrop2"] )
__children["Backdrop2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop2"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop3"] = Gaffer.Backdrop( "Backdrop3" )
parent.addChild( __children["Backdrop3"] )
__children["Backdrop3"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop3"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop4"] = Gaffer.Backdrop( "Backdrop4" )
parent.addChild( __children["Backdrop4"] )
__children["Backdrop4"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop4"].addChild( Gaffer.Box2fPlug( "__uiBound", defaultValue = imath.Box2f( imath.V2f( -10, -10 ), imath.V2f( 10, 10 ) ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Backdrop"]["__uiPosition"].setValue( imath.V2f( -78.0102539, -20.6657429 ) )
__children["Backdrop"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -117.566849, -80.2190247 ), imath.V2f( 16.1086426, 31.4921875 ) ) )
__children["Backdrop1"]["scale"].setValue( 8.0 )
__children["Backdrop1"]["__uiPosition"].setValue( imath.V2f( 209.852493, -21.0240974 ) )
__children["Backdrop1"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -10.1086426, -81.0847321 ), imath.V2f( 107.71962, 31.4921875 ) ) )
__children["Backdrop2"]["scale"].setValue( 2.0 )
__children["Backdrop2"]["__uiPosition"].setValue( imath.V2f( -43.7364426, -20.7096901 ) )
__children["Backdrop2"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -10.1086426, -81.0847321 ), imath.V2f( 107.71962, 31.4921875 ) ) )
__children["Backdrop3"]["scale"].setValue( 4.0 )
__children["Backdrop3"]["__uiPosition"].setValue( imath.V2f( 81.9468536, -20.4968834 ) )
__children["Backdrop3"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -10.1086426, -81.0847321 ), imath.V2f( 107.71962, 30.4885979 ) ) )
__children["Backdrop4"]["scale"].setValue( 16.0 )
__children["Backdrop4"]["__uiPosition"].setValue( imath.V2f( 333.908722, -21.6228676 ) )
__children["Backdrop4"]["__uiBound"].setValue( imath.Box2f( imath.V2f( -10.1086426, -81.0847321 ), imath.V2f( 107.71962, 31.4921875 ) ) )


del __children

```

</details>