### PR TITLE
GafferCycles : Fix handling of OSL component connections

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- Cycles : Fixed crash when attempting to use a non-existent OSL shader.
+- Cycles :
+  - Fixed handling of OSL shader component connections (#4926).
+  - Fixed crash when attempting to use a non-existent OSL shader.
 
 1.1.6.0 (relative to 1.1.5.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.1.x.x (relative to 1.1.6.0)
+=======
+
+Fixes
+-----
+
+- Cycles : Fixed crash when attempting to use a non-existent OSL shader.
+
 1.1.6.0 (relative to 1.1.5.0)
 =======
 

--- a/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
@@ -65,11 +65,6 @@ IECORECYCLES_API ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwor
                                                  ccl::ShaderManager *shaderManager,
                                                  const std::string &namePrefix = "" );
 
-IECORECYCLES_API ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader,
-                                       const IECoreScene::ShaderNetwork *displacementShader,
-                                       const IECoreScene::ShaderNetwork *volumeShader,
-                                       ccl::ShaderManager *shaderManager,
-                                       const std::string &namePrefix = "" );
 IECORECYCLES_API void convertAOV( const IECoreScene::ShaderNetwork *shaderNetwork, ccl::ShaderGraph *graph, ccl::ShaderManager *shaderManager, const std::string &namePrefix = "" );
 IECORECYCLES_API void setSingleSided( ccl::ShaderGraph *graph );
 IECORECYCLES_API ccl::Shader *createDefaultShader();

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -1280,6 +1280,47 @@ class RendererTest( GafferTest.TestCase ) :
 
 		del plane
 
+	def testMissingOSLShader( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			renderer.attributes( IECore.CompoundObject ( {
+				"cycles:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "NonExistentShader", "osl:surface" ),
+					},
+					output = "output",
+				)
+			} ) )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, "Couldn't load shader \"NonExistentShader\"" )
+
+	def testMissingCyclesShader( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			renderer.attributes( IECore.CompoundObject ( {
+				"cycles:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "NonExistentShader", "cycles:surface" ),
+					},
+					output = "output",
+				)
+			} ) )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, "Couldn't load shader \"NonExistentShader\"" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -1322,5 +1322,57 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].message, "Couldn't load shader \"NonExistentShader\"" )
 
+	def testOSLComponentConnections( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		renderer.output(
+			"testOutput",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testOSLComponentConnections",
+				}
+			)
+		)
+
+		plane = renderer.object(
+			"/plane",
+			IECoreScene.MeshPrimitive.createPlane(
+				imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ),
+			),
+			renderer.attributes( IECore.CompoundObject ( {
+				"cycles:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+						"multiplyColor" : IECoreScene.Shader( "Maths/MultiplyColor", "osl:shader", { "b" : imath.Color3f( 0, 0, 0 ) } ),
+						"multiplyFloat" : IECoreScene.Shader( "Maths/MultiplyFloat", "osl:shader" ),
+					},
+					connections = [
+						( ( "multiplyFloat", "out" ), ( "multiplyColor", "b.b" ) ),
+						( ( "multiplyColor", "out" ), ( "output", "emission" ) ),
+					],
+					output = "output",
+				)
+			} ) )
+		)
+
+		plane.transform( imath.M44f().translate( imath.V3f( 0, 0, 1 ) ) )
+
+		renderer.render()
+		time.sleep( 2 )
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testOSLComponentConnections" )
+		self.assertIsInstance( image, IECoreImage.ImagePrimitive )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.55 ) ), imath.Color4f( 0, 0, 1, 1 ) )
+
+		del plane
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -504,18 +504,24 @@ ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
 	{
 		if( surfaceShader )
 		{
+			ShaderNetworkPtr toConvert = surfaceShader->copy();
+			IECoreScene::ShaderNetworkAlgo::convertOSLComponentConnections( toConvert.get() );
 			ShaderMap converted;
-			convertWalk( surfaceShader->getOutput(), surfaceShader, namePrefix, shaderManager, graph, converted );
+			convertWalk( toConvert->getOutput(), toConvert.get(), namePrefix, shaderManager, graph, converted );
 		}
 		if( displacementShader )
 		{
+			ShaderNetworkPtr toConvert = surfaceShader->copy();
+			IECoreScene::ShaderNetworkAlgo::convertOSLComponentConnections( toConvert.get() );
 			ShaderMap converted;
-			convertWalk( displacementShader->getOutput(), displacementShader, namePrefix, shaderManager, graph, converted );
+			convertWalk( toConvert->getOutput(), toConvert.get(), namePrefix, shaderManager, graph, converted );
 		}
 		if( volumeShader )
 		{
+			ShaderNetworkPtr toConvert = surfaceShader->copy();
+			IECoreScene::ShaderNetworkAlgo::convertOSLComponentConnections( toConvert.get() );
 			ShaderMap converted;
-			convertWalk( volumeShader->getOutput(), volumeShader, namePrefix, shaderManager, graph, converted );
+			convertWalk( toConvert->getOutput(), toConvert.get(), namePrefix, shaderManager, graph, converted );
 		}
 	}
 

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -153,11 +153,6 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 {
 	// Reuse previously created node if we can.
 	const IECoreScene::Shader *shader = shaderNetwork->getShader( outputParameter.shader );
-	const bool isOSLShader = boost::starts_with( shader->getType(), "osl:" );
-	const bool isConverter = boost::starts_with( shader->getName(), "convert" );
-	const bool isAOV = boost::starts_with( shader->getType(), "cycles:aov:" );
-	const bool isImageTexture = shader->getName() == "image_texture";
-
 	auto inserted = converted.insert( { outputParameter.shader, nullptr } );
 	ccl::ShaderNode *&node = inserted.first->second;
 	if( !inserted.second )
@@ -166,6 +161,8 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 	}
 
 	// Create node for shader.
+
+	const bool isOSLShader = boost::starts_with( shader->getType(), "osl:" );
 
 	if( isOSLShader )
 	{
@@ -181,7 +178,7 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 			return node;
 		}
 	}
-	else if( isConverter )
+	else if( boost::starts_with( shader->getName(), "convert" ) )
 	{
 		/// \todo Why can't this be handled by the generic case below? There are NodeTypes
 		/// registered for each of these conversions, so `NodeType::find()` does work. The
@@ -221,6 +218,8 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 	node->name = ccl::ustring( nodeName.c_str() );
 
 	// Set the shader parameters
+
+	const bool isImageTexture = shader->getName() == "image_texture";
 
 	for( const auto &namedParameter : shader->parameters() )
 	{
@@ -364,7 +363,7 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		}
 	}
 
-	if( shaderNetwork->outputShader() == shader && !isAOV )
+	if( shaderNetwork->outputShader() == shader && !boost::starts_with( shader->getType(), "cycles:aov:" ) )
 	{
 		// Connect to the main output node of the cycles shader graph.
 		// Either cycles:surface, cycles:volume or cycles:displacement.

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -176,7 +176,6 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 	}
 	else if( isOSLShader )
 	{
-#ifdef WITH_OSL
 		if( shaderManager && shaderManager->use_osl() )
 		{
 			ccl::OSLShaderManager *manager = (ccl::OSLShaderManager*)shaderManager;
@@ -185,13 +184,8 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 			node = shaderGraph->add( node );
 		}
 		else
-#endif
 		{
-#ifdef WITH_OSL
 			msg( Msg::Warning, "IECoreCycles::ShaderNetworkAlgo", boost::format( "Couldn't load OSL shader \"%s\" as the shading system is not set to OSL." ) % shader->getName() );
-#else
-			msg( Msg::Warning, "IECoreCycles::ShaderNetworkAlgo", boost::format( "Couldn't load OSL shader \"%s\" as GafferCycles wasn't compiled with OSL support." ) % shader->getName() );
-#endif
 			return node;
 		}
 	}

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -538,26 +538,6 @@ ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
 	return graph;
 }
 
-ccl::Shader *convert( const IECoreScene::ShaderNetwork *surfaceShader,
-					  const IECoreScene::ShaderNetwork *displacementShader,
-					  const IECoreScene::ShaderNetwork *volumeShader,
-					  ccl::ShaderManager *shaderManager,
-					  const std::string &namePrefix )
-{
-	string shaderName(
-		namePrefix +
-		surfaceShader->getOutput().shader.string()
-	);
-
-	ccl::ShaderGraph *graph = convertGraph( surfaceShader, displacementShader, volumeShader, shaderManager, namePrefix );
-
-	ccl::Shader *result = new ccl::Shader();
-	result->name = ccl::ustring( shaderName.c_str() );
-	result->set_graph( graph );
-
-	return result;
-}
-
 void convertAOV( const IECoreScene::ShaderNetwork *shaderNetwork, ccl::ShaderGraph *graph, ccl::ShaderManager *shaderManager, const std::string &namePrefix )
 {
 	ShaderMap converted;

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -151,13 +151,8 @@ typedef boost::unordered_map<ShaderNetwork::Parameter, ccl::ShaderNode *> Shader
 
 ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECoreScene::ShaderNetwork *shaderNetwork, const std::string &namePrefix, ccl::ShaderManager *shaderManager, ccl::ShaderGraph *shaderGraph, ShaderMap &converted )
 {
-	// Reuse previously created node if we can. It is ideal for all assigned
-	// shaders in the graph to funnel through the default "output" so
-	// that things like MIS/displacement/etc. can be set, however it isn't a
-	// requirement. Regardless, we look out for this special node as it already
-	// exists in the graph and we simply point to it.
+	// Reuse previously created node if we can.
 	const IECoreScene::Shader *shader = shaderNetwork->getShader( outputParameter.shader );
-	const bool isOutput = ( boost::starts_with( shader->getType(), "cycles:" ) ) && ( shader->getName() == "output" );
 	const bool isOSLShader = boost::starts_with( shader->getType(), "osl:" );
 	const bool isConverter = boost::starts_with( shader->getName(), "convert" );
 	const bool isAOV = boost::starts_with( shader->getType(), "cycles:aov:" );
@@ -170,11 +165,7 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		return node;
 	}
 
-	if( isOutput )
-	{
-		node = (ccl::ShaderNode*)shaderGraph->output();
-	}
-	else if( isOSLShader )
+	if( isOSLShader )
 	{
 		if( shaderManager && shaderManager->use_osl() )
 		{
@@ -373,10 +364,9 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		}
 	}
 
-	if( !isOutput && ( shaderNetwork->outputShader() == shader ) && !isAOV )
+	if( shaderNetwork->outputShader() == shader && !isAOV )
 	{
-		// In the cases where there is no cycles output attached in the network
-		// we just connect to the main output node of the cycles shader graph.
+		// Connect to the main output node of the cycles shader graph.
 		// Either cycles:surface, cycles:volume or cycles:displacement.
 		ccl::ShaderNode *outputNode = (ccl::ShaderNode*)shaderGraph->output();
 		string input = string( shader->getType().c_str() + 7 );

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -165,6 +165,8 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		return node;
 	}
 
+	// Create node for shader.
+
 	if( isOSLShader )
 	{
 		if( shaderManager && shaderManager->use_osl() )
@@ -172,7 +174,6 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 			ccl::OSLShaderManager *manager = (ccl::OSLShaderManager*)shaderManager;
 			std::string shaderFileName = g_shaderSearchPathCache.get( shader->getName() );
 			node = manager->osl_node( shaderGraph, shaderManager, shaderFileName.c_str() );
-			node = shaderGraph->add( node );
 		}
 		else
 		{
@@ -192,8 +193,6 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		{
 			ccl::ConvertNode *convertNode = shaderGraph->create_node<ccl::ConvertNode>( getSocketType( split[1] ), getSocketType( split[3] ), true );
 			node = (ccl::ShaderNode*)convertNode;
-			if( node )
-				node = shaderGraph->add( node );
 		}
 	}
 	else if( const ccl::NodeType *nodeType = ccl::NodeType::find( ccl::ustring( shader->getName() ) ) )
@@ -202,7 +201,6 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		{
 			node = static_cast<ccl::ShaderNode *>( nodeType->create( nodeType ) );
 			node->set_owner( shaderGraph );
-			shaderGraph->add( node );
 		}
 	}
 
@@ -212,7 +210,9 @@ ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, c
 		return node;
 	}
 
-	// Create the ShaderNode for this shader output
+	// Add node to graph
+
+	node = shaderGraph->add( node );
 
 	string nodeName(
 		namePrefix +


### PR DESCRIPTION
This fixes the bug handling connections into individual components of colors and points of OSL shaders, as reported in #4926. I've also included several other commits to tidy up various loose ends in ShaderNetworkAlgo.