### PR TITLE
`Gaffer.rootPath()` followup

### DIFF
--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -70,13 +70,13 @@ def rootPath() :
 	return pathlib.Path( os.path.expandvars( "$GAFFER_ROOT" ) )
 
 # Returns the path of the Gaffer executable for the current platform.
-# If `resolve` is `True`, the full path will be returned, otherwise
-# only a path to the executable name and extension are returned.
-def executablePath( resolve = False ) :
+# If `absolute` is `True`, the full path will be returned, otherwise
+# only a path with the executable name and extension are returned.
+def executablePath( absolute = True ) :
 
 	executable = pathlib.Path( "gaffer" ) if os.name != "nt" else pathlib.Path( "gaffer.cmd" )
 
-	if resolve :
+	if absolute :
 		return rootPath() / "bin" / executable
 
 	return executable

--- a/python/GafferAppleseedTest/AppleseedRenderTest.py
+++ b/python/GafferAppleseedTest/AppleseedRenderTest.py
@@ -74,7 +74,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s.save()
 
 		subprocess.check_call(
-			[ "gaffer", "execute", self.__scriptFileName, "-frames", "1-3" ]
+			[ str( Gaffer.executablePath() ), "execute", self.__scriptFileName, "-frames", "1-3" ]
 		)
 
 		for i in range( 1, 4 ) :
@@ -129,7 +129,7 @@ class AppleseedRenderTest( GafferTest.TestCase ) :
 		s.save()
 
 		subprocess.check_call(
-			[ "gaffer", "execute", self.__scriptFileName, "-frames", "1-3" ]
+			[ str( Gaffer.executablePath() ), "execute", self.__scriptFileName, "-frames", "1-3" ]
 		)
 
 		for i in range( 1, 4 ) :

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -67,7 +67,7 @@ def withMetadata( func ) :
 
 			try :
 				subprocess.check_output(
-					[ "gaffer", "test", "GafferArnoldTest.ArnoldShaderTest." + func.__name__ ],
+					[ str( Gaffer.executablePath() ), "test", "GafferArnoldTest.ArnoldShaderTest." + func.__name__ ],
 					env = env, stderr = subprocess.STDOUT
 				)
 			except subprocess.CalledProcessError as e :

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -151,7 +151,7 @@ root["SceneWriter"].execute()
 
 		env = os.environ.copy()
 		subprocess.check_call(
-			[ "gaffer", "env", "python","-c", script ],
+			[ str( Gaffer.executablePath() ), "env", "python","-c", script ],
 			env = env
 		)
 		scene = IECoreScene.SceneCache( str( cacheFilePath ), IECore.IndexedIO.OpenMode.Read )
@@ -170,7 +170,7 @@ root["SceneWriter"].execute()
 
 		env["ARNOLD_PLUGIN_PATH"] = pathlib.Path( __file__ ).parent / "metadata"
 		subprocess.check_call(
-			[ "gaffer", "env", "python","-c", script ],
+			[ str( Gaffer.executablePath() ), "env", "python","-c", script ],
 			env = env
 		)
 		scene = IECoreScene.SceneCache( str( cacheFilePath ), IECore.IndexedIO.OpenMode.Read )

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -259,8 +259,8 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 			taskContext = batch.context()
 			frames = str( IECore.frameListFromList( [ int(x) for x in batch.frames() ] ) )
 
-			args = [ "gaffer.cmd" ] if os.name == "nt" else [ "gaffer" ]
-			args = args + [
+			args = [
+				str( Gaffer.executablePath() ),
 				"execute",
 				"-script", self.__scriptFile,
 				"-nodes", batch.blindData()["nodeName"].value,

--- a/python/GafferDispatchTest/ExecuteApplicationTest.py
+++ b/python/GafferDispatchTest/ExecuteApplicationTest.py
@@ -310,7 +310,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 		s.context().setFrame( 10 )
 		s.save()
 
-		subprocess.check_call( [ "gaffer", "execute", self.__scriptFileName ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "execute", self.__scriptFileName ] )
 
 		self.assertEqual(
 			list( self.temporaryDirectory().glob( "test.*.txt" ) ),
@@ -334,7 +334,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 		s["fileName"].setValue(  self.temporaryDirectory() / "test.gfr" )
 		s.save()
 
-		subprocess.check_call( [ "gaffer", "execute", s["fileName"].getValue(), "-context", "c", "imath.Color3f( 0, 1, 2 )" ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "execute", s["fileName"].getValue(), "-context", "c", "imath.Color3f( 0, 1, 2 )" ] )
 
 		self.assertEqual(
 			open( s["t"]["fileName"].getValue() ).read(),
@@ -368,7 +368,7 @@ class ExecuteApplicationTest( GafferTest.TestCase ) :
 			s.context().setFrame( 10 )
 			s.save()
 
-			subprocess.check_call( [ "gaffer", "execute", self.__scriptFileName, "-frames", "5", "-nodes", "PythonCommand" ] )
+			subprocess.check_call( [ str( Gaffer.executablePath() ), "execute", self.__scriptFileName, "-frames", "5", "-nodes", "PythonCommand" ] )
 
 			self.assertTrue( ( self.temporaryDirectory() / "canSerialiseFrameDependentPlug.gfr" ).exists() )
 

--- a/python/GafferDispatchTest/StatsApplicationTest.py
+++ b/python/GafferDispatchTest/StatsApplicationTest.py
@@ -61,7 +61,7 @@ class StatsApplicationTest( GafferTest.TestCase ) :
 
 		o = subprocess.check_output(
 			[
-				"gaffer", "stats", script["fileName"].getValue(),
+				str( Gaffer.executablePath() ), "stats", script["fileName"].getValue(),
 				"-task", "command",
 				"-context", "-valueOne", "1", "-valueTwo", "2"
 			],

--- a/python/GafferImageTest/CollectImagesTest.py
+++ b/python/GafferImageTest/CollectImagesTest.py
@@ -48,7 +48,7 @@ import GafferImageTest
 
 class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 
-	layersPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/layers.10x10.exr" )
+	layersPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "layers.10x10.exr"
 
 	# Test against an image which has a different positioned box in each image layer, and a datawindow
 	# that has been enlarged to hold all layers

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -49,7 +49,7 @@ import GafferImageTest
 
 class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def test( self ) :
 
@@ -131,7 +131,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
 
 		o = GafferImage.ColorSpace()
 		o["in"].setInput( i["out"] )
@@ -193,7 +193,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		env = os.environ.copy()
-		env["OCIO"] = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/openColorIO/context.ocio" )
+		env["OCIO"] = str( Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio" )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
 
@@ -204,7 +204,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker_ocio_context.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextImageFile )
@@ -228,7 +228,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker_ocio_context_override.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context_override.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextOverrideImageFile )
@@ -265,7 +265,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 	def testUnpremultiplied( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
 
 		shuffleAlpha = GafferImage.Shuffle()
 		shuffleAlpha["channels"].addChild( GafferImage.Shuffle.ChannelPlug( "channel" ) )

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -198,7 +198,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		env["CDL"] = "cineon.spi1d"
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName,"-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName,"-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env,
 		)
@@ -222,7 +222,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName,"-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName,"-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env
 		)

--- a/python/GafferImageTest/CopyImageMetadataTest.py
+++ b/python/GafferImageTest/CopyImageMetadataTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class CopyImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/CreateViewsTest.py
+++ b/python/GafferImageTest/CreateViewsTest.py
@@ -48,8 +48,8 @@ import GafferImageTest
 
 class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
-	__stereoFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/channelTestMultiViewPartPerView.exr" )
+	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	__stereoFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "channelTestMultiViewPartPerView.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -48,10 +48,9 @@ import GafferImageTest
 
 class CropTest( GafferImageTest.ImageTestCase ) :
 
-	imageFileUndersizeDataWindow = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/blueWithDataWindow.100x100.exr" )
-	imageFileOversizeDataWindow = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerWithNegWindows.200x150.exr" )
-	representativeDeepImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
-
+	imageFileUndersizeDataWindow = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr"
+	imageFileOversizeDataWindow = Gaffer.rootPath() / "python"/ "GafferImageTest" / "images" / "checkerWithNegWindows.200x150.exr"
+	representativeDeepImagePath = Gaffer.rootPath() / "python"/ "GafferImageTest"/ "images" /"representativeDeepImage.exr"
 
 	def testDefaultState( self ) :
 

--- a/python/GafferImageTest/DeepHoldoutTest.py
+++ b/python/GafferImageTest/DeepHoldoutTest.py
@@ -41,13 +41,14 @@ import os
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferImage
 import GafferImageTest
 
 class DeepHoldoutTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
+	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
 
 	def testBasics( self ):
 		representativeImage = GafferImage.ImageReader()

--- a/python/GafferImageTest/DeepRecolorTest.py
+++ b/python/GafferImageTest/DeepRecolorTest.py
@@ -41,14 +41,15 @@ import os
 
 import IECore
 
+import Gaffer
 import GafferTest
 import GafferImage
 import GafferImageTest
 
 class DeepRecolorTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
-	flatImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
+	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	flatImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
 
 	def testBasics( self ):
 		representativeImage = GafferImage.ImageReader()

--- a/python/GafferImageTest/DeepStateTest.py
+++ b/python/GafferImageTest/DeepStateTest.py
@@ -52,13 +52,10 @@ import GafferImageTest
 
 # \todo : Add tests for how DeepState responds when A, Z and/or ZBack
 #         channels do not exist on input
-
-
 class DeepStateTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
-	mergeReferencePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/deepMergeReference.exr" )
-
+	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	mergeReferencePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "deepMergeReference.exr"
 
 	longMessage = True
 

--- a/python/GafferImageTest/DeleteChannelsTest.py
+++ b/python/GafferImageTest/DeleteChannelsTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class DeleteChannelsTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def testDirtyPropagation( self ) :
 

--- a/python/GafferImageTest/DeleteImageMetadataTest.py
+++ b/python/GafferImageTest/DeleteImageMetadataTest.py
@@ -45,7 +45,7 @@ import GafferImageTest
 
 class DeleteImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/DeleteViewsTest.py
+++ b/python/GafferImageTest/DeleteViewsTest.py
@@ -47,10 +47,9 @@ import GafferImageTest
 
 class DeleteViewsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
+	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
 
 	def test( self ) :
-
 
 		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( self.__rgbFilePath )

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -204,15 +204,15 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 	def testTransferChecker( self ) :
 
-		self.__testTransferImage( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+		self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
 
 	def testTransferWithDataWindow( self ) :
 
-		self.__testTransferImage( "$GAFFER_ROOT/python/GafferImageTest/images/checkerWithNegativeDataWindow.200x150.exr" )
+		self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr" )
 
 	def testAccessOutsideDataWindow( self ) :
 
-		node = self.__testTransferImage( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+		node = self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
 
 		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -239,7 +239,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		output = subprocess.check_output(
-			[ "gaffer", "execute", self.temporaryDirectory() / "test.gfr", "-nodes", "p" ],
+			[ str( Gaffer.executablePath() ), "execute", self.temporaryDirectory() / "test.gfr", "-nodes", "p" ],
 			stderr = subprocess.STDOUT, universal_newlines = True
 		)
 		self.assertEqual( output, "" )

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -204,7 +204,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		env["CDL"] = "cineon.spi1d"
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName,"-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName,"-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env,
 		)
@@ -228,7 +228,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName,"-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName,"-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env
 		)

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -48,7 +48,7 @@ import GafferImageTest
 
 class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 
-	imageFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	imageFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def test( self ) :
 
@@ -134,7 +134,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
 
 		o = GafferImage.DisplayTransform()
 		o["in"].setInput( i["out"] )
@@ -199,7 +199,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		env = os.environ.copy()
-		env["OCIO"] = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/openColorIO/context.ocio" )
+		env["OCIO"] = str( Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio" )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
 
@@ -210,7 +210,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker_ocio_context.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextImageFile )
@@ -234,7 +234,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker_ocio_context_override.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context_override.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextOverrideImageFile )

--- a/python/GafferImageTest/FilterAlgoTest.py
+++ b/python/GafferImageTest/FilterAlgoTest.py
@@ -48,8 +48,8 @@ import math
 
 class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 
-	derivativesReferenceParallelFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/filterDerivativesTest.parallel.exr" )
-	derivativesReferenceBoxFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/filterDerivativesTest.box.exr" )
+	derivativesReferenceParallelFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "filterDerivativesTest.parallel.exr"
+	derivativesReferenceBoxFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "filterDerivativesTest.box.exr"
 
 	# Artificial test of several filters passing in different derivatives, including a bunch of 15 degree rotations
 	def testFilterDerivatives( self ):
@@ -124,8 +124,8 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 			IECore.Writer.create( parallelogramImage, "/tmp/filterDerivativesTestResult.parallelogram.exr" ).write()
 			IECore.Writer.create( boxImage, "/tmp/filterDerivativesTestResult.box.exr" ).write()
 
-		parallelogramReference = IECore.Reader.create( self.derivativesReferenceParallelFileName ).read()
-		boxReference = IECore.Reader.create( self.derivativesReferenceBoxFileName ).read()
+		parallelogramReference = IECore.Reader.create( str( self.derivativesReferenceParallelFileName ) ).read()
+		boxReference = IECore.Reader.create( str( self.derivativesReferenceBoxFileName ) ).read()
 
 		for i in range( len( parallelogramImage["R"] ) ):
 			self.assertAlmostEqual( parallelogramReference["R"][i], parallelogramImage["R"][i], places = 5 )

--- a/python/GafferImageTest/FormatQueryTest.py
+++ b/python/GafferImageTest/FormatQueryTest.py
@@ -96,7 +96,7 @@ class FormatQueryTest( GafferImageTest.ImageTestCase ) :
 		constantSource["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 512 ) ), 1 ) )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerboard.100x100.exr" ) )
+		reader["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr" )
 
 		views = GafferImage.CreateViews()
 		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )

--- a/python/GafferImageTest/GradeTest.py
+++ b/python/GafferImageTest/GradeTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class GradeTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	# Test that when gamma == 0 that the coresponding channel isn't modified.
 	def testChannelEnable( self ) :

--- a/python/GafferImageTest/ImageMetadataTest.py
+++ b/python/GafferImageTest/ImageMetadataTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -156,7 +156,7 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 	def testImageHash( self ) :
 
 		r = GafferImage.ImageReader()
-		r['fileName'].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" ) )
+		r['fileName'].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
 
 		h = GafferImage.ImageAlgo.imageHash( r['out'] )
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -49,11 +49,11 @@ import GafferImageTest
 
 class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.exr" )
-	colorSpaceFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles_as_cineon.exr" )
-	offsetDataWindowFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
-	jpgFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.jpg" )
-	largeFileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/colorbars_max_clamp.exr" )
+	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr"
+	colorSpaceFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles_as_cineon.exr"
+	offsetDataWindowFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	jpgFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.jpg"
+	largeFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "colorbars_max_clamp.exr"
 
 	def setUp( self ) :
 

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -98,7 +98,7 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 		constantSource["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/blueWithDataWindow.100x100.exr" ) )
+		reader["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr" )
 
 		views = GafferImage.CreateViews()
 		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -47,8 +47,8 @@ import GafferImageTest
 
 class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
-	__file300PxPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/dotGrid.warped.exr" )
+	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	__file300PxPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "dotGrid.warped.exr"
 
 	# Test that the outputs change when different channels are selected.
 	def testChannels( self ) :

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -49,8 +49,8 @@ import GafferImageTest
 
 class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
-	path = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/" )
+	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	path = Gaffer.rootPath() / "python" / "GafferImageTest" / "images"
 
 	def testNoPassThrough( self ) :
 
@@ -78,7 +78,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		# tiles apart.
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.join( self.path, "rgb.100x100.exr" ) )
+		r["fileName"].setValue( self.path / "rgb.100x100.exr" )
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
@@ -86,7 +86,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t["transform"]["scale"].setValue( imath.V2f( 1.5, 1. ) )
 
 		r2 = GafferImage.ImageReader()
-		r2["fileName"].setValue( os.path.join( self.path, "knownTransformBug.exr" ) )
+		r2["fileName"].setValue( self.path / "knownTransformBug.exr" )
 
 		self.assertImagesEqual( t["out"], r2["out"], ignoreMetadata = True, maxDifference = 0.05 )
 
@@ -296,7 +296,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 	def testNegativeScale( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker2x2.exr" ) )
+		r["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker2x2.exr" )
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -56,10 +56,10 @@ import GafferImageTest
 
 class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
-	__largeFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/large.exr" )
-	__rgbFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100" )
-	__negativeDataWindowFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerWithNegativeDataWindow.200x150" )
-	__representativeDeepPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
+	__largeFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "large.exr"
+	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	__negativeDataWindowFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr"
+	__representativeDeepPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
 
 	longMessage = True
 
@@ -77,7 +77,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testChannelMask( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__rgbFilePath+".exr" )
+		r["fileName"].setValue( self.__rgbFilePath )
 
 		testFile = self.__testFile( "default", "RB", "exr" )
 		self.assertFalse( os.path.exists( testFile ) )
@@ -403,8 +403,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def __testExtension( self, ext, formatName, options = {}, metadataToIgnore = [] ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__rgbFilePath+".exr" )
-		expectedFile = "{base}.{ext}".format( base=self.__rgbFilePath, ext=ext )
+		r["fileName"].setValue( self.__rgbFilePath )
+		expectedFile = self.__rgbFilePath.with_suffix( "." + ext )
 
 		tests = [
 			{
@@ -558,11 +558,11 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def __testAdjustDataWindowToDisplayWindow( self, ext, filePath ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( filePath+".exr" )
+		r["fileName"].setValue( filePath )
 		w = GafferImage.ImageWriter()
 
 		testFile = self.__testFile( os.path.basename(filePath), "RGBA", ext )
-		expectedFile = filePath+"."+ext
+		expectedFile = filePath.with_suffix( "." + ext )
 
 		self.assertFalse( os.path.exists( testFile ), "Temporary file already exists : {}".format( testFile ) )
 
@@ -670,7 +670,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testMetadataDocumentName( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__rgbFilePath+".exr" )
+		r["fileName"].setValue( self.__rgbFilePath )
 		w = GafferImage.ImageWriter()
 
 		testFile = self.__testFile( "metadataTest", "RGBA", "exr" )
@@ -708,7 +708,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def __testMetadataDoesNotAffectPixels( self, ext, overrideMetadata = {}, metadataToIgnore = [] ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( self.__rgbFilePath+"."+ext )
+		reader["fileName"].setValue( self.__rgbFilePath.with_suffix( "." + ext ) )
 
 		# IPTC:Creator will have the current username appended to the end of
 		# the existing one, creating a list of creators. Blank out the initial
@@ -904,7 +904,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testPixelAspectRatio( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__rgbFilePath+".exr" )
+		r["fileName"].setValue( self.__rgbFilePath )
 		self.assertEqual( r["out"]["format"].getValue().getPixelAspect(), 1 )
 		self.assertEqual( r["out"]["metadata"].getValue()["PixelAspectRatio"], IECore.FloatData( 1 ) )
 
@@ -1121,7 +1121,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testJpgChroma( self ):
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.__rgbFilePath+".exr" )
+		r["fileName"].setValue( self.__rgbFilePath )
 
 		w = GafferImage.ImageWriter()
 		w["in"].setInput( r["out"] )
@@ -1248,7 +1248,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def testNonDefaultColorSpace( self ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( self.__rgbFilePath + ".exr" )
+		reader["fileName"].setValue( self.__rgbFilePath )
 
 		extraChannel = GafferImage.Shuffle()
 		extraChannel["in"].setInput( reader["out"] )

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -49,8 +49,8 @@ import GafferImageTest
 
 class LUTTest( GafferImageTest.ImageTestCase ) :
 
-	imageFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
-	lut = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/openColorIO/luts/slog10.spi1d" )
+	imageFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	lut = Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "luts" / "slog10.spi1d"
 
 	def test( self ) :
 
@@ -166,7 +166,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/circles.exr" ) )
+		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
 
 		o = GafferImage.LUT()
 		o["in"].setInput( i["out"] )

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -48,9 +48,9 @@ import GafferImageTest
 
 class LookTransformTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
-	groundTruth = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker_ocio_look.exr" )
-	ocioConfig = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/openColorIO/context.ocio" )
+	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	groundTruth = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_look.exr"
+	ocioConfig = Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -96,7 +96,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		env["CDL"] = "cineon.spi1d"
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName, "-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName, "-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env,
 		)
@@ -141,7 +141,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		env["CDL"] = "cineon.spi1d"
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName, "-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName, "-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env,
 		)
@@ -187,7 +187,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		env["CDL"] = "cineon.spi1d"
 
 		subprocess.check_call(
-			["gaffer", "execute", scriptFileName, "-frames", "1"],
+			[ str( Gaffer.executablePath() ), "execute", scriptFileName, "-frames", "1" ],
 			stderr = subprocess.PIPE,
 			env = env,
 		)

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -47,13 +47,13 @@ import GafferImageTest
 
 class MergeTest( GafferImageTest.ImageTestCase ) :
 
-	rPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/redWithDataWindow.100x100.exr" )
-	gPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/greenWithDataWindow.100x100.exr" )
-	bPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/blueWithDataWindow.100x100.exr" )
-	checkerPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerboard.100x100.exr" )
-	checkerRGBPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgbOverChecker.100x100.exr" )
-	rgbPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
-	mergeBoundariesRefPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/mergeBoundariesRef.exr" )
+	rPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "redWithDataWindow.100x100.exr"
+	gPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "greenWithDataWindow.100x100.exr"
+	bPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr"
+	checkerPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr"
+	checkerRGBPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
+	rgbPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	mergeBoundariesRefPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "mergeBoundariesRef.exr"
 
 	# Do several tests to check the cache is working correctly:
 	def testHashes( self ) :

--- a/python/GafferImageTest/MixTest.py
+++ b/python/GafferImageTest/MixTest.py
@@ -47,13 +47,13 @@ import GafferImageTest
 
 class MixTest( GafferImageTest.ImageTestCase ) :
 
-	rPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/redWithDataWindow.100x100.exr" )
-	gPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/greenWithDataWindow.100x100.exr" )
-	checkerPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerboard.100x100.exr" )
-	checkerNegativeDataWindowPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerWithNegativeDataWindow.200x150.exr" )
-	checkerMixPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checkerMix.100x100.exr" )
-	representativeDeepImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
-	radialPath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/radial.exr" )
+	rPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "redWithDataWindow.100x100.exr"
+	gPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "greenWithDataWindow.100x100.exr"
+	checkerPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr"
+	checkerNegativeDataWindowPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr"
+	checkerMixPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerMix.100x100.exr"
+	representativeDeepImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	radialPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "radial.exr"
 
 	# Do several tests to check the cache is working correctly:
 	def testHashes( self ) :

--- a/python/GafferImageTest/PremultiplyTest.py
+++ b/python/GafferImageTest/PremultiplyTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgbOverChecker.100x100.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
 
 	def testAlphaChannel( self ) :
 		# Test that changing the channel to use as the alpha channel changes the hash

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class SamplerTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/checker.exr" )
+	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
 
 	def testOutOfBoundsSampleModeBlack( self ) :
 

--- a/python/GafferImageTest/SelectViewTest.py
+++ b/python/GafferImageTest/SelectViewTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class SelectViewTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgb.100x100.exr" )
+	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class ShuffleTest( GafferImageTest.ImageTestCase ) :
 
-	representativeDeepImagePath = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/representativeDeepImage.exr" )
+	representativeDeepImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/UnpremultiplyTest.py
+++ b/python/GafferImageTest/UnpremultiplyTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgbOverChecker.100x100.exr" )
+	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
 
 	def testAlphaChannel( self ) :
 		# Test that changing the channel to use as the alpha channel changes the hash

--- a/python/GafferSceneTest/EncapsulateTest.py
+++ b/python/GafferSceneTest/EncapsulateTest.py
@@ -269,7 +269,7 @@ class EncapsulateTest( GafferSceneTest.SceneTestCase ) :
 
 		# This exposed a crash caused by non-threadsafe access to signals from Capsules. It
 		# will throw if the subprocess crashes.
-		subprocess.check_output( [ "gaffer", "stats", script["fileName"].getValue(), "-scene", "collect" ] )
+		subprocess.check_output( [ str( Gaffer.executablePath() ), "stats", script["fileName"].getValue(), "-scene", "collect" ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -555,7 +555,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 				env["GAFFERSCENE_SHADERASSIGNMENT_OSL_PREFIX"] = envVar
 
 			o = subprocess.check_output(
-				[ "gaffer", "execute", script["fileName"].getValue(), "-nodes", "writer" ],
+				[ str( Gaffer.executablePath() ), "execute", script["fileName"].getValue(), "-nodes", "writer" ],
 				env = env
 			)
 

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -63,7 +63,7 @@ class ApplicationTest( GafferTest.TestCase ) :
 	@unittest.skipIf( os.name == "nt", "Process name is not controllable on Windows.")
 	def testProcessName( self ) :
 
-		process = subprocess.Popen( [ "gaffer", "env", "sleep", "100" ] )
+		process = subprocess.Popen( [ str( Gaffer.executablePath() ), "env", "sleep", "100" ] )
 		time.sleep( 1 )
 		command = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "command=" ], universal_newlines = True ).strip()
 		name = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "comm=" ], universal_newlines = True ).strip()

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -57,7 +57,7 @@ class ApplicationTest( GafferTest.TestCase ) :
 	def testWrapperDoesntDuplicatePaths( self ) :
 
 		for v in ["GAFFER_STARTUP_PATHS", "GAFFER_APP_PATHS"] :
-			value = subprocess.check_output( [ str( Gaffer.executablePath( True ) ), "env", "python", "-c", "import os; print(os.environ['{}'])".format( v ) ], universal_newlines = True )
+			value = subprocess.check_output( [ str( Gaffer.executablePath() ), "env", "python", "-c", "import os; print(os.environ['{}'])".format( v ) ], universal_newlines = True )
 			self.assertEqual( value.strip(), os.environ[v] )
 
 	@unittest.skipIf( os.name == "nt", "Process name is not controllable on Windows.")

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1566,7 +1566,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		env["GAFFERTEST_SCRIPT_FILENAME"] = script["fileName"].getValue()
 		try :
 			subprocess.check_output(
-				[ str( Gaffer.executablePath( True ) ), "test", "GafferTest.ExpressionTest.checkReferenceOutputs" ],
+				[ str( Gaffer.executablePath() ), "test", "GafferTest.ExpressionTest.checkReferenceOutputs" ],
 				env = env, stderr = subprocess.STDOUT
 			)
 		except subprocess.CalledProcessError as e :

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1052,7 +1052,7 @@ class MetadataTest( GafferTest.TestCase ) :
 	@staticmethod
 	def testPythonUnload() :
 
-		subprocess.check_call( [ str( Gaffer.executablePath( True ) ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "unloadExceptionScript.py" ) ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "unloadExceptionScript.py" ) ] )
 
 	def testWildcardsAndDot( self ) :
 

--- a/python/GafferTest/PythonApplicationTest.py
+++ b/python/GafferTest/PythonApplicationTest.py
@@ -46,12 +46,12 @@ class PythonApplicationTest( GafferTest.TestCase ) :
 
 	def testVariableScope( self ) :
 
-		subprocess.check_call( [ str( Gaffer.executablePath( True ) ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "variableScope.py" ) ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "variableScope.py" ) ] )
 
 	def testErrorReturnStatus( self ) :
 
 		p = subprocess.Popen(
-			[ str( Gaffer.executablePath( True ) ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "exception.py" ) ],
+			[ str( Gaffer.executablePath() ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "exception.py" ) ],
 			stderr = subprocess.PIPE,
 			universal_newlines = True,
 		)
@@ -62,11 +62,11 @@ class PythonApplicationTest( GafferTest.TestCase ) :
 
 	def testFlagArguments( self ) :
 
-		subprocess.check_call( [ str( Gaffer.executablePath( True ) ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "flagArguments.py" ), "-arguments", "-flag1", "-flag2" ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "flagArguments.py" ), "-arguments", "-flag1", "-flag2" ] )
 
 	def testName( self ) :
 
-		subprocess.check_call( [ str( Gaffer.executablePath( True ) ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "name.py" ) ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "python", str( pathlib.Path( __file__ ).parent / "pythonScripts" / "name.py" ) ] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/StatsApplicationTest.py
+++ b/python/GafferTest/StatsApplicationTest.py
@@ -59,7 +59,7 @@ class StatsApplicationTest( GafferTest.TestCase ) :
 		script["fileName"].setValue( self.temporaryDirectory() / "script.gfr" )
 		script.save()
 
-		o = subprocess.check_output( [ str( Gaffer.executablePath( True ) ), "stats", script["fileName"].getValue() ], universal_newlines = True )
+		o = subprocess.check_output( [ str( Gaffer.executablePath() ), "stats", script["fileName"].getValue() ], universal_newlines = True )
 
 		self.assertTrue( Gaffer.About.versionString() in o )
 		self.assertTrue( re.search( r"frameRange\.start\s*10", o ) )

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -347,7 +347,7 @@ class TestCase( unittest.TestCase ) :
 			f.write( "import sys\n" )
 			f.write( "assert( 'GafferUI' not in sys.modules )\n" )
 
-		subprocess.check_call( [ str( Gaffer.executablePath( True ) ), "python", str( script ) ] )
+		subprocess.check_call( [ str( Gaffer.executablePath() ), "python", str( script ) ] )
 
 	def assertFloat32Equal( self, value0, value1 ) :
 

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -907,7 +907,7 @@ class ValuePlugTest( GafferTest.TestCase ) :
 				env = os.environ.copy()
 				env["VALUEPLUGTEST_SUBPROCESS"] = "1"
 				subprocess.check_output(
-					[ str( Gaffer.executablePath( True ) ), "test", "-threads", "3", "GafferTest.ValuePlugTest.testCancellationOfSecondGetValueCall" ],
+					[ str( Gaffer.executablePath() ), "test", "-threads", "3", "GafferTest.ValuePlugTest.testCancellationOfSecondGetValueCall" ],
 					stderr = subprocess.STDOUT,
 					env = env
 				)

--- a/python/GafferUITest/LayoutsTest.py
+++ b/python/GafferUITest/LayoutsTest.py
@@ -91,7 +91,7 @@ class LayoutsTest( GafferUITest.TestCase ) :
 		# (the user running these tests may have their own personal configs).
 		startupPaths = os.environ["GAFFER_STARTUP_PATHS"]
 		try :
-			os.environ["GAFFER_STARTUP_PATHS"] = os.path.expandvars( "$GAFFER_ROOT/startup" )
+			os.environ["GAFFER_STARTUP_PATHS"] = str( Gaffer.rootPath() / "startup" )
 			app._executeStartupFiles( "gui" )
 		finally :
 			os.environ["GAFFER_STARTUP_PATHS"] = startupPaths


### PR DESCRIPTION
This uses `Gaffer.executablePath()` and `Gaffer.rootPath()` in a few more places.