### PR TITLE
UIEditor : Remove unnecessary Spacer

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
   - Added `use_camera`, `use_caustics` and `normalize` parameters to lights.
 - TweakPlug : Added a `CreateIfMissing` mode, to only create a new value if one does not currently exist.
 - OSLObject : Added support for attribute substitutions using `<attr:myAttrName>` syntax in string parameters, provided that `useAttributes` is turned on.
+- UIEditor : Increased maximum size of the "Button Click Code" editor.
 
 Fixes
 -----

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1404,8 +1404,6 @@ class _PlugEditor( GafferUI.Widget ) :
 						_Label( "Connection Color" )
 						self.__metadataWidgets["connectionGadget:color"] = MetadataWidget.ColorSwatchMetadataWidget( key = "connectionGadget:color", defaultValue = imath.Color3f( 0.125 ) )
 
-			GafferUI.Spacer( imath.V2i( 0 ), parenting = { "expand" : True } )
-
 		self.__plug = None
 
 	def setPlug( self, plug ) :


### PR DESCRIPTION
This allows the "Button Click Code" MultiLineTextWidget to expand to take any additional space that might be available.

Fixes #5062.
