### PR TITLE
ShufflePlug : GCC error "range-loop-construct"

### DIFF
--- a/include/Gaffer/ShufflePlug.inl
+++ b/include/Gaffer/ShufflePlug.inl
@@ -77,7 +77,7 @@ T ShufflesPlug::shuffle( const T &sourceContainer ) const
 
 	NameContainer names;
 
-	for( const ConstShufflePlugPtr &plug : ShufflePlug::Range( *this ) )
+	for( auto &plug : ShufflePlug::Range( *this ) )
 	{
 		// NOTE : "source" context variable only applies to the destination plug.
 		//        So retrieve values of other plugs before setting context variable.


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- GCC 11.2.1 fix error "range-loop-construct"

### Related issues ###

- NA

### Dependencies ###

- NA

### Breaking changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
