### PR TITLE
PathBinding : Fix StdPathFromPathlibPath conversion

### DIFF
--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -481,12 +481,12 @@ struct StdPathFromPathlibPath
 		data->convertible = storage;
 
 		object o( handle<>( borrowed( obj ) ) );
-		std::string s;
 		if( !PyUnicode_Check( obj ) )
 		{
 			o = o.attr( "__str__" )();
 		}
-		*path = std::string( extract<std::string>( o ) );
+		const std::string s = extract<std::string>( o );
+		*path = s;
 	}
 
 };


### PR DESCRIPTION
Somehow, using a temporary `extract` in the assignment to `path` causes the path to be constructed in a corrupted state. This was causing `ApplicationRootTest.testPreferences` to fail, due to `parent_path()` returning the original path rather than the parent directory.
