### PR TITLE
ie/options : Support for running scons in Python 3

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -531,6 +531,7 @@ ENV_VARS_TO_IMPORT = " ".join( [
 	"QT_VERSION",
 	"QT_QPA_PLATFORM_PLUGIN_PATH",
 	"GAFFER_JEMALLOC",
+	"CORTEX_PREFERRED_PYTHON_VERSION",
 ] )
 
 # required if scons compiler version doesn't match the build compiler version

--- a/config/ie/options
+++ b/config/ie/options
@@ -282,13 +282,17 @@ elif targetApp == "houdini" and distutils.version.LooseVersion(targetAppVersion)
 		LOCATE_DEPENDENCY_SYSTEMPATH[:0] = [ os.path.join( IEEnv.Environment.rootPath(), "apps", "OpenVDB", vdbVersion, IEEnv.platform(), compiler, compilerVersion, "python", "include", "python{0}".format( pythonVersion ) ) ]
 
 if targetAppVersion :
+	appSpecificPaths = []
+	for x in targetAppReg.get( 'includes', [] ) :
+		appSpecificPaths.append( os.path.join( targetAppReg['location'], x ) )
+
 	# for Houdini, we are favouring our dependency rather than sideFx's
 	# given that 17.5 is shipping with openExr mangled lib without python binding.
 	# We should reassess for next version of Houdini to see if that still holds true.
 	if targetApp == "houdini" :
-		LOCATE_DEPENDENCY_SYSTEMPATH += [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
+		LOCATE_DEPENDENCY_SYSTEMPATH += appSpecificPaths
 	else :
-		LOCATE_DEPENDENCY_SYSTEMPATH[:0] = [ os.path.join( targetAppReg['location'], x ) for x in targetAppReg.get( 'includes', [] ) ]
+		LOCATE_DEPENDENCY_SYSTEMPATH[:0] = appSpecificPaths
 
 LOCATE_DEPENDENCY_CPPPATH = [
 	os.path.join( IEEnv.Environment.rootPath(), "apps", "cortex", cortexVersion, IEEnv.platform(), "base", "include" ),


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Allow IE to run scons in python 3 to install gaffer

I assume there is no need to update the Changes.md file, but let me know if you think otherwise.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
