### PR TITLE
PlugBinding : Don't serialise internal connections on Reference nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - UI : Fixed tooltips containing raw HTML.
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
+- Reference : Fixed unnecessary serialisation of connections from internal plugs to external plugs. These are serialised in the `.grf` file already, so do not need to be duplicated on the Reference node itself. This bug prevented changes to the internal connections from taking effect when reloading a modified `.grf` file, and could cause load failures when the connections were from an internal Expression (#4935).
 
 1.0.6.1 (relative to 1.0.6.0)
 =======

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -41,6 +41,11 @@ import unittest
 import imath
 import re
 import six
+import sys
+if os.name == 'posix' and sys.version_info[0] < 3 :
+	import subprocess32 as subprocess
+else :
+	import subprocess
 
 import IECore
 
@@ -1536,6 +1541,50 @@ class ExpressionTest( GafferTest.TestCase ) :
 				"""
 			)
 		)
+
+	def testReferenceOutputs( self ) :
+
+		# Load a reference that uses an internal expression to set the value
+		# of some external plugs.
+
+		script = Gaffer.ScriptNode()
+
+		script["reference"] = Gaffer.Reference()
+		script["reference"].load( os.path.join( os.path.dirname( __file__ ), "references", "multipleOutputExpression.grf" ) )
+
+		# Check all is well.
+
+		self.checkReferenceOutputs( script )
+
+		# Save script, and check all is well _in another process_. This exposes
+		# a bug where PythonExpressionEngine's parsing was sensitive to the
+		# iteration order of Python sets, which is non-deterministic since
+		# Python 3 (see `PYTHONHASHSEED`).
+
+		script["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.gfr" ) )
+		script.save()
+
+		env = os.environ.copy()
+		env["GAFFERTEST_SCRIPT_FILENAME"] = script["fileName"].getValue()
+		try :
+			subprocess.check_output(
+				[ "gaffer", "test", "GafferTest.ExpressionTest.checkReferenceOutputs" ],
+				env = env, stderr = subprocess.STDOUT
+			)
+		except subprocess.CalledProcessError as e :
+			self.fail( e.output )
+
+	def checkReferenceOutputs( self, script = None ) :
+
+		if script is None :
+			script = Gaffer.ScriptNode()
+			script["fileName"].setValue( os.environ["GAFFERTEST_SCRIPT_FILENAME"] )
+			script.load()
+
+		self.assertEqual( script["reference"]["StringPlug"].getValue(), "abcd" )
+		self.assertEqual( script["reference"]["BoolPlug"].getValue(), True )
+		self.assertEqual( script["reference"]["IntPlug"].getValue(), 99 )
+		self.assertEqual( script["reference"]["FloatPlug"].getValue(), 2.5 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/references/multipleOutputExpression.grf
+++ b/python/GafferTest/references/multipleOutputExpression.grf
@@ -1,0 +1,39 @@
+import Gaffer
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 2, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["StringPlug"] = Gaffer.StringPlug( "StringPlug", direction = Gaffer.Plug.Direction.Out, defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["StringPlug"] )
+__children["BoolPlug"] = Gaffer.BoolPlug( "BoolPlug", direction = Gaffer.Plug.Direction.Out, defaultValue = False, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["BoolPlug"] )
+__children["IntPlug"] = Gaffer.IntPlug( "IntPlug", direction = Gaffer.Plug.Direction.Out, defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["IntPlug"] )
+__children["FloatPlug"] = Gaffer.FloatPlug( "FloatPlug", direction = Gaffer.Plug.Direction.Out, defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["FloatPlug"] )
+__children["Expression"] = Gaffer.Expression( "Expression" )
+parent.addChild( __children["Expression"] )
+__children["Expression"]["__out"].addChild( Gaffer.IntPlug( "p0", direction = Gaffer.Plug.Direction.Out, defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"]["__out"].addChild( Gaffer.FloatPlug( "p1", direction = Gaffer.Plug.Direction.Out, defaultValue = 0.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"]["__out"].addChild( Gaffer.BoolPlug( "p2", direction = Gaffer.Plug.Direction.Out, defaultValue = False, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"]["__out"].addChild( Gaffer.StringPlug( "p3", direction = Gaffer.Plug.Direction.Out, defaultValue = '', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Expression"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["StringPlug"].setInput( __children["Expression"]["__out"]["p3"] )
+Gaffer.Metadata.registerValue( __children["StringPlug"], 'nodule:type', '' )
+__children["BoolPlug"].setInput( __children["Expression"]["__out"]["p2"] )
+Gaffer.Metadata.registerValue( __children["BoolPlug"], 'nodule:type', '' )
+__children["IntPlug"].setInput( __children["Expression"]["__out"]["p0"] )
+Gaffer.Metadata.registerValue( __children["IntPlug"], 'nodule:type', '' )
+__children["FloatPlug"].setInput( __children["Expression"]["__out"]["p1"] )
+Gaffer.Metadata.registerValue( __children["FloatPlug"], 'nodule:type', '' )
+__children["Expression"]["__uiPosition"].setValue( imath.V2f( 7.05570412, -1.56343818 ) )
+__children["Expression"]["__engine"].setValue( 'python' )
+__children["Expression"]["__expression"].setValue( 'parent["__out"]["p3"] = "abcd"\nparent["__out"]["p1"] = 2.5\nparent["__out"]["p0"] = 99\nparent["__out"]["p2"] = True\n\n' )
+
+
+del __children

--- a/src/GafferBindings/PlugBinding.cpp
+++ b/src/GafferBindings/PlugBinding.cpp
@@ -43,6 +43,7 @@
 #include "Gaffer/Dot.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/Plug.h"
+#include "Gaffer/Reference.h"
 #include "Gaffer/Switch.h"
 
 #include "GafferBindings/PlugBinding.h"
@@ -143,6 +144,16 @@ bool shouldSerialiseInput( const Plug *plug, const Serialisation &serialisation 
 	{
 		if( plug == sw->outPlug() )
 		{
+			return false;
+		}
+	}
+	else if( auto reference = runTimeCast<const Reference>( plug->node() ) )
+	{
+		if( reference->isAncestorOf( plug->getInput()->node() ) )
+		{
+			// Don't serialise connection from a plug on an internal node
+			// onto an external plug of the Reference. These will have been
+			// serialised in the `.grf` file itself.
 			return false;
 		}
 	}


### PR DESCRIPTION
When a `Reference.foo` plug was receiving its input from a node internal to the `.grf` file, we were "baking" that input by also serialising it into the `.gfr` file containing the Reference node.

This caused a couple of problems :

- Baked inputs prevented changes to the internal connections being picked up when reloading or upgrading a reference.
- When the inputs came from an internal expression, the order of expression outputs could change during loading, and the baked `setInput()` calls could fail as they were invalid.

Fixes https://github.com/GafferHQ/gaffer/issues/4935.