### PR TITLE
Fix Display of Negative Colors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
   - Fixed crash rendering a scene containing a CoordinateSystem (#4865).
   - Fixed crash rendering a PointPrimitive with `N` primitive variable (#4876).
 - PathFilter : Fixed error when selecting a path element from a promoted `PathFilter.paths` plug (introduced in 0.61.13.0).
+- ImageView : Fixed error with display of negative colors.
 
 API
 ---

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -1521,6 +1521,8 @@ ImageView::ImageView( const std::string &name )
 	clampNode->minClampToPlug()->setValue( Color4f( 1.0f, 1.0f, 1.0f, 0.0f ) );
 	clampNode->maxClampToPlug()->setValue( Color4f( 0.0f, 0.0f, 0.0f, 1.0f ) );
 	m_cpuClippingPlug = clampNode->enabledPlug();
+	// Default false to match the plug that drives it
+	m_cpuClippingPlug->setValue( false );
 
 	GradePtr gradeNode = new Grade();
 	preprocessor->addChild( gradeNode );

--- a/src/GafferImageUI/OpenColorIOAlgo.cpp
+++ b/src/GafferImageUI/OpenColorIOAlgo.cpp
@@ -182,8 +182,10 @@ vec4 colorTransformWithSolo( vec4 inPixel, bool absoluteValue, bool clipping, ve
 			inPixel.a
 		);
 	}
-	inPixel = vec4( pow( inPixel.rgb * multiply, power ), inPixel.a );
-
+	inPixel = vec4( inPixel.rgb * multiply, inPixel.a );
+	if( inPixel.r > 0.0 && power.r != 1.0 ) inPixel.r = pow( inPixel.r, power.r );
+	if( inPixel.g > 0.0 && power.g != 1.0 ) inPixel.g = pow( inPixel.g, power.g );
+	if( inPixel.b > 0.0 && power.b != 1.0 ) inPixel.b = pow( inPixel.b, power.b );
 
 	if( soloChannel == -1 )
 	{


### PR DESCRIPTION
Fortunately a simple fix.  Main question is just whether we should be backporting it further back.  ImageEngine doesn't have any shows on 1.0, but there are current shows on 61 where this fix would help ... but we don't usually backport that far, and it sounds like IE can work around it by switching to CPU.

I also snuck in an unrelated simple fix to the CPU color path ... see my comment, maybe we should just be deprecated it harder, but until it's gone, no sense in having it broken.