### PR TITLE
Spreadsheet : Fix crash connecting a StringVectorDataPlug to a row's `name` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - MessagesBinding : Fixed GIL management bug that could cause crashes when performing an interactive render.
+- Spreadsheet : Fixed crash when connecting a StringVectorDataPlug to a row's `name` plug.
 
 1.0.6.3 (relative to 1.0.6.2)
 =======

--- a/python/GafferTest/SpreadsheetTest.py
+++ b/python/GafferTest/SpreadsheetTest.py
@@ -1235,5 +1235,17 @@ class SpreadsheetTest( GafferTest.TestCase ) :
 			c["testSelector"] = "b"
 			self.assertEqual( s["activeRowIndex"].getValue(), 2 )
 
+	def testRowNameWithStringVectorDataInput( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["stringVector"] = Gaffer.StringVectorDataPlug( defaultValue = IECore.StringVectorData(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["user"]["stringVector"].setValue( IECore.StringVectorData( [ "a", "b", "c" ] ) )
+
+		s = Gaffer.Spreadsheet()
+		r = s["rows"].addRow()
+		r["name"].setInput( n["user"]["stringVector"] )
+
+		self.assertEqual( s["rows"].row( "a b c" ), r )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -423,7 +423,7 @@ class Spreadsheet::RowsPlug::RowNameMap
 
 		string rowName( const RowPlug *row )
 		{
-			auto namePlug = row->namePlug()->source<StringPlug>();
+			auto namePlug = row->namePlug()->source<ValuePlug>();
 			if( namePlug->direction() == Plug::Out )
 			{
 				return "__rowNameMap::computedNameSentinel__";


### PR DESCRIPTION
With the introduction of #4693 it was possible to crash Gaffer by connecting a `StringVectorDataPlug` to a Spreadsheet row's `name` plug.