### PR TITLE
DotNodeGadget : Handle computation errors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+0.61.14.x (relative to 0.61.14.5)
+=========
+
+Fixes
+-----
+
+- GraphEditor : Fixed handling of errors on `Dot.labelType` and `Dot.label` plugs.
+
 0.61.14.5 (relative to 0.61.14.4)
 =========
 

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -44,6 +44,7 @@
 
 #include "Gaffer/Dot.h"
 #include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/UndoScope.h"
@@ -166,23 +167,30 @@ void DotNodeGadget::updateLabel()
 {
 	const Dot *dot = dotNode();
 
-	const Dot::LabelType labelType = (Dot::LabelType)dot->labelTypePlug()->getValue();
-	if( labelType == Dot::None )
+	try
 	{
-		m_label.clear();
+		const Dot::LabelType labelType = (Dot::LabelType)dot->labelTypePlug()->getValue();
+		if( labelType == Dot::None )
+		{
+			m_label.clear();
+		}
+		else if( labelType == Dot::NodeName )
+		{
+			m_label = dot->getName();
+		}
+		else if( labelType == Dot::UpstreamNodeName )
+		{
+			const Node *n = upstreamNode();
+			m_label = n ? n->getName() : "";
+		}
+		else
+		{
+			m_label = dot->labelPlug()->getValue();
+		}
 	}
-	else if( labelType == Dot::NodeName )
+	catch( const Gaffer::ProcessException &e )
 	{
-		m_label = dot->getName();
-	}
-	else if( labelType == Dot::UpstreamNodeName )
-	{
-		const Node *n = upstreamNode();
-		m_label = n ? n->getName() : "";
-	}
-	else
-	{
-		m_label = dot->labelPlug()->getValue();
+		m_label = "Error";
 	}
 
 	Edge labelEdge = RightEdge;


### PR DESCRIPTION
Because we weren't handling these before, they could leave the GraphEditor in a completely unusable state.
