### PR TITLE
FileMenu: Add option to skip asking and loading a backup

### DIFF
--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -100,7 +100,7 @@ def __addScript( application, fileName, dialogueParentWindow = None, asNew = Fal
 
 	recoveryFileName = None
 	backups = GafferUI.Backups.acquire( application, createIfNecessary = False )
-	if backups is not None :
+	if backups is not None and "DISABLE_BACKUP" not in os.environ :
 		recoveryFileName = backups.recoveryFile( fileName )
 		if recoveryFileName :
 			dialogue = GafferUI.ConfirmationDialogue(


### PR DESCRIPTION
Add an environmental variable which stops Gaffer from asking users if they want to open an already existing backup.

Sometimes it can get quite annoying when one opens Gaffer, then goes to grab a coffee, but only then realises that there was a backup which wasn't clicked, and thus we have to wait once more. It's a little annoyance that can add up.

I don't know if this warrants a entry in the change log since it is best to only exposes this feature to devs?

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
