### PR TITLE
Proposed fix for #4978

### DIFF
--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -747,7 +747,7 @@ class TaskParallel
 			template<typename F>
 			void execute( F &&f )
 			{
-				if( m_spawnsTasks && m_itemLock.lockType() == TaskMutex::ScopedLock::LockType::Write )
+				if( m_spawnsTasks )
 				{
 					// The getter function will spawn tasks. Execute
 					// it via the TaskMutex, so that other threads trying
@@ -815,9 +815,8 @@ class TaskParallel
 						// found a pre-existing item we optimistically take
 						// just a read lock, because it is faster when
 						// many threads just need to read from the same
-						// cached item. We accept WorkerRead locks when necessary,
-						// to support Getter recursion.
-						TaskMutex::ScopedLock::LockType lockType = TaskMutex::ScopedLock::LockType::WorkerRead;
+						// cached item.
+						TaskMutex::ScopedLock::LockType lockType = TaskMutex::ScopedLock::LockType::Read;
 						if( inserted || mode == FindWritable || mode == InsertWritable )
 						{
 							lockType = TaskMutex::ScopedLock::LockType::Write;

--- a/python/GafferSceneTest/RenameTest.py
+++ b/python/GafferSceneTest/RenameTest.py
@@ -60,7 +60,7 @@ class RenameTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( rename["out"].exists( "/group/sphere" ) )
 		self.assertScenesEqual( rename["out"], rename["in"] )
-		self.assertSceneHashesEqual( rename["out"], rename["in"] )
+		self.assertSceneHashesEqual( rename["out"], rename["in"], checks = self.allSceneChecks - { "sets" } )
 
 		# Filter, but not matching anything yet
 
@@ -69,7 +69,7 @@ class RenameTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( rename["out"].exists( "/group/sphere" ) )
 		self.assertScenesEqual( rename["out"], rename["in"] )
-		self.assertSceneHashesEqual( rename["out"], rename["in"] )
+		self.assertSceneHashesEqual( rename["out"], rename["in"], checks = self.allSceneChecks - { "sets" } )
 
 		# Filter matching something, but node disabled
 
@@ -589,6 +589,18 @@ class RenameTest( GafferSceneTest.SceneTestCase ) :
 		spreadsheet["rows"][1]["cells"]["newName"]["enabled"].setValue( True )
 		self.assertSceneValid( rename["out"] )
 		self.assertEqual( rename["out"].childNames( "/" )[0], "newSphere" )
+
+	def testSetPassThroughWithCacheEviction( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue( "setA" )
+
+		rename = GafferScene.Rename()
+		rename["in"].setInput( sphere["out"] )
+
+		rename["out"].set( "setA" )
+		Gaffer.ValuePlug.clearCache()
+		rename["out"].set( "setA" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
+++ b/python/GafferTest/IECorePreviewTest/TaskMutexTest.py
@@ -64,10 +64,6 @@ class TaskMutexTest( GafferTest.TestCase ) :
 
 		GafferTest.testTaskMutexHeavyContention( False )
 
-	def testWorkerRecursion( self ) :
-
-		GafferTest.testTaskMutexWorkerRecursion()
-
 	def testAcquireOr( self ) :
 
 		GafferTest.testTaskMutexAcquireOr()

--- a/src/Gaffer/ComputeNode.cpp
+++ b/src/Gaffer/ComputeNode.cpp
@@ -89,7 +89,7 @@ ValuePlug::CachePolicy ComputeNode::computeCachePolicy( const ValuePlug *output 
 	{
 		return ValuePlug::CachePolicy::Uncached;
 	}
-	/// \todo Return `Standard` once all task-spawning computes are
+	/// \todo Return `Standard` once all task-spawning computes are <===== NO
 	/// known to be declaring an appropriate policy.
 	return ValuePlug::CachePolicy::Legacy;
 }

--- a/src/GafferScene/FilterResults.cpp
+++ b/src/GafferScene/FilterResults.cpp
@@ -162,6 +162,10 @@ void FilterResults::hash( const Gaffer::ValuePlug *output, const Gaffer::Context
 		ScenePlug::ScenePath rootPath;
 		ScenePlug::stringToPath( rootPlug()->getValue(), rootPath );
 		h.append( SceneAlgo::matchingPathsHash( filterPlug(), scenePlug(), rootPath ) );
+		// Ensure hash is unique to this plug, to avoid deadlocks that would be
+		// caused by depending on an identical upstream FilterResults output.
+		// See `SetTest.testRecursion()` and `FilterResults.testComputeCacheRecursion()`.
+		h.append( (uint64_t)output );
 	}
 	else if( output == outPlug() )
 	{

--- a/src/GafferScene/Rename.cpp
+++ b/src/GafferScene/Rename.cpp
@@ -845,16 +845,9 @@ void Rename::hashSet( const IECore::InternedString &setName, const Gaffer::Conte
 		}
 	);
 
-	if( renamesHash != MurmurHash() )
-	{
-		FilteredSceneProcessor::hashSet( setName, context, parent, h );
-		h.append( inputSetHash );
-		h.append( renamesHash );
-	}
-	else
-	{
-		h = inputSetHash;
-	}
+	FilteredSceneProcessor::hashSet( setName, context, parent, h );
+	h.append( inputSetHash );
+	h.append( renamesHash );
 }
 
 IECore::ConstPathMatcherDataPtr Rename::computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const


### PR DESCRIPTION
This is a draft PR with a proposed fix for the deadlock highlighted in #4978. I've done my best to explain what I understand so far in the first commit message. While my understanding is certainly incomplete, I do think the fix is real. And the semi-related performance problem I highlighted in `testChainedNodesWithIdenticalBranches` is what convinced me to pursue this direction for the fix, rather than doubling down on trying to fix WorkerRead recursion somehow. The result is a simpler TaskMutex, but a need to be more careful implementing `ComputeNode::hash()` for TBB-based computes (although given the deadlock, I think the truth is that those requirements already existed, but were harder to trigger before). The implications for real-world performance are unclear. It seems likely that best-case performance is worse, but the improvements in pathological case performance are vast (orders of magnitude in that test).

Technically we don't need the second commit. We could keep the WorkerRead stuff around longer as a (not completely reliable) safety net for any `hash()` fixes we've missed. Or we could keep it but add a warning when detecting attempts at worker recursion. But ultimately I think we should definitely remove all that stuff - it's just a matter of when.

The main reason this is a draft PR is that I still have a small list of nodes that I need to check the `hash()` implementation for. I believe there are a couple of bugs still to fix. But I wanted to get this up now in the hope of having thoughts from @danieldresser-ie to read tomorrow morning...