### PR TITLE
PathListingWidget : Disable Qt's keyboard search feature

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Cycles : Disabled auto-tiling mode for the viewport/interactive render mode, which caused odd/glitchy behaviour on larger than 2k renders.
+- HierarchyView : Fixed <kbd>P</kbd> and <kbd>N</kbd> editor focus hotkeys.
 
 1.1.7.0 (relative to 1.1.6.1)
 =======

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -902,6 +902,24 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 		self.__recalculatingColumnWidths = False
 
+	def keyPressEvent( self, event ) :
+
+		# When the tree view has focus, the base class steals most
+		# keypresses to perform a search for a matching item. We don't
+		# like that because it prevents our own hotkeys from working,
+		# including the `P` and `N` shortcuts for managing editor focus.
+		# There is no way of turning off this behaviour, so we override
+		# `keyboardSearch()` to do nothing, and then reject the event
+		# after the fact.
+		self.__didKeyboardSearch = False
+		QtWidgets.QTreeView.keyPressEvent( self, event )
+		if self.__didKeyboardSearch :
+			event.setAccepted( False )
+
+	def keyboardSearch( self, search ) :
+
+		self.__didKeyboardSearch = True
+
 	def paintEvent( self, event ) :
 
 		QtWidgets.QTreeView.paintEvent( self, event )


### PR DESCRIPTION
This makes the key events available for our own handlers. In particular, this fixes the `P` and `N` hotkeys for pinning and following selection in the HierarchyView.

I don't know if folks are relying on the keyboard search feature or not, so this might be contentious. One possibility would be to limit the disabling to only the HierarchyView and not to other PathListingWidgets. Feedback welcome.