### PR TITLE
MessagesBinding : Fix GIL management bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.6.x (relative to 1.0.6.3)
+=======
+
+Fixes
+-----
+
+- MessagesBinding : Fixed GIL management bug that could cause crashes when performing an interactive render.
+
 1.0.6.3 (relative to 1.0.6.2)
 =======
 

--- a/src/GafferModule/MessagesBinding.cpp
+++ b/src/GafferModule/MessagesBinding.cpp
@@ -83,8 +83,11 @@ long hashMessage( const Message &m )
 
 object firstDifferenceWrapper( const Messages &m, const Messages &others )
 {
-	IECorePython::ScopedGILRelease gilRelease;
-	auto d = m.firstDifference( others );
+	std::optional<size_t> d;
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		d = m.firstDifference( others );
+	}
 	return d ? object( *d ) : object();
 }
 


### PR DESCRIPTION
We were constructing `object` (which uses the Python C API) without holding the GIL. Somehow we have been getting away with this in Python 2.7, 3.7 and 3.8, but it leads to crashes in 3.9. See https://groups.google.com/g/gaffer-dev/c/9QB2nbOBu-A/m/t6YNu1YZBwAJ.