### PR TITLE
GafferDelight : Import IECoreDelight on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 - FilteredSceneProcessor :
   - Fixed bugs which allowed read-only nodes to be edited.
   - Fixed undo for `Remove` menu item in Filter tab.
+- 3Delight : Fixed bug preventing 3delight from loading on Windows. (#5081). This also caused errors in the light editor at startup : `IECore.Exception: File "maya/osl/pointLight" could not be found.` [^2]
 
 API
 ---
@@ -28,6 +29,9 @@ Breaking Changes
 ----------------
 
 - Arnold : Changed the default values for the `ai:GI_diffuse_depth` and `ai:GI_specular_depth` options.
+
+[^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
+[^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 
 1.2.0.0a2 (relative to 1.2.0.0a1)
 =========

--- a/python/GafferDelight/__init__.py
+++ b/python/GafferDelight/__init__.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+__import__( "IECoreDelight" )
 __import__( "GafferScene" )
 
 from ._GafferDelight import *

--- a/python/IECoreDelight/__init__.py
+++ b/python/IECoreDelight/__init__.py
@@ -35,3 +35,18 @@
 ##########################################################################
 
 from ._IECoreDelight import *
+
+# The IECoreDelight module does not need any symbols from IECoreDelight, so MSVC tries
+# to be helpful and not load IECoreDelight.dll. Skipping that means that
+# 3Delight is never registered as a renderer, so we import / register it manually.
+
+import os
+
+if os.name == "nt" :
+
+	import ctypes
+
+	try :
+		ctypes.CDLL( "IECoreDelight.dll" )
+	except :
+		raise ImportError


### PR DESCRIPTION
GafferDelight does not need any symbols from IECoreDelight, so MSVC tries to be helpful and not load IECoreDelight.dll. Skipping that means that 3Delight is never registered as a renderer, so we import / register it manually.

This was causing errors loading the UI because GafferDelight was not throwing an exception when it was expected to. It also caused Gaffer to crash when trying to render with 3delight.

Fixes #5081 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
