### PR TITLE
GraphEditor : Store framing history per-Editor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - SceneReader : Added reading of more Alembic GeomParam types. Specifically `unsigned char`, `uint16`, `int16` and `uint32` GeomParams are loaded as `UCharVectorData`, `UShortVectorData`, `ShortVectorData` and `UIntVectorData` PrimitiveVariables respectively.
 - SceneWriter : Added writing of more Alembic GeomParam types, mirroring the improved reading mentioned above.
 - Light Editor : Added the ability to select linked objects and to delete lights. Both commands can can be accessed by right-clicking a light name and selecting either 'Select Linked Objects' or 'Delete'.
+- Graph Editor : When changing the root of the Graph Editor (such as entering or exiting a Box), framing is now restored specifically for the current Graph Editor. Previously, a single framing history was used for all Graph Editors.
 
 Fixes
 -----

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -561,9 +561,9 @@ class GraphEditor( GafferUI.Editor ) :
 		# save/restore the current framing so jumping in
 		# and out of Boxes isn't a confusing experience.
 
-		Gaffer.Metadata.registerValue( previousRoot, "ui:graphEditor:framing", self.__currentFrame(), persistent = False )
+		Gaffer.Metadata.registerValue( previousRoot, "ui:graphEditor{}:framing".format( id( self ) ), self.__currentFrame(), persistent = False )
 
-		frame = Gaffer.Metadata.value( self.graphGadget().getRoot(), "ui:graphEditor:framing" )
+		frame = Gaffer.Metadata.value( self.graphGadget().getRoot(), "ui:graphEditor{}:framing".format( id( self ) ) )
 		if frame is not None :
 			self.graphGadgetWidget().getViewportGadget().frame(
 				imath.Box3f( imath.V3f( frame.min().x, frame.min().y, 0 ), imath.V3f( frame.max().x, frame.max().y, 0 ) )


### PR DESCRIPTION
This changes the Graph Editor `setRoot` behavior to store framing uniquely for each Graph Editor. Previously there was a single framing stored in metadata for all Graph Editors. When changing roots of multiple Graph Editors, such as entering and exiting Boxes, the framing restored would be the same for all Editors, making it harder to orient yourself when using multiple Graph Editors.

Is there a better solution to identifying Graph Editors than using their memory address?

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
