### PR TITLE
GafferCycles : Refactor the problematic reset code

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 - SceneReader : Fixed reading of USD primitives containing `primvars:normals`. These are now correctly loaded as a primitive variable called N, taking precedence over the UsdGeomPointBased normals attribute.
 - SceneWriter : Fixed writing of indexed normals to USD files, so that the indexing is retained on load. Note that this means that normals are now always written as `primvars:normals` and never via the UsdGeomPointBased `normals` attribute.
 - CompoundDataPlugValueWidget : Fixed bug which prevented the addition of new plugs when an existing plug had an input connection. This affected the ContextVariables, CustomOptions and CustomAttributes nodes, among others.
+- Cycles : Refactor the problematic reset code, we now only allow scene/session parameters to be set before rendering starts (#5101). Fixes (#5234)
 
 API
 ---


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Remove and refactor the problematic reset code as we now only allow scene/session parameters to be set before rendering starts. 
- This will also avoid a mutex lock issue with Windows, and replaces the need for this PR: https://github.com/GafferHQ/gaffer/pull/5100

### Related issues ###

- Windows has deadlocks on scene/session resets due to mutex handling (a reset could delete the mutex and try to unlock a new one).

### Dependencies ###

-

### Breaking changes ###

-

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.

This will probably need a bit of testing before I'd be confident in merging, this could break interactive scene updating.