### PR TITLE
Capsule : Remove tracking of `m_scene` parent

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.x.x.x
+=======
+
+API
+---
+
+- Capsule : Removed attempts to detect invalidated Capsules.
+
 1.1.1.0 (relative to 1.1.0.0)
 =======
 

--- a/python/GafferSceneTest/CapsuleTest.py
+++ b/python/GafferSceneTest/CapsuleTest.py
@@ -73,9 +73,5 @@ class CapsuleTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( capsuleCopy.bound(), sphere["out"].bound( "/" ) )
 		self.assertEqual( capsuleCopy.hash(), capsule.hash() )
 
-		del sphere
-
-		six.assertRaisesRegex( self, RuntimeError, "Source scene plug no longer valid.", capsule.scene )
-
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This was intended to provide some safety rails to diagnose the use of invalidated capsules. But in practice, the reparenting of a ScenePlug is just one of a great many ways of invalidating a capsule, none of which we have protected against since 02ac22ee8a5ea91716f3f9bb6f714198515d5648.

My main motivation here was actually to remove one more use of `Signal::disconnect( slot )`, so that we can eventually remove that method. It would be perfectly possible to keep the parent tracking by using a `ScopedConnection` member variable to do the disconnection with instead. But given the documented thread-safety issues with using signals in this context, and the general ineffectiveness of the invalidation tracking, I thought it preferable just to remove it.

Note that `throwIfNoScene()` still has a use - it detects the case where the scene was lost during save/load of a Capsule.
