### PR TITLE
Remove Use of Imath Functionality that is Going To Be Deprecated

### DIFF
--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -39,8 +39,6 @@
 
 #include "Gaffer/Plug.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 namespace Gaffer
 {
 

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -66,8 +66,8 @@ class GAFFER_API CompoundNumericPlug : public ValuePlug
 			const std::string &name = defaultName<CompoundNumericPlug>(),
 			Direction direction=In,
 			T defaultValue = T( 0 ),
-			T minValue = T( Imath::limits<typename T::BaseType>::min() ),
-			T maxValue = T( Imath::limits<typename T::BaseType>::max() ),
+			T minValue = T( std::numeric_limits<typename T::BaseType>::lowest() ),
+			T maxValue = T( std::numeric_limits<typename T::BaseType>::max() ),
 			unsigned flags = Default,
 			IECore::GeometricData::Interpretation interpretation = IECore::GeometricData::None
 		);

--- a/include/Gaffer/NumericPlug.h
+++ b/include/Gaffer/NumericPlug.h
@@ -42,8 +42,6 @@
 
 #include "IECore/SimpleTypedData.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 namespace Gaffer
 {
 
@@ -61,8 +59,8 @@ class GAFFER_API NumericPlug : public ValuePlug
 			const std::string &name = defaultName<NumericPlug>(),
 			Direction direction=In,
 			T defaultValue = T(),
-			T minValue = Imath::limits<T>::min(),
-			T maxValue = Imath::limits<T>::max(),
+			T minValue = std::numeric_limits<T>::lowest(),
+			T maxValue = std::numeric_limits<T>::max(),
 			unsigned flags = Default
 		);
 		~NumericPlug() override;

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -62,7 +62,7 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.
-		AttributeProcessor( const std::string &name, size_t minInputs, size_t maxInputs = Imath::limits<size_t>::max() );
+		AttributeProcessor( const std::string &name, size_t minInputs, size_t maxInputs = std::numeric_limits<size_t>::max() );
 
 		/// Must be implemented by derived classes to return true if `input` is used
 		/// by `computeProcessedAttributes()`. Overrides must start by calling the base

--- a/include/GafferSceneUI/ContextAlgo.h
+++ b/include/GafferSceneUI/ContextAlgo.h
@@ -43,8 +43,6 @@
 
 #include "IECore/PathMatcher.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 namespace Gaffer
 {
 
@@ -99,7 +97,7 @@ GAFFERSCENEUI_API void expand( Gaffer::Context *context, const IECore::PathMatch
 
 /// Appends descendant paths to the current expansion up to a specified maximum depth.
 /// Returns a new PathMatcher containing the new leafs of this expansion.
-GAFFERSCENEUI_API IECore::PathMatcher expandDescendants( Gaffer::Context *context, const IECore::PathMatcher &paths, const GafferScene::ScenePlug *scene, int depth = Imath::limits<int>::max() );
+GAFFERSCENEUI_API IECore::PathMatcher expandDescendants( Gaffer::Context *context, const IECore::PathMatcher &paths, const GafferScene::ScenePlug *scene, int depth = std::numeric_limits<int>::max() );
 
 /// Clears the currently expanded paths
 GAFFERSCENEUI_API void clearExpansion( Gaffer::Context *context );

--- a/src/Gaffer/BoxPlug.cpp
+++ b/src/Gaffer/BoxPlug.cpp
@@ -56,8 +56,8 @@ BoxPlug<T>::BoxPlug(
 		new ChildType(
 			"min", direction,
 			defaultValue.min,
-			typename ChildType::ValueType( Imath::limits<typename ChildType::ValueType::BaseType>::min() ),
-			typename ChildType::ValueType( Imath::limits<typename ChildType::ValueType::BaseType>::max() ),
+			typename ChildType::ValueType( std::numeric_limits<typename ChildType::ValueType::BaseType>::lowest() ),
+			typename ChildType::ValueType( std::numeric_limits<typename ChildType::ValueType::BaseType>::max() ),
 			childFlags
 		)
 	);
@@ -66,8 +66,8 @@ BoxPlug<T>::BoxPlug(
 		new ChildType(
 			"max", direction,
 			defaultValue.max,
-			typename ChildType::ValueType( Imath::limits<typename ChildType::ValueType::BaseType>::min() ),
-			typename ChildType::ValueType( Imath::limits<typename ChildType::ValueType::BaseType>::max() ),
+			typename ChildType::ValueType( std::numeric_limits<typename ChildType::ValueType::BaseType>::lowest() ),
+			typename ChildType::ValueType( std::numeric_limits<typename ChildType::ValueType::BaseType>::max() ),
 			childFlags
 		)
 	);

--- a/src/Gaffer/NumericPlug.cpp
+++ b/src/Gaffer/NumericPlug.cpp
@@ -109,13 +109,13 @@ T NumericPlug<T>::defaultValue() const
 template<class T>
 bool NumericPlug<T>::hasMinValue() const
 {
-	return m_minValue!=Imath::limits<T>::min();
+	return m_minValue!=std::numeric_limits<T>::lowest();
 }
 
 template<class T>
 bool NumericPlug<T>::hasMaxValue() const
 {
-	return m_maxValue!=Imath::limits<T>::max();
+	return m_maxValue!=std::numeric_limits<T>::max();
 }
 
 template<class T>

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -216,8 +216,8 @@ ValuePlugPtr compoundNumericValuePlug( const std::string &name, Plug::Direction 
 		name,
 		direction,
 		value->readable(),
-		ValueType( Imath::limits<BaseType>::min() ),
-		ValueType( Imath::limits<BaseType>::max() ),
+		ValueType( std::numeric_limits<BaseType>::lowest() ),
+		ValueType( std::numeric_limits<BaseType>::max() ),
 		flags
 	);
 
@@ -235,8 +235,8 @@ ValuePlugPtr geometricCompoundNumericValuePlug( const std::string &name, Plug::D
 		name,
 		direction,
 		value->readable(),
-		ValueType( Imath::limits<BaseType>::min() ),
-		ValueType( Imath::limits<BaseType>::max() ),
+		ValueType( std::numeric_limits<BaseType>::lowest() ),
+		ValueType( std::numeric_limits<BaseType>::max() ),
 		flags,
 		value->getInterpretation()
 	);
@@ -275,8 +275,8 @@ ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direct
 				name,
 				direction,
 				static_cast<const FloatData *>( value )->readable(),
-				Imath::limits<float>::min(),
-				Imath::limits<float>::max(),
+				std::numeric_limits<float>::lowest(),
+				std::numeric_limits<float>::max(),
 				flags
 			);
 			return valuePlug;
@@ -287,8 +287,8 @@ ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direct
 				name,
 				direction,
 				static_cast<const IntData *>( value )->readable(),
-				Imath::limits<int>::min(),
-				Imath::limits<int>::max(),
+				std::numeric_limits<int>::lowest(),
+				std::numeric_limits<int>::max(),
 				flags
 			);
 			return valuePlug;

--- a/src/Gaffer/Transform2DPlug.cpp
+++ b/src/Gaffer/Transform2DPlug.cpp
@@ -62,8 +62,8 @@ Transform2DPlug::Transform2DPlug(
 			"translate",
 			direction,
 			defaultTranslate,
-			V2f( limits<float>::min() ),
-			V2f( limits<float>::max() ),
+			V2f( std::numeric_limits<float>::lowest() ),
+			V2f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);
@@ -73,8 +73,8 @@ Transform2DPlug::Transform2DPlug(
 			"rotate",
 			direction,
 			defaultRotate,
-			limits<float>::min(),
-			limits<float>::max(),
+			std::numeric_limits<float>::lowest(),
+			std::numeric_limits<float>::max(),
 			flags
 		)
 	);
@@ -84,8 +84,8 @@ Transform2DPlug::Transform2DPlug(
 			"scale",
 			direction,
 			defaultScale,
-			V2f( limits<float>::min() ),
-			V2f( limits<float>::max() ),
+			V2f( std::numeric_limits<float>::lowest() ),
+			V2f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);
@@ -95,8 +95,8 @@ Transform2DPlug::Transform2DPlug(
 			"pivot",
 			direction,
 			defaultPivot,
-			V2f( limits<float>::min() ),
-			V2f( limits<float>::max() ),
+			V2f( std::numeric_limits<float>::lowest() ),
+			V2f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);

--- a/src/Gaffer/TransformPlug.cpp
+++ b/src/Gaffer/TransformPlug.cpp
@@ -63,8 +63,8 @@ TransformPlug::TransformPlug(
 			"translate",
 			direction,
 			defaultTranslate,
-			V3f( limits<float>::min() ),
-			V3f( limits<float>::max() ),
+			V3f( std::numeric_limits<float>::lowest() ),
+			V3f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);
@@ -74,8 +74,8 @@ TransformPlug::TransformPlug(
 			"rotate",
 			direction,
 			defaultRotate,
-			V3f( limits<float>::min() ),
-			V3f( limits<float>::max() ),
+			V3f( std::numeric_limits<float>::lowest() ),
+			V3f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);
@@ -85,8 +85,8 @@ TransformPlug::TransformPlug(
 			"scale",
 			direction,
 			defaultScale,
-			V3f( limits<float>::min() ),
-			V3f( limits<float>::max() ),
+			V3f( std::numeric_limits<float>::lowest() ),
+			V3f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);
@@ -96,8 +96,8 @@ TransformPlug::TransformPlug(
 			"pivot",
 			direction,
 			defaultPivot,
-			V3f( limits<float>::min() ),
-			V3f( limits<float>::max() ),
+			V3f( std::numeric_limits<float>::lowest() ),
+			V3f( std::numeric_limits<float>::max() ),
 			flags
 		)
 	);

--- a/src/GafferArnold/ArnoldVDB.cpp
+++ b/src/GafferArnold/ArnoldVDB.cpp
@@ -72,7 +72,7 @@ Box3f boundAndAutoStepSize( const std::string &fileName, const std::set<std::str
 	file.setCopyMaxBytes( 0 );
 	file.open();
 
-	autoStepSize = Imath::limits<float>::max();
+	autoStepSize = std::numeric_limits<float>::max();
 
 	openvdb::BBoxd result;
 	for( std::set<std::string>::const_iterator it = sets.begin(), eIt = sets.end(); it != eIt; ++it )

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -77,8 +77,8 @@ Gaffer::Plug *setupNumericPlug( const AtNodeEntry *node, const AtParamEntry *par
 	using ValueType = typename PlugType::ValueType;
 
 	ValueType defaultValue = 0;
-	ValueType minValue = Imath::limits<ValueType>::min();
-	ValueType maxValue = Imath::limits<ValueType>::max();
+	ValueType minValue = std::numeric_limits<ValueType>::lowest();
+	ValueType maxValue = std::numeric_limits<ValueType>::max();
 
 	AtString name = AiParamGetName( parameter );
 	bool defaultOverridden = false;
@@ -241,8 +241,8 @@ Gaffer::Plug *setupColorPlug( const AtNodeEntry *node, const AtParamEntry *param
 
 	// Now create (or reuse) a plug as necessary.
 
-	ValueType minValue( Imath::limits<BaseType>::min() );
-	ValueType maxValue( Imath::limits<BaseType>::max() );
+	ValueType minValue( std::numeric_limits<BaseType>::lowest() );
+	ValueType maxValue( std::numeric_limits<BaseType>::max() );
 
 	PlugType *existingPlug = plugParent->getChild<PlugType>( name.c_str() );
 	if(

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -79,7 +79,7 @@ Gaffer::Plug *setupNumericPlug( const ccl::NodeType *nodeType, const ccl::Socket
 {
 	using ValueType = typename PlugType::ValueType;
 
-	ValueType minValue = Imath::limits<ValueType>::min();
+	ValueType minValue = std::numeric_limits<ValueType>::lowest();
 	if( socketType.type == ccl::SocketType::UINT )
 	{
 		minValue = 0;
@@ -97,7 +97,7 @@ Gaffer::Plug *setupNumericPlug( const ccl::NodeType *nodeType, const ccl::Socket
 		return existingPlug;
 	}
 
-	typename PlugType::Ptr plug = new PlugType( name, direction, defaultValue, minValue, Imath::limits<ValueType>::max(), Plug::Default );
+	typename PlugType::Ptr plug = new PlugType( name, direction, defaultValue, minValue, std::numeric_limits<ValueType>::max(), Plug::Default );
 	PlugAlgo::replacePlug( plugParent, plug );
 
 	return plug.get();
@@ -162,8 +162,8 @@ Gaffer::Plug *setupColorPlug( const ccl::NodeType *nodeType, const ccl::SocketTy
 	defaultValue[1] = defaultCValue->y;
 	defaultValue[2] = defaultCValue->z;
 
-	ValueType minValue( Imath::limits<BaseType>::min() );
-	ValueType maxValue( Imath::limits<BaseType>::max() );
+	ValueType minValue( std::numeric_limits<BaseType>::lowest() );
+	ValueType maxValue( std::numeric_limits<BaseType>::max() );
 
 	string name = boost::replace_first_copy( string( socketType.name.c_str() ), ".", "__" );
 	PlugType *existingPlug = plugParent->getChild<PlugType>( name );

--- a/src/GafferImage/Display.cpp
+++ b/src/GafferImage/Display.cpp
@@ -395,7 +395,7 @@ Display::Display( const std::string &name )
 			Plug::In,
 			0,
 			0,
-			Imath::limits<int>::max(),
+			std::numeric_limits<int>::max(),
 			Plug::Default & ~Plug::Serialisable
 		)
 	);
@@ -408,7 +408,7 @@ Display::Display( const std::string &name )
 			Plug::In,
 			0,
 			0,
-			Imath::limits<int>::max(),
+			std::numeric_limits<int>::max(),
 			Plug::Default & ~Plug::Serialisable
 		)
 	);

--- a/src/GafferImage/FormatPlug.cpp
+++ b/src/GafferImage/FormatPlug.cpp
@@ -59,7 +59,7 @@ FormatPlug::FormatPlug( const std::string &name, Direction direction, Format def
 {
 	const unsigned childFlags = flags & ~Dynamic;
 	addChild( new Box2iPlug( "displayWindow", direction, defaultValue.getDisplayWindow(), childFlags ) );
-	addChild( new FloatPlug( "pixelAspect", direction, defaultValue.getPixelAspect(), Imath::limits<float>::min(), Imath::limits<float>::max(), childFlags ) );
+	addChild( new FloatPlug( "pixelAspect", direction, defaultValue.getPixelAspect(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max(), childFlags ) );
 }
 
 FormatPlug::~FormatPlug()

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -419,8 +419,8 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 
 		IECore::ConstFloatVectorDataPtr channelData = flattenedInPlug()->channelDataPlug()->getValue();
 
-		float min = Imath::limits<float>::max();
-		float max = Imath::limits<float>::min();
+		float min = std::numeric_limits<float>::max();
+		float max = std::numeric_limits<float>::lowest();
 		double sum = 0.;
 
 		const std::vector<float> &channel = channelData->readable();
@@ -444,8 +444,8 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 			static_cast<ObjectPlug *>( output )->setValue( new IECore::V3dData( Imath::V3d( 0 ) ) );
 			return;
 		}
-		float min = Imath::limits<float>::max();
-		float max = Imath::limits<float>::min();
+		float min = std::numeric_limits<float>::max();
+		float max = std::numeric_limits<float>::lowest();
 		double sum = 0.;
 
 		// We traverse in TopToBottom order because floating point precision means that changing

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -1487,12 +1487,12 @@ ImageView::ImageView( const std::string &name )
 	addChild( clippingPlug );
 
 	FloatPlugPtr exposurePlug = new FloatPlug( "exposure", Plug::In, 0.0f,
-		Imath::limits<float>::min(), Imath::limits<float>::max(), Plug::Default & ~Plug::AcceptsInputs
+		std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max(), Plug::Default & ~Plug::AcceptsInputs
 	);
 	addChild( exposurePlug ); // dealt with in plugSet()
 
 	PlugPtr gammaPlug = new FloatPlug( "gamma", Plug::In, 1.0f,
-		Imath::limits<float>::min(), Imath::limits<float>::max(), Plug::Default & ~Plug::AcceptsInputs
+		std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max(), Plug::Default & ~Plug::AcceptsInputs
 	);
 	addChild( gammaPlug );
 

--- a/src/GafferModule/BoxPlugBinding.cpp
+++ b/src/GafferModule/BoxPlugBinding.cpp
@@ -90,8 +90,8 @@ void bind()
 					boost::python::arg_( "name" )=GraphComponent::defaultName<T>(),
 					boost::python::arg_( "direction" )=Plug::In,
 					boost::python::arg_( "defaultValue" )=V(),
-					boost::python::arg_( "minValue")=P( Imath::limits<B>::min() ),
-					boost::python::arg_( "maxValue")=P( Imath::limits<B>::max() ),
+					boost::python::arg_( "minValue")=P( std::numeric_limits<B>::lowest() ),
+					boost::python::arg_( "maxValue")=P( std::numeric_limits<B>::max() ),
 					boost::python::arg_( "flags" )=Plug::Default
 				)
 			)

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -146,8 +146,8 @@ void bind()
 					boost::python::arg_( "name" )=GraphComponent::defaultName<T>(),
 					boost::python::arg_( "direction" )=Plug::In,
 					boost::python::arg_( "defaultValue" )=V( 0 ),
-					boost::python::arg_( "minValue" )=V(Imath::limits<typename V::BaseType>::min()),
-					boost::python::arg_( "maxValue" )=V(Imath::limits<typename V::BaseType>::max()),
+					boost::python::arg_( "minValue" )=V(std::numeric_limits<typename V::BaseType>::lowest()),
+					boost::python::arg_( "maxValue" )=V(std::numeric_limits<typename V::BaseType>::max()),
 					boost::python::arg_( "flags" )=Plug::Default,
 					boost::python::arg_( "interpretation" )=IECore::GeometricData::None
 				)

--- a/src/GafferModule/NumericPlugBinding.cpp
+++ b/src/GafferModule/NumericPlugBinding.cpp
@@ -85,8 +85,8 @@ void bind()
 					boost::python::arg_( "name" )=GraphComponent::defaultName<T>(),
 					boost::python::arg_( "direction" )=Plug::In,
 					boost::python::arg_( "defaultValue" )=V(),
-					boost::python::arg_( "minValue" )=Imath::limits<V>::min(),
-					boost::python::arg_( "maxValue" )=Imath::limits<V>::max(),
+					boost::python::arg_( "minValue" )=std::numeric_limits<V>::lowest(),
+					boost::python::arg_( "maxValue" )=std::numeric_limits<V>::max(),
 					boost::python::arg_( "flags" )=Plug::Default
 				)
 			)

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -359,8 +359,8 @@ Plug *loadNumericParameter( const OSLQuery::Parameter *parameter, const Interned
 		defaultValue = ValueType( parameter->fdefault[0] );
 	}
 
-	ValueType minValue( Imath::limits<ValueType>::min() );
-	ValueType maxValue( Imath::limits<ValueType>::max() );
+	ValueType minValue( std::numeric_limits<ValueType>::lowest() );
+	ValueType maxValue( std::numeric_limits<ValueType>::max() );
 	if( metadata )
 	{
 		const TypedData<ValueType> *minMeta = metadata->member< TypedData<ValueType> >( "min" );
@@ -472,8 +472,8 @@ Plug *loadCompoundNumericParameter( const OSLQuery::Parameter *parameter, const 
 	}
 
 	/// \todo Get from metadata
-	ValueType minValue( Imath::limits<BaseType>::min() );
-	ValueType maxValue( Imath::limits<BaseType>::max() );
+	ValueType minValue( std::numeric_limits<BaseType>::lowest() );
+	ValueType maxValue( std::numeric_limits<BaseType>::max() );
 	if( metadata )
 	{
 		const TypedData<ValueType> *minMeta = metadata->member< TypedData<ValueType> >( "min" );

--- a/src/GafferOSLUI/OSLImageUI.cpp
+++ b/src/GafferOSLUI/OSLImageUI.cpp
@@ -144,7 +144,7 @@ class OSLImagePlugAdder : public PlugAdder
 				if( color4fDefaultData )
 				{
 					const Imath::Color4f &default4 = color4fDefaultData->readable();
-					alphaValuePlug = new FloatPlug( "value", Plug::In, default4[3], Imath::limits<float>::min(), Imath::limits<float>::max(), Plug::Flags::Default | Plug::Flags::Dynamic );
+					alphaValuePlug = new FloatPlug( "value", Plug::In, default4[3], std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max(), Plug::Flags::Default | Plug::Flags::Dynamic );
 					defaultData = new IECore::Color3fData( Imath::Color3f( default4[0], default4[1], default4[2] ) );
 				}
 

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -164,7 +164,7 @@ InteractiveRender::InteractiveRender( const IECore::InternedString &rendererType
 	addChild( new ScenePlug( "__adaptedIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
 	// Incremented when new messages are received, triggering a dirty signal for the output plug.
-	addChild( new IntPlug( "__messageUpdateCount", Plug::In, 0, 0, Imath::limits<int>::max(), Plug::Default & ~Plug::Serialisable ) );
+	addChild( new IntPlug( "__messageUpdateCount", Plug::In, 0, 0, std::numeric_limits<int>::max(), Plug::Default & ~Plug::Serialisable ) );
 
 	SceneProcessorPtr adaptors = SceneAlgo::createRenderAdaptors();
 	setChild( "__adaptors", adaptors );

--- a/src/GafferSceneUI/AttributeQueryUI.cpp
+++ b/src/GafferSceneUI/AttributeQueryUI.cpp
@@ -70,8 +70,8 @@ Gaffer::ConstValuePlugPtr createNumericPlug(
 	const std::string& name, const Gaffer::Plug::Direction direction, const ValueType& value, const unsigned flags )
 {
 	const Gaffer::ConstValuePlugPtr plug( new Gaffer::NumericPlug< ValueType >( name, direction, value,
-		ValueType( Imath::limits< ValueType >::min() ),
-		ValueType( Imath::limits< ValueType >::max() ), flags ) );
+		ValueType( std::numeric_limits< ValueType >::lowest() ),
+		ValueType( std::numeric_limits< ValueType >::max() ), flags ) );
 	return plug;
 }
 
@@ -80,8 +80,8 @@ Gaffer::ConstValuePlugPtr createCompoundNumericPlug(
 	const std::string& name, const Gaffer::Plug::Direction direction, const ValueType& value, const unsigned flags )
 {
 	const Gaffer::ConstValuePlugPtr plug( new Gaffer::CompoundNumericPlug< ValueType >( name, direction, value,
-		ValueType( Imath::limits< typename ValueType::BaseType >::min() ),
-		ValueType( Imath::limits< typename ValueType::BaseType >::max() ), flags ) );
+		ValueType( std::numeric_limits< typename ValueType::BaseType >::lowest() ),
+		ValueType( std::numeric_limits< typename ValueType::BaseType >::max() ), flags ) );
 	return plug;
 }
 
@@ -90,8 +90,8 @@ Gaffer::ConstValuePlugPtr createBoxPlug(
 	const std::string& name, const Gaffer::Plug::Direction direction, const Imath::Box< ValueType >& value, const unsigned flags )
 {
 	const Gaffer::ConstValuePlugPtr plug( new Gaffer::BoxPlug< Imath::Box< ValueType > >( name, direction, value,
-		ValueType( Imath::limits< typename ValueType::BaseType >::min() ),
-		ValueType( Imath::limits< typename ValueType::BaseType >::max() ), flags ) );
+		ValueType( std::numeric_limits< typename ValueType::BaseType >::lowest() ),
+		ValueType( std::numeric_limits< typename ValueType::BaseType >::max() ), flags ) );
 	return plug;
 }
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -1331,7 +1331,7 @@ class SceneView::Camera : public Signals::Trackable
 					"clippingPlanes", Plug::In,
 					V2f( 0.1, 100000 ),
 					V2f( 0.0001 ),
-					V2f( Imath::limits<float>::max() ),
+					V2f( std::numeric_limits<float>::max() ),
 					Plug::Default & ~Plug::AcceptsInputs
 				)
 			);
@@ -1343,7 +1343,7 @@ class SceneView::Camera : public Signals::Trackable
 					"lightLookThroughDefaultDistantAperture", Plug::In,
 					2.0f,
 					0.0f,
-					Imath::limits<float>::max(),
+					std::numeric_limits<float>::max(),
 					Plug::Default & ~Plug::AcceptsInputs
 				)
 			);
@@ -1352,8 +1352,8 @@ class SceneView::Camera : public Signals::Trackable
 				new Gaffer::V2fPlug(
 					"lightLookThroughDefaultClippingPlanes", Plug::In,
 					V2f( -100000, 100000 ),
-					V2f( Imath::limits<float>::min() ),
-					V2f( Imath::limits<float>::max() ),
+					V2f( std::numeric_limits<float>::lowest() ),
+					V2f( std::numeric_limits<float>::max() ),
 					Plug::Default & ~Plug::AcceptsInputs
 				)
 			);
@@ -1941,7 +1941,7 @@ SceneView::SceneView( const std::string &name )
 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new IntPlug( "minimumExpansionDepth", Plug::In, 0, 0, Imath::limits<int>::max(), Plug::Default & ~Plug::AcceptsInputs ) );
+	addChild( new IntPlug( "minimumExpansionDepth", Plug::In, 0, 0, std::numeric_limits<int>::max(), Plug::Default & ~Plug::AcceptsInputs ) );
 
 	plugSetSignal().connect( boost::bind( &SceneView::plugSet, this, ::_1 ) );
 

--- a/src/GafferSceneUIModule/ContextAlgoBinding.cpp
+++ b/src/GafferSceneUIModule/ContextAlgoBinding.cpp
@@ -126,7 +126,7 @@ void GafferSceneUIModule::bindContextAlgo()
 	def( "getLastSelectedPath", &getLastSelectedPathWrapper );
 	def( "affectsLastSelectedPath", &affectsLastSelectedPath );
 	def( "expand", &expandWrapper, ( arg( "expandAncestors" ) = true ) );
-	def( "expandDescendants", &expandDescendantsWrapper, ( arg( "context" ), arg( "paths" ), arg( "scene" ), arg( "depth" ) = Imath::limits<int>::max() ) );
+	def( "expandDescendants", &expandDescendantsWrapper, ( arg( "context" ), arg( "paths" ), arg( "scene" ), arg( "depth" ) = std::numeric_limits<int>::max() ) );
 	def( "clearExpansion", &clearExpansionWrapper );
 	def( "setSelectedPaths", &setSelectedPathsWrapper );
 	def( "getSelectedPaths", &getSelectedPaths );

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -1676,7 +1676,7 @@ bool GraphGadget::dragMove( GadgetPtr gadget, const DragDropEvent &event )
 			const std::vector<float> &snapOffsets = m_dragSnapOffsets[axis];
 
 			float offset = pos[axis] - m_dragStartPosition[axis];
-			float snappedDist = Imath::limits<float>::max();
+			float snappedDist = std::numeric_limits<float>::max();
 			float snappedOffset = offset;
 			vector<float>::const_iterator it = lower_bound( snapOffsets.begin(), snapOffsets.end(), offset );
 			if( it != snapOffsets.end() )

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -394,7 +394,7 @@ float StandardConnectionGadget::distanceToNodeGadget( const IECore::LineSegment3
 	const NodeGadget *nodeGadget = nodule ? nodule->ancestor<NodeGadget>() : nullptr;
 	if( !nodeGadget )
 	{
-		return Imath::limits<float>::max();
+		return std::numeric_limits<float>::max();
 	}
 
 	const M44f relativeTransform = fullTransform() * nodeGadget->fullTransform().inverse();

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -743,8 +743,8 @@ class LayoutEngine
 		{
 			// Offsets of plugs relative to
 			// parent node origin.
-			V2f sourceOffset;
-			V2f targetOffset;
+			V2f sourceOffset = V2f( 0.0f );
+			V2f targetOffset = V2f( 0.0f );
 
 			Direction sourceTangent;
 			Direction targetTangent;

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -1167,7 +1167,7 @@ ConnectionCreator *StandardNodeGadget::closestDragDestination( const DragDropEve
 	}
 
 	ConnectionCreator *result = nullptr;
-	float maxDist = Imath::limits<float>::max();
+	float maxDist = std::numeric_limits<float>::max();
 
 	for( ConnectionCreator::RecursiveIterator it( this ); !it.done(); it++ )
 	{

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -482,7 +482,7 @@ V3f auxiliaryConnectionArrowPosition( const Box2f &dstNodeFrame, const V3f &p, c
 {
 	const float offset = 1.0;
 
-	float xT = limits<float>::max();
+	float xT = std::numeric_limits<float>::max();
 	if( v.x > 0 )
 	{
 		xT = ( offset + dstNodeFrame.max.x - p.x ) / v.x;
@@ -492,7 +492,7 @@ V3f auxiliaryConnectionArrowPosition( const Box2f &dstNodeFrame, const V3f &p, c
 		xT = ( offset + p.x - dstNodeFrame.min.x ) / -v.x;
 	}
 
-	float yT = limits<float>::max();
+	float yT = std::numeric_limits<float>::max();
 	if( v.y > 0 )
 	{
 		yT = ( offset + dstNodeFrame.max.y - p.y ) / v.y;

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1653,7 +1653,7 @@ bool ViewportGadget::mouseMove( GadgetPtr gadget, const ButtonEvent &event )
 IECore::RunTimeTypedPtr ViewportGadget::dragBegin( GadgetPtr gadget, const DragDropEvent &event )
 {
 	m_dragButton = event.buttons;
-	m_dragTrackingThreshold = limits<float>::max();
+	m_dragTrackingThreshold = std::numeric_limits<float>::max();
 
 	CameraController::MotionType cameraMotionType = m_cameraController->cameraMotionType( event, m_variableAspectZoom, m_preciseMotionAllowed );
 	bool unmodifiedMiddleDrag = event.buttons == ButtonEvent::Middle && event.modifiers == ModifiableEvent::None;


### PR DESCRIPTION
As with the corresponding Cortex PR, these changes already make sense, and get us closer to being able to use Imath 3.

There is also a branch which looks into actually being ready for imath 3, but before we PR that we need to decide whether to preserve backwards compatibility: https://github.com/danieldresser-ie/gaffer/tree/imath3