### PR TITLE
Windows CI : Enable GafferVDBTest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
             containerImage:
             dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.4.3.0/cortex-10.4.3.0-windows-python3.zip
             testRunner: Invoke-Expression
-            testArguments: GafferTest
+            testArguments: GafferTest GafferVDBTest
             sconsCacheMegabytes: 400
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I believe 64fbfa2cc9b2c7745dfd20c4558ba45b3c91ca1d was sufficient to get the tests passing on Windows. Let's find out!
