### PR TITLE
ArnoldDisplacementUI : Hide `name` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.
 - ArnoldColorManager : Fixed broken presets for `color_space_narrow` and `color_space_linear`.
+- ArnoldDisplacement : Removed irrelevant shader name widget and `Reload` button.
 - ImageView : Fixed error with display of negative colors.
 - Spreadsheet :
   - Fixed bugs with inconsistent column ordering.

--- a/python/GafferArnoldUI/ArnoldDisplacementUI.py
+++ b/python/GafferArnoldUI/ArnoldDisplacementUI.py
@@ -59,6 +59,14 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"name" : [
+
+			# The `name` plug is inherited from Shader, but unused by ArnoldDisplacement.
+			# Hide it to avoid confusion. See comments in ArnoldDisplacement.h.
+			"plugValueWidget:type", "",
+
+		],
+
 		"map" : [
 
 			"description",


### PR DESCRIPTION
It isn't used at all, and always have an empty value, which is confusing to the user.