### PR TITLE
GafferCycles : Remove problematic mutex lock

### DIFF
--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3199,24 +3199,21 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
+			if( m_renderState == RENDERSTATE_RENDERING && m_renderType == Interactive )
 			{
-				std::scoped_lock sceneLock( m_scene->mutex );
-				if( m_renderState == RENDERSTATE_RENDERING && m_renderType == Interactive )
-				{
-					clearUnused();
-				}
+				clearUnused();
+			}
 
-				updateSceneObjects();
-				updateOptions();
-				updateCamera();
-				updateOutputs();
+			updateSceneObjects();
+			updateOptions();
+			updateCamera();
+			updateOutputs();
 
-				if( m_renderState == RENDERSTATE_RENDERING )
+			if( m_renderState == RENDERSTATE_RENDERING )
+			{
+				if( m_scene->need_reset() )
 				{
-					if( m_scene->need_reset() )
-					{
-						m_session->reset( m_sessionParams, m_bufferParams );
-					}
+					m_session->reset( m_sessionParams, m_bufferParams );
 				}
 			}
 


### PR DESCRIPTION
When using `SVM` shader mode on Windows, this lock was causing Gaffer to hang after any scene change. @boberfly, in #4951, you said that we're now flagging a warning to the user about resetting instead of trying to manage it here. I'm hoping that means that this lock is ok to remove entirely. Do you know of anything that would make that a bad idea?

In limited interactive testing it seemed to work fine.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
