### PR TITLE
Animation enum description metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,11 +11,19 @@ Improvements
 
 - UIEditor : Added `Allow Custom Values` checkbox to the Widget Settings section for the Presets Menu widget. When on, this allows the user to enter their own custom values in addition to choosing presets from the menu.
 - Image View : Added support for custom presets for choosing catalogue outputs to compare to.  This can be set up like `Gaffer.Metadata.registerNodeValue( GafferImageUI.ImageView, "compare.catalogueOutput", "preset:MyPreset", "myNamespace:specialImage" )`.  The Catalogue won't know how to deal with a request for "myNamespace:specialImage", and will just output an error image, but this could be useful in pipelines where Catalogue's are wrapped in custom nodes that can respond to this special value of the `catalogue:imageName`.  If you want to provide a custom icon for your custom mode, Gaffer will search for an icon name `catalogueOutput{preset name}.png`.
+- Animation Editor : Added UI tooltips to menu items for TieMode and Interpolation.
 
 Fixes
 -----
 
 - Viewer : Added missing missing bookmarks 1-4 to the image comparison menu.
+
+API
+---
+
+- Animation :
+  - Added `description` metadata for `Animation.Interpolation` enum values that is used to generate UI tooltips.
+  - Added `description` metadata for `Animation.TieMode` enum values that is used to generate UI tooltips.
 
 1.1.5.0 (relative to 1.1.4.0)
 =======

--- a/include/Gaffer/Animation.h
+++ b/include/Gaffer/Animation.h
@@ -61,14 +61,19 @@ class GAFFER_API Animation : public ComputeNode
 		/// Defines the method used to interpolate between a key and the next one.
 		enum class Interpolation
 		{
+			/// Curve span has in key's value.
 			Constant = 0,
+			/// Curve span has out key's value.
 			ConstantNext,
+			/// Curve span is linearly interpolated between values of in key and out key.
 			Linear,
+			/// Curve span is smoothly interpolated between values of in key and out key using tangent slope.
 			Cubic,
+			/// Curve span is smoothly interpolated between values of in key and out key using tangent slope and scale.
 			Bezier
 		};
 
-		/// Defines direction relative to a key.
+		/// Defines direction relative to a key or curve span.
 		enum class Direction
 		{
 			In = 0,
@@ -78,8 +83,11 @@ class GAFFER_API Animation : public ComputeNode
 		/// Defines whether slope and scale are tied.
 		enum class TieMode
 		{
+			/// Tangent slope and scale can be independently adjusted.
 			Manual = 0,
+			/// Tangent slopes are kept equal.
 			Slope,
+			/// Tangent slopes are kept equal and scales are kept proportional.
 			Scale
 		};
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -456,6 +456,16 @@ class _KeyWidget( GafferUI.GridContainer ) :
 		slopeToolTip = "# Slope\n\nThe slope of the %stangents of the currently selected keys."
 		scaleToolTip = "# Scale\n\nThe scale of the %stangents of the currently selected keys."
 
+		# append interpolation mode descriptions to tooltip
+		for mode in sorted( Gaffer.Animation.Interpolation.values.values() ) :
+			description = Gaffer.Metadata.value( "Animation.Interpolation.%s" % mode.name, "description" )
+			interpolationToolTip += "\n* %s%s" % ( mode.name, " : %s" % description if description is not None else "" )
+
+		# append tie mode descriptions to tooltip
+		for mode in sorted( Gaffer.Animation.TieMode.values.values() ) :
+			description = Gaffer.Metadata.value( "Animation.TieMode.%s" % mode.name, "description" )
+			tieModeToolTip += "\n* %s%s" % ( mode.name, " : %s" % description if description is not None else "" )
+
 		# create labels
 		frameLabel = GafferUI.Label( text="Frame", toolTip=frameToolTip )
 		valueLabel = GafferUI.Label( text="Value", toolTip=valueToolTip )

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -342,7 +342,8 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 						mode=mode
 					),
 					"active" : not emptySelectedKeys,
-					"checkBox" : interpolation == mode
+					"checkBox" : interpolation == mode,
+					"description" : Gaffer.Metadata.value( "Animation.Interpolation.%s" % mode.name, "description" ),
 				}
 			)
 
@@ -355,7 +356,8 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 						mode=mode
 					),
 					"active" : not emptySelectedKeys,
-					"checkBox" : tieMode == mode
+					"checkBox" : tieMode == mode,
+					"description" : Gaffer.Metadata.value( "Animation.TieMode.%s" % mode.name, "description" ),
 				}
 			)
 
@@ -492,7 +494,9 @@ class _KeyWidget( GafferUI.GridContainer ) :
 		for mode in sorted( Gaffer.Animation.Interpolation.values.values() ) :
 			im.append( "%s" % ( mode.name ), {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setInterpolation ), mode=mode ),
-				"checkBox" : functools.partial( Gaffer.WeakMethod( self.__checkBoxStateForKeyInterpolation ), mode=mode ) } )
+				"checkBox" : functools.partial( Gaffer.WeakMethod( self.__checkBoxStateForKeyInterpolation ), mode=mode ),
+				"description" : Gaffer.Metadata.value( "Animation.Interpolation.%s" % mode.name, "description" ),
+			} )
 		self.__interpolationEditor.setMenu( GafferUI.Menu( im ) )
 
 		# build tie mode menu
@@ -500,7 +504,9 @@ class _KeyWidget( GafferUI.GridContainer ) :
 		for mode in sorted( Gaffer.Animation.TieMode.values.values() ) :
 			tm.append( "%s" % ( mode.name ), {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setTieMode ), mode=mode ),
-				"checkBox" : functools.partial( Gaffer.WeakMethod( self.__checkBoxStateForTieMode ), mode=mode ) } )
+				"checkBox" : functools.partial( Gaffer.WeakMethod( self.__checkBoxStateForTieMode ), mode=mode ),
+				"description" : Gaffer.Metadata.value( "Animation.TieMode.%s" % mode.name, "description" ),
+			} )
 		self.__tieModeEditor.setMenu( GafferUI.Menu( tm ) )
 
 		# setup editor connections

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -73,6 +73,16 @@ Gaffer.Metadata.registerNode(
 
 )
 
+Gaffer.Metadata.registerValue( "Animation.Interpolation.Constant", "description", "Curve span has in key's value." )
+Gaffer.Metadata.registerValue( "Animation.Interpolation.ConstantNext", "description", "Curve span has out key's value." )
+Gaffer.Metadata.registerValue( "Animation.Interpolation.Linear", "description", "Curve span is linearly interpolated between values of in key and out key." )
+Gaffer.Metadata.registerValue( "Animation.Interpolation.Cubic", "description", "Curve span is smoothly interpolated between values of in key and out key using tangent slope." )
+Gaffer.Metadata.registerValue( "Animation.Interpolation.Bezier", "description", "Curve span is smoothly interpolated between values of in key and out key using tangent slope and scale." )
+
+Gaffer.Metadata.registerValue( "Animation.TieMode.Manual", "description", "Tangent slope and scale can be independently adjusted." )
+Gaffer.Metadata.registerValue( "Animation.TieMode.Slope", "description", "Tangent slopes are kept equal." )
+Gaffer.Metadata.registerValue( "Animation.TieMode.Scale", "description", "Tangent slopes are kept equal and scales are kept proportional." )
+
 # PlugValueWidget popup menu for setting keys
 ##########################################################################
 

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -145,6 +145,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 					),
 					"active" : spanKeyOnThisFrame and plugValueWidget._editable( canEditAnimation = True ),
 					"checkBox" : spanKeyOnThisFrame and ( spanKey.getInterpolation() == mode ),
+					"description" : Gaffer.Metadata.value( "Animation.Interpolation.%s" % mode.name, "description" ),
 				}
 			)
 


### PR DESCRIPTION
This PR is a rewrite of #4492 that uses Gaffer's metadata system.

`description` metadata can now be registered for individual enum values of `Animation.Interpolation` and `Animation.TieMode`.

This `description` metadata is then used to generate UI tooltips for menu items and to improve the tooltips of the existing  interpolation and tie mode controls in the `AnimationEditor`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
