### PR TITLE
PlugAlgo : Add `findDestination()` method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.2.0.0ax (relative to 1.2.0.0a2)
+=========
+
+API
+---
+
+- PlugAlgo : Added `findDestination()` utility method.
+
 1.2.0.0a2 (relative to 1.2.0.0a1)
 =========
 

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -67,6 +67,12 @@ GAFFER_API void replacePlug( GraphComponent *parent, PlugPtr plug );
 /// of a ComputeNode, and `false` otherwise.
 GAFFER_API bool dependsOnCompute( const ValuePlug *plug );
 
+/// Visits the plug and its downstream outputs, returning the first `predicate( plug )`
+/// result which evaluates to `true`. Traverses across Spreadsheets to visit the output
+/// corresponding to a CellPlug input.
+template<typename Predicate>
+std::invoke_result_t<Predicate, Plug *> findDestination( Plug *plug, Predicate &&predicate );
+
 /// Conversion to and from `IECore::Data`
 /// =====================================
 
@@ -125,5 +131,7 @@ GAFFER_API void unpromote( Plug *plug );
 } // namespace PlugAlgo
 
 } // namespace Gaffer
+
+#include "Gaffer/PlugAlgo.inl"
 
 #endif // GAFFER_PLUGALGO_H

--- a/include/Gaffer/PlugAlgo.inl
+++ b/include/Gaffer/PlugAlgo.inl
@@ -1,0 +1,90 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFER_PLUGALGO_INL
+#define GAFFER_PLUGALGO_INL
+
+#include "Gaffer/Spreadsheet.h"
+
+namespace Gaffer::PlugAlgo
+{
+
+template<typename Predicate>
+std::invoke_result_t<Predicate, Plug *> findDestination( Plug *plug, Predicate &&predicate )
+{
+	if( !plug )
+	{
+		// Typically a null pointer.
+		return std::invoke_result_t<Predicate, Plug *>();
+	}
+
+	if( auto destination = predicate( plug ) )
+	{
+		return destination;
+	}
+
+	for( const auto &output : plug->outputs() )
+	{
+		if( auto destination = findDestination( output, predicate ) )
+		{
+			return destination;
+		}
+	}
+
+	if( auto cell = plug->ancestor<Spreadsheet::CellPlug>() )
+	{
+		if( plug == cell->valuePlug() || cell->valuePlug()->isAncestorOf( plug ) )
+		{
+			if( auto spreadsheet = IECore::runTimeCast<Spreadsheet>( cell->node() ) )
+			{
+				if( auto output = spreadsheet->outPlug()->getChild<Plug>( cell->getName() ) )
+				{
+					if( plug != cell->valuePlug() )
+					{
+						output = output->descendant<Plug>( plug->relativeName( cell->valuePlug() ) );
+					}
+					return findDestination( output, predicate );
+				}
+			}
+		}
+	}
+
+	return std::invoke_result_t<Predicate, Plug *>();
+}
+
+} // namespace Gaffer::PlugAlgo
+
+#endif // GAFFER_PLUGALGO_INL

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -176,19 +176,10 @@ class _CommandPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __pythonCommandNode( self ) :
 
-		def walk( plug ) :
-
-			if isinstance( plug.parent(), GafferDispatch.PythonCommand ) :
-				return plug.parent()
-
-			for output in plug.outputs() :
-				r = walk( output )
-				if r is not None :
-					return r
-
-			return None
-
-		return walk( self.getPlug() )
+		return Gaffer.PlugAlgo.findDestination(
+			self.getPlug(),
+			lambda plug : plug.parent() if isinstance( plug.parent(), GafferDispatch.PythonCommand ) else None
+		)
 
 	def __pythonCommandPlugDirtied( self, plug ) :
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -587,22 +587,6 @@ def _duplicateImages( catalogue, plugIndices ) :
 # _CataloguePath
 ##########################################################################
 
-def _findSourceCatalogue( imagesPlug ) :
-
-	def walk( plug ) :
-
-		if isinstance( plug.parent(), GafferImage.Catalogue ) :
-			return plug.parent()
-
-		for output in plug.outputs() :
-			r = walk( output )
-			if r is not None :
-				return r
-
-		return None
-
-	return walk( imagesPlug )
-
 class _ImagesPath( Gaffer.Path ) :
 
 	indexMetadataName = 'image:index'
@@ -612,7 +596,9 @@ class _ImagesPath( Gaffer.Path ) :
 		Gaffer.Path.__init__( self, path, root, filter )
 
 		self.__images = images
-		self.__catalogue = _findSourceCatalogue( images )
+		self.__catalogue = Gaffer.PlugAlgo.findDestination(
+			images, lambda plug : plug.parent() if isinstance( plug.parent(), GafferImage.Catalogue ) else None
+		)
 
 	def copy( self ) :
 
@@ -863,7 +849,9 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __catalogue( self ) :
 
-		return _findSourceCatalogue( self.getPlug() )
+		return Gaffer.PlugAlgo.findDestination(
+			self.getPlug(), lambda plug : plug.parent() if isinstance( plug.parent(), GafferImage.Catalogue ) else None
+		)
 
 	def __images( self ) :
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -54,19 +54,10 @@ def _idToManifestKey( value ) :
 
 def _findCryptomatteNode( sourcePlug ) :
 
-	def walk( plug ) :
-
-		if isinstance( plug.parent(), GafferScene.Cryptomatte ) :
-			return plug.parent()
-
-		for output in plug.outputs() :
-			r = walk( output )
-			if r is not None :
-				return r
-
-		return None
-
-	return walk( sourcePlug )
+	return Gaffer.PlugAlgo.findDestination(
+		sourcePlug,
+		lambda plug : plug.parent() if isinstance( plug.parent(), GafferScene.Cryptomatte ) else None
+	)
 
 class _CryptomatteNamesPlugValueWidget( GafferUI.VectorDataPlugValueWidget ) :
 

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -285,29 +285,6 @@ Gaffer.Metadata.registerNode(
 )
 
 ##########################################################################
-# Internal utilities
-##########################################################################
-
-def _optionQueryNode( plugValueWidget ) :
-
-	# The plug may not belong to a OptionQuery node
-	# directly. Instead it may have been promoted
-	# elsewhere and be driving a target plug on a
-	# OptionQuery node.
-
-	def walkOutputs( plug ) :
-
-		if isinstance( plug.node(), GafferScene.OptionQuery ) :
-			return plug.node()
-
-		for output in plug.outputs() :
-			node = walkOutputs( output )
-			if node is not None :
-				return node
-
-	return walkOutputs( plugValueWidget.getPlug() )
-
-##########################################################################
 # _OutputQueryFooter
 ##########################################################################
 
@@ -384,12 +361,11 @@ class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
 
 		result = IECore.MenuDefinition()
 
-		node = _optionQueryNode( self )
-		options = {}
+		node = self.getPlug().node()
+		assert( isinstance( node, GafferScene.OptionQuery ) )
 
-		if node is not None :
-			with self.getContext() :
-				options = node["scene"]["globals"].getValue()
+		with self.getContext() :
+			options = node["scene"]["globals"].getValue()
 
 		prefix = "option:"
 

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -92,29 +92,6 @@ Gaffer.Metadata.registerNode(
 )
 
 ##########################################################################
-# Internal utilities
-##########################################################################
-
-def _optionTweaksNode( plugValueWidget ) :
-
-	# The plug may not belong to an OptionTweaks node
-	# directly. Instead it may have been promoted
-	# elsewhere and be driving a target plug on an
-	# OptionTweaks node.
-
-	def walkOutputs( plug ) :
-
-		if isinstance( plug.node(), GafferScene.OptionTweaks ) :
-			return plug.node()
-
-		for output in plug.outputs() :
-			node = walkOutputs( output )
-			if node is not None :
-				return node
-
-	return walkOutputs( plugValueWidget.getPlug() )
-
-##########################################################################
 # _TweaksFooter
 ##########################################################################
 
@@ -188,12 +165,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 
 		result = IECore.MenuDefinition()
 
-		node = _optionTweaksNode( self )
-		options = {}
+		node = self.getPlug().node()
+		assert( isinstance( node, GafferScene.OptionTweaks ) )
 
-		if node is not None :
-			with self.getContext() :
-				options = node["out"]["globals"].getValue()
+		with self.getContext() :
+			options = node["out"]["globals"].getValue()
 
 		prefix = "option:"
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -651,11 +651,12 @@ class _PlugTableView( GafferUI.Widget ) :
 			# can show a plug menu. We should probably refactor so we can do it
 			# without the widget, but this would touch `PlugValueWidget.popupMenuSignal()`
 			# and all connected client code.
-			self.__menuPlugValueWidget = GafferUI.PlugValueWidget.create( plug )
-			definition = self.__menuPlugValueWidget._popupMenuDefinition()
+			self.__plugMenuParent = GafferUI.PlugValueWidget.create( plug )
+			definition = self.__plugMenuParent._popupMenuDefinition()
 
 		else :
 
+			self.__plugMenuParent = None
 			definition = IECore.MenuDefinition()
 
 		if self.__mode == self.Mode.RowNames :
@@ -664,7 +665,7 @@ class _PlugTableView( GafferUI.Widget ) :
 			self.__prependCellMenuItems( definition, selectedPlugs )
 
 		self.__plugMenu = GafferUI.Menu( definition )
-		self.__plugMenu.popup()
+		self.__plugMenu.popup( parent = self.__plugMenuParent )
 
 		return True
 

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -57,6 +57,17 @@ void replacePlug( GraphComponent &parent, Plug &plug )
 	PlugAlgo::replacePlug( &parent, &plug );
 }
 
+object findDestinationWrapper( Plug *plug, object predicate )
+{
+	return PlugAlgo::findDestination(
+		plug,
+		[&predicate] ( Plug *plug ) {
+			object o = predicate( PlugPtr( plug ) );
+			return o;
+		}
+	);
+}
+
 ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direction, unsigned flags, const IECore::Data *value )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -120,6 +131,7 @@ void GafferModule::bindPlugAlgo()
 
 	def( "replacePlug", &replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
 	def( "dependsOnCompute", &PlugAlgo::dependsOnCompute );
+	def( "findDestination", &findDestinationWrapper );
 
 	def( "createPlugFromData", &createPlugFromData );
 	def( "extractDataFromPlug", &extractDataFromPlug );


### PR DESCRIPTION
Multiple places in the UI need to find out if a plug is driving a particular input on a particular node type, taking into account promotion to Boxes and Spreadsheets. In each of these places we were repeating this logic in various forms, sometimes with Spreadsheet support and sometimes without. This PR consolidates all this traversal logic into a single `findDestination()` utility method, which takes a predicate that is responsible for determining when the search has been successful. This lets us remove a bunch of duplicate code from the UI.