### PR TITLE
Cycles RendererTest : Remove Python 2 support

### DIFF
--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -38,7 +38,6 @@ import os
 import math
 import time
 import unittest
-import six
 
 import imath
 
@@ -611,8 +610,8 @@ class RendererTest( GafferTest.TestCase ) :
 				renderer.object( data.typeName(), primitive, attributes )
 
 				self.assertEqual( len( mh.messages ), 1 )
-				six.assertRegex(
-					self, mh.messages[0].message,
+				self.assertRegex(
+					mh.messages[0].message,
 					"Primitive variable \"test\" has unsupported type \"{}\"".format( data.typeName() )
 				)
 


### PR DESCRIPTION
These uses of `six` are going to continue to trickle into main via `1.1_maintenance` for a while, and will need removing each time to keep `main` in a pure Python-3-only state.
