### PR TITLE
Arnold ParameterAlgo : Accept InternedStringData for enum parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 - FilterQuery : Fixed bug which prevented the output from updating when the input scene changed (#5066).
 - Random : Fixed GIL management bug which could lead to hangs.
+- Arnold : Fixed rendering of `token` enum parameter values loaded from USD.
 
 1.0.6.5 (relative to 1.0.6.4)
 =======

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -1007,5 +1007,23 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 		self.assertEqual( texture.name, "image" )
 		self.assertEqual( texture.parameters["filename"].value, "myFile.tx" )
 
+	def testInternedStringsForEnumParameters( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"noiseHandle" : IECoreScene.Shader(
+					"cell_noise", "ai:surface",
+					{ "pattern" : IECore.InternedStringData( "worley1" ) }
+				),
+			},
+			output = "noiseHandle"
+		)
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			nodes = IECoreArnold.ShaderNetworkAlgo.convert( network, universe, "test" )
+			self.assertEqual( len( nodes ), 1 )
+			self.assertEqual( arnold.AiNodeGetStr( nodes[0], "pattern" ), "worley1" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -145,14 +145,21 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 				}
 				break;
 			case AI_TYPE_ENUM :
-				// Arnold supports setting enums with either the integer index or the string name
-
-				// First try getting an integer, but don't warn if it fails
+				// Arnold supports setting enums with either the integer index
+				// or the string name. First try getting an integer, but don't
+				// warn if it fails.
 				if( const IntData *data = runTimeCast<const IntData>( value ) )
 				{
 					AiNodeSetInt( node, name, data->readable() );
 				}
-				// Then try getting a string, with the usual warning if nothing has been found yet
+				// Maya exports enum parameters as `TfToken`, which get loaded
+				// as InternedStringData by Cortex. Try that next.
+				else if( const InternedStringData *data = runTimeCast<const InternedStringData>( value ) )
+				{
+					AiNodeSetStr( node, name, AtString( data->readable().c_str() ) );
+				}
+				// Then try getting a string, with the usual warning if nothing
+				// has been found yet.
 				else if( const StringData *data = dataCast<StringData>( name, value ) )
 				{
 					AiNodeSetStr( node, name, AtString( data->readable().c_str() ) );


### PR DESCRIPTION
As described in https://groups.google.com/g/gaffer-dev/c/L11sdhzF2YM?hl=en, Maya exports Arnold enum shader parameters as type `token` in USD. We then load those parameters as `InternedStringData` in Cortex so that they can be round-tripped back to `token` in USD. This commit adds support for exporting such parameter values successfully to Arnold, allowing the Maya exported shaders to render successfully in Gaffer.

This is similar to what we did for [string parameters](a540ceefbb286484b8def502b17df1732d21a253) and [attributes](4e03c93921b2edbdcfa0abdcd68aff2425016633) already. What's different this time is that before we were just being pragmatic and supporting `token` where we thought really the values should be `string`. This time I believe the `token` type is correct, as documented in an [obscure note](https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html#version-2-3) in the USDPreviewSurface spec. Basically, `string` should be used for open-ended string parameters, and `token` should be used for enum-like parameters. What this means is that we need to reconsider how we load enums in ArnoldShader (where we create StringData) and how we might support InternedString in things like ShaderTweaks. That can wait for another day though.