### PR TITLE
FileSystemPath : Add `std::filesystem::path` API

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,9 @@ API
 ---
 
 - PlugAlgo : Added `dependsOnCompute()` utility method.
+- FileSystemPath :
+  - Added a constructor that accepts a `filesystem::path`.
+  - Added a `standardPath()` method returning a `std::filesystem::path` object in C++ and a `pathlib.Path` object in Python.
 
 Build
 -----

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -42,6 +42,8 @@
 
 #include "IECore/FileSequence.h"
 
+#include <filesystem>
+
 namespace Gaffer
 {
 
@@ -61,6 +63,7 @@ class GAFFER_API FileSystemPath : public Path
 
 		FileSystemPath( PathFilterPtr filter = nullptr, bool includeSequences = false );
 		FileSystemPath( const std::string &path, PathFilterPtr filter = nullptr, bool includeSequences = false );
+		FileSystemPath( const std::filesystem::path &path, PathFilterPtr filter = nullptr, bool includeSequences = false );
 		FileSystemPath( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = nullptr, bool includeSequences = false );
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSystemPath, FileSystemPathTypeId, Path );
@@ -93,6 +96,8 @@ class GAFFER_API FileSystemPath : public Path
 
 		// Returns the path converted to the OS native format
 		std::string nativeString() const;
+
+		std::filesystem::path standardPath() const;
 
 		static PathFilterPtr createStandardFilter( const std::vector<std::string> &extensions = std::vector<std::string>(), const std::string &extensionsLabel = "", bool includeSequenceFilter = false );
 

--- a/python/GafferTest/FileSequencePathFilterTest.py
+++ b/python/GafferTest/FileSequencePathFilterTest.py
@@ -44,7 +44,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 
 	def test( self ) :
 
-		p = Gaffer.FileSystemPath( self.__dir.as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
 		self.assertTrue( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
@@ -117,7 +117,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 			( self.__dir / "b.###.txt" ).as_posix()
 		] ) )
 
-		p = Gaffer.FileSystemPath( self.__dir.as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
 		self.assertTrue( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
@@ -197,7 +197,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 		# path that by definition has no sequences,
 		# but we may as well verify that it works.
 
-		p = Gaffer.FileSystemPath( self.__dir.as_posix(), includeSequences = False )
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = False )
 		self.assertFalse( p.getIncludeSequences() )
 
 		self.assertEqual( set( [ str( c ) for c in p.children() ] ), set( [
@@ -264,7 +264,7 @@ class FileSequencePathFilterTest( GafferTest.TestCase ) :
 
 	def testEnabled( self ) :
 
-		p = Gaffer.FileSystemPath( self.__dir.as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( self.__dir, includeSequences = True )
 		self.assertTrue( p.getIncludeSequences() )
 
 		p.setFilter( Gaffer.FileSequencePathFilter( mode = Gaffer.FileSequencePathFilter.Keep.Files ) )

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -87,7 +87,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		os.symlink( self.temporaryDirectory() / "nonExistent", self.temporaryDirectory() / "broken" )
 
 		# we do want symlinks to appear in children, even if they're broken
-		d = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		d = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		c = d.children()
 		self.assertEqual( len( c ), 1 )
 
@@ -113,8 +113,8 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		# symlinks should report the info for the file
 		# they point to.
-		a = Gaffer.FileSystemPath( ( self.temporaryDirectory() / "a" ).as_posix() )
-		l = Gaffer.FileSystemPath( ( self.temporaryDirectory() / "l" ).as_posix() )
+		a = Gaffer.FileSystemPath( self.temporaryDirectory() / "a" )
+		l = Gaffer.FileSystemPath( self.temporaryDirectory() / "l" )
 		aInfo = a.info()
 		self.assertEqual( aInfo["fileSystem:size"], l.info()["fileSystem:size"] )
 		# unless they're broken
@@ -123,7 +123,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testCopy( self ) :
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		p2 = p.copy()
 
 		self.assertEqual( p, p2 )
@@ -355,7 +355,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testModificationTimes( self ) :
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		p.append( "t" )
 
 		with open( p.nativeString(), "w" ) as f :
@@ -376,7 +376,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testOwner( self ) :
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		p.append( "t" )
 
 		with open( p.nativeString(), "w" ) as f :
@@ -389,7 +389,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testGroup( self ) :
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		p.append( "t" )
 
 		with open( p.nativeString(), "w" ) as f :
@@ -401,7 +401,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testPropertyNames( self ) :
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory() )
 
 		a = p.propertyNames()
 		self.assertTrue( isinstance( a, list ) )
@@ -412,7 +412,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		self.assertTrue( "fileSystem:size" in a )
 
 		self.assertTrue( "fileSystem:frameRange" not in a )
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory(), includeSequences = True )
 		self.assertTrue( "fileSystem:frameRange" in p.propertyNames() )
 
 	def testSequences( self ) :
@@ -422,7 +422,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 			with open( self.temporaryDirectory() / n, "w" ) as f :
 				f.write( "AAAA" )
 
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory(), includeSequences = True )
 		self.assertTrue( p.getIncludeSequences() )
 
 		c = p.children()
@@ -482,7 +482,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 		self.assertEqual( len( p2.children() ), 8 )
 
 		# make sure we can still exclude the sequences
-		p = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix(), includeSequences = False )
+		p = Gaffer.FileSystemPath( self.temporaryDirectory(), includeSequences = False )
 		self.assertFalse( p.getIncludeSequences() )
 
 		c = p.children()
@@ -511,7 +511,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 	def testCancellation( self ) :
 
-		p = Gaffer.FileSystemPath( pathlib.Path( __file__ ).parent.as_posix() )
+		p = Gaffer.FileSystemPath( pathlib.Path( __file__ ).parent )
 
 		# Children
 
@@ -527,7 +527,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 			with open( self.temporaryDirectory() / ( str( f ) + ".txt" ), "w" ) as f :
 				f.write( "x" )
 
-		p = Gaffer.FileSystemPath( ( self.temporaryDirectory() / "#.txt" ).as_posix(), includeSequences = True )
+		p = Gaffer.FileSystemPath( ( self.temporaryDirectory() / "#.txt" ), includeSequences = True )
 
 		with self.assertRaises( IECore.Cancelled ) :
 			p.property( "fileSystem:owner", c )
@@ -540,6 +540,10 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		with self.assertRaises( IECore.Cancelled ) :
 			p.property( "fileSystem:modificationTime", c )
+
+	def testPath( self ) :
+
+		self.assertEqual( Gaffer.FileSystemPath( pathlib.Path( __file__ ) ).standardPath(), pathlib.Path( __file__ ) )
 
 	def setUp( self ) :
 
@@ -570,6 +574,7 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )
 			group, domain = securityDescriptor.group()
 			return group
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/HiddenFilePathFilterTest.py
+++ b/python/GafferTest/HiddenFilePathFilterTest.py
@@ -46,17 +46,17 @@ class HiddenFilePathFilterTest( GafferTest.TestCase ) :
 
 	def test( self ) :
 
-		hiddenFile = Gaffer.FileSystemPath( ( self.temporaryDirectory() / ".sneaky.txt" ).as_posix() )
+		hiddenFile = Gaffer.FileSystemPath( self.temporaryDirectory() / ".sneaky.txt" )
 		with open( hiddenFile.nativeString(), "w" ) as f :
 			f.write( "Can't see me" )
 		if os.name == "nt" :
 			subprocess.check_call( [ "attrib", "+H", hiddenFile.nativeString() ] )
 
-		visibleFile = Gaffer.FileSystemPath( ( self.temporaryDirectory() / "frank.txt" ).as_posix() )
+		visibleFile = Gaffer.FileSystemPath( self.temporaryDirectory() / "frank.txt" )
 		with open( visibleFile.nativeString(), "w" ) as f :
 			f.write( "Can see me" )
 
-		p = Gaffer.FileSystemPath( pathlib.Path( hiddenFile.nativeString() ).parent.as_posix() )
+		p = Gaffer.FileSystemPath( pathlib.Path( hiddenFile.nativeString() ).parent )
 
 		self.assertEqual(
 			sorted( [ str( i ) for i in p.children() ] ),

--- a/python/GafferTest/PathFilterTest.py
+++ b/python/GafferTest/PathFilterTest.py
@@ -62,7 +62,7 @@ class PathFilterTest( GafferTest.TestCase ) :
 
 		# Check that an unfiltered path can see all the files
 
-		path = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		path = Gaffer.FileSystemPath( self.temporaryDirectory() )
 		children = path.children()
 		self.assertEqual( len( children ), len( list( self.temporaryDirectory().glob( "*" ) ) ) )
 
@@ -84,7 +84,7 @@ class PathFilterTest( GafferTest.TestCase ) :
 
 	def testEnabledState( self ) :
 
-		path = Gaffer.FileSystemPath( self.temporaryDirectory().as_posix() )
+		path = Gaffer.FileSystemPath( self.temporaryDirectory() )
 
 		f = Gaffer.FileNamePathFilter( [ "*.txt" ] )
 		self.assertEqual( f.getEnabled(), True )

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -582,6 +582,13 @@ void GafferModule::bindPath()
 			) )
 		)
 		.def(
+			init<const std::filesystem::path &, PathFilterPtr, bool>( (
+				arg( "path" ),
+				arg( "filter" ) = object(),
+				arg( "includeSequences" ) = false
+			) )
+		)
+		.def(
 			init<const std::string &, PathFilterPtr, bool>( (
 				arg( "path" ),
 				arg( "filter" ) = object(),
@@ -599,6 +606,7 @@ void GafferModule::bindPath()
 			)
 		)
 		.def( "nativeString", &FileSystemPath::nativeString )
+		.def( "standardPath", &FileSystemPath::standardPath )
 		.staticmethod( "createStandardFilter" )
 	;
 


### PR DESCRIPTION
This adds the ability to set a `Gaffer::FileSystemPath` from a `std::filesystem::path`, and to return a `std::filesystem::path` from a `Gaffer::FileSystemPath`. The same conversion applies to python `pathlib.Path` objects to and from `Gaffer::FileSystemPath` by virtue of the automatic conversion from `pathlib.Path` to `std::filesystem::path`.

I don't know if this is quite the way to go - my reasoning for adding it is :
- There's currently a nasty bug on Windows preventing references from working because of inconsistent path handling. We use `Gaffer.FileSystemPath` there for the filtering capability, and while updating `ReferenceUI` I found myself having to carefully track what was a string vs `Gaffer.FileSystemPath` vs `pathlib.Path`. Keeping everything in `ReferenceUI` as a `pathlib.Path` except for the dialogs seems like an improvement.
- With the ability to hand `pathlib.Path` objects around already, it seems natural to want to be able to give those to a `FileSystemPath` and have it just work.
- There are a few more `as_posix()` I was able to get rid of in the tests.
- We'll eventually migrate `FileSystemPath` to use `std::filesystem::path` instead of `boost::filesystempath`, so hopefully they won't have to coexist for too long?

### Related issues ###

#5003 gives the rationale for keeping `boost::filesystem::path` in `Gaffer::FileSystemPath` for now.

### Breaking changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
