### PR TITLE
Cycles Renderer : Fix return value from `CyclesCamera::attributes()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
   - Fixed handling of `Varying` primitive variable interpolation (#4849).
   - Fixed handling of `Constant Color3f` primitive variables.
   - Fixed handling of indexed primitive variables.
+  - Fixed `"attribute edit required geometry to be regenerated"` error when changing attributes on a camera.
 - PathFilter : Fixed error when selecting a path element from a promoted `PathFilter.paths` plug (introduced in 0.61.13.0).
 - ImageView : Fixed error with display of negative colors.
 - NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -415,6 +415,22 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 		del o
 
+	def testCameraAttributeEdits( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		camera = renderer.camera( "test", IECoreScene.Camera(), renderer.attributes( IECore.CompoundObject() ) )
+
+		# Edit should succeed.
+		self.assertTrue( camera.attributes(
+			renderer.attributes( IECore.CompoundObject( { "user:test" : IECore.IntData( 10 ) } ) )
+		) )
+
+		del camera
+
 	def testDisplayDriverCropWindow( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2303,7 +2303,8 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
 		{
-			return false;
+			// Attributes don't affect the camera, so the edit always "succeeds".
+			return true;
 		}
 
 		void assignID( uint32_t id ) override
@@ -2314,7 +2315,6 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 	private :
 
 		SharedCCameraPtr m_camera;
-		//ConstCyclesAttributesPtr m_attributes;
 
 };
 


### PR DESCRIPTION
Returning `false` is for when you can't apply an attribute edit for something you would normally support, and you require the object to be regenerated from scratch. Since we don't support any attributes for cameras, this is never relevant and we always return `true`.

@ericmehl, this should fix the test failures from #4918. But I still need to do a bit of digging to convince myself it's reasonable that we would have started sending attribute edits in this case...