### PR TITLE
ImageView : Use presets to store possible catalog outputs to select

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - UIEditor : Added `Allow Custom Values` checkbox to the Widget Settings section for the Presets Menu widget. When on, this allows the user to enter their own custom values in addition to choosing presets from the menu.
+- Image View : Added support for custom presets for choosing catalogue outputs to compare to.  This can be set up like `Gaffer.Metadata.registerNodeValue( GafferImageUI.ImageView, "compare.catalogueOutput", "preset:MyPreset", "myNamespace:specialImage" )`.  The Catalogue won't know how to deal with a request for "myNamespace:specialImage", and will just output an error image, but this could be useful in pipelines where Catalogue's are wrapped in custom nodes that can respond to this special value of the `catalogue:imageName`.  If you want to provide a custom icon for your custom mode, Gaffer will search for an icon name `catalogueOutput{preset name}.png`.
 
 1.1.5.0 (relative to 1.1.4.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Improvements
 - UIEditor : Added `Allow Custom Values` checkbox to the Widget Settings section for the Presets Menu widget. When on, this allows the user to enter their own custom values in addition to choosing presets from the menu.
 - Image View : Added support for custom presets for choosing catalogue outputs to compare to.  This can be set up like `Gaffer.Metadata.registerNodeValue( GafferImageUI.ImageView, "compare.catalogueOutput", "preset:MyPreset", "myNamespace:specialImage" )`.  The Catalogue won't know how to deal with a request for "myNamespace:specialImage", and will just output an error image, but this could be useful in pipelines where Catalogue's are wrapped in custom nodes that can respond to this special value of the `catalogue:imageName`.  If you want to provide a custom icon for your custom mode, Gaffer will search for an icon name `catalogueOutput{preset name}.png`.
 
+Fixes
+-----
+
+- Viewer : Added missing missing bookmarks 1-4 to the image comparison menu.
+
 1.1.5.0 (relative to 1.1.4.0)
 =======
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1401,7 +1401,7 @@ class _CompareParentPlugValueWidget( GafferUI.PlugValueWidget ) :
 		node = self.__dropNode( event )
 
 		if node:
-			self.__row[-1]._setState( Gaffer.StandardSet( [ node ] ), 0 )
+			self.__row[-1]._setState( Gaffer.StandardSet( [ node ] ), "" )
 
 			if not self.getPlug()["mode"].getValue():
 				self.getPlug()["mode"].setValue( self.__row[0]._CompareModePlugValueWidget__hotkeyTarget() )
@@ -1592,6 +1592,9 @@ class _CompareImageWidget( GafferUI.Frame ) :
 		self._setState( self.__defaultNodeSet, Gaffer.NodeAlgo.presets( self.__node["compare"]["catalogueOutput"] )[0] )
 
 	def _setState( self, nodeSet, catalogueOutputPreset ):
+
+		assert( isinstance( catalogueOutputPreset, str ) )
+
 		self.__nodeSet = nodeSet
 		self.__catalogueOutput = catalogueOutputPreset
 		self.__memberAddedConnection = self.__nodeSet.memberAddedSignal().connect(
@@ -1675,19 +1678,19 @@ class _CompareImageWidget( GafferUI.Frame ) :
 		return "\n".join( toolTipElements )
 
 	def __pinToNodeSelection( self, *unused ) :
-		self._setState( Gaffer.StandardSet( list( self.__scriptNode.selection() ) ), 0 )
+		self._setState( Gaffer.StandardSet( list( self.__scriptNode.selection() ) ), "" )
 
 	def __followNodeSelection( self, *unused ) :
-		self._setState( self.__scriptNode.selection(), 0 )
+		self._setState( self.__scriptNode.selection(), "" )
 
 	def __followFocusNode( self, *unused ) :
-		self._setState( self.__scriptNode.focusSet(), 0 )
+		self._setState( self.__scriptNode.focusSet(), "" )
 
 	def __followCatalogueOutput( self, i, *unused ) :
 		self._setState( self.__defaultNodeSet, i )
 
 	def __followBookmark( self, i, *unused ) :
-		self._setState( Gaffer.NumericBookmarkSet( self.__scriptNode, i ), 0 )
+		self._setState( Gaffer.NumericBookmarkSet( self.__scriptNode, i ), "" )
 
 
 	def __showEditorFocusMenu( self, *unused ) :

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1699,10 +1699,10 @@ class _CompareImageWidget( GafferUI.Frame ) :
 
 		m.append( "/Catalogue Divider", { "divider" : True, "label" : "Follow Catalogue Output" } )
 		for i in Gaffer.NodeAlgo.presets( self.__node["compare"]["catalogueOutput"] ):
-			m.append( "/" + i, {
+			m.append( "/CatalogueOutput{}".format( i ), {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__followCatalogueOutput ), i ),
-				"checkBox" : self.__catalogueOutput == i
-				#"shortCut" : "`"
+				"checkBox" : self.__catalogueOutput == i,
+				"label" : i,
 			} )
 		m.append( "/Pin Divider", { "divider" : True, "label" : "Pin" } )
 
@@ -1743,9 +1743,10 @@ class _CompareImageWidget( GafferUI.Frame ) :
 			if bookmarkNode is not None :
 				title += " : %s" % bookmarkNode.getName()
 			isCurrent = isinstance( self.__nodeSet, Gaffer.NumericBookmarkSet ) and self.__nodeSet.getBookmark() == i
-			m.append( "%s" % title, {
+			m.append( "/NumericBookMark{}".format( i ), {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__followBookmark ), i ),
 				"checkBox" : isCurrent,
+				"label" : title,
 			} )
 
 		self.__pinningMenu = GafferUI.Menu( m, title = "Comparison Image" )

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -1284,7 +1284,14 @@ void Catalogue::compute( ValuePlug *output, const Context *context ) const
 
 		if( boost::starts_with( imageName, g_outputPrefix ) )
 		{
-			outputIndex = std::stoi( imageName.substr( g_outputPrefix.size() ) );
+			try
+			{
+				outputIndex = std::stoi( imageName.substr( g_outputPrefix.size() ) );
+			}
+			catch( ... )
+			{
+				// If stoi failed, leave the outputIndex at 0
+			}
 		}
 
 		std::string result;


### PR DESCRIPTION
The goal is to allow you to do something like:

`Gaffer.Metadata.registerNodeValue( GafferImageUI.ImageView, "compare.catalogueOutput", "preset:Plate", "output:plate" )`

to add another option to the catalog outputs.  This won't do anything with default catalogs, but you can then wrap a catalog in a custom node that does something special in response to a value of "output:plate" in "catalogue:imageName".

This was a fairly hasty implementation, but it seems to work.  Biggest issue is probably what to do about icons ... currently, I've just used the circle with a hash in it for all custom output types, just because it's a matching icon that was already lying around.