### PR TITLE
Documentation : Fix TOC on pages containing headerlinks under figures

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - MessagesBinding : Fixed GIL management bug that could cause crashes when performing an interactive render.
 - Spreadsheet : Fixed crash when connecting a StringVectorDataPlug to a row's `name` plug.
+- Documentation : Fixed "In this article" navigation column contents on pages containing figures.
 
 1.0.6.3 (relative to 1.0.6.2)
 =======

--- a/doc/source/_static/scrollspy.js
+++ b/doc/source/_static/scrollspy.js
@@ -223,6 +223,11 @@ function GenerateTOC() {
     /* Build the TOC */
     anchors.forEach(
         function(anchor) {
+            var headingMatch = anchor.parentNode.nodeName.match(/^H([1-6])$/);
+            if (!headingMatch) {
+                /* Only include anchors that are children of a heading */
+                return;
+            }
             /* Grab the bookmark */
             var bookmark = anchor.getAttribute('href');
             /* Clone the heading, since we must manipulate its nodes in
@@ -231,7 +236,7 @@ function GenerateTOC() {
             /* Remove the anchor (and pilcrow) from the cloned node */
             heading.removeChild(heading.lastChild);
             var headingHTML = heading.innerHTML;
-            var curLevel = heading.nodeName.replace('H', '');
+            var curLevel = Number(headingMatch[1]);
 
             if (curLevel > prevLevel) {
                 TOCHTML += (new Array(curLevel - prevLevel + 1)).join('<ul>');
@@ -241,7 +246,7 @@ function GenerateTOC() {
                 TOCHTML += (new Array(prevLevel + 1)).join('</li>');
             }
 
-            prevLevel = Number(curLevel);
+            prevLevel = curLevel;
             TOCHTML += '<li><a href="' + bookmark + '">' + headingHTML + '</a>';
         }
     );


### PR DESCRIPTION
The "In this article" navigation column has been broken on some (but not all) documentation pages since the 1.0 release. For example compare [this](http://www.gafferhq.org/documentation/1.1.5.0/WorkingWithScenes/LightLinking/index.html) page with the [equivalent](http://www.gafferhq.org/documentation/0.61.0.0/WorkingWithScenes/LightLinking/index.html) in the 0.61 documentation. 

It appears that after migrating from recommonmark to myst-parser Sphinx now also adds anchor links under figures, and gives them the `headerlink` class. This change broke the TOC generation as it was previously assumed that every `headerlink` would have a `<H#>` parent. With this PR we now ignore headerlinks that aren't a child of a heading when generating the table of contents.

Maybe there's a better way to generate the TOC statically from Sphinx rather than requiring this JavaScript to do it, but this seemed like a simple enough change to restore the existing functionality.