### PR TITLE
GafferCycles : Mesh-light improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,10 @@
+1.1.x.x (relative to 1.1.6.1)
+
+Improvements
+------------
+
+- Cycles : Added `useMis` and more visibility flags and removed the previously erroneous removal of non-camera visibility flags to the Mesh Light.
+
 1.1.7.0 (relative to 1.1.6.1)
 =======
 

--- a/python/GafferCyclesUI/CyclesMeshLightUI.py
+++ b/python/GafferCyclesUI/CyclesMeshLightUI.py
@@ -64,6 +64,81 @@ Gaffer.Metadata.registerNode(
 			rays.
 			""",
 
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"diffuseVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible to diffuse
+			rays.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"glossyVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible in
+			glossy rays.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"transmissionVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible in
+			transmission.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"shadowVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible to shadow
+			rays - whether it casts shadows or not.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"scatterVisibility" : [
+
+			"description",
+			"""
+			Whether or not the object is visible to
+			scatter rays.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"useMis" : [
+
+			"description",
+			"""
+			Use multiple importance sampling for this material,
+			disabling may reduce overall noise for large
+			objects that emit little light compared to other light sources.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
 		],
 
 		"lightGroup" : [
@@ -72,6 +147,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The light group that the mesh light will contribute to.
 			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
 
 		],
 

--- a/python/GafferCyclesUI/ShaderMenu.py
+++ b/python/GafferCyclesUI/ShaderMenu.py
@@ -72,7 +72,7 @@ def appendShaders( menuDefinition, prefix="/Cycles" ) :
 		nodeCreator = functools.partial( __lightCreator, lightName, GafferCycles.CyclesLight )
 		menuItems.append( MenuItem( "%s/%s" % ( menuPath, displayName ), nodeCreator ) )
 
-	menuItems.append( MenuItem( "%s/%s" % ( "Light", "MeshLight" ), GafferCycles.CyclesMeshLight ) )
+	menuItems.append( MenuItem( "%s/%s" % ( "Light", "Mesh Light" ), GafferCycles.CyclesMeshLight ) )
 
 	# Create the actual menu items.
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Progress on https://github.com/GafferHQ/gaffer/issues/5060 :

![Screenshot from 2023-01-14 00-36-32](https://user-images.githubusercontent.com/5601445/212332585-8068ea43-b937-47a5-a846-1316de6f8a6d.png)

I've added `useMis` and more visibility flags and removed the previously erroneous removal of non-camera visibility flags to the Mesh Light, as well as some cosmetic metadata UI fixups.

With a bit of testing, I didn't realise that the visibility flags corresponded to the mesh-light's contribution to other objects, rather than other objects contributing to the mesh-light and this is what the code is showing as well:
https://github.com/blender/cycles/blob/master/src/scene/light.cpp#L341
So I removed this behaviour, it was also causing it to not be a mesh-light here due to them being disabled (which is probably why I thought it was "working" but noisy, as it was regular emission at that point):
https://github.com/blender/cycles/blob/master/src/scene/light.cpp#L252
After this change, mesh-lights sample a _lot_ better at lower samples.

I haven't addressed making virtual intensity, exposure and normalize yet, any tips on that? Maybe I should make some expression in-code under the hood or a hidden shader network of `math` nodes? I am wondering if we do indeed just keep it as a surface and not a light, as we would also lose motion step samples probably.

Also, any ideas on unit-tests? It's mostly cosmetic UI fixes.

### Related issues ###

- https://github.com/GafferHQ/gaffer/issues/5060

### Dependencies ###

-

### Breaking changes ###

-

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
