### PR TITLE
Cycles various lights update

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,20 @@
 1.1.x.x (relative to 1.1.6.1)
 =======
 
+Features
+--------
+
+- Cycles :
+  - Replaced size on portals and quad lights with width and height. Disks are width-only.
+  - Added use_camera and use_caustics for lights.
+  - Added normalize option for lights.
+
 Fixes
 -----
 
 - Cycles :
   - Fixed custom AOVs not being created properly for SVM shading mode only, OSL is not supported. (#5044).
+  - Fixed distant light angle is in degrees and not radians.
 
 1.1.6.1 (relative to 1.1.6.0)
 =======

--- a/python/GafferCyclesTest/CyclesLightTest.py
+++ b/python/GafferCyclesTest/CyclesLightTest.py
@@ -119,5 +119,23 @@ class CyclesLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( shader.parameters["color"], IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ) )
 		self.assertEqual( shader.parameters["size"], IECore.FloatData( 2 ) )
 
+	def testQuadSize( self ) :
+
+		node = GafferCycles.CyclesLight()
+		node.loadShader( "quad_light" )
+
+		self.assertEqual( node["parameters"]["width"].defaultValue(), 2.0 )
+		self.assertTrue( node["parameters"]["width"].isSetToDefault() )
+		self.assertEqual( node["parameters"]["height"].defaultValue(), 2.0 )
+		self.assertTrue( node["parameters"]["height"].isSetToDefault() )
+
+		self.assertNotIn( "size", node["parameters"] )
+
+		shader = node["out"].attributes( "/light" )["cycles:light"].outputShader()
+		self.assertEqual( shader.parameters["width"].value, 2.0 )
+		self.assertEqual( shader.parameters["height"].value, 2.0 )
+
+		self.assertNotIn( "size", shader.parameters )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesUI/CyclesLightUI.py
+++ b/python/GafferCyclesUI/CyclesLightUI.py
@@ -90,6 +90,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"parameters.normalize" : [
+
+			"nodule:type", ""
+
+		],
+
 	}
 
 )

--- a/python/GafferCyclesUI/CyclesLightUI.py
+++ b/python/GafferCyclesUI/CyclesLightUI.py
@@ -78,6 +78,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"parameters.width" : [
+
+			"nodule:type", ""
+
+		],
+
+		"parameters.height" : [
+
+			"nodule:type", ""
+
+		],
+
 	}
 
 )

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -393,13 +393,15 @@ T parameterValue( const IECore::CompoundDataMap &parameters, const IECore::Inter
 
 // Cycles lights just have a single `strength` parameter which
 // we want to present as separate "virtual" parameters for
-// intensity, color and exposure.
+// intensity, color, exposure and normalize. We calculate un-normalized
+// lights by multiplying the surface area of the light source.
 bool contributesToLightStrength( InternedString parameterName )
 {
 	return
 		parameterName == "intensity" ||
 		parameterName == "color" ||
-		parameterName == "exposure"
+		parameterName == "exposure" ||
+		parameterName == "normalize"
 	;
 }
 
@@ -421,6 +423,48 @@ Imath::Color3f constantLightStrength( const IECoreScene::ShaderNetwork *light )
 	// We don't support input connections to exposure - it seems unlikely that
 	// you'd want to texture that.
 	strength *= powf( 2.0f, parameterValue<float>( lightShader->parameters(), "exposure", 0.0f ) );
+
+	// Cycles has normalized lights as a default, we can emulate un-normalized lights
+	// with a bit of surface area size calculation onto the strength parameter.
+	/// \todo I think we should move normalization into Cycles itself -
+	/// https://developer.blender.org/D16838
+	if( !parameterValue<bool>( lightShader->parameters(), "normalize", true ) )
+	{
+		if( lightShader->getName() == "distant_light" )
+		{
+			const float angle = IECore::degreesToRadians( parameterValue<float>( lightShader->parameters(), "angle", 0.0f ) ) / 2.0f;
+			const float radius = tanf( angle );
+			const float area = M_PI_F * radius * radius;
+			if( area > 0.0f )
+			{
+				strength *= area;
+			}
+		}
+		else if( lightShader->getName() == "background_light" )
+		{
+			// Do nothing.
+		}
+		else if(
+			lightShader->getName() == "quad_light" ||
+			lightShader->getName() == "portal"
+		)
+		{
+			const float width = parameterValue( lightShader->parameters(), "width", 1.0f );
+			const float height = parameterValue( lightShader->parameters(), "height", 1.0f );
+			strength *= width * height;
+		}
+		else if( lightShader->getName() == "disk_light" )
+		{
+			const float width = parameterValue( lightShader->parameters(), "width", 2.0f ) * 0.5f;
+			const float height = parameterValue( lightShader->parameters(), "height", 2.0f ) * 0.5f;
+			strength *= M_PI * width * height;
+		}
+		else // Point or spot light.
+		{
+			const float size = parameterValue( lightShader->parameters(), "size", 1.0f ) * 0.5f;
+			strength *= M_PI * size * size * 4.0f;
+		}
+	}
 
 	return strength;;
 }

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -615,12 +615,19 @@ void convertLight( const IECoreScene::ShaderNetwork *light, ccl::Light *cyclesLi
 	)
 	{
 		cyclesLight->set_light_type( ccl::LIGHT_AREA );
-		cyclesLight->set_size( 2.0f );
+		cyclesLight->set_size( 1.0f );
+		cyclesLight->set_sizeu( 2.0f );
+		cyclesLight->set_sizev( 2.0f );
+
+		cyclesLight->set_round( false );
 	}
 	else if( lightShader->getName() == "disk_light" )
 	{
 		cyclesLight->set_light_type( ccl::LIGHT_AREA );
-		cyclesLight->set_size( 2.0f );
+		cyclesLight->set_size( 1.0f );
+		cyclesLight->set_sizeu( 2.0f );
+		cyclesLight->set_sizev( 2.0f );
+
 		cyclesLight->set_round( true );
 	}
 	else
@@ -648,6 +655,19 @@ void convertLight( const IECoreScene::ShaderNetwork *light, ccl::Light *cyclesLi
 		else if( name == "spread" )
 		{
 			cyclesLight->set_spread( IECore::degreesToRadians( parameterValue<float>( value.get(), name, 180.0f ) ) );
+		}
+		else if( name == "width" )
+		{
+			cyclesLight->set_sizeu( parameterValue<float>( value.get(), name, 2.0f ) );
+			// No oval support yet, just apply width to height.
+			if( lightShader->getName() == "disk_light" )
+			{
+				cyclesLight->set_sizev( parameterValue<float>( value.get(), name, 2.0f ) );
+			}
+		}
+		else if( name == "height" )
+		{
+			cyclesLight->set_sizev( parameterValue<float>( value.get(), name, 2.0f ) );
 		}
 		// Convert generic parameters.
 		else

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -527,7 +527,6 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 	if( shaderName != "portal" )
 	{
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "cast_shadow" ) )), plugsParent, Gaffer::Plug::In ) );
-		//validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_mis" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupTypedPlug<BoolPlug>( "use_mis", plugsParent, Gaffer::Plug::In, true ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_camera" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_diffuse" ) )), plugsParent, Gaffer::Plug::In ) );
@@ -597,6 +596,11 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 				IECore::radiansToDegrees( *static_cast<const float *>( spreadSocket->default_value ) )
 			)
 		);
+	}
+
+	if( shaderName != "portal" && shaderName != "background_light" )
+	{
+		validPlugs.insert( setupTypedPlug<BoolPlug>( "normalize", plugsParent, Gaffer::Plug::In, true ) );
 	}
 
 	// Remove any old plugs which it turned out we didn't need.

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -524,11 +524,7 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 
 	std::set<const Plug *> validPlugs;
 
-	if( shaderName == "portal" )
-	{
-		validPlugs.insert( setupTypedPlug<FloatPlug>( "size", plugsParent, Gaffer::Plug::In, 2.0f ) );
-	}
-	else
+	if( shaderName != "portal" )
 	{
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "cast_shadow" ) )), plugsParent, Gaffer::Plug::In ) );
 		//validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_mis" ) )), plugsParent, Gaffer::Plug::In ) );
@@ -546,7 +542,12 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 		validPlugs.insert( setupTypedPlug<Color3fPlug>( "color", plugsParent, Gaffer::Plug::In, Color3f( 1.0f ) ) );
 	}
 
-	if( shaderName == "spot_light" )
+	if( shaderName == "portal" || shaderName == "quad_light" )
+	{
+		validPlugs.insert( setupTypedPlug<FloatPlug>( "width", plugsParent, Gaffer::Plug::In, 2.0f ) );
+		validPlugs.insert( setupTypedPlug<FloatPlug>( "height", plugsParent, Gaffer::Plug::In, 2.0f ) );
+	}
+	else if( shaderName == "spot_light" )
 	{
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "size" ) )), plugsParent, Gaffer::Plug::In ) );
 		const ccl::SocketType *angleSocket = nodeType->find_input( ccl::ustring( "spot_angle" ) );
@@ -566,7 +567,7 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 	}
 	else if( shaderName == "disk_light" )
 	{
-		validPlugs.insert( setupTypedPlug<FloatPlug>( "size", plugsParent, Gaffer::Plug::In, 2.0f ) );
+		validPlugs.insert( setupTypedPlug<FloatPlug>( "width", plugsParent, Gaffer::Plug::In, 2.0f ) );
 	}
 	else if( shaderName == "background_light" )
 	{

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -533,10 +533,12 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "cast_shadow" ) )), plugsParent, Gaffer::Plug::In ) );
 		//validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_mis" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupTypedPlug<BoolPlug>( "use_mis", plugsParent, Gaffer::Plug::In, true ) );
+		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_camera" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_diffuse" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_glossy" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_transmission" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_scatter" ) )), plugsParent, Gaffer::Plug::In ) );
+		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "use_caustics" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "max_bounces" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "lightgroup" ) )), plugsParent, Gaffer::Plug::In ) );
 		validPlugs.insert( setupTypedPlug<FloatPlug>( "intensity", plugsParent, Gaffer::Plug::In, 1.0f ) );

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -574,7 +574,15 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 	}
 	else if( shaderName == "distant_light" )
 	{
-		validPlugs.insert( setupTypedPlug<FloatPlug>( "angle", plugsParent, Gaffer::Plug::In, 0.0f ) );
+		const ccl::SocketType *angleSocket = nodeType->find_input( ccl::ustring( "angle" ) );
+		validPlugs.insert(
+			setupNumericPlug<FloatPlug>(
+				nodeType, *angleSocket, plugsParent, Gaffer::Plug::In,
+				// Cycles API uses radians, but that isn't user-friendly so we convert to degrees.
+				// We convert back to radians in the renderer backend.
+				IECore::radiansToDegrees( *static_cast<const float *>( angleSocket->default_value ) )
+			)
+		);
 	}
 
 	if( shaderName == "quad_light" || shaderName == "disk_light" )

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -365,11 +365,13 @@ py::dict getLights()
 
 			in["size"] = _in["size"];
 			in["cast_shadow"] = _in["cast_shadow"];
+			in["use_camera"] = _in["use_camera"];
 			in["use_mis"] = _in["use_mis"];
 			in["use_diffuse"] = _in["use_diffuse"];
 			in["use_glossy"] = _in["use_glossy"];
 			in["use_transmission"] = _in["use_transmission"];
 			in["use_scatter"] = _in["use_scatter"];
+			in["use_caustics"] = _in["use_caustics"];
 			in["max_bounces"] = _in["max_bounces"];
 			in["strength"] = _in["strength"];
 			in["lightgroup"] = _in["lightgroup"];

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -414,7 +414,8 @@ py::dict getLights()
 		py::dict d;
 		py::dict in;
 		in["is_portal"] = _in["is_portal"];
-		in["size"] = _in["size"];
+		in["sizeu"] = _in["sizeu"];
+		in["sizev"] = _in["sizev"];
 		d["enum"] = result["quad_light"]["enum"];
 		d["in"] = in;
 		result["portal"] = d;

--- a/startup/GafferScene/cyclesLights.py
+++ b/startup/GafferScene/cyclesLights.py
@@ -61,14 +61,18 @@ Gaffer.Metadata.registerValue( "cycles:light:quad_light", "intensityParameter", 
 Gaffer.Metadata.registerValue( "cycles:light:quad_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "cycles:light:quad_light", "colorParameter", "color" )
 Gaffer.Metadata.registerValue( "cycles:light:quad_light", "textureNameParameter", "image" )
+Gaffer.Metadata.registerValue( "cycles:light:quad_light", "widthParameter", "width" )
+Gaffer.Metadata.registerValue( "cycles:light:quad_light", "heightParameter", "height" )
 
 Gaffer.Metadata.registerValue( "cycles:light:portal", "type", "quad" )
+Gaffer.Metadata.registerValue( "cycles:light:portal", "widthParameter", "width" )
+Gaffer.Metadata.registerValue( "cycles:light:portal", "heightParameter", "height" )
 
 Gaffer.Metadata.registerValue( "cycles:light:disk_light", "type", "disk" )
 Gaffer.Metadata.registerValue( "cycles:light:disk_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "cycles:light:disk_light", "exposureParameter", "exposure" )
 Gaffer.Metadata.registerValue( "cycles:light:disk_light", "colorParameter", "color" )
-Gaffer.Metadata.registerValue( "cycles:light:disk_light", "widthParameter", "size" )
+Gaffer.Metadata.registerValue( "cycles:light:disk_light", "widthParameter", "width" )
 Gaffer.Metadata.registerValue( "cycles:light:disk_light", "textureNameParameter", "image" )
 
 Gaffer.Metadata.registerValue( "cycles:light:background_light", "type", "environment" )


### PR DESCRIPTION
This is a precursor for an upcoming PR update to support USD Lux lights and USDPreviewSurface and friends.

Generally describe what this PR will do, and why it is needed

- Added `use_camera` and `use_caustics` light parameters
- Use degrees for the `distant_light` angle parameter
- Replace the uniform `size` with `sizeu` and `sizev` for disk, quad and portals
- Fixed a bug where quad lights become round by setting this explicitly to false
- Added virtual `normalize` parameter which multiplies based on the light's surface area (it will be inaccurate if scale is used on the light)

### Related issues ###

- NA

### Dependencies ###

- NA

### Breaking changes ###

- Breaks existing quad/disk/portals which use the size parameter.
- Breaks distant light angle that implied radians and not degrees.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
