### PR TITLE
Cycles : Various crash fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Fixes
 -----
 
 - Image Viewer : Fixed dragging a color from the image view using a context with the wrong time, and an error that could show up when deleting the currently viewed image.
-- Cycles : Fixed background shader bug that could cause a crash, or cause the initial render in the Cycles viewport to be blank.
+- Cycles :
+  - Fixed background shader bug that could cause a crash, or cause the initial render in the Cycles viewport to be blank.
+  - Fixed light bug that triggered an assertion in Cycles debug builds.
 
 1.1.3.0 (relative to 1.1.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Image Viewer : Fixed dragging a color from the image view using a context with the wrong time, and an error that could show up when deleting the currently viewed image.
+- Cycles : Fixed background shader bug that could cause a crash, or cause the initial render in the Cycles viewport to be blank.
 
 1.1.3.0 (relative to 1.1.2.0)
 =======

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1809,6 +1809,7 @@ class LightCache : public IECore::RefCounted
 		{
 			ccl::Light *light = new ccl::Light();
 			light->name = nodeName.c_str();
+			light->set_owner( m_scene );
 			light->tag_update( m_scene );
 			auto clight = SharedCLightPtr( light, nullNodeDeleter );
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3706,6 +3706,8 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				m_scene->film->copy_value(socketType, m_film, *m_film.type->find_input( socketType.name ) );
 			}
 
+			m_scene->background->set_shader( m_scene->default_background );
+
 			m_scene->shader_manager->tag_update( m_scene, ccl::ShaderManager::UPDATE_ALL );
 			m_scene->integrator->tag_update( m_scene, ccl::Integrator::UPDATE_ALL );
 			m_scene->background->tag_update( m_scene );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

A fresh Gaffer session when creating something like a sphere and viewing it through Cycles would always crash. On a scene reset the background light's "stale" shader was causing this which this PR should fix.

- Ensure a re-setted Cycles session hasn't got a stale pointer for the background shader which was causing a crash.
- Ensure lights are owned by the Cycles scene to prevent a crash when `clearUnused()` is called.

### Related issues ###

- NA

### Dependencies ###

- NA

### Breaking changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
