### PR TITLE
SpreadsheetUI : Support metadata on `row.name` and `row.enabled`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - Plugs promoted from a `PathFilter.paths` plug (an unpromoted `PathFilter.paths` plug supports this since 0.61.13.0)
   - Spreadsheet cells connected to a `PathFilter.paths` plug.
   - Spreadsheet row names when the spreadsheet selector is set to `scene:path`.
+- Spreadsheet : Added support for metadata on the `name` and `enabled` plug of each row. Metadata registered on plugs in the default row is mirrored automatically onto all other rows.
 
 Fixes
 -----

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -261,7 +261,7 @@ for key in [
 ] :
 
 	Gaffer.Metadata.registerValue(
-		Gaffer.Spreadsheet.RowsPlug, "row*.cells...", key,
+		Gaffer.Spreadsheet.RowsPlug, "row*.*...", key,
 		functools.partial( __defaultCellMetadata, key = key ),
 	)
 
@@ -314,5 +314,5 @@ def __presetValuesMetadata( plug ) :
 	result.extend( Gaffer.Metadata.value( source, "presetValues" ) or [] )
 	return result
 
-Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetNames", __presetNamesMetadata )
-Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.cells...", "presetValues", __presetValuesMetadata )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.*...", "presetNames", __presetNamesMetadata )
+Gaffer.Metadata.registerValue( Gaffer.Spreadsheet.RowsPlug, "row*.*...", "presetValues", __presetValuesMetadata )

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -837,5 +837,20 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 
 				self.assertEqual( [ qtHeader.visualIndex( i ) for i in range( l ) ], list( p ) )
 
+	def testRowMetadata( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.IntPlug( "a" ) )
+		s["rows"].addColumn( Gaffer.IntPlug( "b" ) )
+		s["rows"].addRow()
+
+		Gaffer.Metadata.registerValue( s["rows"].defaultRow()["name"], "plugValueWidget:type", "Test" )
+		Gaffer.Metadata.registerValue( s["rows"].defaultRow()["cells"]["a"]["value"], "plugValueWidget:type", "Test2" )
+		Gaffer.Metadata.registerValue( s["rows"].defaultRow()["cells"]["b"]["value"], "plugValueWidget:type", "Test3" )
+
+		self.assertEqual( Gaffer.Metadata.value( s["rows"][1]["name"], "plugValueWidget:type" ), "Test" )
+		self.assertEqual( Gaffer.Metadata.value( s["rows"][1]["cells"]["a"]["value"], "plugValueWidget:type" ), "Test2" )
+		self.assertEqual( Gaffer.Metadata.value( s["rows"][1]["cells"]["b"]["value"], "plugValueWidget:type" ), "Test3" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
We were already supporting this for the cell plugs, but not these two. The initial motivation for extending support is to allow a custom widget to be used for editing the `name` plug.