### PR TITLE
ArnoldOptions : Add user defaults for GI depth plugs 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.2.0.0ax (relative to 1.2.0.0a2)
+=========
+
+Fixes
+-----
+
+- NodeEditor : Fixed bugs in handling of "green dot" non-default-value indicators with nested plugs.
+
 1.2.0.0a2 (relative to 1.2.0.0a1)
 =========
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -602,6 +602,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.giDiffuseDepth.value" : [
+
+			"userDefault", 0,
+
+		],
+
 		"options.giSpecularDepth" : [
 
 			"description",
@@ -612,6 +618,12 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Ray Depth",
 			"label", "Specular Depth",
+
+		],
+
+		"options.giSpecularDepth.value" : [
+
+			"userDefault", 0,
 
 		],
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -383,28 +383,7 @@ class PlugLayout( GafferUI.Widget ) :
 		if hasattr( widget, 'getPlugs' ) :
 			plugs = widget.getPlugs()
 
-		for plug in plugs :
-			if PlugLayout.__plugValueChanged( plug ) :
-				return True
-
-		return False
-
-	@staticmethod
-	def __plugValueChanged( plug ) :
-
-		## \todo This mirrors LabelPlugValueWidget. This doesn't handle child plug defaults/connections
-		# properly. We need to improve NodeAlgo when we have the next API break.
-
-		if plug.direction() == Gaffer.Plug.Direction.Out :
-			return False
-		elif plug.getInput() is not None :
-			return True
-		elif not isinstance( plug, Gaffer.ValuePlug ) :
-			return False
-		elif Gaffer.NodeAlgo.hasUserDefault( plug ) :
-			return not Gaffer.NodeAlgo.isSetToUserDefault( plug )
-		else :
-			return not plug.isSetToDefault()
+		return any( GafferUI.LabelPlugValueWidget._hasUserValue( p ) for p in plugs )
 
 	def __import( self, path ) :
 

--- a/python/GafferUITest/LabelPlugValueWidgetTest.py
+++ b/python/GafferUITest/LabelPlugValueWidgetTest.py
@@ -1,0 +1,141 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class LabelPlugValueWidgetTest( GafferUITest.TestCase ) :
+
+	def testHasUserValue( self ) :
+
+		node = Gaffer.Node()
+		node["user"]["v"] = Gaffer.V2fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		# No user-made edits to the value.
+
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+
+		# Even if it happens to be at the default value, the existence of a connection
+		# means that we consider the value to be user-provided. This differs from
+		# `ValuePlug.isSetToDefault()` which allows input connections if they provide
+		# a static (non-context-sensitive) value that matches the default value. For
+		# `ValuePlug` we only care about things that impact computed results, but for
+		# `LabelPlugValueWidget` we want to highlight any edits made by the user.
+
+		node["user"]["v"]["x"].setInput( node["user"]["v"]["y"] )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+
+		# And that applies even if a user default was registered on a parent plug.
+
+		Gaffer.Metadata.registerValue( node["user"]["v"], "userDefault", imath.V2f( 0 ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+
+		# If we remove the connection, we should be back to the default state.
+
+		node["user"]["v"]["x"].setInput( None )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+
+		# If the value differs to the user default, then that's a user-provided value,
+		# even if `ValuePlug.isSetToDefault()` is True.
+
+		Gaffer.Metadata.registerValue( node["user"]["v"], "userDefault", imath.V2f( 1, 2 ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertTrue( node["user"]["v"].isSetToDefault() )
+
+		# But if the value of the plug matches the user default, then it hasn't been
+		# edited by the user, regardless of what `ValuePlug.isSetToDefault()` might say.
+
+		Gaffer.NodeAlgo.applyUserDefault( node["user"]["v"] )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( node["user"]["v"].isSetToDefault() )
+
+		# And this all applies if we put the user default on the leaf plugs instead.
+
+		Gaffer.Metadata.deregisterValue( node["user"]["v"], "userDefault" )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertTrue( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+
+		Gaffer.Metadata.registerValue( node["user"]["v"]["x"], "userDefault", 1 )
+		Gaffer.Metadata.registerValue( node["user"]["v"]["y"], "userDefault", 2 )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( node["user"]["v"].isSetToDefault() )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+
+		# Output plugs are never considered to have user edits, because the user doesn't
+		# provide their values directly.
+
+		node["user"]["o"] = Gaffer.V2fPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["y"] ) )
+
+		node["user"]["o"]["y"].setInput( node["user"]["o"]["x"] )
+
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["v"]["y"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["x"] ) )
+		self.assertFalse( GafferUI.LabelPlugValueWidget._hasUserValue( node["user"]["o"]["y"] ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -128,6 +128,7 @@ from .CodeWidgetTest import CodeWidgetTest
 from .PathColumnTest import PathColumnTest
 from .ToolTest import ToolTest
 from .StandardNodeToolbarTest import StandardNodeToolbarTest
+from .LabelPlugValueWidgetTest import LabelPlugValueWidgetTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
The intention with the ArnoldOptions plugs is that they should have the same default values as Arnold itself. So you only need to enable one and change it if you don't want the Arnold default. But Arnold's default for `GI_diffuse_depth` and `GI_specular_depth` is `0` and not `2`, so we messed up at some point.

We can't change the actual default value of the plugs, because that will break old serialisations (because we omit `setValue()` calls when plugs are at the default value). But we can register `userDefault` metadata so that newly created nodes will be given the proper "default" via a `setValue()` call.

Adding the `userDefault` revealed bugs in the "green dot" logic in the NodeEditor, which I've also fixed. I really wasn't sure where to put the new logic or what to call it, but it seemed so specific to the behaviour we want in the NodeEditor that I didn't move it anywhere more central, despite the pre-existing "todo". Thoughts welcome.