### PR TITLE
ImageView : Fix display transform update bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Viewer : Fixed bug which made it impossible to switch back to a previously used display transform.
 - Cycles : Disabled auto-tiling mode for the viewport/interactive render mode, which caused odd/glitchy behaviour on larger than 2k renders.
 
 1.1.7.0 (relative to 1.1.6.1)

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -2020,29 +2020,32 @@ void ImageView::preRender()
 	{
 		viewportGadget()->setPostProcessShader( nullptr );
 	}
-	else if( !m_displayTransformAndShader->shader || m_displayTransformAndShader->shaderDirty )
+	else
 	{
-		if( !m_displayTransformAndShader->displayTransform )
+		if( !m_displayTransformAndShader->shader || m_displayTransformAndShader->shaderDirty )
 		{
-			m_displayTransformAndShader->shader = OpenColorIOAlgo::displayTransformToFramebufferShader( nullptr );
-		}
-		else
-		{
-			Context::Scope scope( getContext() );
-			const OpenColorIOTransform *ocioTrans = runTimeCast<const OpenColorIOTransform>(
-				m_displayTransformAndShader->displayTransform.get()
-			);
-
-			const IECore::MurmurHash h = ocioTrans->processorHash();
-			if( h != m_displayTransformAndShader->shaderHash )
+			if( !m_displayTransformAndShader->displayTransform )
 			{
-				m_displayTransformAndShader->shader = OpenColorIOAlgo::displayTransformToFramebufferShader(
-					ocioTrans->processor().get()
-				);
-				m_displayTransformAndShader->shaderHash = h;
+				m_displayTransformAndShader->shader = OpenColorIOAlgo::displayTransformToFramebufferShader( nullptr );
 			}
+			else
+			{
+				Context::Scope scope( getContext() );
+				const OpenColorIOTransform *ocioTrans = runTimeCast<const OpenColorIOTransform>(
+					m_displayTransformAndShader->displayTransform.get()
+				);
+
+				const IECore::MurmurHash h = ocioTrans->processorHash();
+				if( h != m_displayTransformAndShader->shaderHash )
+				{
+					m_displayTransformAndShader->shader = OpenColorIOAlgo::displayTransformToFramebufferShader(
+						ocioTrans->processor().get()
+					);
+					m_displayTransformAndShader->shaderHash = h;
+				}
+			}
+			m_displayTransformAndShader->shaderDirty = false;
 		}
-		m_displayTransformAndShader->shaderDirty = false;
 
 		m_displayTransformAndShader->shader->addUniformParameter( "absoluteValue", m_absoluteValueParameter );
 		m_displayTransformAndShader->shader->addUniformParameter( "clipping", m_clippingParameter );


### PR DESCRIPTION
This manifested itself as it being impossible to switch back to a previously used display transform in the Viewer. It was introduced in 549726641a6e4448d3d8f3a1d6e86263ba78c0a2, where I failed to realise that we were previously setting the post process shader unconditionally before _every_ frame, and that was necessary in order to process any new assignments to `m_displayTransformAndShader`. This seems wasteful, but this commit goes back to that approach as its the easiest way of fixing the bug without rejigging things on a larger scale.
