### PR TITLE
GraphGadget : Fix crash focussing NameSwitch, ContextVariables or Loop

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- GraphEditor : Fixed crash when focussing an empty ContextVariables, NameSwitch or Loop node (#4944).
 - UI : Fixed tooltips containing raw HTML.
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -1821,5 +1821,40 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		script["switch"]["index"].setValue( 1 )
 		self.assertHighlighting( graphGadget, { "switch" : True, "add1" : False, "add2" : True } )
 
+	def testFocusEmptyContextVariables( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["contextVariables"] = Gaffer.ContextVariables()
+		plugs, nodes = GafferUI.GraphGadget._activePlugsAndNodes(
+			next( Gaffer.Plug.OutputRange( s["contextVariables"] ) ), Gaffer.Context()
+		)
+
+		self.assertEqual( nodes, [ s["contextVariables" ] ] )
+
+	def testFocusEmptyNameSwitch( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["nameSwitch"] = Gaffer.NameSwitch()
+		plugs, nodes = GafferUI.GraphGadget._activePlugsAndNodes(
+			next( Gaffer.Plug.OutputRange( s["nameSwitch"] ) ), Gaffer.Context()
+		)
+
+		self.assertEqual( nodes, [ s["nameSwitch" ] ] )
+
+	def testFocusEmptyLoop( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["loop"] = Gaffer.Loop()
+		# Fake output plug used to trigger the search for active nodes.
+		# Unlikely to exist in practice (unless someone derived from Loop?),
+		# but useful to provide test coverage against bugs dealing with
+		# Loop nodes before `setUp()` has been called.
+		s["loop"]["__testOutput"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		plugs, nodes = GafferUI.GraphGadget._activePlugsAndNodes(
+			s["loop"]["__testOutput"], Gaffer.Context()
+		)
+
+		self.assertEqual( nodes, [ s["loop" ] ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -341,7 +341,8 @@ void activeWalkOutput(
 				}
 			}
 
-			if( const Gaffer::Switch *switchNode = runTimeCast<const Gaffer::Switch>( node ) )
+			auto switchNode = runTimeCast<const Gaffer::Switch>( node );
+			if( switchNode && switchNode->outPlug() && switchNode->inPlugs() )
 			{
 				const Gaffer::Plug *activeOutput = nullptr;
 
@@ -389,7 +390,10 @@ void activeWalkOutput(
 			}
 			else if( const Gaffer::ContextProcessor *contextProcessorNode = runTimeCast<const Gaffer::ContextProcessor>( node ) )
 			{
-				if( connectionStart == contextProcessorNode->outPlug() || contextProcessorNode->outPlug()->isAncestorOf( connectionStart ) )
+				if(
+					contextProcessorNode->outPlug() &&
+					( connectionStart == contextProcessorNode->outPlug() || contextProcessorNode->outPlug()->isAncestorOf( connectionStart ) )
+				)
 				{
 					Gaffer::Context::Scope s( context );
 					const Gaffer::ContextPtr newContext = contextProcessorNode->inPlugContext();
@@ -399,7 +403,8 @@ void activeWalkOutput(
 			}
 		}
 
-		if( const Gaffer::Loop *loopNode = runTimeCast<const Gaffer::Loop>( node ) )
+		auto loopNode = runTimeCast<const Gaffer::Loop>( node );
+		if( loopNode && loopNode->previousPlug() && loopNode->nextPlug() )
 		{
 			if(
 				!firstVisit &&


### PR DESCRIPTION
When first created, these nodes don't have their standard plugs, because they only get those when `setUp()` has been called to tell them what type of plug to use. We were assuming the plugs always existed and therefore dereferencing null pointers.

Fixes #4944
