### PR TITLE
ShufflePlug : Optionally overwrite source data with same name as dest…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,8 +6,12 @@
 Improvements
 ------------
 
-- ShuffleAttributes : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
-- ShufflePrimitiveVariables : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+- ShuffleAttributes :
+  - Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+  - Shuffles are now performed in the order they are defined, separate shuffles may write to the same destination.
+- ShufflePrimitiveVariables :
+  - Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+  - Shuffles are now performed in the order they are defined, separate shuffles may write to the same destination.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,12 @@
 
 > Note : Python 2 support has been removed. All builds are now using Python 3.
 
+Improvements
+------------
+
+- ShuffleAttributes : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+- ShufflePrimitiveVariables : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+
 API
 ---
 
@@ -17,7 +23,7 @@ Breaking Changes
 - Python : Removed support for Python 2.
 - CatalogueUI : Hid OutputIndexColumn from public API.
 
-1.1.x.x ( relative to 1.1.1.0)
+1.1.x.x (relative to 1.1.1.0)
 =======
 
 Improvements

--- a/include/Gaffer/ShufflePlug.h
+++ b/include/Gaffer/ShufflePlug.h
@@ -95,11 +95,10 @@ class GAFFER_API ShufflesPlug : public ValuePlug
 		bool acceptsInput( const Plug *input ) const override;
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
-		/// Shuffles the sources into a destination container. The container type must have a std::pair value_type
-		/// and string-compatible keys (eg std::string, IECore::InternedString).
+		/// Shuffles the sources into a destination container. The container type should have a map
+		/// compatible interface with string-compatible keys (eg std::string, IECore::InternedString).
 		template<typename T>
 		T shuffle( const T &sourceContainer ) const;
-
 };
 
 } // namespace Gaffer

--- a/include/Gaffer/ShufflePlug.h
+++ b/include/Gaffer/ShufflePlug.h
@@ -54,7 +54,7 @@ class GAFFER_API ShufflePlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::ShufflePlug, ShufflePlugTypeId, ValuePlug );
 
-		ShufflePlug( const std::string &source, const std::string &destination, bool deleteSource=false, bool enabled=true );
+		ShufflePlug( const std::string &source, const std::string &destination, bool deleteSource=false, bool enabled=true, bool replaceDestination=true );
 		/// Primarily used for serialisation.
 		ShufflePlug( const std::string &name = defaultName<ShufflePlug>(), Direction direction=In, unsigned flags = Default );
 
@@ -69,6 +69,9 @@ class GAFFER_API ShufflePlug : public ValuePlug
 
 		BoolPlug *deleteSourcePlug();
 		const BoolPlug *deleteSourcePlug() const;
+
+		BoolPlug *replaceDestinationPlug();
+		const BoolPlug *replaceDestinationPlug() const;
 
 		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;

--- a/python/GafferSceneUI/ShuffleAttributesUI.py
+++ b/python/GafferSceneUI/ShuffleAttributesUI.py
@@ -47,7 +47,9 @@ Gaffer.Metadata.registerNode(
 	"""
 	ShuffleAttributes is used to copy or rename arbitrary numbers of attributes at
 	the filtered locations. The deleteSource plugs may be used to remove the original
-	source attribute(s) after the shuffling has been completed.
+	source attribute(s) after the shuffling has been completed. The replaceDestination
+	plugs may be used to specify whether each shuffle should replace already written
+	destination data with the same name.
 
 	An additional context variable `${source}` can be used on the destination plugs
 	to insert the name of each source attribute. For example, to prefix all attributes
@@ -60,9 +62,10 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The attributes to be shuffled - arbitrary numbers of attributes may be
-			shuffled via the source/destination plugs. The deleteSource plug may be
-			used to remove the original attribute(s).
+			The attributes to be shuffled - arbitrary numbers of attributes may be shuffled
+			via the source/destination plugs. The deleteSource plug may be used to remove the
+			original attribute(s). The replaceDestination plug may be used to specify whether
+			each shuffle should replace already written destination data with the same name.
 			""",
 
 		],

--- a/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
@@ -43,13 +43,15 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	ShufflePrimitiveVariables is used to copy or rename arbitrary numbers of primitive variables
-	at the filtered locations. The deleteSource plugs may be used to remove the original source
-	primitive variable(s) after the shuffling has been completed.
+	ShufflePrimitiveVariables is used to copy or rename arbitrary numbers of primitive
+	variables at the filtered locations. The deleteSource plugs may be used to remove
+	the original source primitive variable(s) after the shuffling has been completed.
+	The replaceDestination plugs may be used to specify whether each shuffle should
+	replace already written destination data with the same name.
 
-	An additional context variable `${source}` can be used on the destination plugs to insert
-	the name of each source primitive variable. For example, to append `ref` to all primitive variables
-	set the source to `*` and the destination to `${source}ref`.
+	An additional context variable `${source}` can be used on the destination plugs
+	to insert the name of each source primitive variable. For example, to append `ref`
+	to all primitive variables set the source to `*` and the destination to `${source}ref`.
 	""",
 
 	plugs = {
@@ -59,8 +61,10 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The primitive variables to be shuffled - arbitrary numbers of primitive variables
-			may be shuffled via the source/destination plugs. The deleteSource plug may be used
-			to remove the original primitive variable(s).
+			may be shuffled via the source/destination plugs. The deleteSource plug may be
+			used to remove the original primitive variable(s). The replaceDestination plug may
+			be used to specify whether each shuffle should replace already written destination
+			data with the same name.
 			""",
 
 			"divider", True,

--- a/python/GafferTest/ShufflePlugTest.py
+++ b/python/GafferTest/ShufflePlugTest.py
@@ -52,8 +52,9 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		self.assertEqual( p["enabled"].defaultValue(), True )
 		self.assertEqual( p["destination"].defaultValue(), "" )
 		self.assertEqual( p["deleteSource"].defaultValue(), False )
+		self.assertEqual( p["replaceDestination"].defaultValue(), True )
 
-		p = Gaffer.ShufflePlug( source = "foo", destination = "bar", deleteSource = True, enabled = False )
+		p = Gaffer.ShufflePlug( source = "foo", destination = "bar", deleteSource = True, enabled = False, replaceDestination = False )
 		self.assertEqual( p["source"].defaultValue(), "" )
 		self.assertEqual( p["source"].getValue(), "foo" )
 		self.assertEqual( p["enabled"].defaultValue(), True )
@@ -62,6 +63,8 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		self.assertEqual( p["destination"].getValue(), "bar" )
 		self.assertEqual( p["deleteSource"].defaultValue(), False )
 		self.assertEqual( p["deleteSource"].getValue(), True )
+		self.assertEqual( p["replaceDestination"].defaultValue(), True )
+		self.assertEqual( p["replaceDestination"].getValue(), False )
 
 		p2 = Gaffer.ShufflesPlug()
 		self.assertFalse( p.acceptsChild( Gaffer.Plug() ) )
@@ -320,6 +323,24 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 			IECore.CompoundData( {
 				"foo" : IECore.FloatData( 0.5 ),
 				"bar" : IECore.FloatData( 0.5 ),
+				"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+				"bongo" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+			} )
+		)
+
+	def testReplaceDestination( self ) :
+
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "bar", replaceDestination = False ) )
+		p.addChild( Gaffer.ShufflePlug( source = "baz", destination = "bongo", replaceDestination = True ) )
+
+		source = IECore.CompoundData( { "foo" : 0.5, "bar" : 1.5, "baz" : imath.Color3f( 1, 2, 3 ), "bongo" : imath.Color3f( 4, 5, 6 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundData( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 1.5 ),
 				"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 				"bongo" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 			} )

--- a/python/GafferTest/ShufflePlugTest.py
+++ b/python/GafferTest/ShufflePlugTest.py
@@ -173,14 +173,64 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 			} )
 		)
 
-	def testCantReuseDestination( self ) :
+	def testReuseDestination( self ) :
 
 		p = Gaffer.ShufflesPlug()
 		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "baz" ) )
 		p.addChild( Gaffer.ShufflePlug( source = "bar", destination = "baz" ) )
 
 		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
-		self.assertRaisesRegex( RuntimeError, '.*this destination was already written.*', p.shuffle, source )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundObject( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 1.0 ),
+				"baz" : IECore.FloatData( 1.0 ),
+			} )
+		)
+
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "bar", destination = "baz" ) )
+		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "baz" ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundObject( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 1.0 ),
+				"baz" : IECore.FloatData( 0.5 ),
+			} )
+		)
+
+	def testIgnoreIdentity( self ) :
+
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "*", destination = "bar" ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundObject( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 0.5 ),
+			} )
+		)
+
+		# replace destination false
+		p[0]["replaceDestination"].setValue( False )
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundObject( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 1.0 ),
+			} )
+		)
 
 	def testNoReShuffle( self ) :
 
@@ -243,11 +293,11 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 
 		# without the ${source} variable in the destination, our "*" match causes collisions
 		p[0]["destination"].setValue( "allValuesCollide" )
-		self.assertRaisesRegex( RuntimeError, '.*this destination was already written.*', p.shuffle, source )
+		self.assertRaisesRegex( RuntimeError, '.*cannot write from multiple sources to destination.*', p.shuffle, source )
 
 		# other substitution variables can also cause collisions
 		p[0]["destination"].setValue( "foo#" )
-		self.assertRaisesRegex( RuntimeError, '.*this destination was already written.*', p.shuffle, source )
+		self.assertRaisesRegex( RuntimeError, '.*cannot write from multiple sources to destination.*', p.shuffle, source )
 
 	def testDrivenDestination( self ) :
 
@@ -255,10 +305,23 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		script["n"] = Gaffer.Node()
 		script["n"]["p"] = Gaffer.ShufflesPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		script["n"]["p"].addChild( Gaffer.ShufflePlug( name = "s", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		script["n"]["p"]["s"]["source"].setValue( "*" )
+		script["n"]["p"]["s"]["source"].setValue( "foo" )
 		script["expr"] = Gaffer.Expression()
 		script["expr"].setExpression( 'parent["n"]["p"]["s"]["destination"] = context["source"] + ":bar"' )
 
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) } )
+		dest = script["n"]["p"].shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundObject( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"foo:bar" : IECore.FloatData( 0.5 ),
+				"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+			} )
+		)
+
+		# source with wildcard
+		script["n"]["p"]["s"]["source"].setValue( "*" )
 		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) } )
 		dest = script["n"]["p"].shuffle( source )
 		self.assertEqual(
@@ -276,7 +339,35 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) } )
 		with Gaffer.Context() as c :
 			c["notSource"] = "bongo"
-			self.assertRaisesRegex( RuntimeError, '.*this destination was already written.*', script["n"]["p"].shuffle, source )
+			self.assertRaisesRegex( RuntimeError, '.*cannot write from multiple sources to destination.*', script["n"]["p"].shuffle, source )
+
+	def testDrivenSource( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["n"] = Gaffer.Node()
+		script["n"]["p"] = Gaffer.ShufflesPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		script["n"]["p"].addChild( Gaffer.ShufflePlug( name = "s", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		script["srcExpr"] = Gaffer.Expression()
+		script["srcExpr"].setExpression( 'parent["n"]["p"]["s"]["source"] = context["source"]' )
+		script["dstExpr"] = Gaffer.Expression()
+		script["dstExpr"].setExpression( 'parent["n"]["p"]["s"]["destination"] = context["source"] + ":bar"' )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) } )
+		self.assertRaisesRegex( RuntimeError, '.*Context has no variable named \"source\".*', script["n"]["p"].shuffle, source )
+
+		# source expression using predefined source variable
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) } )
+		with Gaffer.Context() as c :
+			c["source"] = "baz"
+			dest = script["n"]["p"].shuffle( source )
+			self.assertEqual(
+				dest,
+				IECore.CompoundObject( {
+					"foo" : IECore.FloatData( 0.5 ),
+					"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+					"baz:bar" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+				} )
+			)
 
 	def testCantDeleteDestination( self ) :
 
@@ -345,6 +436,53 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 				"bongo" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 			} )
 		)
+
+	def testReplaceDestinationNoReuseDestination( self ) :
+
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "*", destination = "bar" ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ), "baz" : IECore.FloatData( 1.5 ) } )
+		self.assertRaisesRegex( RuntimeError, '.*cannot write from multiple sources to destination.*', p.shuffle, source )
+
+		# clashing destinations are detected regardless of replace destination
+		p[0]["replaceDestination"].setValue( False )
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ), "baz" : IECore.FloatData( 1.5 ) } )
+		self.assertRaisesRegex( RuntimeError, '.*cannot write from multiple sources to destination.*', p.shuffle, source )
+
+	def testIdentityNoDeleteSource( self ) :
+
+		# simple
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "foo", deleteSource = True ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual( dest, source )
+
+		# source wildcard
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "*", destination = "foo", deleteSource = True ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual( dest, source )
+
+		# source wildcard destination substitution
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "*", destination = "${source}", deleteSource = True ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual( dest, source )
+
+		# no source wildcard destination substitution
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "${source}", deleteSource = True ) )
+
+		source = IECore.CompoundObject( { "foo" : IECore.FloatData( 0.5 ), "bar" : IECore.FloatData( 1.0 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual( dest, source )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/ShufflePlugValueWidget.py
+++ b/python/GafferUI/ShufflePlugValueWidget.py
@@ -70,7 +70,10 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		destinationWidget.textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__row.append( destinationWidget, verticalAlignment = GafferUI.Label.VerticalAlignment.Top )
 
-		self.__row.append( GafferUI.PlugValueWidget.create( plug["deleteSource"] ), expand = True )
+		deleteSourceWidget = GafferUI.PlugValueWidget.create( plug["deleteSource"] )
+		deleteSourceWidget.boolWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() - 40 )
+		self.__row.append( deleteSourceWidget )
+		self.__row.append( GafferUI.PlugValueWidget.create( plug["replaceDestination"] ), expand = True )
 
 		self._updateFromPlug()
 
@@ -82,6 +85,7 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__row[1].setPlug( plug["enabled"] )
 		self.__row[2].setPlug( plug["destination"] )
 		self.__row[3].setPlug( plug["deleteSource"] )
+		self.__row[4].setPlug( plug["replaceDestination"] )
 
 	def hasLabel( self ) :
 
@@ -110,7 +114,7 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			enabled = self.getPlug()["enabled"].getValue()
 
-		for i in ( 0, 2, 3 ) :
+		for i in ( 0, 2, 3, 4 ) :
 			self.__row[i].setEnabled( enabled )
 
 GafferUI.PlugValueWidget.registerType( Gaffer.ShufflePlug, ShufflePlugValueWidget )
@@ -130,6 +134,7 @@ Gaffer.Metadata.registerValue( Gaffer.ShufflePlug,
 	"""
 )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "deleteSource", "description", "Enable to delete the source data after shuffling to the destination(s)." )
+Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "replaceDestination", "description", "Enable to replace already written destination data with the same name as destination(s)." )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "enabled", "description", "Used to enable/disable this shuffle operation." )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "nodule:type", "" )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "*", "nodule:type", "" )
@@ -152,7 +157,8 @@ class ShufflesPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.Label( "<h4><b>Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 				GafferUI.Spacer( imath.V2i( 25, 2 ) ) # approximate width of a BoolWidget Switch
 				GafferUI.Label( "<h4><b>Destination</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
-				GafferUI.Label( "<h4><b>Delete Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+				GafferUI.Label( "<h4><b>Delete Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() - 40 )
+				GafferUI.Label( "<h4><b>Replace</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 
 			self.__plugLayout = GafferUI.PlugLayout( plug )
 			self.__addButton = GafferUI.Button( image = "plus.png", hasFrame = False )

--- a/src/Gaffer/ShufflePlug.cpp
+++ b/src/Gaffer/ShufflePlug.cpp
@@ -46,13 +46,14 @@ using namespace Gaffer;
 
 GAFFER_PLUG_DEFINE_TYPE( ShufflePlug );
 
-ShufflePlug::ShufflePlug( const std::string &source, const std::string &destination, bool deleteSource, bool enabled )
+ShufflePlug::ShufflePlug( const std::string &source, const std::string &destination, bool deleteSource, bool enabled, bool replaceDestination )
 	: ShufflePlug( "shuffle", In, Default | Dynamic )
 {
 	sourcePlug()->setValue( source );
 	destinationPlug()->setValue( destination );
 	deleteSourcePlug()->setValue( deleteSource );
 	enabledPlug()->setValue( enabled );
+	replaceDestinationPlug()->setValue( replaceDestination );
 }
 
 /// Primarily used for serialisation.
@@ -65,6 +66,7 @@ ShufflePlug::ShufflePlug( const std::string &name, Direction direction, unsigned
 	// during `ShufflesPlug::shuffle()`, in order to account for the ${source} variable.
 	addChild( new StringPlug( "destination", direction, "", Plug::Default, IECore::StringAlgo::NoSubstitutions ) );
 	addChild( new BoolPlug( "deleteSource", direction ) );
+	addChild( new BoolPlug( "replaceDestination", direction, true ) );
 }
 
 Gaffer::StringPlug *ShufflePlug::sourcePlug()
@@ -107,6 +109,16 @@ const Gaffer::BoolPlug *ShufflePlug::deleteSourcePlug() const
 	return getChild<BoolPlug>( 3 );
 }
 
+Gaffer::BoolPlug *ShufflePlug::replaceDestinationPlug()
+{
+	return getChild<BoolPlug>( 4 );
+}
+
+const Gaffer::BoolPlug *ShufflePlug::replaceDestinationPlug() const
+{
+	return getChild<BoolPlug>( 4 );
+}
+
 bool ShufflePlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
 {
 	if( !Plug::acceptsChild( potentialChild ) )
@@ -142,6 +154,14 @@ bool ShufflePlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) c
 		potentialChild->isInstanceOf( BoolPlug::staticTypeId() ) &&
 		potentialChild->getName() == "deleteSource" &&
 		!getChild<Plug>( "deleteSource" )
+	)
+	{
+		return true;
+	}
+	else if(
+		potentialChild->isInstanceOf( BoolPlug::staticTypeId() ) &&
+		potentialChild->getName() == "replaceDestination" &&
+		!getChild<Plug>( "replaceDestination" )
 	)
 	{
 		return true;

--- a/src/GafferModule/ShufflesBinding.cpp
+++ b/src/GafferModule/ShufflesBinding.cpp
@@ -92,12 +92,13 @@ void GafferModule::bindShuffles()
 			)
 		)
 		.def(
-			init<const std::string &, const std::string &, bool, bool>(
+			init<const std::string &, const std::string &, bool, bool, bool>(
 				(
 					arg_( "source" ),
 					arg_( "destination" ),
 					arg_( "deleteSource" ) = false,
-					arg_( "enabled" ) = true
+					arg_( "enabled" ) = true,
+					arg_( "replaceDestination" ) = true
 				)
 			)
 		)


### PR DESCRIPTION
The PR adds an overwrite flag to the shuffle plug so that shuffles of primitive variables or attributes can optionally overwrite existing source data with the same name as the shuffle destination. The default value for the plug is true which matches the existing behaviour. This can be used to copy the "P" primitive variable to a "Pref" primitive variable, but only when a "Pref" primitive variable does not already exist on the Primitive.

### Breaking changes ###

The constructor of ShufflePlug has an additional default argument which will break ABI.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
