### PR TITLE
Windows GafferTest no file path plug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
             containerImage:
             dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.2.1/cortex-10.4.2.1-windows-python3.zip
             testRunner: Invoke-Expression
-            testArguments: GafferTest.FileSystemPathTest
+            testArguments: GafferTest
 
     runs-on: ${{ matrix.os }}
 

--- a/include/Gaffer/HiddenFilePathFilter.h
+++ b/include/Gaffer/HiddenFilePathFilter.h
@@ -1,0 +1,81 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Hypothetical Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_HIDDENFILEPATHFILTER_H
+#define GAFFER_HIDDENFILEPATHFILTER_H
+
+#include "Gaffer/PathFilter.h"
+#include "Gaffer/TypeIds.h"
+
+namespace Gaffer
+{
+
+IE_CORE_FORWARDDECLARE( HiddenFilePathFilter )
+
+/// HiddenFilePathFilters can filter the results
+/// of FileSystemPath::children() to provide a masked view
+/// that either includes or excludes hidden files.
+class GAFFER_API HiddenFilePathFilter : public PathFilter
+{
+
+	public :
+
+		HiddenFilePathFilter( IECore::CompoundDataPtr userData = nullptr );
+		~HiddenFilePathFilter() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::HiddenFilePathFilter, HiddenFilePathFilterTypeId, Gaffer::PathFilter );
+
+		void setInverted( bool inverted );
+		bool getInverted() const;
+
+	protected :
+
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override;
+
+	private :
+
+		bool invert( bool b ) const;
+		bool remove( PathPtr path ) const;
+
+		bool m_inverted;
+
+};
+
+IE_CORE_DECLAREPTR( HiddenFilePathFilter )
+
+} // namespace Gaffer
+
+#endif // GAFFER_HIDDENFILEPATHFILTER_H

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -146,6 +146,7 @@ enum TypeId
 	ContextQueryTypeId = 110099,
 	TweakPlugTypeId = 110100,
 	TweaksPlugTypeId = 110101,
+	HiddenFilePathFilterTypeId = 110102,
 
 	LastTypeId = 110159,
 

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -291,7 +291,10 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 			while process.poll() is None :
 
 				if batch.blindData().get( "killed" ) :
-					os.killpg( process.pid, signal.SIGTERM )
+					if os.name == "nt" :
+						subprocess.check_call( [ "TASKKILL", "/F", "/PID", str( process.pid ), "/T" ] )
+					else :
+						os.killpg( process.pid, signal.SIGTERM )
 					self.__reportKilled( batch )
 					return False
 

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import stat
 import unittest
 import imath
 
@@ -103,6 +104,7 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 		a.savePreferences( fileName )
 		os.chmod( fileName, 0 )
 		self.assertRaises( RuntimeError, a.savePreferences, fileName )
+		os.chmod( fileName, stat.S_IWRITE)
 
 	def testPreferencesLocation( self ) :
 

--- a/python/GafferTest/ApplicationRootTest.py
+++ b/python/GafferTest/ApplicationRootTest.py
@@ -110,7 +110,7 @@ class ApplicationRootTest( GafferTest.TestCase ) :
 
 		a = Gaffer.ApplicationRoot( "testApp" )
 
-		self.assertEqual( a.preferencesLocation(), os.path.dirname( self.__defaultPreferencesFile ) )
+		self.assertEqual( a.preferencesLocation(), os.path.dirname( self.__defaultPreferencesFile ).replace( "\\", "/" ) )
 		self.assertTrue( os.path.isdir( a.preferencesLocation() ) )
 
 	def testClipboard( self ) :

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -55,25 +55,56 @@ class ApplicationTest( GafferTest.TestCase ) :
 
 	def testWrapperDoesntDuplicatePaths( self ) :
 
-		output = subprocess.check_output( [ "gaffer", "env", "env" ], universal_newlines = True )
-		externalEnv = {}
-		for line in output.split( '\n' ) :
-			partition = line.partition( "=" )
-			externalEnv[partition[0]] = partition[2]
+		executable = "gaffer" if os.name != "nt" else "gaffer.cmd"
 
-		self.assertEqual( externalEnv["GAFFER_STARTUP_PATHS"], os.environ["GAFFER_STARTUP_PATHS"] )
-		self.assertEqual( externalEnv["GAFFER_APP_PATHS"], os.environ["GAFFER_APP_PATHS"] )
+		for v in ["GAFFER_STARTUP_PATHS", "GAFFER_APP_PATHS"] :
+			value = subprocess.check_output( [ executable, "env", "python", "-c", "import os; print(os.environ['{}'])".format( v ) ], universal_newlines = True )
+			self.assertEqual( value.strip(), os.environ[v] )
 
 	def testProcessName( self ) :
 
-		process = subprocess.Popen( [ "gaffer", "env", "sleep", "100" ] )
-		time.sleep( 1 )
-		command = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "command=" ], universal_newlines = True ).strip()
-		name = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "comm=" ], universal_newlines = True ).strip()
-		process.kill()
+		if os.name == "nt" :
+			process = subprocess.Popen( [ "gaffer.cmd", "env", "python", "-c", "import time; time.sleep(5)" ] )
 
-		self.assertEqual( command, "gaffer env sleep 100" )
-		self.assertEqual( name, "gaffer" )
+			time.sleep( 1 )
+
+			command = subprocess.check_output(
+				[
+					"powershell",
+					"-command",
+					"Get-WmiObject -Query \"SELECT CommandLine FROM Win32_Process WHERE ProcessID={}\" | Format-List -Property CommandLine".format( process.pid )
+				],
+				universal_newlines = True
+			)
+			command = " ".join( [ i.strip() for i in command.strip().split( "\n" ) ] )
+			command = command.replace( "CommandLine : ", "" )
+
+			name = subprocess.check_output(
+				[
+					"powershell",
+					"-command",
+					"Get-WmiObject -Query \"SELECT Name FROM Win32_Process WHERE ProcessID={}\" | Format-List -Property Name".format( process.pid )
+				],
+				universal_newlines = True
+			)
+			name = name.strip().replace( "Name : ", "" )
+
+			subprocess.check_call( [ "TASKKILL", "/F", "/PID", str( process.pid ), "/T" ] )
+
+			self.assertEqual( command, "C:\\Windows\\system32\\cmd.exe /c gaffer.cmd env python -c \"import time; time.sleep(5)\"" )
+			self.assertEqual( name, "cmd.exe" )
+
+		else :
+			process = subprocess.Popen( [ "gaffer", "env", "sleep", "100" ] )
+			time.sleep( 1 )
+
+			command = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "command=" ], universal_newlines = True ).strip()
+			name = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "comm=" ], universal_newlines = True ).strip()
+
+			process.kill()
+
+			self.assertEqual( command, "gaffer env sleep 100" )
+			self.assertEqual( name, "gaffer" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -690,7 +690,10 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
 		self.assertEqual( mh.messages[0].context, "BadAffects::affects()" )
-		self.assertEqual( mh.messages[0].message, "TypeError: No registered converter was able to extract a C++ reference to type Gaffer::Plug from this Python object of type NoneType\n" )
+		self.assertRegex(
+			mh.messages[0].message,
+			r"TypeError: No registered converter was able to extract a C\+\+ reference to type.* Gaffer::Plug from this Python object of type NoneType\n"
+		)
 
 	def testDependencyCyclesDontStopPlugsDirtying( self ) :
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1471,7 +1471,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		s["e"].setExpression( "import math; parent['n']['user']['p'] = math" )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException,
-			".*TypeError: Unsupported type for result \"<module 'math' from .*\" for expression output \"n.user.p\"",
+			".*TypeError: Unsupported type for result \"<module 'math' .* for expression output \"n.user.p\"",
 			s["n"]["user"]["p"].getValue
 		)
 

--- a/python/GafferTest/FileSequencePathFilterTest.py
+++ b/python/GafferTest/FileSequencePathFilterTest.py
@@ -43,12 +43,6 @@ import GafferTest
 
 class FileSequencePathFilterTest( GafferTest.TestCase ) :
 
-	## \todo We should be using `self.temporaryDirectory()` here, but
-	# doing so causes test failures. I believe that a number in the directory
-	# name convince the filter that files are part of a sequence when they are
-	# not. We should fix the filter for that case.
-	__dir = "/tmp/gafferFileSequencePathFilterTest"
-
 	def test( self ) :
 
 		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
@@ -296,6 +290,8 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )
+
+		self.__dir = self.temporaryDirectory().replace( "\\", "/" )
 
 		# clear out old files and make empty directory
 		# to work in

--- a/python/GafferTest/HiddenFilePathFilterTest.py
+++ b/python/GafferTest/HiddenFilePathFilterTest.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2022 Hypothetical Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import subprocess
+import unittest
+
+import Gaffer
+import GafferTest
+
+class HiddenFilePathFilterTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		hiddenFile = Gaffer.FileSystemPath( os.path.join( self.temporaryDirectory(), ".sneaky.txt" ) )
+		with open( hiddenFile.nativeString(), "w" ) as f :
+			f.write( "Can't see me" )
+		if os.name == "nt" :
+			subprocess.check_call( [ "attrib", "+H", hiddenFile.nativeString() ] )
+
+		visibleFile = Gaffer.FileSystemPath( os.path.join( self.temporaryDirectory(), "frank.txt" ) )
+		with open( visibleFile.nativeString(), "w" ) as f :
+			f.write( "Can see me" )
+
+		p = Gaffer.FileSystemPath( os.path.dirname( hiddenFile.nativeString() ) )
+
+		self.assertEqual(
+			sorted( [ str( i ) for i in p.children() ] ),
+			sorted( [ str( hiddenFile ), str( visibleFile ) ] )
+		)
+
+		h = Gaffer.HiddenFilePathFilter()
+		p.setFilter( h )
+
+		self.assertEqual( p.children(), [ hiddenFile ] )
+
+		h.setInverted( True )
+
+		self.assertEqual( p.children(), [ visibleFile ] )
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -874,8 +874,11 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s["r"] = Gaffer.Reference()
 		self.assertEqual( s["r"].fileName(), "" )
 
-		s["r"].load( self.temporaryDirectory() + "/test.grf" )
-		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( os.path.join( self.temporaryDirectory(), "test.grf" ) )
+		self.assertEqual(
+			s["r"].fileName(),
+			self.temporaryDirectory().replace( "\\", "/" ) + "/test.grf"
+		)
 
 	def testUndo( self ) :
 
@@ -899,9 +902,15 @@ class ReferenceTest( GafferTest.TestCase ) :
 			s["r"].load( self.temporaryDirectory() + "/test.grf" )
 
 		self.assertTrue( "p" in s["r"] )
-		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
+		self.assertEqual(
+			s["r"].fileName(),
+			self.temporaryDirectory().replace( "\\", "/" ) + "/test.grf"
+		)
 		self.assertTrue( len( states ), 1 )
-		self.assertEqual( states[0], State( [ "user", "p" ], self.temporaryDirectory() + "/test.grf" ) )
+		self.assertEqual(
+			states[0], State( [ "user", "p" ],
+			self.temporaryDirectory().replace( "\\", "/" ) + "/test.grf" )
+		)
 
 		s.undo()
 		self.assertEqual( s["r"].fileName(), "" )
@@ -911,9 +920,15 @@ class ReferenceTest( GafferTest.TestCase ) :
 
 		s.redo()
 		self.assertTrue( "p" in s["r"] )
-		self.assertEqual( s["r"].fileName(), self.temporaryDirectory() + "/test.grf" )
+		self.assertEqual(
+			s["r"].fileName(),
+			self.temporaryDirectory().replace( "\\", "/" ) + "/test.grf"
+		)
 		self.assertTrue( len( states ), 3 )
-		self.assertEqual( states[2], State( [ "user", "p" ], self.temporaryDirectory() + "/test.grf" ) )
+		self.assertEqual(
+			states[2], State( [ "user", "p" ],
+			self.temporaryDirectory().replace( "\\", "/" ) + "/test.grf" )
+		)
 
 	def testUserPlugsNotReferenced( self ) :
 
@@ -1078,8 +1093,8 @@ class ReferenceTest( GafferTest.TestCase ) :
 		fileB = os.path.join( boxPathB, referenceFile )
 		boxB.exportForReference( fileB )
 
-		searchPathA = ":".join( [boxPathA, boxPathB] )
-		searchPathB = ":".join( [boxPathB, boxPathA] )
+		searchPathA = os.pathsep.join( [boxPathA, boxPathB] )
+		searchPathB = os.pathsep.join( [boxPathB, boxPathA] )
 
 		os.environ["GAFFER_REFERENCE_PATHS"] = searchPathA
 		s["r"] = Gaffer.Reference()

--- a/python/GafferTest/ScriptNodeTest.py
+++ b/python/GafferTest/ScriptNodeTest.py
@@ -1305,7 +1305,7 @@ class ScriptNodeTest( GafferTest.TestCase ) :
 
 	def testFileNameInExecutionError( self ) :
 
-		fileName = self.temporaryDirectory() + "/test.gfr"
+		fileName = self.temporaryDirectory().replace( "\\", "/" ) + "/test.gfr"
 		with open( fileName, "w" ) as f :
 			f.write( "a = 10\n" )
 			f.write( "a = iDontExist\n" )

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -154,6 +154,7 @@ from .EditScopeTest import EditScopeTest
 from .RandomChoiceTest import RandomChoiceTest
 from .ContextQueryTest import ContextQueryTest
 from .TweakPlugTest import TweakPlugTest
+from .HiddenFilePathFilterTest import HiddenFilePathFilterTest
 
 from .IECorePreviewTest import *
 

--- a/src/Gaffer/ApplicationRoot.cpp
+++ b/src/Gaffer/ApplicationRoot.cpp
@@ -130,6 +130,8 @@ std::string ApplicationRoot::preferencesLocation() const
 	}
 
 	std::string result = home;
+	std::replace( result.begin(), result.end(), '\\', '/' );
+
 	result += "/gaffer/startup/" + getName().string();
 
 	boost::filesystem::create_directories( result );

--- a/src/Gaffer/FileSequencePathFilter.cpp
+++ b/src/Gaffer/FileSequencePathFilter.cpp
@@ -109,7 +109,7 @@ bool FileSequencePathFilter::remove( PathPtr path ) const
 		return false;
 	}
 
-	std::vector<std::string> names( 1, fileSystemPath->string() );
+	std::vector<std::string> names( 1, fileSystemPath->names().back().string() );
 	std::vector<FileSequencePtr> sequences;
 	IECore::findSequences( names, sequences, /* minSequenceSize = */ 1 );
 	bool isSequentialFile = !sequences.empty();

--- a/src/Gaffer/FileSystemPath.cpp
+++ b/src/Gaffer/FileSystemPath.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/CompoundPathFilter.h"
 #include "Gaffer/FileSequencePathFilter.h"
+#include "Gaffer/HiddenFilePathFilter.h"
 #include "Gaffer/MatchPatternPathFilter.h"
 #include "Gaffer/PathFilter.h"
 
@@ -546,8 +547,7 @@ PathFilterPtr FileSystemPath::createStandardFilter( const std::vector<std::strin
 
 	// Filter for hidden files
 
-	std::vector<std::string> hiddenFilePatterns; hiddenFilePatterns.push_back( ".*" );
-	MatchPatternPathFilterPtr hiddenFilesFilter = new MatchPatternPathFilter( hiddenFilePatterns, "name", /* leafOnly = */ false );
+	HiddenFilePathFilterPtr hiddenFilesFilter = new HiddenFilePathFilter();
 	hiddenFilesFilter->setInverted( true );
 
 	CompoundDataPtr hiddenFilesUIUserData = new CompoundData;

--- a/src/Gaffer/HiddenFilePathFilter.cpp
+++ b/src/Gaffer/HiddenFilePathFilter.cpp
@@ -1,0 +1,117 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Hypothetical Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/FileSystemPath.h"
+#include "Gaffer/HiddenFilePathFilter.h"
+
+#include "Gaffer/Path.h"
+
+#include "boost/bind.hpp"
+
+#ifdef _MSC_VER
+
+#include <windows.h>
+
+#endif
+
+using namespace Gaffer;
+
+IE_CORE_DEFINERUNTIMETYPED( HiddenFilePathFilter );
+
+HiddenFilePathFilter::HiddenFilePathFilter( IECore::CompoundDataPtr userData )
+	:	PathFilter( userData ), m_inverted( false )
+{
+}
+
+HiddenFilePathFilter::~HiddenFilePathFilter()
+{
+}
+
+void HiddenFilePathFilter::setInverted( bool inverted )
+{
+	if( inverted == m_inverted )
+	{
+		return;
+	}
+	m_inverted = inverted;
+	changedSignal()( this );
+}
+
+bool HiddenFilePathFilter::getInverted() const
+{
+	return m_inverted;
+}
+
+void HiddenFilePathFilter::doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const
+{
+	paths.erase(
+		std::remove_if(
+			paths.begin(),
+			paths.end(),
+			boost::bind( &HiddenFilePathFilter::remove, this, ::_1 )
+		),
+		paths.end()
+	);
+}
+
+bool HiddenFilePathFilter::invert( bool b ) const
+{
+	return b != m_inverted;
+}
+
+bool HiddenFilePathFilter::remove( PathPtr path ) const
+{
+#ifndef _MSC_VER
+	if( !path->names().size() )
+	{
+		return invert( true );
+	}
+
+	const std::string s = path->names().back().string();
+	if( s.size() && s[0] == '.' )
+	{
+		return invert( false );
+	}
+	return invert( true );
+#else
+	DWORD fileAttributes = GetFileAttributes( path->string().c_str() );
+	if( fileAttributes & FILE_ATTRIBUTE_HIDDEN )
+	{
+		return invert( false );
+	}
+	return invert( true );
+#endif
+}

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -451,6 +451,10 @@ Reference::~Reference()
 void Reference::load( const std::string &fileName )
 {
 	const char *s = getenv( "GAFFER_REFERENCE_PATHS" );
+
+	std::string genericFileName = fileName;
+	std::replace( genericFileName.begin(), genericFileName.end(), '\\', '/' );
+
 	IECore::SearchPath sp( s ? s : "" );
 	boost::filesystem::path path = sp.find( fileName );
 	if( path.empty() )
@@ -466,7 +470,7 @@ void Reference::load( const std::string &fileName )
 
 	Action::enact(
 		this,
-		boost::bind( &Reference::loadInternal, ReferencePtr( this ), fileName ),
+		boost::bind( &Reference::loadInternal, ReferencePtr( this ), genericFileName ),
 		boost::bind( &Reference::loadInternal, ReferencePtr( this ), m_fileName )
 	);
 }

--- a/src/GafferModule/PathFilterBinding.cpp
+++ b/src/GafferModule/PathFilterBinding.cpp
@@ -44,6 +44,7 @@
 
 #include "Gaffer/CompoundPathFilter.h"
 #include "Gaffer/FileSequencePathFilter.h"
+#include "Gaffer/HiddenFilePathFilter.h"
 #include "Gaffer/LeafPathFilter.h"
 #include "Gaffer/MatchPatternPathFilter.h"
 #include "Gaffer/Path.h"
@@ -282,6 +283,14 @@ void GafferModule::bindPathFilter()
 		.def( "removeFilter", &CompoundPathFilter::removeFilter )
 		.def( "setFilters", &setFilters )
 		.def( "getFilters", &getFilters )
+	;
+
+	// HiddenFilePathFilter
+
+	RunTimeTypedClass<HiddenFilePathFilter>()
+		.def( init<CompoundDataPtr>( ( arg( "userData" ) = object() ) ) )
+		.def( "setInverted", &HiddenFilePathFilter::setInverted )
+		.def( "getInverted", &HiddenFilePathFilter::getInverted )
 	;
 
 }


### PR DESCRIPTION
This is a sort-of companion to #4867. Here I have `GafferTest` passing as well, except it does not include `FilePathPlug` from #4814.

It's almost identical in its current form (one small difference in `ScriptNodeTest`), though I think it could use at least one additional test demonstrating the issue of an expression of
```
p = parent["SceneReader"]["fileName"]
parent["SceneReader1"]["fileName"] = p
```
losing backslashes due to string substitution if they are present in `parent["SceneReader"]["fileName"]`.

### Breaking changes ###

TBD

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
