### PR TITLE
Tidy whitespace on Windows

### DIFF
--- a/include/GafferCycles/Export.h
+++ b/include/GafferCycles/Export.h
@@ -43,9 +43,9 @@
 // GafferCycles, or including headers for linking to it. the GAFFERCYCLES_API
 // macro is the one that is used in the class definitions.
 #ifdef GafferCycles_EXPORTS
-  #define GAFFERCYCLES_API IECORE_EXPORT
+	#define GAFFERCYCLES_API IECORE_EXPORT
 #else
-  #define GAFFERCYCLES_API IECORE_IMPORT
+	#define GAFFERCYCLES_API IECORE_IMPORT
 #endif
 
 #endif // #ifndef GAFFERCYCLES_EXPORT_H

--- a/include/GafferCycles/IECoreCyclesPreview/Export.h
+++ b/include/GafferCycles/IECoreCyclesPreview/Export.h
@@ -39,16 +39,16 @@
 
 // Comment out if/when placed into Cortex
 #ifdef GafferCycles_EXPORTS
-  #define IECoreCycles_EXPORTS
+	#define IECoreCycles_EXPORTS
 #endif
 
 // define IECORECYCLES_API macro based on whether or not we are compiling
 // IECoreCycles, or including headers for linking to it. the
 // IECORECYCLES_API macro is the one that is used in the class definitions.
 #ifdef IECoreCycles_EXPORTS
-  #define IECORECYCLES_API IECORE_EXPORT
+	#define IECORECYCLES_API IECORE_EXPORT
 #else
-  #define IECORECYCLES_API IECORE_IMPORT
+	#define IECORECYCLES_API IECORE_IMPORT
 #endif
 
 #endif // #ifndef IECORECYCLES_EXPORT_H

--- a/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.h
@@ -59,11 +59,13 @@ IECORECYCLES_API ccl::ShaderInput  *input( ccl::ShaderNode *node, IECore::Intern
 IECORECYCLES_API ccl::ShaderOutput *output( ccl::ShaderNode *node, IECore::InternedString name );
 
 
-IECORECYCLES_API ccl::ShaderGraph *convertGraph( const IECoreScene::ShaderNetwork *surfaceShader,
-                                                 const IECoreScene::ShaderNetwork *displacementShader,
-                                                 const IECoreScene::ShaderNetwork *volumeShader,
-                                                 ccl::ShaderManager *shaderManager,
-                                                 const std::string &namePrefix = "" );
+IECORECYCLES_API ccl::ShaderGraph *convertGraph(
+	const IECoreScene::ShaderNetwork *surfaceShader,
+	const IECoreScene::ShaderNetwork *displacementShader,
+	const IECoreScene::ShaderNetwork *volumeShader,
+	ccl::ShaderManager *shaderManager,
+	const std::string &namePrefix = ""
+);
 
 IECORECYCLES_API void convertAOV( const IECoreScene::ShaderNetwork *shaderNetwork, ccl::ShaderGraph *graph, ccl::ShaderManager *shaderManager, const std::string &namePrefix = "" );
 IECORECYCLES_API void setSingleSided( ccl::ShaderGraph *graph );

--- a/python/GafferCyclesUI/CyclesAttributesUI.py
+++ b/python/GafferCyclesUI/CyclesAttributesUI.py
@@ -437,7 +437,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Scale the distance between volume shader samples when rendering the volume
-            (lower values give more accurate and detailed results, but also increased render time).
+			(lower values give more accurate and detailed results, but also increased render time).
 			""",
 
 			"layout:section", "Shader",

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -730,7 +730,7 @@ Gaffer.Metadata.registerNode(
 			Probabilistically terminate light samples when the light
 			contribution is below this threshold (more noise but faster
 			rendering).
-            Zero disables the test and never ignores lights.
+			Zero disables the test and never ignores lights.
 			""",
 
 			"layout:section", "Sampling",
@@ -836,7 +836,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Minimum number of light bounces. Setting this higher reduces noise in the first bounces,
-            but can also be less efficient for more complex geometry like hair and volumes.
+			but can also be less efficient for more complex geometry like hair and volumes.
 			""",
 
 			"layout:section", "Ray Depth",
@@ -912,7 +912,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Minimum number of transparent bounces. Setting this higher reduces noise in the first bounces,
-            but can also be less efficient for more complex geometry like hair and volumes."
+			but can also be less efficient for more complex geometry like hair and volumes."
 			""",
 
 			"layout:section", "Ray Depth",
@@ -951,7 +951,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Distance between volume shader samples when rendering the volume
-            (lower values give more accurate and detailed results, but also
+			(lower values give more accurate and detailed results, but also
 			increases render time).
 			""",
 
@@ -964,7 +964,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Maximum number of steps through the volume before giving up,
-            to avoid extremely long render times with big objects or small step
+			to avoid extremely long render times with big objects or small step
 			sizes.
 			""",
 

--- a/python/GafferSceneUI/RenameUI.py
+++ b/python/GafferSceneUI/RenameUI.py
@@ -131,7 +131,7 @@ Gaffer.Metadata.registerNode(
 			--------
 
 			- `()` : Captures the subgroup of the pattern within the brackets,
-			  allowing it to be referenced by `{}` in the `replace` string.
+			allowing it to be referenced by `{}` in the `replace` string.
 
 			""",
 

--- a/src/GafferCycles/CyclesBackground.cpp
+++ b/src/GafferCycles/CyclesBackground.cpp
@@ -63,4 +63,3 @@ std::string CyclesBackground::computeOptionName( const Gaffer::Context *context 
 {
 	return "cycles:background:shader";
 }
-

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -576,11 +576,13 @@ class ShaderCache : public IECore::RefCounted
 		}
 
 		// Can be called concurrently with other get() calls.
-		CyclesShaderPtr get( const IECoreScene::ShaderNetwork *surfaceShader,
-							 const IECoreScene::ShaderNetwork *displacementShader,
-							 const IECoreScene::ShaderNetwork *volumeShader,
-							 const IECore::CompoundObject *attributes,
-							 IECore::MurmurHash &h )
+		CyclesShaderPtr get(
+			const IECoreScene::ShaderNetwork *surfaceShader,
+			const IECoreScene::ShaderNetwork *displacementShader,
+			const IECoreScene::ShaderNetwork *volumeShader,
+			const IECore::CompoundObject *attributes,
+			IECore::MurmurHash &h
+		)
 		{
 			IECore::MurmurHash hSubst;
 			IECore::MurmurHash hSubstDisp;
@@ -1559,11 +1561,13 @@ class InstanceCache : public IECore::RefCounted
 		}
 
 		// Can be called concurrently with other get() calls.
-		Instance get( const std::vector<const IECore::Object *> &samples,
-					  const std::vector<float> &times,
-					  const int frameIdx,
-					  const IECoreScenePreview::Renderer::AttributesInterface *attributes,
-					  const std::string &nodeName )
+		Instance get(
+			const std::vector<const IECore::Object *> &samples,
+			const std::vector<float> &times,
+			const int frameIdx,
+			const IECoreScenePreview::Renderer::AttributesInterface *attributes,
+			const std::string &nodeName
+		)
 		{
 			const CyclesAttributes *cyclesAttributes = static_cast<const CyclesAttributes *>( attributes );
 
@@ -3479,13 +3483,17 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			Box2i displayWindow(
 				V2i( 0, 0 ),
 				V2i( width - 1, height - 1 )
-				);
+			);
 			Box2i dataWindow(
-				V2i( (int)(camera->get_border_left()   * (float)width ),
-					 (int)(camera->get_border_bottom() * (float)height ) ),
-				V2i( (int)(camera->get_border_right()  * (float)width ) - 1,
-					 (int)(camera->get_border_top()    * (float)height - 1 ) )
-				);
+				V2i(
+					(int)(camera->get_border_left()   * (float)width ),
+					(int)(camera->get_border_bottom() * (float)height )
+				),
+				V2i(
+					(int)(camera->get_border_right()  * (float)width ) - 1,
+					(int)(camera->get_border_top()    * (float)height - 1 )
+				)
+			);
 
 			ccl::set<ccl::Pass *> clearPasses( m_scene->passes.begin(), m_scene->passes.end() );
 			m_scene->delete_nodes( clearPasses );

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -93,14 +93,14 @@ ShaderSearchPathCache g_shaderSearchPathCache( shaderCacheGetter, 10000 );
 
 ccl::SocketType::Type getSocketType( const std::string &name )
 {
-    if( name == "float" ) return ccl::SocketType::Type::FLOAT;
-    if( name == "int" ) return ccl::SocketType::Type::INT;
-    if( name == "color" ) return ccl::SocketType::Type::COLOR;
-    if( name == "vector" ) return ccl::SocketType::Type::VECTOR;
-    if( name == "point" ) return ccl::SocketType::Type::POINT;
-    if( name == "normal" ) return ccl::SocketType::Type::NORMAL;
-    if( name == "closure" ) return ccl::SocketType::Type::CLOSURE;
-    if( name == "string" ) return ccl::SocketType::Type::STRING;
+	if( name == "float" ) return ccl::SocketType::Type::FLOAT;
+	if( name == "int" ) return ccl::SocketType::Type::INT;
+	if( name == "color" ) return ccl::SocketType::Type::COLOR;
+	if( name == "vector" ) return ccl::SocketType::Type::VECTOR;
+	if( name == "point" ) return ccl::SocketType::Type::POINT;
+	if( name == "normal" ) return ccl::SocketType::Type::NORMAL;
+	if( name == "closure" ) return ccl::SocketType::Type::CLOSURE;
+	if( name == "string" ) return ccl::SocketType::Type::STRING;
 	return ccl::SocketType::Type::UNDEFINED;
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -67,8 +67,7 @@ class GafferVolumeLoader : public ccl::VDBImageLoader
 {
 	public:
 		GafferVolumeLoader( const IECoreVDB::VDBObject *ieVolume, const string &gridName )
-		: VDBImageLoader( gridName ),
-		  m_ieVolume( ieVolume )
+		: VDBImageLoader( gridName ), m_ieVolume( ieVolume )
 		{
 		}
 
@@ -81,10 +80,12 @@ class GafferVolumeLoader : public ccl::VDBImageLoader
 			return ccl::VDBImageLoader::load_metadata( features, metadata );
 		}
 
-		bool load_pixels( const ccl::ImageMetaData &metadata,
-						  void *pixels,
-						  const size_t pixel_size,
-						  const bool associate_alpha ) override
+		bool load_pixels(
+			const ccl::ImageMetaData &metadata,
+			void *pixels,
+			const size_t pixel_size,
+			const bool associate_alpha
+		) override
 		{
 			if( m_ieVolume )
 				return ccl::VDBImageLoader::load_pixels( metadata, pixels, pixel_size, associate_alpha );


### PR DESCRIPTION
I don't know if this is a quirk of how I have my Windows workstation git setup, but I get a a lot of whitespace errors when I do the whitespace check locally. I'm not sure why it doesn't happen on the CI servers, some of the changes here look like they should be causing failure on Linux and Windows.

My intention is not to be the whitespace police, but to clean up my whitespace checks while doing day-to-day work, so I can see if I have introduced new errors. If there's a better solution, I'm happy to adopt it.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
