### PR TITLE
PathColumn : Add signals to allow custom button event handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Breaking Changes
 
 - GafferTest : Removed `expectedFailure()` decorator. Use `unittest.expectedFailure()` instead.
 - Python : Removed support for Python 2.
+- CatalogueUI : Hid OutputIndexColumn from public API.
 
 1.1.x.x ( relative to 1.1.1.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 API
 ---
 
+- PathColumn : Added `buttonPressSignal()`, `buttonReleaseSignal()` and `buttonDoubleClickSignal()`. These allow a PathColumn to implement its own event handling.
 - Capsule : Removed attempts to detect invalidated Capsules.
 
 Breaking Changes

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -78,6 +78,21 @@ PathColumn::PathColumnSignal &PathColumn::changedSignal()
 	return m_changedSignal;
 }
 
+PathColumn::ButtonSignal &PathColumn::buttonPressSignal()
+{
+	return m_buttonPressSignal;
+}
+
+PathColumn::ButtonSignal &PathColumn::buttonReleaseSignal()
+{
+	return m_buttonReleaseSignal;
+}
+
+PathColumn::ButtonSignal &PathColumn::buttonDoubleClickSignal()
+{
+	return m_buttonDoubleClickSignal;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // StandardPathColumn
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -47,11 +47,109 @@
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
 
+#include "boost/python/suite/indexing/container_utils.hpp"
+
 using namespace boost::python;
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferUI;
+
+//////////////////////////////////////////////////////////////////////////
+// PathListingWidgetAccessor class
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// Provides a C++ interface to the functionality implemented in the Python
+// PathListingWidget class.
+class PathListingWidgetAccessor : public GafferUI::PathListingWidget
+{
+
+	public :
+
+		PathListingWidgetAccessor( object widget )
+			:	m_widget( widget )
+		{
+		}
+
+		object widget()
+		{
+			return m_widget;
+		}
+
+		void setColumns( const Columns &columns ) override
+		{
+			IECorePython::ScopedGILLock gilLock;
+			list pythonColumns;
+			for( auto & c : columns )
+			{
+				pythonColumns.append( c );
+			}
+			m_widget.attr( "setColumns" )( pythonColumns );
+		}
+
+		Columns getColumns() const override
+		{
+			IECorePython::ScopedGILLock gilLock;
+			object pythonColumns = m_widget.attr( "getColumns" )();
+			Columns columns;
+			boost::python::container_utils::extend_container( columns, pythonColumns );
+			return columns;
+		}
+
+		void setSelection( const Selection &selection ) override
+		{
+			IECorePython::ScopedGILLock gilLock;
+
+			object pythonSelection;
+			if( std::holds_alternative<IECore::PathMatcher>( selection ) )
+			{
+				pythonSelection = object( std::get<IECore::PathMatcher>( selection ) );
+			}
+			else
+			{
+				list pythonList;
+				for( const auto &c : std::get<std::vector<IECore::PathMatcher>>( selection ) )
+				{
+					pythonList.append( c );
+				}
+				pythonSelection = pythonList;
+			}
+
+			m_widget.attr( "setSelection" )( pythonSelection );
+		}
+
+		Selection getSelection() const override
+		{
+			IECorePython::ScopedGILLock gilLock;
+			object pythonSelection = m_widget.attr( "getSelection" )();
+			extract<IECore::PathMatcher> e( pythonSelection );
+			if( e.check() )
+			{
+				return e();
+			}
+			else
+			{
+				std::vector<IECore::PathMatcher> selection;
+				container_utils::extend_container( selection, pythonSelection );
+				return selection;
+			}
+		}
+
+	private :
+
+		// The Python PathListingWidget object.
+		object m_widget;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Bindings
+//////////////////////////////////////////////////////////////////////////
 
 namespace
 {
@@ -177,6 +275,35 @@ struct ChangedSignalSlotCaller
 	}
 };
 
+struct ButtonSignalCaller
+{
+	static bool call( PathColumn::ButtonSignal &s, Gaffer::Path &path, object widget, const ButtonEvent &event )
+	{
+		// C++-based slots are passed a PathListingWidgetAccessor which gives them limited
+		// access to the functionality of the Python PathListingWidget.
+		PathListingWidgetAccessor accessor( widget );
+		IECorePython::ScopedGILRelease gilRelease;
+		return s( path, accessor, event );
+	}
+};
+
+struct ButtonSignalSlotCaller
+{
+	bool operator()( boost::python::object slot, Path &path, PathListingWidget &widget, const ButtonEvent &event )
+	{
+		try
+		{
+			// Python-based slots are passed the original Python
+			// PathListingWidget, so they have full access to everything.
+			return slot( PathPtr( &path ), static_cast<PathListingWidgetAccessor&>( widget ).widget(), event );
+		}
+		catch( const error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
+	}
+};
+
 } // namespace
 
 void GafferUIModule::bindPathColumn()
@@ -186,6 +313,9 @@ void GafferUIModule::bindPathColumn()
 			.def( init<>() )
 			.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
 			.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
+			.def( "buttonPressSignal", &PathColumn::buttonPressSignal, return_internal_reference<1>() )
+			.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
+			.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )
 		;
 
 		class_<PathColumn::CellData>( "CellData" )
@@ -214,6 +344,7 @@ void GafferUIModule::bindPathColumn()
 		;
 
 		SignalClass<PathColumn::PathColumnSignal, DefaultSignalCaller<PathColumn::PathColumnSignal>, ChangedSignalSlotCaller>( "PathColumnSignal" );
+		SignalClass<PathColumn::ButtonSignal, ButtonSignalCaller, ButtonSignalSlotCaller>( "ButtonSignal" );
 	}
 
 	IECorePython::RefCountedClass<StandardPathColumn, PathColumn>( "StandardPathColumn" )


### PR DESCRIPTION
This will allow us to encapsulate the event handling for a column along with the code for generating the cell data, allowing non-intrusive interactive extensions to things like the LightEditor and HierarchyView. The immediate use cases are custom columns for handling mute/solo and visible set management respectively.

I've demonstrated the functionality by completely encapsulating the CatalogueUI's output index column. Next up will be to do the same for the LightEditor's InspectorColumn, which will also involve key-press handling. But I'd like to get this PR reviewed and merged first to limit the size of the reviews. This hopefully also means that you have earlier access to a "final" version of button handling that you can build on, @murraystevenson and @ericmehl.