### PR TITLE
`OptionTweaks` and `OptionQuery`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Features
 
 - Edit Menu : Added "Duplicate with Inputs" menu item, with <kbd>Ctrl</kbd>+<kbd>D</kbd> shortcut.
 - StandardAttributes : Added `automaticInstancing` plug to allow instancing to be disabled on selected locations. Currently supported only by the Arnold renderer.
+- OptionTweaks : Added node for tweaking options in a scene.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Features
 - Edit Menu : Added "Duplicate with Inputs" menu item, with <kbd>Ctrl</kbd>+<kbd>D</kbd> shortcut.
 - StandardAttributes : Added `automaticInstancing` plug to allow instancing to be disabled on selected locations. Currently supported only by the Arnold renderer.
 - OptionTweaks : Added node for tweaking options in a scene.
+- OptionQuery : Added node for querying options from a scene.
 
 Fixes
 -----

--- a/include/GafferScene/OptionQuery.h
+++ b/include/GafferScene/OptionQuery.h
@@ -1,0 +1,113 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_OPTIONQUERY_H
+#define GAFFERSCENE_OPTIONQUERY_H
+
+#include "GafferScene/Export.h"
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/TypeIds.h"
+
+#include "Gaffer/ArrayPlug.h"
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/NameValuePlug.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+#include <string>
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API OptionQuery : public Gaffer::ComputeNode
+{
+	public :
+		OptionQuery( const std::string& name = defaultName< OptionQuery >() );
+		~OptionQuery() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::OptionQuery, OptionQueryTypeId, Gaffer::ComputeNode );
+
+		ScenePlug *scenePlug();
+		const ScenePlug *scenePlug() const;
+
+		Gaffer::ArrayPlug *queriesPlug();
+		const Gaffer::ArrayPlug *queriesPlug() const;
+
+		Gaffer::ArrayPlug *outPlug();
+		const Gaffer::ArrayPlug *outPlug() const;
+
+		/// Adds a query for option, with a type and default value specified by plug.
+		/// The returned NameValuePlug is parented to queriesPlug() and may be edited
+		/// subsequently to modify the option name and default. Corresponding children
+		/// are added to existsPlug() and valuePlug() to provide the output from the query.
+		Gaffer::NameValuePlug *addQuery(
+			const Gaffer::ValuePlug *plug,
+			const std::string &option = ""
+		);
+		/// Removes a query. Throws an Exception if the query or corresponding children
+		/// of `valuesPlug()` and `existsPlug()` can not be deleted.
+		void removeQuery( Gaffer::NameValuePlug *plug );
+
+		void affects( const Gaffer::Plug* input, AffectedPlugsContainer& outputs ) const override;
+
+		/// Returns the `exists`, `value` or child of `out` corresponding to the specified
+		/// query plug. Throws an exception if the query does not exist or the corresponding output
+		/// plug does not exist or is the wrong type.
+		const Gaffer::BoolPlug *existsPlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const;
+		const Gaffer::ValuePlug *valuePlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const;
+		const Gaffer::ValuePlug *outPlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const;
+
+		/// Returns the child of `queryPlug` or `outPlug` corresponding to the `outputPlug`.
+		/// `outputPlug` can be any descendant of the desired ancestor.
+		/// Throws an exception if there is no corresponding query or the result is the wrong type.
+		const Gaffer::NameValuePlug *queryPlug( const Gaffer::ValuePlug *outputPlug ) const;
+		const Gaffer::ValuePlug *outPlug( const Gaffer::ValuePlug *outputPlug ) const;
+
+	protected :
+
+		void hash( const Gaffer::ValuePlug* output, const Gaffer::Context* context, IECore::MurmurHash& h ) const override;
+		void compute( Gaffer::ValuePlug* output, const Gaffer::Context* context ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+};
+
+IE_CORE_DECLAREPTR( OptionQuery )
+
+} // GafferScene
+
+#endif // GAFFERSCENE_OPTIONQUERY_H

--- a/include/GafferScene/OptionTweaks.h
+++ b/include/GafferScene/OptionTweaks.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,30 +34,48 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include <boost/algorithm/string.hpp>
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_OPTIONTWEAKS_H
+#define GAFFERSCENE_OPTIONTWEAKS_H
 
-#include "TweaksBinding.h"
+#include "GafferScene/Export.h"
+#include "GafferScene/GlobalsProcessor.h"
+#include "GafferScene/TypeIds.h"
 
-#include "GafferScene/AttributeTweaks.h"
-#include "GafferScene/CameraTweaks.h"
-#include "GafferScene/OptionTweaks.h"
-#include "GafferScene/ShaderTweaks.h"
+#include "Gaffer/TweakPlug.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-#include "GafferBindings/PlugBinding.h"
-#include "GafferBindings/SerialisationBinding.h"
-#include "GafferBindings/ValuePlugBinding.h"
-
-using namespace boost::python;
-using namespace Gaffer;
-using namespace GafferBindings;
-using namespace GafferScene;
-
-void GafferSceneModule::bindTweaks()
+namespace GafferScene
 {
-	DependencyNodeClass<ShaderTweaks>();
-	DependencyNodeClass<CameraTweaks>();
-	DependencyNodeClass<AttributeTweaks>();
-	DependencyNodeClass<OptionTweaks>();
-}
+
+class GAFFERSCENE_API OptionTweaks : public GlobalsProcessor
+{
+
+	public :
+
+		OptionTweaks( const std::string &name=defaultName<OptionTweaks>() );
+		~OptionTweaks() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::OptionTweaks, OptionTweaksTypeId, GlobalsProcessor );
+
+		Gaffer::BoolPlug *ignoreMissingPlug();
+		const Gaffer::BoolPlug *ignoreMissingPlug() const;
+
+		Gaffer::TweaksPlug *tweaksPlug();
+		const Gaffer::TweaksPlug *tweaksPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+};
+
+IE_CORE_DECLAREPTR( OptionTweaks )
+
+}  // namespace GafferScene
+
+#endif // GAFFERSCENE_OPTIONTWEAKS_H

--- a/include/GafferScene/ShaderQuery.h
+++ b/include/GafferScene/ShaderQuery.h
@@ -79,8 +79,6 @@ class GAFFERSCENE_API ShaderQuery : public Gaffer::ComputeNode
 		/// The returned NameValuePlug is parented to queriesPlug() and may be edited
 		/// subsequently to modify the parameter name and default. Corresponding children
 		/// are added to existsPlug() and valuePlug() to provide the output from the query.
-		/// Note : `querySuffixOverride` should only be used by the serialiser. It should be
-		/// omitted from calls for normal usage.
 		Gaffer::NameValuePlug *addQuery(
 			const Gaffer::ValuePlug *plug,
 			const std::string &parameter = ""

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -168,6 +168,7 @@ enum TypeId
 	CryptomatteTypeId = 110623,
 	ShaderQueryTypeId = 110624,
 	AttributeTweaksTypeId = 110625,
+	OptionTweaksTypeId = 110626,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -169,6 +169,7 @@ enum TypeId
 	ShaderQueryTypeId = 110624,
 	AttributeTweaksTypeId = 110625,
 	OptionTweaksTypeId = 110626,
+	OptionQueryTypeId = 110627,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/python/GafferSceneTest/OptionQueryTest.py
+++ b/python/GafferSceneTest/OptionQueryTest.py
@@ -1,0 +1,353 @@
+#########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+
+class OptionQueryTest( GafferSceneTest.SceneTestCase ):
+
+	def testDefault( self ) :
+
+		q = GafferScene.OptionQuery()
+
+		self.assertEqual( len( q["queries"].children() ), 0 )
+		self.assertEqual( len( q["out"].children() ), 0 )
+
+	def testOutput( self ) :
+
+		query = GafferScene.OptionQuery()
+
+		n1 = query.addQuery( Gaffer.IntPlug() )
+		n2 = query.addQuery( Gaffer.Color3fPlug() )
+		n3 = query.addQuery( Gaffer.Box2iPlug() )
+		badPlug = Gaffer.NameValuePlug( "missing", Gaffer.Color3fPlug(), "badPlug" )
+
+		self.assertEqual( query.outPlugFromQuery( n1 ), query["out"][0] )
+		self.assertEqual( query.outPlugFromQuery( n2 ), query["out"][1] )
+		self.assertEqual( query.outPlugFromQuery( n3 ), query["out"][2] )
+
+		self.assertEqual( query.existsPlugFromQuery( n1 ), query["out"][0]["exists"] )
+		self.assertEqual( query.existsPlugFromQuery( n2 ), query["out"][1]["exists"] )
+		self.assertEqual( query.existsPlugFromQuery( n3 ), query["out"][2]["exists"] )
+
+		self.assertEqual( query.valuePlugFromQuery( n1 ), query["out"][0]["value"] )
+		self.assertEqual( query.valuePlugFromQuery( n2 ), query["out"][1]["value"] )
+		self.assertEqual( query.valuePlugFromQuery( n3 ), query["out"][2]["value"] )
+
+		self.assertEqual( query.queryPlug( query["out"][0]["value"] ), n1 )
+		self.assertEqual( query.queryPlug( query["out"][1]["value"] ), n2 )
+		self.assertEqual( query.queryPlug( query["out"][1]["value"]["r"] ), n2 )
+		self.assertEqual( query.queryPlug( query["out"][2]["value"] ), n3 )
+		self.assertEqual( query.queryPlug( query["out"][2]["value"]["min"] ), n3 )
+		self.assertEqual( query.queryPlug( query["out"][2]["value"]["min"]["x"] ), n3 )
+		self.assertRaises( IECore.Exception, query.queryPlug, badPlug )
+
+	def testAddRemoveQuery( self ) :
+
+		def checkChildrenCount( plug, count ) :
+			self.assertEqual( len( plug["queries"].children() ), count )
+			self.assertEqual( len( plug["out"].children() ), count )
+
+		query = GafferScene.OptionQuery()
+
+		checkChildrenCount( query, 0 )
+
+		a = query.addQuery( Gaffer.IntPlug() )
+		checkChildrenCount( query, 1 )
+		self.assertEqual( query["queries"][0]["name"].getValue(), "" )
+		self.assertEqual( query["queries"][0]["value"].getValue(), 0 )
+		self.assertEqual( query["out"][0]["exists"].typeId(), Gaffer.BoolPlug.staticTypeId() )
+		self.assertEqual( query["out"][0]["value"].typeId(), Gaffer.IntPlug.staticTypeId() )
+
+		b = query.addQuery( Gaffer.Color3fPlug( "c3f" ), "c" )
+		checkChildrenCount( query, 2 )
+		self.assertEqual( query["queries"].children(), ( a, b ) )
+		self.assertEqual( query["queries"][1]["name"].getValue(), "c" )
+		self.assertEqual( query["queries"][1]["value"].getValue(), imath.Color3f() )
+		self.assertEqual( query["out"][0]["value"].typeId(), Gaffer.IntPlug.staticTypeId() )
+		self.assertEqual( query["out"][1]["value"].typeId(), Gaffer.Color3fPlug.staticTypeId() )
+		for i in range( 0, 2) :
+			self.assertEqual( query["out"][i]["exists"].typeId(), Gaffer.BoolPlug.staticTypeId() )
+
+		c = query.addQuery( Gaffer.Box2iPlug( "b2i", Gaffer.Plug.Direction.Out, imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) ), "b" )
+		checkChildrenCount( query, 3 )
+		self.assertEqual( query["queries"].children(), ( a, b, c ) )
+		self.assertEqual( query["queries"][2]["name"].getValue(), "b" )
+		self.assertEqual( query["queries"][2]["value"].getValue(), imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) )
+		self.assertEqual( query["out"][0]["value"].typeId(), Gaffer.IntPlug.staticTypeId() )
+		self.assertEqual( query["out"][1]["value"].typeId(), Gaffer.Color3fPlug.staticTypeId() )
+		self.assertEqual( query["out"][2]["value"].typeId(), Gaffer.Box2iPlug.staticTypeId() )
+		for i in range( 0, 3) :
+			self.assertEqual( query["out"][i]["exists"].typeId(), Gaffer.BoolPlug.staticTypeId() )
+
+		query.removeQuery( b )
+		checkChildrenCount( query, 2 )
+		self.assertEqual( query["queries"].children(), ( a, c ) )
+		self.assertEqual( query["out"][0]["value"].typeId(), Gaffer.IntPlug.staticTypeId() )
+		self.assertEqual( query["out"][1]["value"].typeId(), Gaffer.Box2iPlug.staticTypeId() )
+		for i in range( 0, 2) :
+			self.assertEqual( query["out"][i]["exists"].typeId(), Gaffer.BoolPlug.staticTypeId() )
+
+		query.removeQuery( c )
+		checkChildrenCount( query, 1 )
+		query.removeQuery( a )
+		checkChildrenCount( query, 0 )
+
+	def testExists( self ) :
+
+		options = GafferScene.CustomOptions()
+
+		query = GafferScene.OptionQuery()
+		query["scene"].setInput( options["out"] )
+
+		q1 = query.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "i" )
+		q2 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 1.0, 1.0, 1.0 ) ), "c1" )
+		q3 = query.addQuery( Gaffer.FloatPlug( "f", Gaffer.Plug.Direction.Out, 0.5 ), "missing" )
+
+		self.assertFalse( query["out"][0]["exists"].getValue() )
+		self.assertFalse( query["out"][1]["exists"].getValue() )
+		self.assertFalse( query["out"][2]["exists"].getValue() )
+
+		options["options"].addChild( Gaffer.NameValuePlug( "i", IECore.IntData( 10 ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c1", IECore.Color3fData( imath.Color3f( 0.5 ) ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c2", IECore.Color3fData( imath.Color3f( 0.5 ) ) ) )
+
+		self.assertTrue( query["out"][0]["exists"].getValue() )
+		self.assertTrue( query["out"][1]["exists"].getValue() )
+		self.assertFalse( query["out"][2]["exists"].getValue() )
+
+		query.removeQuery( q2 )
+		self.assertTrue( query["out"][0]["exists"].getValue() )
+		self.assertFalse( query["out"][1]["exists"].getValue() )
+
+		e4 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 1.0, 1.0, 1.0 ) ), "c2" )
+
+		self.assertTrue( query["out"][2]["exists"].getValue() )
+
+	def testValues( self ) :
+
+		options = GafferScene.CustomOptions()
+
+		query = GafferScene.OptionQuery()
+		query["scene"].setInput( options["out"] )
+
+		q1 = query.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "i" )
+		q2 = query.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "m" )
+		q3 = query.addQuery( Gaffer.Box2iPlug( "b2i", Gaffer.Plug.Direction.Out, imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) ), "b" )
+		q4 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 0.1, 0.2, 0.3 ) ), "c1" )
+
+		self.assertEqual( query["out"][0]["value"].getValue(), 1 )
+		self.assertEqual( query["out"][1]["value"].getValue(), 1 )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) )
+		self.assertEqual( query["out"][3]["value"].getValue(), imath.Color3f( 0.1, 0.2, 0.3 ) )
+
+		options["options"].addChild( Gaffer.NameValuePlug( "i", IECore.IntData( 2 ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "b", IECore.Box2iData( imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c1", IECore.Color3fData( imath.Color3f( 0.4, 0.5, 0.6 ) ) ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c2", IECore.Color3fData( imath.Color3f( 0.7, 0.8, 0.9 ) ) ) )
+
+		self.assertEqual( query["out"][0]["value"].getValue(), 2 )
+		self.assertEqual( query["out"][1]["value"].getValue(), 1 )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertEqual( query["out"][3]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+
+		query.removeQuery( q3 )
+		self.assertEqual( query["out"][0]["value"].getValue(), 2 )
+		self.assertEqual( query["out"][1]["value"].getValue(), 1 )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+
+		v5 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 0.5 ) ), "c2" )
+
+		self.assertEqual( query["out"][3]["value"].getValue(), imath.Color3f( 0.7, 0.8, 0.9 ) )
+
+	def testChangeOptionValue( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "i", IECore.IntData( 2 ), "i" ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "b", IECore.Box2iData( imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) ), "b" ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c", IECore.Color3fData( imath.Color3f( 0.4, 0.5, 0.6 ) ), "c" ) )
+
+		q = GafferScene.OptionQuery()
+		q["scene"].setInput( options["out"] )
+
+		q1 = q.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "i" )
+		q2 = q.addQuery( Gaffer.Box2iPlug( "b2i", Gaffer.Plug.Direction.Out, imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) ), "b" )
+		q3 = q.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 0.1, 0.2, 0.3 ) ), "c" )
+
+		self.assertTrue( q["out"][0]["exists"].getValue() )
+		self.assertEqual( q["out"][0]["value"].getValue(), 2)
+		self.assertTrue( q["out"][1]["exists"].getValue() )
+		self.assertEqual( q["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( q["out"][2]["exists"].getValue() )
+		self.assertEqual( q["out"][2]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+
+		options["options"]["i"]["value"].setValue( 3 )
+		options["options"]["b"]["value"].setValue( imath.Box2i( imath.V2i( 5 ), imath.V2i( 6 ) ) )
+		options["options"]["c"]["value"].setValue( imath.Color3f( 1.0, 1.1, 1.2 ) )
+
+		self.assertTrue( q["out"][0]["exists"].getValue() )
+		self.assertEqual( q["out"][0]["value"].getValue(), 3)
+		self.assertTrue( q["out"][1]["exists"].getValue() )
+		self.assertEqual( q["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 5 ), imath.V2i( 6 ) ) )
+		self.assertTrue( q["out"][2]["exists"].getValue() )
+		self.assertEqual( q["out"][2]["value"].getValue(), imath.Color3f( 1.0, 1.1, 1.2 ) )
+
+	def testChangeDefault( self ) :
+
+		options = GafferScene.CustomOptions()
+
+		query = GafferScene.OptionQuery()
+		query["scene"].setInput( options["out"] )
+
+		q1 = query.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "i" )
+		q2 = query.addQuery( Gaffer.Box2iPlug( "b2i", Gaffer.Plug.Direction.Out, imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) ), "b" )
+		q3 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 0.1, 0.2, 0.3 ) ), "c" )
+
+		self.assertFalse( query["out"][0]["exists"].getValue() )
+		self.assertEqual( query["out"][0]["value"].getValue(), 1)
+		self.assertFalse( query["out"][1]["exists"].getValue() )
+		self.assertEqual( query["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) )
+		self.assertFalse( query["out"][2]["exists"].getValue() )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Color3f( 0.1, 0.2, 0.3 ) )
+
+		q1["value"].setValue( 3 )
+		q2["value"].setValue( imath.Box2i( imath.V2i( 5 ), imath.V2i( 6 ) ) )
+		q3["value"].setValue( imath.Color3f( 1.0, 1.1, 1.2 ) )
+
+		self.assertFalse( query["out"][0]["exists"].getValue() )
+		self.assertEqual( query["out"][0]["value"].getValue(), 3)
+		self.assertFalse( query["out"][1]["exists"].getValue() )
+		self.assertEqual( query["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 5 ), imath.V2i( 6 ) ) )
+		self.assertFalse( query["out"][2]["exists"].getValue() )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Color3f( 1.0, 1.1, 1.2 ) )
+
+	def testSerialisation( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "i", IECore.IntData( 2 ), "i", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "b", IECore.Box2iData( imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) ), "b", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		options["options"].addChild( Gaffer.NameValuePlug( "c", IECore.Color3fData( imath.Color3f( 0.4, 0.5, 0.6 ) ), "c", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		query = GafferScene.OptionQuery()
+		query["scene"].setInput( options["out"] )
+
+		q1 = query.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "i" )
+		q2 = query.addQuery( Gaffer.Box2iPlug( "b2i", Gaffer.Plug.Direction.Out, imath.Box2i( imath.V2i( 1 ), imath.V2i( 2 ) ) ), "b" )
+		q3 = query.addQuery( Gaffer.Color3fPlug( "c3f", Gaffer.Plug.Direction.Out, imath.Color3f( 0.1, 0.2, 0.3 ) ), "c" )
+
+		self.assertTrue( query["out"][0]["exists"].getValue() )
+		self.assertEqual( query["out"][0]["value"].getValue(), 2)
+		self.assertTrue( query["out"][1]["exists"].getValue() )
+		self.assertEqual( query["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( query["out"][2]["exists"].getValue() )
+		self.assertEqual( query["out"][2]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+
+		target = GafferScene.CustomOptions( "target" )
+		target["options"].addChild( Gaffer.NameValuePlug( "i", IECore.IntData( 3 ), "i", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		target["options"].addChild( Gaffer.NameValuePlug( "b", IECore.Box2iData( imath.Box2i( imath.V2i( 5 ), imath.V2i( 6 ) ) ), "b", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		target["options"].addChild( Gaffer.NameValuePlug( "c", IECore.Color3fData( imath.Color3f( 0.7, 0.8, 0.9 ) ), "c", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		target["options"].addChild( Gaffer.NameValuePlug( "bool", IECore.BoolData( False ), "bool", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		target["options"]["i"]["value"].setInput( query["out"][0]["value"] )
+		target["options"]["b"]["value"].setInput( query["out"][1]["value"] )
+		target["options"]["c"]["value"].setInput( query["out"][2]["value"] )
+		target["options"]["bool"]["value"].setInput( query["out"][0]["exists"] )
+
+		scriptNode = Gaffer.ScriptNode()
+		scriptNode.addChild( options )
+		scriptNode.addChild( query )
+		scriptNode.addChild( target )
+
+		self.assertTrue( scriptNode["OptionQuery"]["out"][0]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][0]["value"].getValue(), 2)
+		self.assertTrue( scriptNode["OptionQuery"]["out"][1]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( scriptNode["OptionQuery"]["out"][2]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][2]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+		self.assertEqual( scriptNode["target"]["options"]["i"]["value"].getInput(), query["out"][0]["value"] )
+		self.assertEqual( scriptNode["target"]["options"]["b"]["value"].getInput(), query["out"][1]["value"] )
+		self.assertEqual( scriptNode["target"]["options"]["c"]["value"].getInput(), query["out"][2]["value"] )
+		self.assertEqual( scriptNode["target"]["options"]["bool"]["value"].getInput(), query["out"][0]["exists"] )
+
+		serialised = scriptNode.serialise()
+
+		scriptNode = Gaffer.ScriptNode()
+		scriptNode.execute( serialised )
+
+		self.assertTrue( scriptNode["OptionQuery"]["out"][0]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][0]["value"].getValue(), 2)
+		self.assertTrue( scriptNode["OptionQuery"]["out"][1]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][1]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( scriptNode["OptionQuery"]["out"][2]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][2]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["i"]["value"].getInput() ), str( query["out"][0]["value"] ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["b"]["value"].getInput() ), str( query["out"][1]["value"] ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["c"]["value"].getInput() ), str( query["out"][2]["value"] ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["bool"]["value"].getInput() ), str( query["out"][0]["exists"] ) )
+
+		scriptNode["OptionQuery"].removeQuery( scriptNode["OptionQuery"]["queries"][0] )
+
+		self.assertTrue( scriptNode["OptionQuery"]["out"][0]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][0]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( scriptNode["OptionQuery"]["out"][1]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][1]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+		self.assertIsNone( scriptNode["target"]["options"]["i"]["value"].getInput() )
+		self.assertIsNone( scriptNode["target"]["options"]["bool"]["value"].getInput() )
+		self.assertEqual( str( scriptNode["target"]["options"]["b"]["value"].getInput() ), str( query["out"][1]["value"] ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["c"]["value"].getInput() ), str( query["out"][2]["value"] ) )
+
+		serialised = scriptNode.serialise()
+
+		scriptNode = Gaffer.ScriptNode()
+		scriptNode.execute( serialised )
+
+		self.assertTrue( scriptNode["OptionQuery"]["out"][0]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][0]["value"].getValue(), imath.Box2i( imath.V2i( 3 ), imath.V2i( 4 ) ) )
+		self.assertTrue( scriptNode["OptionQuery"]["out"][1]["exists"].getValue() )
+		self.assertEqual( scriptNode["OptionQuery"]["out"][1]["value"].getValue(), imath.Color3f( 0.4, 0.5, 0.6 ) )
+		self.assertIsNone( scriptNode["target"]["options"]["i"]["value"].getInput() )
+		self.assertIsNone( scriptNode["target"]["options"]["bool"]["value"].getInput() )
+		self.assertEqual( str( scriptNode["target"]["options"]["b"]["value"].getInput() ), str( query["out"][1]["value"] ) )
+		self.assertEqual( str( scriptNode["target"]["options"]["c"]["value"].getInput() ), str( query["out"][2]["value"] ) )
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/OptionTweaksTest.py
+++ b/python/GafferSceneTest/OptionTweaksTest.py
@@ -1,0 +1,145 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import unittest
+import six
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class OptionTweaksTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "test", IECore.IntData( 10 ) ) )
+
+		tweaks = GafferScene.OptionTweaks()
+		tweaks["in"].setInput( options["out"] )
+
+		self.assertSceneValid( tweaks["out"] )
+		self.assertScenesEqual( tweaks["out"], options["out"] )
+		self.assertSceneHashesEqual( tweaks["out"], options["out"] )
+		self.assertEqual( options["out"]["globals"].getValue()["option:test"], IECore.IntData( 10 ) )
+
+		testTweak = Gaffer.TweakPlug( "test", 5 )
+		tweaks["tweaks"].addChild( testTweak )
+
+		self.assertSceneValid( tweaks["out"] )
+
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 5 ) )
+
+		testTweak["value"].setValue( 2 )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 2 ) )
+
+		testTweak["enabled"].setValue( False )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 10 ) )
+
+		testTweak["enabled"].setValue( True )
+		testTweak["mode"].setValue( testTweak.Mode.Add )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 12 ) )
+
+		testTweak["mode"].setValue( testTweak.Mode.Subtract )
+		testTweak["value"].setValue( 1 )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 9 ) )
+
+		testTweak["mode"].setValue( testTweak.Mode.Multiply )
+		testTweak["value"].setValue( 3 )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 30 ) )
+
+	def testSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["t"] = GafferScene.OptionTweaks()
+		s["t"]["tweaks"].addChild( Gaffer.TweakPlug( "test", 1.0 ) )
+		s["t"]["tweaks"].addChild( Gaffer.TweakPlug( "test", imath.Color3f( 1, 2, 3 ) ) )
+
+		ss = Gaffer.ScriptNode()
+		ss.execute( s.serialise() )
+
+		self.assertEqual( len( ss["t"]["tweaks"].children() ), len( s["t"]["tweaks"].children() ) )
+
+		for i in range( 0, len( s["t"]["tweaks"] ) ) :
+			for n in s["t"]["tweaks"][i].keys() :
+				self.assertEqual( ss["t"]["tweaks"][i][n].getValue(), s["t"]["tweaks"][i][n].getValue() )
+
+	def testIgnoreMissing( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "test", IECore.IntData( 10 ) ) )
+
+		tweaks = GafferScene.OptionTweaks()
+		tweaks["in"].setInput( options["out"] )
+
+		tweak = Gaffer.TweakPlug( "badOption", 1 )
+		tweaks["tweaks"].addChild( tweak )
+
+		with six.assertRaisesRegex( self, RuntimeError, "Cannot apply tweak with mode Replace to \"badOption\" : This parameter does not exist" ) :
+			tweaks["out"]["globals"].getValue()
+
+		tweaks["ignoreMissing"].setValue( True )
+		self.assertNotIn( "option:badOption", tweaks["out"]["globals"].getValue() )
+		self.assertEqual( tweaks["out"]["globals"].getValue(), tweaks["in"]["globals"].getValue() )
+
+		tweak["name"].setValue( "test" )
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 1 ) )
+
+		tweak["name"].setValue( "badOption.p" )
+		self.assertNotIn( "option:badOption.p", tweaks["out"]["globals"].getValue() )
+		self.assertEqual( tweaks["out"]["globals"].getValue(), tweaks["in"]["globals"].getValue() )
+
+	def testCreateMode( self ) :
+
+		options = GafferScene.CustomOptions()
+
+		tweaks = GafferScene.OptionTweaks()
+		tweaks["in"].setInput( options["out"] )
+
+		self.assertNotIn( "option:test", tweaks["out"]["globals"].getValue() )
+
+		testTweak = Gaffer.TweakPlug( "test", 10 )
+		testTweak["mode"].setValue( Gaffer.TweakPlug.Mode.Create )
+		tweaks["tweaks"].addChild( testTweak )
+
+		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 10 ) )
+
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -160,6 +160,7 @@ from .NameSwitchTest import NameSwitchTest
 from .CryptomatteTest import CryptomatteTest
 from .ShaderQueryTest import ShaderQueryTest
 from .AttributeTweaksTest import AttributeTweaksTest
+from .OptionTweaksTest import OptionTweaksTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -161,6 +161,7 @@ from .CryptomatteTest import CryptomatteTest
 from .ShaderQueryTest import ShaderQueryTest
 from .AttributeTweaksTest import AttributeTweaksTest
 from .OptionTweaksTest import OptionTweaksTest
+from .OptionQueryTest import OptionQueryTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -1,0 +1,487 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import functools
+import six
+import collections
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferSceneUI
+
+##########################################################################
+# Internal utilities
+##########################################################################
+
+def __getLabel( plug, parentPlug = None ) :
+
+	prefix = ""
+	suffix = ""
+
+	n = plug.node()
+	qPlug = n.queryPlug( plug )
+
+	prefix = qPlug["name"].getValue() if qPlug["name"].getValue() != "" else "none"
+
+	if parentPlug is not None :
+		oPlug = n.outPlugFromQuery( qPlug )
+
+		currentPlug = plug
+		while (
+			currentPlug is not None and
+			currentPlug != oPlug
+		) :
+
+			suffix = "." + currentPlug.getName() + suffix
+			currentPlug = currentPlug.parent()
+
+	result = prefix + suffix
+
+	return result
+
+
+##########################################################################
+# Output widget
+##########################################################################
+
+class _OutputWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, childPlug, **kw ) :
+
+		self.__row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__row, childPlug )
+
+		nameWidget = GafferUI.LabelPlugValueWidget(
+			self.getPlugs(),
+			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
+		)
+		nameWidget.label()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+		self.__row.append(
+			nameWidget,
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+		)
+
+		existsLabelWidget = GafferUI.LabelPlugValueWidget(
+			{ plug["exists"] for plug in self.getPlugs() },
+			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
+		)
+		existsLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		self.__row.append(
+			existsLabelWidget,
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+		)
+
+		self.__row.append(
+			GafferUI.BoolPlugValueWidget( { plug["exists"] for plug in self.getPlugs() } ),
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+		)
+
+		valueLabelWidget = GafferUI.LabelPlugValueWidget(
+			{ plug["value"] for plug in self.getPlugs() },
+			horizontalAlignment = GafferUI.Label.HorizontalAlignment.Right
+		)
+		valueLabelWidget.label()._qtWidget().setFixedWidth( 40 )
+		self.__row.append(
+			valueLabelWidget,
+			verticalAlignment = GafferUI.Label.VerticalAlignment.Top
+		)
+
+		self.__row.append(
+			GafferUI.PlugValueWidget.create( { plug["value"] for plug in self.getPlugs() } )
+		)
+
+	def setPlugs( self, plugs ) :
+
+		GafferUI.PlugValueWidget.setPlugs( self, plugs )
+
+		self.__row[0].setPlugs( plugs )
+		self.__row[1].setPlugs( { plug["exists"] for plug in plugs } )
+		self.__row[2].setPlugs( { plug["exists"] for plug in plugs } )
+		self.__row[3].setPlugs( { plug["value"] for plug in plugs } )
+		self.__row[4].setPlugs( { plug["value"] for plug in plugs } )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def childPlugValueWidget( self, childPlug ) :
+
+		for w in self.__row :
+			if childPlug in w.getPlugs() :
+				return w
+
+		return None
+
+	def setReadOnly( self, readOnly ) :
+
+		if readOnly == self.getReadOnly() :
+			return
+
+		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
+
+		for w in self.__row :
+			w.setReadOnly( readOnly )
+
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.OptionQuery,
+
+	"description",
+	"""
+	Queries global scene options, creating an output for each option.
+	""",
+
+	plugs = {
+
+		"scene" : [
+
+			"description",
+			"""
+			The scene to query the options from.
+			""",
+
+		],
+
+		"queries" : [
+
+			"description",
+			"""
+			The options to be queried - arbitrary numbers of options may be added
+			as children of this plug via the user interface, or via python. Each
+			child is a `NameValuePlug` whose `name` plug is the option to query,
+			and whose `value` plug is the default value to use if the option can
+			not be retrieved.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"layout:customWidget:footer:widgetType", "GafferSceneUI.OptionQueryUI._OptionQueryFooter",
+			"layout:customWidget:footer:index", -1,
+
+			"nodule:type", "",
+
+		],
+
+		"queries.*" : [
+
+			"description",
+			"""
+			A pair of option name to query and default value.
+			""",
+
+		],
+
+		"queries.*.name" : [
+
+			"description",
+			"""
+			The name of the option to query.
+			""",
+
+		],
+
+		"queries.*.value" : [
+
+			"description",
+			"""
+			The value to output if the option does not exist.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The parent plug of the query outputs. The order of outputs corresponds
+			to the order of children of `queries`.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"layout:section", "Settings.Outputs",
+
+			"nodule:type", "GafferUI::CompoundNodule",
+			"noduleLayout:spacing", 0.4,
+			"noduleLayout:customGadget:addButton:gadgetType", "",
+
+		],
+
+		"out.*" : [
+
+			"description",
+			"""
+			The result of the query.
+			""",
+
+			"label", functools.partial( __getLabel, parentPlug = ""),
+
+			"plugValueWidget:type", "GafferSceneUI.OptionQueryUI._OutputWidget",
+
+			"nodule:type", "GafferUI::CompoundNodule",
+
+		],
+
+		"out.*.exists" : [
+
+			"description",
+			"""
+			Outputs true if the option exists, otherwise false.
+			""",
+
+			"noduleLayout:label", functools.partial( __getLabel, parentPlug = "exists" ),
+
+		],
+
+		"out.*.value" : [
+
+			"description",
+			"""
+			Outputs the value of the option, or the default value if the option
+			does not exist.
+			""",
+
+		],
+
+		"out.*.value..." : [
+
+			"noduleLayout:label", functools.partial( __getLabel, parentPlug = "values" ),
+
+		],
+
+	}
+)
+
+##########################################################################
+# Internal utilities
+##########################################################################
+
+def _optionQueryNode( plugValueWidget ) :
+
+	# The plug may not belong to a OptionQuery node
+	# directly. Instead it may have been promoted
+	# elsewhere and be driving a target plug on a
+	# OptionQuery node.
+
+	def walkOutputs( plug ) :
+
+		if isinstance( plug.node(), GafferScene.OptionQuery ) :
+			return plug.node()
+
+		for output in plug.outputs() :
+			node = walkOutputs( output )
+			if node is not None :
+				return node
+
+	return walkOutputs( plugValueWidget.getPlug() )
+
+##########################################################################
+# _OutputQueryFooter
+##########################################################################
+
+class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+			GafferUI.MenuButton(
+				image = "plus.png",
+				hasFrame = False,
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
+			)
+
+			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand": True } )
+
+		plug.node().plugSetSignal().connect(
+			Gaffer.WeakMethod( self.__updateQueryMetadata ),
+			scoped = False
+		)
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		result.append(
+			"/From Scene",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromGlobalsMenuDefinition )
+			}
+		)
+
+		result.append( "/FromPathsDivider", { "divider" : True } )
+
+		for item in [
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			"NumericDivider",
+			Gaffer.StringPlug,
+			"StringDivider",
+			Gaffer.V2iPlug,
+			Gaffer.V3iPlug,
+			Gaffer.V2fPlug,
+			Gaffer.V3fPlug,
+			"VectorDivider",
+			Gaffer.Color3fPlug,
+			Gaffer.Color4fPlug,
+		] :
+			if isinstance( item, six.string_types ) :
+				result.append( "/" + item, { "divider": True } )
+			else :
+				result.append(
+					"/" + item.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__addQuery ), "", "", item ),
+					}
+				)
+
+		return result
+
+	def __addFromGlobalsMenuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		node = _optionQueryNode( self )
+		options = {}
+
+		if node is not None :
+			with self.getContext() :
+				options = node["scene"]["globals"].getValue()
+
+		prefix = "option:"
+
+		options = collections.OrderedDict( ( k, v ) for k, v in options.items() if k.startswith( prefix ) )
+
+		for key, value in [ ( k, v ) for k, v in options.items() if k.replace( ':', '_' ) not in node["queries"] ] :
+			nameWithoutPrefix = key[ len( prefix ): ]
+			result.append(
+				"/" + nameWithoutPrefix,
+				{
+					"command" : functools.partial(
+						Gaffer.WeakMethod( self.__addQuery ),
+						key.replace( ':', '_' ),
+						nameWithoutPrefix,
+						value
+					)
+				}
+			)
+
+		if not len( result.items() ) :
+			result.append(
+				"/No Options Found", { "active" : False }
+			)
+			return result
+
+		return result
+
+	def __addQuery( self, plugName, optionName, plugTypeOrValue ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+
+			node = self.getPlug().node()
+
+			if isinstance( plugTypeOrValue, IECore.Data ) :
+				dummyPlug = Gaffer.PlugAlgo.createPlugFromData(
+					plugName,
+					Gaffer.Plug.Direction.In,
+					Gaffer.Plug.Flags.Default,
+					plugTypeOrValue
+				)
+				node.addQuery( dummyPlug, optionName )
+			else:
+				node.addQuery( plugTypeOrValue(), optionName )
+
+	def __updateQueryMetadata( self, plug ) :
+
+		node = plug.node()
+
+		if node["queries"].isAncestorOf( plug ) :
+
+			qPlug = plug.ancestor( Gaffer.NameValuePlug )
+
+			if qPlug is not None and qPlug["name"] == plug :
+
+				Gaffer.Metadata.plugValueChangedSignal( node )(
+					node.outPlugFromQuery( qPlug ),
+					"label",
+					Gaffer.Metadata.ValueChangedReason.StaticRegistration
+				)
+
+##########################################################################
+# Delete Plug
+##########################################################################
+
+
+def __plugPopupMenu( menuDefinition, plugValueWidget ) :
+
+	readOnlyUI = plugValueWidget.getReadOnly()
+	plug = plugValueWidget.getPlug().ancestor( Gaffer.NameValuePlug )
+
+	if plug is not None and isinstance( plug.node(), GafferScene.OptionQuery ) :
+
+		if len( menuDefinition.items() ) :
+			menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+
+		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not readOnlyUI and not Gaffer.MetadataAlgo.readOnly( plug ) } )
+
+def __deletePlug( plug ) :
+
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+		plug.node().removeQuery( plug )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -1,0 +1,236 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+import six
+import functools
+import collections
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.OptionTweaks,
+
+	"description",
+	"""
+	Makes modifications to options.
+	""",
+
+	plugs = {
+
+		"ignoreMissing" : [
+
+			"description",
+			"""
+			Ignores tweaks targeting missing options. When off, missing options
+			cause the node to error.
+			"""
+
+		],
+
+		"tweaks" : [
+
+			"description",
+			"""
+			The tweaks to be made to the options. Arbitrary numbers of user defined
+			tweaks may be added as children of this plug via the user interface, or
+			using the OptionTweaks API via python.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+			"layout:customWidget:footer:widgetType", "GafferSceneUI.OptionTweaksUI._TweaksFooter",
+			"layout:customWidget:footer:index", -1,
+
+			"nodule:type", "",
+
+		],
+
+		"tweaks.*" : [
+
+			"tweakPlugValueWidget:allowCreate", True,
+
+		],
+
+	}
+)
+
+##########################################################################
+# Internal utilities
+##########################################################################
+
+def _optionTweaksNode( plugValueWidget ) :
+
+	# The plug may not belong to an OptionTweaks node
+	# directly. Instead it may have been promoted
+	# elsewhere and be driving a target plug on an
+	# OptionTweaks node.
+
+	def walkOutputs( plug ) :
+
+		if isinstance( plug.node(), GafferScene.OptionTweaks ) :
+			return plug.node()
+
+		for output in plug.outputs() :
+			node = walkOutputs( output )
+			if node is not None :
+				return node
+
+	return walkOutputs( plugValueWidget.getPlug() )
+
+##########################################################################
+# _TweaksFooter
+##########################################################################
+
+class _TweaksFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+				GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+				GafferUI.MenuButton(
+					image = "plus.png",
+					hasFrame = False,
+					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
+				)
+
+				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
+
+	def _updateFromPlug( self ) :
+
+		self.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		result.append(
+			"/From Scene",
+			{
+				"subMenu" : Gaffer.WeakMethod( self.__addFromGlobalsMenuDefinition )
+			}
+		)
+
+		result.append( "/FromPathsDivider", { "divider" : True } )
+
+		# TODO - would be nice to share these default options with other users of TweakPlug
+		for item in [
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			"NumericDivider",
+			Gaffer.StringPlug,
+			"StringDivider",
+			Gaffer.V2iPlug,
+			Gaffer.V3iPlug,
+			Gaffer.V2fPlug,
+			Gaffer.V3fPlug,
+			"VectorDivider",
+			Gaffer.Color3fPlug,
+			Gaffer.Color4fPlug
+		] :
+
+			if isinstance( item, six.string_types ) :
+				result.append( "/" + item, { "divider" : True } )
+			else :
+				result.append(
+					"/" + item.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__addTweak ), "", "", item ),
+					}
+				)
+
+		return result
+
+	def __addFromGlobalsMenuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		node = _optionTweaksNode( self )
+		options = {}
+
+		if node is not None :
+			with self.getContext() :
+				options = node["out"]["globals"].getValue()
+
+		prefix = "option:"
+
+		options = collections.OrderedDict( ( k, v ) for k, v in options.items() if k.startswith( prefix ) )
+
+		for key, value in [ ( k, v ) for k, v in options.items() if k.replace( ':', '_' ) not in node["tweaks"] ] :
+			nameWithoutPrefix = key[ len( prefix ): ]
+			result.append(
+				"/" + nameWithoutPrefix,
+				{
+					"command" : functools.partial(
+						Gaffer.WeakMethod( self.__addTweak ),
+						key.replace( ':', '_' ),
+						nameWithoutPrefix,
+						value
+					)
+				}
+			)
+
+		if not len( result.items() ) :
+			result.append(
+				"/No Options Found", { "active" : False }
+			)
+			return result
+
+		return result
+
+	def __addTweak( self, plugName, optionName, plugTypeOrValue ) :
+
+		if isinstance( plugTypeOrValue, IECore.Data ) :
+			plug = Gaffer.TweakPlug( optionName, plugTypeOrValue )
+		else :
+			plug = Gaffer.TweakPlug( optionName, plugTypeOrValue() )
+
+		if plugName :
+			plug.setName( plugName )
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().addChild( plug )

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -263,7 +263,7 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The default value to output if the parameter does not exist.
+			A pair of parameter name to query and default value.
 			""",
 
 		],

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -174,6 +174,7 @@ from . import UVSamplerUI
 from . import CryptomatteUI
 from . import ShaderQueryUI
 from . import AttributeTweaksUI
+from . import OptionTweaksUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -175,6 +175,7 @@ from . import CryptomatteUI
 from . import ShaderQueryUI
 from . import AttributeTweaksUI
 from . import OptionTweaksUI
+from . import OptionQueryUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/OptionQuery.cpp
+++ b/src/GafferScene/OptionQuery.cpp
@@ -1,0 +1,423 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/OptionQuery.h"
+
+#include "Gaffer/PlugAlgo.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+#include "IECore/NullObject.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+
+namespace
+{
+
+const size_t g_existsPlugIndex = 0;
+const size_t g_valuePlugIndex = 1;
+
+/// \todo: Can the next function be move to somewhere to be shared with `AttributeQuery`?
+
+const Gaffer::ValuePlug *correspondingPlug(
+	const Gaffer::ValuePlug *parent,
+	const Gaffer::ValuePlug *child,
+	const Gaffer::ValuePlug *other
+)
+{
+	boost::container::small_vector< const Gaffer::ValuePlug*, 4 > path;
+
+	const Gaffer::ValuePlug *plug = child;
+
+	while( plug != parent )
+	{
+		path.push_back( plug );
+		plug = plug->parent< Gaffer::ValuePlug >();
+	}
+
+	plug = other;
+
+	while( ! path.empty() )
+	{
+		plug = plug->getChild< Gaffer::ValuePlug >( path.back()->getName() );
+		path.pop_back();
+	}
+
+	return plug;
+}
+
+void addChildPlugsToAffectedOutputs( const Gaffer::Plug* plug, Gaffer::DependencyNode::AffectedPlugsContainer& outputs )
+{
+	if( plug->children().empty() )
+	{
+		outputs.push_back( plug );
+	}
+	else
+	{
+		for( const Gaffer::PlugPtr& child : Gaffer::Plug::OutputRange( *plug ) )
+		{
+			addChildPlugsToAffectedOutputs( child.get(), outputs );
+		}
+	}
+}
+
+/// Returns the index into the child vector of `parentPlug` that is
+/// either the `childPlug` itself or an ancestor of childPlug.
+/// Throws an Exception if the `childPlug` is not a descendant of `parentPlug`.
+size_t getChildIndex( const Gaffer::Plug *parentPlug, const Gaffer::ValuePlug *descendantPlug )
+{
+	const GraphComponent *p = descendantPlug;
+	while( p )
+	{
+		if( p->parent() == parentPlug )
+		{
+			for( size_t i = 0, eI = parentPlug->children().size(); i < eI; ++i )
+			{
+				if( parentPlug->getChild( i ) == p )
+				{
+					return i;
+				}
+			}
+		}
+		p = p->parent();
+	}
+
+	throw IECore::Exception( "OptionQuery : Plug not in hierarchy." );
+}
+
+}  // namespace
+
+namespace GafferScene
+{
+
+GAFFER_NODE_DEFINE_TYPE( OptionQuery );
+
+const std::string g_namePrefix = "option:";
+
+size_t OptionQuery::g_firstPlugIndex = 0;
+
+OptionQuery::OptionQuery( const std::string &name ) : Gaffer::ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new ScenePlug( "scene" ) );
+	addChild( new ArrayPlug( "queries", Plug::Direction::In, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
+
+	addChild( new ArrayPlug( "out", Plug::Direction::Out, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
+}
+
+OptionQuery::~OptionQuery()
+{
+}
+
+ScenePlug *OptionQuery::scenePlug()
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+const ScenePlug *OptionQuery::scenePlug() const
+{
+	return getChild<ScenePlug>( g_firstPlugIndex );
+}
+
+Gaffer::ArrayPlug *OptionQuery::queriesPlug()
+{
+	return getChild<ArrayPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::ArrayPlug *OptionQuery::queriesPlug() const
+{
+	return getChild<ArrayPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::ArrayPlug *OptionQuery::outPlug()
+{
+	return getChild<ArrayPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::ArrayPlug *OptionQuery::outPlug() const
+{
+	return getChild<ArrayPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::NameValuePlug *OptionQuery::addQuery(
+	const Gaffer::ValuePlug *plug,
+	const std::string &option
+)
+{
+	NameValuePlugPtr childQueryPlug = new NameValuePlug(
+		"",
+		plug->createCounterpart( "query0", Gaffer::Plug::Direction::In ),
+		"query0",
+		Gaffer::Plug::Flags::Default
+	);
+	childQueryPlug->namePlug()->setValue( option );
+
+	ValuePlugPtr newOutPlug = new ValuePlug( "out0", Gaffer::Plug::Direction::Out );
+	newOutPlug->addChild(
+		new BoolPlug(
+			"exists",
+			Gaffer::Plug::Direction::Out,
+			false
+		)
+	);
+	newOutPlug->addChild( plug->createCounterpart( "value", Gaffer::Plug::Direction::Out ) );
+
+	outPlug()->addChild( newOutPlug );
+
+	queriesPlug()->addChild( childQueryPlug );
+
+	return childQueryPlug.get();
+}
+
+void OptionQuery::removeQuery( Gaffer::NameValuePlug *plug )
+{
+	const ValuePlug *oPlug = outPlugFromQuery( plug );
+
+	queriesPlug()->removeChild( plug );
+	outPlug()->removeChild( const_cast<ValuePlug *>( oPlug ) );
+}
+
+void OptionQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if( input == scenePlug()->globalsPlug() )
+	{
+		addChildPlugsToAffectedOutputs( outPlug(), outputs );
+	}
+
+	else if( queriesPlug()->isAncestorOf( input ) )
+	{
+		const NameValuePlug *childQueryPlug = input->ancestor<NameValuePlug>();
+		if( childQueryPlug == nullptr )
+		{
+			throw IECore::Exception( "OptionQuery::affects : Query plugs must be \"NameValuePlug\"" );
+		}
+
+		const ValuePlug *vPlug = valuePlugFromQuery( childQueryPlug );
+
+		if( input == childQueryPlug->namePlug() )
+		{
+			addChildPlugsToAffectedOutputs( vPlug, outputs );
+
+			outputs.push_back( existsPlugFromQuery( childQueryPlug ) );
+		}
+		else if( childQueryPlug->valuePlug() == input || childQueryPlug->valuePlug()->isAncestorOf( input ) )
+		{
+			outputs.push_back(
+				correspondingPlug(
+					static_cast<const ValuePlug *>( childQueryPlug->valuePlug<ValuePlug>() ),
+					runTimeCast<const ValuePlug>( input ),
+					vPlug
+				)
+			);
+		}
+	}
+}
+
+void OptionQuery::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	ComputeNode::hash( output, context, h );
+
+	if( outPlug()->isAncestorOf( output ) )
+	{
+		const ValuePlug *oPlug = outPlug( output );
+
+		if( output == oPlug->getChild( g_existsPlugIndex ) )
+		{
+			const NameValuePlug *childQueryPlug = queryPlug( output );
+			childQueryPlug->namePlug()->hash( h );
+			scenePlug()->globalsPlug()->hash( h );
+		}
+
+		else if(
+			oPlug->getChild( g_valuePlugIndex )->isAncestorOf( output ) ||
+			output == oPlug->getChild( g_valuePlugIndex )
+		)
+		{
+			const NameValuePlug *childQueryPlug = queryPlug( output );
+			childQueryPlug->namePlug()->hash( h );
+			scenePlug()->globalsPlug()->hash( h );
+
+			correspondingPlug(
+				valuePlugFromQuery( childQueryPlug ),
+				output,
+				static_cast<const ValuePlug *>( childQueryPlug->valuePlug() )
+			)->hash( h );
+		}
+	}
+}
+
+void OptionQuery::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const
+{
+	if( outPlug()->isAncestorOf( output ) )
+	{
+		const ValuePlug *oPlug = outPlug( output );
+
+		if( output == oPlug->getChild( g_existsPlugIndex ) )
+		{
+			const NameValuePlug *childQueryPlug = queryPlug( output );
+
+			const std::string optionName = childQueryPlug->namePlug()->getValue();
+
+			if( optionName.size() )
+			{
+				ConstCompoundObjectPtr globals = scenePlug()->globalsPlug()->getValue();
+				const Data *resultData = globals->member<const Data>( g_namePrefix + optionName );
+
+				static_cast<BoolPlug *>( output )->setValue( resultData != nullptr );
+
+				return;
+			}
+
+			static_cast<BoolPlug *>( output )->setValue( false );
+
+			return;
+		}
+
+		else if(
+			oPlug->getChild( g_valuePlugIndex )->isAncestorOf( output ) ||
+			output == oPlug->getChild( g_valuePlugIndex )
+		)
+		{
+			const NameValuePlug *childQueryPlug = queryPlug( output );
+
+			const std::string optionName = childQueryPlug->namePlug()->getValue();
+
+			const ValuePlug *vPlug = valuePlugFromQuery( childQueryPlug );
+
+			if( optionName.size() )
+			{
+				ConstCompoundObjectPtr globals = scenePlug()->globalsPlug()->getValue();
+				const Data *resultData = globals->member<const Data>( g_namePrefix + optionName );
+
+				if( resultData != nullptr )
+				{
+					if( PlugAlgo::setValueFromData( vPlug, output, resultData ) )
+					{
+						return;
+					}
+				}
+			}
+
+			output->setFrom(
+				static_cast<const Gaffer::ValuePlug *>(
+					correspondingPlug(
+						vPlug,
+						output,
+						static_cast<const ValuePlug *>( childQueryPlug->valuePlug() )
+					)
+				)
+			);
+
+			return;
+		}
+	}
+
+	ComputeNode::compute( output, context );
+
+}
+
+const Gaffer::BoolPlug *OptionQuery::existsPlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const
+{
+	if( const ValuePlug *oPlug = outPlugFromQuery( queryPlug ) )
+	{
+		return oPlug->getChild<BoolPlug>( g_existsPlugIndex );
+	}
+
+	throw IECore::Exception( "OptionQuery : \"exists\" plug is missing or of the wrong type." );
+}
+
+const Gaffer::ValuePlug *OptionQuery::valuePlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const
+{
+	if( const ValuePlug *oPlug = outPlugFromQuery( queryPlug ) )
+	{
+		return oPlug->getChild<const ValuePlug>( g_valuePlugIndex );
+	}
+
+	throw IECore::Exception( "OptionQuery : \"value\" plug is missing." );
+}
+
+const Gaffer::ValuePlug *OptionQuery::outPlugFromQuery( const Gaffer::NameValuePlug *queryPlug ) const
+{
+	size_t childIndex = getChildIndex( queriesPlug(), queryPlug );
+
+	if( childIndex < outPlug()->children().size() )
+	{
+		const ValuePlug *oPlug = outPlug()->getChild<const ValuePlug>( childIndex );
+		if( oPlug != nullptr && oPlug->typeId() != Gaffer::ValuePlug::staticTypeId() )
+		{
+			throw IECore::Exception( "OptionQuery : \"outPlug\" must be a `ValuePlug`."  );
+		}
+		return outPlug()->getChild<ValuePlug>( childIndex );
+	}
+
+	throw IECore::Exception( "OptionQuery : \"outPlug\" is missing." );
+}
+
+const Gaffer::NameValuePlug *OptionQuery::queryPlug( const Gaffer::ValuePlug *outputPlug ) const
+{
+	const size_t childIndex = getChildIndex( outPlug(), outputPlug );
+
+	if( childIndex >= queriesPlug()->children().size() )
+	{
+		throw IECore::Exception( "OptionQuery : \"query\" plug is missing." );
+	}
+
+	if( const NameValuePlug *childQueryPlug = queriesPlug()->getChild<NameValuePlug>( childIndex ) )
+	{
+		return childQueryPlug;
+	}
+
+	throw IECore::Exception( "OptionQuery::queryPlug : Queries must be a \"NameValuePlug\".");
+
+}
+
+const Gaffer::ValuePlug *OptionQuery::outPlug( const Gaffer::ValuePlug *outputPlug ) const
+{
+	size_t childIndex = getChildIndex( outPlug(), outputPlug );
+
+	if( const ValuePlug *result = outPlug()->getChild<const ValuePlug>( childIndex ) )
+	{
+		return result;
+	}
+
+	throw IECore::Exception( "OptionQuery : \"out\" plug is missing or of the wrong type.");
+}
+
+}  // namespace GafferScene

--- a/src/GafferScene/OptionTweaks.cpp
+++ b/src/GafferScene/OptionTweaks.cpp
@@ -1,0 +1,143 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/OptionTweaks.h"
+
+#include "Gaffer/TweakPlug.h"
+
+using namespace std;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+
+GAFFER_NODE_DEFINE_TYPE( OptionTweaks );
+
+const std::string g_namePrefix = "option:";
+
+size_t OptionTweaks::g_firstPlugIndex = 0;
+
+OptionTweaks::OptionTweaks( const std::string &name ) : GlobalsProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new BoolPlug( "ignoreMissing", Plug::In, false ) );
+	addChild( new TweaksPlug( "tweaks" ) );
+}
+
+OptionTweaks::~OptionTweaks()
+{
+
+}
+
+Gaffer::BoolPlug *OptionTweaks::ignoreMissingPlug()
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::BoolPlug *OptionTweaks::ignoreMissingPlug() const
+{
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
+}
+
+Gaffer::TweaksPlug *OptionTweaks::tweaksPlug()
+{
+	return getChild<Gaffer::TweaksPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::TweaksPlug *OptionTweaks::tweaksPlug() const
+{
+	return getChild<Gaffer::TweaksPlug>( g_firstPlugIndex + 1 );
+}
+
+void OptionTweaks::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	GlobalsProcessor::affects( input, outputs );
+
+	if( tweaksPlug()->isAncestorOf( input ) || input == ignoreMissingPlug() )
+	{
+		outputs.push_back( outPlug()->globalsPlug() );
+	}
+}
+
+void OptionTweaks::hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	if( tweaksPlug()->children().empty() )
+	{
+		h = inPlug()->globalsPlug()->hash();
+	}
+	else
+	{
+		ignoreMissingPlug()->hash( h );
+		tweaksPlug()->hash( h );
+	}
+}
+
+IECore::ConstCompoundObjectPtr OptionTweaks::computeProcessedGlobals(
+	const Gaffer::Context *context,
+	const IECore::ConstCompoundObjectPtr inputGlobals
+) const
+{
+	const TweaksPlug *tweaksPlug = this->tweaksPlug();
+	if( tweaksPlug->children().empty() )
+	{
+		return inputGlobals;
+	}
+
+	const bool ignoreMissing = ignoreMissingPlug()->getValue();
+
+	CompoundObjectPtr result = new CompoundObject();
+	result->members() = inputGlobals->members();
+
+	const CompoundObject *source = inputGlobals.get();
+
+	tweaksPlug->applyTweaks(
+		[&source]( const std::string &valueName )
+		{
+			return source->member<Data>( g_namePrefix + valueName );
+		},
+		[&result]( const std::string &valueName, DataPtr newData )
+		{
+			if( newData == nullptr )
+			{
+				return result->members().erase( g_namePrefix + valueName ) > 0;
+			}
+			result->members()[g_namePrefix + valueName] = newData;
+			return true;
+		},
+		ignoreMissing ? TweakPlug::MissingMode::Ignore : TweakPlug::MissingMode::Error
+	);
+
+	return result;
+}

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -379,6 +379,7 @@ nodeMenu.append( "/Scene/Globals/Standard Options", GafferScene.StandardOptions,
 nodeMenu.append( "/Scene/Globals/Custom Options", GafferScene.CustomOptions, searchText = "CustomOptions" )
 nodeMenu.append( "/Scene/Globals/Delete Options", GafferScene.DeleteOptions, searchText = "DeleteOptions" )
 nodeMenu.append( "/Scene/Globals/Copy Options", GafferScene.CopyOptions, searchText = "CopyOptions" )
+nodeMenu.append( "/Scene/Globals/Option Tweaks", GafferScene.OptionTweaks, searchText = "OptionTweaks" )
 nodeMenu.append( "/Scene/Globals/Set", GafferScene.Set )
 nodeMenu.append( "/Scene/Globals/Set Visualiser", GafferScene.SetVisualiser, searchText = "SetVisualiser" )
 nodeMenu.append( "/Scene/OpenGL/Attributes", GafferScene.OpenGLAttributes, searchText = "OpenGLAttributes" )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -391,6 +391,7 @@ nodeMenu.append( "/Scene/Utility/Bound Query", GafferScene.BoundQuery, searchTex
 nodeMenu.append( "/Scene/Utility/Existence Query", GafferScene.ExistenceQuery, searchText = "ExistenceQuery" )
 nodeMenu.append( "/Scene/Utility/Attribute Query", GafferScene.AttributeQuery, searchText = "AttributeQuery" )
 nodeMenu.append( "/Scene/Utility/Shader Query", GafferScene.ShaderQuery, searchText = "ShaderQuery" )
+nodeMenu.append( "/Scene/Utility/Option Query", GafferScene.OptionQuery, searchText = "OptionQuery" )
 
 # Image nodes
 


### PR DESCRIPTION
This adds two nodes for working with scene global options : `OptionTweaks` and `OptionQuery`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
