### PR TITLE
Constraint : Add keepReferencePosition plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.x.x (relative to 1.0.5.1)
+=======
+
+Improvements
+------------
+
+- Constraint : Improved performance for UV constraints where the target has static geometry but an animated transform. One such benchmark shows a greater than 40x speedup.
+
 1.0.5.1 (relative to 1.0.5.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- Constraint : Improved performance for UV constraints where the target has static geometry but an animated transform. One such benchmark shows a greater than 40x speedup.
+- Constraint :
+  - Added `maintainReferencePosition` plug. This allows the constraint to maintain the original position of the object at a specifed reference time.
+  - Improved performance for UV constraints where the target has static geometry but an animated transform. One such benchmark shows a greater than 40x speedup.
 
 1.0.5.1 (relative to 1.0.5.0)
 =======

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -94,6 +94,9 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 
 	protected :
 
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
 		/// Reimplemented from SceneElementProcessor to call the constraint functions below.
 		bool processesTransform() const override;
 		void hashProcessedTransform( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
@@ -108,6 +111,16 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 		virtual Imath::M44f computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const = 0;
 
 	private :
+
+		// Plug used to cache the matrix computed from the `TargetMode`
+		// separately. The UV mode in particular is expensive, and caching it
+		// separately allows us to avoid repeating that part of the computation
+		// when the geometry is static but the transform is animated.
+		const Gaffer::M44fPlug *targetModeMatrixPlug() const;
+
+		bool affectsTargetModeMatrix( const Gaffer::Plug *input ) const;
+		void hashTargetModeMatrix( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		Imath::M44f computeTargetModeMatrix( const Gaffer::Context *context ) const;
 
 		struct Target
 		{

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -115,6 +115,7 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 			const ScenePlug *scene;
 		};
 
+		bool affectsTarget( const Gaffer::Plug *input ) const;
 		std::optional<Target> target() const;
 
 		static size_t g_firstPlugIndex;

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -90,6 +90,12 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 		Gaffer::V3fPlug *targetOffsetPlug();
 		const Gaffer::V3fPlug *targetOffsetPlug() const;
 
+		Gaffer::BoolPlug *keepReferencePositionPlug();
+		const Gaffer::BoolPlug *keepReferencePositionPlug() const;
+
+		Gaffer::FloatPlug *referenceFramePlug();
+		const Gaffer::FloatPlug *referenceFramePlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 	protected :
@@ -117,10 +123,18 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 		// separately allows us to avoid repeating that part of the computation
 		// when the geometry is static but the transform is animated.
 		const Gaffer::M44fPlug *targetModeMatrixPlug() const;
+		/// Plug used to cache the local transform derived from
+		/// `computeConstraint()` but without considering `keepReferencePosition`.
+		/// We can then query it at the reference time from `computeProcessedTransform()`.
+		const Gaffer::M44fPlug *constrainedTransformPlug() const;
 
 		bool affectsTargetModeMatrix( const Gaffer::Plug *input ) const;
 		void hashTargetModeMatrix( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		Imath::M44f computeTargetModeMatrix( const Gaffer::Context *context ) const;
+
+		bool affectsConstrainedTransform( const Gaffer::Plug *input ) const;
+		void hashConstrainedTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		Imath::M44f computeConstrainedTransform( const Gaffer::Context *context ) const;
 
 		struct Target
 		{

--- a/include/GafferScene/PointConstraint.h
+++ b/include/GafferScene/PointConstraint.h
@@ -52,9 +52,6 @@ class GAFFERSCENE_API PointConstraint : public Constraint
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PointConstraint, PointConstraintTypeId, Constraint );
 
-		Gaffer::V3fPlug *offsetPlug();
-		const Gaffer::V3fPlug *offsetPlug() const;
-
 		Gaffer::BoolPlug *xEnabledPlug();
 		const Gaffer::BoolPlug *xEnabledPlug() const;
 
@@ -63,6 +60,9 @@ class GAFFERSCENE_API PointConstraint : public Constraint
 
 		Gaffer::BoolPlug *zEnabledPlug();
 		const Gaffer::BoolPlug *zEnabledPlug() const;
+
+		Gaffer::V3fPlug *offsetPlug();
+		const Gaffer::V3fPlug *offsetPlug() const;
 
 	protected :
 

--- a/python/GafferSceneTest/AimConstraintTest.py
+++ b/python/GafferSceneTest/AimConstraintTest.py
@@ -85,7 +85,7 @@ class AimConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		# Test behaviour for missing target
 		plane1["name"].setValue( "targetX" )
-		with six.assertRaisesRegex( self, RuntimeError, 'AimConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+		with six.assertRaisesRegex( self, RuntimeError, 'AimConstraint.__constrainedTransform : Constraint target does not exist: "/group/target"' ):
 			aim["out"].fullTransform( "/group/constrained" )
 
 		aim["ignoreMissingTarget"].setValue( True )

--- a/python/GafferSceneTest/ParentConstraintTest.py
+++ b/python/GafferSceneTest/ParentConstraintTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import imath
+import inspect
 import six
 
 import IECore
@@ -79,7 +80,7 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 
 		# Test behaviour for missing target
 		plane1["name"].setValue( "targetX" )
-		with six.assertRaisesRegex( self, RuntimeError, 'ParentConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+		with six.assertRaisesRegex( self, RuntimeError, 'ParentConstraint.__constrainedTransform : Constraint target does not exist: "/group/target"' ):
 			constraint["out"].fullTransform( "/group/constrained" )
 
 		constraint["ignoreMissingTarget"].setValue( True )
@@ -2074,6 +2075,135 @@ class ParentConstraintTest( GafferSceneTest.SceneTestCase ) :
 		constraint[ "ignoreMissingTarget" ].setValue( True )
 		constraint[ "targetUV" ].setValue( imath.V2f( 0.5, 0.5 ) )
 		self.assertEqual( constraint[ "out" ].fullTransform( "/" + cube[ "name" ].getValue() ), imath.M44f() )
+
+	def testKeepReferencePosition( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			parent["sphere"]["transform"]["translate"]["x"] = context.getFrame()
+			"""
+		) )
+
+		script["cube"] = GafferScene.Cube()
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["sphere"]["out"] )
+		script["parent"]["child"][0].setInput( script["cube"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["constraint"] = GafferScene.ParentConstraint()
+		script["constraint"]["in"].setInput( script["parent"]["out"] )
+		script["constraint"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["constraint"]["target"].setValue( "/sphere" )
+
+		script["constraint"]["keepReferencePosition"].setValue( True )
+
+		for frame in range( 0, 10 ) :
+
+			script["constraint"]["referenceFrame"].setValue( frame )
+
+			with Gaffer.Context( script.context() ) as c :
+
+				c.setFrame( frame )
+
+				cubeTransform = script["constraint"]["out"].transform( "/cube" )
+				self.assertEqual( cubeTransform, script["constraint"]["in"].transform( "/cube" ) )
+
+				c.setFrame( frame + 1 )
+				self.assertEqual(
+					script["constraint"]["out"].transform( "/cube" ),
+					cubeTransform.translate( imath.V3f( 1, 0, 0 ) )
+				)
+
+	def testObjectNonExistentAtReferenceFrame( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["cube"] = GafferScene.Cube()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			parent["sphere"]["transform"]["translate"]["x"] = context.getFrame()
+			parent["cube"]["enabled"] = context.getFrame() > 10
+			"""
+		) )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["sphere"]["out"] )
+		script["group"]["in"][1].setInput( script["cube"]["out"] )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube" ] ) )
+
+		script["constraint"] = GafferScene.ParentConstraint()
+		script["constraint"]["in"].setInput( script["group"]["out"] )
+		script["constraint"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["constraint"]["target"].setValue( "/group/sphere" )
+
+		script["constraint"]["keepReferencePosition"].setValue( True )
+		script["constraint"]["referenceFrame"].setValue( 4 )
+
+		with Gaffer.Context( script.context() ) as context :
+
+			context.setFrame( script["constraint"]["referenceFrame"].getValue() )
+			self.assertFalse( script["constraint"]["in"].exists( "/group/cube" ) )
+
+			context.setFrame( 20 )
+			self.assertTrue( script["constraint"]["in"].exists( "/group/cube" ) )
+
+			with six.assertRaisesRegex( self, Gaffer.ProcessException, ".*Constrained object \"/group/cube\" does not exist at reference frame 4" ) :
+				script["constraint"]["out"].transform( "/group/cube" )
+
+	def testTargetNonexistentAtReferenceFrame( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["cube"] = GafferScene.Cube()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			parent["sphere"]["transform"]["translate"]["x"] = context.getFrame()
+			parent["cube"]["enabled"] = context.getFrame() > 10
+			"""
+		) )
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["sphere"]["out"] )
+		script["group"]["in"][1].setInput( script["cube"]["out"] )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube" ] ) )
+
+		script["constraint"] = GafferScene.ParentConstraint()
+		script["constraint"]["in"].setInput( script["group"]["out"] )
+		script["constraint"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["constraint"]["target"].setValue( "/group/sphere" )
+
+		script["constraint"]["keepReferencePosition"].setValue( True )
+		script["constraint"]["referenceFrame"].setValue( 4 )
+
+		with Gaffer.Context( script.context() ) as context :
+
+			context.setFrame( script["constraint"]["referenceFrame"].getValue() )
+			self.assertFalse( script["constraint"]["in"].exists( "/group/cube" ) )
+
+			context.setFrame( 20 )
+			self.assertTrue( script["constraint"]["in"].exists( "/group/cube" ) )
+
+			with six.assertRaisesRegex( self, Gaffer.ProcessException, ".*Constrained object \"/group/cube\" does not exist at reference frame 4" ) :
+				script["constraint"]["out"].transform( "/group/cube" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -121,7 +121,7 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 		constraint["xEnabled"].setValue( True )
 		constraint["yEnabled"].setValue( True )
 		constraint["zEnabled"].setValue( True )
-		with six.assertRaisesRegex( self, RuntimeError, 'PointConstraint.out.transform : Constraint target does not exist: "/group/target"' ):
+		with six.assertRaisesRegex( self, RuntimeError, 'PointConstraint.__constrainedTransform : Constraint target does not exist: "/group/target"' ):
 			constraint["out"].fullTransform( "/group/constrained" )
 
 		constraint["ignoreMissingTarget"].setValue( True )

--- a/python/GafferSceneTest/PointConstraintTest.py
+++ b/python/GafferSceneTest/PointConstraintTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import imath
+import inspect
 import six
 
 import IECore
@@ -134,6 +135,97 @@ class PointConstraintTest( GafferSceneTest.SceneTestCase ) :
 		# No op
 		constraint["target"].setValue( "" )
 		self.assertEqual( constraint["out"].fullTransform( "/group/constrained" ), constraint["in"].fullTransform( "/group/constrained" ) )
+
+	def testOffsetIgnoredWhenKeepingReferencePosition( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["sphere"] = GafferScene.Sphere()
+		script["cube"] = GafferScene.Cube()
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["sphere"]["out"] )
+		script["parent"]["child"][0].setInput( script["cube"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+		script["cubeFilter"] = GafferScene.PathFilter()
+		script["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		script["constraint"] = GafferScene.PointConstraint()
+		script["constraint"]["in"].setInput( script["parent"]["out"] )
+		script["constraint"]["filter"].setInput( script["cubeFilter"]["out"] )
+		script["constraint"]["target"].setValue( "/sphere" )
+
+		script["sphereExpression"] = Gaffer.Expression()
+		script["sphereExpression"].setExpression( inspect.cleandoc(
+			"""
+			parent["sphere"]["transform"]["translate"]["x"] = context.getFrame()
+			"""
+		) )
+
+		# With `keepReferencePosition == False`. The `offset` is applied.
+		# This was essentially a poor man's way of trying to maintain a reference
+		# position, where the reference position needed to be manually specified.
+
+		offsetY = 2
+		script["constraint"]["offset"]["y"].setValue( offsetY )
+
+		with Gaffer.Context( script.context() ) as context :
+			for frame in range( 0, 10 ) :
+				context.setFrame( frame )
+				self.assertEqual(
+					script["constraint"]["out"].transform( "/cube" ),
+					imath.M44f().translate( imath.V3f(
+						script["sphere"]["transform"]["translate"]["x"].getValue(),
+						offsetY,
+						0
+					) )
+				)
+
+		# With `keepReferencePosition == True`. We don't apply the `offset`.
+		# In this mode it is easier to just use the transform tools to interactively
+		# adjust the original object's transform until you get what you want. We disable
+		# `offset` in the interests of keeping things simple for the user,
+		# and the future possibility of being able to remove it entirely.
+
+		script["constraint"]["keepReferencePosition"].setValue( True )
+		script["cube"]["transform"]["translate"]["y"].setValue( 1 )
+
+		with Gaffer.Context( script.context() ) as context :
+			for frame in range( 0, 10 ) :
+				context.setFrame( frame )
+				self.assertEqual(
+					script["constraint"]["out"].transform( "/cube" ),
+					imath.M44f().translate( imath.V3f(
+						script["sphere"]["transform"]["translate"]["x"].getValue() - 1, # Maintaining `x==0`` at frame 1.
+						1, # From input transform, _not_ `offset`.
+						0
+					) )
+				)
+
+		# But of course, that is just what would happen naturally in a naive implementation,
+		# because even if the `offset` was applied, it would be negated by the
+		# code that maintains the reference position. Animate the `offset` so we
+		# can be sure it really isn't being applied.
+
+		script["offsetExpression"] = Gaffer.Expression()
+		script["offsetExpression"].setExpression( inspect.cleandoc(
+			"""
+			parent["constraint"]["offset"]["y"] = context.getFrame() * 2
+			"""
+		) )
+
+		with Gaffer.Context( script.context() ) as context :
+			for frame in range( 0, 10 ) :
+				context.setFrame( frame )
+				self.assertEqual(
+					script["constraint"]["out"].transform( "/cube" ),
+					imath.M44f().translate( imath.V3f(
+						script["sphere"]["transform"]["translate"]["x"].getValue() - 1, # Maintaining `x==0`` at frame 1.
+						1, # From input transform, _not_ `offset`.
+						0
+					) )
+				)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/AimConstraintUI.py
+++ b/python/GafferSceneUI/AimConstraintUI.py
@@ -49,6 +49,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"referenceFrame" : [
+
+			"divider", True,
+
+		],
+
 		"aim" : [
 
 			"description",

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -149,6 +149,8 @@ Gaffer.Metadata.registerNode(
 			the offset is measured relative to the local surface coordinate frame.
 			""",
 
+			"divider", True,
+
 		],
 
 		"keepReferencePosition" : [

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -151,6 +151,26 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"keepReferencePosition" : [
+
+			"description",
+			"""
+			Adjusts the constraint so that the original position of the object
+			at the `referenceFrame` is maintained.
+			""",
+
+		],
+
+		"referenceFrame" : [
+
+			"description",
+			"""
+			The reference frame used by the `keepReferencePosition` mode. The constraint
+			is adjusted so that the original position at this frame is maintained.
+			""",
+
+		],
+
 	},
 
 )

--- a/python/GafferSceneUI/ConstraintUI.py
+++ b/python/GafferSceneUI/ConstraintUI.py
@@ -55,6 +55,7 @@ Gaffer.Metadata.registerNode(
 
 	"layout:activator:targetModeIsUV", lambda node : node["targetMode"].getValue() == GafferScene.Constraint.TargetMode.UV,
 	"layout:activator:targetModeIsVertex", lambda node : node["targetMode"].getValue() == GafferScene.Constraint.TargetMode.Vertex,
+	"layout:activator:keepReferencePositionIsOff", lambda node : not node["keepReferencePosition"].getValue(),
 
 	plugs = {
 

--- a/python/GafferSceneUI/ParentConstraintUI.py
+++ b/python/GafferSceneUI/ParentConstraintUI.py
@@ -60,9 +60,13 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Transforms the constrained object relative to the target location.
+
+			> Note : This is ignored when `keepReferencePosition` is on. In this case it is easier
+			> to modify the reference position instead.
 			""",
 
 			"layout:section", "Transform",
+			"layout:activator", "keepReferencePositionIsOff",
 
 		],
 

--- a/python/GafferSceneUI/PointConstraintUI.py
+++ b/python/GafferSceneUI/PointConstraintUI.py
@@ -56,21 +56,6 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"offset" : [
-
-			"description",
-			"""
-			A world space translation offset applied on top
-			of the target position.
-
-			> Note : This is ignored when `keepReferencePosition` is on. In this case it is easier
-			> to modify the reference position instead.
-			""",
-
-			"layout:activator", "keepReferencePositionIsOff",
-
-		],
-
 		"xEnabled" : [
 
 			"description",
@@ -95,6 +80,21 @@ Gaffer.Metadata.registerNode(
 			"""
 			Enables the constraint in the world space z axis.
 			""",
+
+		],
+
+		"offset" : [
+
+			"description",
+			"""
+			A world space translation offset applied on top
+			of the target position.
+
+			> Note : This is ignored when `keepReferencePosition` is on. In this case it is easier
+			> to modify the reference position instead.
+			""",
+
+			"layout:activator", "keepReferencePositionIsOff",
 
 		],
 

--- a/python/GafferSceneUI/PointConstraintUI.py
+++ b/python/GafferSceneUI/PointConstraintUI.py
@@ -50,6 +50,12 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"referenceFrame" : [
+
+			"divider", True,
+
+		],
+
 		"offset" : [
 
 			"description",

--- a/python/GafferSceneUI/PointConstraintUI.py
+++ b/python/GafferSceneUI/PointConstraintUI.py
@@ -62,7 +62,12 @@ Gaffer.Metadata.registerNode(
 			"""
 			A world space translation offset applied on top
 			of the target position.
+
+			> Note : This is ignored when `keepReferencePosition` is on. In this case it is easier
+			> to modify the reference position instead.
 			""",
+
+			"layout:activator", "keepReferencePositionIsOff",
 
 		],
 

--- a/src/GafferScene/Constraint.cpp
+++ b/src/GafferScene/Constraint.cpp
@@ -901,12 +901,9 @@ void Constraint::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 	SceneElementProcessor::affects( input, outputs );
 
 	if(
-		input == targetPlug() ||
-		input == ignoreMissingTargetPlug() ||
-		input == inPlug()->existsPlug() ||
+		affectsTarget( input ) ||
 		input == inPlug()->transformPlug() ||
 		input == inPlug()->boundPlug() ||
-		input == targetScenePlug()->existsPlug() ||
 		input == targetScenePlug()->transformPlug() ||
 		input == targetScenePlug()->boundPlug() ||
 		input == targetScenePlug()->objectPlug() ||
@@ -1048,6 +1045,16 @@ Imath::M44f Constraint::computeProcessedTransform( const ScenePath &path, const 
 
 	const M44f fullConstrainedTransform = computeConstraint( fullTargetTransform, fullInputTransform, inputTransform );
 	return fullConstrainedTransform * parentTransform.inverse();
+}
+
+bool Constraint::affectsTarget( const Gaffer::Plug *input ) const
+{
+	return
+		input == targetPlug() ||
+		input == targetScenePlug()->existsPlug() ||
+		input == inPlug()->existsPlug() ||
+		input == ignoreMissingTargetPlug()
+	;
 }
 
 std::optional<Constraint::Target> Constraint::target() const

--- a/src/GafferScene/ParentConstraint.cpp
+++ b/src/GafferScene/ParentConstraint.cpp
@@ -66,15 +66,26 @@ const Gaffer::TransformPlug *ParentConstraint::relativeTransformPlug() const
 
 bool ParentConstraint::affectsConstraint( const Gaffer::Plug *input ) const
 {
-	return relativeTransformPlug()->isAncestorOf( input );
+	return
+		input == keepReferencePositionPlug() ||
+		relativeTransformPlug()->isAncestorOf( input )
+	;
 }
 
 void ParentConstraint::hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	relativeTransformPlug()->hash( h );
+	if( !keepReferencePositionPlug()->getValue() )
+	{
+		relativeTransformPlug()->hash( h );
+	}
 }
 
 Imath::M44f ParentConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
-	return inputTransform * relativeTransformPlug()->matrix() * fullTargetTransform;
+	Imath::M44f relativeMatrix;
+	if( !keepReferencePositionPlug()->getValue() )
+	{
+		relativeMatrix = relativeTransformPlug()->matrix();
+	}
+	return inputTransform * relativeMatrix * fullTargetTransform;
 }

--- a/src/GafferScene/PointConstraint.cpp
+++ b/src/GafferScene/PointConstraint.cpp
@@ -103,6 +103,7 @@ const Gaffer::BoolPlug *PointConstraint::zEnabledPlug() const
 bool PointConstraint::affectsConstraint( const Gaffer::Plug *input ) const
 {
 	return
+		input == keepReferencePositionPlug() ||
 		input->parent<Plug>() == offsetPlug() ||
 		input == xEnabledPlug() ||
 		input == yEnabledPlug() ||
@@ -111,7 +112,10 @@ bool PointConstraint::affectsConstraint( const Gaffer::Plug *input ) const
 
 void PointConstraint::hashConstraint( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	offsetPlug()->hash( h );
+	if( !keepReferencePositionPlug()->getValue() )
+	{
+		offsetPlug()->hash( h );
+	}
 	xEnabledPlug()->hash( h );
 	yEnabledPlug()->hash( h );
 	zEnabledPlug()->hash( h );
@@ -119,7 +123,11 @@ void PointConstraint::hashConstraint( const Gaffer::Context *context, IECore::Mu
 
 Imath::M44f PointConstraint::computeConstraint( const Imath::M44f &fullTargetTransform, const Imath::M44f &fullInputTransform, const Imath::M44f &inputTransform ) const
 {
-	const V3f worldPosition = fullTargetTransform.translation() + offsetPlug()->getValue();
+	V3f worldPosition = fullTargetTransform.translation();
+	if( !keepReferencePositionPlug()->getValue() )
+	{
+		worldPosition += offsetPlug()->getValue();
+	}
 	M44f result = fullInputTransform;
 
 	if( xEnabledPlug()->getValue() )

--- a/src/GafferScene/PointConstraint.cpp
+++ b/src/GafferScene/PointConstraint.cpp
@@ -50,54 +50,54 @@ PointConstraint::PointConstraint( const std::string &name )
 	:	Constraint( name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
-	addChild( new V3fPlug( "offset", Plug::In, V3f( 0, 0, 0 ) ) );
 	addChild( new BoolPlug( "xEnabled", Plug::In, true ) );
 	addChild( new BoolPlug( "yEnabled", Plug::In, true ) );
 	addChild( new BoolPlug( "zEnabled", Plug::In, true ) );
+	addChild( new V3fPlug( "offset", Plug::In, V3f( 0, 0, 0 ) ) );
 }
 
 PointConstraint::~PointConstraint()
 {
 }
 
-Gaffer::V3fPlug *PointConstraint::offsetPlug()
-{
-	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex );
-}
-
-const Gaffer::V3fPlug *PointConstraint::offsetPlug() const
-{
-	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex );
-}
-
 Gaffer::BoolPlug *PointConstraint::xEnabledPlug()
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
 }
 
 const Gaffer::BoolPlug *PointConstraint::xEnabledPlug() const
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex );
 }
 
 Gaffer::BoolPlug *PointConstraint::yEnabledPlug()
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
 }
 
 const Gaffer::BoolPlug *PointConstraint::yEnabledPlug() const
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
 }
 
 Gaffer::BoolPlug *PointConstraint::zEnabledPlug()
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 3 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 2 );
 }
 
 const Gaffer::BoolPlug *PointConstraint::zEnabledPlug() const
 {
-	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 3 );
+	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::V3fPlug *PointConstraint::offsetPlug()
+{
+	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::V3fPlug *PointConstraint::offsetPlug() const
+{
+	return getChild<Gaffer::V3fPlug>( g_firstPlugIndex + 3 );
 }
 
 bool PointConstraint::affectsConstraint( const Gaffer::Plug *input ) const


### PR DESCRIPTION
This adds a `keepReferencePosition` plug to the Constraint base class, allowing the user to get the relative positions of the target and constrained objects to their liking before creating the constraint, without the constraint subsequently breaking that relationship. It also makes a significant optimisation for UV constraints that fell out naturally from refactoring I did to make this easy enough to implement. 

I've marked this PR as draft because there are a few open questions that I want feedback on, but the code itself should be in good shape for review. The main questions are :

- Is `referenceFrame` the right unit, or should it be `referenceTime` (measured in seconds)? The latter is what you want if you change `framesPerSecond` subsequently, but `referenceFrame` seems more intuitive.
- Several options seem pretty pointless and/or confusing when `keepReferencePosition` is on :
    - Switching between BoundMin, BoundMax and BoundCenter modes has no effect at the reference time, and only show any effect if the respective things are animated at frames other than the reference time. Likewise for targetOffset.
- Some options feel like they should trump `keepReferencePosition` - `ParentConstraint.transform` and `PointConstraint.offset`. But they don't. I think we need an API break to allow them to.