### PR TITLE
Catalogue : Use `std::filesystem::path`

### DIFF
--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -548,7 +548,7 @@ class Catalogue::InternalImage : public ImageNode
 
 			private :
 
-				AsynchronousSaver( InternalImagePtr imageCopy, const std::string &fileName )
+				AsynchronousSaver( InternalImagePtr imageCopy, const std::filesystem::path &fileName )
 					:	m_imageCopy( imageCopy )
 				{
 					// Set up an ImageWriter to do the actual saving.


### PR DESCRIPTION
This is the same fix #4998 made, a quick `std::filesystem::path` to satisfy Windows' inability to implicitly cast to `std::string`.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
