### PR TITLE
BackgroundMethod : Prevent `postCall` to zombie widgets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ Fixes
 - ValuePlug : Fixed rare deadlock when a TaskParallel compute recurses to a Legacy compute with the _same_ hash.
 - GafferTest : Fixed bug which caused `parallelGetValue()` to use the wrong context.
 - LightEditor : Fixed bug which could cause attribute edits to be made for a parent location instead of the desired one.
+- BackgroundMethod : Fixed bug that could cause the `postCall` to be called on a widget that had already been removed from the UI.
 
 API
 ---


### PR DESCRIPTION
I tried pretty hard to avoid resorting to `_qtObjectIsValid()`, but became convinced that it was the only option.

My initial attempt was to only pass `weakref( widget )` to `backgroundFunction`, but it still needs to turn that into a strong reference to call the method at some point. If that happens after the UI thread has dropped all references to the widget, then the widget is destroyed on the background thread, which is no good because Qt objects need to be destroyed on the thread they belong in. I think this was also causing `__CurrentCall` to be destroyed from inside `backgroundFunction`, causing `backgroundFunction` to end up waiting on _itself_. This caused a shutdown crash in the new test case.
