### PR TITLE
OSLCode : Backwards compatibility with boost-1.73

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,11 @@ Fixes
 
 - Viewer : Fixed rendering of background in `Replace` comparison mode.
 
+Build
+-----
+
+- Fixed backwards compatibility with Boost 1.73 (broken in 1.1.0.0).
+
 1.1.0.0
 =======
 

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -88,7 +88,14 @@ class GAFFEROSL_API OSLCode : public OSLShader
 		static size_t g_firstPlugIndex;
 
 		ShaderCompiledSignal m_shaderCompiledSignal;
+
+		#if BOOST_VERSION < 107400
+		/// \todo Remove conditional and use this version instead. We are only using the `ConstGraphComponentPtr` version
+		/// below for ABI compatibility.
+		std::unordered_map<const Gaffer::GraphComponent *, Gaffer::Signals::ScopedConnection> m_nameChangedConnections;
+		#else
 		std::unordered_map<Gaffer::ConstGraphComponentPtr, Gaffer::Signals::ScopedConnection> m_nameChangedConnections;
+		#endif
 
 };
 


### PR DESCRIPTION
As discussed, get things compiling at ImageEngine.