### PR TITLE
Minor CyclesShader refactoring

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Cycles :
   - Fixed handling of OSL shader component connections (#4926).
   - Fixed crash when attempting to use a non-existent OSL shader.
+  - Fixed `Unsupported socket "tiles"` warning when loading the `image_texture` shader.
 
 1.1.6.0 (relative to 1.1.5.0)
 =======

--- a/include/GafferCycles/CyclesShader.h
+++ b/include/GafferCycles/CyclesShader.h
@@ -55,11 +55,6 @@ class GAFFERCYCLES_API CyclesShader : public GafferScene::Shader
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesShader, CyclesShaderTypeId, GafferScene::Shader );
 
-		/// Implemented for outPlug(), returning the parameter named in the "primaryInput"
-		/// shader annotation if it has been specified.
-		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
-		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
-
 		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
 
 	protected :

--- a/include/GafferCycles/SocketHandler.h
+++ b/include/GafferCycles/SocketHandler.h
@@ -54,7 +54,7 @@ namespace SocketHandler
 /// A helper class for mapping Cycles Sockets to Gaffer Plugs.
 Gaffer::Plug *setupPlug( const IECore::InternedString &socketName, int socketType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 Gaffer::Plug *setupPlug( const ccl::NodeType *nodeType, const ccl::SocketType socketType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
-void setupPlugs( const ccl::NodeType *node, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In, bool keepExistingChildren = false );
+void setupPlugs( const ccl::NodeType *node, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsParent, bool keepExistingChildren = false );
 
 } // namespace SocketHandler

--- a/include/GafferCycles/SocketHandler.h
+++ b/include/GafferCycles/SocketHandler.h
@@ -56,7 +56,6 @@ Gaffer::Plug *setupPlug( const IECore::InternedString &socketName, int socketTyp
 Gaffer::Plug *setupPlug( const ccl::NodeType *nodeType, const ccl::SocketType socketType, Gaffer::GraphComponent *plugParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In );
 void setupPlugs( const ccl::NodeType *node, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction = Gaffer::Plug::In, bool keepExistingChildren = false );
 void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsParent, bool keepExistingChildren = false );
-Gaffer::Plug *setupOutputNodePlug( Gaffer::GraphComponent *plugParent );
 
 } // namespace SocketHandler
 

--- a/python/GafferCyclesTest/CyclesShaderTest.py
+++ b/python/GafferCyclesTest/CyclesShaderTest.py
@@ -73,5 +73,11 @@ class CyclesShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "attribute" )
 		self.assertEqual( shader["out"].keys(), [ "color", "vector", "fac", "alpha" ] )
 
+	def testLoadAllShaders( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		for s in GafferCycles.shaders :
+			shader.loadShader( s )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/CyclesShaderTest.py
+++ b/python/GafferCyclesTest/CyclesShaderTest.py
@@ -64,5 +64,14 @@ class CyclesShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertIsInstance( shader["out"]["fac"], Gaffer.FloatPlug )
 		self.assertIsInstance( shader["out"]["alpha"], Gaffer.FloatPlug )
 
+	def testLoadRemovesUnneededChildren( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		shader.loadShader( "principled_bsdf" )
+		self.assertEqual( shader["out"].keys(), [ "BSDF" ] )
+
+		shader.loadShader( "attribute" )
+		self.assertEqual( shader["out"].keys(), [ "color", "vector", "fac", "alpha" ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/CyclesShaderTest.py
+++ b/python/GafferCyclesTest/CyclesShaderTest.py
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of Image Engine Design Inc nor the names of
+#      * Neither the name of Cinesite VFX Ltd nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,14 +34,35 @@
 #
 ##########################################################################
 
-from .CyclesLightTest import CyclesLightTest
-from .InteractiveCyclesRenderTest import InteractiveCyclesRenderTest
-from .ModuleTest import ModuleTest
-from .CyclesLightTest import CyclesLightTest
-from .CyclesShaderTest import CyclesShaderTest
+import unittest
 
-from .IECoreCyclesPreviewTest import *
+import Gaffer
+import GafferOSL
+import GafferSceneTest
+import GafferCycles
+
+class CyclesShaderTest( GafferSceneTest.SceneTestCase ) :
+
+	def testInitialPlugs( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		self.assertIn( "parameters", shader )
+		self.assertIn( "out", shader )
+		self.assertIs( type( shader["parameters"] ), Gaffer.Plug )
+		self.assertIs( type( shader["out"] ), Gaffer.Plug )
+		self.assertEqual( len( shader["parameters"] ), 0 )
+		self.assertEqual( len( shader["out"] ), 0 )
+
+	def testLoadOutputs( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		shader.loadShader( "attribute" )
+
+		self.assertEqual( shader["out"].keys(), [ "color", "vector", "fac", "alpha" ] )
+		self.assertIsInstance( shader["out"]["color"], Gaffer.Color3fPlug )
+		self.assertIsInstance( shader["out"]["vector"], Gaffer.V3fPlug )
+		self.assertIsInstance( shader["out"]["fac"], Gaffer.FloatPlug )
+		self.assertIsInstance( shader["out"]["alpha"], Gaffer.FloatPlug )
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/src/GafferCycles/CyclesShader.cpp
+++ b/src/GafferCycles/CyclesShader.cpp
@@ -103,27 +103,6 @@ const Gaffer::Plug *CyclesShader::correspondingInput( const Gaffer::Plug *output
 	}
 
 	return nullptr;
-
-	//const CompoundData *metadata = CyclesShader::metadata();
-	//if( !metadata )
-	//{
-	//	return nullptr;
-	//}
-
-	//const StringData *primaryInput = static_cast<const StringData*>( metadata->member<IECore::CompoundData>( "shader" )->member<IECore::Data>( "primaryInput" ) );
-	//if( !primaryInput )
-	//{
-	//	return nullptr;
-	//}
-
-	//const Plug *result = parametersPlug()->getChild<Plug>( primaryInput->readable() );
-	//if( !result )
-	//{
-	//	IECore::msg( IECore::Msg::Error, "CyclesShader::correspondingInput", boost::format( "Parameter \"%s\" does not exist" ) % primaryInput->readable() );
-	//	return nullptr;
-	//}
-
-	//return result;
 }
 
 void CyclesShader::loadShader( const std::string &shaderName, bool keepExistingValues )

--- a/src/GafferCycles/CyclesShader.cpp
+++ b/src/GafferCycles/CyclesShader.cpp
@@ -87,24 +87,6 @@ CyclesShader::~CyclesShader()
 {
 }
 
-Gaffer::Plug *CyclesShader::correspondingInput( const Gaffer::Plug *output )
-{
-	// better to do a few harmless casts than manage a duplicate implementation
-	return const_cast<Gaffer::Plug *>(
-		const_cast<const CyclesShader *>( this )->correspondingInput( output )
-	);
-}
-
-const Gaffer::Plug *CyclesShader::correspondingInput( const Gaffer::Plug *output ) const
-{
-	if( output != outPlug() )
-	{
-		return Shader::correspondingInput( output );
-	}
-
-	return nullptr;
-}
-
 void CyclesShader::loadShader( const std::string &shaderName, bool keepExistingValues )
 {
 

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -593,25 +593,6 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 	}
 }
 
-Gaffer::Plug *setupOutputNodePlug( Gaffer::GraphComponent *plugParent )
-{
-	Plug *existingPlug = plugParent->getChild<Plug>( "out" );
-	if(
-		existingPlug &&
-		existingPlug->direction() == Gaffer::Plug::Out &&
-		existingPlug->typeId() == Plug::staticTypeId()
-	)
-	{
-		existingPlug->setFlags( Gaffer::Plug::Dynamic, false );
-		return existingPlug;
-	}
-
-	PlugPtr plug = new Plug( "out", Gaffer::Plug::Out, Plug::Default );
-	PlugAlgo::replacePlug( plugParent, plug );
-
-	return plug.get();
-}
-
 } // namespace SocketHandler
 
 } // namespace GafferCycles

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -469,7 +469,7 @@ Gaffer::Plug *setupPlug( const ccl::NodeType *nodeType, const ccl::SocketType so
 	return plug;
 }
 
-void setupPlugs( const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction, bool keepExistingChildren )
+void setupPlugs( const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsParent, Gaffer::Plug::Direction direction )
 {
 
 	// Make sure we have a plug to represent each socket, reusing plugs wherever possible.
@@ -494,15 +494,12 @@ void setupPlugs( const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsPar
 
 	// Remove any old plugs which it turned out we didn't need.
 
-	if( !keepExistingChildren )
+	for( int i = plugsParent->children().size() - 1; i >= 0; --i )
 	{
-		for( int i = plugsParent->children().size() - 1; i >= 0; --i )
+		Plug *child = plugsParent->getChild<Plug>( i );
+		if( validPlugs.find( child ) == validPlugs.end() )
 		{
-			Plug *child = plugsParent->getChild<Plug>( i );
-			if( validPlugs.find( child ) == validPlugs.end() )
-			{
-				plugsParent->removeChild( child );
-			}
+			plugsParent->removeChild( child );
 		}
 	}
 }

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -196,6 +196,15 @@ const string nodeName ( Gaffer::GraphComponent *plugParent )
 	return node->relativeName( node->scriptNode() );
 }
 
+using NodeSocket = std::pair<ccl::ustring, ccl::ustring>;
+boost::container::flat_set<NodeSocket> g_socketBlacklist = {
+	// This socket is used to provide a list of available UDIMs
+	// to Cycles, which unlike other renderers, won't look for them
+	// itself. We handle this automatically in ShaderNetworkAlgo, so
+	// there is no need to expose the socket to the user.
+	{ ccl::ustring( "image_texture" ), ccl::ustring( "tiles" ) }
+};
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -480,6 +489,10 @@ void setupPlugs( const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsPar
 	{
 		for( const ccl::SocketType &socketType : nodeType->inputs )
 		{
+			if( g_socketBlacklist.contains( { nodeType->name, socketType.name } ) )
+			{
+				continue;
+			}
 			validPlugs.insert( setupPlug( nodeType, socketType, plugsParent, direction ) );
 		}
 	}


### PR DESCRIPTION
This simplifies the implementation a little bit, and adds basic unit tests for CyclesShader. The only user-facing change should be that the `image_texture` shader can now be loaded without emitting a warning.