### PR TITLE
Avoid `Signal::disconnect( slot )` (round 1)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,9 @@ Fixes
 API
 ---
 
-- Signals : Added `Trackable::disconnectTrackedConnections()` method.
+- Signals :
+  - Added `Trackable::disconnectTrackedConnections()` method.
+  - Added `ScopedConnection` move constructor and move assignment operator.
 - ViewportGadget : Added `setPostProcessShader()`.  This allows the main layer to be rendered to a framebuffer, and processed by a shader before being displayed.  Useful for applying color transforms on the GPU after rendering.
 - GafferImageUI : Added `OpenColorIOAlgo::displayTransformToFramebufferShader()`.  Converts an OCIO processor to a shader suitable for use with `setPostProcessShader()`.
 - ImageView : ImageView now uses a color transform on the viewport instead of ImageGadget.  Should not impact user visible behaviour, but paves the way for future work.
@@ -38,6 +40,7 @@ Breaking Changes
 
 - ImageGadget : Removed setters and getters for `DisplayTransform`, `UseGPU`, `Clipping`, `Exposure`, `Gamma`.  Instead use `ViewportGadget::setPostProcessShader()` to set up a GPU color transform, or set the plug values on `ImageView`.
 - ImageView : Using CPU color transforms is now deprecated.  We can't properly support wipes in CPU mode, and OCIO now offers full quality on the GPU, in addition to the performance being much better.  While the CPU functionality still exists, the UI has been hidden.
+- Signals : Removed flawed `ScopedConnection` copy constructor and assignment operator. Use move construction and assignment instead.
 
 1.0.x.x (relative to 1.0.4.0)
 =======

--- a/include/Gaffer/BoxIO.h
+++ b/include/Gaffer/BoxIO.h
@@ -173,6 +173,7 @@ class GAFFER_API BoxIO : public Node
 
 		Signals::ScopedConnection m_promotedPlugNameChangedConnection;
 		Signals::ScopedConnection m_promotedPlugParentChangedConnection;
+		Signals::ScopedConnection m_boxPlugInputChangedConnection;
 
 		void setupPassThrough();
 		void setupBoxEnabledPlug();

--- a/include/Gaffer/Signals.h
+++ b/include/Gaffer/Signals.h
@@ -192,10 +192,17 @@ class ScopedConnection : public Connection
 
 		ScopedConnection() = default;
 		ScopedConnection( const Connection &connection );
+		/// Move constructor, which transfers ownership from an existing
+		/// ScopedConnection (which will subsequently be empty).
+		ScopedConnection( ScopedConnection &&scopedConnection );
 		/// Disconnects the slot.
 		~ScopedConnection();
 		/// Disconnects the current connection and assigns a new one.
 		ScopedConnection &operator=( const Connection &connection );
+		/// Disconnects the current connection and takes ownership of
+		/// the connection held by `scopedConnection` (which will
+		/// subsequently be empty).
+		ScopedConnection &operator=( ScopedConnection &&scopedConnection );
 
 };
 

--- a/include/Gaffer/Signals.inl
+++ b/include/Gaffer/Signals.inl
@@ -523,6 +523,12 @@ inline ScopedConnection::ScopedConnection( const Connection &connection )
 {
 }
 
+inline ScopedConnection::ScopedConnection( ScopedConnection &&scopedConnection )
+	:	Connection( scopedConnection )
+{
+	scopedConnection.Connection::operator=( Connection() );
+}
+
 inline ScopedConnection::~ScopedConnection()
 {
 	disconnect();
@@ -532,6 +538,14 @@ inline ScopedConnection &ScopedConnection::operator=( const Connection &connecti
 {
 	disconnect();
 	Connection::operator=( connection );
+	return *this;
+}
+
+inline ScopedConnection &ScopedConnection::operator=( ScopedConnection &&scopedConnection )
+{
+	disconnect();
+	Connection::operator=( scopedConnection );
+	scopedConnection.Connection::operator=( Connection() );
 	return *this;
 }
 

--- a/python/GafferTest/SignalsTest.py
+++ b/python/GafferTest/SignalsTest.py
@@ -600,5 +600,17 @@ class SignalsTest( GafferTest.TestCase ) :
 
 		GafferTest.testSignalSelfDisconnectingSlot()
 
+	def testScopedConnectionMoveConstructor( self ) :
+
+		GafferTest.testSignalScopedConnectionMoveConstructor()
+
+	def testScopedConnectionMoveAssignment( self ) :
+
+		GafferTest.testSignalScopedConnectionMoveAssignment()
+
+	def testVectorOfScopedConnections( self ) :
+
+		GafferTest.testSignalVectorOfScopedConnections()
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -641,6 +641,23 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setColumns( c2 )
 		self.assertEqual( w.getColumns(), c2 )
 
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		updates = []
+		w._qtWidget().model().updateFinished.connect( lambda : updates.append( True ) )
+
+		# When a column signals it has been changed, the model should update.
+		c2[1].changedSignal()( c2[1] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( len( updates ), 1 )
+
+		# But not when that column has been removed from the model.
+		w.setColumns( c1 )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		del updates[:]
+		c2[1].changedSignal()( c2[1] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( len( updates ), 0 )
+
 	def testSortable( self ) :
 
 		w = GafferUI.PathListingWidget( Gaffer.DictPath( {}, "/" ) )

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -411,15 +411,11 @@ void BoxIO::parentChanged( GraphComponent *oldParent )
 	// Manage inputChanged connections on our parent box,
 	// so we can discover our promoted plug when an output
 	// connection is made to it.
-	if( Box *box = runTimeCast<Box>( oldParent ) )
-	{
-		box->plugInputChangedSignal().disconnect(
-			boost::bind( &BoxIO::plugInputChanged, this, ::_1 )
-		);
-	}
+
+	m_boxPlugInputChangedConnection.disconnect();
 	if( Box *box = parent<Box>() )
 	{
-		box->plugInputChangedSignal().connect(
+		m_boxPlugInputChangedConnection = box->plugInputChangedSignal().connect(
 			boost::bind( &BoxIO::plugInputChanged, this, ::_1 )
 		);
 	}

--- a/src/GafferModule/SignalsBinding.cpp
+++ b/src/GafferModule/SignalsBinding.cpp
@@ -182,7 +182,7 @@ void GafferModule::bindSignals()
 		.def( "connected", &Connection::connected )
 	;
 
-	class_<ScopedConnection, bases<Connection> >( "ScopedConnection", no_init )
+	class_<ScopedConnection, bases<Connection>, boost::noncopyable>( "ScopedConnection", no_init )
 		.def( init<const Connection &>() )
 	;
 


### PR DESCRIPTION
This represents progress towards removing `Signal::disconnect( slot )`, which I intend to chip away at over a number of PRs. We want to remove it for several reasons :

- It relies on features of `boost::bind` and `boost::function` not available in the `std` equivalents, and we want to move to `std` everywhere.
- It is linear time whereas `Connection::disconnect()` is constant time.
- It is error prone when disconnecting `binds`, because you have to be certain to pass identical `binds` to both `connect` and `disconnect`. If you change the bind in `connect` and not `disconnect` then you have a bug.
- It isn't reliable under MSVC, for reasons we don't understand.