### PR TITLE
Animation curve style

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,11 +24,13 @@ API
 ---
 
 - PlugAlgo : Added `findDestination()` utility method.
+- Style : `renderAnimationCurve()` function now takes a vector of curve vertices and an `inKeyRange` argument that indicates whether the specified curve vertices lie within the time range of the curve's keys.
 
 Breaking Changes
 ----------------
 
 - Arnold : Changed the default values for the `ai:GI_diffuse_depth` and `ai:GI_specular_depth` options.
+- Style : Changed the signature of the `renderAnimationCurve()` virtual function.
 
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -179,6 +179,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 
 		MoveAxis m_moveAxis;
 
+		mutable std::vector< Imath::V2f > m_vertices;
 		Gaffer::Animation::KeyPtr m_snappingClosestKey;
 		Gaffer::Animation::KeyPtr m_highlightedKey;
 		Gaffer::Animation::CurvePlugPtr m_highlightedCurve;

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -100,7 +100,7 @@ class GAFFERUI_API StandardStyle : public Style
 		void renderRotateHandle( Axes axes, State state = NormalState, const Imath::V3f &highlightVector = Imath::V3f( 0 ) ) const override;
 		void renderScaleHandle( Axes axes, State state = NormalState ) const override;
 
-		void renderAnimationCurve( const Imath::V2f &start, const Imath::V2f &end, const Imath::V2f &startTangent, const Imath::V2f &endTangent, State state, const Imath::Color3f *userColor = nullptr ) const override;
+		void renderAnimationCurve( const std::vector< Imath::V2f > &vertices, bool inKeyRange, State state, const Imath::Color3f *userColor = nullptr ) const override;
 		void renderAnimationKey( const Imath::V2f &position, State state, float size = 2.0, const Imath::Color3f *userColor = nullptr ) const override;
 
 		enum Color

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -160,7 +160,7 @@ class GAFFERUI_API Style : public IECore::RunTimeTyped
 		/// @name Animation UI elements
 		//////////////////////////////////////////////////////////////////////////
 		//@{
-		virtual void renderAnimationCurve( const Imath::V2f &start, const Imath::V2f &end, const Imath::V2f &startTangent, const Imath::V2f &endTangent, State state, const Imath::Color3f *userColor = nullptr ) const = 0;
+		virtual void renderAnimationCurve( const std::vector< Imath::V2f > &vertices, bool inKeyRange, State state, const Imath::Color3f *userColor = nullptr ) const = 0;
 		virtual void renderAnimationKey( const Imath::V2f &position, State state, float size = 2.0, const Imath::Color3f *userColor = nullptr ) const = 0;
 		//@}
 


### PR DESCRIPTION
This PR improves the `Style` api for drawing animation curves.
The signature of the `Style::renderAnimationCurve()` function now takes a vector of evaluated curve vertices which allows an implementation to draw an entire curve as a series of connected lines (GL_LINE_STRIP) with a single opengl draw call and therefore implement stippling effects such as dotted and dashed lines. The function also takes an additional `inKeyRange` argument which specifies whether the evaluated curve vertices lie within the time range of the curve's keys. The intention is that this argument will be set to true for the interpolated portion of each curve and false for extrapolated portions of a curve.

The `StandardStyle` implementation of `renderAnimationCurve()` now draws a curve outside the key range as a single continous dotted line using the opengl 1.0 stipple api. Perhaps in the future this could be improved to use a shader based stippling approach if necessary.

The drawing code for extrapolated curves in #5012 will need to be updated to use this new api. The changes necessary are minimal and could be added as a subsequent PR once both this PR and #5012 have been merged. Alternatively once this PR is merged the changes could be added to the #5012 PR as an additional commit.

### Breaking changes ###

This PR changes the signature of the virtual function `Style::renderAnimationCurve()`

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
