### PR TITLE
CI : Update to Cortex 10.4.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -54,7 +54,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -65,7 +65,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -18,11 +18,19 @@ Improvements
 Fixes
 -----
 
+- SceneReader :
+  - Fixed reading of Alembic files with animated visibility.
+  - Fixed reading of primitive variables from UsdGeomPointInstancers.
 - GraphEditor : Fixed bugs which allowed new connections to be made in read-only graphs.
 - NodeEditor : Fixed bugs which allowed plugs to be added to read-only tweaks nodes.
 - CyclesOptions : Fixed errors in section summaries.
 - NoduleLayout : Fixed shutdown crashes triggered by custom gadgets implemented in Python.
 - ShaderTweaks : Fixed error when attempting to use a `:` in a parameter name.
+
+Build
+-----
+
+- Cortex : Updated to 10.4.1.2.
 
 1.0.3.0 (relative to 1.0.2.1)
 =======


### PR DESCRIPTION
Not updating Windows because we're not publishing the Windows packages from Cortex CI. I think this is OK for now, because we're not actually making Windows releases yet.