### PR TITLE
Arnold Renderer test : Support beta versions

### DIFF
--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3886,7 +3886,7 @@ class RendererTest( GafferTest.TestCase ) :
 			{ "diffuse_{}.{}".format( g, c ) for g in lightGroups for c in "RGB" }
 		)
 
-	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion() ] < [ 7, 1, 3, 0 ], "Fails due to bug ARNOLD-12282" )
+	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 1, 3 ], "Fails due to bug ARNOLD-12282" )
 	def testLightGroupBeautyOutputWithLayerName( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
@@ -4052,7 +4052,7 @@ class RendererTest( GafferTest.TestCase ) :
 			plane = arnold.AiNodeLookUpByName( universe, "testPlane" )
 			self.assertEqual( arnold.AiNodeGetStr( plane, "user:myString" ), "test" )
 
-	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion() ] < [ 7, 1, 4, 0 ], "Option not available in Arnold" )
+	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 1, 4 ], "Option not available in Arnold" )
 	def testTextureAutoGenerate( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(


### PR DESCRIPTION
In this case the 4th element of the version tuple contains a non-numeric beta designation string, so we must omit it from the conversion to int.
