### PR TITLE
OSLCode : Use raw pointer as key in connections map

### DIFF
--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -88,14 +88,7 @@ class GAFFEROSL_API OSLCode : public OSLShader
 		static size_t g_firstPlugIndex;
 
 		ShaderCompiledSignal m_shaderCompiledSignal;
-
-		#if BOOST_VERSION < 107400
-		/// \todo Remove conditional and use this version instead. We are only using the `ConstGraphComponentPtr` version
-		/// below for ABI compatibility.
 		std::unordered_map<const Gaffer::GraphComponent *, Gaffer::Signals::ScopedConnection> m_nameChangedConnections;
-		#else
-		std::unordered_map<Gaffer::ConstGraphComponentPtr, Gaffer::Signals::ScopedConnection> m_nameChangedConnections;
-		#endif
 
 };
 


### PR DESCRIPTION
We add items to the map when they are parented, and remove them when they are unparented. An object can't be destroyed before being unparented, so we know that the raw pointer is valid for as long as it lives in the map.

This is a followup from #4886, but for `main`. It's what we would have done on `1.1_maintenance` if we were confident it had no impact on ABI compatibility.