### PR TITLE
OSLObject : Support <attr:> substitutions (Version 2)

### DIFF
--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -83,7 +83,10 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 
 		/// Append a unique hash representing this shading engine to `h`.
 		void hash( IECore::MurmurHash &h ) const;
+
+		/// \todo : replace with one function with default argument value on main branch
 		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms = Transforms() ) const;
+		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms, const IECore::CompoundObject *attributeSubstitutions ) const;
 
 		bool needsAttribute( const std::string &name ) const;
 		bool hasDeformation() const;

--- a/python/GafferOSLTest/OSLObjectTest.py
+++ b/python/GafferOSLTest/OSLObjectTest.py
@@ -1043,7 +1043,8 @@ class OSLObjectTest( GafferOSLTest.OSLTestCase ) :
 		self.assertEqual( o["out"].object( "/group/plane" )["testString"].data[0], "[/group/plane],/group/plane" )
 
 		code["parameters"]["inString"].setValue( "<attr:testAttribute2>" )
-		# Is this the right behaviour for missing attributes?		
+
+		# Missing attributes are replaced with an empty string
 		self.assertEqual( o["out"].object( "/group/plane" )["testString"].data[0], ",/group/plane" )
 
 		a["attributes"].addChild( Gaffer.NameValuePlug( "testAttribute2", "foo" ) )

--- a/src/GafferOSL/OSLObject.cpp
+++ b/src/GafferOSL/OSLObject.cpp
@@ -356,7 +356,7 @@ IECore::ConstObjectPtr OSLObject::computeProcessedObject( const ScenePath &path,
 		transforms[ g_world ] = ShadingEngine::Transform( Imath::M44f(), Imath::M44f() );
 	}
 
-	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get(), transforms );
+	CompoundDataPtr shadedPoints = shadingEngine->shade( shadingPoints.get(), transforms, gafferAttributes.get() );
 	for( CompoundDataMap::const_iterator it = shadedPoints->readable().begin(), eIt = shadedPoints->readable().end(); it != eIt; ++it )
 	{
 


### PR DESCRIPTION
This is a replacement for #5039, I've made a new PR since the implementation is completely different.

I think this is probably a better approach.

Current downsides:
* I've had to copy a bunch of code from IECoreScene::ShaderNetwork because it wasn't public
* It is currently triggered per-shading point - this is fairly bad, but I think there is a good solution:  we should be recognizing the needed attributes, and setting them up as uniform symLocs.  Haven't really played with this yet, but it should be a good solution.