### PR TITLE
CyclesShader : Load `emission` as `cycles:surface`, not `cycles:light`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - Cycles :
   - Fixed custom AOVs not being created properly for SVM shading mode only, OSL is not supported. (#5044).
   - Fixed distant light angle is in degrees and not radians.
+  - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 
 1.1.6.1 (relative to 1.1.6.0)
 =======

--- a/python/GafferCyclesTest/CyclesShaderTest.py
+++ b/python/GafferCyclesTest/CyclesShaderTest.py
@@ -79,5 +79,11 @@ class CyclesShaderTest( GafferSceneTest.SceneTestCase ) :
 		for s in GafferCycles.shaders :
 			shader.loadShader( s )
 
+	def testLoadEmission( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		shader.loadShader( "emission" )
+		self.assertEqual( shader["type"].getValue(), "cycles:surface" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -69,9 +69,9 @@ class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 	def _createConstantShader( self ) :
 
 		shader = GafferCycles.CyclesShader()
-		shader.loadShader( "principled_bsdf" )
-		shader["parameters"]["base_color"].setValue( imath.Color3f( 0 ) )
-		return shader, shader["parameters"]["emission"]
+		shader.loadShader( "emission" )
+		shader["parameters"]["strength"].setValue( 1 )
+		return shader, shader["parameters"]["color"]
 
 	def _createMatteShader( self ) :
 

--- a/src/GafferCycles/CyclesShader.cpp
+++ b/src/GafferCycles/CyclesShader.cpp
@@ -121,10 +121,6 @@ void CyclesShader::loadShader( const std::string &shaderName, bool keepExistingV
 	{
 		typePlug()->setValue( "cycles:aov:" );
 	}
-	else if( shaderName == "emission" )
-	{
-		typePlug()->setValue( "cycles:light" );
-	}
 	else
 	{
 		typePlug()->setValue( "cycles:surface" );


### PR DESCRIPTION
The loading as `cycles:light` originated in d6bd98b1c12dac2337686ad28d1374b3ea0cab18, which claimed that "every mesh assigned an emission shader will become a light". I don't understand that statement, because :

- An object is not a light unless it is also in the `__lights` set.
- As implemented, `Renderer::light()` is ignoring geometry anyway, so even if the object was in the lights set, the geometry would be ignored.

Now we load as `cycles:surface`, the `emission` shader can be assigned as usual to geometry, and it renders properly, as demonstrated in the modified InteractiveCyclesRenderTest.

Bafflingly, this fixes the rendering of CyclesMeshLight too! You'd expect the mesh light to need the internal shader to be assigned as `cycles:light`, but that's actually not the case, because CyclesMeshLight _doesn't_ put the object in the `__lights` set. So in fact, CyclesMeshLight just outputs regular geometry, and therefore needs a regular shader assignment too.

Fixes #5058.
