### PR TITLE
ShaderView config : Prefer Arnold to Appleseed for OSL shader previews

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.0.0ax (relative to 1.2.0.0a2)
 =========
 
+Improvements
+------------
+
+- Viewer : If Arnold is available, then it is preferred over Appleseed for performing OSL shader previews. If neither is available, then Cycles will be used (#5084).
+
 Fixes
 -----
 

--- a/startup/gui/shaderView.py
+++ b/startup/gui/shaderView.py
@@ -40,6 +40,33 @@ import IECore
 
 import GafferSceneUI
 
+if os.environ.get( "CYCLES_ROOT" ) :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		import GafferCycles
+
+		GafferSceneUI.ShaderView.registerRenderer( "cycles", GafferCycles.InteractiveCyclesRender )
+
+		def __cyclesShaderBall() :
+
+			result = GafferCycles.CyclesShaderBall()
+
+			# Reserve some cores for the rest of the UI
+			result["threads"]["enabled"].setValue( True )
+			result["threads"]["value"].setValue( -3 )
+
+			# Less issues when mixing around OSL shaders
+			result["shadingSystem"]["enabled"].setValue( True )
+			result["shadingSystem"]["value"].setValue( "OSL" )
+
+			return result
+
+		GafferSceneUI.ShaderView.registerScene( "cycles", "Default", __cyclesShaderBall )
+
+		GafferSceneUI.ShaderView.registerRenderer( "osl", GafferCycles.InteractiveCyclesRender )
+		GafferSceneUI.ShaderView.registerScene( "osl", "Default", __cyclesShaderBall )
+
 with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferAppleseed
@@ -78,26 +105,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	GafferSceneUI.ShaderView.registerScene( "ai", "Default", __arnoldShaderBall )
 
-if os.environ.get( "CYCLES_ROOT" ) :
-
-	with IECore.IgnoredExceptions( ImportError ) :
-
-		import GafferCycles
-
-		GafferSceneUI.ShaderView.registerRenderer( "cycles", GafferCycles.InteractiveCyclesRender )
-
-		def __cyclesShaderBall() :
-
-			result = GafferCycles.CyclesShaderBall()
-
-			# Reserve some cores for the rest of the UI
-			result["threads"]["enabled"].setValue( True )
-			result["threads"]["value"].setValue( -3 )
-
-			# Less issues when mixing around OSL shaders
-			result["shadingSystem"]["enabled"].setValue( True )
-			result["shadingSystem"]["value"].setValue( "OSL" )
-
-			return result
-
-		GafferSceneUI.ShaderView.registerScene( "cycles", "Default", __cyclesShaderBall )
+	# If Arnold is available, then we assume that the user would prefer
+	# it over Appleseed or Cycles for OSL previews.
+	GafferSceneUI.ShaderView.registerRenderer( "osl", GafferArnold.InteractiveArnoldRender )
+	GafferSceneUI.ShaderView.registerScene( "osl", "Default", __arnoldShaderBall )


### PR DESCRIPTION
And fall back to Cycles if neither is available. This particularly important on Windows, where we're not shipping with Appleseed.

Fixes #5084
