### PR TITLE
PathListingWidget : Fix tracking of last selected index

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+1.0.6.x (relative to 1.0.6.2)
+=======
+
+Fixes
+-----
+
+- Catalogue : Fixed crashes when using the <kbd>↑</kbd> or <kbd>↓</kbd> keys immediately after adding or removing a column.
+- PathListingWidget : Fixed bug tracking the last selected path, which could cause crashes if the path was deleted or the columns were changed.
+
 1.0.6.2 (relative to 1.0.6.1)
 =======
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -534,6 +534,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			# Use `__lastSelectedIndex` if available so that shift + keypress
 			# accumulates selection.
 			index = self.__lastSelectedIndex
+			assert( isinstance( index, ( type( None ), QtCore.QPersistentModelIndex ) ) )
 			if index is not None and index.isValid() :
 				# Convert from persistent index
 				index = QtCore.QModelIndex( index )
@@ -722,6 +723,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		selection = self.__getSelectionInternal()
 
 		last = self.__lastSelectedIndex
+		assert( isinstance( last, ( type( None ), QtCore.QPersistentModelIndex ) ) )
 		if last is not None and last.isValid() :
 			# Convert from persistent index
 			last = QtCore.QModelIndex( last )
@@ -781,7 +783,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		self._qtWidget().setCurrentIndex( index )
 		self.__setSelectionInternal( selection, scrollToFirst=False, expandNonLeaf=False )
 
-		self.__lastSelectedIndex = index
+		self.__lastSelectedIndex = QtCore.QPersistentModelIndex( index )
 
 	def __singleSelect( self, index ) :
 
@@ -794,7 +796,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			paths = [ IECore.PathMatcher( [ path ] ) if i == index.column() else IECore.PathMatcher() for i in range( 0, len( self.getColumns() ) ) ]
 		self.setSelection( paths, scrollToFirst=False, expandNonLeaf=False )
 
-		self.__lastSelectedIndex = index
+		self.__lastSelectedIndex = QtCore.QPersistentModelIndex( index )
 
 	def __rowSelectionMode( self ) :
 


### PR DESCRIPTION
QModelIndex must _never_ be stored, as it contains a pointer directly into items in the model, that could be deleted at any time. Instead we must use QPersistentModelIndex, which allows us to query the validity of the index before retrieving it. We were doing that originally, but QModelIndex crept back in when we were adding per-column selection handling.

One reliable way of exercising this bug was as follows :

1. Load a Catalogue containing 3 images into the NodeEditor.
2. Click to select the 2nd image.
3. Right click on the header, and add a column. This resets the model, invalidating all previous indexes.
4. Making sure the mouse has never left the image listing (so we don't lose keyboard focus), press <kbd>↓</kbd> to try to move the selection down. This should crash.