### PR TITLE
Ignore Compile Commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ doc/python
 include/Gaffer/Version.h
 contrib/openColorIOPandemonium/luts/*.spi1d
 contrib/openColorIOPandemonium/luts/*.cube
+
+# clang compile commands
+compile_commands.json


### PR DESCRIPTION
I'm coding in Gaffer using clangd as my language server and I have a separate script that creates compile commands out of scons. It would be nice to simply ignore compile commands from git.


### Related issues ###

- n/a

### Dependencies ###

- n/a

### Breaking changes ###

-n/a

### Checklist ###

- [x ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Gaffer project's prevailing coding style and conventions.
