### PR TITLE
PlugValueWidget : Improve API for performing updates in subclasses

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 API
 ---
 
+- PlugValueWidget : Added new API to provide asynchronous updates. The old `_updateFromPlugs()` and `_plugConnections()` methods are deprecated, and support for them will be removed in a future version.
 - PlugAlgo : Added `dependsOnCompute()` utility method.
 - FileSystemPath :
   - Added a constructor that accepts a `filesystem::path`.

--- a/Changes.md
+++ b/Changes.md
@@ -28,7 +28,7 @@ Fixes
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 - ImageViewer : Fixed drawing of pixels to the left of the display window [^1].
 - Random : Fixed GIL management bug which could lead to hangs [^1].
-- ShufflePrimitiveVariables, ShuffleAttributes, OptionQuery, PrimitiveVariableQuery, ShaderQuery, ContextQuery, CreateViews : Fixed bugs which allowed read-only nodes to be edited.
+- ShufflePrimitiveVariables, ShuffleAttributes, OptionQuery, PrimitiveVariableQuery, ShaderQuery, ContextQuery, CreateViews, SetVisualiser : Fixed bugs which allowed read-only nodes to be edited.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -28,7 +28,7 @@ Fixes
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 - ImageViewer : Fixed drawing of pixels to the left of the display window [^1].
 - Random : Fixed GIL management bug which could lead to hangs [^1].
-- ShufflePrimitiveVariables, ShuffleAttributes, OptionQuery, PrimitiveVariableQuery, ShaderQuery, ContextQuery : Fixed bugs which allowed read-only nodes to be edited.
+- ShufflePrimitiveVariables, ShuffleAttributes, OptionQuery, PrimitiveVariableQuery, ShaderQuery, ContextQuery, CreateViews : Fixed bugs which allowed read-only nodes to be edited.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 - ImageViewer : Fixed drawing of pixels to the left of the display window [^1].
 - Random : Fixed GIL management bug which could lead to hangs [^1].
+- ShufflePrimitiveVariables, ShuffleAttributes : Fixed bug which allowed shuffles to be added to a read-only node.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -28,7 +28,7 @@ Fixes
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 - ImageViewer : Fixed drawing of pixels to the left of the display window [^1].
 - Random : Fixed GIL management bug which could lead to hangs [^1].
-- ShufflePrimitiveVariables, ShuffleAttributes : Fixed bug which allowed shuffles to be added to a read-only node.
+- ShufflePrimitiveVariables, ShuffleAttributes, OptionQuery, PrimitiveVariableQuery, ShaderQuery, ContextQuery : Fixed bugs which allowed read-only nodes to be edited.
 
 API
 ---

--- a/python/GafferImageUI/CreateViewsUI.py
+++ b/python/GafferImageUI/CreateViewsUI.py
@@ -129,15 +129,14 @@ class _ViewsFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-			button = GafferUI.Button( image = "plus.png", hasFrame = False )
-			button.setEnabled( not Gaffer.MetadataAlgo.readOnly( plug ) )
-			button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
+			self.__button = GafferUI.Button( image = "plus.png", hasFrame = False )
+			self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
 
 			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__button.setEnabled( self._editable() )
 
 	def __buttonClicked( self, widget ) :
 

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -178,9 +178,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-		self._updateFromPlug()
-
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
 		self.__button.setEnabled( self._editable() )
 

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -179,9 +179,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-		self._updateFromPlug()
-
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
 		self.__button.setEnabled( self._editable() )
 

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -323,7 +323,7 @@ class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-			GafferUI.MenuButton(
+			self.__menuButton = GafferUI.MenuButton(
 				image = "plus.png",
 				hasFrame = False,
 				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -336,9 +336,9 @@ class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
 			scoped = False
 		)
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -138,9 +138,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-		self._updateFromPlug()
-
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
 		self.__button.setEnabled( self._editable() )
 

--- a/python/GafferSceneUI/PrimitiveVariableQueryUI.py
+++ b/python/GafferSceneUI/PrimitiveVariableQueryUI.py
@@ -382,7 +382,7 @@ class _PrimitiveVariableQueryFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-			GafferUI.MenuButton(
+			self.__menuButton = GafferUI.MenuButton(
 				image = "plus.png",
 				hasFrame = False,
 				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -395,9 +395,9 @@ class _PrimitiveVariableQueryFooter( GafferUI.PlugValueWidget ) :
 			scoped = False
 		)
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/SetVisualiserUI.py
+++ b/python/GafferSceneUI/SetVisualiserUI.py
@@ -213,9 +213,9 @@ class _OverridesFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__addButton.setEnabled( self._editable() )
 
 	def __addOverride( self, _ ) :
 

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -436,7 +436,7 @@ class _ShaderQueryFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-			GafferUI.MenuButton(
+			self.__menuButton = GafferUI.MenuButton(
 				image = "plus.png",
 				hasFrame = False,
 				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -449,9 +449,9 @@ class _ShaderQueryFooter( GafferUI.PlugValueWidget ) :
 			scoped = False
 		)
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -229,9 +229,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 				GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand" : True } )
 
-		self._updateFromPlug()
-
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
 		self.__button.setEnabled( self._editable() )
 

--- a/python/GafferUI/ContextQueryUI.py
+++ b/python/GafferUI/ContextQueryUI.py
@@ -295,7 +295,7 @@ class _ContextQueryFooter( GafferUI.PlugValueWidget ) :
 
 			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
 
-			GafferUI.MenuButton(
+			self.__menuButton = GafferUI.MenuButton(
 				image = "plus.png",
 				hasFrame = False,
 				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
@@ -308,9 +308,9 @@ class _ContextQueryFooter( GafferUI.PlugValueWidget ) :
 			scoped = False
 		)
 
-	def _updateFromPlug( self ) :
+	def _updateFromEditable( self ) :
 
-		self.setEnabled( self._editable() )
+		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -175,6 +175,8 @@ Gaffer.Metadata.registerNode(
 
 class _RandomColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
+	__gridSize = imath.V2i( 10, 3 )
+
 	def __init__( self, plug, **kw ) :
 
 		self.__grid = GafferUI.GridContainer( spacing = 4 )
@@ -182,22 +184,41 @@ class _RandomColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug, **kw )
 
 		with self.__grid :
-			for x in range( 0, 10 ) :
-				for y in range( 0, 3 ) :
+			for x in range( 0, self.__gridSize.x ) :
+				for y in range( 0, self.__gridSize.y ) :
 					GafferUI.ColorSwatch( parenting = { "index" : ( x, y ) } )
 
-		self._updateFromPlug()
+	@staticmethod
+	def _valuesForUpdate( plugs ) :
 
-	def _updateFromPlug( self ) :
-
-		node = self.getPlug().source().node()
+		node = next( iter( plugs ) ).source().node()
 		seed = node["seed"].getValue()
 
-		gridSize = self.__grid.gridSize()
-		for x in range( 0, gridSize.x ) :
-			for y in range( 0, gridSize.y ) :
-				self.__grid[x,y].setColor( node.randomColor( seed ) )
+		result = []
+		for x in range( 0, _RandomColorPlugValueWidget.__gridSize.x ) :
+			column = []
+			for y in range( 0, _RandomColorPlugValueWidget.__gridSize.y ) :
+				column.append( node.randomColor( seed ) )
 				seed += 1
+			result.append( column )
+
+		return result
+
+	def _updateFromValues( self, values, exception ) :
+
+		for x in range( 0, self.__gridSize.x ) :
+			for y in range( 0, self.__gridSize.y ) :
+				if exception is not None :
+					self.__grid[x,y].setColor( imath.Color3f( 1, 0.33, 0.33 ) )
+				elif len( values ) :
+					self.__grid[x,y].setColor( values[x][y] )
+				else :
+					# We are called with `values == []` prior to
+					# the BackgroundTask for `_valuesForUpdate()`
+					# being launched. No point displaying a "busy"
+					# state as it is typically so quick as to just
+					# be visual noise.
+					pass
 
 # PlugValueWidget popup menu
 ##########################################################################

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -185,7 +185,6 @@ from .SplineWidget import SplineWidget
 from .Bookmarks import Bookmarks
 from . import WidgetAlgo
 from .CodeWidget import CodeWidget
-from .PlugPopup import PlugPopup
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.
@@ -275,6 +274,7 @@ from .ShufflePlugValueWidget import ShufflesPlugValueWidget
 from .BackgroundTaskDialogue import BackgroundTaskDialogue
 from . import AnnotationsUI
 from .TweakPlugValueWidget import TweakPlugValueWidget
+from .PlugPopup import PlugPopup
 
 # and then specific node uis
 

--- a/python/GafferUITest/BoolPlugValueWidgetTest.py
+++ b/python/GafferUITest/BoolPlugValueWidgetTest.py
@@ -37,6 +37,7 @@
 import unittest
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -54,16 +55,48 @@ class BoolPlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( w.boolWidget().getState(), False )
 
 		n["user"]["p1"].setValue( True )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.boolWidget().getState(), True )
 
 		w.setPlugs( n["user"].children() )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
 
 		n["user"]["p2"].setValue( True )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.boolWidget().getState(), True )
 
 		w.setPlugs( [] )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.boolWidget().getState(), w.boolWidget().State.Indeterminate )
+
+	def testInitialValue( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["p"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		for v in ( True, False ) :
+			n["user"]["p"].setValue( v )
+			w = GafferUI.BoolPlugValueWidget( n["user"]["p"] )
+			GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
+			self.assertEqual( w.boolWidget().getState(), v )
+
+	def testErrorHandling( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["p"] = Gaffer.BoolPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		w = GafferUI.BoolPlugValueWidget( n["user"]["p"] )
+		self.assertFalse( w.boolWidget().getErrored() )
+
+		b = GafferTest.BadNode()
+		n["user"]["p"].setInput( b["out3"] )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
+		self.assertTrue( w.boolWidget().getErrored() )
+
+		n["user"]["p"].setInput( None )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
+		self.assertFalse( w.boolWidget().getErrored() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/NumericPlugValueWidgetTest.py
+++ b/python/GafferUITest/NumericPlugValueWidgetTest.py
@@ -51,10 +51,12 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		w = GafferUI.NumericPlugValueWidget( n["i"] )
 		self.assertTrue( w.getPlug().isSame( n["i"] ) )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertTrue( isinstance( w.numericWidget().getValue(), int ) )
 
 		w.setPlug( n["f"] )
 		self.assertTrue( w.getPlug().isSame( n["f"] ) )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
 
 		w = GafferUI.NumericPlugValueWidget( plugs = [] )
@@ -63,6 +65,7 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		w.setPlug( n["f"] )
 		self.assertTrue( w.getPlug().isSame( n["f"] ) )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertTrue( isinstance( w.numericWidget().getValue(), float ) )
 		self.assertEqual( w.numericWidget().getEditable(), True )
 
@@ -77,9 +80,11 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		n["user"]["i1"].setValue( 2 )
 		n["user"]["i2"].setValue( 2 )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getText(), "2" )
 
 		n["user"]["i1"].setValue( 1 )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getText(), "" )
 		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
 
@@ -99,6 +104,7 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["i2"].setValue( 2 )
 
 		w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getText(), "1" )
 		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "" )
 
@@ -107,6 +113,7 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( n["user"]["i1"].getValue(), 1 )
 		self.assertEqual( n["user"]["i2"].getValue(), 2 )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getText(), "" )
 		self.assertEqual( w.numericWidget()._qtWidget().placeholderText(), "---" )
 
@@ -119,6 +126,7 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		n["user"]["i2"].setValue( 2 )
 
 		w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getValue(), 1 )
 
 		w.numericWidget().setText( "" )
@@ -127,6 +135,7 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( n["user"]["i1"].getValue(), 1 )
 
 		w = GafferUI.NumericPlugValueWidget( n["user"].children() )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getText(), "" )
 
 		w.numericWidget()._qtWidget().editingFinished.emit()
@@ -155,6 +164,38 @@ class NumericPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		w.setPlugs( { n["user"]["i3"] } )
 		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 2 )
+
+	def testFixedCharacterWidthMetadata( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["i1"] = Gaffer.IntPlug()
+		n["user"]["i2"] = Gaffer.IntPlug()
+
+		Gaffer.Metadata.registerValue( n["user"]["i1"], "numericPlugValueWidget:fixedCharacterWidth", 3 )
+		w = GafferUI.NumericPlugValueWidget( n["user"]["i1"] )
+		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 3 )
+
+		w.setPlug( n["user"]["i2"] )
+		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), None )
+
+		Gaffer.Metadata.registerValue( n["user"]["i2"], "numericPlugValueWidget:fixedCharacterWidth", 4 )
+		self.assertEqual( w.numericWidget().getFixedCharacterWidth(), 4 )
+
+	def testEditability( self ) :
+
+		n = GafferTest.AddNode()
+
+		w = GafferUI.NumericPlugValueWidget( n["op1"] )
+		self.assertTrue( w.numericWidget().getEditable() )
+
+		Gaffer.MetadataAlgo.setReadOnly( n["op1"], True )
+		self.assertFalse( w.numericWidget().getEditable() )
+
+		w.setPlug( n["op2"] )
+		self.assertTrue( w.numericWidget().getEditable() )
+
+		w.setPlug( None )
+		self.assertFalse( w.numericWidget().getEditable() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -69,12 +69,14 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( w.getContext().isSame( s.context() ) )
 
 		s.context().setFrame( 10 )
+		self.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getValue(), 10 )
 
 		context = Gaffer.Context()
 		context.setFrame( 20 )
 		w.setContext( context )
 		self.assertTrue( w.getContext().isSame( context ) )
+		self.waitForUpdate( w )
 		self.assertEqual( w.numericWidget().getValue(), 20 )
 
 	def testDisableCreationForSpecificTypes( self ) :

--- a/python/GafferUITest/StandardNodeToolbarTest.py
+++ b/python/GafferUITest/StandardNodeToolbarTest.py
@@ -69,6 +69,7 @@ class StandardNodeToolbarTest( GafferUITest.TestCase ) :
 
 			toolbar = GafferUI.StandardNodeToolbar( node )
 			widget = toolbar._StandardNodeToolbar__layout.plugValueWidget( plug )
+			GafferUITest.PlugValueWidgetTest.waitForUpdate( widget )
 			self.assertEqual( widget.updateCount, 1 )
 			self.assertTrue( widget.updateContexts[0].isSame( script.context() ) )
 

--- a/python/GafferUITest/StringPlugValueWidgetTest.py
+++ b/python/GafferUITest/StringPlugValueWidgetTest.py
@@ -56,10 +56,12 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 		w = GafferUI.StringPlugValueWidget( n["user"]["p1"] )
 		self.assertEqual( w.getPlug(), n["user"]["p1"] )
 		self.assertEqual( w.getPlugs(), { n["user"]["p1"] } )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "p1" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
 		n["user"]["p1"].setValue( "x" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "x" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
@@ -67,28 +69,34 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( n["user"]["p1"].getValue(), "x" )
 		self.assertEqual( n["user"]["p2"].getValue(), "p2" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
 		w = GafferUI.StringPlugValueWidget( n["user"].children() )
 		self.assertEqual( w.getPlugs(), { n["user"]["p1"], n["user"]["p2"] } )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
 		n["user"]["p2"].setValue( "x" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "x" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
 		n["user"]["p1"].setValue( "" )
 		n["user"]["p2"].setValue( "" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
 		Gaffer.Metadata.registerValue( n["user"]["p1"], "stringPlugValueWidget:placeholderText", "test" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "" )
 
 		Gaffer.Metadata.registerValue( n["user"]["p2"], "stringPlugValueWidget:placeholderText", "test" )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "test" )
 
@@ -105,6 +113,7 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 		Gaffer.Metadata.registerValue( n["user"]["p2"], "stringPlugValueWidget:placeholderText", "test" )
 
 		w = GafferUI.StringPlugValueWidget( { n["user"]["p1"], n["user"]["p2"] } )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertEqual( w.textWidget()._qtWidget().placeholderText(), "---" )
 
@@ -141,6 +150,7 @@ class StringPlugValueWidgetTest( GafferUITest.TestCase ) :
 		# We want that to be reflected in the UI.
 
 		w = GafferUI.StringPlugValueWidget( n["p"] )
+		GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
 		self.assertEqual( w.textWidget().getText(), "" )
 		self.assertTrue( w.textWidget().getErrored() )
 


### PR DESCRIPTION
This has several benefits over the old API :

- More granular updates, so we don't perform unnecessary work computing values when only metadata has changed, for instance.
- Easier to implement, avoiding context handling and error handling bugs that have been common in subclasses (and still exist in many).
- Computes are now performed as BackgroundTasks, so the NodeEditor no longer locks the UI for long-running computes.

Backwards compatibility is provided for subclasses still using the old API. In this PR, I've updated some of the main subclasses to give a flavour of how it all looks. I do have versions of almost _all_ widgets in the new flavour, but I'll save those for followup PRs. I want to keep the size of this one manageable so we can focus discussion on the design of the new API, and not on reams of individual updates.