### PR TITLE
FilterQuery : Fix context used to hash the input filter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 1.0.6.x (relative to 1.0.6.5)
 =======
 
+- FilterQuery : Fixed bug which prevented the output from updating when the input scene changed (#5066).
 - Random : Fixed GIL management bug which could lead to hangs.
 
 1.0.6.5 (relative to 1.0.6.4)

--- a/python/GafferSceneTest/FilterQueryTest.py
+++ b/python/GafferSceneTest/FilterQueryTest.py
@@ -167,5 +167,26 @@ class FilterQueryTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( query["ancestorMatch"].getValue(), False )
 		self.assertEqual( query["closestAncestor"].getValue(), "" )
 
+	def testChangingSet( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["sets"].setValue( "setA" )
+
+		setFilter = GafferScene.SetFilter()
+		setFilter["setExpression"].setValue( "setA" )
+
+		query = GafferScene.FilterQuery()
+		query["scene"].setInput( sphere["out"] )
+		query["filter"].setInput( setFilter["out"] )
+		query["location"].setValue( "/sphere" )
+
+		self.assertEqual( query["exactMatch"].getValue(), True )
+		self.assertEqual( query["closestAncestor"].getValue(), "/sphere" )
+
+		sphere["sets"].setValue( "setB" )
+
+		self.assertEqual( query["exactMatch"].getValue(), False )
+		self.assertEqual( query["closestAncestor"].getValue(), "" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/FilterQuery.cpp
+++ b/src/GafferScene/FilterQuery.cpp
@@ -211,6 +211,7 @@ void FilterQuery::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *
 			ScenePlug::PathScope scope( context, &locationPath );
 			if( scenePlug()->existsPlug()->getValue() )
 			{
+				const FilterPlug::SceneScope sceneScope( scope.context(), scenePlug() );
 				filterPlug()->hash( h );
 			}
 		}


### PR DESCRIPTION
We need to provide the scene so that the filter can use it in computing its hash. I'm not sure why `SetFilter::hashMatch()` is a no-op if the scene isn't provided - it might be better if the Filter base class threw an exception if the scene wasn't specified so problems like this can't go undetected. I'm not sure what the consequences of that might be though - might be best to tackle that as part of a larger Filter API overhaul.

Fixes #5066.