### PR TITLE
DocumentationAlgo : Restore raw HTML support in `markdownToHTML()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+1.0.6.x (relative to 1.0.6.1)
+=======
+
+Fixes
+-----
+
+- UI : Fixed tooltips containing raw HTML.
+- DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
+
 1.0.6.1 (relative to 1.0.6.0)
 =======
 

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -202,7 +202,7 @@ def markdownToHTML( markdown ) :
 		return markdown
 
 	markdown = markdown.encode( "UTF-8" )
-	return cmark.cmark_markdown_to_html( markdown, len( markdown ), 0 ).decode( "UTF-8" )
+	return cmark.cmark_markdown_to_html( markdown, len( markdown ), cmark.CMARK_OPT_UNSAFE ).decode( "UTF-8" )
 
 def __nodeDocumentation( node ) :
 
@@ -319,5 +319,7 @@ def __cmark() :
 
 	__cmarkDLL.cmark_markdown_to_html.restype = ctypes.c_char_p
 	__cmarkDLL.cmark_markdown_to_html.argtypes = [ctypes.c_char_p, ctypes.c_long, ctypes.c_long]
+
+	__cmarkDLL.CMARK_OPT_UNSAFE = 1 << 17
 
 	return __cmarkDLL


### PR DESCRIPTION
CMark 0.29.0 turned this off by default. This fixes the tooltips for ResamplePrimitiveVariables in particular.