### PR TITLE
ValuePlug : Avoid deadlock between TaskParallel and Legacy compute

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ Fixes
 - FileSequencePathFilter : Fixed bug whereby files were considered to be part of a sequence if they were in a numbered directory. Now only numbers in the file's name are considered.
 - BoolWidget : Fixed bug triggered by calling `setImage()` from within a `with widgetContainer` block.
 - LevelSetOffset, MeshToLevelSet, LevelSetToMesh, SphereLevelSet : Fixed bugs which could cause unnecessary repeated computations, or in the worst case, lead to deadlock.
+- ValuePlug : Fixed rare deadlock when a TaskParallel compute recurses to a Legacy compute with the _same_ hash.
 - GafferTest : Fixed bug which caused `parallelGetValue()` to use the wrong context.
 
 API

--- a/include/Gaffer/Private/IECorePreview/LRUCache.h
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.h
@@ -132,6 +132,13 @@ class LRUCache : private boost::noncopyable
 		/// when true is returned, the item may be removed from the cache by a
 		/// subsequent (or concurrent) operation.
 		bool set( const Key &key, const Value &value, Cost cost );
+		/// As above, but only if the item is not cached already. This avoids
+		/// calling a potentially expensive cost function in the case that the
+		/// item is cached already.
+		/// \todo Ideally we wouldn't need the cost calculation to be duplicated
+		/// between CostFunction and GetterFunction.
+		template<typename CostFunction>
+		bool setIfUncached( const Key &key, const Value &value, CostFunction &&costFunction );
 
 		/// Returns true if the object is in the cache. Note that the
 		/// return value may be invalidated immediately by operations performed

--- a/python/GafferSceneTest/RenameTest.py
+++ b/python/GafferSceneTest/RenameTest.py
@@ -590,5 +590,22 @@ class RenameTest( GafferSceneTest.SceneTestCase ) :
 		self.assertSceneValid( rename["out"] )
 		self.assertEqual( rename["out"].childNames( "/" )[0], "newSphere" )
 
+	def testSetPassThroughWithCacheEviction( self ) :
+
+		# This reproduces a deadlock that was once triggered by performing the
+		# Legacy policy compute for `sphere.out.set` behind the lock for the
+		# TaskCollaboration compute on `rename.out.set`. The test doesn't
+		# assert anything, because we are just happy if it completes at all.
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue( "setA" )
+
+		rename = GafferScene.Rename()
+		rename["in"].setInput( sphere["out"] )
+
+		rename["out"].set( "setA" )
+		Gaffer.ValuePlug.clearCache()
+		rename["out"].set( "setA" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
+++ b/python/GafferTest/IECorePreviewTest/LRUCacheTest.py
@@ -230,5 +230,18 @@ class LRUCacheTest( GafferTest.TestCase ) :
 
 		GafferTest.testLRUCacheGetIfCached( "taskParallel" )
 
+	def testSetIfUncached( self ) :
+
+		for policy in [ "serial", "parallel", "taskParallel" ] :
+			with self.subTest( policy = policy ) :
+				GafferTest.testLRUCacheSetIfUncached( policy )
+
+	def testSetIfUncachedRecursion( self ) :
+
+		# `parallel` policy omitted because it doesn't support recursion.
+		for policy in [ "serial", "taskParallel" ] :
+			with self.subTest( policy = policy ) :
+				GafferTest.testLRUCacheSetIfUncachedRecursion( policy )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes a separate deadlock discovered during investigation of #4978, based on discussions in #4979. The fix doesn't solve the original problem, but does make sense in isolation. It's actually something I'd been meaning to do anyway, as a very small performance optimisation. Would be good to get this merged so there's one less thing to worry about while continuing investigations.