### PR TITLE
`std::filesystem::path` Windows fix

### DIFF
--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -214,12 +214,12 @@ IE_CORE_DEFINERUNTIMETYPED( ScriptNode::CompoundAction );
 namespace
 {
 
-std::string readFile( const std::string &fileName )
+std::string readFile( const std::filesystem::path &fileName )
 {
 	std::ifstream f( fileName.c_str() );
 	if( !f.good() )
 	{
-		throw IECore::IOException( "Unable to open file \"" + fileName + "\"" );
+		throw IECore::IOException( "Unable to open file \"" + fileName.string() + "\"" );
 	}
 
 	const IECore::Canceller *canceller = Context::current()->canceller();
@@ -230,7 +230,7 @@ std::string readFile( const std::string &fileName )
 		IECore::Canceller::check( canceller );
 		if( !f.good() )
 		{
-			throw IECore::IOException( "Failed to read from \"" + fileName + "\"" );
+			throw IECore::IOException( "Failed to read from \"" + fileName.string() + "\"" );
 		}
 
 		std::string line;
@@ -846,7 +846,7 @@ bool ScriptNode::execute( const std::string &serialisation, Node *parent, bool c
 bool ScriptNode::executeFile( const std::filesystem::path &fileName, Node *parent, bool continueOnError )
 {
 	const std::string serialisation = readFile( fileName );
-	return executeInternal( serialisation, parent, continueOnError, fileName );
+	return executeInternal( serialisation, parent, continueOnError, fileName.generic_string() );
 }
 
 bool ScriptNode::load( bool continueOnError)

--- a/src/GafferModule/SubGraphBinding.cpp
+++ b/src/GafferModule/SubGraphBinding.cpp
@@ -281,13 +281,13 @@ class ReferenceSerialiser : public NodeSerialiser
 	{
 		const Reference *r = static_cast<const Reference *>( graphComponent );
 
-		const std::string &fileName = r->fileName();
+		const std::filesystem::path &fileName = r->fileName();
 		if( fileName.empty() )
 		{
 			return "";
 		};
 
-		return identifier + ".load( \"" + fileName + "\" )\n";
+		return identifier + ".load( \"" + fileName.generic_string() + "\" )\n";
 	}
 
 };


### PR DESCRIPTION
I didn't catch this in my review of #4990 because I was incorrectly assuming that PR would error on Windows. It should at least build, which this PR fixes.

### Breaking changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
