### PR TITLE
EditMenu : Ignore keyboard shortcuts if Graph Editor is not in focus

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.x.x (relative to 1.0.5.0)
+=======
+
+Improvements
+------------
+
+- Edit Menu : Disabled keyboard shortcuts for Cut, Copy, Paste, Delete, Duplicate with Inputs and Rename when a Graph Editor is not in focus.
+
 1.0.5.0 (relative to 1.0.4.0)
 =======
 

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -85,8 +85,10 @@ class CompoundEditor( GafferUI.Editor ) :
 	# Returns the editor of the specified type that the user is most likely to
 	# be interested in. If `focussedOnly` is true, only editors with the keyboard
 	# focus are considered. If `visibleOnly` is true, only visible editors are
-	# considered. Returns None if no suitable editor can be found.
-	def editor( self, type = GafferUI.Editor, focussedOnly = False, visibleOnly = False ) :
+	# considered. If `focusSourceTypes` is not `None`, an editor will only be considered
+	# if the focussed widget's type is in `focusSourceTypes`.
+	# Returns None if no suitable editor can be found.
+	def editor( self, type = GafferUI.Editor, focussedOnly = False, visibleOnly = False, focusSourceTypes = None ) :
 
 		candidates = []
 
@@ -103,6 +105,9 @@ class CompoundEditor( GafferUI.Editor ) :
 			hasWindowFocus = editor == windowFocusWidget or editor.isAncestorOf( windowFocusWidget )
 
 			if focussedOnly and not ( windowIsActive and hasWindowFocus ) :
+				continue
+
+			if focusSourceTypes is not None and not isinstance( windowFocusWidget, focusSourceTypes ) :
 				continue
 
 			candidates.append( {


### PR DESCRIPTION
This is a resumption of https://github.com/GafferHQ/gaffer/pull/4341 that helps prevent accidental deletion of nodes. By checking if the current focussed widget is either a `GraphEditor` or `ScripWindow`, we can prevent unrelated editors from running Graph Editor related shortcuts while also allowing the edit menu to work as well.

An open question is if this should apply to more or less edit menu commands.

### Breaking changes ###

Does changing the arguments to `GafferUI.CompoundEditor.editor()` warrant an API break?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
