### PR TITLE
Plug/Node Widgets : Remove `set/getReadOnly()` methods

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -51,6 +51,11 @@ Breaking Changes
 - CatalogueUI : Hid OutputIndexColumn from public API.
 - ContextAlgo : Removed use of the `ui:scene:expandedPaths` context variable. Any code directly accessing `ui:scene:expandedPaths` should instead use the `getExpandedPaths()/setExpandedPaths()/expand()/expandDescendants()` methods provided by `ContextAlgo`.
 - SceneGadget : Removed `setExpandedPaths()` and `getExpandedPaths()` methods. `setVisibleSet()` and `getVisibleSet()` are now used instead.
+- GafferUI : Removed the `setReadOnly()` and `getReadOnly()` methods from the following widgets :
+  - `GafferUI.PlugValueWidget`
+  - `GafferUI.NodeEditor`
+  - `GafferUI.NodeUI`
+  - `GafferUI.PlugLayout`
 
 1.1.4.0 (relative to 1.1.3.0)
 =======

--- a/python/GafferCortexUI/CompoundPlugValueWidget.py
+++ b/python/GafferCortexUI/CompoundPlugValueWidget.py
@@ -126,25 +126,6 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	## Overridden to propagate status to children.
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__childPlugUIs.values() :
-			if w is None :
-				continue
-			if isinstance( w, GafferUI.PlugValueWidget ) :
-				w.setReadOnly( readOnly )
-			elif isinstance(  w, GafferUI.PlugWidget ) :
-				w.labelPlugValueWidget().setReadOnly( readOnly )
-				w.plugValueWidget().setReadOnly( readOnly )
-			else :
-				w.plugValueWidget().setReadOnly( readOnly )
-
 	def _updateFromPlug( self ) :
 
 		if self.__summary is not None and self.__collapsible is not None :
@@ -209,14 +190,6 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 				widget = self._childPlugWidget( childPlug )
 				assert( isinstance( widget, ( GafferUI.PlugValueWidget, type( None ) ) ) or hasattr( widget, "plugValueWidget" ) )
 				self.__childPlugUIs[childPlug] = widget
-				if widget is not None :
-					if isinstance( widget, GafferUI.PlugValueWidget ) :
-						widget.setReadOnly( self.getReadOnly() )
-					elif isinstance(  widget, GafferUI.PlugWidget ) :
-						widget.labelPlugValueWidget().setReadOnly( self.getReadOnly() )
-						widget.plugValueWidget().setReadOnly( self.getReadOnly() )
-					else :
-						widget.plugValueWidget().setReadOnly( self.getReadOnly() )
 			else :
 				widget = self.__childPlugUIs[childPlug]
 			if widget is not None :

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -64,7 +64,7 @@ __nodeTypes = (
 
 class _ParameterisedHolderNodeUI( GafferUI.NodeUI ) :
 
-	def __init__( self, node, readOnly=False, **kw ) :
+	def __init__( self, node, **kw ) :
 
 		column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 )
 
@@ -81,22 +81,10 @@ class _ParameterisedHolderNodeUI( GafferUI.NodeUI ) :
 				with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) :
 					GafferUI.Spacer( imath.V2i( 10 ), parenting = { "expand"  : True } )
 					toolButton = GafferCortexUI.ToolParameterValueWidget( self.node().parameterHandler() )
-					toolButton.plugValueWidget().setReadOnly( readOnly )
 					_InfoButton( node )
 
 			with GafferUI.ScrolledContainer( horizontalMode=GafferUI.ScrollMode.Never, borderWidth=4 ) :
 				self.__parameterValueWidget = GafferCortexUI.CompoundParameterValueWidget( self.node().parameterHandler(), collapsible = False )
-
-		self.setReadOnly( readOnly )
-
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.NodeUI.setReadOnly( self, readOnly )
-
-		self.__parameterValueWidget.plugValueWidget().setReadOnly( readOnly )
 
 for nodeType in __nodeTypes :
 	GafferUI.NodeUI.registerNodeUI( nodeType, _ParameterisedHolderNodeUI )

--- a/python/GafferCortexUITest/CompoundPlugValueWidgetTest.py
+++ b/python/GafferCortexUITest/CompoundPlugValueWidgetTest.py
@@ -61,26 +61,5 @@ class CompoundPlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertIsInstance( pw.childPlugValueWidget( n["c"]["i"] ), GafferUI.PlugValueWidget )
 		self.assertIsInstance( pw.childPlugValueWidget( n["c"]["s"] ), GafferUI.PlugValueWidget )
 
-	def testChildReadOnlyStatus( self ) :
-
-		n = Gaffer.Node()
-		n["c"] = Gaffer.Plug()
-		n["c"]["i"] = Gaffer.IntPlug()
-		n["c"]["s"] = Gaffer.StringPlug()
-
-		w = CompoundPlugValueWidget( n["c"] )
-		w.setReadOnly( True )
-
-		iw = w.childPlugValueWidget( n["c"]["i"] )
-		sw = w.childPlugValueWidget( n["c"]["s"] )
-
-		self.assertEqual( iw.getReadOnly(), True )
-		self.assertEqual( sw.getReadOnly(), True )
-
-		w.setReadOnly( False )
-
-		self.assertEqual( iw.getReadOnly(), False )
-		self.assertEqual( sw.getReadOnly(), False )
-
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -367,7 +367,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 				"subMenu" : functools.partial(
 					_CodeMenu.commonFunctionMenu,
 					command = plugValueWidget.codeWidget().insertText,
-					activator = lambda : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+					activator = lambda : not Gaffer.MetadataAlgo.readOnly( plug ),
 				),
 			},
 		)

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -150,7 +150,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : attributeName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				"active" : plug.settable() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -125,7 +125,7 @@ def __namesPopupMenu( menuDefinition, plugValueWidget ) :
 			menuPrefix + nameWithoutPrefix,
 			{
 				"command" : functools.partial( __toggleName, plug, nameWithoutPrefix ),
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				"active" : plug.settable() and not Gaffer.MetadataAlgo.readOnly( plug ),
 				"checkBox" : nameWithoutPrefix in currentNames,
 			}
 		)

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -74,15 +74,6 @@ class _ContextVariableListWidget( GafferUI.PlugValueWidget ) :
 		self.__layout = GafferUI.PlugLayout( plug )
 		self.__column[0] = self.__layout
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		self.__layout.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		return self.__layout.plugValueWidget( childPlug )
@@ -135,16 +126,6 @@ class _ContextVariableWidget( GafferUI.PlugValueWidget ) :
 				return w
 
 		return None
-
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
 
 	def _updateFromPlugs( self ) :
 

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -150,17 +150,6 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
-
 ##########################################################################
 # Metadata
 ##########################################################################
@@ -465,10 +454,8 @@ class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
 # Delete Plug
 ##########################################################################
 
-
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
-	readOnlyUI = plugValueWidget.getReadOnly()
 	plug = plugValueWidget.getPlug().ancestor( Gaffer.NameValuePlug )
 
 	if plug is not None and isinstance( plug.node(), GafferScene.OptionQuery ) :
@@ -476,7 +463,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/DeleteDivider", { "divider" : True } )
 
-		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not readOnlyUI and not Gaffer.MetadataAlgo.readOnly( plug ) } )
+		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not Gaffer.MetadataAlgo.readOnly( plug ) } )
 
 def __deletePlug( plug ) :
 

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -165,7 +165,7 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 			{
 				"command" : functools.partial( __toggleTag, plug, tag ),
 				"checkBox" : tag in currentTags,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				"active" : plug.settable() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -1023,7 +1023,7 @@ def __appendClippingPlaneMenuItems( menuDefinition, prefix, view, parentWidget )
 	if isinstance( parentWidget, GafferUI.Viewer ) :
 		editable = view.viewportGadget().getCameraEditable()
 	else :
-		editable = not parentWidget.getReadOnly()
+		editable = True
 
 	menuDefinition.append(
 		prefix + "/Fit To Selection",

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -328,7 +328,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			parameters = {
 				"command" : functools.partial( __setValue, plug, " ".join( sorted( newNames ) ) ),
 				"checkBox" : setName in currentNames,
-				"active" : plug.settable() and not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				"active" : plug.settable() and not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 
 		menuDefinition.prepend( "/Sets/%s" % pathFn( setName ), parameters )

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -150,17 +150,6 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
-
 ##########################################################################
 # Metadata
 ##########################################################################
@@ -564,7 +553,7 @@ def __setShaderFromLocationMenuDefinition( menu ) :
 			"/" + name,
 			{
 				"command" : functools.partial( __setShader, plugValueWidget.getPlug(), name ),
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plugValueWidget.getPlug() ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( plugValueWidget.getPlug() ),
 			}
 		)
 
@@ -601,7 +590,6 @@ GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = Fa
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
-	readOnlyUI = plugValueWidget.getReadOnly()
 	plug = plugValueWidget.getPlug().ancestor( Gaffer.NameValuePlug )
 
 	if plug is not None and isinstance( plug.node(), GafferScene.ShaderQuery ) :
@@ -609,7 +597,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/DeleteDivider", { "divider" : True } )
 
-		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not readOnlyUI and not Gaffer.MetadataAlgo.readOnly( plug ) } )
+		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not Gaffer.MetadataAlgo.readOnly( plug ) } )
 
 def __deletePlug( plug ) :
 

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -362,7 +362,7 @@ def __setShaderFromPathsMenuDefinition( plugValueWidget, paths ) :
 			"/" + name,
 			{
 				"command" : functools.partial( __setShader, plugValueWidget.getPlug(), name ),
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plugValueWidget.getPlug() ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( plugValueWidget.getPlug() ),
 			}
 		)
 

--- a/python/GafferUI/BoxPlugValueWidget.py
+++ b/python/GafferUI/BoxPlugValueWidget.py
@@ -65,16 +65,6 @@ class BoxPlugValueWidget( GafferUI.PlugValueWidget ) :
 		for c in self.__column :
 			c.setHighlighted( highlighted )
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for c in self.__column :
-			c.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		for w in self.__column :

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -295,7 +295,7 @@ def __unpromote( plug ) :
 	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
 		Gaffer.PlugAlgo.unpromote( plug )
 
-def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnlyUI = False ) :
+def __appendPlugPromotionMenuItems( menuDefinition, plug ) :
 
 	node = plug.node()
 	if node is None :
@@ -305,7 +305,7 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnlyUI = False ) :
 	if box is None :
 		return
 
-	readOnly = readOnlyUI or Gaffer.MetadataAlgo.readOnly( plug )
+	readOnly = Gaffer.MetadataAlgo.readOnly( plug )
 
 	ancestorLabel = {
 		Gaffer.ArrayPlug : "Array",
@@ -360,12 +360,12 @@ def __appendPlugPromotionMenuItems( menuDefinition, plug, readOnlyUI = False ) :
 # PlugValueWidget menu
 ##########################################################################
 
-def __appendPlugResetDefaultMenuItems( menuDefinition, plug, readOnlyUI ) :
+def __appendPlugResetDefaultMenuItems( menuDefinition, plug ) :
 
 	if not isinstance( plug.node(), Gaffer.Box ) :
 		return
 
-	readOnly = readOnlyUI or Gaffer.MetadataAlgo.readOnly( plug )
+	readOnly = Gaffer.MetadataAlgo.readOnly( plug )
 
 	menuDefinition.append(
 		"/Reset Default Value",
@@ -377,8 +377,8 @@ def __appendPlugResetDefaultMenuItems( menuDefinition, plug, readOnlyUI ) :
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
-	__appendPlugResetDefaultMenuItems( menuDefinition, plugValueWidget.getPlug(), readOnlyUI = plugValueWidget.getReadOnly() )
-	__appendPlugPromotionMenuItems( menuDefinition, plugValueWidget.getPlug(), readOnlyUI = plugValueWidget.getReadOnly() )
+	__appendPlugResetDefaultMenuItems( menuDefinition, plugValueWidget.getPlug() )
+	__appendPlugPromotionMenuItems( menuDefinition, plugValueWidget.getPlug() )
 
 GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugPopupMenu, scoped = False )
 
@@ -480,6 +480,6 @@ def __graphEditorPlugContextMenu( graphEditor, plug, menuDefinition ) :
 			}
 		)
 
-	__appendPlugPromotionMenuItems( menuDefinition, plug, readOnly )
+	__appendPlugPromotionMenuItems( menuDefinition, plug )
 
 GafferUI.GraphEditor.plugContextMenuSignal().connect( __graphEditorPlugContextMenu, scoped = False )

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -108,15 +108,6 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.setHighlighted( self, highlighted )
 		self.__compoundNumericWidget.setHighlighted( highlighted )
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-		self.__compoundNumericWidget.setReadOnly( readOnly )
-		self.__swatch.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		return self.__compoundNumericWidget.childPlugValueWidget( childPlug )

--- a/python/GafferUI/CompoundDataPlugValueWidget.py
+++ b/python/GafferUI/CompoundDataPlugValueWidget.py
@@ -83,15 +83,6 @@ class CompoundDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__layout = GafferUI.PlugLayout( plug )
 		self.__column[0] = self.__layout
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		self.__layout.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		return self.__layout.plugValueWidget( childPlug )

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -73,17 +73,6 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# End widgets managed by a subclass.
 				break
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			if isinstance( w, GafferUI.PlugValueWidget ) :
-				w.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		for widget in self.__row :
@@ -173,7 +162,7 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if not all( hasattr( p, "isGanged" ) for p in plugs ) :
 			return
 
-		readOnly = plugValueWidget.getReadOnly() or any( Gaffer.MetadataAlgo.readOnly( p ) for p in plugs )
+		readOnly = any( Gaffer.MetadataAlgo.readOnly( p ) for p in plugs )
 
 		if all( p.isGanged() for p in plugs ) :
 			menuDefinition.append( "/GangDivider", { "divider" : True } )

--- a/python/GafferUI/ContextQueryUI.py
+++ b/python/GafferUI/ContextQueryUI.py
@@ -147,17 +147,6 @@ class _OutputWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
-
 ##########################################################################
 # Metadata
 ##########################################################################
@@ -418,7 +407,6 @@ def __createContextQuery( plug ) :
 
 def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
-	readOnlyUI = plugValueWidget.getReadOnly()
 	queryPlug = plugValueWidget.getPlug().ancestor( Gaffer.NameValuePlug )
 
 	# For Query plugs on a ContextQuery, we allow deleting them
@@ -427,7 +415,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/DeleteDivider", { "divider" : True } )
 
-		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, queryPlug ), "active" : not readOnlyUI and not Gaffer.MetadataAlgo.readOnly( queryPlug ) } )
+		menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, queryPlug ), "active" : not Gaffer.MetadataAlgo.readOnly( queryPlug ) } )
 		return
 
 	# For ValuePlug in general, we offer the option to drive them with ContextQuery
@@ -440,7 +428,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	input = plug.getInput()
-	if input is not None or not plugValueWidget._editable() or Gaffer.MetadataAlgo.readOnly( plug ) or readOnlyUI:
+	if input is not None or not plugValueWidget._editable() or Gaffer.MetadataAlgo.readOnly( plug ) :
 		return
 
 	menuDefinition.prepend( "/ContextQueryDivider", { "divider" : True } )

--- a/python/GafferUI/LayoutPlugValueWidget.py
+++ b/python/GafferUI/LayoutPlugValueWidget.py
@@ -68,11 +68,6 @@ class LayoutPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return self.__orientation == GafferUI.ListContainer.Orientation.Vertical
 
-	def setReadOnly( self, readOnly ) :
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-		self.__layout.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		return self.__layout.plugValueWidget( childPlug )

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -178,11 +178,6 @@ class _InPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	def setReadOnly( self, readOnly ) :
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-		self.__plugLayout.setReadOnly( readOnly )
-
 	def childPlugValueWidget( self, childPlug ) :
 
 		return self.__plugLayout.plugValueWidget( childPlug )
@@ -392,16 +387,6 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__plugValueWidgets :
-			w.setReadOnly( readOnly )
-
 	def _updateFromPlug( self ) :
 
 		enabled = False
@@ -413,7 +398,7 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__plugValueWidgets[2].setEnabled( enabled )
 
 		self.__dragHandle.setEnabled(
-			not self.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+			not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
 		)
 
 	def __updateWidgetVisibility( self ) :

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -115,16 +115,6 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
 	def setNameVisible( self, visible ) :
 
 		self.__row[0].setVisible( visible )

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -86,7 +86,6 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 			)
 
 		self.__nodeUI = None
-		self.__readOnly = False
 
 		self._updateFromSet()
 
@@ -96,22 +95,6 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 
 		self._doPendingUpdate()
 		return self.__nodeUI
-
-	## \deprecated
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.__readOnly :
-			return
-
-		self.__readOnly = readOnly
-		if self.__nodeUI is not None :
-			self.__nodeUI.setReadOnly( readOnly )
-			self.__nameWidget.setEditable( not readOnly )
-
-	## \deprecated
-	def getReadOnly( self ) :
-
-		return self.__readOnly
 
 	__toolMenuSignal = Gaffer.Signals.Signal3()
 	## Returns a signal which is emitted to create the
@@ -165,7 +148,6 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 		self.__header.setVisible( True )
 
 		self.__nodeUI = GafferUI.NodeUI.create( node )
-		self.__nodeUI.setReadOnly( self.getReadOnly() )
 		self.__nodeUIFrame.setChild( self.__nodeUI )
 
 	def _titleFormat( self ) :

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -111,7 +111,6 @@ class NodeUI( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
 
 		self.__node = node
-		self.__readOnly = False
 
 	## Returns the node the ui represents.
 	def node( self ) :
@@ -125,17 +124,6 @@ class NodeUI( GafferUI.Widget ) :
 	def plugValueWidget( self, plug ) :
 
 		return None
-
-	## \deprecated
-	def setReadOnly( self, readOnly ) :
-
-		assert( isinstance( readOnly, bool ) )
-		self.__readOnly = readOnly
-
-	## \deprecated
-	def getReadOnly( self ) :
-
-		return self.__readOnly
 
 	## Creates a NodeUI instance for the specified node.
 	@classmethod
@@ -166,9 +154,7 @@ class NodeUI( GafferUI.Widget ) :
 	@staticmethod
 	def appendPlugDeletionMenuDefinitions( plugOrPlugValueWidget, menuDefinition ) :
 
-		readOnlyUI = False
 		if isinstance( plugOrPlugValueWidget, GafferUI.PlugValueWidget ) :
-			readOnlyUI = plugOrPlugValueWidget.getReadOnly()
 			plug = plugOrPlugValueWidget.getPlug()
 		else :
 			plug = plugOrPlugValueWidget
@@ -184,7 +170,7 @@ class NodeUI( GafferUI.Widget ) :
 		if len( menuDefinition.items() ) :
 			menuDefinition.append( "/DeleteDivider", { "divider" : True } )
 
-		menuDefinition.append( "/Delete", { "command" : functools.partial( NodeUI.__deletePlug, plug ), "active" : not readOnlyUI and not Gaffer.MetadataAlgo.readOnly( plug ) } )
+		menuDefinition.append( "/Delete", { "command" : functools.partial( NodeUI.__deletePlug, plug ), "active" : not Gaffer.MetadataAlgo.readOnly( plug ) } )
 
 	@staticmethod
 	def __deletePlug( plug ) :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -103,7 +103,6 @@ class PlugLayout( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, self.__layout, **kw )
 
 		self.__parent = parent
-		self.__readOnly = False
 		self.__layoutName = layoutName
 		# not to be confused with __rootSection, which holds an actual _Section object
 		self.__rootSectionName = rootSection
@@ -142,19 +141,6 @@ class PlugLayout( GafferUI.Widget ) :
 
 		# Build the layout
 		self.__update()
-
-	def getReadOnly( self ) :
-
-		return self.__readOnly
-
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		self.__readOnly = readOnly
-		for widget in self.__widgets.values() :
-			self.__applyReadOnly( widget, self.__readOnly )
 
 	def getContext( self ) :
 
@@ -451,7 +437,6 @@ class PlugLayout( GafferUI.Widget ) :
 				QWIDGETSIZE_MAX = 16777215 # qt #define not exposed by PyQt or PySide
 				result.labelPlugValueWidget().label()._qtWidget().setFixedWidth( QWIDGETSIZE_MAX )
 
-		self.__applyReadOnly( result, self.getReadOnly() )
 		self.__applyContext( result, self.getContext() )
 
 		# Store the metadata value that controlled the type created, so we can compare to it
@@ -522,19 +507,6 @@ class PlugLayout( GafferUI.Widget ) :
 		# upheaval is over.
 		self.__layoutDirty = True
 		self.__updateLazily()
-
-	def __applyReadOnly( self, widget, readOnly ) :
-
-		if widget is None :
-			return
-
-		if hasattr( widget, "setReadOnly" ) :
-			widget.setReadOnly( readOnly )
-		elif isinstance(  widget, GafferUI.PlugWidget ) :
-			widget.labelPlugValueWidget().setReadOnly( readOnly )
-			widget.plugValueWidget().setReadOnly( readOnly )
-		elif hasattr( widget, "plugValueWidget" ) :
-			widget.plugValueWidget().setReadOnly( readOnly )
 
 	def __applyContext( self, widget, context ) :
 

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -234,7 +234,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 			"/Randomise...",
 			{
 				"command" : functools.partial( __createRandom, plug ),
-				"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug ),
+				"active" : not Gaffer.MetadataAlgo.readOnly( plug ),
 			}
 		)
 

--- a/python/GafferUI/ShufflePlugValueWidget.py
+++ b/python/GafferUI/ShufflePlugValueWidget.py
@@ -99,16 +99,6 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
 	def _updateFromPlug( self ) :
 
 		with self.getContext() :
@@ -168,11 +158,6 @@ class ShufflesPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def hasLabel( self ) :
 
 		return True
-
-	def setReadOnly( self, readOnly ) :
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-		self.__plugLayout.setReadOnly( readOnly )
 
 	def childPlugValueWidget( self, childPlug ) :
 

--- a/python/GafferUI/SpreadsheetUI/_Menus.py
+++ b/python/GafferUI/SpreadsheetUI/_Menus.py
@@ -216,8 +216,7 @@ def __nodeEditorToolMenu( nodeEditor, node, menuDefinition ) :
 	menuDefinition.append( "/SpreadsheetDivider", { "divider" : True } )
 
 	itemsActive = (
-		not nodeEditor.getReadOnly()
-		and not Gaffer.MetadataAlgo.readOnly( node )
+		not Gaffer.MetadataAlgo.readOnly( node )
 		and not Gaffer.MetadataAlgo.readOnly( enabledRowNamesConnection )
 		and enabledRowNamesConnection.getInput() is None
 	)

--- a/python/GafferUI/StandardNodeUI.py
+++ b/python/GafferUI/StandardNodeUI.py
@@ -70,13 +70,4 @@ class StandardNodeUI( GafferUI.NodeUI ) :
 
 		return widget
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.NodeUI.setReadOnly( self, readOnly )
-
-		self.__plugLayout.setReadOnly( readOnly )
-
 GafferUI.NodeUI.registerNodeUI( Gaffer.Node, StandardNodeUI )

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -106,16 +106,6 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return None
 
-	def setReadOnly( self, readOnly ) :
-
-		if readOnly == self.getReadOnly() :
-			return
-
-		GafferUI.PlugValueWidget.setReadOnly( self, readOnly )
-
-		for w in self.__row :
-			w.setReadOnly( readOnly )
-
 	def setNameVisible( self, visible ) :
 
 		self.__row[0].setVisible( visible )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -374,7 +374,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 	menuDefinition.append( "/Edit UI...",
 		{
 			"command" : functools.partial( __editPlugUI, node, plug ),
-			"active" : not plugValueWidget.getReadOnly() and not Gaffer.MetadataAlgo.readOnly( plug )
+			"active" : not Gaffer.MetadataAlgo.readOnly( plug )
 		}
 	)
 

--- a/python/GafferUITest/StandardNodeUITest.py
+++ b/python/GafferUITest/StandardNodeUITest.py
@@ -57,22 +57,5 @@ class StandardNodeUITest( GafferUITest.TestCase ) :
 		self.assertTrue( isinstance( u.plugValueWidget( n["c"]["i"] ), GafferUI.PlugValueWidget ) )
 		self.assertTrue( u.plugValueWidget( n["c"]["i"] ).getPlug().isSame( n["c"]["i"] ) )
 
-	def testSetReadOnlyForUserPlugs( self ) :
-
-		n = Gaffer.Node()
-		n["user"]["a"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-
-		u = GafferUI.StandardNodeUI( n )
-		self.assertEqual( u.plugValueWidget( n["user"]["a"] ).getReadOnly(), False )
-
-		u.setReadOnly( True )
-		self.assertEqual( u.plugValueWidget( n["user"]["a"] ).getReadOnly(), True )
-
-		u = GafferUI.StandardNodeUI( n )
-		w = u.plugValueWidget( n["user"]["a"] )
-
-		u.setReadOnly( True )
-		self.assertEqual( w.getReadOnly(), True )
-
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
These are not used at all in the Gaffer codebase, so represent an unnecessary burden when subclassing or extending, particularly for custom PlugValueWidgets. I am about to make the PlugValueWidget API a little more complex for subclassing, and removing `set/getReadOnly()` will help to keep the overall burden lower.

One of the most burdensome aspects of this was the necessity of mirroring a parent widget's state onto all of its children. If we were ever to reintroduce a mechanism like this, we'd want it to be inherited through the widget layout hierarchy automatically somehow.

@ivanimanishi, I mooted doing this back in 2020, and it turned out there was at least some impact on the IE codebase. This is what you said back then :

> I will need some time to fully grasp what is involved here, particularly in relation to backward compatibility, but it's likely we'll find a way to make it work without requiring you to keep those methods around in Gaffer. I'll put in a ticket here at IE to address those changes and let Andrew prioritize it.

Are you happy to proceed with this now, or would you prefer we defer it?