### PR TITLE
GafferVDB nodes : Use TaskCollaboration cache policy as appropriate

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
 - Expression : Fixed non-deterministic parsing order for Python expressions (#4935).
 - FileSequencePathFilter : Fixed bug whereby files were considered to be part of a sequence if they were in a numbered directory. Now only numbers in the file's name are considered.
 - BoolWidget : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
+- GafferTest : Fixed bug which caused `parallelGetValue()` to use the wrong context.
 
 API
 ---
@@ -44,6 +45,7 @@ API
 - SceneGadget : Added `setVisibleSet()`, and `getVisibleSet()` methods.
 - EditScopeAlgo : Added methods to modify and query modifications to set members in an Edit Scope.
 - Widget : Added support for a `_postContructor()` method, which is called after the widget is fully constructed. This can be useful for performing post-initialisation work from a base class.
+- GafferTest : Added ObjectPlug overloads for `repeatGetValue()` and `parallelGetValue()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
 - Expression : Fixed non-deterministic parsing order for Python expressions (#4935).
 - FileSequencePathFilter : Fixed bug whereby files were considered to be part of a sequence if they were in a numbered directory. Now only numbers in the file's name are considered.
 - BoolWidget : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
+- LevelSetOffset, MeshToLevelSet, LevelSetToMesh, SphereLevelSet : Fixed bugs which could cause unnecessary repeated computations, or in the worst case, lead to deadlock.
 - GafferTest : Fixed bug which caused `parallelGetValue()` to use the wrong context.
 
 API
@@ -46,6 +47,7 @@ API
 - EditScopeAlgo : Added methods to modify and query modifications to set members in an Edit Scope.
 - Widget : Added support for a `_postContructor()` method, which is called after the widget is fully constructed. This can be useful for performing post-initialisation work from a base class.
 - GafferTest : Added ObjectPlug overloads for `repeatGetValue()` and `parallelGetValue()`.
+- SceneTestCase : Added `assertParallelGetValueComputesObjectOnce()`. This can be used to check that expensive computes are using an appropriate cache policy.
 
 Breaking Changes
 ----------------

--- a/include/GafferVDB/LevelSetOffset.h
+++ b/include/GafferVDB/LevelSetOffset.h
@@ -69,6 +69,7 @@ class GAFFERVDB_API LevelSetOffset : public GafferScene::Deformer
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
 
 		bool affectsProcessedObjectBound( const Gaffer::Plug *input ) const override;
 		void hashProcessedObjectBound( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferVDB/LevelSetToMesh.h
+++ b/include/GafferVDB/LevelSetToMesh.h
@@ -72,6 +72,7 @@ class GAFFERVDB_API LevelSetToMesh : public GafferScene::Deformer
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
 
 	private :
 

--- a/include/GafferVDB/MeshToLevelSet.h
+++ b/include/GafferVDB/MeshToLevelSet.h
@@ -79,6 +79,7 @@ class GAFFERVDB_API MeshToLevelSet : public GafferScene::ObjectProcessor
 		bool affectsProcessedObject( const Gaffer::Plug *plug ) const override;
 		void hashProcessedObject( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeProcessedObject( const ScenePath &path, const Gaffer::Context *context, const IECore::Object *inputObject ) const override;
+		Gaffer::ValuePlug::CachePolicy processedObjectComputeCachePolicy() const override;
 
 	private :
 

--- a/include/GafferVDB/SphereLevelSet.h
+++ b/include/GafferVDB/SphereLevelSet.h
@@ -80,6 +80,8 @@ class GAFFERVDB_API SphereLevelSet : public GafferScene::ObjectSource
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -43,6 +43,7 @@ import IECore
 import IECoreScene
 
 import Gaffer
+import GafferTest
 import GafferImageTest
 import GafferScene
 import GafferSceneTest
@@ -358,6 +359,20 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 			v2 = getattr( box1, n )()
 			for i in range( 0, 3 ) :
 				self.assertAlmostEqual( v1[i], v2[i], places )
+
+	def assertParallelGetValueComputesObjectOnce( self, scene, path ) :
+
+		with Gaffer.PerformanceMonitor() as pm :
+			with Gaffer.Context() as c :
+				c["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
+				GafferTest.parallelGetValue( scene["object"], 100 )
+
+		if isinstance( scene.node(), GafferScene.ObjectProcessor ) :
+			self.assertEqual( pm.plugStatistics( scene.node()["__processedObject"] ).computeCount, 1 )
+		elif isinstance( scene.node(), GafferScene.ObjectSource ) :
+			self.assertEqual( pm.plugStatistics( scene.node()["__source"] ).computeCount, 1 )
+		else :
+			self.assertEqual( pm.plugStatistics( scene["object"] ).computeCount, 1 )
 
 	__uniqueInts = {}
 	@classmethod

--- a/python/GafferVDBTest/LevelSetOffsetTest.py
+++ b/python/GafferVDBTest/LevelSetOffsetTest.py
@@ -34,6 +34,10 @@
 #
 ##########################################################################
 
+import os
+
+import IECore
+
 import GafferScene
 import GafferVDB
 import GafferVDBTest
@@ -67,3 +71,18 @@ class LevelSetOffsetTest( GafferVDBTest.VDBTestCase ) :
 		levelSetOffset["offset"].setValue( 1.0 )
 		self.assertAlmostEqual( 4.0, levelSetOffset['out'].bound( "sphere" ).max()[0], delta = 0.05 )
 		self.assertTrue( 640 <= levelSetOffset['out'].object( "sphere" ).findGrid( "surface" ).leafCount() <= 650)
+
+	def testParallelGetValueComputesObjectOnce( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "data", "sphere.vdb" ) )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/vdb" ] ) )
+
+		offset = GafferVDB.LevelSetOffset()
+		offset["in"].setInput( reader["out"] )
+		offset["filter"].setInput( pathFilter["out"] )
+		offset["grid"].setValue( "ls_sphere" )
+
+		self.assertParallelGetValueComputesObjectOnce( offset["out"], "/vdb" )

--- a/python/GafferVDBTest/LevelSetOffsetTest.py
+++ b/python/GafferVDBTest/LevelSetOffsetTest.py
@@ -34,26 +34,14 @@
 #
 ##########################################################################
 
-
-import os
-
-import IECore
-import IECoreScene
-import IECoreVDB
-
-import GafferTest
 import GafferScene
 import GafferVDB
 import GafferVDBTest
 
-
 class LevelSetOffsetTest( GafferVDBTest.VDBTestCase ) :
-	def setUp( self ) :
-		GafferVDBTest.VDBTestCase.setUp( self )
-		self.sourcePath = os.path.join( self.dataDir, "sphere.vdb" )
-		self.sceneInterface = IECoreScene.SceneInterface.create( self.sourcePath, IECore.IndexedIO.OpenMode.Read )
 
 	def testBoundsUpdated( self ) :
+
 		sphere = GafferScene.Sphere()
 		sphere["radius"].setValue( 5 )
 

--- a/python/GafferVDBTest/LevelSetToMeshTest.py
+++ b/python/GafferVDBTest/LevelSetToMeshTest.py
@@ -34,26 +34,17 @@
 #
 ##########################################################################
 
-import os
-import imath
-
-import IECore
 import IECoreScene
 import IECoreVDB
 
-import GafferTest
 import GafferScene
 import GafferVDB
 import GafferVDBTest
 
 class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 
-	def setUp( self ) :
-		GafferVDBTest.VDBTestCase.setUp( self )
-		self.sourcePath = os.path.join( self.dataDir, "sphere.vdb" )
-		self.sceneInterface = IECoreScene.SceneInterface.create( self.sourcePath, IECore.IndexedIO.OpenMode.Read )
-
 	def testCanConvertLevelSetToMesh( self ) :
+
 		sphere = GafferScene.Sphere()
 		meshToLevelSet = GafferVDB.MeshToLevelSet()
 		self.setFilter( meshToLevelSet, path='/sphere' )
@@ -112,6 +103,7 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 		self.assertTrue( bound.intersects( levelSetToMesh["out"].bound( "/sphere" ).max() ) )
 
 	def testIncreasingAdapativityDecreasesPolyCount( self ) :
+
 		sphere = GafferScene.Sphere()
 		sphere["radius"].setValue( 5 )
 

--- a/python/GafferVDBTest/LevelSetToMeshTest.py
+++ b/python/GafferVDBTest/LevelSetToMeshTest.py
@@ -34,6 +34,9 @@
 #
 ##########################################################################
 
+import os
+
+import IECore
 import IECoreScene
 import IECoreVDB
 
@@ -123,3 +126,18 @@ class LevelSetToMeshTest( GafferVDBTest.VDBTestCase ) :
 
 		levelSetToMesh['adaptivity'].setValue(1.0)
 		self.assertTrue( 2800 <= len( levelSetToMesh['out'].object( "sphere" ).verticesPerFace ) <= 3200 )
+
+	def testParallelGetValueComputesObjectOnce( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "data", "sphere.vdb" ) )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/vdb" ] ) )
+
+		levelSetToMesh = GafferVDB.LevelSetToMesh()
+		levelSetToMesh["in"].setInput( reader["out"] )
+		levelSetToMesh["filter"].setInput( pathFilter["out"] )
+		levelSetToMesh["grid"].setValue( "ls_sphere" )
+
+		self.assertParallelGetValueComputesObjectOnce( levelSetToMesh["out"], "/vdb" )

--- a/python/GafferVDBTest/MeshToLevelSetTest.py
+++ b/python/GafferVDBTest/MeshToLevelSetTest.py
@@ -36,6 +36,7 @@
 
 import time
 
+import IECore
 import IECoreVDB
 
 import Gaffer
@@ -166,3 +167,16 @@ class MeshToLevelSetTest( GafferVDBTest.VDBTestCase ) :
 			vdbAfterCancellation.findGrid( "surface" ).activeVoxelCount(),
 			vdb.findGrid( "surface" ).activeVoxelCount(),
 		)
+
+	def testParallelGetValueComputesObjectOnce( self ) :
+
+		cube = GafferScene.Cube()
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		meshToLevelSet = GafferVDB.MeshToLevelSet()
+		meshToLevelSet["in"].setInput( cube["out"] )
+		meshToLevelSet["filter"].setInput( pathFilter["out"] )
+
+		self.assertParallelGetValueComputesObjectOnce( meshToLevelSet["out"], "/cube" )

--- a/python/GafferVDBTest/MeshToLevelSetTest.py
+++ b/python/GafferVDBTest/MeshToLevelSetTest.py
@@ -36,13 +36,11 @@
 
 import time
 
-import GafferTest
+import IECoreVDB
 
 import Gaffer
+import GafferTest
 import GafferVDB
-import IECore
-import IECoreScene
-import IECoreVDB
 import GafferVDBTest
 import GafferScene
 

--- a/python/GafferVDBTest/SphereLevelSetTest.py
+++ b/python/GafferVDBTest/SphereLevelSetTest.py
@@ -104,6 +104,11 @@ class SphereLevelSetTest( GafferVDBTest.VDBTestCase ) :
 		translatedLeafCount = sphereLevelSet['out'].object( "vdb" ).findGrid( "surface" ).leafCount()
 		self.assertTrue( abs( translatedLeafCount - newLeafCount ) < 10 )
 
+	def testParallelGetValueComputesObjectOnce( self ) :
+
+		sphere = GafferVDB.SphereLevelSet()
+		self.assertParallelGetValueComputesObjectOnce( sphere["out"], "/sphere" )
+
 	def assertBoundsNearlyEqual( self, lhs, rhs ):
 		self.assertAlmostEqual( lhs.min()[0], lhs.min()[0] )
 		self.assertAlmostEqual( lhs.min()[1], lhs.min()[1] )

--- a/src/GafferVDB/LevelSetOffset.cpp
+++ b/src/GafferVDB/LevelSetOffset.cpp
@@ -156,6 +156,11 @@ IECore::ConstObjectPtr LevelSetOffset::computeProcessedObject( const ScenePath &
 	return newVDBObject;
 }
 
+Gaffer::ValuePlug::CachePolicy LevelSetOffset::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}
+
 bool LevelSetOffset::affectsProcessedObjectBound( const Gaffer::Plug *input ) const
 {
 	return

--- a/src/GafferVDB/LevelSetToMesh.cpp
+++ b/src/GafferVDB/LevelSetToMesh.cpp
@@ -257,3 +257,8 @@ IECore::ConstObjectPtr LevelSetToMesh::computeProcessedObject( const ScenePath &
 
 	return volumeToMesh( grid, isoValuePlug()->getValue(), adaptivityPlug()->getValue() );
 }
+
+Gaffer::ValuePlug::CachePolicy LevelSetToMesh::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}

--- a/src/GafferVDB/MeshToLevelSet.cpp
+++ b/src/GafferVDB/MeshToLevelSet.cpp
@@ -242,3 +242,8 @@ IECore::ConstObjectPtr MeshToLevelSet::computeProcessedObject( const ScenePath &
 
 	return newVDBObject;
 }
+
+Gaffer::ValuePlug::CachePolicy MeshToLevelSet::processedObjectComputeCachePolicy() const
+{
+	return ValuePlug::CachePolicy::TaskCollaboration;
+}

--- a/src/GafferVDB/SphereLevelSet.cpp
+++ b/src/GafferVDB/SphereLevelSet.cpp
@@ -170,3 +170,12 @@ IECore::ConstObjectPtr SphereLevelSet::computeSource( const Context *context ) c
 	return newVDBObject;
 
 }
+
+Gaffer::ValuePlug::CachePolicy SphereLevelSet::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == sourcePlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return ObjectSource::computeCachePolicy( output );
+}


### PR DESCRIPTION
The VDB algorithms all use TBB internally, so we must use TaskCollaboration to ensure that waiting threads do useful work for the compute that they are waiting for, and also so that TBB doesn't steal an outer task that could lead to deadlock. This substantially improves the performance of all the newly added test cases.