### PR TITLE
Stylesheet tweaks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 	- Fixed one pixel alignment issue with highlighted and disabled icons.
 	- Improved appearance of adjoined widgets.
 	- Clicking on a button no longer assigns focus to it.
+  - Fixed appearance of disabled MenuButtons, so that they match the appearance of disabled Buttons.
 
 API
 ---

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -515,11 +515,6 @@ _styleSheet = string.Template(
 		background-color: $backgroundHighlight;
 	}
 
-	QPushButton[gafferWithFrame="true"][gafferThinButton="true"]:disabled {
-		color: $tintLighterStrong;
-		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 $backgroundLighter, stop: 0.1 $backgroundLightHighlight, stop: 0.90 $backgroundLightLowlight);
-	}
-
 	QPushButton::menu-indicator {
 		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
 		subcontrol-position: right center;

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -510,7 +510,7 @@ _styleSheet = string.Template(
 		color: $tintLighterStrong;
 	}
 
-	QPushButton[gafferWithFrame="true"]:disabled {
+	QPushButton[gafferWithFrame="true"]:disabled, QPushButton[gafferWithFrame="true"][gafferClass="GafferUI.MenuButton"]:disabled {
 		color: $tintLighterStrong;
 		background-color: $backgroundHighlight;
 	}

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -7836,7 +7836,7 @@
          transform="translate(4e-6,-3.4667084e-6)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28407288px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.30710185px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28407288px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.30710185px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
            x="402.98151"
            y="1761.36"
            id="text2183-6"><tspan
@@ -7844,14 +7844,14 @@
              id="tspan2181-8"
              x="402.98151"
              y="1761.36"
-             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.30710185px">A</tspan></text>
+             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.30710185px;">A</tspan></text>
         <text
            id="text2187-8"
            y="1761.36"
            x="407.98151"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28407288px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.30710185px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28407288px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.30710185px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;"
            xml:space="preserve"><tspan
-             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.30710185px"
+             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.30710185px;"
              y="1761.36"
              x="407.98151"
              id="tspan2185-3"


### PR DESCRIPTION
This is a small followup to #4837, trying out an alternative style for the disabled comparison buttons. See what you think - I find it slightly more obvious that one button is enabled and two aren't, and avoiding the special cases in the stylesheet seems preferable too.

Before :

![image](https://user-images.githubusercontent.com/1133871/193257193-03bdd1c4-5320-442a-a0e0-b869ae282134.png)

After :

![image](https://user-images.githubusercontent.com/1133871/193257056-0f1fa726-af9b-44e2-b6c7-1338b4a7ce25.png)
