### PR TITLE
LightEditor : Select linked objects

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Improvements
 
 - SceneReader : Added reading of more Alembic GeomParam types. Specifically `unsigned char`, `uint16`, `int16` and `uint32` GeomParams are loaded as `UCharVectorData`, `UShortVectorData`, `ShortVectorData` and `UIntVectorData` PrimitiveVariables respectively.
 - SceneWriter : Added writing of more Alembic GeomParam types, mirroring the improved reading mentioned above.
-- Light Editor : Added the ability to select linked objects. It can be accessed by right-clicking a light name and selecting 'Select Linked Objects'.
+- Light Editor : Added the ability to select linked objects and to delete lights. Both commands can can be accessed by right-clicking a light name and selecting either 'Select Linked Objects' or 'Delete'.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - SceneReader : Added reading of more Alembic GeomParam types. Specifically `unsigned char`, `uint16`, `int16` and `uint32` GeomParams are loaded as `UCharVectorData`, `UShortVectorData`, `ShortVectorData` and `UIntVectorData` PrimitiveVariables respectively.
 - SceneWriter : Added writing of more Alembic GeomParam types, mirroring the improved reading mentioned above.
+- Light Editor : Added the ability to select linked objects. It can be accessed by right-clicking a light name and selecting 'Select Linked Objects'.
 
 Fixes
 -----

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -370,12 +370,14 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 				columnIndex = i
 
 		cellPath = pathListing.pathAt( event.line.p0 )
+		if cellPath is None :
+			return False
 
 		if not selection[columnIndex].match( str( cellPath ) ) & IECore.PathMatcher.Result.ExactMatch :
 			for p in selection :
 				p.clear()
 			selection[columnIndex].addPath( str( cellPath ) )
-			pathListing.setSelection( selection )
+			pathListing.setSelection( selection, expandNonLeaf = False, scrollToFirst = False )
 
 		menuDefinition = IECore.MenuDefinition()
 


### PR DESCRIPTION
This adds a "Select Linked Objects" command to the right-click popup menu. The implementation itself seems straightforward enough. I'm not entirely sure what the best UI is for the menu items - the current scheme is what I prefer at the moment.

Right now I'm doing the following ( :heavy_check_mark:  = enabled, :white_check_mark:  = vsibile but disabled ) :
- Light names selected only? :heavy_check_mark: Select Linked Objects, :white_check_mark:  Show History...
- Parameters selected only?  :heavy_check_mark: Select Linked Objects, :heavy_check_mark: Show History...
- Light names and parameters mixed selection? :heavy_check_mark: Select Linked Objects, :heavy_check_mark: Show History...

When we added the "Show History..." command, we purposefully hid it when right clicking on a light name, even if there were parameters selected. That made sense when there weren't any commands to do for the name column, but now that there are, should it still be hidden? Should it be disabled when clicking on the name even with parameters selected? Should we restrict "Select Linked Objects" to the name column only, and "Show History..." to the parameter columns only?

Thoughts and opinions are welcome!

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
