### PR TITLE
Gadget : Avoid `Signal::disconnect( slot )`

### DIFF
--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -327,6 +327,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 		void emitDescendantVisibilityChanged();
 
 		ConstStylePtr m_style;
+		Gaffer::Signals::ScopedConnection m_styleChangedConnection;
 
 		bool m_visible;
 		bool m_enabled;

--- a/python/GafferUITest/GadgetTest.py
+++ b/python/GafferUITest/GadgetTest.py
@@ -184,6 +184,15 @@ class GadgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 3 )
 		self.assertTrue( cs[2][0].isSame( v ) )
 
+		s.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 1 ) )
+		self.assertEqual( len( cs ), 3 )
+
+		g.setStyle( None )
+		self.assertEqual( len( cs ), 4 )
+
+		s2.setColor( GafferUI.StandardStyle.Color.BackgroundColor, imath.Color3f( 2 ) )
+		self.assertEqual( len( cs ), 4 )
+
 	def testHighlighting( self ) :
 
 		g = GafferUI.Gadget()

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -126,14 +126,13 @@ void Gadget::setStyle( ConstStylePtr style )
 {
 	if( style!=m_style )
 	{
-		if( m_style )
-		{
-			const_cast<Style *>( m_style.get() )->changedSignal().disconnect( boost::bind( &Gadget::styleChanged, this ) );
-		}
+		m_styleChangedConnection.disconnect();
 		m_style = style;
 		if( m_style )
 		{
-			const_cast<Style *>( m_style.get() )->changedSignal().connect( boost::bind( &Gadget::styleChanged, this ) );
+			m_styleChangedConnection = const_cast<Style *>( style.get() )->changedSignal().connect(
+				boost::bind( &Gadget::styleChanged, this )
+			);
 		}
 		// Style affects the bounding box of text,
 		// so we need Layout rather than just Render.


### PR DESCRIPTION
Currently we rarely give a specific style to an individual Gadget, because we prefer to use metadata to control the appearance of nodes and the like. But once upon a time we used to control the appearance of nodes by giving them a style. That would have been the worst case scenario for `Signal::disconnect()`, with lots of Gadgets all having a connection to the same signal, and all paying linear time for the disconnect. We're planning to remove `Signal::disconnect()` to avoid this sort of pitfall, so we now use explicit connections with constant-time `disconnect()`.

Since f36d27b005e11a4638fd0d376c225e748b0e9bd7 showed that draw time was quite sensitive to `sizeof( Gadget )`, I also tried an alternative implementation where both the StylePtr and the connection were held indirectly in a separate struct, keeping `sizeof( Gadget )` as it currently is. If anything, there was _maybe_ ~2% improvement in drawtime with that vs this commit, but the test was pretty noisy and I deemed it not worth the small cost in extra complexity.
