### PR TITLE
Cycles Windows

### DIFF
--- a/.github/workflows/main/sconsOptions
+++ b/.github/workflows/main/sconsOptions
@@ -63,6 +63,5 @@ if sys.platform == "win32" :
 	INKSCAPE = "C:\\Program Files\\Inkscape\\inkscape.com"
 	WARNINGS_AS_ERRORS = False
 	APPLESEED_ROOT = None
-	CYCLES_ROOT = None
 	CXXFLAGS = "\"-DBOOST_ALL_NO_LIB\""
 	SPHINX = "noSphinxYet"

--- a/SConstruct
+++ b/SConstruct
@@ -1238,7 +1238,7 @@ libraries = {
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
-				"Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3",
+				"Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : [
@@ -1252,7 +1252,10 @@ libraries = {
 			"LIBPATH" : [ "$CYCLES_ROOT/lib" ],
 			"LIBS" : [
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferBindings", "GafferCycles",
-				"OpenImageIO_Util$OIIO_LIB_SUFFIX",
+				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
+				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
+				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
+				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex", 
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : [

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -108,6 +108,19 @@ if "%DELIGHT%" NEQ "" (
 	call :appendToPath "%GAFFER_ROOT%\renderMan\displayDrivers" DL_RESOURCES_PATH
 )
 
+rem cycles
+
+if "%CYCLES_ROOT%" EQU "" (
+	if exist %GAFFER_ROOT%\cycles (
+		set CYCLES_ROOT=%GAFFER_ROOT%\cycles
+	)
+)
+
+if "%CYCLES_ROOT%" NEQ "" (
+	call :prependToPath "%CYCLES_ROOT%\bin" PATH
+)
+
+
 rem Set up 3rd party extensions
 rem Batch files are awkward at `for` loops. The default `for`, without `/f`
 rem uses semi-colons AND spaces as delimiters, meaning we would not be able

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2528,7 +2528,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				m_renderType( renderType ),
 				m_frame( 1 ),
 				m_renderState( RENDERSTATE_READY ),
-				m_sessionReset( false ),
 				m_outputsChanged( true ),
 				m_cryptomatteAccurate( true ),
 				m_cryptomatteDepth( 0 ),
@@ -2767,7 +2766,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 					m_deviceName = g_defaultDeviceName;
 					IECore::msg( IECore::Msg::Warning, "CyclesRenderer::option", boost::format( "Unknown value for option \"%s\"." ) % name.string() );
 				}
-				m_sessionReset = true;
 				return;
 			}
 			else if( name == g_threadsOptionName )
@@ -3212,8 +3210,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				updateCamera();
 				updateOutputs();
 
-				m_sessionReset = false;
-
 				if( m_renderState == RENDERSTATE_RENDERING )
 				{
 					if( m_scene->need_reset() )
@@ -3447,13 +3443,12 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 
 			// If anything changes in scene or session, we reset.
 			if( m_scene->params.modified( m_sceneParams ) ||
-				m_session->params.modified( m_sessionParams ) ||
-				m_sessionReset )
+				m_session->params.modified( m_sessionParams )
+			)
 			{
 				// Flag it true here so that we never mutex unlock a different scene pointer due to the reset
 				if( m_renderState != RENDERSTATE_RENDERING )
 				{
-					m_sessionReset = true;
 					reset();
 				}
 			}
@@ -3906,7 +3901,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		int m_frame;
 		string m_camera;
 		RenderState m_renderState;
-		bool m_sessionReset;
 		bool m_outputsChanged;
 		bool m_cryptomatteAccurate;
 		int m_cryptomatteDepth;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -105,6 +105,7 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "util/murmurhash.h"
 #include "util/path.h"
 #include "util/time.h"
+#include "util/types.h"
 #include "util/vector.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
@@ -2936,7 +2937,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 							{
 								auto &vis = data->readable();
 								auto ray = nameToRayType( name.string().c_str() + 29 );
-								uint prevVis = background->get_visibility();
+								uint32_t prevVis = background->get_visibility();
 								background->set_visibility( vis ? prevVis |= ray : prevVis & ~ray );
 							}
 						}


### PR DESCRIPTION
This gets Cycles building and running on Windows. Only the last three commits are relevant, there's a pile of unrelated commits at the start because it's based on #4869 and #4934.

Of particular interest in the last commit, where I made some changes to the scene locking behavior. I was getting a deadlock when doing any scene update where it was waiting for `m_scene->mutex` to be freed up at https://github.com/GafferHQ/gaffer/blob/9199b2d50bcc66d6b5f5b746e5e580b13910a1d6/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp#L3147

I _think_ my logic is sound here because `std::scoped_lock` takes ownership of the mutex, so going out of scope won't unlock another scene's mutex if it changed in one of the `update*` methods. I don't know why this was only causing problems on Windows.

- List specific new features and changes to project components

### Related issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

#4869 and #4934

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
