### PR TITLE
PlugLayout : Update summaries when `summary` metadata changes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.6.x (relative to 1.0.6.0)
+=======
+
+Fixes
+-----
+
+- NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.
+
 1.0.6.0 (relative to 1.0.5.1)
 =======
 


### PR DESCRIPTION
This means that the NodeEditor updates immediately when the summary is edited in the UI Editor.