### PR TITLE
PlugAlgo : Add valueIsComputed() utility function

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.2.0.0ax (relative to 1.2.0.0a1)
+=========
+
+API
+---
+
+- PlugAlgo : Added `dependsOnCompute()` utility method.
+
 1.2.0.0a1
 =========
 

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -55,14 +55,19 @@ IE_CORE_FORWARDDECLARE( ValuePlug )
 namespace PlugAlgo
 {
 
+/// Miscellaneous
+/// =============
+
+/// Adds `plug` as a child of `parent`, replacing an identically-named
+/// child if it exists. Where possible, existing values and connections
+/// are transferred from the original plug to the new one.
 GAFFER_API void replacePlug( GraphComponent *parent, PlugPtr plug );
+
+/// Conversion to and from `IECore::Data`
+/// =====================================
 
 /// Creates an appropriate plug to hold the specified data.
 GAFFER_API ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direction, unsigned flags, const IECore::Data *value );
-
-/// Extracts a Data value from a plug previously created with createPlugFromData().
-/// \deprecated Use `getValueAsData` instead.
-GAFFER_API IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 
 /// Returns a Data value from a plug.
 GAFFER_API IECore::DataPtr getValueAsData( const ValuePlug *plug );
@@ -78,6 +83,9 @@ GAFFER_API bool setValueFromData( const ValuePlug *plug, ValuePlug *leafPlug, co
 /// Returns true if the given plug's value can be set from Data.
 /// If value is provided, then return true if it can be set from Data with this type id
 GAFFER_API bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value = nullptr );
+
+[[deprecated( "Use `getValueAsData()` instead" )]]
+GAFFER_API IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 
 /// Promotion
 /// =========

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -63,6 +63,10 @@ namespace PlugAlgo
 /// are transferred from the original plug to the new one.
 GAFFER_API void replacePlug( GraphComponent *parent, PlugPtr plug );
 
+/// Returns `true` if the plug's value is provided by the output
+/// of a ComputeNode, and `false` otherwise.
+GAFFER_API bool dependsOnCompute( const ValuePlug *plug );
+
 /// Conversion to and from `IECore::Data`
 /// =====================================
 

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -116,8 +116,6 @@ class IECORE_EXPORT Switch : public ComputeNode
 		// if plug is not meaningful to the switching process.
 		const Plug *oppositePlug( const Plug *plug, const Context *context = nullptr ) const;
 
-		bool variesWithContext( const Plug *plug ) const;
-
 		void updateInternalConnection();
 
 		static size_t g_firstPlugIndex;

--- a/python/Gaffer/NodeAlgo.py
+++ b/python/Gaffer/NodeAlgo.py
@@ -156,8 +156,7 @@ def isSetToUserDefault( plug ) :
 	if userDefault is None :
 		return False
 
-	source = plug.source()
-	if source.direction() == Gaffer.Plug.Direction.Out and isinstance( source.node(), Gaffer.ComputeNode ) :
+	if Gaffer.PlugAlgo.dependsOnCompute( plug ) :
 		# Computed values may vary by context, as such there is no
 		# single "current value", so no true concept of whether or not
 		# it's at the user default.

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -94,11 +94,7 @@ class _ChannelsFooter( GafferUI.PlugValueWidget ) :
 		result = IECore.MenuDefinition()
 		usedNames = set()
 		for p in self.getPlug().children():
-			# TODO - this method for checking if a plug variesWithContext should probably live in PlugAlgo
-			# ( it's based on Switch::variesWithContext )
-			sourcePlug = p["name"].source()
-			variesWithContext = sourcePlug.direction() == Gaffer.Plug.Direction.Out and isinstance( ComputeNode, sourcePlug.node() )
-			if not variesWithContext:
+			if not Gaffer.PlugAlgo.dependsOnCompute( p ) :
 				usedNames.add( p["name"].getValue() )
 
 		# Use a fixed order for some standard options that we want to list in a specific order

--- a/python/GafferOSLUI/OSLObjectUI.py
+++ b/python/GafferOSLUI/OSLObjectUI.py
@@ -105,11 +105,7 @@ class _PrimitiveVariablesFooter( GafferUI.PlugValueWidget ) :
 		result = IECore.MenuDefinition()
 		usedNames = set()
 		for p in self.getPlug().children():
-			# TODO - this method for checking if a plug variesWithContext should probably live in PlugAlgo
-			# ( it's based on Switch::variesWithContext )
-			sourcePlug = p["name"].source()
-			variesWithContext = sourcePlug.direction() == Gaffer.Plug.Direction.Out and isinstance( ComputeNode, sourcePlug.node() )
-			if not variesWithContext:
+			if not Gaffer.PlugAlgo.dependsOnCompute( p ) :
 				usedNames.add( p["name"].getValue() )
 
 		categories = { "Standard" : [], "Custom" : [], "Advanced" : [] }

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -39,6 +39,7 @@
 
 #include "Gaffer/Box.h"
 #include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/ComputeNode.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/NumericPlug.h"
@@ -161,6 +162,30 @@ void replacePlug( Gaffer::GraphComponent *parent, PlugPtr plug )
 } // namespace PlugAlgo
 
 } // namespace Gaffer
+
+//////////////////////////////////////////////////////////////////////////
+// Misc
+//////////////////////////////////////////////////////////////////////////
+
+bool Gaffer::PlugAlgo::dependsOnCompute( const ValuePlug *plug )
+{
+	if( plug->children().empty() )
+	{
+		plug = plug->source<Gaffer::ValuePlug>();
+		return plug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( plug->node() );
+	}
+	else
+	{
+		for( const auto &child : ValuePlug::Range( *plug ) )
+		{
+			if( dependsOnCompute( child.get() ) )
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+}
 
 //////////////////////////////////////////////////////////////////////////
 // Convert to/from Data

--- a/src/Gaffer/SplinePlug.cpp
+++ b/src/Gaffer/SplinePlug.cpp
@@ -38,7 +38,7 @@
 #include "Gaffer/SplinePlug.h"
 
 #include "Gaffer/Action.h"
-#include "Gaffer/ComputeNode.h"
+#include "Gaffer/PlugAlgo.h"
 
 using namespace Gaffer;
 
@@ -396,18 +396,13 @@ void SplinePlug<T>::resetDefault()
 template<typename T>
 bool SplinePlug<T>::isSetToDefault() const
 {
-	for( const auto &p : Plug::RecursiveRange( *this ) )
+	for( const auto &p : ValuePlug::RecursiveRange( *this ) )
 	{
-		if( p->children().empty() )
+		if( p->children().empty() && PlugAlgo::dependsOnCompute( p.get() ) )
 		{
-			const Plug *s = p->source();
-			if( s->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( s->node() ) )
-			{
-				// Value is computed, and therefore can vary by context. There is no
-				// single "current value", so no true concept of whether or not it's at
-				// the default.
-				return false;
-			}
+			// Value can vary by context, so there is no single "current value",
+			// and therefore no true concept of whether or not it's at the default.
+			return false;
 		}
 	}
 	return getValue() == m_defaultValue;

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -41,6 +41,7 @@
 #include "Gaffer/ContextAlgo.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameValuePlug.h"
+#include "Gaffer/PlugAlgo.h"
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"
@@ -322,7 +323,7 @@ size_t Switch::inputIndex( const Context *context ) const
 	// an upstream compute. This avoids leakage of context variables such as
 	// `scene:path`.
 	std::optional<ContextAlgo::GlobalScope> globalScope;
-	if( variesWithContext( enabledPlug ) || variesWithContext( indexPlug ) )
+	if( PlugAlgo::dependsOnCompute( enabledPlug ) || PlugAlgo::dependsOnCompute( indexPlug ) )
 	{
 		globalScope.emplace( context, globalScopePlug );
 	}
@@ -400,12 +401,6 @@ const Plug *Switch::oppositePlug( const Plug *plug, const Context *context ) con
 	return result;
 }
 
-bool Switch::variesWithContext( const Plug *plug ) const
-{
-	plug = plug->source<Gaffer::Plug>();
-	return plug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( plug->node() );
-}
-
 void Switch::updateInternalConnection()
 {
 	Plug *out = outPlug();
@@ -414,7 +409,7 @@ void Switch::updateInternalConnection()
 		return;
 	}
 
-	if( variesWithContext( enabledPlug() ) || variesWithContext( indexPlug() ) )
+	if( PlugAlgo::dependsOnCompute( enabledPlug() ) || PlugAlgo::dependsOnCompute( indexPlug() ) )
 	{
 		// We can't use an internal connection to implement the switch,
 		// because the index might vary from context to context. We must

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -119,6 +119,8 @@ void GafferModule::bindPlugAlgo()
 	scope moduleScope( module );
 
 	def( "replacePlug", &replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
+	def( "dependsOnCompute", &PlugAlgo::dependsOnCompute );
+
 	def( "createPlugFromData", &createPlugFromData );
 	def( "extractDataFromPlug", &extractDataFromPlug );
 	def( "getValueAsData", &getValueAsData );

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -246,16 +246,6 @@ const GafferOSL::OSLCode *OSLObject::oslCode() const
 	return getChild<GafferOSL::OSLCode>( g_firstPlugIndex + 7 );
 }
 
-namespace
-{
-	// Copied from Switch::variesWithContext.  Should be shared somewhere central
-	bool requiresCompute( const Plug *plug )
-	{
-		plug = plug->source<Gaffer::Plug>();
-		return plug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( plug->node() );
-	}
-}
-
 void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	Deformer::affects( input, outputs );
@@ -271,23 +261,15 @@ void OSLObject::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 
 bool OSLObject::affectsProcessedObject( const Gaffer::Plug *input ) const
 {
-	const bool transformTrigger = input == inPlug()->transformPlug() && (
-		requiresCompute( useTransformPlug() ) || useTransformPlug()->getValue()
-	);
-
-	const bool attributeTrigger = input == inPlug()->attributesPlug() && (
-		requiresCompute( useAttributesPlug() ) || useAttributesPlug()->getValue()
-	);
-
 	return
 		Deformer::affectsProcessedObject( input ) ||
 		input == shaderPlug() ||
 		input == interpolationPlug() ||
 		input == useTransformPlug() ||
+		( input == inPlug()->transformPlug() && !useTransformPlug()->isSetToDefault() ) ||
 		input == useAttributesPlug() ||
-		input == resampledInPlug()->objectPlug() ||
-		transformTrigger ||
-		attributeTrigger
+		( input == inPlug()->attributesPlug() && !useAttributesPlug()->isSetToDefault() ) ||
+		input == resampledInPlug()->objectPlug()
 	;
 }
 

--- a/src/GafferOSLUI/OSLImageUI.cpp
+++ b/src/GafferOSLUI/OSLImageUI.cpp
@@ -121,15 +121,11 @@ class OSLImagePlugAdder : public PlugAdder
 		std::set<std::string> usedNames() const
 		{
 			std::set<std::string> used;
-			for( NameValuePlug::Iterator it( m_plugsParent.get() ); !it.done(); ++it )
+			for( const auto &plug : NameValuePlug::Range( *m_plugsParent ) )
 			{
-				// TODO - this method for checking if a plug variesWithContext should probably live in PlugAlgo
-				// ( it's based on Switch::variesWithContext )
-				PlugPtr sourcePlug = (*it)->namePlug()->source<Gaffer::Plug>();
-				bool variesWithContext = sourcePlug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( sourcePlug->node() );
-				if( !variesWithContext )
+				if( !PlugAlgo::dependsOnCompute( plug->namePlug() ) )
 				{
-					used.insert( (*it)->namePlug()->getValue() );
+					used.insert( plug->namePlug()->getValue() );
 				}
 			}
 			return used;

--- a/src/GafferOSLUI/OSLObjectUI.cpp
+++ b/src/GafferOSLUI/OSLObjectUI.cpp
@@ -114,15 +114,11 @@ class OSLObjectPlugAdder : public PlugAdder
 		std::set<std::string> usedNames() const
 		{
 			std::set<std::string> used;
-			for( NameValuePlug::Iterator it( m_plugsParent.get() ); !it.done(); ++it )
+			for( const auto &plug : NameValuePlug::Range( *m_plugsParent ) )
 			{
-				// TODO - this method for checking if a plug variesWithContext should probably live in PlugAlgo
-				// ( it's based on Switch::variesWithContext )
-				PlugPtr sourcePlug = (*it)->namePlug()->source<Gaffer::Plug>();
-				bool variesWithContext = sourcePlug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( sourcePlug->node() );
-				if( !variesWithContext )
+				if( !PlugAlgo::dependsOnCompute( plug->namePlug() ) )
 				{
-					used.insert( (*it)->namePlug()->getValue() );
+					used.insert( plug->namePlug()->getValue() );
 				}
 			}
 			return used;

--- a/src/GafferScene/PathFilter.cpp
+++ b/src/GafferScene/PathFilter.cpp
@@ -40,6 +40,7 @@
 #include "GafferScene/ScenePlug.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/PlugAlgo.h"
 
 #include "boost/bind/bind.hpp"
 
@@ -123,9 +124,7 @@ void PathFilter::plugDirtied( const Gaffer::Plug *plug )
 {
 	if( plug == pathsPlug() )
 	{
-		//\todo: share this logic with Switch::variesWithContext()
-		Plug* sourcePlug = pathsPlug()->source();
-		if( sourcePlug->direction() == Plug::Out && IECore::runTimeCast<const ComputeNode>( sourcePlug->node() ) )
+		if( PlugAlgo::dependsOnCompute( pathsPlug() ) )
 		{
 			// pathsPlug() is receiving data from a plug whose value is context varying, meaning
 			// we need to use the intermediate pathMatcherPlug() in computeMatch() instead:


### PR DESCRIPTION
This allows us to consolidate several duplicate versions scattered throughout Gaffer. One reason its taken me so long to do this is that I'm still not sure about the name. Possibilities considered :

- `variesWithContext()` : This was actually used in Switch, but I rejected it for a couple of reasons. First, just because something is computed, doesn't mean it will vary with context. Second, StringPlugs containing substitutions do vary with context, but aren't computed.
- `valueIsComputed()` : What I went for in the end. What makes me unsure is that it could be interpreted as "value is already computed", or "value has been cached".
- `sourceIsComputeNodeOutput()` : Doesn't suffer from the above problem, but is a bit verbose for my liking.