### PR TITLE
EditScopeAlgo : Add set membership edits

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - VisibleSet/VisibleSetData : Added struct used to define a subset of the scene to be rendered based on expansions, inclusions, and exclusions. This is used to allow scene locations to be defined as always or never renderable, overriding the usual UI expansion behaviour.
 - ContextAlgo : Added `setVisiblesSet()`, `getVisibleSet()`, and `affectsVisibleSet()` methods.
 - SceneGadget : Added `setVisibleSet()`, and `getVisibleSet()` methods.
+- EditScopeAlgo : Added methods to modify and query modifications to set members in an Edit Scope.
 
 Breaking Changes
 ----------------

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -123,6 +123,22 @@ GAFFERSCENE_API Gaffer::TweakPlug *acquireAttributeEdit( Gaffer::EditScope *scop
 GAFFERSCENE_API void removeAttributeEdit( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute );
 GAFFERSCENE_API const Gaffer::GraphComponent *attributeEditReadOnlyReason( const Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &attribute );
 
+// Sets
+// ==========
+//
+// These methods edit set membership for one or more locations.
+
+enum class SetMembership
+{
+	Added,
+	Removed,
+	Unchanged
+};
+
+GAFFERSCENE_API void setSetMembership( Gaffer::EditScope *scope, const IECore::PathMatcher &paths, const std::string &set, SetMembership state );
+GAFFERSCENE_API SetMembership getSetMembership( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &set );
+GAFFERSCENE_API const Gaffer::GraphComponent *setMembershipReadOnlyReason( const Gaffer::EditScope *scope, const std::string &set, SetMembership state );
+
 } // namespace EditScopeAlgo
 
 } // namespace GafferScene

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -176,6 +176,26 @@ GraphComponentPtr attributeEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, 
 	return const_cast<GraphComponent *>( EditScopeAlgo::attributeEditReadOnlyReason( &scope, path, attribute ) );
 }
 
+// Set Membership
+// ==============
+
+void setSetMembershipWrapper( Gaffer::EditScope &scope, const IECore::PathMatcher &paths, const std::string &set, EditScopeAlgo::SetMembership state )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	EditScopeAlgo::setSetMembership( &scope, paths, set, state );
+}
+
+EditScopeAlgo::SetMembership getSetMembershipWrapper( Gaffer::EditScope &scope, const ScenePlug::ScenePath &path, const std::string &set )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::getSetMembership( &scope, path, set );
+}
+
+GraphComponentPtr setMembershipReadOnlyReasonWrapper( Gaffer::EditScope &scope, const std::string &set, EditScopeAlgo::SetMembership state )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::setMembershipReadOnlyReason( &scope, set, state ) );
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -218,6 +238,14 @@ void bindEditScopeAlgo()
 	def( "removeAttributeEdit", &removeAttributeEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
 	def( "attributeEditReadOnlyReason", &attributeEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
 
+	def( "setSetMembership", &setSetMembershipWrapper );
+	def( "getSetMembership", &getSetMembershipWrapper );
+	def( "setMembershipReadOnlyReason", &setMembershipReadOnlyReasonWrapper );
+	enum_<EditScopeAlgo::SetMembership>( "SetMembership" )
+		.value( "Added", EditScopeAlgo::SetMembership::Added )
+		.value( "Removed", EditScopeAlgo::SetMembership::Removed )
+		.value( "Unchanged", EditScopeAlgo::SetMembership::Unchanged )
+	;
 }
 
 } // namespace GafferSceneModule


### PR DESCRIPTION
This adds the ability to make changes to Set members in an Edit Scope. Within an edit scope, a list of paths can be set to either be included in a set, removed from a set, or neither. The last case passes through Set membership for the paths + Set combination.

A path + Set combination for an Edit Scope can also be queried to determine which of the add / remove / inherit operations are active.

Most of the related code this is meant to support is in `main`, but as this itself isn't an API break, I'm targeting `1.1_maintenance`. I'm happy to rebase and retarget if it makes more sense to keep it on `main`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
