### PR TITLE
ImageView : Fix display transform regression

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,11 +19,13 @@ Improvements
 Fixes
 -----
 
+- Viewer :
+  - Fixed Default display transform so that it updates correctly when the default is changed via the Preferences dialogue, and when the context changes.
+  - Fixed drawing of image pixels to the left of the display window.
 - Cycles :
   - Fixed custom AOVs not being created properly for SVM shading mode only, OSL is not supported. (#5044).
   - Fixed distant light angle is in degrees and not radians.
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
-- ImageViewer : Fixed drawing of pixels to the left of the display window.
 - UVInspector : Fixed update delay when changing display transform.
 - Random : Fixed GIL management bug which could lead to hangs.
 

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Fixes
   - Fixed distant light angle is in degrees and not radians.
   - Fixed assignment of `emission` shader. Previously this was being assigned as a `cycles:light` attribute instead of `cycles:surface` (#5058).
 - ImageViewer : Fixed drawing of pixels to the left of the display window.
+- UVInspector : Fixed update delay when changing display transform.
 - Random : Fixed GIL management bug which could lead to hangs.
 
 1.1.6.1 (relative to 1.1.6.0)

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -132,6 +132,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		const ImageGadget *imageGadget() const;
 
 		void setContext( Gaffer::ContextPtr context ) override;
+		void contextChanged( const IECore::InternedString &name ) override;
 
 		using DisplayTransformCreator = std::function<GafferImage::ImageProcessorPtr ()>;
 
@@ -184,21 +185,24 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		bool keyPress( const GafferUI::KeyEvent &event );
 		void preRender();
 
-		void insertDisplayTransform();
-		void updateDisplayTransform();
-
 		struct DisplayTransformEntry
 		{
 			GafferImage::ImageProcessorPtr displayTransform;
 			IECoreGL::Shader::SetupPtr shader;
+			bool shaderDirty = true;
+			IECore::MurmurHash shaderHash;
 			bool supportsShader;
 		};
-
-		void setWipeActive( bool active );
 
 		using DisplayTransformMap = std::map<std::string, DisplayTransformEntry>;
 		DisplayTransformMap m_displayTransforms;
 		DisplayTransformEntry *m_displayTransformAndShader;
+
+		void insertDisplayTransform();
+		void displayTransformPlugDirtied( DisplayTransformEntry *displayTransform );
+		void updateDisplayTransform();
+
+		void setWipeActive( bool active );
 
 		IECore::BoolDataPtr m_absoluteValueParameter;
 		IECore::BoolDataPtr m_clippingParameter;

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -761,6 +761,7 @@ void UVView::plugSet( const Gaffer::Plug *plug )
 	if( plug == displayTransformPlug() )
 	{
 		m_displayTransformDirty = true;
+		viewportGadget()->renderRequestSignal()( viewportGadget() );
 	}
 }
 


### PR DESCRIPTION
The node for the "Default" transform registered by `startup/gui/ocio.py` is modified on the fly as users edit the preferences, so we need to respond to `plugDirtiedSignal()` and regenerate the shader.

The same preferences mechanism also allows users to specify OCIO context variables, which may themselves reference Gaffer context variables from the global context. So we need to scope that context when getting the processor, and make sure we dirty the shader when the context changes. The vast majority of context changes will be irrelevant though, and generating a shader isn't free. So we store a hash of the processor to avoid redundant repeat shader generation.