### PR TITLE
LabelPlugValueWidget : Fix initial update

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.0.6.x (relative to 1.0.6.4)
+=======
+
+Fixes
+-----
+
+- NodeEditor : Fixed updates for the green "non-default-value" dots in plug labels.
+
 1.0.6.4 (relative to 1.0.6.3)
 =======
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -84,6 +84,8 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__updatePlugMetadataChangedConnections()
 		self.__updateDoubleClickConnection()
 
+		self._updateFromPlugs()
+
 	def label( self ) :
 
 		return self.__label


### PR DESCRIPTION
The fact that we weren't performing an update in the constructor had gone unnoticed until 501fa6a1d1e7f8533f4b7d5c26735bfd23f66455 removed a "redundant" update that we had been relying on to fill in for us.
