### PR TITLE
Remove Python source encodings

### DIFF
--- a/python/GafferSceneUI/CameraUI.py
+++ b/python/GafferSceneUI/CameraUI.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 ##########################################################################
 #
 #  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 ##########################################################################
 #
 #  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.


### PR DESCRIPTION
This is no longer necessary in Python 3, because [PEP 3120](https://peps.python.org/pep-3120/) made UTF-8 the default encoding.
