### PR TITLE
IECoreArnold : Accept InternedStringData in place of StringData

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Improvements
 - Cycles : Added support for custom attributes with either a `user:` or `render:` prefix. These can be authored in Gaffer and then read at render time using Cycle's attribute shader.
 - Arnold : Added support for attributes containing InternedStringData, as would be obtained by loading `token` primvars from a USD file.
 
+Fixes
+-----
+
+- Arnold : Fixed deletion of `ai:transform_type` attribute during interactive renders. The object now reverts to the default transform type in this case.
+
 1.1.3.0 (relative to 1.1.2.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Cycles : Added support for custom attributes with either a `user:` or `render:` prefix. These can be authored in Gaffer and then read at render time using Cycle's attribute shader.
+- Arnold : Added support for attributes containing InternedStringData, as would be obtained by loading `token` primvars from a USD file.
 
 1.1.3.0 (relative to 1.1.2.0)
 =======

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1261,6 +1261,27 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
+		r.object(
+			"planeInterned",
+			plane,
+			r.attributes(
+				IECore.CompoundObject( {
+					"ai:sss_setname" : IECore.InternedStringData( "testInternedSet" ),
+				} )
+			)
+		)
+
+		r.object(
+			"planeEmpty",
+			plane,
+			r.attributes(
+				IECore.CompoundObject( {
+					"ai:sss_setname" : IECore.StringData( "" ),
+				} )
+			)
+		)
+
+
 		r.render()
 		del r
 
@@ -1269,6 +1290,10 @@ class RendererTest( GafferTest.TestCase ) :
 			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
 			node = arnold.AiNodeLookUpByName( universe, "plane" )
 			self.assertEqual( arnold.AiNodeGetStr( node, "sss_setname" ), "testSet" )
+			node = arnold.AiNodeLookUpByName( universe, "planeInterned" )
+			self.assertEqual( arnold.AiNodeGetStr( node, "sss_setname" ), "testInternedSet" )
+			node = arnold.AiNodeLookUpByName( universe, "planeEmpty" )
+			self.assertIsNone( arnold.AiNodeLookUpUserParameter( node, "sss_setname" ) )
 
 	def testCustomAttributes( self ) :
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3946,6 +3946,32 @@ class RendererTest( GafferTest.TestCase ) :
 			input = arnold.AiNodeGetLink( surfaceShader, "base_color" )
 			self.assertIn( "colorSwitch", arnold.AiNodeGetName( input ) )
 
+	def testInternedStringAttributes( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			os.path.join( self.temporaryDirectory(), "test.ass" )
+		)
+
+		r.object(
+			"testPlane",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			r.attributes( IECore.CompoundObject( {
+				"user:myString" : IECore.InternedStringData( "test" ),
+			} ) ),
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, os.path.join( self.temporaryDirectory(), "test.ass" ), None )
+
+			plane = arnold.AiNodeLookUpByName( universe, "testPlane" )
+			self.assertEqual( arnold.AiNodeGetStr( plane, "user:myString" ), "test" )
+
 	@staticmethod
 	def __m44f( m ) :
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1176,22 +1176,20 @@ class RendererTest( GafferTest.TestCase ) :
 
 		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 
-		r.object(
-			"planeDefault",
-			plane,
-			r.attributes( IECore.CompoundObject() )
-		)
-		r.object(
-			"planeLinear",
-			plane,
-			r.attributes(
-				IECore.CompoundObject( {
-					"ai:transform_type" : IECore.StringData( "linear" ),
-				} )
-			)
+		defaultAttributes = r.attributes( IECore.CompoundObject() )
+		linearAttributes = r.attributes(
+			IECore.CompoundObject( {
+				"ai:transform_type" : IECore.StringData( "linear" ),
+			} )
 		)
 
+		r.object( "planeDefault", plane, defaultAttributes )
+		r.object( "planeLinear", plane, linearAttributes )
+		p = r.object( "planeLinearThenDefault", plane, linearAttributes )
+		p.attributes( defaultAttributes )
+
 		r.render()
+		del defaultAttributes, linearAttributes, p
 		del r
 
 		with IECoreArnold.UniverseBlock( writable = True ) as universe :
@@ -1199,8 +1197,10 @@ class RendererTest( GafferTest.TestCase ) :
 			arnold.AiSceneLoad( universe, self.temporaryDirectory() + "/test.ass", None )
 			defaultNode = arnold.AiNodeLookUpByName( universe, "planeDefault" )
 			linearNode = arnold.AiNodeLookUpByName( universe, "planeLinear" )
+			linearThenDefaultNode = arnold.AiNodeLookUpByName( universe, "planeLinearThenDefault" )
 			self.assertEqual( arnold.AiNodeGetStr( defaultNode, "transform_type" ), "rotate_about_center" )
 			self.assertEqual( arnold.AiNodeGetStr( linearNode, "transform_type" ), "linear" )
+			self.assertEqual( arnold.AiNodeGetStr( linearThenDefaultNode, "transform_type" ), "rotate_about_center" )
 
 	def testSubdivisionAttributes( self ) :
 

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -457,6 +457,7 @@ int parameterType( IECore::TypeId dataType, bool &array )
 			array = false;
 			return AI_TYPE_FLOAT;
 		case StringDataTypeId :
+		case InternedStringDataTypeId :
 			array = false;
 			return AI_TYPE_STRING;
 		case Color3fDataTypeId :

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1042,8 +1042,8 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			m_stepScale = attributeValue<float>( g_shapeVolumeStepScaleAttributeName, attributes, 1.0f );
 			m_volumePadding = attributeValue<float>( g_shapeVolumePaddingAttributeName, attributes, 0.0f );
 
-			m_sssSetName = attribute<IECore::StringData>( g_sssSetNameName, attributes );
-			m_toonId = attribute<IECore::StringData>( g_toonIdName, attributes );
+			m_sssSetName = stringAttribute( g_sssSetNameName, attributes );
+			m_toonId = stringAttribute( g_toonIdName, attributes );
 
 			for( IECore::CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; ++it )
 			{
@@ -1351,18 +1351,26 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeSetArray( node, g_traceSetsArnoldString, AiArray( 1, 1, AI_TYPE_STRING, "__none__" ) );
 				}
 
-				if( m_sssSetName )
+				if( m_sssSetName.length() )
 				{
-					ParameterAlgo::setParameter( node, g_sssSetNameArnoldString, m_sssSetName.get() );
+					if( !AiNodeLookUpUserParameter( node, g_sssSetNameArnoldString ) )
+					{
+						AiNodeDeclare( node, g_sssSetNameArnoldString, "constant STRING" );
+					}
+					AiNodeSetStr( node, g_sssSetNameArnoldString, m_sssSetName );
 				}
 				else
 				{
 					AiNodeResetParameter( node, g_sssSetNameArnoldString );
 				}
 
-				if( m_toonId )
+				if( m_toonId.length() )
 				{
-					ParameterAlgo::setParameter( node, g_toonIdArnoldString, m_toonId.get() );
+					if( !AiNodeLookUpUserParameter( node, g_toonIdArnoldString ) )
+					{
+						AiNodeDeclare( node, g_toonIdArnoldString, "constant STRING" );
+					}
+					AiNodeSetStr( node, g_toonIdArnoldString, m_toonId );
 				}
 				else
 				{
@@ -1753,6 +1761,24 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			return data ? data->readable() : std::optional<T>();
 		}
 
+		static AtString stringAttribute( const IECore::InternedString &name, const IECore::CompoundObject *attributes, AtString defaultValue = AtString() )
+		{
+			IECore::CompoundObject::ObjectMap::const_iterator it = attributes->members().find( name );
+			if( it == attributes->members().end() )
+			{
+				return defaultValue;
+			}
+			if( auto isd = IECore::runTimeCast<const IECore::InternedStringData>( it->second.get() ) )
+			{
+				return AtString( isd->readable().c_str() );
+			}
+			else if( auto sd = reportedCast<const IECore::StringData>( it->second.get(), "attribute", name ) )
+			{
+				return AtString( sd->readable().c_str() );
+			};
+			return defaultValue;
+		}
+
 		static void updateVisibility( unsigned char &visibility, const IECore::InternedString &name, unsigned char rayType, const IECore::CompoundObject *attributes )
 		{
 			if( const IECore::BoolData *d = attribute<IECore::BoolData>( name, attributes ) )
@@ -1871,8 +1897,8 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			m_displacement.hash( h );
 			m_curves.hash( h );
 			m_volume.hash( h );
-			hashOptional( m_toonId.get(), h );
-			hashOptional( m_sssSetName.get(), h );
+			h.append( m_toonId.c_str() ? m_toonId.c_str() : "" );
+			h.append( m_sssSetName.c_str() ? m_sssSetName.c_str() : "" );
 		}
 
 		unsigned char m_visibility;
@@ -1894,8 +1920,8 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		Displacement m_displacement;
 		Curves m_curves;
 		Volume m_volume;
-		IECore::ConstStringDataPtr m_toonId;
-		IECore::ConstStringDataPtr m_sssSetName;
+		AtString m_toonId;
+		AtString m_sssSetName;
 		// When adding fields, please update `hashProceduralGeometry()`!
 
 		// AtString defines implicit cast to a (uniquefied) `const char *`,

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -325,6 +325,7 @@ const AtString g_pixelAspectRatioArnoldString( "pixel_aspect_ratio" );
 const AtString g_pluginSearchPathArnoldString( "plugin_searchpath" );
 const AtString g_polymeshArnoldString("polymesh");
 const AtString g_rasterArnoldString( "raster" );
+const AtString g_rotateAboutCenterArnoldString( "rotate_about_center" );
 const AtString g_receiveShadowsArnoldString( "receive_shadows" );
 const AtString g_referenceTimeString( "reference_time" );
 const AtString g_regionMinXArnoldString( "region_min_x" );
@@ -1036,7 +1037,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			substituteShaderIfNecessary( m_lightFilterShader, attributes );
 
 			m_traceSets = attribute<IECore::InternedStringVectorData>( g_setsAttributeName, attributes );
-			m_transformType = attribute<IECore::StringData>( g_transformTypeAttributeName, attributes );
+			m_transformType = stringAttribute( g_transformTypeAttributeName, attributes, g_rotateAboutCenterArnoldString );
 			m_automaticInstancing = attributeValue<bool>( g_automaticInstancingAttributeName, attributes, true );
 			m_stepSize = attributeValue<float>( g_shapeVolumeStepSizeAttributeName, attributes, 0.0f );
 			m_stepScale = attributeValue<float>( g_shapeVolumeStepScaleAttributeName, attributes, 1.0f );
@@ -1307,18 +1308,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			{
 				AiNodeSetByte( node, g_visibilityArnoldString, m_visibility );
 				AiNodeSetByte( node, g_sidednessArnoldString, m_sidedness );
-
-				if( m_transformType )
-				{
-					// \todo : Arnold quite explicitly discourages constructing AtStrings repeatedly,
-					// but given the need to pass m_transformType around as a string for consistency
-					// reasons, it seems like there's not much else we can do here.
-					// If we start reusing ArnoldAttributes for multiple locations with identical attributes,
-					// it could be worth caching this, or possibly in the future we could come up with
-					// some way of cleanly exposing enum values as something other than strings.
-					AiNodeSetStr( node, g_transformTypeArnoldString, AtString( m_transformType->readable().c_str() ) );
-				}
-
+				AiNodeSetStr( node, g_transformTypeArnoldString, m_transformType );
 				AiNodeSetBool( node, g_receiveShadowsArnoldString, m_shadingFlags & ArnoldAttributes::ReceiveShadows );
 				AiNodeSetBool( node, g_selfShadowsArnoldString, m_shadingFlags & ArnoldAttributes::SelfShadows );
 				AiNodeSetBool( node, g_opaqueArnoldString, m_shadingFlags & ArnoldAttributes::Opaque );
@@ -1888,7 +1878,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				s->hash( h );
 			}
 			hashOptional( m_traceSets.get(), h );
-			hashOptional( m_transformType.get(), h );
+			h.append( m_transformType.c_str() );
 			h.append( m_stepSize );
 			h.append( m_stepScale );
 			h.append( m_volumePadding );
@@ -1911,7 +1901,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		IECoreScene::ConstShaderNetworkPtr m_lightFilterShader;
 		std::vector<ArnoldShaderPtr> m_lightFilterShaders;
 		IECore::ConstInternedStringVectorDataPtr m_traceSets;
-		IECore::ConstStringDataPtr m_transformType;
+		AtString m_transformType;
 		bool m_automaticInstancing;
 		float m_stepSize;
 		float m_stepScale;


### PR DESCRIPTION
This allows us to render USD files from Atoms, where certain string attributes are authored as `token` rather than `string`.