### PR TITLE
Catalogue Index Optimization

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Catalogue : Improved performance when interacting with large Catalogues.
 
+Fixes
+-----
+
+- Catalogue : Removed incorrect error message on empty Catalogues
+
 1.1.1.0 (relative to 1.1.0.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.1.x.x ( relative to 1.1.1.0)
+=======
+
+Improvements
+------------
+
+- Catalogue : Improved performance when interacting with large Catalogues.
+
 1.1.1.0 (relative to 1.1.0.0)
 =======
 

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -143,6 +143,9 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 		Gaffer::IntPlug *internalImageIndexPlug();
 		const Gaffer::IntPlug *internalImageIndexPlug() const;
 
+		Gaffer::ObjectPlug *imageIndexMapPlug();
+		const Gaffer::ObjectPlug *imageIndexMapPlug() const;
+
 		Gaffer::StringPlug *invalidImageTextPlug();
 		const Gaffer::StringPlug *invalidImageTextPlug() const;
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -1288,7 +1288,13 @@ void Catalogue::compute( ValuePlug *output, const Context *context ) const
 		}
 
 		std::string result;
-		if( outputIndex > 0 )
+		if( imageName.empty() )
+		{
+			// Failing to find an image even with no query set can happen on a freshly created
+			// catalog with no images.  This does not require an error.
+			result = "";
+		}
+		else if( outputIndex > 0 )
 		{
 			result = "Catalogue : Unassigned Output " + std::to_string( outputIndex );
 		}

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -54,6 +54,8 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 
+#include "IECore/NullObject.h"
+
 #include "boost/algorithm/string.hpp"
 #include "boost/bind/bind.hpp"
 #include "boost/filesystem/operations.hpp"
@@ -88,6 +90,14 @@ IMATH_INTERNAL_NAMESPACE_HEADER_EXIT
 
 namespace
 {
+	// Used by imageIndexMapPlug()
+	struct ImageIndexMapData : public IECore::Data
+	{
+		using Map = std::unordered_map< std::string, int >;
+		Map map;
+	};
+	IE_CORE_DECLAREPTR( ImageIndexMapData )
+
 	std::string g_isRenderingMetadataName = "gaffer:isRendering";
 	std::string g_emptyString( "" );
 	std::string g_outputPrefix( "output:" );
@@ -810,6 +820,7 @@ Catalogue::Catalogue( const std::string &name )
 	addChild( new StringPlug( "name" ) );
 	addChild( new StringPlug( "directory" ) );
 	addChild( new IntPlug( "__imageIndex", Plug::Out ) );
+	addChild( new ObjectPlug( "__imageIndexMap", Plug::Out, IECore::NullObject::defaultNullObject() ) );
 	addChild( new StringPlug( "__invalidImageText", Plug::Out ) );
 
 	// Switch used to choose which image to output
@@ -912,24 +923,34 @@ const Gaffer::IntPlug *Catalogue::internalImageIndexPlug() const
 	return getChild<IntPlug>( g_firstPlugIndex + 4 );
 }
 
+Gaffer::ObjectPlug *Catalogue::imageIndexMapPlug()
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::ObjectPlug *Catalogue::imageIndexMapPlug() const
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+}
+
 Gaffer::StringPlug *Catalogue::invalidImageTextPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::StringPlug *Catalogue::invalidImageTextPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
 }
 
 Switch *Catalogue::imageSwitch()
 {
-	return getChild<Switch>( g_firstPlugIndex + 6 );
+	return getChild<Switch>( g_firstPlugIndex + 7 );
 }
 
 const Switch *Catalogue::imageSwitch() const
 {
-	return getChild<Switch>( g_firstPlugIndex + 6 );
+	return getChild<Switch>( g_firstPlugIndex + 7 );
 }
 
 Catalogue::InternalImage *Catalogue::imageNode( Image *image )
@@ -1208,10 +1229,14 @@ void Catalogue::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	ImageNode::affects( input, outputs );
 
 	auto image = input->parent<Image>();
-	if(
-		input == imageIndexPlug() ||
-		( image && image->parent() == imagesPlug() && ( input == image->namePlug() || input == image->outputIndexPlug() ) )
+	if( image && image->parent() == imagesPlug() &&
+		( input == image->namePlug() || input == image->outputIndexPlug() )
 	)
+	{
+		outputs.push_back( imageIndexMapPlug() );
+	}
+
+	if( input == imageIndexPlug() || input == imageIndexMapPlug() )
 	{
 		outputs.push_back( internalImageIndexPlug() );
 	}
@@ -1224,6 +1249,14 @@ void Catalogue::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 	{
 		h.append( context->get<std::string>( g_imageNameContextName, g_emptyString ) );
 	}
+	else if( output == imageIndexMapPlug() )
+	{
+		for( const auto &image : Image::Range( *imagesPlug() ) )
+		{
+			image->namePlug()->hash( h );
+			image->outputIndexPlug()->hash( h );
+		}
+	}
 	else if( output == internalImageIndexPlug() )
 	{
 		const std::string &imageName = context->get<std::string>( g_imageNameContextName, g_emptyString );
@@ -1233,22 +1266,11 @@ void Catalogue::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 		}
 		else
 		{
-			if( boost::starts_with( imageName, g_outputPrefix ) )
-			{
-				h.append( imageName.substr( g_outputPrefix.size() ) );
-				for( const auto &image : Image::Range( *imagesPlug() ) )
-				{
-					image->outputIndexPlug()->hash( h );
-				}
-			}
-			else
-			{
-				h.append( imageName );
-				for( const auto &image : Image::Range( *imagesPlug() ) )
-				{
-					image->namePlug()->hash( h );
-				}
-			}
+			h.append( imageName );
+
+			Context::EditableScope mapScope( context );
+			mapScope.remove( g_imageNameContextName );
+			imageIndexMapPlug()->hash( h );
 		}
 	}
 }
@@ -1276,6 +1298,23 @@ void Catalogue::compute( ValuePlug *output, const Context *context ) const
 		}
 		static_cast<StringPlug *>( output )->setValue( result );
 	}
+	else if( output == imageIndexMapPlug() )
+	{
+		ImageIndexMapDataPtr result = new ImageIndexMapData();
+		int childIndex = 0;
+		for( const auto &image : Image::Range( *imagesPlug() ) )
+		{
+			result->map[ image->namePlug()->getValue() ] = childIndex;
+			int outputIndex = image->outputIndexPlug()->getValue();
+			if( outputIndex > 0 )
+			{
+				result->map[ "output:" + std::to_string( outputIndex ) ] = childIndex;
+			}
+			childIndex++;
+		}
+
+		static_cast<ObjectPlug *>( output )->setValue( result );
+	}
 
 	if( output != internalImageIndexPlug() )
 	{
@@ -1291,25 +1330,13 @@ void Catalogue::compute( ValuePlug *output, const Context *context ) const
 	}
 	else
 	{
-		size_t childIndex = 0;
-		int outputIndex = 0;
-
-		if( boost::starts_with( imageName, g_outputPrefix ) )
+		Context::EditableScope mapScope( context );
+		mapScope.remove( g_imageNameContextName );
+		ConstImageIndexMapDataPtr imageIndexMap = boost::static_pointer_cast<const ImageIndexMapData>( imageIndexMapPlug()->getValue() );
+		auto it = imageIndexMap->map.find( imageName );
+		if( it != imageIndexMap->map.end() )
 		{
-			outputIndex = std::stoi( imageName.substr( g_outputPrefix.size() ) );
-		}
-
-		for( const auto &image : Image::Range( *imagesPlug() ) )
-		{
-			if( ( outputIndex > 0 ) ?
-				image->outputIndexPlug()->getValue() == outputIndex :
-				image->namePlug()->getValue() == imageName
-			)
-			{
-				index = childIndex;
-				break;
-			}
-			childIndex++;
+			index = it->second;
 		}
 	}
 


### PR DESCRIPTION
This is a simple initial implementation of the catalogue optimization we talked about.  Definitely needs a bit more interactive testing, and validation that we're actually seeing the performance gains we want, but it feels about right, and the tests are passing.

One thing to think about:  it would have been easy to stick "output:*" in the same map to accelerate those as well ( perhaps even easier than having a separate branch ), but then the map would be invalidated whenever an output index changes - assuming that happens more often than a rename, that would be undesirable.