### PR TITLE
BoxIO : Set nodule section for both plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.x.x (relative to 1.0.4.0)
+=======
+
+Fixes
+-----
+
+- EditScope : Fixed mislocated plug nodules when connecting a new `EditScope` to a `BoxIn`, `BoxOut` or `Box` node.
+
 1.0.4.0 (relative to 1.0.3.0)
 =======
 

--- a/src/GafferUI/EditScopeUI.cpp
+++ b/src/GafferUI/EditScopeUI.cpp
@@ -99,6 +99,9 @@ class EditScopePlugAdder : public PlugAdder
 			{
 				m_editScope->inPlug()->setInput( endpoint );
 			}
+
+			applyEdgeMetadata( m_editScope->inPlug(), endpoint->direction() == Plug::In );
+			applyEdgeMetadata( m_editScope->outPlug(), endpoint->direction() == Plug::Out );
 		}
 
 	private :


### PR DESCRIPTION
When connecting EditScopes, in particular, to `BoxIO` nodes, metadata may be copied from a plug of different direction, resulting in the nodule in the wrong section. Here we remove that metadata from the copy and set the nodule section for both plugs.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
