### PR TITLE
OpenColorIOTransform : Consolidate `Direction` enums

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ API
   - Added `nativeString()` function to return the path as an OS-specific string.
   - (Windows only) Paths beginning with a single `/` or `\` not followed by a drive letter are interpreted as UNC paths.
 - WidgetAlgo : Improved `joinEdges()` to support a wider range of widget types.
+- OpenColorIOTransform : Consolidated the duplicate `Direction` enums from CDL, LookTransform and LUT in to a single `OpenColorIOTransform::Direction` enum.
 
 Breaking Changes
 ----------------

--- a/include/GafferImage/CDL.h
+++ b/include/GafferImage/CDL.h
@@ -55,15 +55,6 @@ class GAFFERIMAGE_API CDL : public OpenColorIOTransform
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CDL, CDLTypeId, OpenColorIOTransform );
 
-		// Direction enum is inline with the other OCIO nodes and will work
-		// with OCIO 1.x and 2.x now. Compatibility will be maintained except
-		// where expressions may have been used to set the direction plug.
-		enum Direction
-		{
-			Forward = 0,
-			Inverse = 1
-		};
-
 		Gaffer::Color3fPlug *slopePlug();
 		const Gaffer::Color3fPlug *slopePlug() const;
 

--- a/include/GafferImage/LUT.h
+++ b/include/GafferImage/LUT.h
@@ -69,12 +69,6 @@ class GAFFERIMAGE_API LUT : public OpenColorIOTransform
 			Tetrahedral
 		};
 
-		enum Direction
-		{
-			Forward = 0,
-			Inverse
-		};
-
 		Gaffer::StringPlug *fileNamePlug();
 		const Gaffer::StringPlug *fileNamePlug() const;
 

--- a/include/GafferImage/LookTransform.h
+++ b/include/GafferImage/LookTransform.h
@@ -52,12 +52,6 @@ class GAFFERIMAGE_API LookTransform : public OpenColorIOTransform
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::LookTransform, LookTransformTypeId, OpenColorIOTransform );
 
-		enum Direction
-		{
-			Forward = 0,
-			Inverse
-		};
-
 		Gaffer::StringPlug *lookPlug();
 		const Gaffer::StringPlug *lookPlug() const;
 		Gaffer::IntPlug *directionPlug();

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -54,6 +54,14 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 
 		~OpenColorIOTransform() override;
 
+		/// Defines values for use in `direction` plugs
+		/// created by derived classes.
+		enum Direction
+		{
+			Forward = 0,
+			Inverse
+		};
+
 		/// Fills the vector will the available color spaces,
 		/// as defined by the current OpenColorIO config.
 		static void availableColorSpaces( std::vector<std::string> &colorSpaces );

--- a/python/GafferImageTest/CDLTest.py
+++ b/python/GafferImageTest/CDLTest.py
@@ -83,7 +83,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 		self.assertNotEqual( offset, saturation )
 		self.assertNotEqual( power, saturation )
 
-		o["direction"].setValue( GafferImage.CDL.Direction.Inverse ) # inverse
+		o["direction"].setValue( GafferImage.OpenColorIOTransform.Direction.Inverse ) # inverse
 		inverse = GafferImage.ImageAlgo.image( o["out"] )
 		self.assertNotEqual( orig, inverse )
 		self.assertNotEqual( slope, inverse )

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -68,7 +68,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 		forward = GafferImage.ImageAlgo.image( o["out"] )
 		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), forward )
 
-		o["direction"].setValue( GafferImage.LUT.Direction.Inverse )
+		o["direction"].setValue( GafferImage.OpenColorIOTransform.Direction.Inverse )
 		inverse = GafferImage.ImageAlgo.image( o["out"] )
 		self.assertNotEqual( GafferImage.ImageAlgo.image( n["out"] ), inverse )
 		self.assertNotEqual( forward, inverse )

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -177,7 +177,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		s["lt"] = GafferImage.LookTransform()
 		s["lt"]["in"].setInput( s["reader"]["out"] )
 		s["lt"]["look"].setValue( "primary" )
-		s["lt"]["direction"].setValue( GafferImage.LookTransform.Direction.Inverse )
+		s["lt"]["direction"].setValue( GafferImage.OpenColorIOTransform.Direction.Inverse )
 
 		s["writer"] = GafferImage.ImageWriter()
 		s["writer"]["fileName"].setValue( contextImageFile )

--- a/python/GafferImageUI/CDLUI.py
+++ b/python/GafferImageUI/CDLUI.py
@@ -96,8 +96,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-			"preset:Forward", GafferImage.CDL.Direction.Forward,
-			"preset:Inverse", GafferImage.CDL.Direction.Inverse,
+			"preset:Forward", GafferImage.OpenColorIOTransform.Direction.Forward,
+			"preset:Inverse", GafferImage.OpenColorIOTransform.Direction.Inverse,
 
 		],
 

--- a/python/GafferImageUI/LUTUI.py
+++ b/python/GafferImageUI/LUTUI.py
@@ -90,8 +90,8 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-			"preset:Forward", GafferImage.LUT.Direction.Forward,
-			"preset:Inverse", GafferImage.LUT.Direction.Inverse,
+			"preset:Forward", GafferImage.OpenColorIOTransform.Direction.Forward,
+			"preset:Inverse", GafferImage.OpenColorIOTransform.Direction.Inverse,
 
 		],
 

--- a/python/GafferImageUI/LookTransformUI.py
+++ b/python/GafferImageUI/LookTransformUI.py
@@ -84,8 +84,8 @@ Gaffer.Metadata.registerNode(
 
 			"description", "Specify the look transform direction",
 
-			"preset:Forward", GafferImage.LookTransform.Direction.Forward,
-			"preset:Inverse", GafferImage.LookTransform.Direction.Inverse,
+			"preset:Forward", GafferImage.OpenColorIOTransform.Direction.Forward,
+			"preset:Inverse", GafferImage.OpenColorIOTransform.Direction.Inverse,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/src/GafferImageModule/OpenColorIOTransformBinding.cpp
+++ b/src/GafferImageModule/OpenColorIOTransformBinding.cpp
@@ -106,10 +106,17 @@ void GafferImageModule::bindOpenColorIOTransform()
 	// This probably shouldn't live in this file, but neither should the ColorProcessor line above?
 	GafferBindings::DependencyNodeClass<Saturation>();
 
-	GafferBindings::DependencyNodeClass<OpenColorIOTransform>()
-		.def( "availableColorSpaces", &availableColorSpaces ).staticmethod( "availableColorSpaces" )
-		.def( "availableRoles", &availableRoles ).staticmethod( "availableRoles" )
-	;
+	{
+		scope s = GafferBindings::DependencyNodeClass<OpenColorIOTransform>()
+			.def( "availableColorSpaces", &availableColorSpaces ).staticmethod( "availableColorSpaces" )
+			.def( "availableRoles", &availableRoles ).staticmethod( "availableRoles" )
+		;
+
+		enum_<OpenColorIOTransform::Direction>( "Direction" )
+			.value( "Forward", OpenColorIOTransform::Forward )
+			.value( "Inverse", OpenColorIOTransform::Inverse )
+		;
+	}
 
 	GafferBindings::DependencyNodeClass<ColorSpace>();
 	GafferBindings::DependencyNodeClass<DisplayTransform>();
@@ -125,30 +132,8 @@ void GafferImageModule::bindOpenColorIOTransform()
 			.value( "Linear", LUT::Linear )
 			.value( "Tetrahedral", LUT::Tetrahedral )
 		;
-
-		enum_<LUT::Direction>( "Direction" )
-			.value( "Forward", LUT::Forward )
-			.value( "Inverse", LUT::Inverse )
-		;
 	}
 
-	{
-		scope s = GafferBindings::DependencyNodeClass<CDL>()
-		;
-
-		enum_<CDL::Direction>( "Direction" )
-			.value( "Forward", CDL::Forward )
-			.value( "Inverse", CDL::Inverse )
-		;
-	}
-
-	{
-		scope s = GafferBindings::DependencyNodeClass<LookTransform>()
-		;
-
-		enum_<LookTransform::Direction>( "Direction" )
-				.value( "Forward", LookTransform::Forward )
-				.value( "Inverse", LookTransform::Inverse )
-		;
-	}
+	GafferBindings::DependencyNodeClass<CDL>();
+	GafferBindings::DependencyNodeClass<LookTransform>();
 }


### PR DESCRIPTION
These were being repeated in the CDL, LookTransform and LUT derived classes. Source compatibility is maintained via virtue of the new enum being in the parent namespace of the original enums, so for example `LUT.Direction.Forward` falls through to `OpenColorIOTransform.Direction.Forward`.
