### PR TITLE
IECoreCycles : Replace ObjectAlgo with GeometryAlgo

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 -----
 
 - Catalogue : Removed incorrect error message on empty Catalogues.
+- Cycles : Fixed crash rendering a scene containing a CoordinateSystem (#4865).
 
 API
 ---

--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -32,8 +32,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef IECORECYCLES_OBJECTALGO_H
-#define IECORECYCLES_OBJECTALGO_H
+#ifndef IECORECYCLES_GEOMETRYALGO_H
+#define IECORECYCLES_GEOMETRYALGO_H
 
 #include "GafferCycles/IECoreCyclesPreview/Export.h"
 
@@ -43,7 +43,7 @@
 
 // Cycles
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "scene/object.h"
+#include "scene/geometry.h"
 // Currently only VDBs need scene to get to the image manager
 #include "scene/scene.h"
 IECORE_POP_DEFAULT_VISIBILITY
@@ -51,24 +51,20 @@ IECORE_POP_DEFAULT_VISIBILITY
 namespace IECoreCycles
 {
 
-namespace ObjectAlgo
+namespace GeometryAlgo
 {
 
-/// A Cycles 'Object' is not necessarily a global thing for all objects, hence why Camera and Lights
-/// are treated separately. They all however subclass from ccl::Node so they all are compatible with
-/// Cycles' internal Node/Socket API to form connections or apply parameters.
-
-/// Converts the specified IECore::Object into a ccl::Object.
-IECORECYCLES_API ccl::Object *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene = nullptr );
+/// Converts the specified `IECore::Object` into `ccl::Geometry`.
+IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene = nullptr );
 /// As above, but converting a moving object. If no motion converter
 /// is available, the first sample is converted instead.
-IECORECYCLES_API ccl::Object *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene = nullptr );
+IECORECYCLES_API ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene = nullptr );
 
-/// Signature of a function which can convert into a Cycles Object.
-using Converter = ccl::Object *(*)( const IECore::Object *, const std::string &, ccl::Scene * );
+/// Signature of a function which can convert to `ccl:Geometry`.
+using Converter = ccl::Geometry *(*)( const IECore::Object *, const std::string &, ccl::Scene * );
 /// Signature of a function which can convert a series of IECore::Object
-/// samples into a moving Cycles object.
-using MotionConverter = ccl::Object *(*)( const std::vector<const IECore::Object *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
+/// samples into a moving `ccl:Geometry` object.
+using MotionConverter = ccl::Geometry *(*)( const std::vector<const IECore::Object *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -84,22 +80,22 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = ccl::Object *(*)( const T *, const std::string &, ccl::Scene * );
-		using MotionConverter = ccl::Object *(*)( const std::vector<const T *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
+		using Converter = ccl::Geometry *(*)( const T *, const std::string &, ccl::Scene * );
+		using MotionConverter = ccl::Geometry *(*)( const std::vector<const T *> &, const std::vector<float> &, const int, const std::string &, ccl::Scene * );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{
 			registerConverter(
 				T::staticTypeId(),
-				reinterpret_cast<ObjectAlgo::Converter>( converter ),
-				reinterpret_cast<ObjectAlgo::MotionConverter>( motionConverter )
+				reinterpret_cast<GeometryAlgo::Converter>( converter ),
+				reinterpret_cast<GeometryAlgo::MotionConverter>( motionConverter )
 			);
 		}
 
 };
 
-} // namespace ObjectAlgo
+} // namespace GeometryAlgo
 
 } // namespace IECoreCycles
 
-#endif // IECORECYCLES_OBJECTALGO_H
+#endif // IECORECYCLES_GEOMETRYALGO_H

--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -61,6 +61,9 @@ IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, const std
 IECORECYCLES_API ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene = nullptr );
 
 /// Signature of a function which can convert to `ccl:Geometry`.
+/// \todo There's really no need to pass the node name here, because it's not a unique handle that
+/// needs to be provided when creating the Geometry (like it is in Arnold). The caller can just set the name
+/// afterwards if they want to.
 using Converter = ccl::Geometry *(*)( const IECore::Object *, const std::string &, ccl::Scene * );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving `ccl:Geometry` object.

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -396,6 +396,22 @@ class RendererTest( GafferTest.TestCase ) :
 
 		del o
 
+		# Likewise for CoordinateSystems and NullObjects.
+
+		o = renderer.object(
+			"/coordinateSystem",
+			IECoreScene.CoordinateSystem(),
+			renderer.attributes( IECore.CompoundObject ( {} ) )
+		)
+		del o
+
+		o = renderer.object(
+			"/nullObject",
+			IECore.NullObject.defaultNullObject(),
+			renderer.attributes( IECore.CompoundObject ( {} ) )
+		)
+		del o
+
 	def testDisplayDriverCropWindow( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/src/GafferCycles/IECoreCyclesPreview/AttributeAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/AttributeAlgo.cpp
@@ -33,7 +33,6 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/AttributeAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
 #include "IECore/SimpleTypedData.h"

--- a/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
@@ -33,7 +33,6 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/CameraAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
 #include "IECoreScene/Camera.h"

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/AttributeAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 
 #include "IECoreScene/CurvesPrimitive.h"
 
@@ -117,15 +117,14 @@ ccl::Hair *convertCommon( const IECoreScene::CurvesPrimitive *curve )
 	return hair;
 }
 
-ccl::Object *convert( const IECoreScene::CurvesPrimitive *curve, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( convertCommon( curve ) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	ccl::Hair *hair = convertCommon( curve );
+	hair->name = ccl::ustring( nodeName.c_str() );
+	return hair;
 }
 
-ccl::Object *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
 	const int numSamples = curves.size();
 
@@ -233,12 +232,10 @@ ccl::Object *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves
 	}
 	mP = attr_mP->data_float3();
 
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( hair );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	hair->name = ccl::ustring( nodeName.c_str() );
+	return hair;
 }
 
-ObjectAlgo::ConverterDescription<CurvesPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<CurvesPrimitive> g_description( convert, convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -32,7 +32,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 
 #include "IECore/MessageHandler.h"
 
@@ -77,8 +77,8 @@ using namespace IECoreCycles;
 struct Converters
 {
 
-	ObjectAlgo::Converter converter;
-	ObjectAlgo::MotionConverter motionConverter;
+	GeometryAlgo::Converter converter;
+	GeometryAlgo::MotionConverter motionConverter;
 
 };
 
@@ -99,10 +99,10 @@ Registry &registry()
 namespace IECoreCycles
 {
 
-namespace ObjectAlgo
+namespace GeometryAlgo
 {
 
-ccl::Object *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene )
 {
 	const Registry &r = registry();
 	Registry::const_iterator it = r.find( object->typeId() );
@@ -113,7 +113,7 @@ ccl::Object *convert( const IECore::Object *object, const std::string &nodeName,
 	return it->second.converter( object, nodeName, scene );
 }
 
-ccl::Object *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
 	if( samples.empty() )
 	{
@@ -151,6 +151,6 @@ void registerConverter( IECore::TypeId fromType, Converter converter, MotionConv
 	registry()[fromType] = { converter, motionConverter };
 }
 
-} // namespace ObjectAlgo
+} // namespace GeometryAlgo
 
 } // namespace IECoreCycles

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/AttributeAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 
 #include "IECoreScene/MeshNormalsOp.h"
 #include "IECoreScene/MeshPrimitive.h"
@@ -619,15 +619,14 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh )
 	return cmesh;
 }
 
-ccl::Object *convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( static_cast<ccl::Geometry*>( convertCommon( mesh ) ) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	ccl::Mesh *cmesh = convertCommon( mesh );
+	cmesh->name = ccl::ustring( nodeName.c_str() );
+	return cmesh;
 }
 
-ccl::Object *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
 	const int numSamples = meshes.size();
 
@@ -780,12 +779,10 @@ ccl::Object *convert( const std::vector<const IECoreScene::MeshPrimitive *> &mes
 		}
 	}
 
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( static_cast<ccl::Geometry*>( cmesh ) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	cmesh->name = ccl::ustring( nodeName.c_str() );
+	return cmesh;
 }
 
-ObjectAlgo::ConverterDescription<MeshPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<MeshPrimitive> g_description( convert, convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/AttributeAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
 #include "IECoreScene/PointsPrimitive.h"
@@ -138,15 +138,14 @@ ccl::PointCloud *convertCommon( const IECoreScene::PointsPrimitive *points )
 	return pointcloud;
 }
 
-ccl::Object *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( (ccl::Geometry*)convertCommon(points) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	ccl::PointCloud *pointCloud = convertCommon( points );
+	pointCloud->name = ccl::ustring( nodeName.c_str() );
+	return pointCloud;
 }
 
-ccl::Object *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
 	const int numSamples = points.size();
 
@@ -254,12 +253,10 @@ ccl::Object *convert( const vector<const IECoreScene::PointsPrimitive *> &points
 	}
 	mP = attr_mP->data_float3();
 
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( pointcloud );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	pointcloud->name = ccl::ustring( nodeName.c_str() );
+	return pointcloud;
 }
 
-ObjectAlgo::ConverterDescription<PointsPrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<PointsPrimitive> g_description( convert, convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferCycles/IECoreCyclesPreview/AttributeAlgo.h"
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
 #include "IECoreScene/SpherePrimitive.h"
@@ -91,22 +91,20 @@ ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere )
 	return pointcloud;
 }
 
-ccl::Object *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( convertCommon( sphere ) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	ccl::Geometry *result = convertCommon( sphere );
+	result->name = ccl::ustring( nodeName.c_str() );
+	return result;
 }
 
-ccl::Object *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Object *cobject = new ccl::Object();
-	cobject->set_geometry( convertCommon( samples.front() ) );
-	cobject->name = ccl::ustring(nodeName.c_str());
-	return cobject;
+	ccl::Geometry *result = convertCommon( samples.front() );
+	result->name = ccl::ustring( nodeName.c_str() );
+	return result;
 }
 
-ObjectAlgo::ConverterDescription<SpherePrimitive> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<SpherePrimitive> g_description( convert, convert );
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -32,7 +32,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferCycles/IECoreCyclesPreview/ObjectAlgo.h"
+#include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
 #include "IECoreVDB/VDBObject.h"
@@ -102,12 +102,10 @@ class GafferVolumeLoader : public ccl::VDBImageLoader
 		const IECoreVDB::VDBObject *m_ieVolume;
 };
 
-ccl::Object *convert( const IECoreVDB::VDBObject *vdbObject, const std::string &nodeName, ccl::Scene *scene )//, const float frame )
+ccl::Geometry *convert( const IECoreVDB::VDBObject *vdbObject, const std::string &nodeName, ccl::Scene *scene )
 {
 	ccl::TypeDesc ctype;// = ccl::TypeDesc::TypeUnknown;
 
-	ccl::Object *cobject = new ccl::Object();
-	cobject->name = ccl::ustring( nodeName.c_str() );
 	ccl::Volume *volume = new ccl::Volume();
 
 	volume->set_object_space( true );
@@ -190,16 +188,15 @@ ccl::Object *convert( const IECoreVDB::VDBObject *vdbObject, const std::string &
 		attr->data_voxel() = scene->image_manager->add_image( loader, params );
 	}
 
-	cobject->set_geometry( volume );
-
-	return cobject;
+	volume->name = ccl::ustring( nodeName.c_str() );
+	return volume;
 }
 
-ccl::Object *convert( const std::vector<const IECoreVDB::VDBObject *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECoreVDB::VDBObject *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
 	return convert( samples.front(), nodeName, scene );
 }
 
-ObjectAlgo::ConverterDescription<IECoreVDB::VDBObject> g_description( convert, convert );
+GeometryAlgo::ConverterDescription<IECoreVDB::VDBObject> g_description( convert, convert );
 
 } // namespace


### PR DESCRIPTION
This follows on from https://github.com/GafferHQ/gaffer/pull/4877, further simplifying the process of converting geometry to Cycles. In doing so it fixes the crash described in https://github.com/GafferHQ/gaffer/issues/4865.