### PR TITLE
PlugValueWidget/Viewer context fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - UI :
   - Fixed tooltips containing raw HTML.
   - Fixed stalls caused by Qt repeatedly accessing the same icon files.
+- Viewer : Fixed context used to compute the view menu for the image being shown. On the first update, an empty context was being used instead of the script's context.
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
 - Reference : Fixed unnecessary serialisation of connections from internal plugs to external plugs. These are serialised in the `.grf` file already, so do not need to be duplicated on the Reference node itself. This bug prevented changes to the internal connections from taking effect when reloading a modified `.grf` file, and could cause load failures when the connections were from an internal Expression (#4935).
 - MeshToLevelSet, LevelSetOffset : Fixed bug that could cause partial results to be returned if a previous operation was cancelled.

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 - DocumentationAlgo : Fixed handling of raw HTML by `markdownToHTML()`.
 - Reference : Fixed unnecessary serialisation of connections from internal plugs to external plugs. These are serialised in the `.grf` file already, so do not need to be duplicated on the Reference node itself. This bug prevented changes to the internal connections from taking effect when reloading a modified `.grf` file, and could cause load failures when the connections were from an internal Expression (#4935).
 - MeshToLevelSet, LevelSetOffset : Fixed bug that could cause partial results to be returned if a previous operation was cancelled.
+- PlugValueWidget : Fixed unnecessary updates when calling `setContext()` with the same context.
 
 1.0.6.1 (relative to 1.0.6.0)
 =======

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -123,6 +123,9 @@ class Editor( six.with_metaclass( _EditorMetaclass, GafferUI.Widget ) ) :
 	## By default Editors operate in the main context held by the script node. This function
 	# allows an alternative context to be provided, making it possible for an editor to
 	# display itself at a custom frame (or with any other context modification).
+	## \todo To our knowledge, this has never been useful, and synchronising contexts
+	# between Editor/PlugLayout/PlugValueWidget has only been a pain. Consider
+	# removing it.
 	def setContext( self, context ) :
 
 		self.__setContextInternal( context, callUpdate=True )

--- a/python/GafferUI/NodeToolbar.py
+++ b/python/GafferUI/NodeToolbar.py
@@ -45,8 +45,6 @@ import GafferUI
 # implementation suitable for most purposes.
 class NodeToolbar( GafferUI.Widget ) :
 
-	__fallbackContext = Gaffer.Context()
-
 	def __init__( self, node, topLevelWidget, **kw ) :
 
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
@@ -54,7 +52,7 @@ class NodeToolbar( GafferUI.Widget ) :
 		self.__node = node
 
 		scriptNode = self.__node.scriptNode()
-		self.__context = scriptNode.context() if scriptNode is not None else self.__fallbackContext
+		self.__context = GafferUI.PlugValueWidget._PlugValueWidget__defaultContext( node )
 
 	## Returns the node the toolbar represents.
 	def node( self ) :

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -104,8 +104,6 @@ Gaffer.Metadata.registerNode(
 ##########################################################################
 
 ## This class forms the base class for all uis for nodes.
-## \todo: We should provide setContext()/getContext() methods
-## as Editor and PlugValueWidget do.
 class NodeUI( GafferUI.Widget ) :
 
 	def __init__( self, node, topLevelWidget, **kw ) :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -90,9 +90,6 @@ from Qt import QtWidgets
 #
 class PlugLayout( GafferUI.Widget ) :
 
-	# We use this when we can't find a ScriptNode to provide the context.
-	__fallbackContext = Gaffer.Context()
-
 	def __init__( self, parent, orientation = GafferUI.ListContainer.Orientation.Vertical, layoutName = "layout", rootSection = "", embedded = False, **kw ) :
 
 		assert( isinstance( parent, ( Gaffer.Node, Gaffer.Plug ) ) )
@@ -141,8 +138,7 @@ class PlugLayout( GafferUI.Widget ) :
 		self.__rootSection = _Section( self.__parent )
 
 		# set up an appropriate default context in which to view the plugs.
-		scriptNode = self.__node() if isinstance( self.__node(), Gaffer.ScriptNode ) else self.__node().scriptNode()
-		self.setContext( scriptNode.context() if scriptNode is not None else self.__fallbackContext )
+		self.setContext( GafferUI.PlugValueWidget._PlugValueWidget__defaultContext( self.__parent ) )
 
 		# Build the layout
 		self.__update()

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -160,6 +160,9 @@ class PlugLayout( GafferUI.Widget ) :
 
 		return self.__context
 
+	## \todo To our knowledge, this has never been useful, and synchronising contexts
+	# between Editor/PlugLayout/PlugValueWidget has only been a pain. Consider
+	# removing it.
 	def setContext( self, context ) :
 
 		self.__context = context

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -144,7 +144,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 	def setContext( self, context ) :
 
 		assert( isinstance( context, Gaffer.Context ) )
-		if context is self.__context :
+		if context.isSame( self.__context ) :
 			return
 
 		self.__context = context

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -500,6 +500,8 @@ class PlugValueWidget( GafferUI.Widget ) :
 			nodes.add( plug.node() )
 			scriptNodes.add( plug.ancestor( Gaffer.ScriptNode ) )
 
+		# We can only edit plugs under one ScriptNode, because UndoScope's
+		# are specific to ScriptNodes.
 		assert( len( scriptNodes ) <= 1 )
 
 		self.__plugs = plugs
@@ -517,8 +519,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			for node in nodes
 		]
 
-		scriptNode = next( iter( scriptNodes ), None )
-		self.__context = scriptNode.context() if scriptNode is not None else self.__fallbackContext
+		self.__context = next( ( self.__defaultContext( p ) for p in self.__plugs ), self.__fallbackContext )
 		self.__updateContextConnection()
 
 		if callUpdateFromPlugs :
@@ -538,9 +539,25 @@ class PlugValueWidget( GafferUI.Widget ) :
 		else :
 			self.__contextChangedConnection = None
 
-	# we use this when the plugs being viewed doesn't have a ScriptNode ancestor
-	# to provide a context.
 	__fallbackContext = Gaffer.Context()
+
+	# Note : Despite being private (because we don't want to include it in the official API),
+	# This method is accessed by NodeToolbar and PlugLayout (because we do want to share the
+	# logic internally).
+	@classmethod
+	def __defaultContext( cls, graphComponent ) :
+
+		scriptNode = graphComponent if isinstance( graphComponent, Gaffer.ScriptNode ) else graphComponent.ancestor( Gaffer.ScriptNode )
+		if scriptNode is not None :
+			return scriptNode.context()
+
+		# Special case for plugs that form the settings for a view.
+
+		view = graphComponent if isinstance( graphComponent, GafferUI.View ) else graphComponent.ancestor( GafferUI.View )
+		if view is not None :
+			return view.getContext()
+
+		return cls.__fallbackContext
 
 	def __buttonPress( self, widget, event, buttonMask ) :
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -141,6 +141,9 @@ class PlugValueWidget( GafferUI.Widget ) :
 	# for the script the plug belongs to. This function allows an alternative context
 	# to be provided, making it possible to view a plug at a custom frame (or with any
 	# other context modification).
+	## \todo To our knowledge, this has never been useful, and synchronising contexts
+	# between Editor/PlugLayout/PlugValueWidget has only been a pain. Consider
+	# removing it.
 	def setContext( self, context ) :
 
 		assert( isinstance( context, Gaffer.Context ) )

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -329,8 +329,6 @@ class _Toolbar( GafferUI.Frame ) :
 		self.__node = node
 		if self.__node is not None :
 			toolbar = self.__nodeToolbarCache.get( ( self.__node, self.__edge ) )
-			if toolbar is not None :
-				toolbar.setContext( self.__context )
 			self.setChild( toolbar )
 		else :
 			self.setChild( None )

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -127,6 +127,7 @@ from .AuxiliaryNodeGadgetTest import AuxiliaryNodeGadgetTest
 from .CodeWidgetTest import CodeWidgetTest
 from .PathColumnTest import PathColumnTest
 from .ToolTest import ToolTest
+from .StandardNodeToolbarTest import StandardNodeToolbarTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes some context handling bugs that caused unnecessary PlugValueWidget updates, and also caused the Viewer to query an image's `viewNames` with an empty context (for the first image viewed only).