### PR TITLE
GafferCycles : Disable auto-tile for interactive and viewport rendering.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.1.x.x (relative to 1.1.7.0)
+=======
+
+Fixes
+-----
+
+- Cycles : Disabled auto-tiling mode for the viewport/interactive render mode, which caused odd/glitchy behaviour on larger than 2k renders.
+
 1.1.7.0 (relative to 1.1.6.1)
 =======
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2546,6 +2546,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			{
 				m_sessionParams.headless = false;
 				m_sessionParams.background = false;
+				m_sessionParams.use_auto_tile = false;
 				m_sceneParams.bvh_type = ccl::BVH_TYPE_DYNAMIC;
 			}
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Disables auto-tiling render behaviour for interactive and viewport rendering, which would split the render into 2k blocks by default. This caused odd behaviour especially for viewport rendering where it has half the screen corrupt on 4k monitors (it does eventually render correctly).

![Screenshot from 2023-01-13 23-31-24](https://user-images.githubusercontent.com/5601445/212322355-43cc0f50-7b8f-4035-a895-7f2c25f53cd9.png)

### Related issues ###

- 

### Dependencies ###

- 

### Breaking changes ###

- 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
