### PR TITLE
SConstruct : Compile stylesheet resources into Qt `.rss` file

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Fixes
 -----
 
 - GraphEditor : Fixed crash when focussing an empty ContextVariables, NameSwitch or Loop node (#4944).
-- UI : Fixed tooltips containing raw HTML.
+- UI :
+  - Fixed tooltips containing raw HTML.
+  - Fixed stalls caused by Qt repeatedly accessing the same icon files.
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
 - Reference : Fixed unnecessary serialisation of connections from internal plugs to external plugs. These are serialised in the `.grf` file already, so do not need to be duplicated on the Reference node itself. This bug prevented changes to the internal connections from taking effect when reloading a modified `.grf` file, and could cause load failures when the connections were from an internal Expression (#4935).
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -38,7 +38,15 @@
 import os
 import string
 
+from Qt import QtCore
 from Qt import QtGui
+
+# Load resource file containing all the files referenced by the stylesheet. In
+# an ideal world we'd be able to trust Qt to load regular `.png` files directly
+# from the filesystem. But we can't : QStyleSheetStyle repeatedly accesses the
+# same files over and over again, and this can lead to UI stalls when Gaffer is
+# installed on a server under heavy load.
+QtCore.QResource.registerResource( os.path.expandvars( "$GAFFER_ROOT/graphics/resources.rcc" ) )
 
 _styleColors = {
 
@@ -138,9 +146,7 @@ _themeVariables = {
 	"monospaceFontFamily" : '"Menlo", "SFMono-Regular", "Consolas", "Liberation Mono", monospace'
 }
 
-substitutions = {
-	"GAFFER_ROOT" : os.environ["GAFFER_ROOT"].replace("\\", "/"),
-}
+substitutions = {}
 
 for k, v in _styleColors.items() :
 	if len( v ) == 3 :
@@ -181,6 +187,11 @@ _styleSheet = string.Template(
 	#     styling of widgets based on their proximity to others, Gaffer sets the
 	#     appropriate `gafferAdjoined(Top|Bottom|Left|Right)` properties rather
 	#     than `gafferRounded`/`gafferFlat*`.
+	#
+	#   - All icons should be referenced as `url(:/<fileName>.png)`, where
+	#    `<fileName>` is one of the icons exported from `resources/graphics.svg`.
+	#    The build process will collect these icons and pack them into the `.rcc`
+	#    resource file automatically.
 	#
 	# We can't use `.<class>` selectors in the stylesheet in many cases as
 	# these reference the Qt Class hierarchy. To help here, GafferUI.Widgets
@@ -234,7 +245,7 @@ _styleSheet = string.Template(
 	}
 
 	QLabel#gafferPlugLabel[gafferValueChanged="true"] {
-		background-image: url($GAFFER_ROOT/graphics/valueChanged.png);
+		background-image: url(:/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;
 		padding-left: 16px;
@@ -313,7 +324,7 @@ _styleSheet = string.Template(
 	}
 
 	QMenu::right-arrow {
-		image: url($GAFFER_ROOT/graphics/subMenuArrow.png);
+		image: url(:/subMenuArrow.png);
 		padding: 0px 7px 0px 0px;
 	}
 
@@ -342,11 +353,11 @@ _styleSheet = string.Template(
 	}
 
 	QMenu::indicator:non-exclusive:checked {
-		image: url($GAFFER_ROOT/graphics/menuChecked.png);
+		image: url(:/menuChecked.png);
 	}
 
 	QMenu::indicator:exclusive:checked:selected {
-		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
+		image: url(:/arrowRight10.png);
 	}
 
 	QLineEdit, QPlainTextEdit {
@@ -390,7 +401,7 @@ _styleSheet = string.Template(
 	}
 
 	#gafferSearchField {
-		background-image: url($GAFFER_ROOT/graphics/search.png);
+		background-image: url(:/search.png);
 		background-repeat:no-repeat;
 		background-position: left center;
 		padding-left: 20px;
@@ -417,7 +428,7 @@ _styleSheet = string.Template(
 
 	QDateTimeEdit::drop-down {
 		width: 15px;
-		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
+		image: url(:/arrowDown10.png);
 	}
 
 	#qt_calendar_navigationbar {
@@ -502,14 +513,14 @@ _styleSheet = string.Template(
 	}
 
 	QPushButton::menu-indicator {
-		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
+		image: url(:/arrowDown10.png);
 		subcontrol-position: right center;
 		subcontrol-origin: padding;
 		left: -4px;
 	}
 
 	QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"] {
-		background-image: url($GAFFER_ROOT/graphics/menuIndicator.png);
+		background-image: url(:/menuIndicator.png);
 		background-repeat: none;
 		background-position: center right;
 		padding-right: 20px
@@ -517,7 +528,7 @@ _styleSheet = string.Template(
 
 	QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]:disabled {
 		color: $foregroundFaded;
-		background-image: url($GAFFER_ROOT/graphics/menuIndicatorDisabled.png);
+		background-image: url(:/menuIndicatorDisabled.png);
 	}
 
 	QComboBox {
@@ -527,7 +538,7 @@ _styleSheet = string.Template(
 
 	QComboBox::drop-down {
 		width: 15px;
-		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
+		image: url(:/arrowDown10.png);
 	}
 
 	QComboBox QAbstractItemView {
@@ -734,19 +745,19 @@ _styleSheet = string.Template(
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"] QToolButton::left-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowLeft10.png);
+		image: url(:/arrowLeft10.png);
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"] QToolButton::left-arrow:disabled {
-		image: url($GAFFER_ROOT/graphics/arrowLeftDisabled10.png);
+		image: url(:/arrowLeftDisabled10.png);
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"] QToolButton::right-arrow { /* the arrow mark in the tool buttons */
-		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
+		image: url(:/arrowRight10.png);
 	}
 
 	QTabBar[gafferClass="GafferUI.SpreadsheetUI._SectionChooser"] QToolButton::right-arrow:disabled { /* the arrow mark in the tool buttons */
-		image: url($GAFFER_ROOT/graphics/arrowRightDisabled10.png);
+		image: url(:/arrowRightDisabled10.png);
 	}
 
 	/* Splitters */
@@ -804,33 +815,33 @@ _styleSheet = string.Template(
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowDown.png);
+		image: url(:/collapsibleArrowDown.png);
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowRight.png);
+		image: url(:/collapsibleArrowRight.png);
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover,
 	QCheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowDownHover.png);
+		image: url(:/collapsibleArrowDownHover.png);
 	}
 
 	QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
 	QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightHover.png);
+		image: url(:/collapsibleArrowRightHover.png);
 	}
 
 	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:unchecked,
 	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:unchecked:hover,
 	*[gafferValueChanged="true"] > CheckBox#gafferCollapsibleToggle::indicator:unchecked:focus {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowDownValueChanged.png);
+		image: url(:/collapsibleArrowDownValueChanged.png);
 	}
 
 	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked,
 	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked:hover,
 	*[gafferValueChanged="true"] > QCheckBox#gafferCollapsibleToggle::indicator:checked:focus {
-		image: url($GAFFER_ROOT/graphics/collapsibleArrowRightValueChanged.png);
+		image: url(:/collapsibleArrowRightValueChanged.png);
 	}
 
 	QHeaderView {
@@ -887,11 +898,11 @@ _styleSheet = string.Template(
 	}
 
 	QHeaderView::down-arrow {
-		image: url($GAFFER_ROOT/graphics/headerSortDown.png);
+		image: url(:/headerSortDown.png);
 	}
 
 	QHeaderView::up-arrow {
-		image: url($GAFFER_ROOT/graphics/headerSortUp.png);
+		image: url(:/headerSortUp.png);
 	}
 
 	QScrollBar {
@@ -968,16 +979,16 @@ _styleSheet = string.Template(
 	}
 
 	QScrollBar::down-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowDown10.png);
+		image: url(:/arrowDown10.png);
 	}
 	QScrollBar::up-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowUp10.png);
+		image: url(:/arrowUp10.png);
 	}
 	QScrollBar::left-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowLeft10.png);
+		image: url(:/arrowLeft10.png);
 	}
 	QScrollBar::right-arrow {
-		image: url($GAFFER_ROOT/graphics/arrowRight10.png);
+		image: url(:/arrowRight10.png);
 	}
 
 	QScrollArea {
@@ -1035,12 +1046,12 @@ _styleSheet = string.Template(
 
 	QTreeView::branch:closed:has-children {
 		border-image : none;
-		image : url($GAFFER_ROOT/graphics/collapsibleArrowRight.png);
+		image : url(:/collapsibleArrowRight.png);
 	}
 
 	QTreeView::branch:open:has-children {
 		border-image : none;
-		image : url($GAFFER_ROOT/graphics/collapsibleArrowDown.png);
+		image : url(:/collapsibleArrowDown.png);
 	}
 
 	/* CheckBoxes */
@@ -1057,51 +1068,51 @@ _styleSheet = string.Template(
 	/* --------- */
 
 	QCheckBox::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/checkBoxUnchecked.png);
+		image: url(:/checkBoxUnchecked.png);
 	}
 
 	QCheckBox::indicator:unchecked:hover,
 	QCheckBox::indicator:unchecked:focus,
 	QCheckBox[gafferHighlighted="true"]::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/checkBoxUncheckedHover.png);
+		image: url(:/checkBoxUncheckedHover.png);
 	}
 
 	QCheckBox::indicator:unchecked:disabled {
-		image: url($GAFFER_ROOT/graphics/checkBoxUncheckedDisabled.png);
+		image: url(:/checkBoxUncheckedDisabled.png);
 	}
 
 	/* Checked */
 	/* ------- */
 
 	QCheckBox::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/checkBoxChecked.png);
+		image: url(:/checkBoxChecked.png);
 	}
 
 	QCheckBox::indicator:checked:hover,
 	QCheckBox::indicator:checked:focus,
 	QCheckBox[gafferHighlighted="true"]::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/checkBoxCheckedHover.png);
+		image: url(:/checkBoxCheckedHover.png);
 	}
 
 	QCheckBox::indicator:checked:disabled {
-		image: url($GAFFER_ROOT/graphics/checkBoxCheckedDisabled.png);
+		image: url(:/checkBoxCheckedDisabled.png);
 	}
 
 	/* Indeterminate */
 	/* ------------- */
 
 	QCheckBox::indicator:indeterminate {
-		image: url($GAFFER_ROOT/graphics/checkBoxIndeterminate.png);
+		image: url(:/checkBoxIndeterminate.png);
 	}
 
 	QCheckBox::indicator:indeterminate:hover,
 	QCheckBox::indicator:indeterminate:focus,
 	QCheckBox[gafferHighlighted="true"]::indicator:indeterminate {
-		image: url($GAFFER_ROOT/graphics/checkBoxIndeterminateHover.png);
+		image: url(:/checkBoxIndeterminateHover.png);
 	}
 
 	QCheckBox::indicator:indeterminate:disabled {
-		image: url($GAFFER_ROOT/graphics/checkBoxIndeterminateDisabled.png);
+		image: url(:/checkBoxIndeterminateDisabled.png);
 	}
 
 	/* Animated/Errored */
@@ -1122,51 +1133,51 @@ _styleSheet = string.Template(
 	/* --------- */
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/toggleOff.png);
+		image: url(:/toggleOff.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:unchecked:hover,
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:unchecked:focus,
 	QCheckBox[gafferDisplayMode="Switch"][gafferHighlighted="true"]::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/toggleOffHover.png);
+		image: url(:/toggleOffHover.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:unchecked:disabled {
-		image: url($GAFFER_ROOT/graphics/toggleOffDisabled.png);
+		image: url(:/toggleOffDisabled.png);
 	}
 
 	/* Checked */
 	/* ------- */
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/toggleOn.png);
+		image: url(:/toggleOn.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:checked:hover,
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:checked:focus,
 	QCheckBox[gafferDisplayMode="Switch"][gafferHighlighted="true"]::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/toggleOnHover.png);
+		image: url(:/toggleOnHover.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:checked:disabled {
-		image: url($GAFFER_ROOT/graphics/toggleOnDisabled.png);
+		image: url(:/toggleOnDisabled.png);
 	}
 
 	/* Indeterminate */
 	/* ------------- */
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:indeterminate {
-		image: url($GAFFER_ROOT/graphics/toggleIndeterminate.png);
+		image: url(:/toggleIndeterminate.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:indeterminate:hover,
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:indeterminate:focus,
 	QCheckBox[gafferDisplayMode="Switch"][gafferHighlighted="true"]::indicator:indeterminate {
-		image: url($GAFFER_ROOT/graphics/toggleIndeterminateHover.png);
+		image: url(:/toggleIndeterminateHover.png);
 	}
 
 	QCheckBox[gafferDisplayMode="Switch"]::indicator:indeterminate:disabled {
-		image: url($GAFFER_ROOT/graphics/toggleIndeterminateDisabled.png);
+		image: url(:/toggleIndeterminateDisabled.png);
 	}
 
 	/* BoolWidget drawn as tool */
@@ -1318,19 +1329,19 @@ _styleSheet = string.Template(
 	}
 
 	QTableView::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/checkBoxUnchecked.png);
+		image: url(:/checkBoxUnchecked.png);
 	}
 
 	QTableView::indicator:unchecked:hover {
-		image: url($GAFFER_ROOT/graphics/checkBoxUncheckedHover.png);
+		image: url(:/checkBoxUncheckedHover.png);
 	}
 
 	QTableView::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/checkBoxChecked.png);
+		image: url(:/checkBoxChecked.png);
 	}
 
 	QTableView::indicator:checked:hover {
-		image: url($GAFFER_ROOT/graphics/checkBoxCheckedHover.png);
+		image: url(:/checkBoxCheckedHover.png);
 	}
 
 	QTableView::indicator:selected {
@@ -1338,19 +1349,19 @@ _styleSheet = string.Template(
 	}
 
 	QTableView[gafferToggleIndicator="true"]::indicator:unchecked {
-		image: url($GAFFER_ROOT/graphics/toggleOff.png);
+		image: url(:/toggleOff.png);
 	}
 
 	QTableView[gafferToggleIndicator="true"]::indicator:unchecked:hover {
-		image: url($GAFFER_ROOT/graphics/toggleOffHover.png);
+		image: url(:/toggleOffHover.png);
 	}
 
 	QTableView[gafferToggleIndicator="true"]::indicator:checked {
-		image: url($GAFFER_ROOT/graphics/toggleOn.png);
+		image: url(:/toggleOn.png);
 	}
 
 	QTableView[gafferToggleIndicator="true"]::indicator:checked:hover {
-		image: url($GAFFER_ROOT/graphics/toggleOnHover.png);
+		image: url(:/toggleOnHover.png);
 	}
 
 	/* highlighted state for VectorDataWidget and tree views */
@@ -1627,4 +1638,3 @@ _styleSheet = string.Template(
 	"""
 
 ).substitute( substitutions )
-


### PR DESCRIPTION
We were originally referencing `$GAFFER_ROOT/graphics/*.png` files directly in the stylesheet, which is nice and simple. When QStyleSheetStyle _draws_ using these icons, it loads via a cache, so the image only gets loaded once, so performance should be fine, right? Wrong. QStyleSheetStyle has a second code path that it uses when it wants to calculate the size of a control. In _that_ case, it goes via an uncached route and hits the filesystem for every size query. Which is OK until you install Gaffer on a server which is buckling under load, and every file access has the potential to cause a stall.

By compiling the image files into a single `.rss` file we get to load it once and then QStyleSheetStyle can merrily access the resources within as many times as it wants without hitting the filesystem. I don't like this additional build complexity, but I can't find another solution short of writing our own Style subclass. I did try giving the controls explicit sizes in the stylesheet, but while those are respected, it doesn't prevent Qt from querying the size of the icon from the `.png` anyway.

Sample output from `ps -p <GAFFERPID> -e trace=file -k` below. This shows how an innocent little `QCheckBox::sizeHint()` call leads through a bunch of Qt code to an `open( "checkBoxChecked.png" )` call.

```
open("/home/john/dev/build/gaffer-1.0-Python3/graphics/checkBoxChecked.png", O_RDONLY|O_CLOEXEC) = 60
 > /usr/lib64/libpthread-2.17.so(__open+0x2d) [0xeefd]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Core.so.5.15.4() [0x23e08b]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Core.so.5.15.4(QFSFileEngine::open(QFlags<QIODevice::OpenModeFlag>)+0x75) [0x20d205]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Core.so.5.15.4(QFile::open(QFlags<QIODevice::OpenModeFlag>)+0x58) [0x1da958]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Gui.so.5.15.4() [0x19a596]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Gui.so.5.15.4(QImageReader::size() const+0x10) [0x19ac10]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Gui.so.5.15.4(QCss::ValueExtractor::extractImage(QIcon*, QFlags<Qt::AlignmentFlag>*, QSize*)+0x116) [0x2e2ad6]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4() [0x2054db]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4() [0x20755f]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4() [0x20801c]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4() [0x20b06d]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4() [0x21c522]
 > /home/john/dev/build/gaffer-1.0-Python3/lib/libQt5Widgets.so.5.15.4(QCheckBox::sizeHint() const+0x173) [0x264c43]
```

If you want to test this to check it's avoiding the `open()` calls, then `ps -e trace=file` is a good way of doing it. Just don't use the `-k` flag as well, as it makes things real slow (it prints a stack trace for each open call, as used to capture the output above).