### PR TITLE
CI : Update to Cortex 10.4.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.2.0/cortex-10.4.2.0-linux-python2.tar.gz
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -54,7 +54,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python2.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.2.0/cortex-10.4.2.0-linux-python2.tar.gz
             testRunner: su testUser -c
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -65,7 +65,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.1.2/cortex-10.4.1.2-linux-python3.tar.gz
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.2.0/cortex-10.4.2.0-linux-python3.tar.gz
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,22 @@
 1.0.x.x (relative to 1.0.4.0)
 =======
 
+Improvements
+------------
+
+- SceneReader : Added reading of more Alembic GeomParam types. Specifically `unsigned char`, `uint16`, `int16` and `uint32` GeomParams are loaded as `UCharVectorData`, `UShortVectorData`, `ShortVectorData` and `UIntVectorData` PrimitiveVariables respectively.
+- SceneWriter : Added writing of more Alembic GeomParam types, mirroring the improved reading mentioned above.
+
 Fixes
 -----
 
 - EditScope : Fixed mislocated plug nodules when connecting a new `EditScope` to a `BoxIn`, `BoxOut` or `Box` node.
 - Backdrop : Fixed bug selecting or moving a backdrop when zoomed out in the GraphEditor, where drag-resizing the top edge was incorrectly being given precedence.
+
+Build
+-----
+
+- Cortex : Updated to 10.4.2.0.
 
 1.0.4.0 (relative to 1.0.3.0)
 =======


### PR DESCRIPTION
This updates Cortex to include the necessary features for https://github.com/GafferHQ/gaffer/pull/4839. Unfortunately it doesn't update the Windows packages because we're not currently publishing release packages for Windows from the Cortex CI setup. @ericmehl, is that something we could turn on?