### PR TITLE
GafferCycles : Hid internal plugs on shaders eg. `surface_mix_weight`.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Fixes
   - Fixed custom AOVs not being created properly for SVM shading mode only, OSL is not supported. (#5044).
   - Fixed distant light angle is in degrees and not radians.
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
+  - Hid internal shader plugs which shouldn't be exposed to the user (e.g. `surface_mix_weight`).
 - UVInspector : Fixed update delay when changing display transform.
 - Random : Fixed GIL management bug which could lead to hangs.
 

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -489,7 +489,8 @@ void setupPlugs( const ccl::NodeType *nodeType, Gaffer::GraphComponent *plugsPar
 	{
 		for( const ccl::SocketType &socketType : nodeType->inputs )
 		{
-			if( g_socketBlacklist.contains( { nodeType->name, socketType.name } ) )
+			if( g_socketBlacklist.contains( { nodeType->name, socketType.name } ) ||
+				( socketType.flags & ccl::SocketType::INTERNAL ) )
 			{
 				continue;
 			}


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Internal plugs/sockets on shaders that shouldn't have user access are now hidden/removed.

### Related issues ###

- 

### Dependencies ###

- 

### Breaking changes ###

- 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
