### PR TITLE
Contex::EditableScope : Remove deprecated functions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -92,6 +92,7 @@ Breaking Changes
 - ApplicationRoot : The `preferencesLocation()` Python binding now returns a `pathlib.Path` argument.
 - StringPlug : `setValue( std::filesystem::path & )` now uses `path.generic_string()` for the value, whereas before an automatic conversion would have used `path.string()` (the native string).
   - Dispatcher : the `jobDirectory()` Python binding now returns a `pathlib.Path`, or `None` if it is empty.
+- Context::EditableScope, ImagePlug::ChannelDataScope, ScenePlug::PathScope/SetScope : Removed deprecated functions which don't take pointers and require duplicating data.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -93,6 +93,7 @@ Breaking Changes
 - StringPlug : `setValue( std::filesystem::path & )` now uses `path.generic_string()` for the value, whereas before an automatic conversion would have used `path.string()` (the native string).
   - Dispatcher : the `jobDirectory()` Python binding now returns a `pathlib.Path`, or `None` if it is empty.
 - Context::EditableScope, ImagePlug::ChannelDataScope, ScenePlug::PathScope/SetScope : Removed deprecated functions which don't take pointers and require duplicating data.
+- ViewportGadget::gadgetsAt : Removed deprecated signature.
 
 Build
 -----

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -232,10 +232,6 @@ class GAFFER_API Context : public IECore::RefCounted
 				template<typename T>
 				void set( const IECore::InternedString &name, const T *value );
 
-				template<typename T, typename Enabler = std::enable_if_t<!std::is_pointer<T>::value > >
-				[[deprecated("Use faster pointer version, or use the more explicit setAllocated if you actually need to allocate ")]]
-				void set( const IECore::InternedString &name, const T &value );
-
 				/// Sets a variable from a copy of `value`. This is more expensive than the
 				/// pointer version above, and should be avoided where possible.
 				template<typename T, typename Enabler = std::enable_if_t<!std::is_pointer<T>::value > >
@@ -249,8 +245,6 @@ class GAFFER_API Context : public IECore::RefCounted
 				void setFrame( float frame );
 				void setTime( float timeInSeconds );
 
-				[[deprecated("Use faster pointer version")]]
-				void setFramesPerSecond( float framesPerSecond );
 				void setFramesPerSecond( const float *framesPerSecond );
 
 				void remove( const IECore::InternedString &name );

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -260,12 +260,6 @@ void Context::EditableScope::set( const IECore::InternedString &name, const T *v
 }
 
 template<typename T, typename Enabler>
-void Context::EditableScope::set( const IECore::InternedString &name, const T &value )
-{
-	m_context->set( name, value );
-}
-
-template<typename T, typename Enabler>
 void Context::EditableScope::setAllocated( const IECore::InternedString &name, const T &value )
 {
 	m_context->set( name, value );

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -187,11 +187,6 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 			ChannelDataScope( const Gaffer::Context *context );
 			ChannelDataScope( const Gaffer::ThreadState &threadState );
 
-			[[deprecated("Use faster pointer version")]]
-			void setTileOrigin( const Imath::V2i &tileOrigin );
-			[[deprecated("Use faster pointer version")]]
-			void setChannelName( const std::string &channelName );
-
 			// These fast calls take pointers, and it is the caller's
 			// responsibility to ensure that the memory pointed to
 			// stays valid for the lifetime of the ChannelDataScope

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -160,19 +160,13 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 
 			/// Standard constructors, for modifying context on the current thread.
 			PathScope( const Gaffer::Context *context );
-			[[deprecated("Use faster pointer version")]]
-			PathScope( const Gaffer::Context *context, const ScenePath &scenePath );
 			PathScope( const Gaffer::Context *context, const ScenePath *scenePath );
 
 			/// Specialised constructors used to transfer state to TBB tasks. See
 			/// ThreadState documentation for more details.
 			PathScope( const Gaffer::ThreadState &threadState );
-			[[deprecated("Use faster pointer version")]]
-			PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath );
 			PathScope( const Gaffer::ThreadState &threadState, const ScenePath *scenePath );
 
-			[[deprecated("Use faster pointer version")]]
-			void setPath( const ScenePath &scenePath );
 			void setPath( const ScenePath *scenePath );
 		};
 
@@ -185,19 +179,13 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 
 			/// Standard constructors, for modifying context on the current thread.
 			SetScope( const Gaffer::Context *context );
-			[[deprecated("Use faster pointer version")]]
-			SetScope( const Gaffer::Context *context, const IECore::InternedString &setName );
 			SetScope( const Gaffer::Context *context, const IECore::InternedString *setName );
 
 			/// Specialised constructors used to transfer state to TBB tasks. See
 			/// ThreadState documentation for more details.
 			SetScope( const Gaffer::ThreadState &threadState );
-			[[deprecated("Use faster pointer version")]]
-			SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName );
 			SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString *setName );
 
-			[[deprecated("Use faster pointer version")]]
-			void setSetName( const IECore::InternedString &setName );
 			void setSetName( const IECore::InternedString *setName );
 		};
 

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -294,9 +294,6 @@ class GAFFERUI_API ViewportGadget : public Gadget
 		/// and optionally accepts filterLayer - if set, only Gadgets in this layer will be rendered
 		std::vector<Gadget*> gadgetsAt( const Imath::Box2f &rasterRegion, Layer filterLayer = Layer::None ) const;
 
-		[[deprecated("Use above form which returns vector")]]
-		void gadgetsAt( const Imath::V2f &rasterPosition, std::vector<GadgetPtr> &gadgets ) const;
-
 		/// The SelectionScope class can be used by child Gadgets to perform
 		/// OpenGL selection from event signal callbacks.
 		class GAFFERUI_API SelectionScope : boost::noncopyable

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -511,11 +511,6 @@ void Context::EditableScope::setFrame( float frame )
 	set( g_frame, &m_frameStorage );
 }
 
-void Context::EditableScope::setFramesPerSecond( float framesPerSecond )
-{
-	m_context->setFramesPerSecond( framesPerSecond );
-}
-
 void Context::EditableScope::setTime( float timeInSeconds )
 {
 	setFrame( timeInSeconds * m_context->getFramesPerSecond() );

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -365,16 +365,6 @@ ImagePlug::ChannelDataScope::ChannelDataScope( const Gaffer::ThreadState &thread
 {
 }
 
-void ImagePlug::ChannelDataScope::setTileOrigin( const V2i &tileOrigin )
-{
-	setAllocated( tileOriginContextName, tileOrigin );
-}
-
-void ImagePlug::ChannelDataScope::setChannelName( const std::string &channelName )
-{
-	setAllocated( channelNameContextName, channelName );
-}
-
 void ImagePlug::ChannelDataScope::setTileOrigin( const V2i *tileOrigin )
 {
 	set( tileOriginContextName, tileOrigin );

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -316,12 +316,6 @@ ScenePlug::PathScope::PathScope( const Gaffer::Context *context )
 	remove( ScenePlug::setNameContextName );
 }
 
-ScenePlug::PathScope::PathScope( const Gaffer::Context *context, const ScenePath &scenePath )
-	:	PathScope( context )
-{
-	setAllocated( scenePathContextName, scenePath );
-}
-
 ScenePlug::PathScope::PathScope( const Gaffer::Context *context, const ScenePath *scenePath )
 	:	PathScope( context )
 {
@@ -333,21 +327,10 @@ ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState )
 {
 }
 
-ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState, const ScenePath &scenePath )
-	:	EditableScope( threadState )
-{
-	setAllocated( scenePathContextName, scenePath );
-}
-
 ScenePlug::PathScope::PathScope( const Gaffer::ThreadState &threadState, const ScenePath *scenePath )
 	:	EditableScope( threadState )
 {
 	setPath( scenePath );
-}
-
-void ScenePlug::PathScope::setPath( const ScenePath &scenePath )
-{
-	setAllocated( scenePathContextName, scenePath );
 }
 
 void ScenePlug::PathScope::setPath( const ScenePath *scenePath )
@@ -360,14 +343,6 @@ ScenePlug::SetScope::SetScope( const Gaffer::Context *context )
 {
 	remove( Filter::inputSceneContextName );
 	remove( ScenePlug::scenePathContextName );
-}
-
-ScenePlug::SetScope::SetScope( const Gaffer::Context *context, const IECore::InternedString &setName )
-	:	EditableScope( context )
-{
-	remove( Filter::inputSceneContextName );
-	remove( ScenePlug::scenePathContextName );
-	setAllocated( setNameContextName, setName );
 }
 
 ScenePlug::SetScope::SetScope( const Gaffer::Context *context, const IECore::InternedString *setName )
@@ -385,25 +360,12 @@ ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState )
 	remove( ScenePlug::scenePathContextName );
 }
 
-ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString &setName )
-	:	EditableScope( threadState )
-{
-	remove( Filter::inputSceneContextName );
-	remove( ScenePlug::scenePathContextName );
-	setAllocated( setNameContextName, setName );
-}
-
 ScenePlug::SetScope::SetScope( const Gaffer::ThreadState &threadState, const IECore::InternedString *setName )
 	:	EditableScope( threadState )
 {
 	remove( Filter::inputSceneContextName );
 	remove( ScenePlug::scenePathContextName );
 	setSetName( setName );
-}
-
-void ScenePlug::SetScope::setSetName( const IECore::InternedString &setName )
-{
-	setAllocated( setNameContextName, setName );
 }
 
 void ScenePlug::SetScope::setSetName( const IECore::InternedString *setName )

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1099,16 +1099,6 @@ std::vector< Gadget* > ViewportGadget::gadgetsAtInternal( const Imath::Box2f &ra
 	return gadgets;
 }
 
-// DEPRECATED
-void ViewportGadget::gadgetsAt( const Imath::V2f &rasterPosition, std::vector<GadgetPtr> &gadgets ) const
-{
-	std::vector< Gadget* > retGadgets = gadgetsAt( rasterPosition );
-	for( Gadget *g : retGadgets )
-	{
-		gadgets.push_back( g );
-	}
-}
-
 IECore::LineSegment3f ViewportGadget::rasterToGadgetSpace( const Imath::V2f &position, const Gadget *gadget ) const
 {
 	LineSegment3f result;


### PR DESCRIPTION
I only see two deprecated functions here, and no use of them, so I think this just requires these two removals?
