### PR TITLE
ShaderTweaks : Fix `Remove` mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 1.0.6.x (relative to 1.0.6.5)
 =======
 
+- ShaderTweaks : Fixed `Remove` mode.
 - FilterQuery : Fixed bug which prevented the output from updating when the input scene changed (#5066).
 - Random : Fixed GIL management bug which could lead to hangs.
 

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -433,5 +433,23 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 		colorTweak["enabled"].setValue( False )
 		self.assertTrue( "surface" not in tweaks["out"].attributes( "/group/plane" ) )
 
+	def testRemove( self ) :
+
+		light = GafferSceneTest.TestLight()
+		self.assertIn( "intensity", light["out"].attributes( "/light" )["light"].outputShader().parameters )
+
+		pathFilter = GafferScene.PathFilter()
+		pathFilter["paths"].setValue( IECore.StringVectorData( [ "/light" ] ) )
+
+		tweaks = GafferScene.ShaderTweaks()
+		tweaks["in"].setInput( light["out"] )
+		tweaks["shader"].setValue( "light" )
+		tweaks["filter"].setInput( pathFilter["out"] )
+
+		tweaks["tweaks"].addChild(
+			Gaffer.TweakPlug( "intensity", 2.0, mode = Gaffer.TweakPlug.Mode.Remove )
+		)
+		self.assertNotIn( "intensity", tweaks["out"].attributes( "/light" )["light"].outputShader().parameters )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -335,8 +335,17 @@ bool ShaderTweaks::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, Tweak
 					},
 					[&parameter, &modifiedShader]( const std::string &valueName, DataPtr newData )
 					{
-						modifiedShader.first->second->parameters()[parameter.name] = newData;
-						return true;
+						if( newData )
+						{
+							modifiedShader.first->second->parameters()[parameter.name] = newData;
+							return true;
+						}
+						else
+						{
+							return static_cast<bool>(
+								modifiedShader.first->second->parameters().erase( parameter.name )
+							);
+						}
 					},
 					missingMode
 				)


### PR DESCRIPTION
This was creating a parameter with a null value, rather than removing the parameter.
