### PR TITLE
GafferScene pathlib

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -55,6 +55,7 @@ API
   - Dispatcher : `jobDirectory()` now returns a `filesystem::path`.
   - Backups : File names are now represented using `pathlib.Path`.
   - TestCase : `temporaryDirectory()` now returns a `pathlib.Path`.
+  - ShaderView : `registerReferenceScene()` now takes a `filesystem::path`.
 - PathColumn : Added `buttonPressSignal()`, `buttonReleaseSignal()` and `buttonDoubleClickSignal()`. These allow a PathColumn to implement its own event handling.
 - Capsule : Removed attempts to detect invalidated Capsules.
 - VisibleSet/VisibleSetData : Added struct used to define a subset of the scene to be rendered based on expansions, inclusions, and exclusions. This is used to allow scene locations to be defined as always or never renderable, overriding the usual UI expansion behaviour.

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -47,6 +47,7 @@
 #include "GafferImage/Display.h"
 
 #include <functional>
+#include <filesystem>
 
 namespace GafferSceneUI
 {
@@ -82,7 +83,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 		using SceneCreator = std::function<Gaffer::NodePtr ()>;
 		static void registerScene( const std::string &shaderPrefix, const std::string &name, SceneCreator sceneCreator );
-		static void registerScene( const std::string &shaderPrefix, const std::string &name, const std::string &referenceFileName );
+		static void registerScene( const std::string &shaderPrefix, const std::string &name, const std::filesystem::path &referenceFileName );
 		static void registeredScenes( const std::string &shaderPrefix, std::vector<std::string> &names );
 
 	private :

--- a/python/GafferSceneTest/AttributeVisualiserTest.py
+++ b/python/GafferSceneTest/AttributeVisualiserTest.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import os
 import imath
 
 import IECore
@@ -163,8 +162,8 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 
 	def testVectors( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "attributes.scc" )
-		scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.Write )
+		filePath = self.temporaryDirectory() / "attributes.scc"
+		scene = IECoreScene.SceneInterface.create( str( filePath ), IECore.IndexedIO.Write )
 		child = scene.createChild( "child" )
 		for name, value in [
 			( "v2f", IECore.V2fData( imath.V2f( 1, 2 ) ) ),
@@ -178,7 +177,7 @@ class AttributeVisualiserTest( GafferSceneTest.SceneTestCase ) :
 		del scene, child
 
 		sceneReader = GafferScene.SceneReader()
-		sceneReader["fileName"].setValue( fileName )
+		sceneReader["fileName"].setValue( filePath )
 
 		childFilter = GafferScene.PathFilter()
 		childFilter["paths"].setValue( IECore.StringVectorData( [ "/child" ] ) )

--- a/python/GafferSceneTest/CollectScenesTest.py
+++ b/python/GafferSceneTest/CollectScenesTest.py
@@ -35,7 +35,7 @@
 ##########################################################################
 
 import inspect
-import os
+import pathlib
 import unittest
 import imath
 
@@ -317,7 +317,7 @@ class CollectScenesTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFromVersion0_48( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/collectScenes-0.48.0.0.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "collectScenes-0.48.0.0.gfr" )
 		s.load()
 
 		self.assertTrue( s["CollectScenes"]["in"].getInput(), s["Sphere"]["out"] )

--- a/python/GafferSceneTest/CryptomatteTest.py
+++ b/python/GafferSceneTest/CryptomatteTest.py
@@ -36,7 +36,7 @@
 
 import unittest
 
-import os
+import pathlib
 import imath
 import json
 
@@ -51,8 +51,8 @@ import GafferSceneTest
 
 class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 
-	testImagePath = os.path.join( os.path.dirname( os.path.abspath( __file__ ) ), "images" )
-	testImage = os.path.join( testImagePath, "cryptomatte.exr" )
+	testImagePath = pathlib.Path( __file__ ).parent / "images"
+	testImage = testImagePath / "cryptomatte.exr"
 
 	def testCryptomatteHash( self ) :
 
@@ -151,10 +151,10 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cryptomatte()
 		c["in"].setInput( r["out"] )
 		c["manifestSource"].setValue( GafferScene.Cryptomatte.ManifestSource.Sidecar )
-		c["sidecarFile"].setValue( os.path.join( self.testImagePath, "crypto_object.json" ) )
+		c["sidecarFile"].setValue( self.testImagePath / "crypto_object.json" )
 		self.compareValues( c, ["crypto_object"] )
 
-		c["sidecarFile"].setValue( os.path.join( self.testImagePath, "crypto_material.json" ) )
+		c["sidecarFile"].setValue( self.testImagePath / "crypto_material.json" )
 		self.compareValues( c, ["crypto_material"] )
 
 		c["sidecarFile"].setValue( "" )
@@ -162,7 +162,7 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaisesRegex( Gaffer.ProcessException, r'No manifest file provided.' ) as raised :
 			self.compareValues( c, ["crypto_object"] )
 
-		invalidPath = os.path.dirname( self.testImage ) + "/not/a/valid/path.json"
+		invalidPath = self.testImage.parent / "not" / "a" / "valid" / "path.json"
 		c["sidecarFile"].setValue( invalidPath )
 
 		with self.assertRaisesRegex( Gaffer.ProcessException, r'Manifest file not found: {}'.format( invalidPath ) ) as raised :
@@ -183,7 +183,7 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cryptomatte()
 		c["in"].setInput( d["out"] )
 		c["manifestSource"].setValue( GafferScene.Cryptomatte.ManifestSource.Metadata )
-		c["manifestDirectory"].setValue( os.path.dirname( self.testImage ) )
+		c["manifestDirectory"].setValue( self.testImage.parent )
 
 		self.compareValues( c, ["crypto_object", "crypto_material"] )
 
@@ -192,7 +192,7 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaisesRegex( Gaffer.ProcessException, r'No manifest directory provided.' ) as raised :
 			self.compareValues( c, ["crypto_object"] )
 
-		invalidPath = os.path.dirname( self.testImage ) + "/not/a/valid/path"
+		invalidPath = self.testImage.parent / "not" / "a" / "valid" / "path"
 		c["manifestDirectory"].setValue( invalidPath )
 
 		with self.assertRaisesRegex( Gaffer.ProcessException, r'Manifest directory not found: {}'.format( invalidPath ) ) as raised :
@@ -355,7 +355,7 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 			"/cow1"
 		] )	)
 
-		resultImage = os.path.join( self.testImagePath, "cryptomatteKeyed.exr" )
+		resultImage = self.testImagePath / "cryptomatteKeyed.exr"
 		r2 = GafferImage.ImageReader()
 		r2["fileName"].setValue( resultImage )
 

--- a/python/GafferSceneTest/CustomAttributesTest.py
+++ b/python/GafferSceneTest/CustomAttributesTest.py
@@ -35,7 +35,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 
 import IECore
@@ -346,7 +346,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadExtraAttributesFrom0_58( self ) :
 
 		script = Gaffer.ScriptNode()
-		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "extraAttributes-0.58.5.2.gfr" ) )
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "extraAttributes-0.58.5.2.gfr" )
 		script.load()
 
 		self.assertEqual(
@@ -439,7 +439,7 @@ class CustomAttributesTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadExtraAttributesFrom0_59( self ) :
 
 		script = Gaffer.ScriptNode()
-		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "extraAttributes-0.59.0.0.gfr" ) )
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "extraAttributes-0.59.0.0.gfr" )
 		script.load()
 
 		self.assertEqual(

--- a/python/GafferSceneTest/EncapsulateTest.py
+++ b/python/GafferSceneTest/EncapsulateTest.py
@@ -36,7 +36,6 @@
 
 import inspect
 import unittest
-import os
 import subprocess
 
 import IECore
@@ -265,7 +264,7 @@ class EncapsulateTest( GafferSceneTest.SceneTestCase ) :
 		script["collect"]["in"].setInput( script["encapsulate"]["out"] )
 		script["collect"]["rootNames"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 100 ) ] ) )
 
-		script["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.gfr" ) )
+		script["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
 		script.save()
 
 		# This exposed a crash caused by non-threadsafe access to signals from Capsules. It

--- a/python/GafferSceneTest/FilterProcessorTest.py
+++ b/python/GafferSceneTest/FilterProcessorTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 
 import IECore
@@ -48,7 +48,7 @@ class FilterProcessorTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFromVersion0_27( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/filterProcessor-0.27.0.0.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "filterProcessor-0.27.0.0.gfr" )
 		s.load()
 
 		self.assertEqual( len( s["FilterSwitch"]["in"] ), 3 )
@@ -73,7 +73,7 @@ class FilterProcessorTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadBoxedFromVersion0_27( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/filterProcessorBoxed-0.27.0.0.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "filterProcessorBoxed-0.27.0.0.gfr" )
 		s.load()
 
 		self.assertEqual( len( s["Box"]["FilterSwitch"]["in"] ), 3 )

--- a/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
+++ b/python/GafferSceneTest/IECoreGLPreviewTest/RendererTest.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import os
 import unittest
 import imath
 
@@ -81,7 +80,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testPrimVars( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
-		renderer.output( "test", IECoreScene.Output( self.temporaryDirectory() + "/testPrimVars.exr", "exr", "rgba", {} ) )
+		renderer.output( "test", IECoreScene.Output( str( self.temporaryDirectory() / "testPrimVars.exr" ), "exr", "rgba", {} ) )
 
 		fragmentSource = """
 		uniform float red;
@@ -140,7 +139,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		renderer.render()
 
-		image = IECore.Reader.create(  self.temporaryDirectory() + "/testPrimVars.exr" ).read()
+		image = IECore.Reader.create( str( self.temporaryDirectory() / "testPrimVars.exr" ) ).read()
 		dimensions = image.dataWindow.size() + imath.V2i( 1 )
 		index = dimensions.x * int( dimensions.y * 0.5 )
 		self.assertEqual( image["R"][index], 0 )
@@ -160,7 +159,7 @@ class RendererTest( GafferTest.TestCase ) :
 	def testShaderParameters( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "OpenGL" )
-		renderer.output( "test", IECoreScene.Output( self.temporaryDirectory() + "/testShaderParameters.exr", "exr", "rgba", {} ) )
+		renderer.output( "test", IECoreScene.Output( str( self.temporaryDirectory() / "testShaderParameters.exr" ), "exr", "rgba", {} ) )
 
 		fragmentSource = """
 		uniform vec3 colorValue;

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -518,10 +518,10 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		script["box"]["in"] = GafferScene.ScenePlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		script["box"]["out"] = GafferScene.ScenePlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		script["box"]["out"].setInput( script["box"]["in"] )
-		script["box"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		script["box"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
 		script["reference"] = Gaffer.Reference()
-		script["reference"].load( self.temporaryDirectory() + "/test.grf" )
+		script["reference"].load( self.temporaryDirectory() / "test.grf" )
 		script["reference"]["in"].setInput( script["instancer"]["out"] )
 
 		script["attributes"] = GafferScene.CustomAttributes()
@@ -530,7 +530,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		traverseConnection = Gaffer.Signals.ScopedConnection( GafferSceneTest.connectTraverseSceneToPlugDirtiedSignal( script["attributes"]["out"] ) )
 		with Gaffer.Context() as c :
 
-			script["reference"].load( self.temporaryDirectory() + "/test.grf" )
+			script["reference"].load( self.temporaryDirectory() / "test.grf" )
 
 	def testContextChangedAndGIL( self ) :
 

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import unittest
 import imath
 
@@ -52,7 +53,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 
 	def test( self ) :
 
-		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
+		self.assertFalse( ( self.temporaryDirectory() / "test.exr" ).exists() )
 
 		s = Gaffer.ScriptNode()
 
@@ -60,7 +61,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["plane"]["transform"]["translate"].setValue( imath.V3f( 0, 0, -5 ) )
 
 		s["image"] = GafferImage.ImageReader()
-		s["image"]["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
+		s["image"]["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checker.exr" )
 
 		s["shader"] = GafferScene.OpenGLShader()
 		s["shader"].loadShader( "Texture" )
@@ -76,7 +77,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				self.temporaryDirectory() + "/test.exr",
+				( self.temporaryDirectory() / "test.exr" ).as_posix(),
 				"exr",
 				"rgba",
 				{}
@@ -87,15 +88,15 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["render"] = GafferScene.OpenGLRender()
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 
-		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+		s["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
 		s.save()
 
 		s["render"]["task"].execute()
 
-		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/test.exr" ) )
+		self.assertTrue( ( self.temporaryDirectory() / "test.exr" ).exists() )
 
 		imageReader = GafferImage.ImageReader()
-		imageReader["fileName"].setValue( self.temporaryDirectory() + "/test.exr" )
+		imageReader["fileName"].setValue( self.temporaryDirectory() / "test.exr" )
 
 		imageSampler = GafferImage.ImageSampler()
 		imageSampler["image"].setInput( imageReader["out"] )
@@ -108,7 +109,7 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 	def testOutputDirectoryCreation( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["variables"].addChild( Gaffer.NameValuePlug( "renderDirectory", self.temporaryDirectory() + "/openGLRenderTest" ) )
+		s["variables"].addChild( Gaffer.NameValuePlug( "renderDirectory", ( self.temporaryDirectory() / "openGLRenderTest" ).as_posix() ) )
 
 		s["plane"] = GafferScene.Plane()
 
@@ -127,14 +128,14 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["render"] = GafferScene.OpenGLRender()
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 
-		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest" ) )
-		self.assertFalse( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest/test.0001.exr" ) )
+		self.assertFalse( ( self.temporaryDirectory() / "openGLRenderTest" ).exists() )
+		self.assertFalse( ( self.temporaryDirectory() / "openGLRenderTest" / "test.0001.exr" ).exists() )
 
 		with s.context() :
 			s["render"]["task"].execute()
 
-		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest" ) )
-		self.assertTrue( os.path.exists( self.temporaryDirectory() + "/openGLRenderTest/test.0001.exr" ) )
+		self.assertTrue( ( self.temporaryDirectory() / "openGLRenderTest" ).exists() )
+		self.assertTrue( ( self.temporaryDirectory() / "openGLRenderTest" / "test.0001.exr" ).exists() )
 
 	def testHash( self ) :
 
@@ -162,12 +163,12 @@ class OpenGLRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		# output varies by new Context entries
 		current = s["render"].hash( c )
-		c["renderDirectory"] = self.temporaryDirectory() + "/openGLRenderTest"
+		c["renderDirectory"] = ( self.temporaryDirectory() / "openGLRenderTest" ).as_posix()
 		self.assertNotEqual( s["render"].hash( c ), current )
 
 		# output varies by changed Context entries
 		current = s["render"].hash( c )
-		c["renderDirectory"] = self.temporaryDirectory() + "/openGLRenderTest2"
+		c["renderDirectory"] = ( self.temporaryDirectory() / "openGLRenderTest2" ).as_posix()
 		self.assertNotEqual( s["render"].hash( c ), current )
 
 		# output doesn't vary by ui Context entries

--- a/python/GafferSceneTest/OpenGLShaderTest.py
+++ b/python/GafferSceneTest/OpenGLShaderTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import sys
 import unittest
 import imath
@@ -67,7 +68,7 @@ class OpenGLShaderTest( GafferSceneTest.SceneTestCase ) :
 		s["parameters"]["tint"].setValue( imath.Color4f( 1, 0.5, 0.25, 1 ) )
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
+		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checker.exr" )
 		s["parameters"]["texture"].setInput( i["out"] )
 
 		a = s.attributes()

--- a/python/GafferSceneTest/ParentTest.py
+++ b/python/GafferSceneTest/ParentTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os.path
+import pathlib
 import inspect
 
 import imath
@@ -451,7 +451,7 @@ class ParentTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFrom0_54( self ) :
 
 		script = Gaffer.ScriptNode()
-		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "parent-0.54.1.0.gfr" ) )
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "parent-0.54.1.0.gfr" )
 		script.load()
 
 		self.assertEqual( script["Parent"]["in"].getInput(), script["Plane"]["out"] )

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -35,7 +35,6 @@
 ##########################################################################
 
 import imath
-import os
 import unittest
 
 import IECore
@@ -765,11 +764,11 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		m["in"].setInput( c["out"] )
 		o["in"].setInput( m["out"] )
 
-		pathWithoutMeta = os.path.join( self.temporaryDirectory(), "sceneAlgoSourceSceneWithoutMeta.exr" )
+		pathWithoutMeta = self.temporaryDirectory() / "sceneAlgoSourceSceneWithoutMeta.exr"
 		o["fileName"].setValue( pathWithoutMeta )
 		o.execute()
 
-		pathWithMeta = os.path.join( self.temporaryDirectory(), "sceneAlgoSourceSceneWithMeta.exr" )
+		pathWithMeta = self.temporaryDirectory() / "sceneAlgoSourceSceneWithMeta.exr"
 		m["metadata"].addChild(
 			Gaffer.NameValuePlug(
 				"gaffer:sourceScene", IECore.StringData( expectedPath ), True, "sourceScene",

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 import inspect
 import imath
@@ -51,7 +51,7 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 	def test( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "cube.abc" )
 
 		p = GafferScene.ScenePath( a["out"], Gaffer.Context(), "/" )
 		c = p.children()
@@ -62,7 +62,7 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 	def testRelative( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles"/ "cube.abc" )
 
 		p = GafferScene.ScenePath( a["out"], Gaffer.Context(), "group1" )
 		self.assertEqual( str( p ), "group1" )

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 import inspect
 import imath
@@ -52,11 +52,11 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		GafferSceneTest.SceneTestCase.setUp( self )
 
-		self.__testFile = self.temporaryDirectory() + "/test.scc"
+		self.__testFile = self.temporaryDirectory() / "test.scc"
 
 	def testFileRefreshProblem( self ) :
 
-		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
+		sc = IECoreScene.SceneCache( str( self.__testFile ), IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "1" )
 		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
@@ -75,7 +75,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		del scene
 
-		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
+		sc = IECoreScene.SceneCache( str( self.__testFile ), IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
 		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
@@ -96,7 +96,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testRead( self ) :
 
-		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
+		sc = IECoreScene.SceneCache( str( self.__testFile ), IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
 		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
@@ -121,7 +121,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def writeAnimatedSCC( self ) :
 
-		scene = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
+		scene = IECoreScene.SceneCache( str( self.__testFile ), IECore.IndexedIO.OpenMode.Write )
 
 		time = 0
 		sc1 = scene.createChild( str( 1 ) )
@@ -187,7 +187,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testEnabled( self ) :
 
-		sc = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
+		sc = IECoreScene.SceneCache( str( self.__testFile ), IECore.IndexedIO.OpenMode.Write )
 
 		t = sc.createChild( "transform" )
 		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
@@ -225,8 +225,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testChildNamesHash( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "test.scc" )
-		s = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		filePath = self.temporaryDirectory() / "test.scc"
+		s = IECoreScene.SceneCache( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 		sphereGroup = s.createChild( "sphereGroup" )
 		sphereGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
 		sphereGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 2, 0, 0 ) ) ), 1.0 )
@@ -236,8 +236,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		del s, sphereGroup, sphere
 
 		s = GafferScene.SceneReader()
-		s["fileName"].setValue( fileName )
-		s["refreshCount"].setValue( self.uniqueInt( fileName ) ) # account for our changing of file contents between tests
+		s["fileName"].setValue( filePath )
+		s["refreshCount"].setValue( self.uniqueInt( filePath ) ) # account for our changing of file contents between tests
 
 		t = Gaffer.TimeWarp()
 		t.setup( GafferScene.ScenePlug() )
@@ -251,8 +251,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testStaticHashes( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "test.scc" )
-		s = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		filePath = self.temporaryDirectory() / "test.scc"
+		s = IECoreScene.SceneCache( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 
 		movingGroup = s.createChild( "movingGroup" )
 		movingGroup.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 0.0 )
@@ -271,8 +271,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		del s, movingGroup, deformingSphere, staticGroup, staticSphere
 
 		s = GafferScene.SceneReader()
-		s["fileName"].setValue( fileName )
-		s["refreshCount"].setValue( self.uniqueInt( fileName ) ) # account for our changing of file contents between tests
+		s["fileName"].setValue( filePath )
+		s["refreshCount"].setValue( self.uniqueInt( filePath ) ) # account for our changing of file contents between tests
 
 		t = Gaffer.TimeWarp()
 		t.setup( GafferScene.ScenePlug() )
@@ -317,8 +317,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testTagFilteringWholeScene( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "test.scc" )
-		s = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		filePath = self.temporaryDirectory() / "test.scc"
+		s = IECoreScene.SceneCache( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 
 		sphereGroup = s.createChild( "sphereGroup" )
 		sphereGroup.writeTags( [ "chrome" ] )
@@ -335,19 +335,19 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		# these are all loading everything, although each with
 		# different filters.
 
-		refreshCount = self.uniqueInt( fileName )
+		refreshCount = self.uniqueInt( filePath )
 
 		s1 = GafferScene.SceneReader()
-		s1["fileName"].setValue( fileName )
+		s1["fileName"].setValue( filePath )
 		s1["refreshCount"].setValue( refreshCount )
 
 		s2 = GafferScene.SceneReader()
-		s2["fileName"].setValue( fileName )
+		s2["fileName"].setValue( filePath )
 		s2["refreshCount"].setValue( refreshCount )
 		s2["tags"].setValue( "chrome wood" )
 
 		s3 = GafferScene.SceneReader()
-		s3["fileName"].setValue( fileName )
+		s3["fileName"].setValue( filePath )
 		s3["refreshCount"].setValue( refreshCount )
 		s3["tags"].setValue( "chrome something" )
 
@@ -363,8 +363,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testTagFilteringPartialScene( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "test.scc" )
-		s = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		filePath = self.temporaryDirectory() / "test.scc"
+		s = IECoreScene.SceneCache( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 
 		sphereGroup = s.createChild( "sphereGroup" )
 		sphereGroup.writeTags( [ "chrome" ] )
@@ -378,25 +378,25 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		del s, sphereGroup, sphere, planeGroup, plane
 
-		refreshCount = self.uniqueInt( fileName )
+		refreshCount = self.uniqueInt( filePath )
 
 		# this one will load everything
 
 		s1 = GafferScene.SceneReader()
-		s1["fileName"].setValue( fileName )
+		s1["fileName"].setValue( filePath )
 		s1["refreshCount"].setValue( refreshCount )
 
 		# this one should load just the sphere
 
 		s2 = GafferScene.SceneReader()
-		s2["fileName"].setValue( fileName )
+		s2["fileName"].setValue( filePath )
 		s2["refreshCount"].setValue( refreshCount )
 		s2["tags"].setValue( "chrome" )
 
 		# this one should load just the plane
 
 		s3 = GafferScene.SceneReader()
-		s3["fileName"].setValue( fileName )
+		s3["fileName"].setValue( filePath )
 		s3["refreshCount"].setValue( refreshCount )
 		s3["tags"].setValue( "wood" )
 
@@ -431,8 +431,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 	def testTagsAsSets( self ) :
 
-		fileName = os.path.join( self.temporaryDirectory(), "test.scc" )
-		s = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		filePath = self.temporaryDirectory() / "test.scc"
+		s = IECoreScene.SceneCache( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 
 		sphereGroup = s.createChild( "sphereGroup" )
 		sphereGroup.writeTags( [ "chrome" ] )
@@ -447,8 +447,8 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		del s, sphereGroup, sphere, planeGroup, plane
 
 		s = GafferScene.SceneReader()
-		s["fileName"].setValue( fileName )
-		s["refreshCount"].setValue( self.uniqueInt( fileName ) ) # account for our changing of file contents between tests
+		s["fileName"].setValue( filePath )
+		s["refreshCount"].setValue( self.uniqueInt( filePath ) ) # account for our changing of file contents between tests
 
 		self.assertEqual(
 			set( [ str( ss ) for ss in s["out"]["setNames"].getValue() ] ),
@@ -505,13 +505,13 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 	def testAlembic( self ) :
 
 		r = GafferScene.SceneReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/cube.abc" )
+		r["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "cube.abc" )
 		self.assertSceneValid( r["out"] )
 
 	def testTransform( self ) :
 
 		r = GafferScene.SceneReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/groupedPlane.abc" )
+		r["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "groupedPlane.abc" )
 		self.assertEqual( r["out"].transform( "/group" ), imath.M44f() )
 
 		r["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
@@ -521,9 +521,9 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 	def testAlembicThreading( self ) :
 
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
-		fileName = self.temporaryDirectory() + "/test.abc"
+		filePath = self.temporaryDirectory() / "test.abc"
 
-		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = IECoreScene.SceneInterface.create( str( filePath ), IECore.IndexedIO.OpenMode.Write )
 		root.writeBound( imath.Box3d( mesh.bound() ), 0 )
 		for i in range( 0, 1000 ) :
 			child = root.createChild( str( i ) )
@@ -533,7 +533,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		del root, child
 
 		sceneReader = GafferScene.SceneReader()
-		sceneReader["fileName"].setValue( fileName )
+		sceneReader["fileName"].setValue( filePath )
 
 		for i in range( 0, 20 ) :
 			sceneReader["refreshCount"].setValue( sceneReader["refreshCount"].getValue() + 1 )
@@ -624,7 +624,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		writer = GafferScene.SceneWriter()
 		writer["in"].setInput( group["out"] )
-		writer["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.usda" ) )
+		writer["fileName"].setValue( self.temporaryDirectory() / "test.usda" )
 		writer["task"].execute()
 
 		reader = GafferScene.SceneReader()
@@ -660,7 +660,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 				# - `IECoreVDB::VDBScene` hasn't implemented sets or tags at all.
 				continue
 
-			writer["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.{}".format( extension ) ) )
+			writer["fileName"].setValue( self.temporaryDirectory() / f"test.{extension}" )
 			writer["task"].execute()
 
 			for setName in writer["in"].setNames() :

--- a/python/GafferSceneTest/SceneSwitchTest.py
+++ b/python/GafferSceneTest/SceneSwitchTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import inspect
 import unittest
 
@@ -173,7 +173,7 @@ class SceneSwitchTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFileFromVersion0_49( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/sceneSwitch-0.49.1.0.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "sceneSwitch-0.49.1.0.gfr" )
 		s.load()
 
 		self.assertEqual( s["SceneSwitch"]["in"][0].getInput(), s["Plane"]["out"] )

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -168,7 +168,7 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 
 			childNames = scenePlug.childNames( scenePath, _copy = False )
 			for childName in childNames :
-				walkScene( os.path.join( scenePath, str( childName ) ) )
+				walkScene( scenePath.rstrip( "/" ) + "/" + str( childName ) )
 
 		walkScene( "/" )
 

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import subprocess
 import unittest
 
@@ -308,10 +309,10 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s["b"] = Gaffer.Box()
 		s["b"]["a"] = GafferScene.ShaderAssignment()
 		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["filter"] )
-		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() / "test.grf" )
 
 		self.assertTrue( s["r"]["a"]["filter"].getInput().isSame( s["r"][p.getName()] ) )
 
@@ -328,10 +329,10 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s["b"]["a"]["filter"].setInput( s["b"]["d"]["out"] )
 
 		p = Gaffer.PlugAlgo.promote( s["b"]["d"]["in"] )
-		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() / "test.grf" )
 
 		self.assertTrue( s["r"]["a"]["filter"].source().isSame( s["r"][p.getName()] ) )
 
@@ -346,10 +347,10 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 		s["b"]["a"] = GafferScene.ShaderAssignment()
 		p = Gaffer.PlugAlgo.promote( s["b"]["a"]["shader"] )
 
-		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() / "test.grf" )
 
 		self.assertTrue( s["r"]["a"]["shader"].getInput().node().isSame( s["r"] ) )
 
@@ -541,9 +542,9 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 
 		script["writer"] = GafferScene.SceneWriter()
 		script["writer"]["in"].setInput( script["assignment"]["out"] )
-		script["writer"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.scc" ) )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() / "test.scc" )
 
-		script["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.gfr" ) )
+		script["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
 		script.save()
 
 
@@ -614,7 +615,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFrom0_55( self ) :
 
 		script = Gaffer.ScriptNode()
-		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "shaderAssignment-0.55.0.0.gfr" ) )
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "shaderAssignment-0.55.0.0.gfr" )
 		script.load()
 
 		self.assertNotIn( "__contextCompatibility", script["ShaderAssignment"] )
@@ -622,7 +623,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 	def testSwitchGraphDestruction( self ) :
 
 		script = Gaffer.ScriptNode()
-		script["fileName"].setValue( os.path.join( os.path.dirname( __file__ ), "scripts", "shaderAssignmentSwitchProblem.gfr" ) )
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "shaderAssignmentSwitchProblem.gfr" )
 		script.load()
 
 		# This exposed a bug whereby `ShaderPlug.acceptsInput()` rejected an input as the inputs

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 import imath
 
@@ -115,7 +115,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadFromVersion0_52( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/lightTweaks-0.52.3.1.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "lightTweaks-0.52.3.1.gfr" )
 		s.load()
 
 		self.assertIsInstance( s["LightTweaks1"], GafferScene.ShaderTweaks )
@@ -142,7 +142,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadAndResaveFromVersion0_52( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/lightTweaks-0.52.3.1.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "lightTweaks-0.52.3.1.gfr" )
 		s.load()
 
 		ss = s.serialise()

--- a/python/GafferSceneTest/StandardAttributesTest.py
+++ b/python/GafferSceneTest/StandardAttributesTest.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 
 import IECore
 
@@ -136,7 +136,7 @@ class StandardAttributesTest( GafferSceneTest.SceneTestCase ) :
 	def testLoadPromotedAttributeFrom0_53( self ) :
 
 		s = Gaffer.ScriptNode()
-		s["fileName"].setValue( os.path.dirname( __file__ ) + "/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr" )
+		s["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "promotedCompoundDataMemberPlug-0.53.4.0.gfr" )
 		s.load()
 		self.assertPromotedAttribute( s )
 

--- a/python/GafferSceneTest/SubTreeTest.py
+++ b/python/GafferSceneTest/SubTreeTest.py
@@ -35,7 +35,7 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import unittest
 
 import imath
@@ -52,7 +52,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testPassThrough( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/groupedPlane.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "groupedPlane.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )
@@ -68,7 +68,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testSubTree( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/groupedPlane.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "groupedPlane.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )
@@ -95,7 +95,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testRootHashesEqual( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/animatedCube.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "animatedCube.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )
@@ -222,7 +222,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testIncludeRoot( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/groupedPlane.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "groupedPlane.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )
@@ -240,7 +240,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testRootBoundWithTransformedChild( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/animatedCube.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "animatedCube.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )
@@ -259,7 +259,7 @@ class SubTreeTest( GafferSceneTest.SceneTestCase ) :
 	def testIncludeRootPassesThroughWhenNoRootSpecified( self ) :
 
 		a = GafferScene.SceneReader()
-		a["fileName"].setValue( os.path.dirname( __file__ ) + "/alembicFiles/animatedCube.abc" )
+		a["fileName"].setValue( pathlib.Path( __file__ ).parent / "alembicFiles" / "animatedCube.abc" )
 
 		s = GafferScene.SubTree()
 		s["in"].setInput( a["out"] )

--- a/python/GafferSceneTest/TextTest.py
+++ b/python/GafferSceneTest/TextTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import unittest
 import imath
 
@@ -92,7 +93,7 @@ class TextTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( "out.transform" in [ x[0].relativeName( x[0].node() ) for x in s ] )
 
 		del s[:]
-		t["font"].setValue( os.path.expandvars( "$GAFFER_ROOT/fonts/VeraBI.ttf" ) )
+		t["font"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "fonts" / "VeraBI.ttf" )
 
 		self.assertTrue( "out.object" in [ x[0].relativeName( x[0].node() ) for x in s ] )
 		self.assertTrue( "out.bound" in [ x[0].relativeName( x[0].node() ) for x in s ] )

--- a/python/GafferSceneTest/UnionFilterTest.py
+++ b/python/GafferSceneTest/UnionFilterTest.py
@@ -199,10 +199,10 @@ class UnionFilterTest( GafferSceneTest.SceneTestCase ) :
 		p = Gaffer.PlugAlgo.promote( s["b"]["f"]["in"][0] )
 		p.setName( "p" )
 
-		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
 		s["r"] = Gaffer.Reference()
-		s["r"].load( self.temporaryDirectory() + "/test.grf" )
+		s["r"].load( self.temporaryDirectory() / "test.grf" )
 
 		s["f"] = GafferScene.PathFilter()
 

--- a/python/GafferSceneUITest/CameraToolTest.py
+++ b/python/GafferSceneUITest/CameraToolTest.py
@@ -405,7 +405,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 
 		script["sceneWriter"] = GafferScene.SceneWriter()
 		script["sceneWriter"]["in"].setInput( script["group"]["out"] )
-		script["sceneWriter"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.usda" ) )
+		script["sceneWriter"]["fileName"].setValue( self.temporaryDirectory() / "test.usda" )
 		script["sceneWriter"]["task"].execute()
 
 		script["sceneReader"] = GafferScene.SceneReader()

--- a/python/GafferSceneUITest/ShaderViewTest.py
+++ b/python/GafferSceneUITest/ShaderViewTest.py
@@ -89,9 +89,9 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 		s["b"]["assignment"]["shader"].setInput( s["b"]["shader"] )
 		s["b"]["out"].setInput( s["b"]["assignment"]["out"] )
 
-		s["b"].exportForReference( self.temporaryDirectory() + "/test.grf" )
+		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
-		GafferSceneUI.ShaderView.registerScene( "test", "Default", self.temporaryDirectory() + "/test.grf" )
+		GafferSceneUI.ShaderView.registerScene( "test", "Default", ( self.temporaryDirectory() / "test.grf" ).as_posix() )
 
 		shader = GafferSceneTest.TestShader()
 		shader["type"].setValue( "test:surface" )
@@ -99,7 +99,7 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		view = GafferUI.View.create( shader["out"] )
 		self.assertTrue( isinstance( view.scene(), Gaffer.Reference ) )
-		self.assertEqual( view.scene().fileName(), self.temporaryDirectory() + "/test.grf" )
+		self.assertEqual( view.scene().fileName(), self.temporaryDirectory() / "test.grf" )
 		self.assertEqual( view.scene()["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "cube" ] ) )
 
 	def testScenesAreReused( self ) :

--- a/python/GafferSceneUITest/ShaderViewTest.py
+++ b/python/GafferSceneUITest/ShaderViewTest.py
@@ -91,7 +91,7 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 
-		GafferSceneUI.ShaderView.registerScene( "test", "Default", ( self.temporaryDirectory() / "test.grf" ).as_posix() )
+		GafferSceneUI.ShaderView.registerScene( "test", "Default", self.temporaryDirectory() / "test.grf" )
 
 		shader = GafferSceneTest.TestShader()
 		shader["type"].setValue( "test:surface" )

--- a/python/GafferSceneUITest/TransformToolTest.py
+++ b/python/GafferSceneUITest/TransformToolTest.py
@@ -72,11 +72,11 @@ class TransformToolTest( GafferUITest.TestCase ) :
 		# Reference internals are not editable, so attempts to access invalid
 		# fields should throw.
 
-		referenceFileName = os.path.join( self.temporaryDirectory(), "test.grf" )
-		script["box"].exportForReference( referenceFileName )
+		referenceFilePath = self.temporaryDirectory() / "test.grf"
+		script["box"].exportForReference( referenceFilePath )
 
 		script["reference"] = Gaffer.Reference()
-		script["reference"].load( referenceFileName )
+		script["reference"].load( referenceFilePath )
 
 		selection = GafferSceneUI.TransformTool.Selection( script["reference"]["out"], "/plane", script.context(), None )
 
@@ -318,11 +318,11 @@ class TransformToolTest( GafferUITest.TestCase ) :
 		# Make sure we don't accidentally traverse through the reference and try to edit
 		# the Plane directly.
 
-		referenceFileName = os.path.join( self.temporaryDirectory(), "test.grf" )
-		script["box"].exportForReference( referenceFileName )
+		referenceFilePath = self.temporaryDirectory() / "test.grf"
+		script["box"].exportForReference( referenceFilePath )
 
 		script["reference"] = Gaffer.Reference()
-		script["reference"].load( referenceFileName )
+		script["reference"].load( referenceFilePath )
 		script["reference"]["in"].setInput( script["plane"]["out"] )
 
 		selection = GafferSceneUI.TransformTool.Selection( script["reference"]["out"], "/plane", script.context(), None )

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -793,7 +793,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["writer"] = GafferScene.SceneWriter()
 		script["writer"]["in"].setInput( script["group"]["out"] )
-		script["writer"]["fileName"].setValue( os.path.join( self.temporaryDirectory(), "test.abc" ) )
+		script["writer"]["fileName"].setValue( self.temporaryDirectory() / "test.abc" )
 		script["writer"]["task"].execute()
 
 		script["reader"] = GafferScene.SceneReader()

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -459,7 +459,7 @@ void ShaderView::deregisterRenderer( const std::string &shaderPrefix )
 	rendererRegistrationChangedSignal()();
 }
 
-void ShaderView::registerScene( const std::string &shaderPrefix, const std::string &name, const std::string &fileName )
+void ShaderView::registerScene( const std::string &shaderPrefix, const std::string &name, const std::filesystem::path &fileName )
 {
 	// See ShaderViewBinding.cpp for details.
 	throw IECore::Exception( "ShaderView::registerScene currently only implemented in Python" );

--- a/src/GafferSceneUIModule/ViewBinding.cpp
+++ b/src/GafferSceneUIModule/ViewBinding.cpp
@@ -52,6 +52,7 @@
 #include "IECorePython/ExceptionAlgo.h"
 
 #include <string>
+#include <filesystem>
 
 using namespace std;
 using namespace boost::python;
@@ -196,7 +197,7 @@ struct CreatorWrapper
 struct ReferenceCreator
 {
 
-	ReferenceCreator( const std::string &referenceFileName )
+	ReferenceCreator( const std::filesystem::path &referenceFileName )
 		:	m_referenceFileName( referenceFileName )
 	{
 	}
@@ -217,7 +218,7 @@ struct ReferenceCreator
 
 	private :
 
-		std::string m_referenceFileName;
+		std::filesystem::path m_referenceFileName;
 
 };
 
@@ -236,7 +237,7 @@ void registerScene( const std::string &shaderPrefix, const std::string &name, ob
 	ShaderView::registerScene( shaderPrefix, name, CreatorWrapper<Node>( creator ) );
 }
 
-void registerReferenceScene( const std::string &shaderPrefix, const std::string &name, const std::string &referenceFileName )
+void registerReferenceScene( const std::string &shaderPrefix, const std::string &name, const std::filesystem::path &referenceFileName )
 {
 	ShaderView::registerScene( shaderPrefix, name, ReferenceCreator( referenceFileName ) );
 }


### PR DESCRIPTION
This converts all of the paths used by `GafferScene` and `GafferSceneUI` to `pathlib.Path` and `as_posix()` where needed.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
