### PR TITLE
New PlugValueWidget API round 4

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - Viewer : If Arnold is available, then it is preferred over Appleseed for performing OSL shader previews. If neither is available, then Cycles will be used (#5084).
-- FormatPlugValueWidget, ChannelPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
+- FormatPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
 - Spreadsheet : Improved display of image formats.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - Viewer : If Arnold is available, then it is preferred over Appleseed for performing OSL shader previews. If neither is available, then Cycles will be used (#5084).
-- FormatPlugValueWidget : Added support for editing multiple plugs at once, as needed when multiple Spreadsheet cells are edited at once.
+- FormatPlugValueWidget, ChannelPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
 - Spreadsheet : Improved display of image formats.
 
 Fixes
@@ -15,6 +15,7 @@ Fixes
 - Arnold : The `ai:GI_diffuse_depth` and `ai:GI_specular_depth` options now default to `2` when they are left unspecified, matching the default values on the ArnoldOptions node.
 - Menu buttons : Fixed missing dropdown menu indicators.
 - CompoundNumericPlugValueWidget : Fixed failure to construct with an empty list of plugs.
+- ChannelPlugValueWidget : Fixed compatibility with multi-view images.
 - FilteredSceneProcessor :
   - Fixed bugs which allowed read-only nodes to be edited.
   - Fixed undo for `Remove` menu item in Filter tab.

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - Viewer : If Arnold is available, then it is preferred over Appleseed for performing OSL shader previews. If neither is available, then Cycles will be used (#5084).
-- FormatPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget, RGBAChannelsPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
+- FormatPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget, RGBAChannelsPlugValueWidget, ViewPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
 - Spreadsheet : Improved display of image formats.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - Viewer : If Arnold is available, then it is preferred over Appleseed for performing OSL shader previews. If neither is available, then Cycles will be used (#5084).
-- FormatPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
+- FormatPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget, RGBAChannelsPlugValueWidget : Added support for showing multiple plugs at once, as needed when multiple Spreadsheet cells are selected for editing.
 - Spreadsheet : Improved display of image formats.
 
 Fixes

--- a/python/GafferImageUI/ChannelPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelPlugValueWidget.py
@@ -34,12 +34,15 @@
 #
 ##########################################################################
 
+import collections
 import functools
 
 import IECore
 
 import Gaffer
 import GafferUI
+
+from GafferUI.PlugValueWidget import sole
 
 import GafferImage
 
@@ -57,90 +60,109 @@ import GafferImage
 #           metadata or different?
 class ChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
-	def __init__( self, plug, **kw ) :
+	def __init__( self, plugs, **kw ) :
 
 		self.__menuButton = GafferUI.MenuButton( menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 
-		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plug, **kw )
+		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plugs, **kw )
 
-		imagePlugName = Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:imagePlugName" )
-		if imagePlugName :
-			self.__imagePlug = plug.node().descendant( imagePlugName )
-		else :
-			self.__imagePlug = plug.node()["in"]
+		self.__availableChannels = set()
+		self.__currentChannel = None
 
-		assert( isinstance( self.__imagePlug, GafferImage.ImagePlug ) )
+	def _auxiliaryPlugs( self, plug ) :
 
-		self._updateFromPlug()
+		name = Gaffer.Metadata.value( plug, "channelPlugValueWidget:imagePlugName" ) or "in"
+		imagePlug = plug.node().descendant( name )
+		return [ imagePlug ] if isinstance( imagePlug, GafferImage.ImagePlug ) else []
 
-	def _updateFromPlug( self ) :
+	@staticmethod
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
-		value = None
-		if self.getPlug() is not None :
-			with self.getContext() :
-				try :
-					value = self.getPlug().getValue()
-				except :
-					# Leave it to other parts of the UI
-					# to display the error.
-					pass
+		result = []
 
-		self.__menuButton.setText( self.__channelLabel( value ) )
+		for plug, imagePlugs in zip( plugs, auxiliaryPlugs ) :
+
+			availableChannels = set()
+			for viewName in imagePlugs[0].viewNames() :
+				availableChannels.update( imagePlugs[0].channelNames( viewName = viewName ) )
+
+			result.append( { "value" : plug.getValue(), "availableChannels" : availableChannels } )
+
+		return result
+
+	def _updateFromValues( self, values, exception ) :
+
+		self.__availableChannels = set().union( *[ v["availableChannels"] for v in values ] )
+		self.__currentChannel = sole( v["value"] for v in values )
+
+		label = self.__extraChannels().get( self.__currentChannel, self.__currentChannel )
+		self.__menuButton.setText(
+			label if label is not None else "---"
+		)
+
+		self.__menuButton.setErrored( exception is not None )
+
+	def _updateFromEditable( self ) :
+
 		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 
-		with self.getContext() :
-			selectedChannel = ""
-			availableChannels = []
-			with IECore.IgnoredExceptions( Exception ):
-				selectedChannel = self.getPlug().getValue()
-				availableChannels = self.__imagePlug["channelNames"].getValue()
-
-
-		if Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:allowNewChannels" ):
+		availableChannels = self.__availableChannels.copy()
+		if all( Gaffer.Metadata.value( plug, "channelPlugValueWidget:allowNewChannels" ) for plug in self.getPlugs() ) :
 			for channel in ( "R", "G", "B", "A" ) :
 				if channel not in availableChannels :
-					availableChannels.append( channel )
-
-		availableChannels = GafferImage.ImageAlgo.sortedChannelNames( availableChannels )
-
-		extraChannels = Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:extraChannels" )
-		if extraChannels:
-			availableChannels.append( "___DIVIDER___" )
-			availableChannels.extend( extraChannels )
+					availableChannels.add( channel )
 
 		result = IECore.MenuDefinition()
-		for channel in availableChannels :
+		for channel in GafferImage.ImageAlgo.sortedChannelNames( availableChannels ) :
+			result.append(
+				"/{}".format( channel.replace( ".", "/" ) ),
+				{
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), value = channel ),
+					"checkBox" : channel == self.__currentChannel,
+				}
+			)
 
-			if channel == "___DIVIDER___" :
-				result.append( "/__Divider", { "divider" : True } )
-			else:
+		extraChannels = self.__extraChannels()
+		if extraChannels :
+			result.append( "__ExtraChannelsDivider", { "divider" : True } )
+			for channel, label in extraChannels.items() :
 				result.append(
-					"/" + self.__channelLabel( channel ).replace( ".", "/" ),
+					f"/{label}",
 					{
 						"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), value = channel ),
-						"checkBox" : selectedChannel == channel,
+						"checkBox" : channel == self.__currentChannel,
 					}
 				)
+
+		if not result.items() :
+			result.append( "/No Channels Available", { "active" : False } )
 
 		return result
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-			self.getPlug().setValue( value )
+		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+			for plug in self.getPlugs() :
+				plug.setValue( value )
 
-	def __channelLabel( self, channelName ) :
+	def __extraChannels( self ) :
 
-		if not channelName :
-			return "None"
+		# Intersection of the extra channels defined by each individual plug.
 
-		extraChannels = Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:extraChannels" )
-		extraChannelLabels = Gaffer.Metadata.value( self.getPlug(), "channelPlugValueWidget:extraChannelLabels" )
-		if extraChannels and extraChannelLabels:
-			for label, value in zip( extraChannelLabels, extraChannels ):
-				if channelName == value:
-					return label
+		if not self.getPlugs() :
+			return {}
 
-		return channelName
+		result = None
+		for plug in self.getPlugs() :
+			extraChannels = Gaffer.Metadata.value( plug, "channelPlugValueWidget:extraChannels" ) or []
+			extraChannelLabels = Gaffer.Metadata.value( plug, "channelPlugValueWidget:extraChannelLabels" ) or []
+			if result is None :
+				result = collections.OrderedDict( zip( extraChannels, extraChannelLabels ) )
+			else :
+				for channel, label in zip( extraChannels, extraChannelLabels ) :
+					if result.get( channel, None ) != label :
+						del result[channel]
+
+		return result

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1284,7 +1284,7 @@ class _CompareParentPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ), scoped = False )
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p["mode"].getValue() for p in plugs ]
 

--- a/python/GafferSceneUI/FilterPlugValueWidget.py
+++ b/python/GafferSceneUI/FilterPlugValueWidget.py
@@ -78,7 +78,7 @@ class FilterPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return True
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ FilterPlugValueWidget.__filterNode( p ) for p in plugs ]
 

--- a/python/GafferSceneUI/OutputsUI.py
+++ b/python/GafferSceneUI/OutputsUI.py
@@ -209,7 +209,7 @@ class ChildPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return True
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [
 			{

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -696,7 +696,7 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton.setHighlighted( highlighted )
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p["lookThroughEnabled"].getValue() for p in plugs ]
 

--- a/python/GafferUI/ConnectionPlugValueWidget.py
+++ b/python/GafferUI/ConnectionPlugValueWidget.py
@@ -92,7 +92,7 @@ class ConnectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return result
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		# Avoid unnecessary overhead of computing values, since
 		# we don't use them in `_updateFromValues()`.

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -124,7 +124,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return result
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		## \todo: This is mirrored in PlugLayout and needs centralising in NodeAlgo (along
 		# with proper support for child plug connections/defaults) at the next API break.

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -389,7 +389,7 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return None
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p["enabled"].getValue() for p in plugs ]
 

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -122,7 +122,7 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 		return self.__row[0].getVisible()
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [
 			p["enabled"].getValue() if "enabled" in p else True

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -690,6 +690,12 @@ class PlugValueWidget( GafferUI.Widget ) :
 			auxiliaryPlugs = Gaffer.PlugAlgo.findDestination( plug, lambda plug : self._auxiliaryPlugs( plug ) ) or []
 			self.__auxiliaryPlugs.append( auxiliaryPlugs )
 			auxiliaryNodes.update( [ plug.node() for plug in auxiliaryPlugs ] )
+			# > Note : Which `auxiliaryPlugs` we find depends on the output connections
+			# from `plug` (because we're using `findDestination()`). So we should redo
+			# this search when the outputs change (or the outputs of the outputs change etc).
+			# But we don't currently have appropriate signals to allow that. For now, we
+			# assume that the results of `findDestination()` change infrequently enough that
+			# it is OK to perform the search only once.
 
 		self.__auxiliaryPlugDirtiedConnections = [
 			node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__auxiliaryPlugDirtied ), scoped = True )

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -76,7 +76,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return self.__menuButton
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ Gaffer.NodeAlgo.currentPreset( p ) or "" for p in plugs ]
 

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -136,7 +136,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return result
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [
 			{

--- a/python/GafferUI/RandomUI.py
+++ b/python/GafferUI/RandomUI.py
@@ -189,7 +189,7 @@ class _RandomColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 					GafferUI.ColorSwatch( parenting = { "index" : ( x, y ) } )
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		node = next( iter( plugs ) ).source().node()
 		seed = node["seed"].getValue()

--- a/python/GafferUI/ShufflePlugValueWidget.py
+++ b/python/GafferUI/ShufflePlugValueWidget.py
@@ -101,7 +101,7 @@ class ShufflePlugValueWidget( GafferUI.PlugValueWidget ) :
 		return None
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p["enabled"].getValue() for p in plugs ]
 

--- a/python/GafferUI/SpreadsheetUI/_CellPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_CellPlugValueWidget.py
@@ -155,7 +155,7 @@ class _CellPlugValueWidget( GafferUI.PlugValueWidget ) :
 	__plugValueWidgetCreators = {}
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p.enabledPlug().getValue() for p in plugs ]
 

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -113,7 +113,7 @@ class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 		return self.__row[0].getVisible()
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		return [ p["enabled"].getValue() for p in plugs ]
 

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -80,7 +80,7 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.vectorDataWidget().setHighlighted( highlighted )
 
 	@staticmethod
-	def _valuesForUpdate( plugs ) :
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		assert( len( plugs ) == 1 )
 		plug = next( iter( plugs ) )


### PR DESCRIPTION
This follows on from #5089, and with a bit of luck, is the last in the series of PRs to refactor all the PlugValueWidgets. With this PR, all widgets except those in GafferCortexUI have been converted - I've left those, both because it's useful to have a few left to demonstrate the support for the old API, and because I don't really want to maintain GafferCortex any more.

What sets the widgets in this PR apart from the preceding ones is that they all require additional information from a secondary plug, on top of the usual values from the plugs the user is editing. For instance, ViewPlugValueWidget needs the list of views from an associated ImagePlug in addition to the string value of the plug being edited. The fundamental requirements here are :

- Discovering the associated plug(s). Each widget here has subtly different requirements, but they all need to use `PlugAlgo.findDestination()` so that they can support promoted plugs and Spreadsheets.
- Tracking dirtiness of the associated plugs, and triggering an update when they are dirtied.
- Ensuring that the update is performed in the background if the auxiliary plugs depend on a compute.
- Rediscovering the new associated plugs when `setPlugs()` is called.

It would _almost_ be possible for a derived class to do this without requiring any changes to the PlugValueWidget base class. The hitch is the requirement that updates are performed in the background if the associated plugs depend on a compute (since the base class doesn't know anything about them). So instead, I've made a small API addition in the form of `PlugValueWidget._auxiliaryPlugs()`, so that all of the tracking logic is consolidated into the base class. This does make for a bigger API, when it was already a bit bigger than I wanted. But on the other hand it has allowed me to update a bunch of the trickier widgets to async, multi-plug-aware, spreadsheet-and-box-compatible form with practically no increase in the volume of overall code. And the new API addition can simply be ignored by most derived classes since it's completely optional.

@danieldresser-ie, when we spoke about this option yesterday, neither of us were that happy about having additional API. But having gone through and done the work today, I'm feeling like it's actually not that unreasonable. See what you think...