### PR TITLE
Cycles shading fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
   - Fixed handling of indexed primitive variables.
   - Fixed `"attribute edit required geometry to be regenerated"` error when changing attributes on a camera.
   - Fixed `cycles:shader:displacement_method` attribute handling (#4893).
+  - Fixed shader attribute substitutions (#4921).
 - PathFilter : Fixed error when selecting a path element from a promoted `PathFilter.paths` plug (introduced in 0.61.13.0).
 - ImageView : Fixed error with display of negative colors.
 - NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
   - Fixed handling of `Constant Color3f` primitive variables.
   - Fixed handling of indexed primitive variables.
   - Fixed `"attribute edit required geometry to be regenerated"` error when changing attributes on a camera.
+  - Fixed `cycles:shader:displacement_method` attribute handling (#4893).
 - PathFilter : Fixed error when selecting a path element from a promoted `PathFilter.paths` plug (introduced in 0.61.13.0).
 - ImageView : Fixed error with display of negative colors.
 - NodeEditor : Fixed updated of section summaries when they are changed in the UI Editor.

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -439,15 +439,17 @@ class CyclesShader : public IECore::RefCounted
 			m_shader->set_owner( scene );
 		}
 
-		CyclesShader( const IECoreScene::ShaderNetwork *surfaceShader,
-					  const IECoreScene::ShaderNetwork *displacementShader,
-					  const IECoreScene::ShaderNetwork *volumeShader,
-					  ccl::Scene *scene,
-					  const std::string &name,
-					  const IECore::MurmurHash &h,
-					  const bool singleSided,
-					  const IECore::InternedString displacementMethod,
-					  vector<const IECoreScene::ShaderNetwork *> &aovShaders )
+		CyclesShader(
+			const IECoreScene::ShaderNetwork *surfaceShader,
+			const IECoreScene::ShaderNetwork *displacementShader,
+			const IECoreScene::ShaderNetwork *volumeShader,
+			ccl::Scene *scene,
+			const std::string &name,
+			const IECore::MurmurHash &h,
+			const bool singleSided,
+			const IECore::InternedString displacementMethod,
+			vector<const IECoreScene::ShaderNetwork *> &aovShaders
+		)
 			:	m_hash( h )
 		{
 			ccl::ShaderGraph *graph = ShaderNetworkAlgo::convertGraph( surfaceShader, displacementShader, volumeShader, scene->shader_manager, name );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -671,9 +671,9 @@ class ShaderCache : public IECore::RefCounted
 				{
 					// Substitute surface (if needed)
 					IECoreScene::ShaderNetworkPtr substitutedSurfaceShader;
-					if( surfaceShader && hSubstDisp != IECore::MurmurHash() )
+					if( surfaceShader && hSubst != IECore::MurmurHash() )
 					{
-						IECoreScene::ShaderNetworkPtr substitutedSurfaceShader = surfaceShader->copy();
+						substitutedSurfaceShader = surfaceShader->copy();
 						substitutedSurfaceShader->applySubstitutions( attributes );
 						surfaceShader = substitutedSurfaceShader.get();
 					}
@@ -681,7 +681,7 @@ class ShaderCache : public IECore::RefCounted
 					IECoreScene::ShaderNetworkPtr substitutedDisplacementShader;
 					if( displacementShader && hSubstDisp != IECore::MurmurHash() )
 					{
-						IECoreScene::ShaderNetworkPtr substitutedDisplacementShader = displacementShader->copy();
+						substitutedDisplacementShader = displacementShader->copy();
 						substitutedDisplacementShader->applySubstitutions( attributes );
 						displacementShader = substitutedDisplacementShader.get();
 					}
@@ -689,7 +689,7 @@ class ShaderCache : public IECore::RefCounted
 					IECoreScene::ShaderNetworkPtr substitutedVolumeShader;
 					if( volumeShader && hSubstVol != IECore::MurmurHash() )
 					{
-						IECoreScene::ShaderNetworkPtr substitutedVolumeShader = volumeShader->copy();
+						substitutedVolumeShader = volumeShader->copy();
 						substitutedVolumeShader->applySubstitutions( attributes );
 						volumeShader = substitutedVolumeShader.get();
 					}


### PR DESCRIPTION
This fixes attribute substitutions and the `cycles:shader:displacementMethod` attribute.