### PR TITLE
flush cache on empty render

### DIFF
--- a/src/GafferArnold/InteractiveArnoldRender.cpp
+++ b/src/GafferArnold/InteractiveArnoldRender.cpp
@@ -91,6 +91,9 @@ void InteractiveArnoldRender::flushCaches( int flags )
 
 		if( !instance->renderer() )
 		{
+			// No renderer found so flush global cache so that new renders spinning up later will see a refereshed
+			// texture cache. This is needed because apparently Arnold only has one texture cache between universes.
+			AiUniverseCacheFlush( nullptr, flags );
 			continue;
 		}
 


### PR DESCRIPTION
When a user does the following:

1. Starts an interactive Arnold render
2. Stops the interactive render
3. Changes textures on disk
4. Flushes Arnold cache 
5. Starts a new interactive Arnold render

The new render does not pick up the new textures. This is because on a cache flush press there are no new renders active so a `AiUniverseCacheFlush` is never called. It also appears that each universe share a texture cache between them. So when a new render is started it picks up the old texture cache even though it is using a new universe.

One way to fix this would be to flush the cache on a new render when the new universe is created. However, I thought it would be better to instead make the cache menu flush the global universe's cache when there are no renders.

Code such as:
```
auto universe = AiUniverse();
AiUniverseCacheFlush(universe, flags);
AiUniverseCacheDestroy(universe);
```
would have also worked since the texture cache (appears to be) is shared between universes. I have posted a question on Arnold slack to clarify if this is intended behavior (so far no reply).

- flushCache: Arnold cache flush will flush the global universes cache when there are no renders active.

### Related issues ###

- Cache not being flushed on new renders.


### Checklist ###

- [ x ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ x ] My code follows the Gaffer project's prevailing coding style and conventions.
