### PR TITLE
Prototype For Fast Bulk Sampling Of Pixels

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1078,10 +1078,10 @@ libraries = {
 
 	"GafferImageTest" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX",  ],
+			"LIBS" : [ "Gaffer", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBS" : [ "GafferImage", "GafferImageTest" ],
+			"LIBS" : [ "GafferImage", "GafferImageTest", "fmt" ],
 		},
 		"additionalFiles" :
 			glob.glob( "python/GafferImageTest/scripts/*" ) + glob.glob( "python/GafferImageTest/images/*" ) +

--- a/SConstruct
+++ b/SConstruct
@@ -491,6 +491,14 @@ if env["PLATFORM"] != "win32" :
 		# Turn off the parts of `-Wextra` that we don't like.
 		env.Append( CXXFLAGS = [ "-Wno-cast-function-type", "-Wno-unused-parameter" ] )
 
+		# Set this weird compiler flag that in general is expected to cause compiled code to be about
+		# half a percent slower, but works around this ridiculous bug:
+		# https://gcc.gnu.org/bugzilla//show_bug.cgi?id=51041
+		# It's a 10 year old bug that sometimes causes important inner loops to get 4X slower for no
+		# reason ( it affects use of visitPixels depending on exact register usage patterns at the call
+		# site ), and there appears to be no real solution ... maybe we should be moving away from GCC?
+		env.Append( CXXFLAGS = [ "-fira-region=all" ] )
+
 		env.Append(
 			CXXFLAGS = [ "-pthread" ],
 			SHLINKFLAGS = [ "-pthread", "-Wl,--no-undefined" ],

--- a/contrib/scripts/graphPerformanceResults.py
+++ b/contrib/scripts/graphPerformanceResults.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python
+
+import argparse
+import inspect
+import subprocess
+import os
+import json
+import matplotlib.pyplot as plt
+import matplotlib.ticker
+
+parser = argparse.ArgumentParser(
+	description = inspect.cleandoc(
+	"""
+	Graph the performance results for a folder of json files.
+	""" )
+)
+
+parser.add_argument(
+	'jsonFolder',
+	help='Folder containing json files'
+)
+
+args = parser.parse_args()
+
+jsonFolder = vars( args )["jsonFolder"]
+
+jsonFileNames = [ i for i in os.listdir( jsonFolder ) if i.endswith( ".json" ) ]
+
+results = []
+for n in jsonFileNames:
+	f = open( "%s/%s" % ( jsonFolder, n ) )
+	d = json.load( f )
+	f.close()
+
+	r = {}
+	for key, value in d.items():
+		if "timings" in value:
+			r[ key.split()[1].split('.')[-1][:-1] + "." + key.split()[0]] = ( min( value["timings"] ), max( value["timings"] ) )
+
+	resultName = n[:-5]
+	resultOrder = resultName
+
+	try:
+		resultOrder = int( subprocess.check_output( [ "git", "rev-list", "--count", resultName ] ) )
+		resultName = subprocess.check_output( [ "git", "log", "--format=%B", "-n 1", resultName ] ).splitlines()[0].decode( "UTF-8" )
+	except:
+		pass
+
+	results.append( [resultOrder, resultName, r] )
+
+results.sort()
+results = [r[1:] for r in results ]
+
+ax = plt.subplot(111)
+
+curveNames = results[0][1].keys()
+curveNames = sorted( curveNames, key = lambda k : -results[-1][1][k][0] )
+for k in curveNames:
+	ax.plot( [ j[1][k][0] for j in results ], label = k )
+	# Use this line instead if you want to see variability
+	#ax.fill_between( range( len( results ) ), [ j[1][k][0] for j in results ], [ j[1][k][1] for j in results ], label = k )
+
+plt.yscale( "log", base = 2 )
+
+# Force labelling of every power of two
+plt.yticks( [2**i for i in range( -4, 4 )] )
+
+ax.xaxis.set_major_formatter( matplotlib.ticker.FuncFormatter( lambda i, pos : results[int(i)][0] ) )
+plt.xticks( rotation = 45, ha = "right" )
+
+box = ax.get_position()
+
+# Create margin
+ax.set_position([box.x0, box.y0 + box.height * 0.2, box.width * 0.8, box.height * 0.8])
+
+# Put a legend to the right of the current axis
+ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+
+# Currently hacking things up to work with very old matplotlib
+#plt.show_all()
+plt.show()

--- a/contrib/scripts/runTestsForCommits.py
+++ b/contrib/scripts/runTestsForCommits.py
@@ -1,0 +1,46 @@
+#! /usr/bin/env python
+
+import argparse
+import inspect
+import subprocess
+import os
+
+parser = argparse.ArgumentParser(
+	description = inspect.cleandoc(
+	"""
+	Run a selection of Gaffer tests for a specified set of commits,
+	outputting a separate json file for the tests for each commit.
+	""" )
+)
+
+parser.add_argument(
+	'--commits', action='store', nargs='+',
+	help='Hashes of commits to build'
+)
+
+parser.add_argument(
+	'--tests', action='store', nargs='+',
+	help='Names of tests to run'
+)
+
+parser.add_argument(
+	'--outputFolder', action='store', required = True,
+	help='Folder to put output json files to'
+)
+
+args = parser.parse_args()
+
+outputFolder = vars( args )["outputFolder"]
+try:
+	os.makedirs( outputFolder )
+except:
+	pass
+
+currentBranch = subprocess.check_output( [ "git", "stat", "-s", "-b" ] ).splitlines()[0].split()[1]
+print( currentBranch )
+for c in vars( args )["commits"]:
+	subprocess.check_call( [ "git", "checkout", c ] )
+	subprocess.check_call( [ "scons", "-j 16", "build" ] )
+	subprocess.check_call( [ "gaffer", "test" ] + vars( args )["tests"] + [ "-outputFile", "%s/%s.json" % ( outputFolder, c ) ] )
+
+subprocess.check_call( [ "git", "checkout", currentBranch ] )

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -256,8 +256,8 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		static const IECore::FloatVectorData *blackTile();
 		static const IECore::FloatVectorData *whiteTile();
 
-		static int tileSize() { return 1 << tileSizeLog2(); };
-		static int tilePixels() { return tileSize() * tileSize(); };
+		static constexpr int tileSize() { return 1 << tileSizeLog2(); };
+		static constexpr int tilePixels() { return tileSize() * tileSize(); };
 
 		/// Returns the index of the tile containing a point
 		/// This just means dividing by tile size ( always rounding down )
@@ -286,9 +286,9 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 		};
 		//@}
 
-	private :
+		static constexpr int tileSizeLog2() { return 7; };
 
-		static int tileSizeLog2() { return 7; };
+	private :
 
 		static void compoundObjectToCompoundData( const IECore::CompoundObject *object, IECore::CompoundData *data );
 

--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -106,8 +106,8 @@ class GAFFERIMAGE_API Sampler
 		/// Cached data access
 		/// @param p Any point within the cache that we wish to retrieve the data for.
 		/// @param tileData Is set to the tile's channel data.
-		/// @param tilePixelIndex XY indices that can be used to access the colour value of point 'p' from tileData.
-		void cachedData( Imath::V2i p, const float *& tileData, Imath::V2i &tilePixelIndex );
+		/// @param tilePixelIndex Is set to the index used to access the colour value of point 'p' from tileData.
+		void cachedData( Imath::V2i p, const float *& tileData, int &tilePixelIndex );
 
 		const ImagePlug *m_plug;
 		const std::string m_channelName;
@@ -117,6 +117,7 @@ class GAFFERIMAGE_API Sampler
 		std::vector< IECore::ConstFloatVectorDataPtr > m_dataCache;
 		std::vector< const float * > m_dataCacheRaw;
 		Imath::Box2i m_cacheWindow;
+		int m_cacheOriginIndex;
 		int m_cacheWidth;
 
 		int m_boundingMode;

--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -94,6 +94,14 @@ class GAFFERIMAGE_API Sampler
 		/// 0.5, 0.5.
 		float sample( float x, float y );
 
+		/// Call a functor for all pixels in the region.
+		/// Much faster than calling sample(int,int) repeatedly for every pixel in the
+		/// region, up to 5 times faster in practical cases.
+		/// The signature of the functor must be `F( float value, int x, int y )`.
+		/// Each pixel is visited in order of increasing X, then increasing Y.
+		template<typename F>
+		inline void visitPixels( const Imath::Box2i &region, F &&lambda );
+
 		/// Appends a hash that represent all the pixel
 		/// values within the requested sample area.
 		void hash( IECore::MurmurHash &h ) const;

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -90,6 +90,191 @@ inline float Sampler::sample( float x, float y )
 	return OIIO::bilerp( x0y0, x1y0, x0y1, x1y1, xf, yf );
 }
 
+template<typename F>
+inline void Sampler::visitPixels( const Imath::Box2i &region, F &&visitor )
+{
+	int x = region.min.x;
+	int y = region.min.y;
+
+	if( region.max.x == region.min.x + 1 )
+	{
+		// The general principle of visitPixels is to find contiguous spans in X, precompute the length
+		// of the span, and then process the whole span in a very tight inner loop with minimal branching
+		// where moving to the next pixel takes just an increment. When the region is just
+		// one pixel wide, however, looking for X spans is really not helping, so we have a big special
+		// case to instead look for vertical spans.
+		while( y < region.max.y )
+		{
+			// Our goal is to prepare these 3 variables:
+			// valuePointer or constantValue will hold the data, and count will hold how many consecutive pixels
+			// we can visit without recomputing valuePointer/constantValue.
+			// The default is that valuePointer is null, and constantValue is 0, meaning that visited pixels
+			// will be treated as 0 unless we set one of the values.
+
+			int count;
+			const float *valuePointer = nullptr;
+			float constantValue = 0.0f;
+
+			// If we are clamping, then we will always treat x as if it is within the nearest edge of the data
+			// window.
+			int clampedX = x;
+			if( m_boundingMode == Clamp )
+			{
+				clampedX = std::clamp( x, m_dataWindow.min.x, m_dataWindow.max.x - 1 );
+			}
+
+			if( clampedX < m_dataWindow.min.x || clampedX >= m_dataWindow.max.x )
+			{
+				// If we're outside, and haven't been clamped, then just use the default constantValue of 0.
+				count = region.max.y - y;
+			}
+			else if( y < m_dataWindow.min.y )
+			{
+				// Everything before the dataWindow gets the first value in the data window, or 0 if not clamped
+				if( m_boundingMode == Clamp )
+				{
+					const float *tileData;
+					int tilePixelIndex;
+					cachedData( Imath::V2i( clampedX, m_dataWindow.min.y ), tileData, tilePixelIndex );
+					constantValue = tileData[ tilePixelIndex ];
+				}
+				count = std::min( region.max.y, m_dataWindow.min.y ) - y;
+			}
+			else if( y >= m_dataWindow.max.y )
+			{
+				// Everything after the dataWindow gets the last value in the data window, or 0 if not clamped
+				if( m_boundingMode == Clamp )
+				{
+					const float *tileData;
+					int tilePixelIndex;
+					cachedData( Imath::V2i( clampedX, m_dataWindow.max.y - 1 ), tileData, tilePixelIndex );
+					constantValue = tileData[ tilePixelIndex ];
+				}
+				count = region.max.y - y;
+			}
+			else
+			{
+				// We're actually in the data window ( or clamped to the side of it ). Need to actually
+				// set valuePointer
+				const float *tileData;
+				int tilePixelIndex;
+				cachedData( Imath::V2i( clampedX, y ), tileData, tilePixelIndex );
+				int pixelY = tilePixelIndex >> ImagePlug::tileSizeLog2();
+				count = std::min( std::min( m_dataWindow.max.y, region.max.y ) - y, ImagePlug::tileSize() - pixelY );
+				valuePointer = &tileData[ tilePixelIndex ];
+			}
+
+			// Now we can do the nice tight inner loop where we call visitor repeatedly with valuePointer, or
+			// constantValue
+			if( valuePointer )
+			{
+				for( int i = 0; i < count; i++ )
+				{
+					visitor( valuePointer[i << ImagePlug::tileSizeLog2()], x, y + i );
+				}
+			}
+			else
+			{
+				for( int i = 0; i < count; i++ )
+				{
+					visitor( constantValue, x, y + i );
+				}
+			}
+
+			y += count;
+		}
+		return;
+	}
+
+	// We didn't take the vertical special case above, so we're going to visit horizontal scanlines
+	while( y < region.max.y )
+	{
+		// As above, our goal is to prepare these 3 variables:
+		// valuePointer or constantValue will hold the data, and count will hold how many consecutive pixels
+		// we can visit without recomputing valuePointer/constantValue.
+		// The default is that valuePointer is null, and constantValue is 0, meaning that visited pixels
+		// will be treated as 0 unless we set one of the values.
+		int count;
+		const float *valuePointer = nullptr;
+		float constantValue = 0.0f;
+
+		// If we are clamping, then we will always treat y as if it is within the nearest edge of the data
+		// window ( reading a scanline below the data window yields the same result as reading a scanline
+		// of the bottom edge of the data window )
+		int clampedY = y;
+		if( m_boundingMode == Clamp )
+		{
+			clampedY = std::clamp( y, m_dataWindow.min.y, m_dataWindow.max.y - 1 );
+		}
+
+		if( clampedY < m_dataWindow.min.y ||  clampedY >= m_dataWindow.max.y )
+		{
+			// If we're outside, and haven't been clamped, then just use the default constantValue of 0.
+			count = region.max.x - x;
+		}
+		else if( x < m_dataWindow.min.x )
+		{
+			// Everything left of the dataWindow gets the first value in the data window on this row, or 0 if not clamped
+			if( m_boundingMode == Clamp )
+			{
+				const float *tileData;
+				int tilePixelIndex;
+				cachedData( Imath::V2i( m_dataWindow.min.x, clampedY ), tileData, tilePixelIndex );
+				constantValue = tileData[ tilePixelIndex ];
+			}
+			count = std::min( region.max.x, m_dataWindow.min.x ) - x;
+		}
+		else if( x >= m_dataWindow.max.x )
+		{
+			// Everything right of the dataWindow gets the last value in the data window on this row, or 0 if not clamped
+			if( m_boundingMode == Clamp )
+			{
+				const float *tileData;
+				int tilePixelIndex;
+				cachedData( Imath::V2i( m_dataWindow.max.x - 1, clampedY ), tileData, tilePixelIndex );
+				constantValue = tileData[ tilePixelIndex ];
+			}
+			count = region.max.x - x;
+		}
+		else
+		{
+			// We're actually in the data window ( or clamped to the top or bottom of it ). Need to actually
+			// set valuePointer
+			const float *tileData;
+			int tilePixelIndex;
+			cachedData( Imath::V2i( x, clampedY ), tileData, tilePixelIndex );
+			int tileX = tilePixelIndex & ( ImagePlug::tileSize() - 1 );
+			count = std::min( std::min( m_dataWindow.max.x, region.max.x ) - x, ImagePlug::tileSize() - tileX );
+			valuePointer = &tileData[ tilePixelIndex ];
+		}
+
+		// Now we can do the nice tight inner loop where we call visitor repeatedly with valuePointer, or
+		// constantValue
+		if( valuePointer )
+		{
+			for( int i = 0; i < count; i++ )
+			{
+				visitor( valuePointer[i], x + i, y );
+			}
+		}
+		else
+		{
+			for( int i = 0; i < count; i++ )
+			{
+				visitor( constantValue, x + i, y );
+			}
+		}
+
+		// Advance in the scanline, and advance to the next scanline if we've finished
+		x += count;
+		if( x == region.max.x )
+		{
+			y++;
+			x = region.min.x;
+		}
+	}
+}
+
 inline void Sampler::cachedData( Imath::V2i p, const float *& tileData, int &tilePixelIndex )
 {
 	// Get the smart pointer to the tile we want.

--- a/python/GafferImageTest/DilateTest.py
+++ b/python/GafferImageTest/DilateTest.py
@@ -138,5 +138,20 @@ class DilateTest( GafferImageTest.ImageTestCase ) :
 			# a master
 			self.assertImagesEqual( masterDilateSingleChannel["out"], defaultDilateSingleChannel["out"] )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testPerf( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		GafferImageTest.processTiles( imageReader["out"] )
+
+		dilate = GafferImage.Dilate()
+		dilate["in"].setInput( imageReader["out"] )
+		dilate["radius"].setValue( imath.V2i( 128 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( dilate["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ErodeTest.py
+++ b/python/GafferImageTest/ErodeTest.py
@@ -140,5 +140,20 @@ class ErodeTest( GafferImageTest.ImageTestCase ) :
 			# a master
 			self.assertImagesEqual( masterErodeSingleChannel["out"], defaultErodeSingleChannel["out"] )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testPerf( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		GafferImageTest.processTiles( imageReader["out"] )
+
+		erode = GafferImage.Erode()
+		erode["in"].setInput( imageReader["out"] )
+		erode["radius"].setValue( imath.V2i( 128 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( erode["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ImageTransformTest.py
+++ b/python/GafferImageTest/ImageTransformTest.py
@@ -356,6 +356,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
 		transform["transform"]["rotate"].setValue( 2.5 )
 
+		GafferImageTest.processTiles( checker["out"] )
+
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform["out"] )
 
@@ -368,6 +370,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform = GafferImage.ImageTransform()
 		transform["in"].setInput( checker["out"] )
 		transform["transform"]["translate"].setValue( imath.V2f( 2.2 ) )
+
+		GafferImageTest.processTiles( checker["out"] )
 
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform["out"] )
@@ -382,6 +386,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform["in"].setInput( checker["out"] )
 		transform["transform"]["scale"].setValue( imath.V2f( 0.1 ) )
 
+		GafferImageTest.processTiles( checker["out"] )
+
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform["out"] )
 
@@ -394,6 +400,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform = GafferImage.ImageTransform()
 		transform["in"].setInput( checker["out"] )
 		transform["transform"]["scale"].setValue( imath.V2f( 3 ) )
+
+		GafferImageTest.processTiles( checker["out"] )
 
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform["out"] )
@@ -409,6 +417,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform["transform"]["pivot"].setValue( imath.V2f( 1500 ) )
 		transform["transform"]["rotate"].setValue( 2.5 )
 		transform["transform"]["scale"].setValue( imath.V2f( 0.75 ) )
+
+		GafferImageTest.processTiles( checker["out"] )
 
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform["out"] )
@@ -428,6 +438,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform2["in"].setInput( transform1["out"] )
 		transform2["transform"]["translate"].setValue( imath.V2f( 10 ) )
 
+		GafferImageTest.processTiles( checker["out"] )
+
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform2["out"] )
 
@@ -446,6 +458,8 @@ class ImageTransformTest( GafferImageTest.ImageTestCase ) :
 		transform2 = GafferImage.ImageTransform( "Transform2" )
 		transform2["in"].setInput( transform1["out"] )
 		transform2["transform"]["translate"].setValue( imath.V2f( 10 ) )
+
+		GafferImageTest.processTiles( checker["out"] )
 
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( transform2["out"] )

--- a/python/GafferImageTest/MedianTest.py
+++ b/python/GafferImageTest/MedianTest.py
@@ -172,5 +172,20 @@ class MedianTest( GafferImageTest.ImageTestCase ) :
 		bt.cancelAndWait()
 		self.assertLess( time.time() - t, acceptableCancellationDelay )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testPerf( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		GafferImageTest.processTiles( imageReader["out"] )
+
+		median = GafferImage.Median()
+		median["in"].setInput( imageReader["out"] )
+		median["radius"].setValue( imath.V2i( 128 ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( median["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -151,7 +151,8 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		]
 
 		for args in tests :
-			__test( *args )
+			with self.subTest( fileName = args[0], size = args[1], ftilter = args[2] ):
+				__test( *args )
 
 	def testSincUpsize( self ) :
 
@@ -219,6 +220,87 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		resample["matrix"].setValue( imath.M33f().scale( imath.V2f( 0.5 ) ) )
 
 		self.assertRaisesDeepNotSupported( resample )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testPerfHorizontal( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 1920, 1080, 1.000 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'box' )
+		resample["filterScale"].setValue( imath.V2f( 300.0 ) )
+
+		GafferImageTest.processTiles( resize["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["__horizontalPass"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testPerfVertical( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 1920, 1080, 1.000 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'box' )
+		resample["filterScale"].setValue( imath.V2f( 300.0 ) )
+
+		GafferImageTest.processTiles( resample["__horizontalPass"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testPerfSmallFilter( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 4000, 4000, 1.000 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'box' )
+		resample["filterScale"].setValue( imath.V2f( 4.0 ) )
+
+		GafferImageTest.processTiles( resize["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testPerfVerySmallFilter( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 4000, 4000, 1.000 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'box' )
+		resample["filterScale"].setValue( imath.V2f( 2.0 ) )
+
+		GafferImageTest.processTiles( resize["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["out"] )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResampleTest.py
+++ b/python/GafferImageTest/ResampleTest.py
@@ -301,6 +301,46 @@ class ResampleTest( GafferImageTest.ImageTestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferImageTest.processTiles( resample["out"] )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testPerfInseparableLanczos( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 64, 64 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'radial-lanczos3' )
+		resample["filterScale"].setValue( imath.V2f( 20.0 ) )
+
+		GafferImageTest.processTiles( resize["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testPerfInseparableDisk( self ) :
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		resize = GafferImage.Resize()
+		resize["in"].setInput( imageReader["out"] )
+		resize["format"].setValue( GafferImage.Format( 1920, 1920 ) )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( resize["out"] )
+		resample["filter"].setValue( 'disk' )
+		resample["filterScale"].setValue( imath.V2f( 20.0 ) )
+
+		GafferImageTest.processTiles( resize["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( resample["out"] )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ResizeTest.py
+++ b/python/GafferImageTest/ResizeTest.py
@@ -306,5 +306,35 @@ class ResizeTest( GafferImageTest.ImageTestCase ) :
 
 						self.assertEqual( r["out"]["dataWindow"].getValue(), r["out"]["format"].getValue().getDisplayWindow() )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testSimplestUpscalePerf( self ) :
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		r = GafferImage.Resize()
+		r["in"].setInput( imageReader["out"] )
+		r["format"].setValue( GafferImage.Format( 10000, 10000 ) )
+		r["filter"].setValue( 'box' )
+
+		GafferImageTest.processTiles( imageReader["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( r["out"] )
+
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 5 )
+	def testSimpleUpscalePerf( self ) :
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.imagesPath() / 'deepMergeReference.exr' )
+
+		r = GafferImage.Resize()
+		r["in"].setInput( imageReader["out"] )
+		r["format"].setValue( GafferImage.Format( 10000, 10000 ) )
+		r["filter"].setValue( 'triangle' )
+
+		GafferImageTest.processTiles( imageReader["out"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferImageTest.processTiles( r["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUI/WarpUI.py
+++ b/python/GafferImageUI/WarpUI.py
@@ -69,8 +69,10 @@ Gaffer.Metadata.registerNode(
 			"""
 			The filter used to perform the resampling. The name
 			of any OIIO filter may be specified, but this UI
-			only exposes a limited range of 4 options which perform
-			well for warping, ordered from softest to sharpest.
+			only exposes a limited range of 5 options which perform
+			well for warping, ordered from softest to sharpest. Plus
+			the extra "bilinear" mode which is lower quality, but
+			fast.
 			""",
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
@@ -80,6 +82,7 @@ Gaffer.Metadata.registerNode(
 			"preset:Keys", "keys",
 			"preset:Simon", "simon",
 			"preset:Rifman", "rifman",
+			"preset:Bilinear", "bilinear",
 
 		],
 
@@ -94,6 +97,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"userDefault", False,
+			"layout:activator", lambda plug : plug.node()["filter"].getValue() != "bilinear",
 		],
 
 	}

--- a/src/GafferImage/RankFilter.cpp
+++ b/src/GafferImage/RankFilter.cpp
@@ -237,15 +237,14 @@ void RankFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 				IECore::Canceller::check( context->canceller() );
 
 				// Fill array with all nearby samples
-				V2i o;
 				vector<float>::iterator pixelsIt = pixels.begin();
-				for( o.y = -radius.y; o.y <= radius.y; ++o.y )
-				{
-					for( o.x = -radius.x; o.x <= radius.x; ++o.x )
+				sampler.visitPixels(
+					Imath::Box2i( p - radius, p + radius + Imath::V2i( 1 ) ),
+					[&pixelsIt] ( float v, int x, int y )
 					{
-						*pixelsIt++ = sampler.sample( p.x + o.x, p.y + o.y );
+						*pixelsIt++ = v;
 					}
-				}
+				);
 
 				switch( m_mode )
 				{
@@ -269,6 +268,7 @@ void RankFilter::compute( Gaffer::ValuePlug *output, const Gaffer::Context *cont
 
 				int closestMatch = INT_MAX;
 				pixelsIt = pixels.begin();
+				V2i o;
 				for( o.y = -radius.y; o.y <= radius.y; ++o.y )
 				{
 					for( o.x = -radius.x; o.x <= radius.x; ++o.x )
@@ -408,15 +408,14 @@ IECore::ConstFloatVectorDataPtr RankFilter::computeChannelData( const std::strin
 		{
 			IECore::Canceller::check( context->canceller() );
 
-			V2i o;
 			vector<float>::iterator pixelsIt = pixels.begin();
-			for( o.y = -radius.y; o.y <= radius.y; ++o.y )
-			{
-				for( o.x = -radius.x; o.x <= radius.x; ++o.x )
+			sampler.visitPixels(
+				Imath::Box2i( p - radius, p + radius + Imath::V2i( 1 ) ),
+				[&pixelsIt] ( float v, int x, int y )
 				{
-					*pixelsIt++ = sampler.sample( p.x + o.x, p.y + o.y );
+					*pixelsIt++ = v;
 				}
-			}
+			);
 			switch( m_mode )
 			{
 				case MedianRank:

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -73,6 +73,10 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 		// all bounds checking.
 		m_boundingMode = -1;
 	}
+	else if( BufferAlgo::empty( m_dataWindow ) )
+	{
+		m_boundingMode = Black;
+	}
 
 	// Compute the area we need to cache in order to
 	// be able to service calls within m_sampleWindow
@@ -105,6 +109,8 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	int cacheHeight = int( ceil( float( m_cacheWindow.size().y ) / ImagePlug::tileSize() ) );
 	m_dataCache.resize( m_cacheWidth * cacheHeight, nullptr );
 	m_dataCacheRaw.resize( m_cacheWidth * cacheHeight, nullptr );
+
+	m_cacheOriginIndex = ( m_cacheWindow.min.x >> ImagePlug::tileSizeLog2() ) + m_cacheWidth * ( m_cacheWindow.min.y >> ImagePlug::tileSizeLog2() );
 }
 
 void Sampler::hash( IECore::MurmurHash &h ) const

--- a/src/GafferImage/Warp.cpp
+++ b/src/GafferImage/Warp.cpp
@@ -309,7 +309,8 @@ void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 		h.append( tileOrigin );
 		enginePlug()->hash( h );
 
-		bool useDerivatives = useDerivativesPlug()->getValue();
+		std::string filterName = filterPlug()->getValue();
+		bool useDerivatives = ( filterName != "bilinear" ) && useDerivativesPlug()->getValue();
 		h.append( useDerivatives );
 		if( useDerivatives )
 		{
@@ -331,7 +332,7 @@ void Warp::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context
 
 		// The sampleRegionsPlug() includes an overall bound for the tile which depends on the filter
 		// support width
-		filterPlug()->hash( h );
+		h.append( filterName );
 	}
 
 	FlatImageProcessor::hash( output, context, h );
@@ -359,8 +360,14 @@ void Warp::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 			dataWindow = outPlug()->dataWindowPlug()->getValue();
 		}
 
-		const OIIO::Filter2D *filter = FilterAlgo::acquireFilter( filterPlug()->getValue() );
-		const float filterWidth = filter->width();
+		std::string filterName = filterPlug()->getValue();
+		const OIIO::Filter2D *filter = nullptr;
+		float filterWidth = 1.0f;
+		if( filterName != "bilinear" )
+		{
+			filter = FilterAlgo::acquireFilter( filterPlug()->getValue() );
+			filterWidth = filter->width();
+		}
 
 		const V2i tileOrigin = context->get<V2i>( ImagePlug::tileOriginContextName );
 
@@ -417,7 +424,7 @@ void Warp::compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) 
 		std::vector< V2f > &pixelInputDerivatives = pixelInputDerivativesData->writable();
 		pixelInputDerivatives.reserve( ImagePlug::tileSize() * ImagePlug::tileSize() );
 
-		bool useDerivatives = useDerivativesPlug()->getValue();
+		bool useDerivatives = filter && useDerivativesPlug()->getValue();
 
 		if( useDerivatives )
 		{
@@ -650,7 +657,12 @@ IECore::ConstFloatVectorDataPtr Warp::computeChannelData( const std::string &cha
 	vector<float> &result = resultData->writable();
 	result.reserve( ImagePlug::tileSize() * ImagePlug::tileSize() );
 
-	const OIIO::Filter2D *filter = FilterAlgo::acquireFilter( filterPlug()->getValue() );
+	std::string filterName = filterPlug()->getValue();
+	const OIIO::Filter2D *filter = nullptr;
+	if( filterName != "bilinear" )
+	{
+		filter = FilterAlgo::acquireFilter( filterPlug()->getValue() );
+	}
 
 
 	const Box2i &tileInputBound = sampleRegions->member< Box2iData >( g_tileInputBoundName, true )->readable();
@@ -685,7 +697,14 @@ IECore::ConstFloatVectorDataPtr Warp::computeChannelData( const std::string &cha
 				const V2f &input = pixelInputPositions[i];
 				if( input != Engine::black )
 				{
-					v = FilterAlgo::sampleBox( sampler, input, pixelInputDerivatives[i].x, pixelInputDerivatives[i].y, filter, scratchMemory );
+					if( filter )
+					{
+						v = FilterAlgo::sampleBox( sampler, input, pixelInputDerivatives[i].x, pixelInputDerivatives[i].y, filter, scratchMemory );
+					}
+					else
+					{
+						v = sampler.sample( input.x, input.y );
+					}
 				}
 			}
 			result.push_back( v );

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -35,6 +35,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "boost/python.hpp"
+#include "fmt/format.h"
 
 #include "GafferImageTest/ContextSanitiser.h"
 
@@ -43,6 +44,7 @@
 #include "GafferImage/ImageAlgo.h"
 #include "GafferImage/ImagePlug.h"
 #include "GafferImage/Format.h"
+#include "GafferImage/Sampler.h"
 
 #include "Gaffer/Node.h"
 
@@ -118,6 +120,43 @@ void testEditableScopeForFormat()
 	);
 }
 
+void validateVisitPixels( GafferImage::Sampler &sampler, const Imath::Box2i &region )
+{
+	int i = 0;
+	int sizeX = region.size().x;
+	sampler.visitPixels( region,
+		[&region, &sampler, &i, sizeX ] ( float value, int x, int y )
+		{
+			int expectedX = ( i % sizeX ) + region.min.x;
+			int expectedY = ( i / sizeX ) + region.min.y;
+			if( x != expectedX || y != expectedY )
+			{
+				throw IECore::Exception( fmt::format (
+					"visitPixels passed incorrect coordinate - expected {},{}, received {},{}",
+					expectedX, expectedY, x, y
+				) );
+			}
+
+			float expectedValue = sampler.sample( x, y );
+			if( value != expectedValue )
+			{
+				throw IECore::Exception( fmt::format(
+					"visitPixels passed incorrect value for pixel {},{} - expected {} received {}",
+					x, y, expectedValue, value
+				) );
+			}
+			i++;
+		}
+	);
+	if( i != region.size().x * region.size().y )
+	{
+		throw IECore::Exception( fmt::format(
+			"visitPixels processed wrong number of pixels: visited {} in region of size {},{}",
+			i, region.size().x, region.size().y
+		) );
+	}
+}
+
 } // namespace
 
 BOOST_PYTHON_MODULE( _GafferImageTest )
@@ -129,4 +168,5 @@ BOOST_PYTHON_MODULE( _GafferImageTest )
 	def( "processTiles", &processTilesWrapper );
 	def( "connectProcessTilesToPlugDirtiedSignal", &connectProcessTilesToPlugDirtiedSignal );
 	def( "testEditableScopeForFormat", &testEditableScopeForFormat );
+	def( "validateVisitPixels", &validateVisitPixels );
 }


### PR DESCRIPTION
I was doing some experimenting with some of our more expensive image operations, and found that Sampler.sample() is a big bottleneck.  In cases where we need to sample every pixel in a region, we can do much better by doing the iteration within Sampler, where we can iterate through every pixel in the region within a particular tile with a single call to cachedData.

I was a bit unsure how to demonstrate the benefit from this ... Resample with a non-separable filter should benefit because it needs to do an enormous amount of sampling ... but the only case we have currently of a non-separable filter is a filter which is incredibly slow to evaluate, so it doesn't really demonstrate the benefit.

I've ended up demonstrating this on RankFilter - this is a little silly, because RankFilter doesn't need to do all this repeated sampling of the same pixels, but for our current naive implementation, it does show a noticeable speedup, 4X for Erode/Dilate, and 2X for Median.

A more practical demonstration of benefit would be optimizing Blur, but that feels a little bit more contentious, because doing that efficiently would probably require adding a special case to Resample for when the matrix is an identity and the filter weights are identical for every pixel ... I think this makes a lot of sense, but perhaps should be a separate PR.

I think this is looking pretty good, though I wish I had slightly more thorough tests for the rank filters in order to validate this sort of work, and ideally I would double check that visitPixels is fully getting inlined and optimized away properly - the goal is that copying a scanline into a vector should be optimized to basically a memcpy per tile.