### PR TITLE
RandomUI : Don't hide `outFloat`, and move outputs to their own section

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Arnold : Added support for attributes containing InternedStringData, as would be obtained by loading `token` primvars from a USD file.
+- Random : Added the `outFloat` plug to the NodeEditor, and moved output plugs into their own `Outputs` section.
 
 Fixes
 -----

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -148,7 +148,7 @@ Gaffer.Metadata.registerNode(
 			and float range plugs.
 			""",
 
-			"plugValueWidget:type", "",
+			"layout:section", "Settings.Outputs",
 
 		],
 
@@ -159,6 +159,8 @@ Gaffer.Metadata.registerNode(
 			Random colour output derived from seed, Context Variable, base
 			colour, hue, saturation and value plugs.
 			""",
+
+			"layout:section", "Settings.Outputs",
 
 			"plugValueWidget:type", "GafferUI.RandomUI._RandomColorPlugValueWidget",
 


### PR DESCRIPTION
This makes the UI more useable when the node is not created via the `Randomise` item in the plug context menu.
