### PR TITLE
CopyPrimitiveVariables : ignore mismatched topology

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - UIEditor : Added `Allow Custom Values` checkbox to the Widget Settings section for the Presets Menu widget. When on, this allows the user to enter their own custom values in addition to choosing presets from the menu.
 - Image View : Added support for custom presets for choosing catalogue outputs to compare to.  This can be set up like `Gaffer.Metadata.registerNodeValue( GafferImageUI.ImageView, "compare.catalogueOutput", "preset:MyPreset", "myNamespace:specialImage" )`.  The Catalogue won't know how to deal with a request for "myNamespace:specialImage", and will just output an error image, but this could be useful in pipelines where Catalogue's are wrapped in custom nodes that can respond to this special value of the `catalogue:imageName`.  If you want to provide a custom icon for your custom mode, Gaffer will search for an icon name `catalogueOutput{preset name}.png`.
 - Animation Editor : Added UI tooltips to menu items for TieMode and Interpolation.
+- CopyPrimitiveVariables : Added `ignoreIncompatible` plug which will cause the node to not error when attempting to copy primitive variables from the source object that are imcompatible with the destination object.
 
 Fixes
 -----

--- a/include/GafferScene/CopyPrimitiveVariables.h
+++ b/include/GafferScene/CopyPrimitiveVariables.h
@@ -66,6 +66,9 @@ class GAFFERSCENE_API CopyPrimitiveVariables : public Deformer
 		Gaffer::StringPlug *prefixPlug();
 		const Gaffer::StringPlug *prefixPlug() const;
 
+		Gaffer::BoolPlug *ignoreIncompatiblePlug();
+		const Gaffer::BoolPlug *ignoreIncompatiblePlug() const;
+
 	protected :
 
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;

--- a/python/GafferSceneTest/CopyPrimitiveVariablesTest.py
+++ b/python/GafferSceneTest/CopyPrimitiveVariablesTest.py
@@ -38,6 +38,7 @@ import unittest
 import six
 
 import IECore
+import IECoreScene
 
 import Gaffer
 import GafferScene
@@ -296,6 +297,44 @@ class CopyPrimitiveVariablesTest( GafferSceneTest.SceneTestCase ) :
 				copy["out"].boundHash( location ),
 				sphere1["out"].boundHash( location )
 			)
+
+	def testIgnoreIncompatible( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		cube = GafferScene.Cube()
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		cubeVariables = GafferScene.PrimitiveVariables()
+		cubeVariables["in"].setInput( cube["out"] )
+		cubeVariables["filter"].setInput( cubeFilter["out"] )
+		cubeVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "c", IECore.IntData( 1 ) ) )
+		cubeVariables["enabled"].setValue( False )
+
+		copy = GafferScene.CopyPrimitiveVariables()
+		copy["in"].setInput( sphere["out"] )
+		copy["source"].setInput( cubeVariables["out"] )
+		copy["sourceLocation"].setValue( "/cube" )
+		copy["filter"].setInput( sphereFilter["out"] )
+		copy["primitiveVariables"].setValue( "*" )
+
+		with six.assertRaisesRegex(
+			self,
+			RuntimeError,
+			'Cannot copy .* from "/cube" to "/sphere" because source and destination primitives have different topology. Turn on `ignoreIncompatible` to disable this error and ignore invalid primitive variables.'
+		) :
+			copy["out"].object( "/sphere" )
+
+		copy["ignoreIncompatible"].setValue( True )
+
+		self.assertScenesEqual( copy["out"], sphere["out"] )
+
+		# Variables that can be copied should succeed, even if others don't
+		cubeVariables["enabled"].setValue( True )
+		self.assertEqual( copy["out"].object( "/sphere" )["c"], IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntData( 1 ) )  )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/CopyPrimitiveVariablesUI.py
+++ b/python/GafferSceneUI/CopyPrimitiveVariablesUI.py
@@ -93,6 +93,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"ignoreIncompatible" : [
+
+			"description",
+			"""
+			Causes the node to not error when attempting to copy primitive variables from
+			the source object that are not compatible with the destination object.
+			""",
+		]
+
 	}
 
 )

--- a/src/GafferScene/CopyPrimitiveVariables.cpp
+++ b/src/GafferScene/CopyPrimitiveVariables.cpp
@@ -203,7 +203,7 @@ IECore::ConstObjectPtr CopyPrimitiveVariables::computeProcessedObject( const Sce
 			const string &sourcePath = sourceLocation.size() ? sourceLocation : destinationPath;
 			throw IECore::Exception( boost::str(
 				boost::format( "Cannot copy \"%1%\" from \"%2%\" to \"%3%\" because source and destination primitives have different topology" )
-					% variable.first % destinationPath % sourcePath
+					% variable.first % sourcePath % destinationPath
 			) );
 		}
 		result->variables[prefix + variable.first] = variable.second;

--- a/src/GafferScene/CopyPrimitiveVariables.cpp
+++ b/src/GafferScene/CopyPrimitiveVariables.cpp
@@ -60,6 +60,7 @@ CopyPrimitiveVariables::CopyPrimitiveVariables( const std::string &name )
 	addChild( new StringPlug( "primitiveVariables", Plug::In, "" ) );
 	addChild( new StringPlug( "sourceLocation" ) );
 	addChild( new StringPlug( "prefix" ) );
+	addChild( new BoolPlug( "ignoreIncompatible" ) );
 }
 
 CopyPrimitiveVariables::~CopyPrimitiveVariables()
@@ -106,6 +107,16 @@ const Gaffer::StringPlug *CopyPrimitiveVariables::prefixPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 3 );
 }
 
+Gaffer::BoolPlug *CopyPrimitiveVariables::ignoreIncompatiblePlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::BoolPlug *CopyPrimitiveVariables::ignoreIncompatiblePlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 4 );
+}
+
 bool CopyPrimitiveVariables::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
 	return Deformer::affectsProcessedObject( input ) ||
@@ -113,7 +124,8 @@ bool CopyPrimitiveVariables::affectsProcessedObject( const Gaffer::Plug *input )
 		input == primitiveVariablesPlug() ||
 		input == prefixPlug() ||
 		input == sourceLocationPlug() ||
-		input == sourcePlug()->existsPlug()
+		input == sourcePlug()->existsPlug() ||
+		input == ignoreIncompatiblePlug()
 	;
 }
 
@@ -135,6 +147,8 @@ void CopyPrimitiveVariables::hashProcessedObject( const ScenePath &path, const G
 		h = inPlug()->objectPlug()->hash();
 		return;
 	}
+
+	ignoreIncompatiblePlug()->hash( h );
 
 	if( sourceLocationPath )
 	{
@@ -190,6 +204,8 @@ IECore::ConstObjectPtr CopyPrimitiveVariables::computeProcessedObject( const Sce
 		return inputObject;
 	}
 
+	bool ignoreIncompatible = ignoreIncompatiblePlug()->getValue();
+
 	PrimitivePtr result = primitive->copy();
 	for( auto &variable : sourcePrimitive->variables )
 	{
@@ -199,11 +215,18 @@ IECore::ConstObjectPtr CopyPrimitiveVariables::computeProcessedObject( const Sce
 		}
 		if( !result->isPrimitiveVariableValid( variable.second ) )
 		{
+			if( ignoreIncompatible )
+			{
+				continue;
+			}
 			string destinationPath; ScenePlug::pathToString( path, destinationPath );
 			const string &sourcePath = sourceLocation.size() ? sourceLocation : destinationPath;
 			throw IECore::Exception( boost::str(
-				boost::format( "Cannot copy \"%1%\" from \"%2%\" to \"%3%\" because source and destination primitives have different topology" )
-					% variable.first % sourcePath % destinationPath
+				boost::format(
+					"Cannot copy \"%1%\" from \"%2%\" to \"%3%\" because source and "
+					"destination primitives have different topology. Turn on `ignoreIncompatible` "
+					"to disable this error and ignore invalid primitive variables."
+				) % variable.first % sourcePath % destinationPath
 			) );
 		}
 		result->variables[prefix + variable.first] = variable.second;


### PR DESCRIPTION
This adds a new option to `CopyPrimitiveVariables` which avoids errors for primitive variables that can't be copied from the source to the destination because of incompatible topology.

It also fixes a small wording confusion where the source and destination object names were swapped.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
