### PR TITLE
AttributeInspector : Test chained scopes

### DIFF
--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -736,5 +736,27 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( row["name"].getValue(), "/parent/child" )
 
+	def testChainedEditScopes( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		editScope1 = Gaffer.EditScope()
+		editScope1.setup( light["out"] )
+		editScope1["in"].setInput( light["out"] )
+
+		editScope2 = Gaffer.EditScope()
+		editScope2.setup( editScope1["out"] )
+		editScope2["in"].setInput( editScope1["out"] )
+
+		inspection2 = self.__inspect( editScope2["out"], "/light", "gl:visualiser:scale", editScope2 )
+
+		self.assertTrue( inspection2.editable() )
+		edit2 = inspection2.acquireEdit()
+		edit2["enabled"].setValue( True )
+
+		inspection1 = self.__inspect( editScope2["out"], "/light", "gl:visualiser:scale", editScope1 )
+
+		self.assertTrue( inspection1.editable() )
+
 if __name__ == "__main__" :
 	unittest.main()


### PR DESCRIPTION
This is another bug that has surfaced in the course of adding a mute attribute in #4948.

Starting with a light followed by two edit scopes, make an attribute edit to the second scope in the Light Editor. Now change the Light Editor edit scope to the first scope. Making changes to the same attribute is not possible because the edit scope hasn't been discovered in the history.

I only have a test case for now, I haven't tracked through the history code to locate exactly where it originates. I suspect it may be similar to #4994.

### Breaking changes ###

- List any breaking API/ABI changes  (and apply the pr-majorVersion label)

### Checklist ###

- [ ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Gaffer project's prevailing coding style and conventions.
