### PR TITLE
gui App : Fix recent file list on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
   - Fixed undo for `Remove` menu item in Filter tab.
 - 3Delight : Fixed bug preventing 3delight from loading on Windows. (#5081). This also caused errors in the light editor at startup : `IECore.Exception: File "maya/osl/pointLight" could not be found.` [^2]
 - NodeEditor : Fixed bugs in handling of "green dot" non-default-value indicators with nested plugs.
+- GUI App : Fixed error on Windows when launching the `gui` app after a previous launch loaded a script with `\` in the path. [^2]
 
 API
 ---

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -220,7 +220,7 @@ def addRecentFile( application, fileName, *_reserved ) :
 
 		f.write( "import GafferUI\n" )
 		for fileName in reversed( applicationRoot.__recentFiles ) :
-			f.write( "GafferUI.FileMenu.addRecentFile( application, \"%s\" )\n" % fileName )
+			f.write( "GafferUI.FileMenu.addRecentFile( application, {} )\n".format( repr( fileName ) ) )
 
 ## A function suitable as the command for a File/Save menu item. It must be invoked from a menu which
 # has a ScriptWindow in its ancestry.


### PR DESCRIPTION
This fixes `SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape` on Windows when executing `recentFiles.py` after having launched the Gaffer `gui` app with a script path containing a `\`.

This is particularly useful when loading a script at launch with a system-provided environment variable like `USERPROFILE` for the home directory, which will use `\`.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
