### PR TITLE
PlugValueWidget : Remove no-op `_updateFromPlug()` overrides

### DIFF
--- a/python/GafferImageUI/ShuffleUI.py
+++ b/python/GafferImageUI/ShuffleUI.py
@@ -136,8 +136,4 @@ class _ShuffleChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 GafferUI.PlugValueWidget.registerType( GafferImage.Shuffle.ChannelPlug, _ShuffleChannelPlugValueWidget )

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -145,10 +145,6 @@ class OutputsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 	def __addMenuDefinition( self ) :
 
 		node = self.getPlug().node()

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -319,10 +319,6 @@ class _RendererSettingsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ), scoped = False )
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 	def __clicked( self, button ) :
 
 		if self.__window is None :
@@ -354,10 +350,6 @@ class _DrawingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 
 		return True
-
-	def _updateFromPlug( self ) :
-
-		pass
 
 	def __menuDefinition( self ) :
 
@@ -508,10 +500,6 @@ class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			return True
 
-		def _updateFromPlug( self ) :
-
-			pass
-
 		def __menuDefinition( self ) :
 
 			m = IECore.MenuDefinition()
@@ -551,10 +539,6 @@ class _ExpansionPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 
 		return True
-
-	def _updateFromPlug( self ) :
-
-		pass
 
 	def __menuDefinition( self ) :
 
@@ -963,10 +947,6 @@ class _GridPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 
 		return True
-
-	def _updateFromPlug( self ) :
-
-		pass
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/ShaderViewUI.py
+++ b/python/GafferSceneUI/ShaderViewUI.py
@@ -85,10 +85,6 @@ class _ScenePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 	def __menuDefinition( self ) :
 
 		m = IECore.MenuDefinition()

--- a/python/GafferUI/BoxPlugValueWidget.py
+++ b/python/GafferUI/BoxPlugValueWidget.py
@@ -83,10 +83,6 @@ class BoxPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 GafferUI.PlugValueWidget.registerType( Gaffer.Box2fPlug, BoxPlugValueWidget )
 GafferUI.PlugValueWidget.registerType( Gaffer.Box3fPlug, BoxPlugValueWidget )
 GafferUI.PlugValueWidget.registerType( Gaffer.Box2iPlug, BoxPlugValueWidget )

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -93,10 +93,6 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def _updateFromPlugs( self ) :
-
-		pass
-
 	## Returns the ListContainer used as the main layout for this Widget.
 	# Derived classes may use it to add to the layout.
 	def _row( self ) :

--- a/python/GafferUI/LayoutPlugValueWidget.py
+++ b/python/GafferUI/LayoutPlugValueWidget.py
@@ -77,8 +77,4 @@ class LayoutPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return self.__layout.plugValueWidget( childPlug )
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 GafferUI.PlugValueWidget.registerType( Gaffer.TransformPlug, LayoutPlugValueWidget )

--- a/python/GafferUI/RefreshPlugValueWidget.py
+++ b/python/GafferUI/RefreshPlugValueWidget.py
@@ -49,10 +49,6 @@ class RefreshPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ), scoped = False )
 
-	def _updateFromPlug( self ) :
-
-		pass
-
 	def __clicked( self, widget ) :
 
 		# Deliberately not making this undoable, as once we've refreshed

--- a/python/GafferUI/ToolPlugValueWidget.py
+++ b/python/GafferUI/ToolPlugValueWidget.py
@@ -54,7 +54,3 @@ class ToolPlugValueWidget( GafferUI.PlugValueWidget ) :
 				Gaffer.WeakMethod( self._popupMenuDefinition )
 			)
 		)
-
-	def _updateFromPlug( self ) :
-
-		pass


### PR DESCRIPTION
The method is no longer required to be overridden, and I intend to replace it with a more granular set of update functions in future. Getting rid of the unneeded overrides helps clear the way for that refactoring.
