### PR TITLE
Metadata : Allow concurrent access to values for the same instance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - 3Delight : Fixed rendering with recent versions of 3Delight, which no longer use the `DL_DISPLAYS_PATH` to search for display drivers.
+- Metadata : Fixed memory leak.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Fixes
 -----
 
 - 3Delight : Fixed rendering with recent versions of 3Delight, which no longer use the `DL_DISPLAYS_PATH` to search for display drivers.
-- Metadata : Fixed memory leak.
+- Metadata :
+  - Fixed memory leak.
+  - Fixed thread safety bug that prevented concurrent access to metadata for the _same_ plug or node from multiple threads.
 
 API
 ---

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -464,6 +464,10 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		_MetadataTest.testConcurrentAccessToDifferentInstances()
 
+	def testConcurrentAccessToSameInstance( self ) :
+
+		_MetadataTest.testConcurrentAccessToSameInstance()
+
 	def testVectorTypes( self ) :
 
 		n = Gaffer.Node()
@@ -1227,6 +1231,19 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		del n
 		self.assertEqual( v.refCount(), 1 )
+
+	def testReentrantSlot( self ) :
+
+		node = Gaffer.Node()
+
+		def changed( node, key, reason ) :
+
+			if Gaffer.Metadata.value( node, key ) != 1 :
+				Gaffer.Metadata.registerValue( node, key, 1 )
+
+		Gaffer.Metadata.nodeValueChangedSignal( node ).connect( changed, scoped = False )
+		Gaffer.Metadata.registerValue( node, "test", 2 )
+		self.assertEqual( Gaffer.Metadata.value( node, "test" ), 1 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1215,5 +1215,18 @@ class MetadataTest( GafferTest.TestCase ) :
 		with self.assertRaisesRegex( Exception, r"did not match C\+\+ signature" ) :
 			Gaffer.Metadata.value( None, "test" )
 
+	def testInstanceValueLifetime( self ) :
+
+		n = GafferTest.MultiplyNode()
+
+		v = IECore.IntData( 2 )
+		self.assertEqual( v.refCount(), 1 )
+
+		Gaffer.Metadata.registerValue( n, "test", v )
+		self.assertEqual( v.refCount(), 2 )
+
+		del n
+		self.assertEqual( v.refCount(), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -45,6 +45,8 @@ import IECore
 import Gaffer
 import GafferTest
 
+from GafferTest._GafferTest import _MetadataTest
+
 class MetadataTest( GafferTest.TestCase ) :
 
 	class DerivedAddNode( GafferTest.AddNode ) :
@@ -458,9 +460,9 @@ class MetadataTest( GafferTest.TestCase ) :
 			]
 		)
 
-	def testThreading( self ) :
+	def testConcurrentAccessToDifferentInstances( self ) :
 
-		GafferTest.testMetadataThreading()
+		_MetadataTest.testConcurrentAccessToDifferentInstances()
 
 	def testVectorTypes( self ) :
 

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -294,7 +294,7 @@ using InstanceValues = multi_index::multi_index_container<
 	>
 >;
 
-using InstanceMetadataMap = concurrent_hash_map<const GraphComponent *, InstanceValues *>;
+using InstanceMetadataMap = concurrent_hash_map<const GraphComponent *, std::unique_ptr<InstanceValues>>;
 
 InstanceMetadataMap &instanceMetadataMap()
 {
@@ -309,15 +309,15 @@ InstanceValues *instanceMetadata( const GraphComponent *instance, bool createIfM
 	InstanceMetadataMap::accessor accessor;
 	if( m.find( accessor, instance ) )
 	{
-		return accessor->second;
+		return accessor->second.get();
 	}
 	else
 	{
 		if( createIfMissing )
 		{
 			m.insert( accessor, instance );
-			accessor->second = new InstanceValues();
-			return accessor->second;
+			accessor->second = std::make_unique<InstanceValues>();
+			return accessor->second.get();
 		}
 	}
 

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -64,6 +64,12 @@ static void testConcurrentAccessToDifferentInstancesWrapper()
 	testConcurrentAccessToDifferentInstances();
 }
 
+static void testConcurrentAccessToSameInstanceWrapper()
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	testConcurrentAccessToSameInstance();
+}
+
 static boost::python::tuple countContextHash32CollisionsWrapper( int entries, int mode, int seed )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -116,5 +122,6 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	scope moduleScope( module );
 
 	def( "testConcurrentAccessToDifferentInstances", &testConcurrentAccessToDifferentInstancesWrapper );
+	def( "testConcurrentAccessToSameInstance", &testConcurrentAccessToSameInstanceWrapper );
 
 }

--- a/src/GafferTestModule/GafferTestModule.cpp
+++ b/src/GafferTestModule/GafferTestModule.cpp
@@ -41,7 +41,6 @@
 #include "GafferTest/ContextTest.h"
 #include "GafferTest/DownstreamIteratorTest.h"
 #include "GafferTest/FilteredRecursiveChildIteratorTest.h"
-#include "GafferTest/MetadataTest.h"
 #include "GafferTest/MultiplyNode.h"
 #include "GafferTest/RandomTest.h"
 #include "GafferTest/RecursiveChildIteratorTest.h"
@@ -50,6 +49,7 @@
 #include "TaskMutexTest.h"
 #include "ValuePlugTest.h"
 #include "MessagesTest.h"
+#include "MetadataTest.h"
 #include "SignalsTest.h"
 
 #include "IECorePython/ScopedGILRelease.h"
@@ -58,10 +58,10 @@ using namespace boost::python;
 using namespace GafferTest;
 using namespace GafferTestModule;
 
-static void testMetadataThreadingWrapper()
+static void testConcurrentAccessToDifferentInstancesWrapper()
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	testMetadataThreading();
+	testConcurrentAccessToDifferentInstances();
 }
 
 static boost::python::tuple countContextHash32CollisionsWrapper( int entries, int mode, int seed )
@@ -91,7 +91,6 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	def( "asFloat32", &asFloat32 );
 	def( "testRecursiveChildIterator", &testRecursiveChildIterator );
 	def( "testFilteredRecursiveChildIterator", &testFilteredRecursiveChildIterator );
-	def( "testMetadataThreading", &testMetadataThreadingWrapper );
 	def( "testManyContexts", &testManyContexts );
 	def( "testManySubstitutions", &testManySubstitutions );
 	def( "testManyEnvironmentSubstitutions", &testManyEnvironmentSubstitutions );
@@ -111,5 +110,11 @@ BOOST_PYTHON_MODULE( _GafferTest )
 	bindValuePlugTest();
 	bindMessagesTest();
 	bindSignalsTest();
+
+	object module( borrowed( PyImport_AddModule( "GafferTest._MetadataTest" ) ) );
+	scope().attr( "_MetadataTest" ) = module;
+	scope moduleScope( module );
+
+	def( "testConcurrentAccessToDifferentInstances", &testConcurrentAccessToDifferentInstancesWrapper );
 
 }

--- a/src/GafferTestModule/MetadataTest.cpp
+++ b/src/GafferTestModule/MetadataTest.cpp
@@ -34,7 +34,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GafferTest/MetadataTest.h"
+#include "MetadataTest.h"
 
 #include "GafferTest/Assert.h"
 
@@ -50,7 +50,7 @@ using namespace tbb;
 using namespace IECore;
 using namespace Gaffer;
 
-void GafferTest::testMetadataThreading()
+void GafferTestModule::testConcurrentAccessToDifferentInstances()
 {
 	// This test simulates many different scripts being loaded concurrently in
 	// separate threads, with each script registering per-instance metadata for

--- a/src/GafferTestModule/MetadataTest.h
+++ b/src/GafferTestModule/MetadataTest.h
@@ -41,6 +41,7 @@ namespace GafferTestModule
 {
 
 void testConcurrentAccessToDifferentInstances();
+void testConcurrentAccessToSameInstance();
 
 } // namespace GafferTestModule
 

--- a/src/GafferTestModule/MetadataTest.h
+++ b/src/GafferTestModule/MetadataTest.h
@@ -34,16 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef GAFFERTEST_METADATATEST_H
-#define GAFFERTEST_METADATATEST_H
+#ifndef GAFFERTESTMODULE_METADATATEST_H
+#define GAFFERTESTMODULE_METADATATEST_H
 
-#include "GafferTest/Export.h"
-
-namespace GafferTest
+namespace GafferTestModule
 {
 
-GAFFERTEST_API void testMetadataThreading();
+void testConcurrentAccessToDifferentInstances();
 
-} // namespace GafferTest
+} // namespace GafferTestModule
 
-#endif // GAFFERTEST_METADATATEST_H
+#endif // GAFFERTESTMODULE_METADATATEST_H


### PR DESCRIPTION
We have always provided concurrent access to values on different instances, so that we could load scripts (writing metadata) in a background thread while doing other work (potentially manipulating metadata) on a different script on the foreground thread. But we now allow multiple threads to concurrently access metadata on the _same_ node or plug.

This will make it easier to implement widgets that do work in the background and might need access to metadata as part of that. The primary motivation is to allow an asynchronous PresetsPlugValueWidget to call `NodeAlgo::currentPreset()` from a background thread, as part of https://github.com/GafferHQ/gaffer/pull/5055.