### PR TITLE
Edit scopes list improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,10 @@ Features
 Improvements
 ------------
 
-- EditScope Menu : Changed the order of listed EditScopes to be alphabetical.
+- EditScope Menu :
+  - Changed the order of listed EditScopes to be alphabetical.
+  - Added an icon to menu items that are ancestors of the active EditScope.
+  - Menu items that only have a single item in their sub-menu are now collapsed into the parent item.
 
 Fixes
 -----
@@ -29,6 +32,11 @@ Fixes
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
 - Reference : Fixed unnecessary serialisation of connections from internal plugs to external plugs. These are serialised in the `.grf` file already, so do not need to be duplicated on the Reference node itself. This bug prevented changes to the internal connections from taking effect when reloading a modified `.grf` file, and could cause load failures when the connections were from an internal Expression (#4935).
 - MeshToLevelSet, LevelSetOffset : Fixed bug that could cause partial results to be returned if a previous operation was cancelled.
+
+API
+---
+
+- MenuDefinition : Added `icon` attribute support to `subMenu` items.
 
 1.1.2.0 (relative to 1.1.1.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Features
   - Added "Match Display Windows" option to Compare Mode menu. This allows the comparison mode to directly view a low-res render over a high-res plate, providing better performance than scaling up the render using the node graph.
   - The Color Inspector now shows color values for both images when comparing. Picking a color by dragging from the image now selects the composited on-screen color, taking into account  "Compare Mode" and the wipe.
 
+Improvements
+------------
+
+- EditScope Menu : Changed the order of listed EditScopes to be alphabetical.
+
 Fixes
 -----
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -218,7 +218,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result.append( "/__UpstreamDivider__", { "divider" : True, "label" : "Upstream" } )
 		if upstream :
-			for editScope in reversed( upstream ) :
+			for editScope in sorted( upstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
 				addItem( editScope )
 		else :
 			result.append( "/None Available", { "active" : False } )
@@ -227,7 +227,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			downstream = Gaffer.NodeAlgo.findAllDownstream( node, self.__editScopePredicate )
 			if downstream :
 				result.append( "/__DownstreamDivider__", { "divider" : True, "label" : "Downstream" } )
-				for editScope in downstream :
+				for editScope in sorted( downstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
 					addItem( editScope, enabled = False )
 
 		result.append( "/__NoneDivider__", { "divider" : True } )

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import functools
+from collections import deque
+from collections import OrderedDict
 
 import imath
 
@@ -176,6 +178,56 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.getPlug().setInput( editScope["out"] )
 
+	def __buildMenu( self, result, path, currentEditScope ) :
+
+		result = IECore.MenuDefinition()
+
+		for childPath in path.children() :
+			itemName = childPath[-1]
+
+			if childPath.isLeaf() :
+				editScope = childPath.property( "dict:value" )
+			else :
+				singlesStack = deque( [ childPath ] )
+				while singlesStack :
+					childPath = singlesStack.popleft()
+					children = childPath.children()
+					if len( children ) == 1 :
+						itemName += "." + children[0][-1]
+						if children[0].isLeaf() :
+							childPath = children[0]
+							editScope = children[0].property( "dict:value" )
+						else :
+							singlesStack.extend( [ children[0] ] )
+
+			if currentEditScope is not None :
+				# Ignore the first entry, which is the menu category
+				node = currentEditScope.scriptNode().descendant( ".".join( childPath[1:] ) )
+				icon = "menuBreadCrumb.png" if node.isAncestorOf( currentEditScope ) else None
+			else :
+				icon = None
+
+			if childPath.isLeaf() :
+				result.append(
+					itemName,
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__connectEditScope ), editScope ),
+						"active" : path[0] != "Downstream",
+						"label" : itemName,
+						"checkBox" : editScope == currentEditScope,
+					}
+				)
+			else :
+				result.append(
+					itemName,
+					{
+						"subMenu" : functools.partial( Gaffer.WeakMethod( self.__buildMenu ), result, childPath, currentEditScope ),
+						"icon" : icon
+					}
+				)
+
+		return result
+
 	def __menuDefinition( self ) :
 
 		result = IECore.MenuDefinition()
@@ -195,40 +247,58 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug().getInput() is not None :
 			currentEditScope = self.getPlug().getInput().parent()
 
-		def addItem( editScope, enabled = True ) :
-
-			result.append(
-				# The underscore suffix prevents collisions with a node and
-				# it's submenu if it has nested edit scopes.
-				"/%s_" % editScope.relativeName( editScope.scriptNode() ).replace( ".", "/" ),
-				{
-					"command" : functools.partial( Gaffer.WeakMethod( self.__connectEditScope ), editScope ),
-					"active" : enabled,
-					"label" : editScope.getName(),
-					"checkBox" : editScope == currentEditScope,
-				}
-			)
-
 		if node is not None :
 			upstream = Gaffer.NodeAlgo.findAllUpstream( node, self.__editScopePredicate )
 			if self.__editScopePredicate( node ) :
 				upstream.insert( 0, node )
+
+			downstream = Gaffer.NodeAlgo.findAllDownstream( node, self.__editScopePredicate )
 		else :
 			upstream = []
+			downstream = []
 
-		result.append( "/__UpstreamDivider__", { "divider" : True, "label" : "Upstream" } )
+		# Each child of the root will get its own section in the menu
+		# if it has children. The section will be preceded by a divider
+		# with its name in the divider label.
+
+		menuHierarchy = OrderedDict()
+
+		def addToMenuHierarchy( editScope, root ) :
+			ancestorNodes = []
+			currentNode = editScope
+			while currentNode.parent() != editScope.scriptNode() :
+				currentNode = currentNode.parent()
+				ancestorNodes.append( currentNode )
+
+			ancestorNodes.reverse()
+
+			currentNode = menuHierarchy.setdefault( root, {} )
+			for n in ancestorNodes :
+				currentNode = currentNode.setdefault( n.getName(), {} )
+			currentNode[editScope.getName()] = editScope
+
 		if upstream :
 			for editScope in sorted( upstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
-				addItem( editScope )
-		else :
-			result.append( "/None Available", { "active" : False } )
+				addToMenuHierarchy( editScope, "Upstream" )
 
-		if node is not None :
-			downstream = Gaffer.NodeAlgo.findAllDownstream( node, self.__editScopePredicate )
-			if downstream :
-				result.append( "/__DownstreamDivider__", { "divider" : True, "label" : "Downstream" } )
-				for editScope in sorted( downstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
-					addItem( editScope, enabled = False )
+		if downstream :
+			for editScope in sorted( downstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
+				addToMenuHierarchy( editScope, "Downstream" )
+
+		menuPath = Gaffer.DictPath( menuHierarchy, "/" )
+
+		for category in menuPath.children() :
+
+			if len( category.children() ) == 0 :
+				continue
+
+			result.append(
+				"/__{}Divider__".format( category[-1] ),
+				{ "divider" : True, "label" : category[-1] }
+			)
+
+			result.update( self.__buildMenu( result, category, currentEditScope ) )
+
 
 		result.append( "/__NoneDivider__", { "divider" : True } )
 		result.append(

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -316,6 +316,16 @@ class Menu( GafferUI.Widget ) :
 						subMenu = _Menu( qtMenu, name )
 						active = self.__evaluateItemValue( item.active )
 						subMenu.setEnabled( active )
+
+						icon = getattr( item, "icon", None )
+						if icon is not None :
+							if isinstance( icon, str ) :
+								image = GafferUI.Image( icon )
+							else :
+								assert( isinstance( icon, GafferUI.Image ) )
+								image = icon
+							subMenu.setIcon( QtGui.QIcon( image._qtPixmap() ) )
+
 						qtMenu.addMenu( subMenu )
 
 						subMenu.__definition = item.subMenu

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -370,6 +370,20 @@
 				"listPrependSmall",
 				"listRemoveSmall",
 			]
+		},
+
+		"menu" : {
+
+			"options" : {
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"menuBreadCrumb",
+				"menuChecked",
+				"menuIndicator",
+				"menuIndicatorDisabled",
+			]
 		}
 
 	},
@@ -403,9 +417,6 @@
 		'localDispatcherStatusFailed',
 		'localDispatcherStatusKilled',
 		'localDispatcherStatusRunning',
-		'menuChecked',
-		'menuIndicator',
-		'menuIndicatorDisabled',
 		'minus',
 		'navigationArrow',
 		'nodeSetNodeSelection',

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -15,13 +15,21 @@
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
    sodipodi:docname="graphics.svg"
    enable-background="new">
   <title
      id="title2005">Gaffer Icons</title>
   <defs
      id="defs4">
+    <linearGradient
+       id="linearGradient7011"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1;"
+         offset="0"
+         id="stop7009" />
+    </linearGradient>
     <linearGradient
        id="nodeBorder"
        osb:paint="solid">
@@ -97,7 +105,8 @@
     </linearGradient>
     <linearGradient
        id="backgroundDark"
-       osb:paint="solid">
+       osb:paint="solid"
+       gradientTransform="translate(5.989806,2637.8795)">
       <stop
          style="stop-color:#383838;stop-opacity:1;"
          offset="0"
@@ -130,7 +139,8 @@
     </linearGradient>
     <linearGradient
        id="foreground"
-       osb:paint="solid">
+       osb:paint="solid"
+       gradientTransform="translate(5.989806,2637.8795)">
       <stop
          style="stop-color:#e0e0e0;stop-opacity:1;"
          offset="0"
@@ -541,8 +551,7 @@
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Annotations"
-     style="display:inline;opacity:1"
-     sodipodi:insensitive="true">
+     style="display:inline;opacity:1">
     <flowRoot
        xml:space="preserve"
        id="flowRoot2508"
@@ -597,7 +606,7 @@
          sodipodi:role="line"
          id="tspan2563"
          x="280"
-         y="1103.0781" /></text>
+         y="1103.2791" /></text>
     <flowRoot
        inkscape:label="overview"
        transform="translate(5.4023437,213.09198)"
@@ -890,7 +899,7 @@
          sodipodi:role="line"
          id="tspan3324"
          x="-10"
-         y="1839.3906" /></text>
+         y="1840.395" /></text>
     <path
        style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M -6,1915 H 743.99999"
@@ -1435,13 +1444,34 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1217"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">TweakModes</flowPara></flowRoot>  </g>
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">TweakModes</flowPara></flowRoot>    <path
+       id="path1211-3"
+       inkscape:label="hr1"
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       d="M -6,2664 H 743.99999"
+       style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <flowRoot
+       id="flowRoot1219-6"
+       inkscape:label="docTitle"
+       transform="matrix(1,0,0,1.0000138,288.10156,1651.0796)"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1.00000381"
+       xml:space="preserve"><flowRegion
+         id="flowRegion1215-7"
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"><rect
+           id="rect1213-5"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           y="983"
+           x="-295"
+           height="54.25"
+           width="343.75" /></flowRegion><flowPara
+         id="flowPara1217-3"
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">Menus</flowPara></flowRoot>  </g>
   <g
-     inkscape:groupmode="layer"
      id="layer4"
      inkscape:label="ExportAreas"
      style="display:inline"
-     sodipodi:insensitive="true">
+     inkscape:groupmode="layer">
     <g
        id="g2711"
        inkscape:label="pointers">
@@ -2637,6 +2667,46 @@
          y="2612"
          id="listRemoveSmall" />
     </g>
+    <g
+       id="menus"
+       inkscape:label="menus">
+      <rect
+         inkscape:label="menuChecked"
+         transform="matrix(0,1,1,0,0,0)"
+         y="12"
+         x="2669"
+         height="15"
+         width="15"
+         id="menuChecked"
+         style="fill:none;fill-opacity:1;stroke:none" />
+      <rect
+         inkscape:label="menuIndicatorDisabled"
+         transform="matrix(0,1,1,0,0,0)"
+         y="59"
+         x="2670"
+         height="15"
+         width="9"
+         id="menuIndicatorDisabled"
+         style="display:inline;fill:none;fill-opacity:1;stroke:none;stroke-width:1" />
+      <rect
+         inkscape:label="menuIndicator"
+         transform="matrix(0,1,1,0,0,0)"
+         y="35"
+         x="2670"
+         height="15"
+         width="9"
+         id="menuIndicator"
+         style="display:inline;fill:none;fill-opacity:1;stroke:none;stroke-width:1" />
+      <rect
+         style="fill:none;fill-opacity:1;stroke:none;stroke-width:1"
+         id="menuBreadCrumb"
+         width="10"
+         height="10"
+         x="2674"
+         y="79"
+         transform="matrix(0,1,1,0,0,0)"
+         inkscape:label="menuBreadCrumb" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
@@ -2764,18 +2834,10 @@
        inkscape:connector-curvature="0" />
     <path
        inkscape:connector-curvature="0"
-       id="path3925"
-       d="M 10.00302,97.80467 C 9.67541,97.72127 9.47879,97.53041 9.00785,96.83864 8.50927,96.10629 7.99375,95.44349 7.46993,94.861385 7.07136,94.41847 6.77491,93.979131 6.7087,93.733211 6.56363,93.194492 7.01148,92.546373 7.80796,92.142372 8.16548,91.961019 8.2243,91.946405 8.5966,91.946405 c 0.37755,0 0.4281,0.01307 0.82179,0.212704 0.45178,0.22907 1.04314,0.733631 1.38454,1.181315 0.10373,0.135954 0.20206,0.247188 0.21862,0.247188 0.0166,0 0.12472,-0.208644 0.24037,-0.463659 0.25544,-0.563226 1.31289,-2.542595 1.75455,-3.284175 1.63774,-2.749977 3.44733,-5.032904 4.31459,-5.443186 0.3245,-0.15351 1.01672,-0.290822 1.81381,-0.359796 0.55651,-0.04814 0.62125,-0.04487 0.81712,0.04177 0.13992,0.0619 0.24167,0.150061 0.29727,0.257584 0.0971,0.187734 0.10594,0.516424 0.0185,0.685008 -0.0328,0.06347 -0.39478,0.457143 -0.80411,0.874793 -1.1208,1.143589 -1.74543,1.912562 -2.73766,3.370297 -1.32415,1.9454 -2.422,3.954681 -3.38197,6.189678 -0.73648,1.714674 -0.74612,1.734684 -0.93659,1.945504 -0.0953,0.10545 -0.28876,0.24251 -0.42999,0.30458 -0.22736,0.0999 -0.34668,0.11437 -1.04066,0.1261 -0.43112,0.007 -0.85582,-0.005 -0.94379,-0.0275 z"
-       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-opacity:1" />
-    <rect
-       style="fill:none;stroke:none"
-       id="menuChecked"
-       width="15"
-       height="15"
-       x="83.362183"
-       y="6"
-       transform="matrix(0,1,1,0,0,0)"
-       inkscape:label="#rect3946" />
+       id="menuCheckedShape"
+       d="m 15.992825,2735.6842 c -0.32761,-0.083 -0.52423,-0.2743 -0.99517,-0.9661 -0.49858,-0.7323 -1.0141,-1.3951 -1.53792,-1.9772 -0.39857,-0.4429 -0.69502,-0.8823 -0.76123,-1.1282 -0.14507,-0.5387 0.30278,-1.1868 1.09926,-1.5908 0.35752,-0.1814 0.41634,-0.196 0.78864,-0.196 0.37755,0 0.4281,0.013 0.82179,0.2127 0.45178,0.2291 1.04314,0.7336 1.38454,1.1813 0.10373,0.136 0.20206,0.2472 0.21862,0.2472 0.0166,0 0.12472,-0.2086 0.24037,-0.4636 0.25544,-0.5633 1.31289,-2.5426 1.75455,-3.2842 1.63774,-2.75 3.44733,-5.0329 4.31459,-5.4432 0.3245,-0.1535 1.01672,-0.2908 1.81381,-0.3598 0.55651,-0.048 0.62125,-0.045 0.81712,0.042 0.13992,0.062 0.24167,0.1501 0.29727,0.2576 0.0971,0.1877 0.10594,0.5164 0.0185,0.685 -0.0328,0.063 -0.39478,0.4571 -0.80411,0.8748 -1.1208,1.1436 -1.74543,1.9126 -2.73766,3.3703 -1.32415,1.9454 -2.422,3.9547 -3.38197,6.1897 -0.73648,1.7146 -0.74612,1.7346 -0.93659,1.9455 -0.0953,0.1054 -0.28876,0.2425 -0.42999,0.3045 -0.22736,0.1 -0.34668,0.1144 -1.04066,0.1261 -0.43112,0.01 -0.85582,-0.01 -0.94379,-0.028 z"
+       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.00157475;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path3925" />
     <g
        id="g2739"
        inkscape:label="arrows 10">
@@ -3764,57 +3826,40 @@
        cx="158"
        cy="38"
        r="8" />
-    <g
-       id="g4104">
-      <rect
-         inkscape:label="#menuIndicator"
-         y="72.362183"
-         x="35"
-         height="8.5"
-         width="15"
-         id="menuIndicator"
-         style="opacity:0.5;fill:none;stroke:none" />
-      <path
-         sodipodi:type="star"
-         style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path2818-2"
-         sodipodi:sides="3"
-         sodipodi:cx="117.14286"
-         sodipodi:cy="578.07648"
-         sodipodi:r1="7.1428571"
-         sodipodi:r2="5.7786927"
-         sodipodi:arg1="1.0471976"
-         sodipodi:arg2="2.0943952"
-         inkscape:flatsided="true"
-         inkscape:rounded="0"
-         inkscape:randomized="0"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         transform="matrix(0,-0.65333366,0.646633,0,-333.80333,151.72889)" />
-      <rect
-         style="opacity:0.5;fill:none;stroke:none"
-         id="menuIndicatorDisabled"
-         width="15"
-         height="8.5"
-         x="52"
-         y="72.362183"
-         inkscape:label="#menuIndicatorDisabled" />
-      <path
-         transform="matrix(0,-0.65333366,0.646633,0,-316.80333,151.72889)"
-         d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
-         inkscape:randomized="0"
-         inkscape:rounded="0"
-         inkscape:flatsided="true"
-         sodipodi:arg2="2.0943952"
-         sodipodi:arg1="1.0471976"
-         sodipodi:r2="5.7786927"
-         sodipodi:r1="7.1428571"
-         sodipodi:cy="578.07648"
-         sodipodi:cx="117.14286"
-         sodipodi:sides="3"
-         id="path1498"
-         style="opacity:0.4;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:type="star" />
-    </g>
+    <path
+       transform="matrix(0,-0.65333366,0.646633,0,-333.80632,2801.7276)"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0"
+       inkscape:flatsided="true"
+       sodipodi:arg2="2.0943952"
+       sodipodi:arg1="1.0471976"
+       sodipodi:r2="5.7786927"
+       sodipodi:r1="7.1428571"
+       sodipodi:cy="578.07648"
+       sodipodi:cx="117.14286"
+       sodipodi:sides="3"
+       id="menuIndicatorShape"
+       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="star"
+       inkscape:label="menuIndicator" />
+    <path
+       sodipodi:type="star"
+       style="opacity:0.4;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="menuIndicatorDisabledShape"
+       sodipodi:sides="3"
+       sodipodi:cx="117.14286"
+       sodipodi:cy="578.07648"
+       sodipodi:r1="7.1428571"
+       sodipodi:r2="5.7786927"
+       sodipodi:arg1="1.0471976"
+       sodipodi:arg2="2.0943952"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 120.71429,584.26237 110,578.07648 l 10.71429,-6.1859 z"
+       transform="matrix(0,-0.65333366,0.646633,0,-309.80332,2801.7289)"
+       inkscape:label="menuIndicatorDisabled" />
     <g
        id="g4488"
        transform="matrix(1.3868993,0,0,1.3868993,-57.129221,-84.589805)"
@@ -5144,7 +5189,7 @@
       <g
          id="g2119"
          transform="translate(68)"
-         style="opacity:0.643">
+         style="opacity:0.64299999">
         <circle
            style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974006;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2111"
@@ -5171,7 +5216,7 @@
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.643"
+         style="display:inline;opacity:0.64299999"
          id="g2129">
         <circle
            r="6.4999876"
@@ -5200,7 +5245,7 @@
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.643"
+         style="display:inline;opacity:0.64299999"
          id="g2139">
         <circle
            cx="579.5"
@@ -5228,7 +5273,7 @@
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.643"
+         style="display:inline;opacity:0.64299999"
          id="g2149">
         <circle
            cx="613.5"
@@ -8273,5 +8318,16 @@
            id="path2103-95" />
       </g>
     </g>
+    <circle
+       id="menuBreadCrumbShape"
+       style="display:inline;fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="menuBreadCrumb"
+       cx="84"
+       cy="2731.3623"
+       r="4.5" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="menus" />
   </g>
 </svg>


### PR DESCRIPTION
This improves the Edit Scope dropdown menu in a few ways :
- Edit Scopes are listed alphabetically now, instead of in the order of their distance from the active node.
- A dot icon has been added next to menu items whose descendant is the selected Scope.
- Menu items with only one child are collapsed into the parent. This applies recursively so multiple levels of single-child items are collapsed into one.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
