### PR TITLE
Shuffle plug replace destination11

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,4 @@
-1.1.x.x ( relative to 1.1.1.0)
+1.1.x.x (relative to 1.1.1.0)
 =======
 
 Improvements
@@ -18,8 +18,12 @@ Improvements
   - Spreadsheet row names when the spreadsheet selector is set to `scene:path`.
 - Spreadsheet : Added support for metadata on the `name` and `enabled` plug of each row. Metadata registered on plugs in the default row is mirrored automatically onto all other rows.
 - ImageView : Added support for selecting a comparison node.  This can be accessed by selecting the focus or selected node from the comparison widget at the top of the  viewer, or by dragging an image node to the comparison widget.
-- ShuffleAttributes : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
-- ShufflePrimitiveVariables : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+- ShuffleAttributes :
+  - Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+  - Shuffles are now performed in the order they are defined, separate shuffles may write to the same destination.
+- ShufflePrimitiveVariables :
+  - Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+  - Shuffles are now performed in the order they are defined, separate shuffles may write to the same destination.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,8 @@ Improvements
   - Spreadsheet row names when the spreadsheet selector is set to `scene:path`.
 - Spreadsheet : Added support for metadata on the `name` and `enabled` plug of each row. Metadata registered on plugs in the default row is mirrored automatically onto all other rows.
 - ImageView : Added support for selecting a comparison node.  This can be accessed by selecting the focus or selected node from the comparison widget at the top of the  viewer, or by dragging an image node to the comparison widget.
+- ShuffleAttributes : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
+- ShufflePrimitiveVariables : Added `replaceDestination` plugs that may be used to specify whether each shuffle replaces already written destination data with the same name.
 
 Fixes
 -----

--- a/include/Gaffer/ShufflePlug.h
+++ b/include/Gaffer/ShufflePlug.h
@@ -70,6 +70,9 @@ class GAFFER_API ShufflePlug : public ValuePlug
 		BoolPlug *deleteSourcePlug();
 		const BoolPlug *deleteSourcePlug() const;
 
+		BoolPlug *replaceDestinationPlug();
+		const BoolPlug *replaceDestinationPlug() const;
+
 		bool acceptsChild( const GraphComponent *potentialChild ) const override;
 		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 

--- a/include/Gaffer/ShufflePlug.h
+++ b/include/Gaffer/ShufflePlug.h
@@ -95,11 +95,10 @@ class GAFFER_API ShufflesPlug : public ValuePlug
 		bool acceptsInput( const Plug *input ) const override;
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
-		/// Shuffles the sources into a destination container. The container type must have a std::pair value_type
-		/// and string-compatible keys (eg std::string, IECore::InternedString).
+		/// Shuffles the sources into a destination container. The container type should have a map
+		/// compatible interface with string-compatible keys (eg std::string, IECore::InternedString).
 		template<typename T>
 		T shuffle( const T &sourceContainer ) const;
-
 };
 
 } // namespace Gaffer

--- a/python/GafferSceneUI/ShuffleAttributesUI.py
+++ b/python/GafferSceneUI/ShuffleAttributesUI.py
@@ -47,7 +47,9 @@ Gaffer.Metadata.registerNode(
 	"""
 	ShuffleAttributes is used to copy or rename arbitrary numbers of attributes at
 	the filtered locations. The deleteSource plugs may be used to remove the original
-	source attribute(s) after the shuffling has been completed.
+	source attribute(s) after the shuffling has been completed. The replaceDestination
+	plugs may be used to specify whether each shuffle should replace already written
+	destination data with the same name.
 
 	An additional context variable `${source}` can be used on the destination plugs
 	to insert the name of each source attribute. For example, to prefix all attributes
@@ -60,9 +62,10 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The attributes to be shuffled - arbitrary numbers of attributes may be
-			shuffled via the source/destination plugs. The deleteSource plug may be
-			used to remove the original attribute(s).
+			The attributes to be shuffled - arbitrary numbers of attributes may be shuffled
+			via the source/destination plugs. The deleteSource plug may be used to remove the
+			original attribute(s). The replaceDestination plug may be used to specify whether
+			each shuffle should replace already written destination data with the same name.
 			""",
 
 		],

--- a/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/ShufflePrimitiveVariablesUI.py
@@ -43,13 +43,15 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	ShufflePrimitiveVariables is used to copy or rename arbitrary numbers of primitive variables
-	at the filtered locations. The deleteSource plugs may be used to remove the original source
-	primitive variable(s) after the shuffling has been completed.
+	ShufflePrimitiveVariables is used to copy or rename arbitrary numbers of primitive
+	variables at the filtered locations. The deleteSource plugs may be used to remove
+	the original source primitive variable(s) after the shuffling has been completed.
+	The replaceDestination plugs may be used to specify whether each shuffle should
+	replace already written destination data with the same name.
 
-	An additional context variable `${source}` can be used on the destination plugs to insert
-	the name of each source primitive variable. For example, to append `ref` to all primitive variables
-	set the source to `*` and the destination to `${source}ref`.
+	An additional context variable `${source}` can be used on the destination plugs
+	to insert the name of each source primitive variable. For example, to append `ref`
+	to all primitive variables set the source to `*` and the destination to `${source}ref`.
 	""",
 
 	plugs = {
@@ -59,8 +61,10 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The primitive variables to be shuffled - arbitrary numbers of primitive variables
-			may be shuffled via the source/destination plugs. The deleteSource plug may be used
-			to remove the original primitive variable(s).
+			may be shuffled via the source/destination plugs. The deleteSource plug may be
+			used to remove the original primitive variable(s). The replaceDestination plug may
+			be used to specify whether each shuffle should replace already written destination
+			data with the same name.
 			""",
 
 			"divider", True,

--- a/python/GafferTest/ShufflePlugTest.py
+++ b/python/GafferTest/ShufflePlugTest.py
@@ -53,6 +53,7 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		self.assertEqual( p["enabled"].defaultValue(), True )
 		self.assertEqual( p["destination"].defaultValue(), "" )
 		self.assertEqual( p["deleteSource"].defaultValue(), False )
+		self.assertEqual( p["replaceDestination"].defaultValue(), True )
 
 		p = Gaffer.ShufflePlug( source = "foo", destination = "bar", deleteSource = True, enabled = False )
 		self.assertEqual( p["source"].defaultValue(), "" )
@@ -63,6 +64,7 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 		self.assertEqual( p["destination"].getValue(), "bar" )
 		self.assertEqual( p["deleteSource"].defaultValue(), False )
 		self.assertEqual( p["deleteSource"].getValue(), True )
+		self.assertEqual( p["replaceDestination"].defaultValue(), True )
 
 		p2 = Gaffer.ShufflesPlug()
 		self.assertFalse( p.acceptsChild( Gaffer.Plug() ) )
@@ -321,6 +323,25 @@ class ShufflePlugTest( GafferTest.TestCase ) :
 			IECore.CompoundData( {
 				"foo" : IECore.FloatData( 0.5 ),
 				"bar" : IECore.FloatData( 0.5 ),
+				"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+				"bongo" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+			} )
+		)
+
+	def testReplaceDestination( self ) :
+
+		p = Gaffer.ShufflesPlug()
+		p.addChild( Gaffer.ShufflePlug( source = "foo", destination = "bar" ) )
+		p.addChild( Gaffer.ShufflePlug( source = "baz", destination = "bongo" ) )
+		p[0]["replaceDestination"].setValue( False )
+
+		source = IECore.CompoundData( { "foo" : 0.5, "bar" : 1.5, "baz" : imath.Color3f( 1, 2, 3 ), "bongo" : imath.Color3f( 4, 5, 6 ) } )
+		dest = p.shuffle( source )
+		self.assertEqual(
+			dest,
+			IECore.CompoundData( {
+				"foo" : IECore.FloatData( 0.5 ),
+				"bar" : IECore.FloatData( 1.5 ),
 				"baz" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 				"bongo" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
 			} )

--- a/python/GafferUI/ShufflePlugValueWidget.py
+++ b/python/GafferUI/ShufflePlugValueWidget.py
@@ -70,7 +70,10 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		destinationWidget.textWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 		self.__row.append( destinationWidget, verticalAlignment = GafferUI.Label.VerticalAlignment.Top )
 
-		self.__row.append( GafferUI.PlugValueWidget.create( plug["deleteSource"] ), expand = True )
+		deleteSourceWidget = GafferUI.PlugValueWidget.create( plug["deleteSource"] )
+		deleteSourceWidget.boolWidget()._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() - 40 )
+		self.__row.append( deleteSourceWidget )
+		self.__row.append( GafferUI.PlugValueWidget.create( plug["replaceDestination"] ), expand = True )
 
 		self._updateFromPlug()
 
@@ -82,6 +85,7 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__row[1].setPlug( plug["enabled"] )
 		self.__row[2].setPlug( plug["destination"] )
 		self.__row[3].setPlug( plug["deleteSource"] )
+		self.__row[4].setPlug( plug["replaceDestination"] )
 
 	def hasLabel( self ) :
 
@@ -110,7 +114,7 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		with self.getContext() :
 			enabled = self.getPlug()["enabled"].getValue()
 
-		for i in ( 0, 2, 3 ) :
+		for i in ( 0, 2, 3, 4 ) :
 			self.__row[i].setEnabled( enabled )
 
 GafferUI.PlugValueWidget.registerType( Gaffer.ShufflePlug, ShufflePlugValueWidget )
@@ -130,6 +134,7 @@ Gaffer.Metadata.registerValue( Gaffer.ShufflePlug,
 	"""
 )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "deleteSource", "description", "Enable to delete the source data after shuffling to the destination(s)." )
+Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "replaceDestination", "description", "Enable to replace already written destination data with the same name as destination(s)." )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "enabled", "description", "Used to enable/disable this shuffle operation." )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "nodule:type", "" )
 Gaffer.Metadata.registerValue( Gaffer.ShufflePlug, "*", "nodule:type", "" )
@@ -152,7 +157,8 @@ class ShufflesPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.Label( "<h4><b>Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 				GafferUI.Spacer( imath.V2i( 25, 2 ) ) # approximate width of a BoolWidget Switch
 				GafferUI.Label( "<h4><b>Destination</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
-				GafferUI.Label( "<h4><b>Delete Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
+				GafferUI.Label( "<h4><b>Delete Source</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() - 40 )
+				GafferUI.Label( "<h4><b>Replace</b></h4>" )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
 
 			self.__plugLayout = GafferUI.PlugLayout( plug )
 			self.__addButton = GafferUI.Button( image = "plus.png", hasFrame = False )

--- a/src/Gaffer/ShufflePlug.cpp
+++ b/src/Gaffer/ShufflePlug.cpp
@@ -65,6 +65,7 @@ ShufflePlug::ShufflePlug( const std::string &name, Direction direction, unsigned
 	// during `ShufflesPlug::shuffle()`, in order to account for the ${source} variable.
 	addChild( new StringPlug( "destination", direction, "", Plug::Default, IECore::StringAlgo::NoSubstitutions ) );
 	addChild( new BoolPlug( "deleteSource", direction ) );
+	addChild( new BoolPlug( "replaceDestination", direction, true ) );
 }
 
 Gaffer::StringPlug *ShufflePlug::sourcePlug()
@@ -107,6 +108,16 @@ const Gaffer::BoolPlug *ShufflePlug::deleteSourcePlug() const
 	return getChild<BoolPlug>( 3 );
 }
 
+Gaffer::BoolPlug *ShufflePlug::replaceDestinationPlug()
+{
+	return getChild<BoolPlug>( 4 );
+}
+
+const Gaffer::BoolPlug *ShufflePlug::replaceDestinationPlug() const
+{
+	return getChild<BoolPlug>( 4 );
+}
+
 bool ShufflePlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) const
 {
 	if( !Plug::acceptsChild( potentialChild ) )
@@ -142,6 +153,14 @@ bool ShufflePlug::acceptsChild( const Gaffer::GraphComponent *potentialChild ) c
 		potentialChild->isInstanceOf( BoolPlug::staticTypeId() ) &&
 		potentialChild->getName() == "deleteSource" &&
 		!getChild<Plug>( "deleteSource" )
+	)
+	{
+		return true;
+	}
+	else if(
+		potentialChild->isInstanceOf( BoolPlug::staticTypeId() ) &&
+		potentialChild->getName() == "replaceDestination" &&
+		!getChild<Plug>( "replaceDestination" )
 	)
 	{
 		return true;


### PR DESCRIPTION
Backport of recent shuffle plug "replaceDestination" changes to 1.1 maintenance branch
Note : There is an additional commit that removes the new ShufflePlug "replaceDestination" constructor argument to maintain ABI compatibility on the 1.1 maintenance branch.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
