### PR TITLE
HierarchyView : Minor UI improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - TweakPlug : Added a `CreateIfMissing` mode, to only create a new value if one does not currently exist [^1].
 - OSLObject : Added support for attribute substitutions using `<attr:myAttrName>` syntax in string parameters, provided that `useAttributes` is turned on [^1].
 - UIEditor : Increased maximum size of the "Button Click Code" editor [^1].
+- HierarchyView : Inclusions and Exclusions column header icons now update to show when one or more locations have been added to or excluded from the Visible Set [^2].
 
 Fixes
 -----
@@ -46,6 +47,7 @@ Build
 - 3Delight : Updated to 3Delight version 2.9.17.
 
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
+[^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 
 1.2.0.0a1
 =========

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1273,6 +1273,12 @@ _styleSheet = string.Template(
 		paint-alternating-row-colors-for-empty-area: 1;
 	}
 
+	*[gafferClass="GafferSceneUI.HierarchyView"] QTreeView::item {
+		height: 18px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+	}
+
 	QTreeView::item {
 		padding-top: 2px;
 		padding-bottom: 2px;

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -597,7 +597,8 @@ class InclusionsColumn : public PathColumn
 
 		CellData headerData( const IECore::Canceller *canceller ) const override
 		{
-			return CellData( /* value = */ nullptr, /* icon = */ g_locationIncludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Inclusions" ) );
+			const auto visibleSet = ContextAlgo::getVisibleSet( m_context.get() );
+			return CellData( /* value = */ nullptr, /* icon = */ visibleSet.inclusions.isEmpty() ? g_ancestorIncludedIconName : g_locationIncludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Inclusions" ) );
 		}
 
 	private :
@@ -816,7 +817,8 @@ class ExclusionsColumn : public PathColumn
 
 		CellData headerData( const IECore::Canceller *canceller ) const override
 		{
-			return CellData( /* value = */ nullptr, /* icon = */ g_locationExcludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Exclusions" ) );
+			const auto visibleSet = ContextAlgo::getVisibleSet( m_context.get() );
+			return CellData( /* value = */ nullptr, /* icon = */ visibleSet.exclusions.isEmpty() ? g_ancestorExcludedIconName : g_locationExcludedIconName, /* background = */ nullptr, /* tooltip = */ new StringData( "Visible Set Exclusions" ) );
 		}
 
 	private :

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -1735,6 +1735,7 @@ class PathModel : public QAbstractItemModel
 		{
 			cancelUpdate();
 			m_rootItem->dirty( /* dirtyChildItems = */ false, /* dirtyData = */ true );
+			headerDataChanged( Qt::Horizontal, 0, m_columns.size() - 1 );
 			scheduleUpdate();
 		}
 


### PR DESCRIPTION
This adjusts the icon display in the Inclusions and Exclusions column headers to show the more subtle "ancestor" variants of each icon when no inclusions or exclusions have been added to the VisibleSet, and the original brighter icon when inclusions or exclusions have been added. This tones down the UI in the initial state, while providing some visual distinction once inclusions or exclusions have been set.

There's also a small adjustment to the StyleSheet setting a fixed 18 pixel height to the HierarchyView's rows. This allows for consistent row heights whether the first row has an icon or not, and removes the additional vertical padding noticed when introducing the Inclusions and Exclusions columns and their 16px icons.