### PR TITLE
Signal : Remove `disconnect( slot )` method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ API
 Breaking Changes
 ----------------
 
+- Signal : Removed `disconnect( slot )` method. This was a performance hazard because it was linear in the number of connections. Use `Connection::disconnect()` instead, which is constant time.
 - GafferTest : Removed `expectedFailure()` decorator. Use `unittest.expectedFailure()` instead.
 - Python : Removed support for Python 2.
 - CatalogueUI : Hid OutputIndexColumn from public API.

--- a/include/Gaffer/Loop.h
+++ b/include/Gaffer/Loop.h
@@ -95,6 +95,8 @@ class IECORE_EXPORT Loop : public ComputeNode
 		size_t m_outPlugIndex;
 		size_t m_firstPlugIndex;
 
+		Signals::Connection m_childAddedConnection;
+
 		void childAdded();
 		bool setupPlugs();
 

--- a/include/Gaffer/Signals.h
+++ b/include/Gaffer/Signals.h
@@ -127,10 +127,6 @@ class Signal<Result( Args... ), Combiner> : boost::noncopyable
 		template<typename SlotFunctor>
 		Connection connectFront( const SlotFunctor &slot );
 
-		/// Disconnects all slots that compare equal to `slotFunctor`.
-		template<typename SlotFunctor>
-		void disconnect( const SlotFunctor &slotFunctor );
-
 		/// Disconnects all connected slots. Not recommended, because
 		/// it allows the disconnection of slots belonging to others.
 		void disconnectAllSlots();

--- a/include/Gaffer/Signals.inl
+++ b/include/Gaffer/Signals.inl
@@ -232,11 +232,7 @@ template<typename Result, typename... Args, typename Combiner>
 struct Signal<Result( Args... ), Combiner>::Slot : public Private::SlotBase
 {
 
-	/// \todo We'd like to use `std::function` here, but it doesn't support
-	/// equality comparison, which makes implementing
-	/// `Signal::disconnect( const SlotFunctor & )` hard to implement. Perhaps
-	/// it's achievable using `function::target_type` and `function::target`?
-	using FunctionType = boost::function<Result( Args... )>;
+	using FunctionType = std::function<Result( Args... )>;
 
 	Slot( Private::SlotBase::Ptr &previous, const FunctionType &function = FunctionType() )
 		: 	SlotBase( previous ), function( function )
@@ -257,7 +253,7 @@ struct Signal<Result( Args... ), Combiner>::Slot : public Private::SlotBase
 			// destruction of ScopedConnections for this slot, causing reentrant
 			// calls to `this->disconnect()`. We use `wasConnected` to protect
 			// against the double-clear this could otherwise cause.
-			function.clear();
+			function = nullptr;
 		}
 	}
 
@@ -284,7 +280,7 @@ struct Signal<Result( Args... ), Combiner>::Slot : public Private::SlotBase
 				// Slot was disconnected during call, and we couldn't
 				// clear the function while it was being called. Clear
 				// it now instead.
-				slot.function.clear();
+				slot.function = nullptr;
 			}
 		}
 		Slot &slot;

--- a/include/Gaffer/Signals.inl
+++ b/include/Gaffer/Signals.inl
@@ -45,7 +45,6 @@
 
 #include <optional>
 
-
 namespace Gaffer::Signals
 {
 
@@ -167,21 +166,6 @@ Connection Signal<Result( Args... ), Combiner>::connectInternal( const SlotFunct
 	Trackable::trackConnection( slot, result );
 	return result;
 }
-
-template<typename Result, typename... Args, typename Combiner>
-template<typename SlotFunctor>
-void Signal<Result( Args... ), Combiner>::disconnect( const SlotFunctor &slotFunctor )
-{
-	Private::SlotBase::Ptr slot = m_firstSlot;
-	while( slot != lastSlot() )
-	{
-		if( static_cast<Slot *>( slot.get() )->function == slotFunctor )
-		{
-			slot->disconnect();
-		}
-		slot = slot->next;
-	}
-};
 
 template<typename Result, typename... Args, typename Combiner>
 Result Signal<Result( Args... ), Combiner>::operator() ( Args... args ) const

--- a/python/GafferTest/SignalsTest.py
+++ b/python/GafferTest/SignalsTest.py
@@ -588,14 +588,6 @@ class SignalsTest( GafferTest.TestCase ) :
 
 		self.assertFalse( connection.connected() )
 
-	def testDisconnectMatchingLambda( self ) :
-
-		GafferTest.testSignalDisconnectMatchingLambda()
-
-	def testDisconnectMatchingBind( self ) :
-
-		GafferTest.testSignalDisconnectMatchingBind()
-
 	def testSelfDisconnectingSlot( self ) :
 
 		GafferTest.testSignalSelfDisconnectingSlot()

--- a/src/Gaffer/Loop.cpp
+++ b/src/Gaffer/Loop.cpp
@@ -52,7 +52,7 @@ Loop::Loop( const std::string &name )
 	// Connect to `childAddedSignal()` so we can set ourselves up later when the
 	// appropriate plugs are added manually.
 	/// \todo Remove this and do all the work in `setup()`.
-	childAddedSignal().connect( boost::bind( &Loop::childAdded, this ) );
+	m_childAddedConnection = childAddedSignal().connect( boost::bind( &Loop::childAdded, this ) );
 }
 
 Loop::~Loop()
@@ -246,7 +246,7 @@ bool Loop::setupPlugs()
 		return false;
 	}
 
-	childAddedSignal().disconnect( boost::bind( &Loop::childAdded, this ) );
+	m_childAddedConnection.disconnect();
 
 	m_inPlugIndex = std::find( children().begin(), children().end(), in ) - children().begin();
 	m_outPlugIndex = std::find( children().begin(), children().end(), out ) - children().begin();

--- a/src/GafferTestModule/SignalsTest.cpp
+++ b/src/GafferTestModule/SignalsTest.cpp
@@ -83,63 +83,6 @@ void testCallPerformance()
 	GAFFERTEST_ASSERTEQUAL( callsMade, callsToMake );
 }
 
-void testDisconnectMatchingLambda()
-{
-	Signals::Signal<void()> signal;
-
-	auto slot1 = [](){};
-	auto slot2 = [](){};
-
-	auto connection1 = signal.connect( slot1 );
-	auto connection2 = signal.connect( slot2 );
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 2 );
-
-	/// \todo Can this be dealt with internally in`Signal::disconnect()`?
-#ifdef _MSC_VER
-	signal.disconnect( static_cast<void( __cdecl * )()>( slot1 ) );
-#else
-	signal.disconnect( slot1 );
-#endif
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 1 );
-	GAFFERTEST_ASSERT( !connection1.connected() );
-	GAFFERTEST_ASSERT( connection2.connected() );
-
-#ifdef _MSC_VER
-	signal.disconnect( static_cast<void( __cdecl * )()>( slot2 ) );
-#else
-	signal.disconnect( slot2 );
-#endif
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 0 );
-	GAFFERTEST_ASSERT( signal.empty() );
-	GAFFERTEST_ASSERT( !connection1.connected() );
-	GAFFERTEST_ASSERT( !connection2.connected() );
-
-}
-
-void testSlot( const char *arg1 )
-{
-}
-
-void testDisconnectMatchingBind()
-{
-	Signals::Signal<void()> signal;
-
-	auto connection1 = signal.connect( boost::bind( testSlot, "hello" ) );
-	auto connection2 = signal.connect( boost::bind( testSlot, "there" ) );
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 2 );
-
-	signal.disconnect( boost::bind( testSlot, "there" ) );
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 1 );
-	GAFFERTEST_ASSERT( connection1.connected() );
-	GAFFERTEST_ASSERT( !connection2.connected() );
-
-	signal.disconnect( boost::bind( testSlot, "hello" ) );
-	GAFFERTEST_ASSERTEQUAL( signal.numSlots(), 0 );
-	GAFFERTEST_ASSERT( signal.empty() );
-	GAFFERTEST_ASSERT( !connection1.connected() );
-	GAFFERTEST_ASSERT( !connection2.connected() );
-}
-
 void testSelfDisconnectingSlot()
 {
 	// To be captured by our lambda slot. We use this to determine if the slot
@@ -285,8 +228,6 @@ void GafferTestModule::bindSignalsTest()
 	def( "testSignalConstructionPerformance", &testConstructionPerformance );
 	def( "testSignalConnectionPerformance", &testConnectionPerformance );
 	def( "testSignalCallPerformance", &testCallPerformance );
-	def( "testSignalDisconnectMatchingLambda", &testDisconnectMatchingLambda );
-	def( "testSignalDisconnectMatchingBind", &testDisconnectMatchingBind );
 	def( "testSignalSelfDisconnectingSlot", &testSelfDisconnectingSlot );
 	def( "testSignalScopedConnectionMoveConstructor", &testScopedConnectionMoveConstructor );
 	def( "testSignalScopedConnectionMoveAssignment", &testScopedConnectionMoveAssignment );


### PR DESCRIPTION
We included this method when introducing our own `Signal` class, to provide backwards compatibility for the old `boost::signals` we used before. But we don't intend to keep compatibility forever, and intend to continue to make API improvements where relevant. In this case, our motivation is threefold :

- The performance of `disconnect( slot )` is linear in the number of connected slots, since it requires a linear search to find matching slots. It's therefore a performance hazard - disconnecting all N slots this way is `O(n^2) `. Disconnecting via `Connection::disconnect()` is constant time, and therefore a significant improvement.
- It wasn't reliable on Windows, and despite @ericmehl's best efforts, the reason has eluded us.
- It was using an equality operator of `boost::function` that doesn't exist in `std::function`, and we want to use `std` components in preference to `boost`.