### PR TITLE
GafferImageTest : Replace Remaining Uses Of os.path

### DIFF
--- a/python/GafferImageTest/AnaglyphTest.py
+++ b/python/GafferImageTest/AnaglyphTest.py
@@ -48,7 +48,7 @@ import GafferImageTest
 
 class AnaglyphTest( GafferImageTest.ImageTestCase ) :
 
-	file = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "multipart.exr"
+	file = GafferImageTest.ImageTestCase.imagesPath() / "multipart.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/BleedFillTest.py
+++ b/python/GafferImageTest/BleedFillTest.py
@@ -49,13 +49,11 @@ import GafferImageTest
 
 class BleedFillTest( GafferImageTest.ImageTestCase ) :
 
-	path = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images"
-
 	def testBasics( self ) :
 
 		# Load a basic black/white checker, and resize it to 8x8 pixels
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.path / "checker2x2.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		resize = GafferImage.Resize()
 		resize["in"].setInput( r["out"] )

--- a/python/GafferImageTest/CDLTest.py
+++ b/python/GafferImageTest/CDLTest.py
@@ -48,7 +48,7 @@ import GafferImageTest
 
 class CDLTest( GafferImageTest.ImageTestCase ) :
 
-	imageFile = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checker.exr"
+	imageFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 
@@ -139,7 +139,7 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "circles.exr" )
+		i["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		o = GafferImage.CDL()
 		o["in"].setInput( i["out"] )

--- a/python/GafferImageTest/CatalogueSelectTest.py
+++ b/python/GafferImageTest/CatalogueSelectTest.py
@@ -52,7 +52,7 @@ class CatalogueSelectTest( GafferImageTest.ImageTestCase ) :
 
 		outputIndex = 0
 		for fileName in fileNames :
-			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
+			images.append( GafferImage.Catalogue.Image.load( self.imagesPath() / fileName ) )
 			outputIndex += 1
 			images[-1]["outputIndex"].setValue( outputIndex )
 			readers.append( GafferImage.ImageReader() )

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -71,7 +71,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		images = []
 		readers = []
 		for i, fileName in enumerate( [ "checker.exr", "blurRange.exr", "noisyRamp.exr", "resamplePatterns.exr" ] ) :
-			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
+			images.append( GafferImage.Catalogue.Image.load( self.imagesPath() / fileName ) )
 			readers.append( GafferImage.ImageReader() )
 			readers[-1]["fileName"].setValue( images[-1]["fileName"].getValue() )
 
@@ -97,7 +97,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 	def testDescription( self ) :
 
 		c = GafferImage.Catalogue()
-		c["images"].addChild( c.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" ) )
+		c["images"].addChild( c.Image.load( self.imagesPath() / "blurRange.exr" ) )
 		self.assertNotIn( "ImageDescription", c["out"]["metadata"].getValue() )
 
 		c["images"][-1]["description"].setValue( "ddd" )
@@ -132,7 +132,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		for i, fileName in enumerate( [ "checker.exr", "blurRange.exr" ] ) :
 			s["c"]["images"].addChild(
 				GafferImage.Catalogue.Image.load(
-					"${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName,
+					self.imagesPath() / fileName,
 				)
 			)
 
@@ -160,12 +160,12 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		c1 = GafferImage.Catalogue()
 		c1["images"].addChild(
-			GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+			GafferImage.Catalogue.Image.load( self.imagesPath() / "checker.exr" )
 		)
 
 		c2 = GafferImage.Catalogue()
 		c2["images"].addChild(
-			GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+			GafferImage.Catalogue.Image.load( self.imagesPath() / "checker.exr" )
 		)
 
 		self.assertImagesEqual( c1["out"], c2["out"] )
@@ -185,7 +185,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( len( c["images"] ), 0 )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 
 		driver = self.sendImage( r["out"], c, close = False )
 		self.assertEqual( c["out"]["metadata"].getValue()[ self.__catalogueIsRenderingMetadataKey ].value, True )
@@ -198,7 +198,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( r["out"], c["out"] )
 
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 		self.sendImage( r["out"], c )
 
 		self.assertEqual( len( c["images"] ), 2 )
@@ -236,7 +236,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		s["c"]["directory"].setValue( self.temporaryDirectory() / "catalogue" )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 		self.sendImage( r["out"], s["c"] )
 		self.assertEqual( len( s["c"]["images"] ), 1 )
 		self.assertEqual( pathlib.Path( s["c"]["images"][0]["fileName"].getValue() ).parent.as_posix(), s["c"]["directory"].getValue() )
@@ -321,7 +321,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		images = []
 		readers = []
 		for i, fileName in enumerate( [ "checker.exr", "blurRange.exr", "noisyRamp.exr" ] ) :
-			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
+			images.append( GafferImage.Catalogue.Image.load( self.imagesPath() / fileName ) )
 			readers.append( GafferImage.ImageReader() )
 			readers[-1]["fileName"].setValue( images[-1]["fileName"].getValue() )
 
@@ -371,14 +371,14 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		promotedOut = Gaffer.PlugAlgo.promote( s["b"]["c"]["out"] )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 		self.sendImage( r["out"], s["b"]["c"] )
 
 		self.assertEqual( len( promotedImages ), 1 )
 		self.assertEqual( promotedImageIndex.getValue(), 0 )
 		self.assertImagesEqual( r["out"], promotedOut, ignoreMetadata = True )
 
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 		self.sendImage( r["out"], s["b"]["c"] )
 
 		self.assertEqual( len( promotedImages ), 2 )
@@ -409,7 +409,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		promotedOut = Gaffer.PlugAlgo.promote( s["b"]["c"]["out"] )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 		self.sendImage( r["out"], s["b"]["c"] )
 
 		self.assertEqual( len( promotedImages ), 1 )
@@ -423,10 +423,10 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["c"] = GafferImage.Catalogue()
-		s["c"]["images"].addChild( s["c"].Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" ) )
+		s["c"]["images"].addChild( s["c"].Image.load( self.imagesPath() / "checker.exr" ) )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 
 		def assertPreconditions() :
 
@@ -483,7 +483,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		# we do not deadlock on the GIL.
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 
 		self.sendImage( r["out"], s["catalogue"] )
 
@@ -499,7 +499,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		drivers = GafferTest.CapturingSlot( GafferImage.Display.driverCreatedSignal() )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 		self.sendImage( r["out"], c )
 
 		self.assertEqual( len( drivers ), 1 )
@@ -552,7 +552,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 	def testCopyFrom( self ) :
 
 		c = GafferImage.Catalogue()
-		c["images"].addChild( c.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" ) )
+		c["images"].addChild( c.Image.load( self.imagesPath() / "checker.exr" ) )
 		c["images"][0]["description"].setValue( "test" )
 
 		c["images"].addChild( c.Image( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
@@ -570,7 +570,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		c["directory"].setValue( self.temporaryDirectory() / "catalogue" )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 
 		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :
 			self.sendImage( r["out"], c, waitForSave = False )
@@ -598,7 +598,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		self.assertFalse( fullDirectory.exists() )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/checker.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker.exr" )
 
 		driver = self.sendImage( r["out"], s["c"], waitForSave = False, close = False )
 		# Simulate deletion by removing it from the script but keeping it alive.
@@ -621,7 +621,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		os.chmod( self.temporaryDirectory(), stat.S_IREAD )
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 
 		originalMessageHandler = IECore.MessageHandler.getDefaultHandler()
 		mh = IECore.CapturingMessageHandler()
@@ -831,7 +831,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 	def testInternalImagePythonType( self ) :
 
 		c = GafferImage.Catalogue()
-		c["images"].addChild( c.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" ) )
+		c["images"].addChild( c.Image.load( self.imagesPath() / "blurRange.exr" ) )
 
 		for g in Gaffer.GraphComponent.RecursiveRange( c ) :
 			self.assertTrue(
@@ -938,7 +938,7 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		images = []
 		readers = []
 		for i, fileName in enumerate( [ "checker.exr", "blurRange.exr", "noisyRamp.exr", "resamplePatterns.exr" ] ) :
-			images.append( GafferImage.Catalogue.Image.load( "${GAFFER_ROOT}/python/GafferImageTest/images/" + fileName ) )
+			images.append( GafferImage.Catalogue.Image.load( self.imagesPath() / fileName ) )
 			readers.append( GafferImage.ImageReader() )
 			readers[-1]["fileName"].setValue( images[-1]["fileName"].getValue() )
 

--- a/python/GafferImageTest/ClampTest.py
+++ b/python/GafferImageTest/ClampTest.py
@@ -51,7 +51,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testClamp( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" /"colorbars_half_max.exr" )
+		i["fileName"].setValue( self.imagesPath() / "colorbars_half_max.exr" )
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
@@ -62,7 +62,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testPerChannelHash( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_half_max.exr" )
+		i["fileName"].setValue( self.imagesPath() / "colorbars_half_max.exr" )
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
@@ -86,7 +86,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testDisconnectedDirty( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_half_max.exr" )
+		r["fileName"].setValue( self.imagesPath() / "colorbars_half_max.exr" )
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput( r["out"] )
 
@@ -106,7 +106,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testClampWithMaxTo( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_max_clamp.exr" )
+		i["fileName"].setValue( self.imagesPath() / "colorbars_max_clamp.exr" )
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
@@ -133,7 +133,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testEnabledBypass( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_half_max.exr" )
+		i["fileName"].setValue( self.imagesPath() / "colorbars_half_max.exr" )
 
 		clamp = GafferImage.Clamp()
 		clamp["in"].setInput(i["out"])
@@ -158,7 +158,7 @@ class ClampTest( GafferImageTest.ImageTestCase ) :
 	def testPassThrough( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_half_max.exr" )
+		i["fileName"].setValue( self.imagesPath() / "colorbars_half_max.exr" )
 
 		c = GafferImage.Clamp()
 		c["in"].setInput( i["out"] )

--- a/python/GafferImageTest/CollectImagesTest.py
+++ b/python/GafferImageTest/CollectImagesTest.py
@@ -48,7 +48,7 @@ import GafferImageTest
 
 class CollectImagesTest( GafferImageTest.ImageTestCase ) :
 
-	layersPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "layers.10x10.exr"
+	layersPath = GafferImageTest.ImageTestCase.imagesPath() / "layers.10x10.exr"
 
 	# Test against an image which has a different positioned box in each image layer, and a datawindow
 	# that has been enlarged to hold all layers

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -49,7 +49,7 @@ import GafferImageTest
 
 class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 
@@ -131,7 +131,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
+		i["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		o = GafferImage.ColorSpace()
 		o["in"].setInput( i["out"] )
@@ -193,7 +193,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		env = os.environ.copy()
-		env["OCIO"] = str( Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio" )
+		env["OCIO"] = self.openColorIOPath() / "context.ocio"
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
 
@@ -204,7 +204,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context.exr" )
+		i["fileName"].setValue( self.imagesPath() / "checker_ocio_context.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextImageFile )
@@ -228,7 +228,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context_override.exr" )
+		i["fileName"].setValue( self.imagesPath() / "checker_ocio_context_override.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextOverrideImageFile )
@@ -242,7 +242,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 	def testSingleChannelImage( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 		self.assertEqual( r["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R" ] ) )
 
 		s = GafferImage.Shuffle()
@@ -265,7 +265,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 	def testUnpremultiplied( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
+		i["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		shuffleAlpha = GafferImage.Shuffle()
 		shuffleAlpha["channels"].addChild( GafferImage.Shuffle.ChannelPlug( "channel" ) )

--- a/python/GafferImageTest/CopyImageMetadataTest.py
+++ b/python/GafferImageTest/CopyImageMetadataTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class CopyImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/CreateViewsTest.py
+++ b/python/GafferImageTest/CreateViewsTest.py
@@ -48,8 +48,8 @@ import GafferImageTest
 
 class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	__stereoFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "channelTestMultiViewPartPerView.exr"
+	__rgbFilePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	__stereoFilePath = GafferImageTest.ImageTestCase.imagesPath() / "channelTestMultiViewPartPerView.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/CropTest.py
+++ b/python/GafferImageTest/CropTest.py
@@ -48,9 +48,10 @@ import GafferImageTest
 
 class CropTest( GafferImageTest.ImageTestCase ) :
 
-	imageFileUndersizeDataWindow = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr"
-	imageFileOversizeDataWindow = Gaffer.rootPath() / "python"/ "GafferImageTest" / "images" / "checkerWithNegWindows.200x150.exr"
-	representativeDeepImagePath = Gaffer.rootPath() / "python"/ "GafferImageTest"/ "images" /"representativeDeepImage.exr"
+	imageFileUndersizeDataWindow = GafferImageTest.ImageTestCase.imagesPath() / "blueWithDataWindow.100x100.exr"
+	imageFileOversizeDataWindow = GafferImageTest.ImageTestCase.imagesPath() / "checkerWithNegWindows.200x150.exr"
+	representativeDeepImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
+
 
 	def testDefaultState( self ) :
 

--- a/python/GafferImageTest/DeepHoldoutTest.py
+++ b/python/GafferImageTest/DeepHoldoutTest.py
@@ -41,14 +41,13 @@ import os
 
 import IECore
 
-import Gaffer
 import GafferTest
 import GafferImage
 import GafferImageTest
 
 class DeepHoldoutTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	representativeImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
 
 	def testBasics( self ):
 		representativeImage = GafferImage.ImageReader()

--- a/python/GafferImageTest/DeepRecolorTest.py
+++ b/python/GafferImageTest/DeepRecolorTest.py
@@ -41,15 +41,14 @@ import os
 
 import IECore
 
-import Gaffer
 import GafferTest
 import GafferImage
 import GafferImageTest
 
 class DeepRecolorTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
-	flatImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	representativeImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
+	flatImagePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
 
 	def testBasics( self ):
 		representativeImage = GafferImage.ImageReader()

--- a/python/GafferImageTest/DeepStateTest.py
+++ b/python/GafferImageTest/DeepStateTest.py
@@ -52,10 +52,13 @@ import GafferImageTest
 
 # \todo : Add tests for how DeepState responds when A, Z and/or ZBack
 #         channels do not exist on input
+
+
 class DeepStateTest( GafferImageTest.ImageTestCase ) :
 
-	representativeImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
-	mergeReferencePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "deepMergeReference.exr"
+	representativeImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
+	mergeReferencePath = GafferImageTest.ImageTestCase.imagesPath() / "deepMergeReference.exr"
+
 
 	longMessage = True
 

--- a/python/GafferImageTest/DeepStateTest.py
+++ b/python/GafferImageTest/DeepStateTest.py
@@ -353,7 +353,7 @@ class DeepStateTest( GafferImageTest.ImageTestCase ) :
 		iState['deepState'].setValue( GafferImage.DeepState.TargetState.Flat )
 
 		testFile = self.temporaryDirectory() / "test.Flat.exr"
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w = GafferImage.ImageWriter()
 		w['in'].setInput( iState["out"] )

--- a/python/GafferImageTest/DeleteChannelsTest.py
+++ b/python/GafferImageTest/DeleteChannelsTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class DeleteChannelsTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def testDirtyPropagation( self ) :
 

--- a/python/GafferImageTest/DeleteImageMetadataTest.py
+++ b/python/GafferImageTest/DeleteImageMetadataTest.py
@@ -45,7 +45,7 @@ import GafferImageTest
 
 class DeleteImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/DeleteViewsTest.py
+++ b/python/GafferImageTest/DeleteViewsTest.py
@@ -47,9 +47,10 @@ import GafferImageTest
 
 class DeleteViewsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	__rgbFilePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
 
 	def test( self ) :
+
 
 		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( self.__rgbFilePath )

--- a/python/GafferImageTest/DilateTest.py
+++ b/python/GafferImageTest/DilateTest.py
@@ -76,7 +76,7 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 	def testFilter( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/radial.exr" )
+		r["fileName"].setValue( self.imagesPath() / "radial.exr" )
 
 		m = GafferImage.Dilate()
 		m["in"].setInput( r["out"] )
@@ -93,7 +93,7 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 	def testDriverChannel( self ) :
 
 		rRaw = GafferImage.ImageReader()
-		rRaw["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circles.exr" )
+		rRaw["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
@@ -108,7 +108,7 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 		masterDilate["masterChannel"].setValue( "G" )
 
 		expected = GafferImage.ImageReader()
-		expected["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circlesGreenDilate.exr" )
+		expected["fileName"].setValue( self.imagesPath() / "circlesGreenDilate.exr" )
 
 		# Note that in this expected image, the green channel is nicely medianed, and red and blue are completely
 		# unchanged in areas where there is no green.  In areas where red and blue overlap with a noisy green,

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -204,15 +204,15 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 
 	def testTransferChecker( self ) :
 
-		self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
+		self.__testTransferImage( self.imagesPath() / "checker.exr" )
 
 	def testTransferWithDataWindow( self ) :
 
-		self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr" )
+		self.__testTransferImage( self.imagesPath() / "checkerWithNegativeDataWindow.200x150.exr" )
 
 	def testAccessOutsideDataWindow( self ) :
 
-		node = self.__testTransferImage( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
+		node = self.__testTransferImage( self.imagesPath() / "checker.exr" )
 
 		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 
@@ -312,7 +312,7 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 	def __testTransferImage( self, fileName ) :
 
 		imageReader = GafferImage.ImageReader()
-		imageReader["fileName"].setValue( os.path.expandvars( fileName ) )
+		imageReader["fileName"].setValue( fileName )
 
 		imagesReceived = GafferTest.CapturingSlot( GafferImage.Display.imageReceivedSignal() )
 

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import unittest
 import subprocess
 import imath
@@ -48,7 +49,7 @@ import GafferImageTest
 
 class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 
-	imageFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	imageFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 
@@ -134,7 +135,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
+		i["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		o = GafferImage.DisplayTransform()
 		o["in"].setInput( i["out"] )
@@ -199,7 +200,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		s.save()
 
 		env = os.environ.copy()
-		env["OCIO"] = str( Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio" )
+		env["OCIO"] = self.openColorIOPath() / "context.ocio"
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
 
@@ -210,7 +211,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context.exr" )
+		i["fileName"].setValue( self.imagesPath() / "checker_ocio_context.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextImageFile )
@@ -234,7 +235,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		)
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_context_override.exr" )
+		i["fileName"].setValue( self.imagesPath() / "checker_ocio_context_override.exr" )
 
 		o = GafferImage.ImageReader()
 		o["fileName"].setValue( contextOverrideImageFile )

--- a/python/GafferImageTest/ErodeTest.py
+++ b/python/GafferImageTest/ErodeTest.py
@@ -76,7 +76,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 	def testFilter( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/radial.exr" )
+		r["fileName"].setValue( self.imagesPath() / "radial.exr" )
 
 		m = GafferImage.Erode()
 		m["in"].setInput( r["out"] )
@@ -95,7 +95,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 	def testDriverChannel( self ) :
 
 		rRaw = GafferImage.ImageReader()
-		rRaw["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circles.exr" )
+		rRaw["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
@@ -110,7 +110,7 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 		masterErode["masterChannel"].setValue( "G" )
 
 		expected = GafferImage.ImageReader()
-		expected["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circlesGreenErode.exr" )
+		expected["fileName"].setValue( self.imagesPath() / "circlesGreenErode.exr" )
 
 		# Note that in this expected image, the green channel is nicely medianed, and red and blue are completely
 		# unchanged in areas where there is no green.  In areas where red and blue overlap with a noisy green,

--- a/python/GafferImageTest/FilterAlgoTest.py
+++ b/python/GafferImageTest/FilterAlgoTest.py
@@ -48,8 +48,8 @@ import math
 
 class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 
-	derivativesReferenceParallelFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "filterDerivativesTest.parallel.exr"
-	derivativesReferenceBoxFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "filterDerivativesTest.box.exr"
+	derivativesReferenceParallelFileName = GafferImageTest.ImageTestCase.imagesPath() / "filterDerivativesTest.parallel.exr"
+	derivativesReferenceBoxFileName = GafferImageTest.ImageTestCase.imagesPath() / "filterDerivativesTest.box.exr"
 
 	# Artificial test of several filters passing in different derivatives, including a bunch of 15 degree rotations
 	def testFilterDerivatives( self ):
@@ -134,7 +134,7 @@ class FilterAlgoTest( GafferImageTest.ImageTestCase ) :
 	def testMatchesResample( self ):
 		def __test( fileName, size, filter ) :
 
-			inputFileName = os.path.dirname( __file__ ) + "/images/" + fileName
+			inputFileName = self.imagesPath() / fileName
 
 			reader = GafferImage.ImageReader()
 			reader["fileName"].setValue( inputFileName )

--- a/python/GafferImageTest/FormatQueryTest.py
+++ b/python/GafferImageTest/FormatQueryTest.py
@@ -96,7 +96,7 @@ class FormatQueryTest( GafferImageTest.ImageTestCase ) :
 		constantSource["format"].setValue( GafferImage.Format( imath.Box2i( imath.V2i( 0 ), imath.V2i( 512 ) ), 1 ) )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "checkerboard.100x100.exr" )
 
 		views = GafferImage.CreateViews()
 		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )

--- a/python/GafferImageTest/GradeTest.py
+++ b/python/GafferImageTest/GradeTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class GradeTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	# Test that when gamma == 0 that the coresponding channel isn't modified.
 	def testChannelEnable( self ) :

--- a/python/GafferImageTest/ImageMetadataTest.py
+++ b/python/GafferImageTest/ImageMetadataTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class ImageMetadataTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/ImagePlugTest.py
+++ b/python/GafferImageTest/ImagePlugTest.py
@@ -156,7 +156,7 @@ class ImagePlugTest( GafferImageTest.ImageTestCase ) :
 	def testImageHash( self ) :
 
 		r = GafferImage.ImageReader()
-		r['fileName'].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr" )
+		r['fileName'].setValue( self.imagesPath() / "checker.exr" )
 
 		h = GafferImage.ImageAlgo.imageHash( r['out'] )
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -36,6 +36,7 @@
 
 import math
 import os
+import pathlib
 import shutil
 import unittest
 import imath
@@ -612,7 +613,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 	@unittest.skipIf( not "OPENEXR_IMAGES_DIR" in os.environ, "If you want to run tests using the OpenEXR sample images, then download https://github.com/AcademySoftwareFoundation/openexr-images and set the env var OPENEXR_IMAGES_DIR to the directory" )
 	def testWithEXRSampleImages( self ):
 
-		directory = os.environ["OPENEXR_IMAGES_DIR"]
+		directory = pathlib.Path( os.environ["OPENEXR_IMAGES_DIR"] )
 
 		reader = GafferImage.ImageReader()
 
@@ -781,7 +782,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 					[ "left", "RGBAZ", ((0,0), (1920,814)), (0.0072465, 0.00569297, 0.00303837, 0.0964944), (0, 0, 0, 0), (0.397461, 0.307129, 0.177368, 1) ],
 					[ "right", "RGBAZ", ((0,0), (1883,814)), (0.00711977, 0.00569962, 0.00315493, 0.111899), (0, 0, 0, 0), (0.396729, 0.306396, 0.17749, 1) ] ] ]
 		]:
-			reader["fileName"].setValue( os.path.join( directory, name ) )
+			reader["fileName"].setValue( directory / name )
 
 			# The EXR examples should load correctly with either our default interpretation, or a strict
 			# interpretation of the spec

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -49,11 +49,11 @@ import GafferImageTest
 
 class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr"
-	colorSpaceFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles_as_cineon.exr"
-	offsetDataWindowFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	jpgFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.jpg"
-	largeFileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "colorbars_max_clamp.exr"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "circles.exr"
+	colorSpaceFileName = GafferImageTest.ImageTestCase.imagesPath() / "circles_as_cineon.exr"
+	offsetDataWindowFileName = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	jpgFileName = GafferImageTest.ImageTestCase.imagesPath() / "circles.jpg"
+	largeFileName = GafferImageTest.ImageTestCase.imagesPath() / "colorbars_max_clamp.exr"
 
 	def setUp( self ) :
 
@@ -472,7 +472,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			for name, value in channels:
 				self.assertAlmostEqual( reader["out"].channelData( name, imath.V2i( 0 ), view )[0], value, places = 3 )
 
-		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/imitateProductionLayers1.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "imitateProductionLayers1.exr" )
 
 		reader["channelInterpretation"].setValue( GafferImage.ImageReader.ChannelInterpretation.Default )
 		validateChannels( [ ( "R", 0.1 ), ( "G", 0.2 ), ( "B", 0.3 ), ( "character.R", 0.4 ), ( "character.G", 0.5 ), ( "character.B", 0.6 ) ] )
@@ -484,7 +484,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		#for the specification interpretation, then you actually get a view named "main"
 		validateChannels( [ ( "R", 0.1 ), ( "G", 0.2 ), ( "B", 0.3 ), ( "red", 0.4 ), ( "green", 0.5 ), ( "blue", 0.6 ) ], "main" )
 
-		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/imitateProductionLayers2.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "imitateProductionLayers2.exr" )
 		reader["channelInterpretation"].setValue( GafferImage.ImageReader.ChannelInterpretation.Default )
 		validateChannels( [ ( "R", 0.1 ), ( "G", 0.2 ), ( "B", 0.3 ), ( "Z", 0.4 ) ] )
 		reader["channelInterpretation"].setValue( GafferImage.ImageReader.ChannelInterpretation.Legacy )
@@ -499,7 +499,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		# something like "RGB" or "rgba" or "main", which we recognize.  If you have an EXR with weird part
 		# names though, you can load it correctly by switching channelInterpretation from Default to
 		# Specification
-		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/weirdPartNames.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "weirdPartNames.exr" )
 		reader["channelInterpretation"].setValue( GafferImage.ImageReader.ChannelInterpretation.Default )
 		validateChannels( [
 			( "part0.R", 0.1 ), ( "part1.G", 0.2 ), ( "part2.B", 0.3 ), ( "layer.R", 0.4 ),
@@ -523,7 +523,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		for n in [ "SinglePart", "PartPerLayer", "NukeSinglePart", "NukePartPerLayer" ]:
 
-			reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/channelTest" + n + ".exr" )
+			reader["fileName"].setValue( self.imagesPath() / ( "channelTest" + n + ".exr" ) )
 
 			# The default channel interpretation should work fine with files coming from Nuke, or from a
 			# spec compliant writer ( like Gaffer's new default )
@@ -585,7 +585,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 				# like the spec says they must.  I guess we just give up on this?
 				continue
 
-			reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/channelTestMultiView" + n + ".exr" )
+			reader["fileName"].setValue( self.imagesPath() / ( "channelTestMultiView" + n + ".exr" ) )
 
 			# Our reference comes from channelTestImageMultiView, which tries to exercise a bunch of corner
 			# cases, including one view with some channels deleted so the channels aren't the same between views.

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -98,7 +98,7 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 		constantSource["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "blueWithDataWindow.100x100.exr" )
 
 		views = GafferImage.CreateViews()
 		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -47,8 +47,8 @@ import GafferImageTest
 
 class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	__file300PxPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "dotGrid.warped.exr"
+	__rgbFilePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	__file300PxPath = GafferImageTest.ImageTestCase.imagesPath() / "dotGrid.warped.exr"
 
 	# Test that the outputs change when different channels are selected.
 	def testChannels( self ) :

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -35,6 +35,8 @@
 ##########################################################################
 
 import imath
+import os
+import pathlib
 
 import IECore
 import IECoreImage
@@ -235,3 +237,11 @@ parent["color"] = imath.Color4f( 0.5, 0.6, 0.7, 0.8 ) if context.get( "collect:l
 		deep = GafferImage.Empty()
 		node["in"].setInput( deep["out"] )
 		self.assertRaisesRegex( RuntimeError, 'Deep data not supported in input "in*', GafferImage.ImageAlgo.image, node["out"] )
+
+	@staticmethod
+	def imagesPath() :
+		return Gaffer.rootPath() / "python" / "GafferImageTest" / "images"
+
+	@staticmethod
+	def openColorIOPath() :
+		return Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO"

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -49,8 +49,7 @@ import GafferImageTest
 
 class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
-	path = Gaffer.rootPath() / "python" / "GafferImageTest" / "images"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def testNoPassThrough( self ) :
 
@@ -78,7 +77,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		# tiles apart.
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( self.path / "rgb.100x100.exr" )
+		r["fileName"].setValue( self.imagesPath() / "rgb.100x100.exr" )
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )
@@ -86,7 +85,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		t["transform"]["scale"].setValue( imath.V2f( 1.5, 1. ) )
 
 		r2 = GafferImage.ImageReader()
-		r2["fileName"].setValue( self.path / "knownTransformBug.exr" )
+		r2["fileName"].setValue( self.imagesPath() / "knownTransformBug.exr" )
 
 		self.assertImagesEqual( t["out"], r2["out"], ignoreMetadata = True, maxDifference = 0.05 )
 
@@ -296,7 +295,7 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 	def testNegativeScale( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker2x2.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		t = GafferImage.ImageTransform()
 		t["in"].setInput( r["out"] )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -56,10 +56,10 @@ import GafferImageTest
 
 class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
-	__largeFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "large.exr"
-	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	__negativeDataWindowFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr"
-	__representativeDeepPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	__largeFilePath = GafferImageTest.ImageTestCase.imagesPath() / "large.exr"
+	__rgbFilePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	__negativeDataWindowFilePath = GafferImageTest.ImageTestCase.imagesPath() / "checkerWithNegativeDataWindow.200x150.exr"
+	__representativeDeepPath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
 
 	longMessage = True
 
@@ -561,8 +561,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		r["fileName"].setValue( filePath )
 		w = GafferImage.ImageWriter()
 
-		testFile = self.__testFile( os.path.basename(filePath), "RGBA", ext )
-		expectedFile = filePath.with_suffix( "." + ext )
+		testFile = self.__testFile( filePath.with_suffix("").name, "RGBA", ext )
+		expectedFile = filePath.with_suffix( "."+ext )
 
 		self.assertFalse( os.path.exists( testFile ), "Temporary file already exists : {}".format( testFile ) )
 
@@ -708,7 +708,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 	def __testMetadataDoesNotAffectPixels( self, ext, overrideMetadata = {}, metadataToIgnore = [] ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( self.__rgbFilePath.with_suffix( "." + ext ) )
+		reader["fileName"].setValue( self.__rgbFilePath.with_suffix( "."+ext ) )
 
 		# IPTC:Creator will have the current username appended to the end of
 		# the existing one, creating a list of creators. Blank out the initial
@@ -1372,7 +1372,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		# Load an image with various layers.
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/multipart.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "multipart.exr" )
 		self.assertEqual(
 			set( reader["out"].channelNames() ),
 			{
@@ -1451,7 +1451,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		writer["task"].execute()
 
 		refReader = GafferImage.ImageReader()
-		refReader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/imitateProductionLayers1.exr" )
+		refReader["fileName"].setValue( self.imagesPath() / "imitateProductionLayers1.exr" )
 
 		rereader = GafferImage.ImageReader()
 		rereader["channelInterpretation"].setInput( refReader["channelInterpretation"] )
@@ -1479,7 +1479,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		)
 		writer["task"].execute()
 
-		refReader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/imitateProductionLayers2.exr" )
+		refReader["fileName"].setValue( self.imagesPath() / "imitateProductionLayers2.exr" )
 		refReader["refreshCount"].setValue( 2 )
 		rereader["refreshCount"].setValue( 2 )
 
@@ -1513,7 +1513,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		writer["task"].execute()
 
 		refReader = GafferImage.ImageReader()
-		refReader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/weirdPartNames.exr" )
+		refReader["fileName"].setValue( self.imagesPath() / "weirdPartNames.exr" )
 
 		rereader = GafferImage.ImageReader()
 		rereader["channelInterpretation"].setInput( refReader["channelInterpretation"] )
@@ -1590,7 +1590,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			rereader["refreshCount"].setValue( rereader["refreshCount"].getValue() + 1 )
 			self.assertImagesEqual( rereader["out"], reference["out"], ignoreMetadata = True, maxDifference = 0.0002, ignoreChannelNamesOrder = layout.startswith( "Nuke" ) )
 			header = self.usefulHeader( writePath )
-			refHeader = self.usefulHeader( os.path.expandvars( "${GAFFER_ROOT}/python/GafferImageTest/images/channelTest" + referenceFile + ".exr" ) )
+			refHeader = self.usefulHeader( self.imagesPath() / ( "channelTest" + referenceFile + ".exr" ) )
 
 			if layout == "Nuke/Interleave Channels":
 				# We don't match the view metadata which Nuke sticks on files without specific views
@@ -1625,7 +1625,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			self.assertImagesEqual( rereader["out"], reference["out"], ignoreMetadata = True, maxDifference = 0.0002, ignoreChannelNamesOrder = layout == "Single Part", ignoreDataWindow = layout == "Single Part" )
 
 			header = self.usefulHeader( writePath )
-			refHeader = self.usefulHeader( os.path.expandvars( "${GAFFER_ROOT}/python/GafferImageTest/images/channelTestMultiView" + referenceFile + ".exr" ) )
+			refHeader = self.usefulHeader( self.imagesPath() / ( "channelTestMultiView" + referenceFile + ".exr" ) )
 
 			self.assertEqual( header, refHeader )
 
@@ -1659,7 +1659,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 				continue
 
 			header = self.usefulHeader( writePath )
-			refHeader = self.usefulHeader( os.path.expandvars( "${GAFFER_ROOT}/python/GafferImageTest/images/channelTestMultiView" + referenceFile + ".exr" ) )
+			refHeader = self.usefulHeader( self.imagesPath() / ( "channelTestMultiView" + referenceFile + ".exr" ) )
 
 			if layout == "Nuke/Interleave Channels and Layers":
 				# Swap the order of left and right to match Nuke having arbitrarily reordered

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import platform
 import unittest
 import shutil
@@ -80,7 +81,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		r["fileName"].setValue( self.__rgbFilePath )
 
 		testFile = self.__testFile( "default", "RB", "exr" )
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w = GafferImage.ImageWriter()
 		w["in"].setInput( r["out"] )
@@ -444,7 +445,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			testFile = self.__testFile( name, "RGBA", ext )
 			removeAlpha = "removeAlpha" in test
 
-			self.assertFalse( os.path.exists( testFile ), "Temporary file already exists : {}".format( testFile ) )
+			self.assertFalse( testFile.exists(), "Temporary file already exists : {}".format( testFile ) )
 
 			# Setup the writer.
 			w = GafferImage.ImageWriter()
@@ -458,7 +459,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			# Execute
 			with Gaffer.Context() :
 				w["task"].execute()
-			self.assertTrue( os.path.exists( testFile ), "Failed to create file : {} ({}) : {}".format( ext, name, testFile ) )
+			self.assertTrue( testFile.exists(), "Failed to create file : {} ({}) : {}".format( ext, name, testFile ) )
 
 			# Check the output.
 			expectedOutput = GafferImage.ImageReader()
@@ -564,7 +565,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		testFile = self.__testFile( filePath.with_suffix("").name, "RGBA", ext )
 		expectedFile = filePath.with_suffix( "."+ext )
 
-		self.assertFalse( os.path.exists( testFile ), "Temporary file already exists : {}".format( testFile ) )
+		self.assertFalse( testFile.exists(), "Temporary file already exists : {}".format( testFile ) )
 
 		# Setup the writer.
 		w["in"].setInput( r["out"] )
@@ -573,7 +574,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		# Execute
 		w["task"].execute()
-		self.assertTrue( os.path.exists( testFile ), "Failed to create file : {} : {}".format( ext, testFile ) )
+		self.assertTrue( testFile.exists(), "Failed to create file : {} : {}".format( ext, testFile ) )
 
 		# Check the output.
 		expectedOutput = GafferImage.ImageReader()
@@ -597,7 +598,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		w["task"].execute()
 
-		self.assertTrue( os.path.exists( testFile ) )
+		self.assertTrue( testFile.exists() )
 		i = IECore.Reader.create( str( testFile ) ).read()
 
 		# Cortex uses the EXR convention, which differs
@@ -674,13 +675,13 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w = GafferImage.ImageWriter()
 
 		testFile = self.__testFile( "metadataTest", "RGBA", "exr" )
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w["in"].setInput( r["out"] )
 		w["fileName"].setValue( testFile )
 
 		w["task"].execute()
-		self.assertTrue( os.path.exists( testFile ) )
+		self.assertTrue( testFile.exists() )
 
 		result = GafferImage.ImageReader()
 		result["fileName"].setValue( testFile )
@@ -735,12 +736,12 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		regularWriter = GafferImage.ImageWriter()
 		regularWriter["in"].setInput( regularMetadata["out"] )
 		regularWriter["fileName"].setValue( self.__testFile( "regularMetadata", "RGBA", ext ) )
-		self.assertFalse( os.path.exists( regularWriter["fileName"].getValue() ) )
+		self.assertFalse( pathlib.Path( regularWriter["fileName"].getValue() ).exists() )
 
 		misledWriter = GafferImage.ImageWriter()
 		misledWriter["in"].setInput( misleadingMetadata["out"] )
 		misledWriter["fileName"].setValue( self.__testFile( "misleadingMetadata", "RGBA", ext ) )
-		self.assertFalse( os.path.exists( misledWriter["fileName"].getValue() ) )
+		self.assertFalse( pathlib.Path( misledWriter["fileName"].getValue() ).exists() )
 
 		# Check that the writer is indeed being given misleading metadata.
 
@@ -756,8 +757,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		regularWriter["task"].execute()
 		misledWriter["task"].execute()
 
-		self.assertTrue( os.path.exists( regularWriter["fileName"].getValue() ) )
-		self.assertTrue( os.path.exists( misledWriter["fileName"].getValue() ) )
+		self.assertTrue( pathlib.Path( regularWriter["fileName"].getValue() ).exists() )
+		self.assertTrue( pathlib.Path( misledWriter["fileName"].getValue() ).exists() )
 
 		# Make readers to read back what we wrote out
 
@@ -860,14 +861,14 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		c["in"].setInput( overscanCrop["out"] )
 
 		testFile = self.__testFile( "emptyImage", "RGBA", "exr" )
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w = GafferImage.ImageWriter()
 		w["in"].setInput( c["out"] )
 		w["fileName"].setValue( testFile )
 
 		w["task"].execute()
-		self.assertTrue( os.path.exists( testFile ) )
+		self.assertTrue( testFile.exists() )
 
 		after = GafferImage.ImageReader()
 		after["fileName"].setValue( testFile )
@@ -887,14 +888,14 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		c["in"].setInput( i["out"] )
 
 		testFile = self.__testFile( "emptyImage", "RGBA", "exr" )
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w = GafferImage.ImageWriter()
 		w["in"].setInput( c["out"] )
 		w["fileName"].setValue( testFile )
 
 		w["task"].execute()
-		self.assertTrue( os.path.exists( testFile ) )
+		self.assertTrue( testFile.exists() )
 
 		after = GafferImage.ImageReader()
 		after["fileName"].setValue( testFile )
@@ -917,7 +918,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( r["out"]["metadata"].getValue()["PixelAspectRatio"], IECore.FloatData( 1 ) )
 
 		testFile = self.__testFile( "pixelAspectFromFormat", "RGBA", "exr" )
-		self.assertFalse( os.path.exists( testFile ) )
+		self.assertFalse( testFile.exists() )
 
 		w = GafferImage.ImageWriter()
 		w["in"].setInput( f["out"] )
@@ -925,7 +926,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["channels"].setValue( "*" )
 
 		w["task"].execute()
-		self.assertTrue( os.path.exists( testFile ) )
+		self.assertTrue( testFile.exists() )
 
 		after = GafferImage.ImageReader()
 		after["fileName"].setValue( testFile )
@@ -987,7 +988,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		with context :
 			s["w"]["task"].execute()
 
-		self.assertTrue( os.path.isfile( self.temporaryDirectory() / "test.tif" ) )
+		self.assertTrue( ( self.temporaryDirectory() / "test.tif" ).is_file() )
 
 	def testErrorMessages( self ) :
 
@@ -1042,8 +1043,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		with s.context() :
 			d.dispatch( [ s["w2"] ] )
 
-		self.assertTrue( os.path.isfile( s["w1"]["fileName"].getValue() ) )
-		self.assertTrue( os.path.isfile( s["w2"]["fileName"].getValue() ) )
+		self.assertTrue( pathlib.Path( s["w1"]["fileName"].getValue() ).is_file() )
+		self.assertTrue( pathlib.Path( s["w2"]["fileName"].getValue() ).is_file() )
 
 	def testBackgroundDispatch( self ) :
 
@@ -1064,7 +1065,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		d.jobPool().waitForAll()
 
-		self.assertTrue( os.path.isfile( s["w"]["fileName"].getValue() ) )
+		self.assertTrue( pathlib.Path( s["w"]["fileName"].getValue() ).is_file() )
 
 	def testDerivingInPython( self ) :
 
@@ -1093,8 +1094,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		w["task"].execute()
 
-		self.assertTrue( os.path.isfile( w["fileName"].getValue() ) )
-		self.assertTrue( os.path.isfile( w["copyFileName"].getValue() ) )
+		self.assertTrue( pathlib.Path( w["fileName"].getValue() ).is_file() )
+		self.assertTrue( pathlib.Path( w["copyFileName"].getValue() ).is_file() )
 
 	def testStringMetadata( self ) :
 
@@ -1138,7 +1139,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 			w["task"].execute()
 
-			self.assertTrue( os.path.exists( testFile ), "Failed to create file : {} : {}".format( chromaSubSampling, testFile ) )
+			self.assertTrue( testFile.exists(), "Failed to create file : {} : {}".format( chromaSubSampling, testFile ) )
 
 			result["fileName"].setValue( testFile )
 
@@ -1271,7 +1272,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 			writer["task"].execute()
 
-			self.assertTrue( os.path.exists( writer["fileName"].getValue() ), "Failed to create file : {}".format( writer["fileName"].getValue() ) )
+			self.assertTrue( pathlib.Path( writer["fileName"].getValue() ).exists(), "Failed to create file : {}".format( writer["fileName"].getValue() ) )
 
 			resultReader["colorSpace"].setValue( colorSpace )
 			self.assertImagesEqual( resultReader["out"], reader["out"], ignoreMetadata=True, maxDifference=0.0008 )
@@ -1337,7 +1338,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		with self.assertRaisesRegex( Gaffer.ProcessException, "No channels to write" ) :
 			writer["task"].execute()
 
-		self.assertFalse( os.path.exists( writer["fileName"].getValue() ) )
+		self.assertFalse( pathlib.Path( writer["fileName"].getValue() ).exists() )
 
 	def testDWACompressionLevel( self ) :
 

--- a/python/GafferImageTest/LUTTest.py
+++ b/python/GafferImageTest/LUTTest.py
@@ -49,8 +49,8 @@ import GafferImageTest
 
 class LUTTest( GafferImageTest.ImageTestCase ) :
 
-	imageFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
-	lut = Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "luts" / "slog10.spi1d"
+	imageFile = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
+	lut = GafferImageTest.ImageTestCase.openColorIOPath() / "luts" / "slog10.spi1d"
 
 	def test( self ) :
 
@@ -166,7 +166,7 @@ class LUTTest( GafferImageTest.ImageTestCase ) :
 	def testChannelsAreSeparate( self ) :
 
 		i = GafferImage.ImageReader()
-		i["fileName"].setValue( Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "circles.exr" )
+		i["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		o = GafferImage.LUT()
 		o["in"].setInput( i["out"] )

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import unittest
 import subprocess
 import imath
@@ -48,9 +49,9 @@ import GafferImageTest
 
 class LookTransformTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
-	groundTruth = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker_ocio_look.exr"
-	ocioConfig = Gaffer.rootPath() / "python" / "GafferImageTest" / "openColorIO" / "context.ocio"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
+	groundTruth = GafferImageTest.ImageTestCase.imagesPath() / "checker_ocio_look.exr"
+	ocioConfig = GafferImageTest.ImageTestCase.openColorIOPath() / "context.ocio"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/MedianTest.py
+++ b/python/GafferImageTest/MedianTest.py
@@ -77,7 +77,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 	def testFilter( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/noisyRamp.exr" )
+		r["fileName"].setValue( self.imagesPath() / "noisyRamp.exr" )
 
 		m = GafferImage.Median()
 		m["in"].setInput( r["out"] )
@@ -98,7 +98,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 	def testDriverChannel( self ) :
 
 		rRaw = GafferImage.ImageReader()
-		rRaw["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circles.exr" )
+		rRaw["fileName"].setValue( self.imagesPath() / "circles.exr" )
 
 		r = GafferImage.Grade()
 		r["in"].setInput( rRaw["out"] )
@@ -113,7 +113,7 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 		masterMedian["masterChannel"].setValue( "G" )
 
 		expected = GafferImage.ImageReader()
-		expected["fileName"].setValue( os.path.dirname( __file__ ) + "/images/circlesGreenMedian.exr" )
+		expected["fileName"].setValue( self.imagesPath() / "circlesGreenMedian.exr" )
 
 		# Note that in this expected image, the green channel is nicely medianed, and red and blue are completely
 		# unchanged in areas where there is no green.  In areas where red and blue overlap with a noisy green,

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -47,13 +47,13 @@ import GafferImageTest
 
 class MergeTest( GafferImageTest.ImageTestCase ) :
 
-	rPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "redWithDataWindow.100x100.exr"
-	gPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "greenWithDataWindow.100x100.exr"
-	bPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "blueWithDataWindow.100x100.exr"
-	checkerPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr"
-	checkerRGBPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
-	rgbPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	mergeBoundariesRefPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "mergeBoundariesRef.exr"
+	rPath = GafferImageTest.ImageTestCase.imagesPath() / "redWithDataWindow.100x100.exr"
+	gPath = GafferImageTest.ImageTestCase.imagesPath() / "greenWithDataWindow.100x100.exr"
+	bPath = GafferImageTest.ImageTestCase.imagesPath() / "blueWithDataWindow.100x100.exr"
+	checkerPath = GafferImageTest.ImageTestCase.imagesPath() / "checkerboard.100x100.exr"
+	checkerRGBPath = GafferImageTest.ImageTestCase.imagesPath() / "rgbOverChecker.100x100.exr"
+	rgbPath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	mergeBoundariesRefPath = GafferImageTest.ImageTestCase.imagesPath() / "mergeBoundariesRef.exr"
 
 	# Do several tests to check the cache is working correctly:
 	def testHashes( self ) :

--- a/python/GafferImageTest/MirrorTest.py
+++ b/python/GafferImageTest/MirrorTest.py
@@ -49,7 +49,7 @@ class MirrorTest( GafferImageTest.ImageTestCase ) :
 	def testPassThrough( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		m = GafferImage.Mirror()
 		m["in"].setInput( r["out"] )
@@ -87,7 +87,7 @@ class MirrorTest( GafferImageTest.ImageTestCase ) :
 	def testHorizontal( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		m = GafferImage.Mirror()
 		m["in"].setInput( r["out"] )
@@ -106,7 +106,7 @@ class MirrorTest( GafferImageTest.ImageTestCase ) :
 	def testVertical( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+		r["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		m = GafferImage.Mirror()
 		m["in"].setInput( r["out"] )

--- a/python/GafferImageTest/MixTest.py
+++ b/python/GafferImageTest/MixTest.py
@@ -47,13 +47,13 @@ import GafferImageTest
 
 class MixTest( GafferImageTest.ImageTestCase ) :
 
-	rPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "redWithDataWindow.100x100.exr"
-	gPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "greenWithDataWindow.100x100.exr"
-	checkerPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr"
-	checkerNegativeDataWindowPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr"
-	checkerMixPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checkerMix.100x100.exr"
-	representativeDeepImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
-	radialPath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "radial.exr"
+	rPath = GafferImageTest.ImageTestCase.imagesPath() / "redWithDataWindow.100x100.exr"
+	gPath = GafferImageTest.ImageTestCase.imagesPath() / "greenWithDataWindow.100x100.exr"
+	checkerPath = GafferImageTest.ImageTestCase.imagesPath() / "checkerboard.100x100.exr"
+	checkerNegativeDataWindowPath = GafferImageTest.ImageTestCase.imagesPath() / "checkerWithNegativeDataWindow.200x150.exr"
+	checkerMixPath = GafferImageTest.ImageTestCase.imagesPath() / "checkerMix.100x100.exr"
+	representativeDeepImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
+	radialPath = GafferImageTest.ImageTestCase.imagesPath() / "radial.exr"
 
 	# Do several tests to check the cache is working correctly:
 	def testHashes( self ) :

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -52,18 +52,18 @@ import GafferImageTest
 
 class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checker.exr"
-	offsetDataWindowFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
-	fullDataWindowFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checkerboard.100x100.exr"
-	negativeDataWindowFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "checkerWithNegativeDataWindow.200x150.exr"
-	negativeDisplayWindowFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "negativeDisplayWindow.exr"
-	circlesExrFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "circles.exr"
-	circlesJpgFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "circles.jpg"
-	alignmentTestSourceFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "colorbars_half_max.exr"
-	multipartFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "multipart.exr"
-	unsupportedMultipartFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "unsupportedMultipart.exr"
-	multipartDefaultChannelsFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "multipartDefaultChannels.exr"
-	multipartDefaultChannelsOverlapFileName = pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" / "multipartDefaultChannelsOverlap.exr"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
+	offsetDataWindowFileName = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
+	fullDataWindowFileName = GafferImageTest.ImageTestCase.imagesPath() / "checkerboard.100x100.exr"
+	negativeDataWindowFileName = GafferImageTest.ImageTestCase.imagesPath() / "checkerWithNegativeDataWindow.200x150.exr"
+	negativeDisplayWindowFileName = GafferImageTest.ImageTestCase.imagesPath() / "negativeDisplayWindow.exr"
+	circlesExrFileName = GafferImageTest.ImageTestCase.imagesPath() / "circles.exr"
+	circlesJpgFileName = GafferImageTest.ImageTestCase.imagesPath() / "circles.jpg"
+	alignmentTestSourceFileName = GafferImageTest.ImageTestCase.imagesPath() / "colorbars_half_max.exr"
+	multipartFileName = GafferImageTest.ImageTestCase.imagesPath() / "multipart.exr"
+	unsupportedMultipartFileName = GafferImageTest.ImageTestCase.imagesPath() / "unsupportedMultipart.exr"
+	multipartDefaultChannelsFileName = GafferImageTest.ImageTestCase.imagesPath() / "multipartDefaultChannels.exr"
+	multipartDefaultChannelsOverlapFileName = GafferImageTest.ImageTestCase.imagesPath() / "multipartDefaultChannelsOverlap.exr"
 
 	def testInternalImageSpaceConversion( self ) :
 
@@ -475,7 +475,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( r["out"]["metadata"].getValue()["dataType"].value, "uint8" )
 		self.assertEqual( r["out"]["metadata"].getValue()["fileFormat"].value, "jpeg" )
 
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/rgb.100x100.dpx" )
+		r["fileName"].setValue( self.imagesPath() / "rgb.100x100.dpx" )
 		self.assertEqual( r["out"]["metadata"].getValue()["dataType"].value, "uint10" )
 		self.assertEqual( r["out"]["metadata"].getValue()["fileFormat"].value, "dpx" )
 
@@ -684,7 +684,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 	def testSubimageMetadataNotLoaded( self ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/multipart.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "multipart.exr" )
 		metadata = reader["out"].metadata()
 
 		self.assertNotIn( "name", metadata )
@@ -695,7 +695,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testImageOpenPerformance( self ):
 		# Test the overhead of opening images by opening lots of images, but only reading the view count
-		files = ( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "python" / "GafferImageTest" / "images" ).glob( "*.exr" )
+		files = self.imagesPath().glob( "*.exr" )
 		files = filter( lambda f : not ( "ChannelsOverlap" in f.stem or "NukeSinglePart" in f.stem ), files )
 		files = sorted( files )
 		filesWithResult = [ (i, 2 if "channelTestMultiView" in i.stem else 1 ) for i in files ]

--- a/python/GafferImageTest/PremultiplyTest.py
+++ b/python/GafferImageTest/PremultiplyTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "rgbOverChecker.100x100.exr"
 
 	def testAlphaChannel( self ) :
 		# Test that changing the channel to use as the alpha channel changes the hash

--- a/python/GafferImageTest/RampTest.py
+++ b/python/GafferImageTest/RampTest.py
@@ -145,7 +145,7 @@ class RampTest( GafferImageTest.ImageTestCase ) :
 		ramp["ramp"]["p2"].addChild( Gaffer.Color4fPlug( "y", defaultValue = imath.Color4f( 0.530900002, 0, 0, 0.50999999 ) ) )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/GafferRamp.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "GafferRamp.exr" )
 
 		self.assertImagesEqual( ramp["out"], reader["out"], ignoreMetadata = True, maxDifference = 0.001 )
 

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -75,7 +75,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 		def __test( fileName, size, filter ) :
 
-			inputFileName = os.path.dirname( __file__ ) + "/images/" + fileName
+			inputFileName = self.imagesPath() / fileName
 
 			reader = GafferImage.ImageReader()
 			reader["fileName"].setValue( inputFileName )
@@ -107,12 +107,13 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 
 			expected = GafferImage.ImageReader()
 			expected["fileName"].setValue(
-				"%s/images/%s_%dx%d_%s.exr" % (
-					os.path.dirname( __file__ ),
-					os.path.splitext( fileName )[0],
-					size.x,
-					size.y,
-					filter
+				self.imagesPath() / (
+					"%s_%dx%d_%s.exr" % (
+						os.path.splitext( fileName )[0],
+						size.x,
+						size.y,
+						filter
+					)
 				)
 			)
 

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import shutil
 import unittest
 import subprocess
@@ -95,7 +96,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 			crop["in"].setInput( resample["out"] )
 			crop["area"].setValue( imath.Box2i( imath.V2i( 0 ), size ) )
 
-			outputFileName = self.temporaryDirectory() / ( "%s_%dx%d_%s.exr" % ( os.path.splitext( fileName )[0], size.x, size.y, filter ) )
+			outputFileName = self.temporaryDirectory() / ( "%s_%dx%d_%s.exr" % ( pathlib.Path( fileName ).with_suffix(""), size.x, size.y, filter ) )
 			writer = GafferImage.ImageWriter()
 			writer["in"].setInput( crop["out"] )
 			writer["channels"].setValue( "[RGB]" )
@@ -109,7 +110,7 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 			expected["fileName"].setValue(
 				self.imagesPath() / (
 					"%s_%dx%d_%s.exr" % (
-						os.path.splitext( fileName )[0],
+						pathlib.Path( fileName ).with_suffix(""),
 						size.x,
 						size.y,
 						filter
@@ -124,12 +125,12 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 			# of the current directory.
 			if False :
 
-				if not os.path.exists( "resampleComparison" ) :
-					os.makedirs( "resampleComparison" )
+				resampleComparisonDir = pathlib.Path( "resampleComparison" )
+				resampleComparisonDir.mkdir( exist_ok=True )
 
-				shutil.copyfile( outputFileName, "resampleComparison/gaffer_" + os.path.basename( outputFileName ) )
+				shutil.copyfile( outputFileName, resampleComparisonDir / ( "gaffer_" + outputFileName.name ) )
 
-				oiioOutputFileName = "resampleComparison/oiio_%s_%dx%d_%s.exr" % ( os.path.splitext( fileName )[0], size.x, size.y, filter )
+				oiioOutputFileName = resampleComparisonDir / ( "oiio_%s_%dx%d_%s.exr" % ( pathlib.Path( fileName ).with_suffix(""), size.x, size.y, filter ) )
 
 				subprocess.check_call(
 					"oiiotool --threads 1 %s --ch R,G,B --resize:filter=%s %dx%d  -o %s" %

--- a/python/GafferImageTest/SamplerTest.py
+++ b/python/GafferImageTest/SamplerTest.py
@@ -46,7 +46,7 @@ import GafferImageTest
 
 class SamplerTest( GafferImageTest.ImageTestCase ) :
 
-	fileName = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "checker.exr"
+	fileName = GafferImageTest.ImageTestCase.imagesPath() / "checker.exr"
 
 	def testOutOfBoundsSampleModeBlack( self ) :
 
@@ -119,7 +119,7 @@ class SamplerTest( GafferImageTest.ImageTestCase ) :
 	def test2x2Checker( self ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		# As long as the sample region includes the valid range of our image, and all
 		# the pixels we're going to request, it should have no effect on our sampling.

--- a/python/GafferImageTest/SelectViewTest.py
+++ b/python/GafferImageTest/SelectViewTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class SelectViewTest( GafferImageTest.ImageTestCase ) :
 
-	__rgbFilePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgb.100x100.exr"
+	__rgbFilePath = GafferImageTest.ImageTestCase.imagesPath() / "rgb.100x100.exr"
 
 	def test( self ) :
 

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class ShuffleTest( GafferImageTest.ImageTestCase ) :
 
-	representativeDeepImagePath = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "representativeDeepImage.exr"
+	representativeDeepImagePath = GafferImageTest.ImageTestCase.imagesPath() / "representativeDeepImage.exr"
 
 	def test( self ) :
 
@@ -153,7 +153,7 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 	def testMissingInputChannel( self ) :
 
 		r = GafferImage.ImageReader()
-		r["fileName"].setValue( "${GAFFER_ROOT}/python/GafferImageTest/images/blurRange.exr" )
+		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )
 		self.assertEqual( r["out"]["channelNames"].getValue(), IECore.StringVectorData( [ "R" ] ) )
 
 		s = GafferImage.Shuffle()

--- a/python/GafferImageTest/TextTest.py
+++ b/python/GafferImageTest/TextTest.py
@@ -109,7 +109,7 @@ class TextTest( GafferImageTest.ImageTestCase ) :
 		text["transform"]["rotate"].setValue( 90 )
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/text.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "text.exr" )
 
 		self.assertImagesEqual( text["out"], reader["out"], ignoreMetadata = True, maxDifference = 0.001 )
 

--- a/python/GafferImageTest/UnpremultiplyTest.py
+++ b/python/GafferImageTest/UnpremultiplyTest.py
@@ -47,7 +47,7 @@ import GafferImageTest
 
 class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 
-	checkerFile = Gaffer.rootPath() / "python" / "GafferImageTest" / "images" / "rgbOverChecker.100x100.exr"
+	checkerFile = GafferImageTest.ImageTestCase.imagesPath() / "rgbOverChecker.100x100.exr"
 
 	def testAlphaChannel( self ) :
 		# Test that changing the channel to use as the alpha channel changes the hash

--- a/python/GafferImageTest/VectorWarpTest.py
+++ b/python/GafferImageTest/VectorWarpTest.py
@@ -71,7 +71,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 	def testVectorWarp( self ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker2x2.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "checker2x2.exr" )
 
 		# Constant provides the same Vector across the board
 		# for the VectorWarp vector input.
@@ -102,7 +102,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 	def testNegativeDataWindowOrigin( self ) :
 
 		reader = GafferImage.ImageReader()
-		reader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/checker.exr" )
+		reader["fileName"].setValue( self.imagesPath() / "checker.exr" )
 
 		constant = GafferImage.Constant()
 		constant["color"].setValue( imath.Color4f( 0.5, 0, 0, 1 ) )
@@ -119,7 +119,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 
 	def testWarpImage( self ):
 		dotGridReader = GafferImage.ImageReader()
-		dotGridReader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/dotGrid.300.exr" )
+		dotGridReader["fileName"].setValue( self.imagesPath() / "dotGrid.300.exr" )
 
 		vectorWarp = GafferImage.VectorWarp()
 		vectorWarp["in"].setInput( dotGridReader["out"] )
@@ -146,7 +146,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 
 		# Test that a warp with distortion produces an expected output
 		warpPatternReader = GafferImage.ImageReader()
-		warpPatternReader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/warpPattern.exr" )
+		warpPatternReader["fileName"].setValue( self.imagesPath() / "warpPattern.exr" )
 
 		toAbsoluteMerge["in"]["in2"].setInput( warpPatternReader["out"] )
 
@@ -154,7 +154,7 @@ class VectorWarpTest( GafferImageTest.ImageTestCase ) :
 		vectorWarp["vector"].setInput( toAbsoluteMerge["out"] )
 
 		expectedReader = GafferImage.ImageReader()
-		expectedReader["fileName"].setValue( os.path.dirname( __file__ ) + "/images/dotGrid.warped.exr" )
+		expectedReader["fileName"].setValue( self.imagesPath() / "dotGrid.warped.exr" )
 		self.assertImagesEqual( vectorWarp["out"], expectedReader["out"], maxDifference = 0.0005, ignoreMetadata = True )
 
 		# Test that we can get the same result using pixel offsets instead of normalized coordinates


### PR DESCRIPTION
The only part that I think will merit discussion is `GafferImageTest.imagesDir()`.  When I raised this on the previous PR, you sounded more in favour of a variable for `pathlib.Path( os.environ["GAFFER_ROOT"] )` that would be stored somewhere central, but we weren't sure where.  I think even once we have that, `GafferImageTest.imagesDir()` makes sense - for reducing duplication, improving clarity, and theoretically allowing us to more easily change where we store these images if we ever want to?  All the code changes seem pretty positive to me anyway.