### PR TITLE
Two Minor UI Fixes For Comparison Support in Color Inspector

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Cycles : Added support for custom attributes with either a `user:` or `render:` prefix. These can be authored in Gaffer and then read at render time using Cycle's attribute shader.
 
+Fixes
+-----
+
+- Image Viewer : Fixed dragging a color from the image view using a context with the wrong time, and an error that could show up when deleting the currently viewed image.
+
 1.1.3.0 (relative to 1.1.2.0)
 =======
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -673,12 +673,12 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		inputImagePlug = self.getPlug().node()["in"].getInput()
 
+		sources = self.__getSampleSources( self.getPlug()["mode"].getValue() )
+
 		if not inputImagePlug:
 			# This can happen when the source is deleted - can't get pixel values if there's no input image
 			self.__updateLabels( sources, [ imath.Color4f( 0 ) ] * 2 )
 			return
-
-		sources = self.__getSampleSources( self.getPlug()["mode"].getValue() )
 
 		with inputImagePlug.node().scriptNode().context() :
 			self.__updateInBackground( sources )
@@ -854,7 +854,10 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 
 		sources = self.__getSampleSources( GafferImageUI.ImageView.ColorInspectorPlug.Mode.Cursor )
-		colors = self.__evaluateColors( sources )
+
+		inputImagePlug = self.getPlug().node()["in"].getInput()
+		with inputImagePlug.node().scriptNode().context() :
+			colors = self.__evaluateColors( sources )
 
 		ig = viewportGadget.getPrimaryChild()
 		wipeAngle = ig.getWipeAngle() * math.pi / 180.0


### PR DESCRIPTION
Fixed dragging a color from the image view using a context with the wrong time, and an error that could show up when deleting the currently viewed image.

There were broken in #4931

Reported by R on the mailing list, and Murray.

Hopefully I haven't overlooked anything else, I guess I've gotten used to having good test coverage, but we don't have much of a backstop on this UI stuff.