### PR TITLE
GafferCycles : Custom AOV fix + unit test

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,12 @@
+1.1.x.x (relative to 1.1.6.1)
+=======
+
+Fixes
+-----
+
+- Cycles :
+  - Fixed custom AOVs not being created properly for SVM shading mode only, OSL is not supported. (#5044).
+
 1.1.6.1 (relative to 1.1.6.0)
 =======
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -328,18 +328,32 @@ class CyclesOutput : public IECore::RefCounted
 			}
 			else if( tokens.size() == 2 )
 			{
-				if( tokens[0] == "aovv" )
+				if( tokens[0] == "float" && tokens[1] == "Z" )
+				{
+					m_data = tokens[1];
+					p["name"] = new StringData( tokens[1] );
+					p["type"] = new StringData( "depth" );
+					passType = "depth";
+				}
+				else if( tokens[0] == "uint" && tokens[1] == "id" )
+				{
+					m_data = tokens[1];
+					p["name"] = new StringData( tokens[1] );
+					p["type"] = new StringData( "object_id" );
+					passType = "object_id";
+				}
+				else if( tokens[0] == "float" )
 				{
 					p["name"] = m_denoise ? new StringData( ccl::string_printf( "%s_denoised", tokens[1].c_str() ) ) : new StringData( tokens[1] );
 					p["type"] = new StringData( "aov_value" );
-					passType = tokens[1];
+					passType = "aov_value";
 					m_data = tokens[1];
 				}
-				else if( tokens[0] == "aovc" )
+				else if( tokens[0] == "color" )
 				{
 					p["name"] = m_denoise ? new StringData( ccl::string_printf( "%s_denoised", tokens[1].c_str() ) ) : new StringData( tokens[1] );
 					p["type"] = new StringData( "aov_color" );
-					passType = tokens[1];
+					passType = "aov_color";
 					m_data = tokens[1];
 				}
 				else if( tokens[0] == "lg" )
@@ -356,20 +370,6 @@ class CyclesOutput : public IECore::RefCounted
 					p["name"] = new StringData( m_data );
 					p["type"] = new StringData( tokens[0] );
 					passType = tokens[0];
-				}
-				else if( tokens[0] == "float" && tokens[1] == "Z" )
-				{
-					m_data = tokens[1];
-					p["name"] = new StringData( tokens[1] );
-					p["type"] = new StringData( "depth" );
-					passType = "depth";
-				}
-				else if( tokens[0] == "uint" && tokens[1] == "id" )
-				{
-					m_data = tokens[1];
-					p["name"] = new StringData( tokens[1] );
-					p["type"] = new StringData( "object_id" );
-					passType = "object_id";
 				}
 			}
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -349,10 +349,10 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 					label = "Light_Group"
 
 				if data == "aov_color" :
-					data = "aovc aov_color"
+					data = "color aov_color"
 
 				if data == "aov_value" :
-					data = "aovv aov_value"
+					data = "float aov_value"
 
 				if data.startswith( "cryptomatte" ) :
 					data = data.replace( "_", " " )


### PR DESCRIPTION
https://groups.google.com/g/gaffer-dev/c/m8NXKI9NIVE

Generally describe what this PR will do, and why it is needed

- Fix for incorrectly passing the wrong pass name enum when constructing a custom AOV CyclesOutput, which caused custom AOVs to never be rendered unless they were named `aov_color` or `aov_value`
- Unit test added for custom AOVs

### Related issues ###

-

### Dependencies ###

-

### Breaking changes ###

-

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
