### PR TITLE
FileSystemPath : Handle escaped characters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ API
 
 - Capsule : Removed attempts to detect invalidated Capsules.
 
+Fixes
+-----
+
+FileSystemPath : (Windows only) Fixed escaped characters `\$`, `\#` and `\~` in paths. Previously, these would cause an incorrect directory split at the `\`. 
+
 Breaking Changes
 ----------------
 


### PR DESCRIPTION
Because Windows can use a backslash to separate paths, and Gaffer can use a backslash to indicate a literal `$`, `#` or `~`, we need a way of indicating what a backslash is used for.

Given a `\$`, `\#` or `\~`, we settle on treating it as an escaped special character as it would be on Linux. To prevent boost from treating it as a path separator, we substitute a temporary value (an illegal file path character so we don't have to worry about incorrectly substituting intended characters) before having boost decompose the path.

Those standin characters are then reversed when setting the root and name values.

One case is left, which is a special character after what is meant to be a directory separator. In this case, the user must use a double backslash - one for the directory separator, one for the escaped character. Or use forward slashes throughout, which is what we do in `FileSystemPath::doChildren()`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
