### PR TITLE
MenuButton : Fix missing arrow indicator in PresetsPlugValueWidget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Cycles : Disabled auto-tiling mode for the viewport/interactive render mode, which caused odd/glitchy behaviour on larger than 2k renders [^1].
+- Menu buttons : Fixed missing dropdown menu indicators.
 
 API
 ---

--- a/python/GafferUI/MenuButton.py
+++ b/python/GafferUI/MenuButton.py
@@ -88,7 +88,11 @@ class MenuButton( GafferUI.Button ) :
 		# we also can't use the QPushButton::menu-indicator subcontrol to
 		# style menus. Instead we use this custom property to drive the
 		# stylesheet.
-		self._qtWidget().setProperty( "gafferMenuIndicator", text != "" )
+		wantMenuIndicator = bool( text )
+		haveMenuIndicator = self._qtWidget().property( "gafferMenuIndicator" ) or False
+		if wantMenuIndicator != haveMenuIndicator :
+			self._qtWidget().setProperty( "gafferMenuIndicator", wantMenuIndicator )
+			self._repolish()
 
 	def setErrored( self, errored ) :
 


### PR DESCRIPTION
This was broken in 5b22c8fcd9e96bbc88d833c81a60c51e4fac7426, because it moved the first `setText()` call _after_ the point the widget was first shown and polished. After that, if we want any Qt property changes to be picked up by the stylesheet, we must do a manual repolish.
