### PR TITLE
Documentation : Cross-platform example code

### DIFF
--- a/doc/source/Reference/ScriptingReference/CommonOperations/index.md
+++ b/doc/source/Reference/ScriptingReference/CommonOperations/index.md
@@ -164,7 +164,7 @@ attribute = attributes["name"].value
 def visit( scene, path ) :
 
 	for childName in scene.childNames( path ) :
-		visit( scene, os.path.join( path, str( childName )  ) )
+		visit( scene, path.rstrip( "/" ) + "/" + str( childName ) )
 
 visit( node["out"], "/" )
 ```

--- a/doc/source/WorkingWithThePythonScriptingAPI/TutorialQueryingAScene/index.md
+++ b/doc/source/WorkingWithThePythonScriptingAPI/TutorialQueryingAScene/index.md
@@ -180,8 +180,6 @@ print( root["StandardOptions"]["out"].childNames( "/world" ) )
 Rather than continue this manual exploration, let's write a simple recursive function to traverse the scene and print what it finds :
 
 ```
-import os
-
 def visit( scene, path ) :
 
 	print( path )
@@ -190,7 +188,7 @@ def visit( scene, path ) :
 	print( "\tAttributes : " + " ".join( scene.attributes( path ).keys() ) )
 	print( "\tBound : " + str( scene.bound( path ) ) + "\n" )
 	for childName in scene.childNames( path ) :
-		visit( scene, os.path.join( path, str( childName )  ) )
+		visit( scene, path.rstrip( "/" ) + "/" + str( childName ) )
 
 visit( root["StandardOptions"]["out"], "/" )
 ```


### PR DESCRIPTION
Thanks for @noizfactory for pointing out a Windows-incompatible code example in the documentation in #4993. 

On Windows, using `os.path.join()` will use `\` which is not what we want for scene paths (or file paths).

### Related issues ###

#4993 

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
