### PR TITLE
PathColumn : Resize modes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
   - Added warning when a shader contains a parameter with an unsupported datatype.
   - Added warning when a shader contains an enum parameter with an invalid value.
   - Added support for passing InternedStringData to enum and string parameters.
+- PathListingWidget : Added support for columns that can automatically stretch to make use of available space.
 
 Fixes
 -----
@@ -20,6 +21,11 @@ Fixes
   - Fixed support for Color4f values on colour shader parameters. This can be useful when loading non-standard USD files.
   - Fixed support for V[23]i values on vector shader parameters.
   - Fixed handling of colour array parameters.
+
+API
+---
+
+- PathColumn : Added `setSizeMode()` and `getSizeMode()` methods, and `sizeMode` constructor argument. These allow the size behaviour of a PathColumn to be configured.
 
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
   - Added warning when a shader contains an enum parameter with an invalid value.
   - Added support for passing InternedStringData to enum and string parameters.
 - PathListingWidget : Added support for columns that can automatically stretch to make use of available space.
+- LightEditor : Adjustments made to the width of the "Name" column are now preserved when switching between sections.
 
 Fixes
 -----

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -63,6 +63,24 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 
 		IE_CORE_DECLAREMEMBERPTR( PathColumn )
 
+		/// Defines the UI size behaviour of the column.
+		enum SizeMode
+		{
+			/// The column is user resizable.
+			Interactive = 0,
+			/// The column will automatically resize to fill available space.
+			Stretch = 1,
+
+			Default = Interactive,
+		};
+
+		PathColumn( SizeMode sizeMode = Default );
+
+		/// Returns the current column size mode.
+		SizeMode getSizeMode() const;
+		/// Sets the column size mode.
+		void setSizeMode( SizeMode sizeMode );
+
 		/// Display data
 		/// ============
 
@@ -141,6 +159,8 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ButtonSignal m_buttonReleaseSignal;
 		ButtonSignal m_buttonDoubleClickSignal;
 
+		SizeMode m_sizeMode;
+
 };
 
 IE_CORE_DECLAREPTR( PathColumn )
@@ -153,7 +173,7 @@ class GAFFERUI_API StandardPathColumn : public PathColumn
 
 		IE_CORE_DECLAREMEMBERPTR( StandardPathColumn )
 
-		StandardPathColumn( const std::string &label, IECore::InternedString property );
+		StandardPathColumn( const std::string &label, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
 
 		IECore::InternedString property() const;
 
@@ -183,7 +203,7 @@ class GAFFERUI_API IconPathColumn : public PathColumn
 		/// - StringData
 		/// - IntData, UInt44Data
 		/// - BoolData
-		IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property );
+		IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
 		CellData headerData( const IECore::Canceller *canceller ) const override;
@@ -207,7 +227,7 @@ class GAFFERUI_API FileIconPathColumn : public PathColumn
 
 		IE_CORE_DECLAREMEMBERPTR( FileIconPathColumn )
 
-		FileIconPathColumn();
+		FileIconPathColumn( PathColumn::SizeMode sizeMode = Default );
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
 		CellData headerData( const IECore::Canceller *canceller ) const override;

--- a/python/GafferDispatchUI/LocalDispatcherUI.py
+++ b/python/GafferDispatchUI/LocalDispatcherUI.py
@@ -213,7 +213,7 @@ class _LocalJobsWindow( GafferUI.Window ) :
 					_LocalJobsPath( jobPool ),
 					columns = (
 						GafferUI.PathListingWidget.IconColumn( "Status", "localDispatcherStatus", "localDispatcher:status" ),
-						GafferUI.PathListingWidget.StandardColumn( "Name", "localDispatcher:jobName" ),
+						GafferUI.PathListingWidget.StandardColumn( "Name", "localDispatcher:jobName", sizeMode = GafferUI.PathColumn.SizeMode.Stretch ),
 						GafferUI.PathListingWidget.StandardColumn( "Id", "localDispatcher:id" ),
 						GafferUI.PathListingWidget.StandardColumn( "CPU", "localDispatcher:cpu" ),
 						GafferUI.PathListingWidget.StandardColumn( "Memory", "localDispatcher:memory" ),

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -81,9 +81,9 @@ _columnsMetadataKey = "catalogue:columns"
 # `_imageCellData()`.
 class Column( GafferUI.PathColumn ) :
 
-	def __init__( self, title ) :
+	def __init__( self, title, sizeMode = GafferUI.PathColumn.SizeMode.Default ) :
 
-		GafferUI.PathColumn.__init__( self )
+		GafferUI.PathColumn.__init__( self, sizeMode )
 
 		self.__title = IECore.StringData( title )
 
@@ -203,9 +203,9 @@ class SimpleColumn( Column ) :
 # image's origin.
 class ImageMetadataColumn( Column ) :
 
-	def __init__( self, title, nameOrNames, defaultValue = None ) :
+	def __init__( self, title, nameOrNames, defaultValue = None, sizeMode = GafferUI.PathColumn.SizeMode.Default ) :
 
-		Column.__init__( self, title )
+		Column.__init__( self, title, sizeMode )
 
 		if isinstance( nameOrNames, str ) :
 			nameOrNames = [ nameOrNames, ]
@@ -271,7 +271,7 @@ class __StatusIconColumn( Column ) :
 registerColumn( "Status", __StatusIconColumn() )
 registerColumn( "Name", GafferUI.PathListingWidget.defaultNameColumn )
 registerColumn( "Frame", ContextVariableColumn( "Frame", "frame" ) )
-registerColumn( "Description", ImageMetadataColumn( "Description", "ImageDescription" ) )
+registerColumn( "Description", ImageMetadataColumn( "Description", "ImageDescription", sizeMode = GafferUI.PathColumn.SizeMode.Stretch ) )
 
 # Image properties
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import collections
+import math
 import warnings
 
 import imath
@@ -117,7 +118,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		# Install an empty model. We'll update the model contents shortly in setPath().
 
 		_GafferUI._pathListingWidgetUpdateModel( GafferUI._qtAddress( self._qtWidget() ), None )
-		_GafferUI._pathListingWidgetSetColumns( GafferUI._qtAddress( self._qtWidget() ), columns )
+		self.setColumns( columns )
 
 		# Turn off selection in Qt. QItemSelectionModel is full of quadratic performance
 		# hazards so we rely entirely on our own PathMatcher instead. We update the PathMatcher
@@ -302,6 +303,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			return
 
 		_GafferUI._pathListingWidgetSetColumns( GafferUI._qtAddress( self._qtWidget() ), columns )
+		self._qtWidget().updateColumnWidths()
 
 	def getColumns( self ) :
 
@@ -844,10 +846,22 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 		QtWidgets.QTreeView.__init__( self )
 
-		self.header().geometriesChanged.connect( self.updateGeometry )
+		self.header().geometriesChanged.connect( self.__geometriesChanged )
 		self.header().sectionResized.connect( self.__sectionResized )
 
+		# Disable Qt's stretchLastSection behaviour as it will claim any available space in the header
+		# before our stretch columns have a chance to resize themselves. We control our own equivalent
+		# behaviour based on the result of _shouldStretchLastColumn()
+		self.header().setStretchLastSection( False )
+		# width of the last column after being automatically stretched to use available space
+		self.__lastColumnWidth = 0
+
 		self.__recalculatingColumnWidths = False
+		self.__updatingGeometry = False
+
+		# we track the previous viewport width to aid in determining whether stretchable columns should
+		# be resized when the viewport width changes
+		self.__previousViewportWidth = 0
 		# the ideal size for each column. we cache these because they're slow to compute
 		self.__idealColumnWidths = collections.defaultdict( int )
 		# offsets to the ideal sizes made by the user
@@ -859,6 +873,13 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 		QtWidgets.QTreeView.setModel( self, model )
 
+		## \todo We may want more granular behaviour on model update.
+		# Currently column widths are updated when a location is
+		# expanded for the first time and requires a model update.
+		# This can lead to situations where first expanding and collapsing
+		# /a/veryLongName followed by /b/shortName leaves the column
+		# resized to /b/shortName. Expanding /a/veryLongName again will
+		# not update the column width and truncate to /a/veryLo...
 		model.updateFinished.connect( self.updateColumnWidths )
 
 		self.updateColumnWidths()
@@ -903,14 +924,35 @@ class _TreeView( QtWidgets.QTreeView ) :
 		self.__recalculatingColumnWidths = True
 
 		header = self.header()
-		numColumnsToResize = header.count() - 1 # leave the last section alone, as it's expandable
+		numColumnsToResize = header.count()
+		stretchLastColumn = self._shouldStretchLastColumn()
+		if stretchLastColumn :
+			numColumnsToResize -= 1 # leave the last section alone, as it's expandable
 
+		columns = self.__getColumns()
+		columnWidthsChanged = False
 		for i in range( 0, numColumnsToResize ) :
-			column = self.__getColumn( i )
-			idealWidth = max( header.sectionSizeHint( i ), self.sizeHintForColumn( i ) )
-			self.__idealColumnWidths[column] = idealWidth
+			if columns[i].getSizeMode() == GafferUI.PathColumn.SizeMode.Interactive :
+				idealWidth = max( header.sectionSizeHint( i ), self.sizeHintForColumn( i ) )
+				self.__idealColumnWidths[columns[i]] = idealWidth
+				adjustedWidth = idealWidth + self.__columnWidthAdjustments[columns[i]]
+				if i == header.count() - 1  :
+					# the last column may have been automatically extended to fill available space
+					# reuse that extended width to provide some consistency between column width updates
+					## \todo this may be better handled as a proportion of the overall width
+					adjustedWidth = max( adjustedWidth, self.__lastColumnWidth )
+				if header.sectionSize( i ) != adjustedWidth :
+					header.resizeSection( i, adjustedWidth )
+					columnWidthsChanged = True
 
-			header.resizeSection( i, idealWidth + self.__columnWidthAdjustments[column] )
+		if columnWidthsChanged :
+			# an update to column widths can require resizing columns configured to stretch
+			# to make use of any change in available space
+			self.__resizeStretchColumns()
+
+		if stretchLastColumn :
+			# finally, resize the last column to make use of any remaining available width
+			self.__resizeLastColumnToAvailableWidth()
 
 		self.__recalculatingColumnWidths = False
 
@@ -1019,20 +1061,125 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 	def __sectionResized( self, index, oldWidth, newWidth ) :
 
-		if self.__recalculatingColumnWidths :
+		if self.__recalculatingColumnWidths or self.__updatingGeometry :
 			# we're only interested in resizing being done by the user
 			return
 
 		# store the difference between the ideal size and what the user would prefer, so
 		# we can apply it again in updateColumnWidths
-		column = self.__getColumn( index )
+		column = self.__getColumns()[index]
 		self.__columnWidthAdjustments[column] = newWidth - self.__idealColumnWidths[column]
 
-	def __getColumn( self, index ) :
+		# When any column is user resized, automatically adjust the last column's width
+		# in order to make use of any empty space.
+		if index == self.header().count() - 1 :
+			# We prevent the last column from being user resized narrower than the
+			# available empty space in the header, but still allow it to be enlarged
+			# by providing the user specified column width as the minimum.
+			self.__resizeLastColumnToAvailableWidth( newWidth )
+		else :
+			self.__resizeLastColumnToAvailableWidth()
 
-		columns = _GafferUI._pathListingWidgetGetColumns( GafferUI._qtAddress( self ) )
+	def __resizeLastColumnToAvailableWidth( self, minimumSuggestedWidth = 0 ) :
 
-		if index >= len( columns ) :
-			raise IndexError( index )
+		header = self.header()
+		availableWidth = header.width()
+		lastColumn = header.count() - 1
+		for i in range( 0, lastColumn ) :
+			availableWidth -= header.sectionSize( i )
 
-		return columns[index]
+		minimumSectionWidth = max( header.minimumSectionSize(), header.sectionSizeHint( lastColumn ) )
+		minimumWidth = max( minimumSectionWidth, minimumSuggestedWidth )
+
+		# take column width adjustment into account when resizing, so we don't
+		# inadvertently truncate the last column after a user has extended it
+		column = self.__getColumns()[lastColumn]
+		if self.__columnWidthAdjustments[ column ] != 0 :
+			preferredWidth = self.__idealColumnWidths[ column ] + self.__columnWidthAdjustments[ column ]
+			minimumWidth = max( preferredWidth, minimumWidth )
+
+		adjustedWidth = max( minimumWidth, availableWidth )
+		self.__lastColumnWidth = adjustedWidth
+
+		self.__recalculatingColumnWidths = True
+		header.resizeSection( lastColumn, adjustedWidth )
+		self.__recalculatingColumnWidths = False
+
+	def __geometriesChanged( self ) :
+
+		self.updateGeometry()
+
+		viewportWidth = self.viewport().width()
+		if viewportWidth == self.__previousViewportWidth :
+			# We're only interested in changes to width
+			return
+
+		if self.header().length() <= self.__previousViewportWidth or self.header().length() < viewportWidth :
+			# We use the previous viewport width to help determine whether the columns should be resized,
+			# if the columns fit within the previous width, then we should maintain that relationship and
+			# resize to fit the new width. If the columns are narrower than the current viewport width,
+			# then we resize to make use of the newly available space.
+			self.__updatingGeometry = True
+			self.__resizeStretchColumns()
+			self.__updatingGeometry = False
+
+		self.__previousViewportWidth = viewportWidth
+
+	def __resizeStretchColumns( self ) :
+
+		header = self.header()
+		availableWidth = header.width()
+		stretchColumnWidth = 0
+		columnsToStretch = []
+
+		columns = self.__getColumns()
+		stretchLastColumn = self._shouldStretchLastColumn()
+		for i in range( 0, header.count() ) :
+			if (
+				columns[i].getSizeMode() == GafferUI.PathColumn.SizeMode.Stretch or
+				( stretchLastColumn and i == header.count() - 1 )
+			) :
+				stretchColumnWidth += header.sectionSize( i )
+				columnsToStretch.append( i )
+			else :
+				availableWidth -= header.sectionSize( i )
+
+		if len( columnsToStretch ) == 0 or availableWidth <= 0 :
+			return
+
+		self.__recalculatingColumnWidths = True
+
+		weight = 1.0 / len( columnsToStretch )
+		for c in columnsToStretch :
+			if stretchColumnWidth > 0 :
+				# preserve any existing column proportions
+				weight = header.sectionSize( c ) / stretchColumnWidth
+
+			## \todo A very small resize with multiple stretch columns can result in the
+			# larger column(s) taking all available space. Doing this repeatedly, such as a
+			# slow interactive resize, makes only the larger column(s) appear to stretch.
+
+			minimumWidth = max( header.minimumSectionSize(), header.sectionSizeHint( c ) )
+			idealWidth = max( math.floor( availableWidth * weight ), minimumWidth )
+			self.__idealColumnWidths[columns[c]] = idealWidth
+
+			header.resizeSection( c, idealWidth )
+
+		self.__recalculatingColumnWidths = False
+
+	def __getColumns( self ) :
+
+		if self.header().count() == 0 :
+			return []
+
+		return _GafferUI._pathListingWidgetGetColumns( GafferUI._qtAddress( self ) )
+
+	# Protected rather than private to allow access by PathListingWidgetTest
+	def _shouldStretchLastColumn( self ) :
+
+		if self.header().count() == 0 :
+			return False
+
+		# automatically stretch the last column to fill available space in the header
+		# when no other columns are configured to stretch
+		return not any( c.getSizeMode() == GafferUI.PathColumn.SizeMode.Stretch for c in self.__getColumns() )

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -63,7 +63,7 @@ class PathListingWidget( GafferUI.Widget ) :
 	IconColumn = _GafferUI.IconPathColumn
 
 	## A collection of handy column definitions for FileSystemPaths
-	defaultNameColumn = StandardColumn( "Name", "name" )
+	defaultNameColumn = StandardColumn( "Name", "name", GafferUI.PathColumn.SizeMode.Stretch )
 	defaultFileSystemOwnerColumn = StandardColumn( "Owner", "fileSystem:owner" )
 	defaultFileSystemModificationTimeColumn = StandardColumn( "Modified", "fileSystem:modificationTime" )
 	defaultFileSystemIconColumn = GafferUI.FileIconPathColumn()

--- a/python/GafferUITest/PathColumnTest.py
+++ b/python/GafferUITest/PathColumnTest.py
@@ -82,5 +82,13 @@ class PathColumnTest( GafferUITest.TestCase ) :
 		d.toolTip = "help!"
 		self.assertEqual( d.toolTip, "help!" )
 
+	def testSizeMode( self ) :
+
+		p = GafferUI.PathColumn( sizeMode = GafferUI.PathColumn.SizeMode.Stretch )
+		self.assertEqual( p.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
+
+		p.setSizeMode( GafferUI.PathColumn.SizeMode.Interactive )
+		self.assertEqual( p.getSizeMode(), GafferUI.PathColumn.SizeMode.Interactive )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -1236,6 +1236,47 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( cs[0][0], centerPath )
 		self.assertIs( cs[0][1], widget )
 
+	def testColumnSizeMode( self ) :
+
+		columns = [
+				GafferUI.PathListingWidget.defaultNameColumn,
+				GafferUI.PathListingWidget.StandardColumn( "Test", "test", sizeMode = GafferUI.PathColumn.SizeMode.Interactive ),
+				GafferUI.PathListingWidget.StandardColumn( "Test", "test", sizeMode = GafferUI.PathColumn.SizeMode.Stretch ),
+			]
+
+		widget = GafferUI.PathListingWidget(
+			path = Gaffer.DictPath( {}, "/" ),
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
+			columns = columns,
+		)
+
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( widget._qtWidget() ) )
+
+		for i, c in enumerate( widget.getColumns() ) :
+			self.assertEqual( columns[i].getSizeMode(), c.getSizeMode() )
+
+		reorderedColumns = [ columns[1], columns[2], columns[0] ]
+		widget.setColumns( reorderedColumns )
+
+		for i, c in enumerate( widget.getColumns() ) :
+			self.assertEqual( reorderedColumns[i].getSizeMode(), c.getSizeMode() )
+
+	def testStretchLastColumnIsSetFromColumns( self ) :
+
+		widget = GafferUI.PathListingWidget(
+			path = Gaffer.DictPath( {}, "/" ),
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
+			columns = [
+				GafferUI.PathListingWidget.StandardColumn( "Test", "test", sizeMode = GafferUI.PathColumn.SizeMode.Stretch ),
+				GafferUI.PathListingWidget.StandardColumn( "Test", "test" )
+			],
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( widget._qtWidget() ) )
+
+		self.assertFalse( widget._qtWidget()._shouldStretchLastColumn() )
+		widget.setColumns( [ GafferUI.PathListingWidget.StandardColumn( "Test", "test" ) ] )
+		self.assertTrue( widget._qtWidget()._shouldStretchLastColumn() )
+
 	@staticmethod
 	def __emitPathChanged( widget ) :
 

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -73,6 +73,21 @@ const std::string basisName( StandardCubicBasis basis )
 // PathColumn
 //////////////////////////////////////////////////////////////////////////
 
+PathColumn::PathColumn( SizeMode sizeMode )
+	:	m_sizeMode( sizeMode )
+{
+}
+
+PathColumn::SizeMode PathColumn::getSizeMode() const
+{
+	return m_sizeMode;
+}
+
+void PathColumn::setSizeMode( SizeMode sizeMode )
+{
+	m_sizeMode = sizeMode;
+}
+
 PathColumn::PathColumnSignal &PathColumn::changedSignal()
 {
 	return m_changedSignal;
@@ -97,8 +112,8 @@ PathColumn::ButtonSignal &PathColumn::buttonDoubleClickSignal()
 // StandardPathColumn
 //////////////////////////////////////////////////////////////////////////
 
-StandardPathColumn::StandardPathColumn( const std::string &label, IECore::InternedString property )
-	:	m_label( new IECore::StringData( label ) ), m_property( property )
+StandardPathColumn::StandardPathColumn( const std::string &label, IECore::InternedString property, SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_label( new IECore::StringData( label ) ), m_property( property )
 {
 }
 
@@ -149,8 +164,8 @@ PathColumn::CellData StandardPathColumn::headerData( const IECore::Canceller *ca
 // IconPathColumn
 //////////////////////////////////////////////////////////////////////////
 
-IconPathColumn::IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property )
-	:	m_label( new StringData( label ) ), m_prefix( prefix ), m_property( property )
+IconPathColumn::IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property, SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_label( new StringData( label ) ), m_prefix( prefix ), m_property( property )
 {
 }
 
@@ -197,8 +212,8 @@ PathColumn::CellData IconPathColumn::headerData( const IECore::Canceller *cancel
 // FileIconPathColumn
 //////////////////////////////////////////////////////////////////////////
 
-FileIconPathColumn::FileIconPathColumn()
-	:	m_label( new IECore::StringData( "Type" ) )
+FileIconPathColumn::FileIconPathColumn( SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_label( new IECore::StringData( "Type" ) )
 {
 }
 

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -159,8 +159,8 @@ class PathColumnWrapper : public IECorePython::RefCountedWrapper<PathColumn>
 
 	public :
 
-		PathColumnWrapper( PyObject *self )
-			:	 IECorePython::RefCountedWrapper<PathColumn>( self )
+		PathColumnWrapper( PyObject *self, PathColumn::SizeMode sizeMode )
+			:	 IECorePython::RefCountedWrapper<PathColumn>( self, sizeMode )
 		{
 		}
 
@@ -308,14 +308,13 @@ struct ButtonSignalSlotCaller
 
 void GafferUIModule::bindPathColumn()
 {
+	IECorePython::RefCountedClass<PathColumn, IECore::RefCounted, PathColumnWrapper> pathColumnClass( "PathColumn" );
 	{
-		scope s = IECorePython::RefCountedClass<PathColumn, IECore::RefCounted, PathColumnWrapper>( "PathColumn" )
-			.def( init<>() )
-			.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
-			.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
-			.def( "buttonPressSignal", &PathColumn::buttonPressSignal, return_internal_reference<1>() )
-			.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
-			.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )
+		scope s = pathColumnClass;
+		enum_<PathColumn::SizeMode>( "SizeMode" )
+			.value( "Interactive", PathColumn::SizeMode::Interactive )
+			.value( "Stretch", PathColumn::SizeMode::Stretch )
+			.value( "Default", PathColumn::SizeMode::Default )
 		;
 
 		class_<PathColumn::CellData>( "CellData" )
@@ -347,15 +346,25 @@ void GafferUIModule::bindPathColumn()
 		SignalClass<PathColumn::ButtonSignal, ButtonSignalCaller, ButtonSignalSlotCaller>( "ButtonSignal" );
 	}
 
+	pathColumnClass.def( init<PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::SizeMode::Default ) )
+		.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
+		.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
+		.def( "buttonPressSignal", &PathColumn::buttonPressSignal, return_internal_reference<1>() )
+		.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
+		.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )
+		.def( "getSizeMode", (PathColumn::SizeMode (PathColumn::*)() const )&PathColumn::getSizeMode )
+		.def( "setSizeMode", &PathColumn::setSizeMode, ( arg( "sizeMode" ) ) )
+	;
+
 	IECorePython::RefCountedClass<StandardPathColumn, PathColumn>( "StandardPathColumn" )
-		.def( init<const std::string &, IECore::InternedString>() )
+		.def( init<const std::string &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
 	;
 
 	IECorePython::RefCountedClass<IconPathColumn, PathColumn>( "IconPathColumn" )
-		.def( init<const std::string &, const std::string &, IECore::InternedString>() )
+		.def( init<const std::string &, const std::string &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
 	;
 
 	IECorePython::RefCountedClass<FileIconPathColumn, PathColumn>( "FileIconPathColumn" )
-		.def( init<>() )
+		.def( init<PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
 	;
 }


### PR DESCRIPTION
Originating from attempts to stretch the width of the HierarchyView's Name column after the addition of the Inclusions and Exclusions columns, this PR adds flags to PathColumn allowing a resize mode to be defined, which is then converted to Qt header resize behaviour when the column is added to a PathListingWidget.

The PathListingWidget's `defaultNameColumn` now defaults to ResizeStretch, allowing it to make use of available space, rather than the previous behaviour of whichever column was added last to a PathListingWidget stretching via Qt's `stretchLastSection` property. `stretchLastSection` is now disabled when there are columns in the PathListingWidget specifically configured to stretch, but enabled for PathListingWidgets containing none, to preserve the existing behaviour. There's also a small optimization to `updateColumnWidths()` as we should be able to ignore columns that aren't interactively resizable.

To demonstrate wider use, additional commits have been included to set ResizeStretch on the ShaderUI, _HistoryWindow and LightEditor's name column equivalents. Of these, the LightEditor may benefit from a custom resize behaviour where the column is permitted to stretch while also maintaining a minimum width, as the potentially large and varying number of columns in the LightEditor can cause the `LocationNameColumn` to shrink down to nothing when there isn't enough available space to display all columns. The Catalogue's Name column could suffer a similar fate. @ericmehl, maybe you could take this for a spin and see what you think?

John, please let me know any thoughts on the structure here. I went with the generic `flags` in case we need to support other behaviours/interesting quirks of Qt in the future, but maybe it's preferable to have a more specific `ResizeMode` enum and deal with any future cases if/when they arise. I may also need a hand with the boost::python incantation required to get the enum binding first for use in PathColumn's `init`...