### PR TITLE
GafferScene : Add VisibleSet

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ API
 - Capsule : Removed attempts to detect invalidated Capsules.
 - VisibleSet/VisibleSetData : Added struct used to define a subset of the scene to be rendered based on expansions, inclusions, and exclusions. This is used to allow scene locations to be defined as always or never renderable, overriding the usual UI expansion behaviour.
 - ContextAlgo : Added `setVisiblesSet()`, `getVisibleSet()`, and `affectsVisibleSet()` methods.
+- SceneGadget : Added `setVisibleSet()`, and `getVisibleSet()` methods.
 
 Breaking Changes
 ----------------
@@ -48,6 +49,7 @@ Breaking Changes
 - SceneReader : `SceneInterface::readSet()` is now used in preference to `SceneInterface::readTags()` for all non-legacy formats.
 - CatalogueUI : Hid OutputIndexColumn from public API.
 - ContextAlgo : Removed use of the `ui:scene:expandedPaths` context variable. Any code directly accessing `ui:scene:expandedPaths` should instead use the `getExpandedPaths()/setExpandedPaths()/expand()/expandDescendants()` methods provided by `ContextAlgo`.
+- SceneGadget : Removed `setExpandedPaths()` and `getExpandedPaths()` methods. `setVisibleSet()` and `getVisibleSet()` are now used instead.
 
 1.1.x.x (relative to 1.1.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ API
 - PathColumn : Added `buttonPressSignal()`, `buttonReleaseSignal()` and `buttonDoubleClickSignal()`. These allow a PathColumn to implement its own event handling.
 - Capsule : Removed attempts to detect invalidated Capsules.
 - VisibleSet/VisibleSetData : Added struct used to define a subset of the scene to be rendered based on expansions, inclusions, and exclusions. This is used to allow scene locations to be defined as always or never renderable, overriding the usual UI expansion behaviour.
+- ContextAlgo : Added `setVisiblesSet()`, `getVisibleSet()`, and `affectsVisibleSet()` methods.
 
 Breaking Changes
 ----------------
@@ -46,6 +47,7 @@ Breaking Changes
   - `SceneInterface::writeSet()` is now used in preference to `SceneInterface::writeTags()` for all non-legacy file formats.
 - SceneReader : `SceneInterface::readSet()` is now used in preference to `SceneInterface::readTags()` for all non-legacy formats.
 - CatalogueUI : Hid OutputIndexColumn from public API.
+- ContextAlgo : Removed use of the `ui:scene:expandedPaths` context variable. Any code directly accessing `ui:scene:expandedPaths` should instead use the `getExpandedPaths()/setExpandedPaths()/expand()/expandDescendants()` methods provided by `ContextAlgo`.
 
 1.1.x.x (relative to 1.1.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ API
 
 - PathColumn : Added `buttonPressSignal()`, `buttonReleaseSignal()` and `buttonDoubleClickSignal()`. These allow a PathColumn to implement its own event handling.
 - Capsule : Removed attempts to detect invalidated Capsules.
+- VisibleSet/VisibleSetData : Added struct used to define a subset of the scene to be rendered based on expansions, inclusions, and exclusions. This is used to allow scene locations to be defined as always or never renderable, overriding the usual UI expansion behaviour.
 
 Breaking Changes
 ----------------

--- a/include/GafferScene/RenderController.h
+++ b/include/GafferScene/RenderController.h
@@ -38,6 +38,7 @@
 #define GAFFERSCENE_RENDERCONTROLLER_H
 
 #include "GafferScene/Export.h"
+#include "GafferScene/VisibleSet.h"
 
 #include "Gaffer/Signals.h"
 
@@ -74,8 +75,8 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		void setContext( const Gaffer::ConstContextPtr &context );
 		const Gaffer::Context *getContext() const;
 
-		void setExpandedPaths( const IECore::PathMatcher &expandedPaths );
-		const IECore::PathMatcher &getExpandedPaths() const;
+		void setVisibleSet( const GafferScene::VisibleSet &visibleSet );
+		const GafferScene::VisibleSet &getVisibleSet() const;
 
 		void setMinimumExpansionDepth( size_t depth );
 		size_t getMinimumExpansionDepth() const;
@@ -150,7 +151,7 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		IECoreScenePreview::RendererPtr m_renderer;
 		std::unique_ptr<IDMap> m_idMap;
 
-		IECore::PathMatcher m_expandedPaths;
+		GafferScene::VisibleSet m_visibleSet;
 		size_t m_minimumExpansionDepth;
 
 		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -170,6 +170,7 @@ enum TypeId
 	AttributeTweaksTypeId = 110625,
 	OptionTweaksTypeId = 110626,
 	OptionQueryTypeId = 110627,
+	VisibleSetDataTypeId = 110628,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/include/GafferScene/VisibleSet.h
+++ b/include/GafferScene/VisibleSet.h
@@ -38,7 +38,6 @@
 #define GAFFERSCENE_VISIBLESET_H
 
 #include "GafferScene/Export.h"
-#include "GafferScene/ScenePlug.h"
 
 #include "IECore/PathMatcher.h"
 
@@ -68,7 +67,7 @@ struct GAFFERSCENE_API VisibleSet
 	/// Returns the result of a match made against the VisibleSet.
 	/// ExactMatch : The location should be rendered.
 	/// DescendantMatch : Some (but not necessarily all) descendants of the location should be rendered (but this location shouldn't be unless ExactMatch is also set).
-	PathMatcher::Result match( const ScenePlug::ScenePath &path ) const;
+	PathMatcher::Result match( const std::vector<InternedString> &path, const size_t minimumExpansionDepth = 0 ) const;
 
 	bool operator == ( const VisibleSet &rhs ) const;
 	bool operator != ( const VisibleSet &rhs ) const;

--- a/include/GafferScene/VisibleSet.h
+++ b/include/GafferScene/VisibleSet.h
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENE_VISIBLESET_H
+#define GAFFERSCENE_VISIBLESET_H
+
+#include "GafferScene/Export.h"
+#include "GafferScene/ScenePlug.h"
+
+#include "IECore/PathMatcher.h"
+
+using namespace IECore;
+
+namespace GafferScene
+{
+
+/// Defines a subset of the scene hierarchy to be rendered.
+/// A location will be rendered if _either_ of the following is true :
+///
+/// 1. All its ancestors appear in `expansions`. This maps neatly to "tree view" style navigation
+/// as provided by the HierarchyView.
+/// 2. At least one of its ancestors appears in `inclusions`. This allows entire subtrees of the
+/// scene to be included concisely, without them cluttering the `expansions` (and therefore the HierarchyView).
+///
+/// Regardless of all the above, a location will _never_ be rendered if it - or any ancestor -
+/// appears in `exclusions`. This allows expensive or irrelevant portions of the scene to be ignored,
+/// regardless of any other setting.
+struct GAFFERSCENE_API VisibleSet
+{
+
+	PathMatcher expansions;
+	PathMatcher inclusions;
+	PathMatcher exclusions;
+
+	/// Returns the result of a match made against the VisibleSet. This can be used to provide the behaviour described above :
+	/// NoMatch : The location does not match a member of `expansions` or `inclusions`, or is explicitly excluded by it or its ancestor being present in `exclusions`.
+	/// DescendantMatch : The location has one or more descendants present in `inclusions`.
+	/// ExactMatch : The location is present in `expansions` and/or `inclusions`.
+	/// AncestorMatch : The location has an ancestor present in `inclusions`.
+	PathMatcher::Result match( const ScenePlug::ScenePath &path ) const;
+
+	bool operator == ( const VisibleSet &rhs ) const;
+	bool operator != ( const VisibleSet &rhs ) const;
+
+};
+
+void murmurHashAppend( MurmurHash &h, const VisibleSet &data );
+
+} // namespace GafferScene
+
+#include "GafferScene/VisibleSet.inl"
+
+#endif // GAFFERSCENE_VISIBLESET_H

--- a/include/GafferScene/VisibleSet.h
+++ b/include/GafferScene/VisibleSet.h
@@ -65,11 +65,9 @@ struct GAFFERSCENE_API VisibleSet
 	PathMatcher inclusions;
 	PathMatcher exclusions;
 
-	/// Returns the result of a match made against the VisibleSet. This can be used to provide the behaviour described above :
-	/// NoMatch : The location does not match a member of `expansions` or `inclusions`, or is explicitly excluded by it or its ancestor being present in `exclusions`.
-	/// DescendantMatch : The location has one or more descendants present in `inclusions`.
-	/// ExactMatch : The location is present in `expansions` and/or `inclusions`.
-	/// AncestorMatch : The location has an ancestor present in `inclusions`.
+	/// Returns the result of a match made against the VisibleSet.
+	/// ExactMatch : The location should be rendered.
+	/// DescendantMatch : Some (but not necessarily all) descendants of the location should be rendered (but this location shouldn't be unless ExactMatch is also set).
 	PathMatcher::Result match( const ScenePlug::ScenePath &path ) const;
 
 	bool operator == ( const VisibleSet &rhs ) const;

--- a/include/GafferScene/VisibleSet.inl
+++ b/include/GafferScene/VisibleSet.inl
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,62 +34,44 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_VISIBLESET_INL
+#define GAFFERSCENE_VISIBLESET_INL
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
+#include "IECore/PathMatcher.h"
 
-using namespace boost::python;
-using namespace GafferSceneModule;
-
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace GafferScene
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
+inline PathMatcher::Result VisibleSet::match( const ScenePlug::ScenePath &path ) const
+{
+
+	if( exclusions.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) )
+	{
+		// Exclusions override all other potential matches for the excluded path and all of its descendants
+		return PathMatcher::Result::NoMatch;
+	}
+
+	return (PathMatcher::Result)( ( expansions.match( path ) & PathMatcher::ExactMatch ) | inclusions.match( path ) );
 
 }
+
+inline bool VisibleSet::operator == ( const VisibleSet& rhs ) const
+{
+	return expansions == rhs.expansions && inclusions == rhs.inclusions && exclusions == rhs.exclusions;
+}
+
+inline bool VisibleSet::operator != ( const VisibleSet& rhs ) const
+{
+	return expansions != rhs.expansions || inclusions != rhs.inclusions || exclusions != rhs.exclusions;
+}
+
+inline void murmurHashAppend( MurmurHash &h, const VisibleSet &data )
+{
+	h.append( data.expansions );
+	h.append( data.inclusions );
+	h.append( data.exclusions );
+}
+
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_VISIBLESET_INL

--- a/include/GafferScene/VisibleSet.inl
+++ b/include/GafferScene/VisibleSet.inl
@@ -42,7 +42,7 @@
 namespace GafferScene
 {
 
-inline PathMatcher::Result VisibleSet::match( const ScenePlug::ScenePath &path ) const
+inline PathMatcher::Result VisibleSet::match( const std::vector<InternedString> &path, const size_t minimumExpansionDepth ) const
 {
 
 	if( exclusions.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) )
@@ -52,6 +52,15 @@ inline PathMatcher::Result VisibleSet::match( const ScenePlug::ScenePath &path )
 	}
 
 	unsigned result = PathMatcher::NoMatch;
+	if( minimumExpansionDepth >= path.size() )
+	{
+		// Paths within minimumExpansionDepth are considered visible and having visible children
+		/// \todo Return ExactMatch for child locations of paths equal to the minimumExpansionDepth,
+		/// and AncestorMatch for locations with ancestors within the minimumExpansionDepth. We should
+		/// also be able to return early and avoid testing inclusions and expansions for these paths.
+		result |= ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch );
+	}
+
 	result |= inclusions.match( path );
 	if( result & PathMatcher::AncestorMatch )
 	{

--- a/include/GafferScene/VisibleSetData.h
+++ b/include/GafferScene/VisibleSetData.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,62 +34,25 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENE_VISIBLESETDATA_H
+#define GAFFERSCENE_VISIBLESETDATA_H
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
+#include "GafferScene/VisibleSet.h"
+#include "GafferScene/TypeIds.h"
 
-using namespace boost::python;
-using namespace GafferSceneModule;
+#include "IECore/TypedData.h"
 
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace IECore
+{
+	IECORE_DECLARE_TYPEDDATA( VisibleSetData, GafferScene::VisibleSet, void, IECore::SimpleDataHolder );
+} // namespace IECore
+
+namespace GafferScene
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
+using VisibleSetData = IECore::VisibleSetData;
+IE_CORE_DECLAREPTR( VisibleSetData );
 
-}
+} // namespace GafferScene
+
+#endif // GAFFERSCENE_VISIBLESETDATA_H

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -39,6 +39,8 @@
 
 #include "GafferSceneUI/Export.h"
 
+#include "GafferScene/VisibleSet.h"
+
 #include "IECore/PathMatcher.h"
 
 #include "OpenEXR/ImathLimits.h"
@@ -101,6 +103,21 @@ GAFFERSCENEUI_API IECore::PathMatcher expandDescendants( Gaffer::Context *contex
 
 /// Clears the currently expanded paths
 GAFFERSCENEUI_API void clearExpansion( Gaffer::Context *context );
+
+/// VisibleSet
+/// ==========
+
+/// On top of the expansion mechanics described above (`expansions`), a VisibleSet
+/// allows subsets of the scene to be defined as _always_ rendered (`inclusions`),
+/// or _never_ rendered (`exclusions`).
+
+GAFFERSCENEUI_API void setVisibleSet( Gaffer::Context *context, const GafferScene::VisibleSet &visibleSet );
+GAFFERSCENEUI_API GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context );
+
+/// Returns true if the named context variable affects the result of `getVisibleSet()`.
+/// This can be used from `Context::changedSignal()` to determine if the VisibleSet has been
+/// changed.
+GAFFERSCENEUI_API bool affectsVisibleSet( const IECore::InternedString &name );
 
 /// Path Selection
 /// ==============

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -65,27 +65,27 @@ namespace GafferSceneUI
 namespace ContextAlgo
 {
 
+/// VisibleSet
+/// ==========
+
+/// The UI components coordinate with each other to perform on-demand scene
+/// generation by using the Context to store a VisibleSet specifying which
+/// scene locations should be shown.
+/// For instance, this allows the Viewer to show the objects from locations
+/// exposed by expansion performed in the HierarchyView, and vice versa.
+GAFFERSCENEUI_API void setVisibleSet( Gaffer::Context *context, const GafferScene::VisibleSet &visibleSet );
+GAFFERSCENEUI_API GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context );
+
+/// Returns true if the named context variable affects the result of `getVisibleSet()`.
+/// This can be used from `Context::changedSignal()` to determine if the VisibleSet has been
+/// changed.
+GAFFERSCENEUI_API bool affectsVisibleSet( const IECore::InternedString &name );
+
 /// Path Expansion
 /// ==============
 
-/// The UI components coordinate with each other to perform on-demand scene
-/// generation by using the Context to store paths to the currently expanded
-/// locations within the scene. For instance, this allows the Viewer show the
-/// objects from locations exposed by expansion performed in the HierarchyView,
-/// and vice versa.
-///
-/// By convention, an expanded location is one whose children are visible,
-/// meaning that they are listed below it in the HierarchyView and their objects
-/// are drawn in the Viewer. Conversely, a collapsed location's children are
-/// not listed in the HierarchyView and the location itself is drawn as a
-/// the bounding box of the children.
-///
-/// As a consequence of this definition, it is not necessary to expand locations
-/// without children. For a simple node such as Sphere, it is only necessary
-/// to expand the root location ("/") to view the geometry. For nodes which
-/// construct a deeper hierarchy, if the name of a location is visible in
-/// the HierarchyView, then it's geometry will be displayed in the Viewer.
-
+/// These are temporary legacy methods allowing access to `VisibleSet::expansions`
+/// for the purposes of providing backwards compatibility.
 GAFFERSCENEUI_API void setExpandedPaths( Gaffer::Context *context, const IECore::PathMatcher &paths );
 GAFFERSCENEUI_API IECore::PathMatcher getExpandedPaths( const Gaffer::Context *context );
 
@@ -103,21 +103,6 @@ GAFFERSCENEUI_API IECore::PathMatcher expandDescendants( Gaffer::Context *contex
 
 /// Clears the currently expanded paths
 GAFFERSCENEUI_API void clearExpansion( Gaffer::Context *context );
-
-/// VisibleSet
-/// ==========
-
-/// On top of the expansion mechanics described above (`expansions`), a VisibleSet
-/// allows subsets of the scene to be defined as _always_ rendered (`inclusions`),
-/// or _never_ rendered (`exclusions`).
-
-GAFFERSCENEUI_API void setVisibleSet( Gaffer::Context *context, const GafferScene::VisibleSet &visibleSet );
-GAFFERSCENEUI_API GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context );
-
-/// Returns true if the named context variable affects the result of `getVisibleSet()`.
-/// This can be used from `Context::changedSignal()` to determine if the VisibleSet has been
-/// changed.
-GAFFERSCENEUI_API bool affectsVisibleSet( const IECore::InternedString &name );
 
 /// Path Selection
 /// ==============

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -80,9 +80,9 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		void setContext( Gaffer::ConstContextPtr context );
 		const Gaffer::Context *getContext() const;
 
-		/// Limits the expanded parts of the scene to those in the specified paths.
-		void setExpandedPaths( const IECore::PathMatcher &expandedPaths );
-		const IECore::PathMatcher &getExpandedPaths() const;
+		/// Limits the expanded parts of the scene to those in the specified VisibleSet.
+		void setVisibleSet( const GafferScene::VisibleSet &visibleSet );
+		const GafferScene::VisibleSet &getVisibleSet() const;
 
 		void setMinimumExpansionDepth( size_t depth );
 		size_t getMinimumExpansionDepth() const;

--- a/python/GafferSceneTest/VisibleSetDataTest.py
+++ b/python/GafferSceneTest/VisibleSetDataTest.py
@@ -1,0 +1,94 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class VisibleSetDataTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		d = GafferScene.VisibleSetData()
+		self.assertEqual( d.value, GafferScene.VisibleSet() )
+
+		v1 = GafferScene.VisibleSet()
+		v1.expansions = IECore.PathMatcher( [ "/a" ] )
+		v1.inclusions = IECore.PathMatcher( [ "/b" ] )
+		v1.exclusions = IECore.PathMatcher( [ "/c" ] )
+
+		v2 = GafferScene.VisibleSet()
+		v2.expansions = IECore.PathMatcher( [ "/d" ] )
+		v2.inclusions = IECore.PathMatcher( [ "/e" ] )
+		v2.exclusions = IECore.PathMatcher( [ "/f" ] )
+
+		vd1a = GafferScene.VisibleSetData( v1 )
+		vd1b = GafferScene.VisibleSetData( v1 )
+		vd2 = GafferScene.VisibleSetData( v2 )
+
+		self.assertEqual( vd1a.value, v1 )
+		self.assertEqual( vd1b.value, v1 )
+		self.assertEqual( vd2.value, v2 )
+
+		self.assertEqual( vd1a, vd1b )
+		self.assertNotEqual( vd1a, vd2 )
+
+		self.assertEqual( vd1a.hash(), vd1b.hash() )
+		self.assertNotEqual( vd1a.hash(), vd2.hash() )
+
+		vd2c = vd2.copy()
+		self.assertEqual( vd2c, vd2 )
+		self.assertEqual( vd2c.hash(), vd2.hash() )
+
+	def testStoreInContext( self ) :
+
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/a" ] )
+		v.inclusions = IECore.PathMatcher( [ "/b" ] )
+		v.exclusions = IECore.PathMatcher( [ "/c" ] )
+
+		d = GafferScene.VisibleSetData( v )
+
+		c = Gaffer.Context()
+		c["v"] = d
+		self.assertEqual( c["v"], d )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/VisibleSetTest.py
+++ b/python/GafferSceneTest/VisibleSetTest.py
@@ -1,0 +1,148 @@
+##########################################################################
+#
+#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import GafferSceneTest
+import GafferScene
+
+class VisibleSetTest( GafferSceneTest.SceneTestCase ) :
+
+	def testExpansions( self ) :
+
+		e = GafferScene.VisibleSet()
+		e.expansions = IECore.PathMatcher( [ "/a", "/b", "/a/b", "/b/c", "/c/d/e" ] )
+
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/a/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/c/d/e" ), IECore.PathMatcher.Result.ExactMatch )
+
+		self.assertEqual( e.match( "/" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/c" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/c/d" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/a/b/c" ), IECore.PathMatcher.Result.NoMatch )
+
+	def testInclusions( self ) :
+
+		e = GafferScene.VisibleSet()
+		e.inclusions = IECore.PathMatcher( [ "/a", "/b/c" ] )
+
+		# Paths specifically added as inclusions
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+
+		# Paths with included descendants
+		self.assertEqual( e.match( "/" ), IECore.PathMatcher.Result.DescendantMatch )
+		self.assertEqual( e.match( "/b" ), IECore.PathMatcher.Result.DescendantMatch )
+
+		# Paths with included ancestors
+		self.assertEqual( e.match( "/a/b" ), IECore.PathMatcher.Result.AncestorMatch )
+		self.assertEqual( e.match( "/b/c/d/e" ), IECore.PathMatcher.Result.AncestorMatch )
+
+		# Paths unrelated to those in inclusions
+		self.assertEqual( e.match( "/c" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/a2" ), IECore.PathMatcher.Result.NoMatch )
+
+	def testExpansionsCombineWithInclusions( self ) :
+
+		e = GafferScene.VisibleSet()
+		e.expansions = IECore.PathMatcher( [ "/a", "/b", "/a/b", "/b/c" ] )
+		e.inclusions = IECore.PathMatcher( [ "/a", "/b/c", "/c" ] )
+
+		self.assertTrue( e.match( "/a" ) & IECore.PathMatcher.Result.ExactMatch )
+		self.assertTrue( e.match( "/a/b" ) & ( IECore.PathMatcher.Result.ExactMatch | IECore.PathMatcher.Result.AncestorMatch ) )
+		self.assertTrue( e.match( "/b" ) & ( IECore.PathMatcher.Result.ExactMatch | IECore.PathMatcher.Result.DescendantMatch ) )
+		self.assertTrue( e.match( "/c" ) & IECore.PathMatcher.Result.ExactMatch )
+		self.assertTrue( e.match( "/c/d" ) & IECore.PathMatcher.Result.AncestorMatch )
+
+	def testExclusionsOverrideExpansions( self ) :
+
+		e = GafferScene.VisibleSet()
+		e.expansions = IECore.PathMatcher( [ "/a", "/b", "/a/b", "/b/c", "/a/b/c" ] )
+
+		# Excluding "/b" should only affect "/b" and its descendants
+		e.exclusions = IECore.PathMatcher( [ "/b" ] )
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/a/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/a/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+
+		self.assertEqual( e.match( "/b" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/b/c" ), IECore.PathMatcher.Result.NoMatch )
+
+		# Removing the exclusion on "/b" should result in "/b" and "/b/c" matching
+		e.exclusions.removePath( "/b" )
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/a/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/a/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+
+		self.assertEqual( e.match( "/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+
+		# Excluding "/a/b" should not affect "/a", but also exclude "/a/b/c"
+		e.exclusions.addPath( "/a/b" )
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+
+		self.assertEqual( e.match( "/a/b" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/a/b/c" ), IECore.PathMatcher.Result.NoMatch )
+
+		self.assertEqual( e.match( "/b" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/b/c" ), IECore.PathMatcher.Result.ExactMatch )
+
+	def testExclusionsOverrideInclusions( self ) :
+
+		e = GafferScene.VisibleSet()
+		e.inclusions = IECore.PathMatcher( [ "/a", "/d", "/e/f" ] )
+
+		# Excluding "/d" & "/e" should not affect "/a"
+		e.exclusions = IECore.PathMatcher( [ "/d", "/e" ] )
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+
+		self.assertEqual( e.match( "/d" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/d/e" ), IECore.PathMatcher.Result.NoMatch )
+		self.assertEqual( e.match( "/e" ), IECore.PathMatcher.Result.NoMatch )
+
+		# Removing the exclusion on "/d" should result in only "/e" not matching
+		e.exclusions.removePath( "/d" )
+		self.assertEqual( e.match( "/a" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/d" ), IECore.PathMatcher.Result.ExactMatch )
+		self.assertEqual( e.match( "/d/e" ), IECore.PathMatcher.Result.AncestorMatch )
+
+		self.assertEqual( e.match( "/e" ), IECore.PathMatcher.Result.NoMatch )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -163,6 +163,8 @@ from .AttributeTweaksTest import AttributeTweaksTest
 from .OptionTweaksTest import OptionTweaksTest
 from .OptionQueryTest import OptionQueryTest
 from .RenameTest import RenameTest
+from .VisibleSetTest import VisibleSetTest
+from .VisibleSetDataTest import VisibleSetDataTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUITest/ContextAlgoTest.py
+++ b/python/GafferSceneUITest/ContextAlgoTest.py
@@ -136,6 +136,16 @@ class ContextAlgoTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ContextAlgo.setSelectedPaths( context, IECore.PathMatcher( [ "/A/C", "/A/B/D" ] ) )
 		self.assertEqual( GafferSceneUI.ContextAlgo.getSelectedPaths( context ), IECore.PathMatcher( [ "/A/C", "/A/B/D" ] )  )
 
+	def testVisibleSet( self ) :
+
+		context = Gaffer.Context()
+
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/A" ] )
+
+		GafferSceneUI.ContextAlgo.setVisibleSet( context, v )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getVisibleSet( context ), v )
+
 	def testAffectsExpandedPaths( self ) :
 
 		c = Gaffer.Context()
@@ -159,6 +169,18 @@ class ContextAlgoTest( GafferUITest.TestCase ) :
 		self.assertTrue( GafferSceneUI.ContextAlgo.affectsSelectedPaths( cs[0][1] ) )
 
 		self.assertFalse( GafferSceneUI.ContextAlgo.affectsSelectedPaths( "frame" ) )
+
+	def testAffectsVisibleSet( self ) :
+
+		c = Gaffer.Context()
+		cs = GafferTest.CapturingSlot( c.changedSignal() )
+
+		GafferSceneUI.ContextAlgo.setVisibleSet( c, GafferScene.VisibleSet() )
+
+		self.assertEqual( len( cs ), 1 )
+		self.assertTrue( GafferSceneUI.ContextAlgo.affectsVisibleSet( cs[0][1] ) )
+
+		self.assertFalse( GafferSceneUI.ContextAlgo.affectsVisibleSet( "frame" ) )
 
 	def testSelectionIsCopied( self ) :
 
@@ -193,6 +215,52 @@ class ContextAlgoTest( GafferUITest.TestCase ) :
 
 		e.addPath( "/a/b" )
 		self.assertNotEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), e )
+
+	def testVisibleSetIsCopied( self ) :
+
+		c = Gaffer.Context()
+
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/a" ] )
+
+		GafferSceneUI.ContextAlgo.setVisibleSet( c, v )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getVisibleSet( c ), v )
+
+		v.expansions.addPath( "/a/b" )
+		self.assertNotEqual( GafferSceneUI.ContextAlgo.getVisibleSet( c ), v )
+
+		v = GafferSceneUI.ContextAlgo.getVisibleSet( c )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getVisibleSet( c ), v )
+
+		v.expansions.addPath( "/a/b" )
+		self.assertNotEqual( GafferSceneUI.ContextAlgo.getVisibleSet( c ), v )
+
+	def testExpansionAffectsVisibleSet( self ) :
+
+		c = Gaffer.Context()
+
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/a" ] )
+
+		GafferSceneUI.ContextAlgo.setVisibleSet( c, v )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getVisibleSet( c ), v )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), v.expansions )
+
+		GafferSceneUI.ContextAlgo.setExpandedPaths( c, IECore.PathMatcher( [ "/b" ] ) )
+		self.assertNotEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), v.expansions )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), IECore.PathMatcher( [ "/b" ] ) )
+		v = GafferSceneUI.ContextAlgo.getVisibleSet( c )
+		self.assertEqual( v.expansions, IECore.PathMatcher( [ "/b" ] ) )
+
+		GafferSceneUI.ContextAlgo.expand( c, IECore.PathMatcher( [ "/a" ] ), False )
+		self.assertEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), IECore.PathMatcher( [ "/a", "/b" ] ) )
+		self.assertNotEqual( GafferSceneUI.ContextAlgo.getExpandedPaths( c ), v.expansions )
+		v = GafferSceneUI.ContextAlgo.getVisibleSet( c )
+		self.assertEqual( v.expansions, IECore.PathMatcher( [ "/a", "/b" ] ) )
+
+		GafferSceneUI.ContextAlgo.clearExpansion( c )
+		v = GafferSceneUI.ContextAlgo.getVisibleSet( c )
+		self.assertEqual( v.expansions, IECore.PathMatcher() )
 
 	def testLastSelectedPath( self ) :
 

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -83,7 +83,9 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		# Nothing selected, so selected bound is empty
 		self.assertEqual( sg.bound( True ), imath.Box3f() )
 
-		sg.setExpandedPaths( IECore.PathMatcher( ["/group/"] ) )
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/group" ] )
+		sg.setVisibleSet( v )
 		sg.setSelection( IECore.PathMatcher( ["/group/plane"] ) )
 		self.waitForRender( sg )
 
@@ -197,13 +199,30 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
 		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group" ] )
 
-		sg.setExpandedPaths( IECore.PathMatcher( [ "/group" ] ) )
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/group" ] )
+		sg.setVisibleSet( v )
 		self.waitForRender( sg )
 
 		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
 		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group/sphere" ] )
 
-		sg.setExpandedPaths( IECore.PathMatcher( [] ) )
+		v.expansions = IECore.PathMatcher( [] )
+		v.inclusions = IECore.PathMatcher( [ "/group" ] )
+		sg.setVisibleSet( v )
+		self.waitForRender( sg )
+
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), IECore.InternedStringVectorData( [ "group", "sphere" ] ) )
+		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group/sphere" ] )
+
+		v.exclusions = IECore.PathMatcher( [ "/group" ] )
+		sg.setVisibleSet( v )
+		self.waitForRender( sg )
+
+		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )
+		self.assertObjectsAt( sg, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ), [ "/group" ] )
+
+		sg.setVisibleSet( GafferScene.VisibleSet() )
 		self.waitForRender( sg )
 
 		self.assertObjectAt( sg, imath.V2f( 0.5 ), None )

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -959,9 +959,9 @@ class RenderController::SceneGraph
 		{
 			const bool expanded =
 				( minimumExpansionDepth >= path.size() && !( visibleSet.exclusions.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) ) ) ||
-				/// \todo Using EveryMatch ensures the ancestors of paths in `visibleSet.inclusions` are also matched for expansion
+				/// \todo We also include DescendantMatch here to ensures the ancestors of included paths are also visible,
 				/// ideally we'd avoid expanding those ancestors and instead render only the included path and its descendants.
-				visibleSet.match( path ) & PathMatcher::EveryMatch
+				visibleSet.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch )
 			;
 
 			if( expanded == m_expanded )

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -524,7 +524,7 @@ class RenderController::SceneGraph
 
 			// Expansion
 
-			if( ( m_dirtyComponents & ExpansionComponent ) && updateExpansion( path, controller->m_expandedPaths, controller->m_minimumExpansionDepth ) )
+			if( ( m_dirtyComponents & ExpansionComponent ) && updateExpansion( path, controller->m_visibleSet, controller->m_minimumExpansionDepth ) )
 			{
 				m_changedComponents |= ExpansionComponent;
 			}
@@ -955,9 +955,15 @@ class RenderController::SceneGraph
 			m_objectHash = MurmurHash();
 		}
 
-		bool updateExpansion( const ScenePlug::ScenePath &path, const IECore::PathMatcher &expandedPaths, size_t minimumExpansionDepth )
+		bool updateExpansion( const ScenePlug::ScenePath &path, const GafferScene::VisibleSet &visibleSet, size_t minimumExpansionDepth )
 		{
-			const bool expanded = ( minimumExpansionDepth >= path.size() ) || ( expandedPaths.match( path ) & PathMatcher::ExactMatch );
+			const bool expanded =
+				( minimumExpansionDepth >= path.size() && !( visibleSet.exclusions.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) ) ) ||
+				/// \todo Using EveryMatch ensures the ancestors of paths in `visibleSet.inclusions` are also matched for expansion
+				/// ideally we'd avoid expanding those ancestors and instead render only the included path and its descendants.
+				visibleSet.match( path ) & PathMatcher::EveryMatch
+			;
+
 			if( expanded == m_expanded )
 			{
 				return false;
@@ -1383,18 +1389,18 @@ const Gaffer::Context *RenderController::getContext() const
 	return m_context.get();
 }
 
-void RenderController::setExpandedPaths( const IECore::PathMatcher &expandedPaths )
+void RenderController::setVisibleSet( const GafferScene::VisibleSet &visibleSet )
 {
 	cancelBackgroundTask();
 
-	m_expandedPaths = expandedPaths;
+	m_visibleSet = visibleSet;
 	dirtySceneGraphs( SceneGraph::ExpansionComponent );
 	requestUpdate();
 }
 
-const IECore::PathMatcher &RenderController::getExpandedPaths() const
+const GafferScene::VisibleSet &RenderController::getVisibleSet() const
 {
-	return m_expandedPaths;
+	return m_visibleSet;
 }
 
 void RenderController::setMinimumExpansionDepth( size_t depth )

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -957,12 +957,9 @@ class RenderController::SceneGraph
 
 		bool updateExpansion( const ScenePlug::ScenePath &path, const GafferScene::VisibleSet &visibleSet, size_t minimumExpansionDepth )
 		{
-			const bool expanded =
-				( minimumExpansionDepth >= path.size() && !( visibleSet.exclusions.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) ) ) ||
-				/// \todo We also include DescendantMatch here to ensures the ancestors of included paths are also visible,
-				/// ideally we'd avoid expanding those ancestors and instead render only the included path and its descendants.
-				visibleSet.match( path ) & ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch )
-			;
+			/// \todo We also include DescendantMatch here to ensure the ancestors of visible paths are also visible,
+			/// ideally we'd avoid expanding those ancestors and instead render only the ExactMatch.
+			const bool expanded = visibleSet.match( path, minimumExpansionDepth ) & ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch );
 
 			if( expanded == m_expanded )
 			{

--- a/src/GafferScene/VisibleSetData.cpp
+++ b/src/GafferScene/VisibleSetData.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,62 +34,39 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#include "GafferScene/VisibleSetData.h"
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
+#include "GafferScene/TypeIds.h"
 
-using namespace boost::python;
-using namespace GafferSceneModule;
+#include "Gaffer/Context.h"
 
-BOOST_PYTHON_MODULE( _GafferScene )
+#include "IECore/TypedData.h"
+#include "IECore/TypedData.inl"
+
+namespace
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
+Gaffer::Context::TypeDescription<GafferScene::VisibleSetData> g_visibleSetDataTypeDescription;
 
+} // namespace
+
+namespace IECore
+{
+
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( GafferScene::VisibleSetData, GafferScene::VisibleSetDataTypeId )
+
+template<>
+void VisibleSetData::save( SaveContext *context ) const
+{
+	throw IECore::NotImplementedException( "VisibleSetData::save Not implemented" );
 }
+
+template<>
+void VisibleSetData::load( LoadContextPtr context )
+{
+	throw IECore::NotImplementedException( "VisibleSetData::load Not implemented" );
+}
+
+template class TypedData<GafferScene::VisibleSet>;
+
+} // namespace IECore

--- a/src/GafferSceneModule/RenderControllerBinding.cpp
+++ b/src/GafferSceneModule/RenderControllerBinding.cpp
@@ -79,10 +79,10 @@ ContextPtr getContext( RenderController &r )
 	return const_cast<Context *>( r.getContext() );
 }
 
-void setExpandedPaths( RenderController &r, const IECore::PathMatcher &expandedPaths )
+void setVisibleSet( RenderController &r, const GafferScene::VisibleSet &visibleSet )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	r.setExpandedPaths( expandedPaths );
+	r.setVisibleSet( visibleSet );
 }
 
 void setMinimumExpansionDepth( RenderController &r, size_t depth )
@@ -158,8 +158,8 @@ void GafferSceneModule::bindRenderController()
 		.def( "getScene", &getScene )
 		.def( "setContext", &setContext )
 		.def( "getContext", &getContext )
-		.def( "setExpandedPaths", &setExpandedPaths )
-		.def( "getExpandedPaths", &RenderController::getExpandedPaths, return_value_policy<copy_const_reference>() )
+		.def( "setVisibleSet", &setVisibleSet )
+		.def( "getVisibleSet", &RenderController::getVisibleSet, return_value_policy<copy_const_reference>() )
 		.def( "setMinimumExpansionDepth", &setMinimumExpansionDepth )
 		.def( "getMinimumExpansionDepth", &RenderController::getMinimumExpansionDepth )
 		.def( "updateRequiredSignal", &RenderController::updateRequiredSignal, return_internal_reference<1>() )

--- a/src/GafferSceneModule/VisibleSetBinding.cpp
+++ b/src/GafferSceneModule/VisibleSetBinding.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,60 +36,39 @@
 
 #include "boost/python.hpp"
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
 #include "VisibleSetBinding.h"
 
-using namespace boost::python;
-using namespace GafferSceneModule;
+#include "GafferScene/ScenePlug.h"
+#include "GafferScene/VisibleSet.h"
+#include "GafferScene/VisibleSetData.h"
 
-BOOST_PYTHON_MODULE( _GafferScene )
+#include "IECorePython/RunTimeTypedBinding.h"
+#include "IECorePython/SimpleTypedDataBinding.h"
+
+using namespace boost::python;
+using namespace IECore;
+using namespace GafferScene;
+
+void GafferSceneModule::bindVisibleSet()
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
+	IECorePython::RunTimeTypedClass<VisibleSetData>()
+		.def( init<>() )
+		.def( init<const VisibleSet &>() )
+		.add_property( "value", make_function( &VisibleSetData::writable, return_internal_reference<1>() ) )
+		.def( "hasBase", &VisibleSetData::hasBase ).staticmethod( "hasBase" )
+	;
+
+	IECorePython::TypedDataFromType<VisibleSetData>();
+
+	class_<VisibleSet>( "VisibleSet" )
+		.def( init<>() )
+		.def( init<const VisibleSet &>() )
+		.def( "match", (PathMatcher::Result (VisibleSet ::*)( const ScenePlug::ScenePath & ) const)&VisibleSet::match )
+		.def_readwrite( "expansions", &VisibleSet::expansions )
+		.def_readwrite( "inclusions", &VisibleSet::inclusions )
+		.def_readwrite( "exclusions", &VisibleSet::exclusions )
+		.def( "__eq__", &VisibleSet::operator== )
+	;
 
 }

--- a/src/GafferSceneModule/VisibleSetBinding.cpp
+++ b/src/GafferSceneModule/VisibleSetBinding.cpp
@@ -38,7 +38,6 @@
 
 #include "VisibleSetBinding.h"
 
-#include "GafferScene/ScenePlug.h"
 #include "GafferScene/VisibleSet.h"
 #include "GafferScene/VisibleSetData.h"
 
@@ -64,7 +63,7 @@ void GafferSceneModule::bindVisibleSet()
 	class_<VisibleSet>( "VisibleSet" )
 		.def( init<>() )
 		.def( init<const VisibleSet &>() )
-		.def( "match", (PathMatcher::Result (VisibleSet ::*)( const ScenePlug::ScenePath & ) const)&VisibleSet::match )
+		.def( "match", (PathMatcher::Result (VisibleSet ::*)( const std::vector<InternedString> &, const size_t ) const)&VisibleSet::match, arg( "minimumExpansionDepth" ) = 0 )
 		.def_readwrite( "expansions", &VisibleSet::expansions )
 		.def_readwrite( "inclusions", &VisibleSet::inclusions )
 		.def_readwrite( "exclusions", &VisibleSet::exclusions )

--- a/src/GafferSceneModule/VisibleSetBinding.h
+++ b/src/GafferSceneModule/VisibleSetBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,62 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENEMODULE_VISIBLESETBINDING_H
+#define GAFFERSCENEMODULE_VISIBLESETBINDING_H
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
-
-using namespace boost::python;
-using namespace GafferSceneModule;
-
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace GafferSceneModule
 {
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
+void bindVisibleSet();
 
-}
+} // namespace GafferSceneModule
+
+#endif // GAFFERSCENEMODULE_VISIBLESETBINDING_H

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -100,6 +100,21 @@ namespace GafferSceneUI
 namespace ContextAlgo
 {
 
+void setVisibleSet( Context *context, const GafferScene::VisibleSet &visibleSet )
+{
+	context->set( g_visibleSetName, visibleSet );
+}
+
+GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context )
+{
+	return context->get<VisibleSet>( g_visibleSetName, VisibleSet() );
+}
+
+bool affectsVisibleSet( const IECore::InternedString &name )
+{
+	return name == g_visibleSetName;
+}
+
 void setExpandedPaths( Context *context, const IECore::PathMatcher &paths )
 {
 	auto visibleSet = getVisibleSet( context );
@@ -178,21 +193,6 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 void clearExpansion( Gaffer::Context *context )
 {
 	setExpandedPaths( context, IECore::PathMatcher() );
-}
-
-void setVisibleSet( Context *context, const GafferScene::VisibleSet &visibleSet )
-{
-	context->set( g_visibleSetName, visibleSet );
-}
-
-GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context )
-{
-	return context->get<VisibleSet>( g_visibleSetName, VisibleSet() );
-}
-
-bool affectsVisibleSet( const IECore::InternedString &name )
-{
-	return name == g_visibleSetName;
 }
 
 void setSelectedPaths( Context *context, const IECore::PathMatcher &paths )

--- a/src/GafferSceneUI/ContextAlgo.cpp
+++ b/src/GafferSceneUI/ContextAlgo.cpp
@@ -37,6 +37,8 @@
 #include "GafferSceneUI/ContextAlgo.h"
 
 #include "GafferScene/ScenePlug.h"
+#include "GafferScene/VisibleSet.h"
+#include "GafferScene/VisibleSetData.h"
 
 #include "Gaffer/Context.h"
 
@@ -49,9 +51,9 @@ using namespace GafferScene;
 namespace
 {
 
-InternedString g_expandedPathsName( "ui:scene:expandedPaths" );
 InternedString g_selectedPathsName( "ui:scene:selectedPaths" );
 InternedString g_lastSelectedPathName( "ui:scene:lastSelectedPath" );
+InternedString g_visibleSetName( "ui:scene:visibleSet" );
 
 bool expandWalk( const ScenePlug::ScenePath &path, const ScenePlug *scene, size_t depth, PathMatcher &expanded, PathMatcher &leafPaths )
 {
@@ -100,42 +102,45 @@ namespace ContextAlgo
 
 void setExpandedPaths( Context *context, const IECore::PathMatcher &paths )
 {
-	context->set( g_expandedPathsName, new IECore::PathMatcherData( paths ) );
+	auto visibleSet = getVisibleSet( context );
+	visibleSet.expansions = paths;
+	setVisibleSet( context, visibleSet );
 }
 
 IECore::PathMatcher getExpandedPaths( const Gaffer::Context *context )
 {
-	return context->get<PathMatcher>( g_expandedPathsName, IECore::PathMatcher() );
+	auto visibleSet = getVisibleSet( context );
+	return visibleSet.expansions;
 }
 
 bool affectsExpandedPaths( const IECore::InternedString &name )
 {
-	return name == g_expandedPathsName;
+	return name == g_visibleSetName;
 }
 
 void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 {
-	const IECore::PathMatcher *expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
-	if( !expandedPaths )
+	const auto *visibleSet = context->getIfExists<VisibleSet>( g_visibleSetName );
+	if( !visibleSet )
 	{
-		context->set( g_expandedPathsName, new IECore::PathMatcherData() );
-		expandedPaths = context->getIfExists<PathMatcher>( g_expandedPathsName );
+		setVisibleSet( context, VisibleSet() );
+		visibleSet = context->getIfExists<VisibleSet>( g_visibleSetName );
 	}
-	IECore::PathMatcher &expanded = *const_cast<IECore::PathMatcher*>(expandedPaths);
+	VisibleSet &visible = *const_cast<VisibleSet*>(visibleSet);
 
 	bool needUpdate = false;
 	if( expandAncestors )
 	{
 		for( IECore::PathMatcher::RawIterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
 		{
-			needUpdate |= expanded.addPath( *it );
+			needUpdate |= visible.expansions.addPath( *it );
 		}
 	}
 	else
 	{
 		for( IECore::PathMatcher::Iterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
 		{
-			needUpdate |= expanded.addPath( *it );
+			needUpdate |= visible.expansions.addPath( *it );
 		}
 	}
 
@@ -144,13 +149,13 @@ void expand( Context *context, const PathMatcher &paths, bool expandAncestors )
 		// We modified the expanded paths in place with const_cast to avoid unecessary copying,
 		// so the context doesn't know they've changed. So we must let it know
 		// about the change.
-		context->set( g_expandedPathsName, *expandedPaths );
+		setVisibleSet( context, *visibleSet );
 	}
 }
 
 IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatcher &paths, const ScenePlug *scene, int depth )
 {
-	IECore::PathMatcher expandedPaths = context->get<PathMatcher>( g_expandedPathsName, IECore::PathMatcher() );
+	auto visibleSet = getVisibleSet( context );
 
 	bool needUpdate = false;
 	IECore::PathMatcher leafPaths;
@@ -158,13 +163,13 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 	// \todo: parallelize the walk
 	for( IECore::PathMatcher::Iterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
 	{
-		needUpdate |= expandWalk( *it, scene, depth + 1, expandedPaths, leafPaths );
+		needUpdate |= expandWalk( *it, scene, depth + 1, visibleSet.expansions, leafPaths );
 	}
 
 	if( needUpdate )
 	{
 		// If we modified the expanded paths, we need to set the value back on the context
-		context->set( g_expandedPathsName, expandedPaths );
+		setVisibleSet( context, visibleSet );
 	}
 
 	return leafPaths;
@@ -173,6 +178,21 @@ IECore::PathMatcher expandDescendants( Context *context, const IECore::PathMatch
 void clearExpansion( Gaffer::Context *context )
 {
 	setExpandedPaths( context, IECore::PathMatcher() );
+}
+
+void setVisibleSet( Context *context, const GafferScene::VisibleSet &visibleSet )
+{
+	context->set( g_visibleSetName, visibleSet );
+}
+
+GafferScene::VisibleSet getVisibleSet( const Gaffer::Context *context )
+{
+	return context->get<VisibleSet>( g_visibleSetName, VisibleSet() );
+}
+
+bool affectsVisibleSet( const IECore::InternedString &name )
+{
+	return name == g_visibleSetName;
 }
 
 void setSelectedPaths( Context *context, const IECore::PathMatcher &paths )

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -237,14 +237,14 @@ const Gaffer::Context *SceneGadget::getContext() const
 	return m_controller->getContext();
 }
 
-void SceneGadget::setExpandedPaths( const IECore::PathMatcher &expandedPaths )
+void SceneGadget::setVisibleSet( const GafferScene::VisibleSet &visibleSet )
 {
-	m_controller->setExpandedPaths( expandedPaths );
+	m_controller->setVisibleSet( visibleSet );
 }
 
-const IECore::PathMatcher &SceneGadget::getExpandedPaths() const
+const GafferScene::VisibleSet &SceneGadget::getVisibleSet() const
 {
-	return m_controller->getExpandedPaths();
+	return m_controller->getVisibleSet();
 }
 
 void SceneGadget::setMinimumExpansionDepth( size_t depth )
@@ -381,7 +381,7 @@ void SceneGadget::setRenderer( IECore::InternedString name )
 
 	if( m_controller )
 	{
-		newController->setExpandedPaths( m_controller->getExpandedPaths() );
+		newController->setVisibleSet( m_controller->getVisibleSet() );
 		newController->setMinimumExpansionDepth( m_controller->getMinimumExpansionDepth() );
 	}
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -2120,9 +2120,9 @@ void SceneView::contextChanged( const IECore::InternedString &name )
 		m_sceneGadget->setSelection( ContextAlgo::getSelectedPaths( getContext() ) );
 		return;
 	}
-	else if( ContextAlgo::affectsExpandedPaths( name ) )
+	else if( ContextAlgo::affectsVisibleSet( name ) )
 	{
-		m_sceneGadget->setExpandedPaths( ContextAlgo::getExpandedPaths( getContext() ) );
+		m_sceneGadget->setVisibleSet( ContextAlgo::getVisibleSet( getContext() ) );
 		return;
 	}
 	else if( boost::starts_with( name.value(), "ui:" ) )

--- a/src/GafferSceneUIModule/ContextAlgoBinding.cpp
+++ b/src/GafferSceneUIModule/ContextAlgoBinding.cpp
@@ -59,6 +59,12 @@ void setExpandedPathsWrapper( Context &context, const IECore::PathMatcher &paths
 	setExpandedPaths( &context, paths );
 }
 
+void setVisibleSetWrapper( Context &context, const GafferScene::VisibleSet &visibleSet )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	setVisibleSet( &context, visibleSet );
+}
+
 void expandWrapper( Context &context, const IECore::PathMatcher &paths, bool expandAncestors )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -113,6 +119,9 @@ void GafferSceneUIModule::bindContextAlgo()
 	def( "setExpandedPaths", &setExpandedPathsWrapper );
 	def( "getExpandedPaths", &getExpandedPaths );
 	def( "affectsExpandedPaths", &affectsExpandedPaths );
+	def( "setVisibleSet", &setVisibleSetWrapper );
+	def( "getVisibleSet", &getVisibleSet );
+	def( "affectsVisibleSet", &affectsVisibleSet );
 	def( "setLastSelectedPath", &setLastSelectedPathWrapper );
 	def( "getLastSelectedPath", &getLastSelectedPathWrapper );
 	def( "affectsLastSelectedPath", &affectsLastSelectedPath );

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -73,10 +73,10 @@ void setContext( SceneGadget &g, Context &context )
 	g.setContext( &context );
 }
 
-void setExpandedPaths( SceneGadget &g, const IECore::PathMatcher &expandedPaths )
+void setVisibleSet( SceneGadget &g, const GafferScene::VisibleSet &visibleSet )
 {
 	ScopedGILRelease gilRelease;
-	g.setExpandedPaths( expandedPaths );
+	g.setVisibleSet( visibleSet );
 }
 
 void setMinimumExpansionDepth( SceneGadget &g, size_t depth )
@@ -190,8 +190,8 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "getScene", &getScene )
 		.def( "setContext", &setContext )
 		.def( "getContext", (Gaffer::Context *(SceneGadget::*)())&SceneGadget::getContext, return_value_policy<CastToIntrusivePtr>() )
-		.def( "setExpandedPaths", &setExpandedPaths )
-		.def( "getExpandedPaths", &SceneGadget::getExpandedPaths, return_value_policy<copy_const_reference>() )
+		.def( "setVisibleSet", &setVisibleSet )
+		.def( "getVisibleSet", &SceneGadget::getVisibleSet, return_value_policy<copy_const_reference>() )
 		.def( "setMinimumExpansionDepth", &setMinimumExpansionDepth )
 		.def( "getMinimumExpansionDepth", &SceneGadget::getMinimumExpansionDepth )
 		.def( "getPaused", &SceneGadget::getPaused )


### PR DESCRIPTION
This introduces `VisibleSet`, a way of defining a subset of the overall scene hierarchy to be rendered. This replaces the current approach of storing a PathMatcher of expanded paths in the context, with a struct containing three PathMatchers representing:

`expansions` - These locations are rendered in the Viewer as long as all of their ancestors also appear in `expansions`, this maps to the current behaviour of locations being expanded in the HierarchyView in order to be rendered in the Viewer. 
`inclusions` - Locations that are specifically included, these locations and all their descendants should always be rendered in the Viewer. This can be used to render important or commonly viewed locations in the Viewer without requiring them to be expanded in the HierarchyView.
`exclusions` - Specifically excluded locations. These locations and all their descendants will not be rendered in the Viewer, regardless of their presence in `expansions` or `inclusions`. Exclusions can be used to ignore expensive or irrelevant portions of the scene.

VisibleSet follows similar semantics to PathMatcher, where a path can be matched to the VisibleSet with the following results:

`NoMatch` - The path should not be rendered, either by not matching a path in `expansions` or `inclusions`, or by having been specifically excluded via it or its ancestor being a member of `exclusions`
`ExactMatch` - The path should be rendered as it is a member of `expansions` or `inclusions`
`AncestorMatch` - The path should be rendered as it has an ancestor in `inclusions`
`DescendantMatch` - The path has one or more descendants in `inclusions` and requires expansion in order for those descendants to be rendered

This includes changes to SceneView, SceneGadget and RenderController to support use of VisibleSet, though suggestions are very welcome if there are better ways of achieving this. I've left a todo in RenderController for the previously discussed improvements to expansion of inclusions.

This PR is intended to provide the foundations for the follow-up work of adding columns to the HierarchyView for controlling membership of inclusions and exclusions, though the inclusions and exclusions behaviour can still be tested interactively:

```
v = GafferSceneUI.ContextAlgo.getVisibleSet( root.context() )
v.exclusions.addPath( '/GAFFERBOT/C_torso_GRP/C_head_GRP' )
v.inclusions.addPath( '/GAFFERBOT/C_torso_GRP/R_armUpper_GRP' )
GafferSceneUI.ContextAlgo.setVisibleSet( root.context(), v )
```

### Breaking changes ###

The existing `GafferSceneUI::ContextAlgo` methods for managing scene expansion have been updated to support `VisibleSet`. Tools using `ContextAlgo::setExpandedPaths`, `getExpandedPaths`, `expand`, `expandDescendants`, should continue to work, but any code currently directly accessing the PathMatcher stored in the context under `ui:scene:expandedPaths` will need to be updated to instead use `ContextAlgo`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
