### PR TITLE
ArnoldColorManagerUI : Fix broken presets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.
+- ArnoldColorManager : Fixed broken presets for `color_space_narrow` and `color_space_linear`.
 
 1.0.6.0 (relative to 1.0.5.1)
 =======

--- a/python/GafferArnoldUI/ArnoldColorManagerUI.py
+++ b/python/GafferArnoldUI/ArnoldColorManagerUI.py
@@ -68,10 +68,7 @@ def __ocioConfig( plug ) :
 
 def __roles( config ) :
 
-	result = []
-	for i in range( 0, config.getNumRoles() ) :
-		result.append( config.getRoleName( i ) )
-	return result
+	return [ r[0] for r in config.getRoles() ]
 
 def __colorSpaces( config ) :
 


### PR DESCRIPTION
This should have been updated when we moved to OpenColorIO 2, as the OpenColorIO API for accessing roles has changed.
