### PR TITLE
SceneReader/SceneWriter : Prefer SceneInterface sets API for USD & ABC

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,14 @@ Features
   - Cycles : Muted lights are disabled in renders.
   - Arnold : Muted lights are disabled in renders.
 
+Improvements
+------------
+
+- SceneReader :
+  - Improved read performance for sets in USD files, with a benchmark reading a moderately large set seeing more than 2x speedup.
+  - Improved cancellation responsiveness when reading large sets from USD files.
+- SceneWriter : Improved performance when writing sets to USD files.
+
 Fixes
 -----
 
@@ -31,6 +39,10 @@ Breaking Changes
 - Signal : Removed `disconnect( slot )` method. This was a performance hazard because it was linear in the number of connections. Use `Connection::disconnect()` instead, which is constant time.
 - GafferTest : Removed `expectedFailure()` decorator. Use `unittest.expectedFailure()` instead.
 - Python : Removed support for Python 2.
+- SceneWriter :
+  - Sets are now only written on the first frame for each file written.
+  - `SceneInterface::writeSet()` is now used in preference to `SceneInterface::writeTags()` for all non-legacy file formats.
+- SceneReader : `SceneInterface::readSet()` is now used in preference to `SceneInterface::readTags()` for all non-legacy formats.
 - CatalogueUI : Hid OutputIndexColumn from public API.
 
 1.1.2.0 (relative to 1.1.1.0)

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -133,6 +133,12 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 		static const double g_frameRate;
 		static size_t g_firstPlugIndex;
 
+		// SceneInterface has two different APIs related to sets : the legacy tags API and the
+		// new sets API. We prefer the sets API for standard formats like Alembic and USD, but
+		// fall back to the tags API for legacy SceneInterfaces.
+		friend class SceneWriter;
+		static bool useSetsAPI( const IECoreScene::SceneInterface *scene );
+
 };
 
 IE_CORE_DECLAREPTR( SceneReader )


### PR DESCRIPTION
This is a better match for the data structures in Gaffer (PathMatcher), USD (UsdCollection) and Alembic (AbcCollection), resulting in simpler implementation and improved performance. This gives a greater than 2x speedup reading a large set from USD. It _should_ also have meant that we supported the writing of sets to Alembic files, but that won't be the case until IECoreAlembic is fixed to support writing sets at the root of the scene.

A side effect of this is that cancellation is now responsive when reading large sets from USD. There is no cancellation API for `readTags()`, and USDScene was emulating tags by loading the entire set on the first call to `readTags()`.

I've implemented this as a blacklist of formats that use tags rather than a whitelist of formats that use sets, as going forwards I think all new formats should prefer to implement the sets API.

Once this is merged, I intend to resurrect #3944, which gives a further performance boost.