### PR TITLE
Prefer `std::filesystem` to `boost::filesystem`

### DIFF
--- a/src/Gaffer/FileSequencePathFilter.cpp
+++ b/src/Gaffer/FileSequencePathFilter.cpp
@@ -42,7 +42,8 @@
 #include "IECore/FileSequenceFunctions.h"
 
 #include "boost/bind/bind.hpp"
-#include "boost/filesystem.hpp"
+
+#include <filesystem>
 
 using namespace std;
 using namespace boost::placeholders;
@@ -97,7 +98,7 @@ bool FileSequencePathFilter::remove( PathPtr path ) const
 		return false;
 	}
 
-	if( m_mode == All || boost::filesystem::is_directory( fileSystemPath->string() ) )
+	if( m_mode == All || std::filesystem::is_directory( fileSystemPath->string() ) )
 	{
 		// always keep directories (and All)
 		return false;
@@ -120,7 +121,7 @@ bool FileSequencePathFilter::remove( PathPtr path ) const
 		return false;
 	}
 
-	if( ( m_mode & Files ) && !isSequentialFile && boost::filesystem::is_regular_file( fileSystemPath->string() ) )
+	if( ( m_mode & Files ) && !isSequentialFile && std::filesystem::is_regular_file( fileSystemPath->string() ) )
 	{
 		// its a real file on disk that isn't a sequential file, so keep it
 		return false;

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -55,8 +55,6 @@
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"
-#include "boost/filesystem/convenience.hpp"
-#include "boost/filesystem/path.hpp"
 
 #include <fstream>
 
@@ -987,12 +985,12 @@ void ScriptNode::plugSet( Plug *plug )
 	}
 	else if( plug == fileNamePlug() )
 	{
-		const boost::filesystem::path fileName( fileNamePlug()->getValue() );
+		const std::filesystem::path fileName( fileNamePlug()->getValue() );
 		context()->set( g_scriptName, fileName.stem().string() );
 
 		MetadataAlgo::setReadOnly(
 			this,
-			boost::filesystem::exists( fileName ) && 0 != access( fileName.c_str(), W_OK ),
+			std::filesystem::exists( fileName ) && 0 != access( fileName.c_str(), W_OK ),
 			/* persistent = */ false
 		);
 	}

--- a/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
+++ b/src/GafferAppleseed/IECoreAppleseedPreview/Renderer.cpp
@@ -86,13 +86,13 @@
 #include "renderer/api/utility.h"
 
 #include "boost/algorithm/string.hpp"
-#include "boost/filesystem/convenience.hpp"
-#include "boost/filesystem/operations.hpp"
 #include "boost/lexical_cast.hpp"
 #include "boost/smart_ptr/scoped_ptr.hpp"
 #include "boost/thread.hpp"
 
 #include "tbb/concurrent_hash_map.h"
+
+#include <filesystem>
 
 namespace asf = foundation;
 namespace asr = renderer;
@@ -247,7 +247,7 @@ class AppleseedRendererBase : public IECoreScenePreview::Renderer
 		float m_shutterCloseTime;
 
 		string m_appleseedFileName;
-		boost::filesystem::path m_projectPath;
+		std::filesystem::path m_projectPath;
 };
 
 } // namespace
@@ -1191,7 +1191,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			AppleseedPrimitive::attributes( attributes );
 		}
 
-		AppleseedPrimitive( asr::Project &project, const string &name, const Object *object, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const boost::filesystem::path &projectPath )
+		AppleseedPrimitive( asr::Project &project, const string &name, const Object *object, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::filesystem::path &projectPath )
 			:	AppleseedEntity( project, name, false )
 		{
 			init();
@@ -1201,7 +1201,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			createSceneDescriptionObject( samples, projectPath, attributes );
 		}
 
-		AppleseedPrimitive( asr::Project &project, const string &name, const vector<const Object *> &samples, const vector<float> &times, float shutterOpenTime, float shutterCloseTime, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const boost::filesystem::path &projectPath )
+		AppleseedPrimitive( asr::Project &project, const string &name, const vector<const Object *> &samples, const vector<float> &times, float shutterOpenTime, float shutterCloseTime, const IECoreScenePreview::Renderer::AttributesInterface *attributes, const std::filesystem::path &projectPath )
 			:	AppleseedEntity( project, name, false )
 		{
 			init();
@@ -1450,7 +1450,7 @@ class AppleseedPrimitive : public AppleseedEntity
 			return ".binarymesh";
 		}
 
-		void writeGeomFile( const Object *object, const boost::filesystem::path &path ) const
+		void writeGeomFile( const Object *object, const std::filesystem::path &path ) const
 		{
 			asf::auto_release_ptr<asr::Object> obj( ObjectAlgo::convert( object ) );
 
@@ -1463,7 +1463,7 @@ class AppleseedPrimitive : public AppleseedEntity
 		}
 
 		template<class ObjectType>
-		void createSceneDescriptionObject( const vector<ObjectType> &samples, const boost::filesystem::path &projectPath, const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+		void createSceneDescriptionObject( const vector<ObjectType> &samples, const std::filesystem::path &projectPath, const IECoreScenePreview::Renderer::AttributesInterface *attributes )
 		{
 			const AppleseedAttributes *appleseedAttributes = static_cast<const AppleseedAttributes*>( attributes );
 
@@ -1476,14 +1476,14 @@ class AppleseedPrimitive : public AppleseedEntity
 				MurmurHash hash = object.hash();
 
 				string fileName = string( "_geometry/" ) + hash.toString() + filenameExtensionForObject( &object );
-				boost::filesystem::path p = projectPath / fileName;
+				std::filesystem::path p = projectPath / fileName;
 
 				// todo: can we do something better than locking here?
 				{
 					boost::lock_guard<boost::mutex> lock( g_geomFilesMutex );
 
 					// Write a geom file for the object if needed.
-					if( !boost::filesystem::exists( p ) )
+					if( !std::filesystem::exists( p ) )
 					{
 						writeGeomFile( &object, p );
 					}
@@ -2389,13 +2389,13 @@ void AppleseedRendererBase::createProject()
 			msg( MessageHandler::Error, "AppleseedRenderer", "Empty project filename" );
 		}
 
-		m_projectPath = boost::filesystem::path( m_appleseedFileName ).parent_path();
+		m_projectPath = std::filesystem::path( m_appleseedFileName ).parent_path();
 
 		// Create a dir to store the mesh files if it does not exist yet.
-		boost::filesystem::path geomPath = m_projectPath / "_geometry";
-		if( !boost::filesystem::exists( geomPath ) )
+		std::filesystem::path geomPath = m_projectPath / "_geometry";
+		if( !std::filesystem::exists( geomPath ) )
 		{
-			if( !boost::filesystem::create_directory( geomPath ) )
+			if( !std::filesystem::create_directory( geomPath ) )
 			{
 				msg( MessageHandler::Error, "AppleseedRenderer", "Couldn't create _geometry directory." );
 			}

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -53,7 +53,6 @@
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/lexical_cast.hpp"
-#include "boost/filesystem.hpp"
 #include "boost/unordered_map.hpp"
 
 // Cycles
@@ -62,6 +61,8 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/osl.h"
 #include "util/path.h"
 IECORE_POP_DEFAULT_VISIBILITY
+
+#include <filesystem>
 
 using namespace std;
 using namespace IECore;
@@ -280,12 +281,12 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 					// Workaround to find all available tiles
 					string baseFileName = fileName.substr( 0, offset );
 					vector<string> files;
-					boost::filesystem::path path( ccl::path_dirname( pathFileName ) );
-					for( boost::filesystem::directory_iterator it( path ); it != boost::filesystem::directory_iterator(); ++it )
+					const std::filesystem::path path( ccl::path_dirname( pathFileName ) );
+					for( const auto &d : std::filesystem::directory_iterator( path ) )
 					{
-						if( boost::filesystem::is_regular_file( it->status() ) || boost::filesystem::is_symlink( it->status() ) )
+						if( std::filesystem::is_regular_file( d.status() ) || std::filesystem::is_symlink( d.status() ) )
 						{
-							string foundFile = it->path().stem().string();
+							string foundFile = d.path().stem().string();
 							if( baseFileName == ( foundFile.substr( 0, offset ) ) )
 							{
 								files.push_back( foundFile );

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -64,11 +64,11 @@
 #include "OpenColorIO/OpenColorIO.h"
 
 #include "boost/algorithm/string.hpp"
-#include "boost/filesystem.hpp"
 #include "boost/functional/hash.hpp"
 
 #include "tbb/spin_mutex.h"
 
+#include <filesystem>
 #include <memory>
 
 #ifndef _MSC_VER
@@ -2009,10 +2009,10 @@ void ImageWriter::execute() const
 
 	// Create the directory we need and open the file
 
-	boost::filesystem::path directory = boost::filesystem::path( fileName ).parent_path();
+	const std::filesystem::path directory = std::filesystem::path( fileName ).parent_path();
 	if( !directory.empty() )
 	{
-		boost::filesystem::create_directories( directory );
+		std::filesystem::create_directories( directory );
 	}
 
 

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -59,7 +59,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include "boost/bind/bind.hpp"
-#include "boost/filesystem/path.hpp"
 #include "boost/regex.hpp"
 
 #include <memory>

--- a/src/GafferModule/ApplicationRootBinding.cpp
+++ b/src/GafferModule/ApplicationRootBinding.cpp
@@ -49,8 +49,6 @@
 #include "IECorePython/RunTimeTypedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
 
-#include "boost/filesystem.hpp"
-
 #include <fstream>
 
 using namespace boost::python;

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -197,24 +197,24 @@ class ScopedDirectory : boost::noncopyable
 
 	public :
 
-		ScopedDirectory( const boost::filesystem::path &p )
+		ScopedDirectory( const std::filesystem::path &p )
 			:	m_path( p )
 		{
-			boost::filesystem::create_directories( m_path );
+			std::filesystem::create_directories( m_path );
 		}
 
 		~ScopedDirectory()
 		{
-			boost::filesystem::remove_all( m_path );
+			std::filesystem::remove_all( m_path );
 		}
 
 	private :
 
-		boost::filesystem::path m_path;
+		std::filesystem::path m_path;
 
 };
 
-boost::filesystem::path compile( const std::string &shaderName, const std::string &shaderSource )
+std::filesystem::path compile( const std::string &shaderName, const std::string &shaderSource )
 {
 
 	// We need to ensure the existence of a unique .oso file
@@ -233,7 +233,7 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 
 	// Start by generating our final desired filename.
 
-	boost::filesystem::path directory = boost::filesystem::temp_directory_path() / "gafferOSLCode";
+	std::filesystem::path directory = std::filesystem::temp_directory_path() / "gafferOSLCode";
 	if( const char *cd = getenv( "GAFFEROSL_CODE_DIRECTORY" ) )
 	{
 		directory = cd;
@@ -246,11 +246,11 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 		directory /= shaderName.substr( i, 8 );
 	}
 
-	const boost::filesystem::path osoFileName = directory / ( shaderName + ".oso" );
+	const std::filesystem::path osoFileName = directory / ( shaderName + ".oso" );
 
 	// If that exists, then someone else has done our work already.
 
-	if( boost::filesystem::exists( osoFileName ) )
+	if( std::filesystem::exists( osoFileName ) )
 	{
 		return osoFileName.generic_string();
 	}
@@ -259,7 +259,7 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 	// ScopedDirectory class will remove it for us automatically on
 	// destruction, so we don't need to worry about exception handling.
 
-	const boost::filesystem::path tempDirectory = directory / boost::filesystem::unique_path();
+	const std::filesystem::path tempDirectory = directory / boost::filesystem::unique_path().string();
 	ScopedDirectory scopedTempDirectory( tempDirectory );
 
 	// Write the source code out.
@@ -308,7 +308,7 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 		}
 	}
 
-	if( !boost::filesystem::file_size( tempOSLFileName ) )
+	if( !std::filesystem::file_size( tempOSLFileName ) )
 	{
 		// Belt and braces. `compiler.compile()` should be reporting all errors,
 		// but on rare occasions we have still seen empty `.oso` files being
@@ -318,9 +318,9 @@ boost::filesystem::path compile( const std::string &shaderName, const std::strin
 
 	// Move temp file where we really want it, and clean up.
 
-	boost::filesystem::rename( tempOSOFileName, osoFileName );
+	std::filesystem::rename( tempOSOFileName, osoFileName );
 
-	if( !boost::filesystem::file_size( osoFileName ) )
+	if( !std::filesystem::file_size( osoFileName ) )
 	{
 		// Belt and braces. `rename()` should be reporting all errors,
 		// but on rare occasions we have still seen empty `.oso` files being
@@ -343,7 +343,7 @@ class CompileProcess : public Gaffer::Process
 			{
 				string shaderName;
 				string shaderSource = generate( oslCode, shaderName );
-				boost::filesystem::path shaderFile = compile( shaderName, shaderSource );
+				std::filesystem::path shaderFile = compile( shaderName, shaderSource );
 				oslCode->namePlug()->setValue( shaderFile.replace_extension().generic_string() );
 				oslCode->typePlug()->setValue( "osl:shader" );
 			}

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -42,12 +42,12 @@
 
 #include "IECore/MessageHandler.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/regex.hpp>
 
+#include <filesystem>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -217,7 +217,7 @@ IECore::CompoundDataPtr parseManifestFromSidecarFile( const std::string &manifes
 	{
 		throw IECore::Exception( "No manifest file provided." );
 	}
-	else if( !boost::filesystem::is_regular_file( manifestFile ) )
+	else if( !std::filesystem::is_regular_file( manifestFile ) )
 	{
 		throw IECore::Exception( boost::str( boost::format( "Manifest file not found: %s" ) % manifestFile ) );
 	}
@@ -247,13 +247,13 @@ IECore::CompoundDataPtr parseManifestFromMetadataAndSidecar( const std::string &
 	{
 		throw IECore::Exception( "No manifest directory provided. A directory is required to locate the manifest." );
 	}
-	else if( !boost::filesystem::is_directory( manifestDirectory ) )
+	else if( !std::filesystem::is_directory( manifestDirectory ) )
 	{
 		throw IECore::Exception( boost::str( boost::format( "Manifest directory not found: %s") % manifestDirectory ) );
 	}
 
 	const StringData *manifestFile = metadata->member<StringData>( metadataKey );
-	boost::filesystem::path p( manifestDirectory );
+	std::filesystem::path p( manifestDirectory );
 	// append manifest file to directory path
 	p /= manifestFile->readable();
 

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -48,8 +48,7 @@
 
 #include "IECore/ObjectPool.h"
 
-#include "boost/filesystem.hpp"
-
+#include <filesystem>
 #include <memory>
 
 using namespace IECore;
@@ -278,11 +277,11 @@ void Render::executeInternal( bool flushCaches ) const
 		}
 		else
 		{
-			boost::filesystem::path fileNamePath( fileName );
-			boost::filesystem::path directoryPath = fileNamePath.parent_path();
+			const std::filesystem::path fileNamePath( fileName );
+			const std::filesystem::path directoryPath = fileNamePath.parent_path();
 			if( !directoryPath.empty() && !renderScope.sceneTranslationOnly() )
 			{
-				boost::filesystem::create_directories( directoryPath );
+				std::filesystem::create_directories( directoryPath );
 			}
 		}
 	}

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -60,12 +60,13 @@
 #include "IECore/NullObject.h"
 
 #include "boost/algorithm/string/predicate.hpp"
-#include "boost/filesystem.hpp"
 
 #include "tbb/blocked_range.h"
 #include "tbb/parallel_reduce.h"
 #include "tbb/parallel_for.h"
 #include "tbb/task.h"
+
+#include <filesystem>
 
 using namespace std;
 using namespace Imath;
@@ -102,16 +103,15 @@ namespace RendererAlgo
 
 void createOutputDirectories( const IECore::CompoundObject *globals )
 {
-	CompoundObject::ObjectMap::const_iterator it, eIt;
-	for( it = globals->members().begin(), eIt = globals->members().end(); it != eIt; it++ )
+	for( const auto &m : globals->members() )
 	{
-		if( const Output *o = runTimeCast<Output>( it->second.get() ) )
+		if( const Output *o = runTimeCast<Output>( m.second.get() ) )
 		{
-			boost::filesystem::path fileName( o->getName() );
-			boost::filesystem::path directory = fileName.parent_path();
+			const std::filesystem::path fileName( o->getName() );
+			const std::filesystem::path directory = fileName.parent_path();
 			if( !directory.empty() )
 			{
-				boost::filesystem::create_directories( directory );
+				std::filesystem::create_directories( directory );
 			}
 		}
 	}

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -44,9 +44,9 @@
 
 #include "IECoreScene/SceneInterface.h"
 
-#include "boost/filesystem.hpp"
-
 #include "tbb/mutex.h"
+
+#include <filesystem>
 
 using namespace std;
 using namespace IECore;
@@ -291,10 +291,10 @@ bool SceneWriter::requiresSequenceExecution() const
 
 void SceneWriter::createDirectories( const std::string &fileName ) const
 {
-	boost::filesystem::path filePath( fileName );
-	boost::filesystem::path directory = filePath.parent_path();
+	const std::filesystem::path filePath( fileName );
+	const std::filesystem::path directory = filePath.parent_path();
 	if( !directory.empty() )
 	{
-		boost::filesystem::create_directories( directory );
+		std::filesystem::create_directories( directory );
 	}
 }

--- a/src/GafferUSD/USDLayerWriter.cpp
+++ b/src/GafferUSD/USDLayerWriter.cpp
@@ -51,6 +51,8 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/filesystem.hpp"
 
+#include <filesystem>
+
 using namespace std;
 using namespace pxr;
 using namespace IECore;
@@ -71,30 +73,30 @@ class ScopedDirectory : boost::noncopyable
 
 	public :
 
-		ScopedDirectory( const boost::filesystem::path &p )
+		ScopedDirectory( const std::filesystem::path &p )
 			:	m_path( p )
 		{
-			boost::filesystem::create_directories( m_path );
+			std::filesystem::create_directories( m_path );
 		}
 
 		~ScopedDirectory()
 		{
-			boost::filesystem::remove_all( m_path );
+			std::filesystem::remove_all( m_path );
 		}
 
 	private :
 
-		boost::filesystem::path m_path;
+		std::filesystem::path m_path;
 
 };
 
 void createDirectories( const std::string &fileName )
 {
-	boost::filesystem::path filePath( fileName );
-	boost::filesystem::path directory = filePath.parent_path();
+	std::filesystem::path filePath( fileName );
+	std::filesystem::path directory = filePath.parent_path();
 	if( !directory.empty() )
 	{
-		boost::filesystem::create_directories( directory );
+		std::filesystem::create_directories( directory );
 	}
 }
 
@@ -352,7 +354,7 @@ void USDLayerWriter::executeSequence( const std::vector<float> &frames ) const
 	/// which are identical in both scenes, to avoid the overhead of writing
 	/// them only to discard them in `createDiff()`?
 
-	const boost::filesystem::path tempDirectory = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+	const std::filesystem::path tempDirectory = std::filesystem::temp_directory_path() / boost::filesystem::unique_path().string();
 	ScopedDirectory scopedTempDirectory( tempDirectory );
 
 	const string baseFileName = ( tempDirectory / "base.usdc" ).generic_string();

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -64,7 +64,6 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/container/flat_map.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
-#include "boost/filesystem/operations.hpp"
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"
 
@@ -82,6 +81,7 @@
 #include "tbb/spin_mutex.h"
 
 #include <condition_variable>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <sstream>
@@ -89,7 +89,6 @@
 #include <unordered_set>
 
 using namespace std;
-using namespace boost::filesystem;
 using namespace IECoreArnold;
 
 //////////////////////////////////////////////////////////////////////////
@@ -3217,9 +3216,9 @@ class ArnoldGlobals
 					{
 						try
 						{
-							boost::filesystem::path path( d->readable() );
-							path.remove_filename();
-							boost::filesystem::create_directories( path );
+							std::filesystem::create_directories(
+								std::filesystem::path( d->readable() ).parent_path()
+							);
 						}
 						catch( const std::exception &e )
 						{
@@ -3246,9 +3245,9 @@ class ArnoldGlobals
 					{
 						try
 						{
-							boost::filesystem::path path( d->readable() );
-							path.remove_filename();
-							boost::filesystem::create_directories( path );
+							std::filesystem::create_directories(
+								std::filesystem::path( d->readable() ).parent_path()
+							);
 						}
 						catch( const std::exception &e )
 						{
@@ -3272,9 +3271,9 @@ class ArnoldGlobals
 					{
 						try
 						{
-							boost::filesystem::path path( d->readable() );
-							path.remove_filename();
-							boost::filesystem::create_directories( path );
+							std::filesystem::create_directories(
+								std::filesystem::path( d->readable() ).parent_path()
+							);
 						}
 						catch( const std::exception &e )
 						{

--- a/src/IECoreArnold/UniverseBlock.cpp
+++ b/src/IECoreArnold/UniverseBlock.cpp
@@ -37,7 +37,6 @@
 #include "IECore/Exception.h"
 #include "IECore/MessageHandler.h"
 
-#include "boost/filesystem.hpp"
 #include "boost/tokenizer.hpp"
 
 #include "ai_metadata.h"
@@ -45,6 +44,8 @@
 #include "ai_plugins.h"
 #include "ai_render.h"
 #include "ai_universe.h"
+
+#include <filesystem>
 
 using namespace IECore;
 using namespace IECoreArnold;
@@ -61,17 +62,17 @@ void loadMetadata( const std::string &pluginPaths )
 		const char *separator = ":";
 	#endif
 	Tokenizer t( pluginPaths, boost::char_separator<char>( separator ) );
-	for( Tokenizer::const_iterator it = t.begin(), eIt = t.end(); it != eIt; ++it )
+	for( const auto &pluginPath : t )
 	{
 		try
 		{
-			for( boost::filesystem::recursive_directory_iterator dIt( *it ), deIt; dIt != deIt; ++dIt )
+			for( const auto &d : std::filesystem::recursive_directory_iterator( pluginPath ) )
 			{
-				if( dIt->path().extension() == ".mtd" )
+				if( d.path().extension() == ".mtd" )
 				{
-					if( !AiMetaDataLoadFile( dIt->path().string().c_str() ) )
+					if( !AiMetaDataLoadFile( d.path().string().c_str() ) )
 					{
-						throw IECore::Exception( boost::str( boost::format( "Failed to load \"%s\"" ) % dIt->path().string() ) );
+						throw IECore::Exception( boost::str( boost::format( "Failed to load \"%s\"" ) % d.path().string() ) );
 					}
 				}
 			}


### PR DESCRIPTION
Continuing our great-filesystem-shakeup-of-2022, this replaces the majority of our uses of `boost::filesystem` with `std::filesystem`. Boost still hangs on by its fingernails in a couple of places :

- Where we use `IECore::SearchPath`, which returns `boost` paths.
- Where we use `unique_name`, because that has no equivalent in C++ yet.
- Where we query file times in FileSystemPath and convert them to `boost::posix_time::ptime` via `std::time_t`. This thread on Stack Overflow says we need to wait till C++20 for a decent way of doing that : https://stackoverflow.com/questions/61030383/how-to-convert-stdfilesystemfile-time-type-to-time-t.

Only the final commit needs reviewing. The rest are all inherited from #5001, so I could run the unit tests.