### PR TITLE
Arnold Renderer : Change default values for GI ray depth options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,12 +10,18 @@ Fixes
 -----
 
 - Cycles : Disabled auto-tiling mode for the viewport/interactive render mode, which caused odd/glitchy behaviour on larger than 2k renders [^1].
+- Arnold : The `ai:GI_diffuse_depth` and `ai:GI_specular_depth` options now default to `2` when they are left unspecified, matching the default values on the ArnoldOptions node.
 - Menu buttons : Fixed missing dropdown menu indicators.
 
 API
 ---
 
 - PlugAlgo : Added `findDestination()` utility method.
+
+Breaking Changes
+----------------
+
+- Arnold : Changed the default values for the `ai:GI_diffuse_depth` and `ai:GI_specular_depth` options.
 
 1.2.0.0a2 (relative to 1.2.0.0a1)
 =========

--- a/python/GafferArnoldTest/ArnoldTextureBakeTest.py
+++ b/python/GafferArnoldTest/ArnoldTextureBakeTest.py
@@ -147,8 +147,15 @@ class ArnoldTextureBakeTest( GafferSceneTest.SceneTestCase ) :
 			combineGroup["in"][-1].setInput( light["out"] )
 			lights.append( light )
 
+		arnoldOptions = GafferArnold.ArnoldOptions()
+		arnoldOptions["in"].setInput( combineGroup["out"] )
+		arnoldOptions["options"]["giDiffuseDepth"]["enabled"].setValue( True )
+		arnoldOptions["options"]["giDiffuseDepth"]["value"].setValue( 0 )
+		arnoldOptions["options"]["giSpecularDepth"]["enabled"].setValue( True )
+		arnoldOptions["options"]["giSpecularDepth"]["value"].setValue( 0 )
+
 		arnoldTextureBake = GafferArnold.ArnoldTextureBake()
-		arnoldTextureBake["in"].setInput( combineGroup["out"] )
+		arnoldTextureBake["in"].setInput( arnoldOptions["out"] )
 		arnoldTextureBake["filter"].setInput( allFilter["out"] )
 		arnoldTextureBake["bakeDirectory"].setValue( self.temporaryDirectory() / 'bakeSpheres' )
 		arnoldTextureBake["defaultResolution"].setValue( 32 )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -4073,6 +4073,28 @@ class RendererTest( GafferTest.TestCase ) :
 		r.option( "ai:texture_auto_generate_tx", IECore.BoolData( False ) )
 		self.assertEqual( arnold.AiNodeGetBool( options, "texture_auto_generate_tx" ), False )
 
+	def testDiffuseAndSpecularDepthDefaults( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		universe = ctypes.cast( r.command( "ai:queryUniverse", {} ), ctypes.POINTER( arnold.AtUniverse ) )
+		options = arnold.AiUniverseGetOptions( universe )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_diffuse_depth" ), 2 )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_specular_depth" ), 2 )
+
+		r.option( "ai:GI_diffuse_depth", IECore.IntData( 3 ) )
+		r.option( "ai:GI_specular_depth", IECore.IntData( 4 ) )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_diffuse_depth" ), 3 )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_specular_depth" ), 4 )
+
+		r.option( "ai:GI_diffuse_depth", None )
+		r.option( "ai:GI_specular_depth", None )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_diffuse_depth" ), 2 )
+		self.assertEqual( arnold.AiNodeGetInt( options, "GI_specular_depth" ), 2 )
+
 	@staticmethod
 	def __m44f( m ) :
 


### PR DESCRIPTION
As discussed in #5087, this changes the Arnold renderer defaults to match the ArnoldOptions defaults for ray depth, rather than vice versa.