### PR TITLE
ApplicationRoot : Return `preferenceLocation()` as generic string

### DIFF
--- a/src/Gaffer/ApplicationRoot.cpp
+++ b/src/Gaffer/ApplicationRoot.cpp
@@ -39,7 +39,7 @@
 
 #include "Gaffer/Preferences.h"
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
 
 using namespace Gaffer;
 
@@ -129,12 +129,12 @@ std::string ApplicationRoot::preferencesLocation() const
 		throw IECore::Exception( "$HOME environment variable not set" );
 	}
 
-	std::string result = home;
-	result += "/gaffer/startup/" + getName().string();
+	std::filesystem::path result = home;
+	result = result / "gaffer" / "startup" / getName().string();
 
-	boost::filesystem::create_directories( result );
+	std::filesystem::create_directories( result );
 
-	return result;
+	return result.generic_string();
 }
 
 std::string ApplicationRoot::defaultPreferencesFileName() const


### PR DESCRIPTION
@ericmehl, this is an alternative implementation of https://github.com/GafferHQ/gaffer/pull/4934/commits/3eee07d98eaad15e555a10cb555137acda4ccbc1 from #4934. It uses `path::generic_string()` rather than `string.replace( `\\`, `/` )`. The latter is bothering me because `\` is actually a valid character in a filename on Mac/Linux, so shouldn't be replaced unconditionally like that. I'm shooting for a future where everything uses `filesystem::path::generic_string()` in C++ and `pathlib.Path.as_posix()` in Python, so we're never doing manual handling of separators. Is that viable? Does this commit work on Windows?