### PR TITLE
Arnold ShaderNetworkAlgo : Fix render of Maya-exported Arnold shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
   - Fixed bug which caused images to be evaluated in the wrong context.
   - Fixed bug handling images with non-default views.
 - Cycles : Fixed rendering with a non-default crop window.
+- Arnold : Fixed handling of closure shader connections in USD materials exported from Maya.
 
 Build
 -----

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -224,7 +224,12 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 		}
 		else
 		{
-			AiNodeLinkOutput( sourceNode, sourceName.c_str(), node, parameterName.c_str() );
+			const char *output = sourceName.c_str();
+			if( sourceName.string() == "out" && AiNodeEntryGetNumOutputs( AiNodeGetNodeEntry( sourceNode ) ) == 0 )
+			{
+				output = "";
+			}
+			AiNodeLinkOutput( sourceNode, output, node, parameterName.c_str() );
 		}
 	}
 


### PR DESCRIPTION
USD requires all shader connections to come from a named output attribute on a shader, taking the form `shaderName.attributeName`. But Arnold originally didn't have named outputs from shaders at all, with only the shader itself being necessary to specify the source - `shaderName`. This presents a conundrum when representing Arnold shader connection in USD, and there are at least two known conventions for dealing with it :

- Ours. We make an attribute called `DEFAULT_OUTPUT` in USD, and ignore the name on loading, so that just `shaderName` is the source of the connection after loading. This let us round-trip shaders where the output name was empty, but it's not a convention used anywhere else as far as I know.
- Autodesk's. They make an attribute called `out`, and we currently don't ignore it on loading, so we end up with a `shaderName.out` source in Gaffer.

We could debate the relative merits of these conventions, but the Autodesk one is clearly going to be the more pervasive and we need to support it. That gives us two options :

1) Ignore the `out` part on loading. This would require the ability to query the Arnold shader at loading time, to see if it has multiple outputs, with one actually called `out`. Seems doable, but harder than the alternative. 2) Keep the `out` part on loading, and deal with it in the renderer backend, where we have ready access to information about the Arnold shader. This is certainly easier to implement.

Option 2 is the lazy option, but I think it's also the better one. We've got various bits of special-case code for dealing with empty output names (and for dealing with leaf `Shader.out` plugs in Gaffer) and it would actually be nice to get rid of them over time. This is a first step towards doing that, and eventually just requiring `shaderName.outputName` everywhere.

This fixes the bug reported in https://groups.google.com/g/gaffer-dev/c/tH7kPSDT8DQ/m/__wRNbUoAAAJ.
