### PR TITLE
ScaleHandle : Normalize uniform `scaling()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Shape : Fixed unnecessary serialisation of internal connection.
+- ScaleTool : Fixed oversensitive scaling when zoomed out in the Viewer.
 
 0.61.14.6 (relative to 0.61.14.5)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Fixes
 -----
 
 - Shape : Fixed unnecessary serialisation of internal connection.
-- ScaleTool : Fixed oversensitive scaling when zoomed out in the Viewer.
+- ScaleTool :
+  - Fixed oversensitive scaling when zoomed out in the Viewer.
+  - Prevented uniform scaling from becoming negative.
 
 0.61.14.6 (relative to 0.61.14.5)
 =========

--- a/src/GafferUI/ScaleHandle.cpp
+++ b/src/GafferUI/ScaleHandle.cpp
@@ -122,6 +122,10 @@ Imath::V3f ScaleHandle::scaling( const DragDropEvent &event )
 		// transform is uniform, which is currently all cases. If that changes,
 		// a more sophisticated scale factor may need to be used.
 		scale = ( m_drag.updatedPosition( event ) - m_drag.startPosition() ) / rasterScaleFactor().x;
+		if( scale < 0 )
+		{
+			scale = ( 1.f / ( 1.f - scale ) ) - 1.f;
+		}
 	}
 
 	// snap

--- a/src/GafferUI/ScaleHandle.cpp
+++ b/src/GafferUI/ScaleHandle.cpp
@@ -113,8 +113,15 @@ Imath::V3f ScaleHandle::scaling( const DragDropEvent &event )
 		// When performing uniform scales, the handle is at the origin, so the
 		// pattern we use above gets very twitchy. We instead need to treat the
 		// click point as scale=1 and relative movement in +ve x as a scale
-		// increase and anything in -ve x as a scale decrease.
-		scale = m_drag.updatedPosition( event ) - m_drag.startPosition();
+		// increase and anything in -ve x as a scale decrease. Coordinates are in
+		// gadget-space, which does not scale by camera position. Normalize
+		// by `rasterScaleFactor()` to prevent very large scaling when zoomed out
+		// and small scaling when zoomed in.
+		//
+		// Note that using `rasterScaleFactor()` here works as long as the handle
+		// transform is uniform, which is currently all cases. If that changes,
+		// a more sophisticated scale factor may need to be used.
+		scale = ( m_drag.updatedPosition( event ) - m_drag.startPosition() ) / rasterScaleFactor().x;
 	}
 
 	// snap


### PR DESCRIPTION
`updatePosition()` returns coordinates in gadget-space, which does not include scaling based on the viewport position. This works fine for non-uniform scaling modes because they are normalized by the start position, which is also high when zoomed out, low when zoomed in.

We use `rasterScaleFactor()` to normalize the scaling, making `scaling()` more consistent with the gadget's viewport size and prevents very large scaling when zoomed out, very small scaling when zoomed in. The `m_startPosition()` subtraction is dropped because it is insignificant compared to `rasterScaleFactor()`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
