### PR TITLE
Context query affects typo

### DIFF
--- a/python/GafferTest/ContextQueryTest.py
+++ b/python/GafferTest/ContextQueryTest.py
@@ -196,6 +196,30 @@ class ContextQueryTest( GafferTest.TestCase ):
 			self.assertTrue( q["out"][6]["exists"].getValue() )
 			self.assertEqual( q["out"][6]["value"].getValue(), imath.Color3f( 0.7, 0.8, 0.9 ) )
 
+	def testNameChange( self ) :
+
+		q = Gaffer.ContextQuery()
+
+		v1 = q.addQuery( Gaffer.IntPlug( "i", Gaffer.Plug.Direction.Out, 1 ), "foo" )
+
+		testC = Gaffer.Context()
+		testC["foo"] = 2
+		testC["baa"] = 5
+
+		with testC:
+			self.assertTrue( q["out"][0]["exists"].getValue() )
+			self.assertEqual( q["out"][0]["value"].getValue(), 2)
+
+			v1["name"].setValue("baa")
+
+			self.assertTrue( q["out"][0]["exists"].getValue() )
+			self.assertEqual( q["out"][0]["value"].getValue(), 5)
+
+			v1["name"].setValue("boo")
+
+			self.assertFalse( q["out"][0]["exists"].getValue() )
+			self.assertEqual( q["out"][0]["value"].getValue(), 1)
+
 	def testChangeDefault( self ) :
 
 		q = Gaffer.ContextQuery()

--- a/src/Gaffer/ContextQuery.cpp
+++ b/src/Gaffer/ContextQuery.cpp
@@ -212,7 +212,7 @@ void ContextQuery::affects( const Gaffer::Plug *input, AffectedPlugsContainer &o
 		{
 			addChildPlugsToAffectedOutputs( valuePlug, outputs );
 
-			outputs.push_back( outputPlug->getChild<ValuePlug>( g_existsPlugIndex ) );
+			outputs.push_back( outputPlug->getChild<BoolPlug>( g_existsPlugIndex ) );
 		}
 		else if( childQueryPlug->valuePlug() == input || childQueryPlug->valuePlug()->isAncestorOf( input ) )
 		{


### PR DESCRIPTION
Fixes a posssible typo in `ContextQuery::affects()`

BoolPlug derives from ValuePlug so the previous code compiles and works fine, but it seems like this is probably a typo that just happens to work. Please ignore this PR if the previous code is as intended.

Also added an additional test case for context query name change.

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
