### PR TITLE
Don't `#include "IECoreScene/Transform.h"`

### DIFF
--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -50,7 +50,6 @@
 #include "IECoreScene/MeshPrimitive.h"
 #include "IECoreScene/Shader.h"
 #include "IECoreScene/SpherePrimitive.h"
-#include "IECoreScene/Transform.h"
 
 #include "IECore/CompoundParameter.h"
 #include "IECore/LRUCache.h"

--- a/src/GafferScene/Camera.cpp
+++ b/src/GafferScene/Camera.cpp
@@ -40,7 +40,6 @@
 #include "Gaffer/StringPlug.h"
 
 #include "IECoreScene/Camera.h"
-#include "IECoreScene/Transform.h"
 
 #include "IECore/AngleConversion.h"
 

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -47,7 +47,6 @@
 
 #include "Gaffer/Private/IECorePreview/MessagesData.h"
 
-#include "IECoreScene/Transform.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/MessageHandler.h"

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -42,7 +42,6 @@
 #include "IECoreScene/Camera.h"
 #include "IECoreScene/Shader.h"
 #include "IECoreScene/ShaderNetwork.h"
-#include "IECoreScene/Transform.h"
 
 #include "IECore/CompoundData.h"
 #include "IECore/Export.h"

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -42,7 +42,6 @@
 #include "Gaffer/ParallelAlgo.h"
 
 #include "IECoreScene/CurvesPrimitive.h"
-#include "IECoreScene/Transform.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/Interpolator.h"

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -53,7 +53,6 @@
 #include "IECoreScene/PreWorldRenderable.h"
 #include "IECoreScene/Primitive.h"
 #include "IECoreScene/Shader.h"
-#include "IECoreScene/Transform.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/Data.h"

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -59,7 +59,6 @@
 #include "IECoreScene/Camera.h"
 #include "IECoreScene/ClippingPlane.h"
 #include "IECoreScene/CoordinateSystem.h"
-#include "IECoreScene/MatrixMotionTransform.h"
 #include "IECoreScene/VisibleRenderable.h"
 
 #include "IECore/MessageHandler.h"

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -66,8 +66,6 @@
 #include "IECoreGL/Primitive.h"
 #include "IECoreGL/State.h"
 
-#include "IECoreScene/Transform.h"
-
 #include "IECore/AngleConversion.h"
 #include "IECore/VectorTypedData.h"
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -46,8 +46,6 @@
 #include "IECoreGL/State.h"
 #include "IECoreGL/ToGLCameraConverter.h"
 
-#include "IECoreScene/Transform.h"
-
 #include "IECore/AngleConversion.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/NullObject.h"

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -49,7 +49,6 @@
 #include "IECoreScene/MeshPrimitive.h"
 #include "IECoreScene/Shader.h"
 #include "IECoreScene/SpherePrimitive.h"
-#include "IECoreScene/Transform.h"
 
 #include "IECoreVDB/VDBObject.h"
 #include "IECoreVDB/TypeIds.h"


### PR DESCRIPTION
This is obsolete, and needs removing from Cortex. It's part of the cruft that is still clinging on because IECoreMaya uses the old IECoreGL renderer still.
