### PR TITLE
CollectScenes : Multithread `hashSet()` and `computeSet()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Features
 Improvements
 ------------
 
+- CollectScenes : Improved performance when computing sets, with a 3x speedup being seen in one particular benchmark.
 - LightTool : Changed spot light and quad light edge tool tip locations so that they follow the cone and edge during drag.
 - Arnold : Improved speed of translation of encapsulated scenes when using many threads.
 

--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -77,6 +77,9 @@ class GAFFERSCENE_API CollectScenes : public SceneProcessor
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 		void hashBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		Imath::Box3f computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const override;
 


### PR DESCRIPTION
This gives a 3x speedup in `CollectScenesTest.testSetPerformance`.

Perhaps more interestingly, it also gives almost a 2x speedup in `SetQueryTest.testScaling()`, but almost half of that speedup is due to the change in hash cache policy _alone_. In `testScaling()`, the same set is required by every location in the scene, but we are visiting enough locations that the hash cache is under significant pressure. By moving `out.set` to the TaskCollaboration policy, the set hash is stored in the shared central cache, from which it is exceedingly unlikely to be evicted (because per-location hashes are not stored in the global cache).
