### PR TITLE
Light Editor Solo Column

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,11 @@ Fixes
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 
+API
+---
+
+- EditScopeAlgo : Added `acquireSetEdits()` method.
+
 1.2.0.0a3 (relative to 1.2.0.0a2)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,11 @@ API
 
 - EditScopeAlgo : Added `acquireSetEdits()` method.
 
+Breaking Changes
+----------------
+
+- Mute/Solo : Changed the dominant state to mute. If a light is both muted and soloed, its final state will be `mute`. [^2]
+
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 

--- a/Changes.md
+++ b/Changes.md
@@ -30,10 +30,18 @@ Fixes
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 
+Fixes
+-----
+
+- Light Editor : Fixed tooltips that were missing the "Double-click to toggle" hint. [^2]
+
 API
 ---
 
 - EditScopeAlgo : Added `acquireSetEdits()` method.
+
+[^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
+[^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 
 1.2.0.0a3 (relative to 1.2.0.0a2)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.0.0a3)
 =======
 
+Features
+--------
+
+- Light Editor : Added a read-only "Solo" column to indicate lights that are in the `soloLights` set.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- Light Editor : Added a read-only "Solo" column to indicate lights that are in the `soloLights` set.
+- Light Editor : Added a "Solo" column to quickly add and remove lights from the `soloLights` set.
 
 Improvements
 ------------

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -135,6 +135,7 @@ enum class SetMembership
 	Unchanged
 };
 
+GAFFERSCENE_API Gaffer::ValuePlug *acquireSetEdits( Gaffer::EditScope *scope, const std::string &set, bool createIfNecessary = true  );
 GAFFERSCENE_API void setSetMembership( Gaffer::EditScope *scope, const IECore::PathMatcher &paths, const std::string &set, SetMembership state );
 GAFFERSCENE_API SetMembership getSetMembership( Gaffer::EditScope *scope, const ScenePlug::ScenePath &path, const std::string &set );
 GAFFERSCENE_API const Gaffer::GraphComponent *setMembershipReadOnlyReason( const Gaffer::EditScope *scope, const std::string &set, SetMembership state );

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef GAFFERSCENEUI_SETMEMBERSHIPINSPECTOR_H
+#define GAFFERSCENEUI_SETMEMBERSHIPINSPECTOR_H
+
+#include "GafferSceneUI/Export.h"
+
+#include "GafferSceneUI/Private/Inspector.h"
+
+namespace GafferSceneUI
+{
+
+namespace Private
+{
+
+class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
+{
+
+	public :
+
+		SetMembershipInspector(
+			const GafferScene::ScenePlugPtr &scene,
+			const Gaffer::PlugPtr &editScope,
+			IECore::InternedString setName
+		);
+
+		IE_CORE_DECLAREMEMBERPTR( SetMembershipInspector );
+
+	protected :
+
+		GafferScene::SceneAlgo::History::ConstPtr history() const override;
+		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
+		/// For the given `history`, returns either the "sets" `StringPlug` of an `ObjectSource`
+		/// node, the "name" `StringPlug` of a `Set` node, the `Spreadsheet::RowPlug` for the
+		/// appropriate row of a set membership processor spreadsheet or `nullptr` if none of
+		/// those are found.
+		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
+		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+
+	private :
+
+		void plugDirtied( Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
+
+		const GafferScene::ScenePlugPtr m_scene;
+		const IECore::InternedString m_setName;
+};
+
+}
+
+}
+
+#endif // GAFFERSCENEUI_SETMEMBERSHIPINSPECTOR_H

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -41,6 +41,9 @@
 
 #include "GafferSceneUI/Private/Inspector.h"
 
+#include "GafferScene/EditScopeAlgo.h"
+#include "GafferScene/ScenePlug.h"
+
 namespace GafferSceneUI
 {
 
@@ -57,6 +60,15 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 			const Gaffer::PlugPtr &editScope,
 			IECore::InternedString setName
 		);
+
+		/// Convenience method to acquire an edit from `inspection` and
+		/// edit the set membership to include or exclude `path`. Returns true
+		/// if an edit was made, false otherwise.
+		bool editSetMembership(
+			const Result *inspection,
+			const GafferScene::ScenePlug::ScenePath &path,
+			GafferScene::EditScopeAlgo::SetMembership setMembership
+		) const;
 
 		IE_CORE_DECLAREMEMBERPTR( SetMembershipInspector );
 

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -1078,12 +1078,12 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		# - lightSolo2                  False           in          False
 		# - lightMute                   True            out         True
 		# --- lightMuteChild            undefined       out         True
-		# --- lightMuteChildSolo        undefined       in          False
-		# - lightMuteSolo               True            in          False
-		# --- lightMuteSoloChild        undefined       out         False
-		# --- lightMuteSoloChildSolo    undefined       in          False
+		# --- lightMuteChildSolo        undefined       in          True
+		# - lightMuteSolo               True            in          True
+		# --- lightMuteSoloChild        undefined       out         True
+		# --- lightMuteSoloChildSolo    undefined       in          True
 		# - groupMute                   True            out         --
-		# --- lightGroupMuteChildSolo   undefined       in          False
+		# --- lightGroupMuteChildSolo   undefined       in          True
 
 		lightSolo = GafferSceneTest.TestLight()
 		lightSolo["name"].setValue( "lightSolo" )
@@ -1229,25 +1229,25 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( renderer.capturedObject( "/lightSolo2" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightMute" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightMute/lightMuteChild" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMute/lightMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMuteSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChild" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/groupMute/lightGroupMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMute/lightMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMuteSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChild" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/groupMute/lightGroupMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
 
 		#   Light                       light:mute      soloLights  Mute Result
 		#   ---------------------------------------------------------------------------
 		# - lightSolo                   undefined       out         True
 		# - light                       undefined       in          False
 		# - lightSolo2                  False           out         True
-		# - lightMute                   True            in          False
-		# --- lightMuteChild            undefined       in          False
-		# --- lightMuteChildSolo        undefined       out         False
+		# - lightMute                   True            in          True
+		# --- lightMuteChild            undefined       in          True
+		# --- lightMuteChildSolo        undefined       out         True
 		# - lightMuteSolo               True            out         True
-		# --- lightMuteSoloChild        undefined       in          False
+		# --- lightMuteSoloChild        undefined       in          True
 		# --- lightMuteSoloChildSolo    undefined       out         True
 		# - groupMute                   True            in          --
-		# --- lightGroupMuteChildSolo   undefined       out         False
+		# --- lightGroupMuteChildSolo   undefined       out         True
 
 		soloFilter["paths"].setValue(
 			IECore.StringVectorData(
@@ -1265,13 +1265,13 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( renderer.capturedObject( "/lightSolo" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertFalse( renderer.capturedObject( "/light" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightSolo2" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMute" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMute/lightMuteChild" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMute/lightMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMute" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMute/lightMuteChild" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMute/lightMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightMuteSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChild" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChild" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/groupMute/lightGroupMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/groupMute/lightGroupMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
 
 	def testSoloLightsSetUpdate( self ) :
 

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -157,7 +157,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		# - lightMute                   True            out         True
 		# --- lightMuteChild            undefined       out         True
 		# --- lightMuteChildSolo        undefined       in          False
-		# - lightMuteSolo               True            in          False
+		# - lightMuteSolo               True            in          True
 		# --- lightMuteSoloChild        undefined       out         False
 		# --- lightMuteSoloChildSolo    undefined       in          False
 		# - groupMute                   True            out         --
@@ -312,7 +312,7 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertTrue( renderer.capturedObject( "/lightMute" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertTrue( renderer.capturedObject( "/lightMute/lightMuteChild" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertFalse( renderer.capturedObject( "/lightMute/lightMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
-		self.assertFalse( renderer.capturedObject( "/lightMuteSolo" ).capturedAttributes().attributes()["light:mute"].value )
+		self.assertTrue( renderer.capturedObject( "/lightMuteSolo" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertFalse( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChild" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertFalse( renderer.capturedObject( "/lightMuteSolo/lightMuteSoloChildSolo" ).capturedAttributes().attributes()["light:mute"].value )
 		self.assertFalse( renderer.capturedObject( "/groupMute/lightGroupMuteChildSolo" ).capturedAttributes().attributes()["light:mute"].value )

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -112,6 +112,12 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 						self.__settingsNode["in"],
 						self.__settingsNode["editScope"]
 					),
+					_GafferSceneUI._LightEditorSetMembershipColumn(
+						self.__settingsNode["in"],
+						self.__settingsNode["editScope"],
+						"soloLights",
+						"Solo"
+					),
 				],
 				selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
@@ -248,7 +254,8 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 
 		nameColumn = self.__pathListing.getColumns()[0]
 		muteColumn = self.__pathListing.getColumns()[1]
-		self.__pathListing.setColumns( [ nameColumn, muteColumn ] + sectionColumns )
+		soloColumn = self.__pathListing.getColumns()[2]
+		self.__pathListing.setColumns( [ nameColumn, muteColumn, soloColumn ] + sectionColumns )
 
 	def __settingsPlugSet( self, plug ) :
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -123,6 +123,9 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 				horizontalScrollMode = GafferUI.ScrollMode.Automatic
 			)
+
+			self.__soloColumnIndex = 2
+
 			self.__pathListing.setDragPointer( "objects" )
 			self.__pathListing.setSortable( False )
 			self.__selectionChangedConnection = self.__pathListing.selectionChangedSignal().connect(
@@ -618,7 +621,8 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			menuDefinition.append(
 				"Edit...",
 				{
-					"command" : functools.partial( self.__editSelectedCells, pathListing, False )
+					"command" : functools.partial( self.__editSelectedCells, pathListing, False ),
+					"active" : pathListing.getSelection()[self.__soloColumnIndex].isEmpty(),
 				}
 			)
 			menuDefinition.append(

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -220,7 +220,10 @@ class _HistoryWindow( GafferUI.Window ) :
 				selectedPath.property( "history:node" ),
 				floating = True
 			)
-		elif selectedColumn == self.__valueColumnIndex or selectedColumn == self.__operationColumnIndex :
+		elif (
+			( selectedColumn == self.__valueColumnIndex or selectedColumn == self.__operationColumnIndex ) and
+			not isinstance( self.__inspector, GafferSceneUI.Private.SetMembershipInspector )
+		) :
 			editPlug = selectedPath.property( "history:source" )
 			self.__popup = GafferUI.PlugPopup(
 				[ editPlug ], warning = selectedPath.property( "history:editWarning" )

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -96,6 +98,35 @@ class _NodeNameColumn( GafferUI.PathColumn ) :
 
 		return self.CellData( self.__title )
 
+# \todo This duplicates logic from (in this case) `_GafferSceneUI._LightEditorSetMembershipColumn`.
+# Refactor to allow calling `_GafferSceneUI.InspectorColumn.cellData()` from `_HistoryWindow` to
+# remove this duplication for columns that customize their value presentation.
+class _SetMembershipColumn( GafferUI.PathColumn ) :
+
+	def __init__( self, title, property ) :
+
+		GafferUI.PathColumn.__init__( self )
+
+		self.__title = title
+		self.__property = property
+
+	def cellData( self, path, canceller = None ) :
+
+		cellValue = path.property( self.__property )
+
+		data = self.CellData()
+
+		if cellValue & IECore.PathMatcher.Result.ExactMatch :
+			data.icon = "setMember.png"
+		elif cellValue & IECore.PathMatcher.Result.AncestorMatch :
+			data.icon = "setMemberFaded.png"
+
+		return data
+
+	def headerData( self, canceller = None ) :
+
+		return self.CellData( self.__title )
+
 class _HistoryWindow( GafferUI.Window ) :
 
 	def __init__( self, inspector, scenePath, context, scriptNode, title=None, **kw ) :
@@ -116,7 +147,9 @@ class _HistoryWindow( GafferUI.Window ) :
 				Gaffer.DictPath( {}, "/" ),
 				columns = (
 					_NodeNameColumn( "Node", "history:node", self.__scriptNode ),
-					GafferUI.PathListingWidget.StandardColumn( "Value", "history:value" ),
+					_SetMembershipColumn( "Value", "history:value" ) if (
+						isinstance( inspector, GafferSceneUI.Private.SetMembershipInspector )
+					) else GafferUI.PathListingWidget.StandardColumn( "Value", "history:value" ),
 					_OperationIconColumn( "Operation", "history:operation" ),
 				),
 				sortable = False,

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -637,12 +637,12 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 			if muteIndex is None :
 				for i, c in zip( range( 0, len( columns ) ), columns ) :
-					if isinstance( c, _GafferSceneUI._LightEditorInspectorColumn ) :
+					if isinstance( c, _GafferSceneUI._LightEditorMuteColumn ) :
 						muteIndex = i
 
 			self.assertIsNotNone( muteIndex )
 
-			selection = [IECore.PathMatcher()] * len( columns )
+			selection = [ IECore.PathMatcher() for i in range( 0, len( columns ) ) ]
 			for path in togglePaths :
 				selection[muteIndex].addPath( path )
 

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -1,0 +1,420 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class SetMembershipInspectorTest( GafferUITest.TestCase ) :
+
+	def testName( self ) :
+
+		plane = GafferScene.Plane()
+
+		inspector = GafferSceneUI.Private.SetMembershipInspector( plane["out"], None, "planeSet" )
+		self.assertEqual( inspector.name(), "planeSet" )
+
+	@staticmethod
+	def __inspect( scene, path, setName, editScope=None ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.SetMembershipInspector( scene, editScopePlug, setName )
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( path.split( "/" )[1:] )
+			return inspector.inspect()
+
+	def __assertExpectedResult(
+		self,
+		result,
+		source,
+		sourceType,
+		editable,
+		nonEditableReason = "",
+		edit = None,
+		editWarning = ""
+	) :
+
+		self.assertEqual( result.source(), source )
+		self.assertEqual( result.sourceType(), sourceType )
+		self.assertEqual( result.editable(), editable )
+
+		if editable :
+			self.assertEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), "" )
+
+			acquiredEdit = result.acquireEdit()
+			self.assertIsNotNone( acquiredEdit )
+			if result.editScope() :
+				self.assertTrue( result.editScope().isAncestorOf( acquiredEdit ) )
+
+			if edit is not None :
+				self.assertEqual(
+					acquiredEdit.fullName() if acquiredEdit is not None else "",
+					edit.fullName() if edit is not None else ""
+				)
+
+			self.assertEqual( result.editWarning(), editWarning )
+
+		else :
+			self.assertIsNone( edit )
+			self.assertEqual( editWarning, "" )
+			self.assertEqual( result.editWarning(), "" )
+			self.assertNotEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), nonEditableReason )
+			self.assertRaises( RuntimeError, result.acquireEdit )
+
+	def testValue( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "planeSet" )
+
+		self.assertEqual(
+			self.__inspect( plane["out"], "/plane", "planeSet" ).value().value,
+			IECore.PathMatcher.Result.ExactMatch
+		)
+
+	def testSourceAndEdits( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["plane"] = GafferScene.Plane()
+		s["plane"]["sets"].setValue( "planeSet" )
+
+		s["group"] = GafferScene.Group()
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope2"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["plane"]["out"] )
+
+		s["editScope1"].setup( s["group"]["out"] )
+		s["editScope1"]["in"].setInput( s["group"]["out"] )
+
+		s["editScope2"].setup( s["editScope1"]["out"] )
+		s["editScope2"]["in"].setInput( s["editScope1"]["out"] )
+
+		# Should be able to edit the plane directly.
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "/group/plane", "planeSet", None ),
+			source = s["plane"]["sets"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["plane"]["sets"]
+		)
+
+		# Even if there is an edit scope in the way
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSet", None ),
+			source = s["plane"]["sets"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["plane"]["sets"]
+		)
+
+		# We shouldn't be able to edit it if we've been told to use an EditScope and it isn't in the history
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "/group/plane", "planeSet", s["editScope1"] ),
+			source = s["plane"]["sets"],
+			sourceType = SourceType.Other,
+			editable = False,
+			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+		)
+
+		# If it is in the history though, and we're told to use it, then we will.
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/plane", "planeSet", s["editScope2"] )
+		self.assertIsNone(
+			GafferScene.EditScopeAlgo.acquireSetEdits(
+				s["editScope2"], "planeSet", createIfNecessary = False
+			)
+		)
+
+		self.__assertExpectedResult(
+			inspection,
+			source = s["plane"]["sets"],
+			sourceType = SourceType.Upstream,
+			editable = True
+		)
+
+		planeEditScope2Edit = inspection.acquireEdit()
+
+		self.assertIsNotNone( planeEditScope2Edit )
+		self.assertEqual(
+			planeEditScope2Edit,
+			GafferScene.EditScopeAlgo.acquireSetEdits(
+				s["editScope2"], "planeSet", createIfNecessary = False
+			)
+		)
+
+		# If there's an edit downstream of the EditScope we're asked to use,
+		# then we're allowed to be editable still
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/plane", "planeSet", s["editScope1"] )
+		self.assertTrue( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "" )
+		planeEditScope1Edit = inspection.acquireEdit()
+		self.assertEqual(
+			planeEditScope1Edit,
+			GafferScene.EditScopeAlgo.acquireSetEdits(
+				s["editScope1"], "planeSet", createIfNecessary = False
+			)
+		)
+		self.assertEqual( inspection.editWarning(), "" )
+
+		# If there is a source node inside an edit scope, make sure we use that
+
+		s["editScope1"]["plane2"] = GafferScene.Plane()
+		s["editScope1"]["plane2"]["sets"].setValue( "planeSet" )
+		s["editScope1"]["plane2"]["name"].setValue( "plane2" )
+		s["editScope1"]["parentPlane2"] = GafferScene.Parent()
+		s["editScope1"]["parentPlane2"]["parent"].setValue( "/" )
+		s["editScope1"]["parentPlane2"]["children"][0].setInput( s["editScope1"]["plane2"]["out"] )
+		s["editScope1"]["parentPlane2"]["in"].setInput( s["editScope1"]["BoxIn"]["out"] )
+		s["editScope1"]["SetMembershipEdits"]["in"].setInput( s["editScope1"]["parentPlane2"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope1"] ),
+			source = s["editScope1"]["plane2"]["sets"],
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = s["editScope1"]["plane2"]["sets"]
+		)
+
+		# If there is a set node in the scope's processor, make sure we use that
+
+		GafferScene.EditScopeAlgo.setSetMembership(
+			s["editScope1"],
+			IECore.PathMatcher( [ "/plane2" ] ),
+			"planeSet",
+			GafferScene.EditScopeAlgo.SetMembership.Added
+		)
+		plane2Edit = GafferScene.EditScopeAlgo.acquireSetEdits(
+			s["editScope1"], "planeSet", createIfNecessary = False
+		)
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope1"] ),
+			source = plane2Edit,
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = plane2Edit
+		)
+
+		# If there is a manual set node downstream of the scope's scene processor, make sure we use that
+
+		s["editScope1"]["setPlane2"] = GafferScene.Set()
+		s["editScope1"]["setPlane2"]["name"].setValue( "planeSet" )
+		s["editScope1"]["setPlane2"]["mode"].setValue( GafferScene.Set.Mode.Add )
+		s["editScope1"]["setPlane2"]["in"].setInput( s["editScope1"]["SetMembershipEdits"]["out"] )
+		s["editScope1"]["setPlane2Filter"] = GafferScene.PathFilter()
+		s["editScope1"]["setPlane2Filter"]["paths"].setValue( IECore.StringVectorData( [ "/plane2"] ) )
+		s["editScope1"]["setPlane2"]["filter"].setInput( s["editScope1"]["setPlane2Filter"]["out"] )
+		s["editScope1"]["BoxOut"]["in"].setInput( s["editScope1"]["setPlane2"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope1"] ),
+			source = s["editScope1"]["setPlane2"]["name"],
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = s["editScope1"]["setPlane2"]["name"]
+		)
+
+		# If there is a manual set node outside of an edit scope, make sure we use that with no scope
+		s["independentSet"] = GafferScene.Set()
+		s["independentSet"]["name"].setValue( "planeSet" )
+		s["independentSet"]["mode"].setValue( GafferScene.Set.Mode.Add )
+		s["independentSet"]["in"].setInput( s["editScope2"]["out"] )
+
+		s["independentSetFilter"] = GafferScene.PathFilter()
+		s["independentSetFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/plane" ] ) )
+		s["independentSet"]["filter"].setInput( s["independentSetFilter"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentSet"]["out"], "/group/plane", "planeSet", None ),
+			source = s["independentSet"]["name"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["independentSet"]["name"]
+		)
+
+		# Check editWarnings and nonEditableRasons
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentSet"]["out"], "/group/plane", "planeSet", s["editScope2"] ),
+			source = s["independentSet"]["name"],
+			sourceType = SourceType.Downstream,
+			editable = True,
+			edit = planeEditScope2Edit,
+			editWarning = "SetMembership has edits downstream in independentSet."
+		)
+
+		s["editScope2"]["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentSet"]["out"], "/group/plane", "planeSet", s["editScope2"] ),
+			source = s["independentSet"]["name"],
+			sourceType = SourceType.Downstream,
+			editable = False,
+			nonEditableReason = "The target EditScope (editScope2) is disabled."
+		)
+
+		s["editScope2"]["enabled"].setValue( True )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope2"] ),
+			source = s["editScope1"]["setPlane2"]["name"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2 is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], False )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["SetMembershipEdits"]["edits"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope2"] ),
+			source = s["editScope1"]["setPlane2"]["name"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.SetMembershipEdits.edits is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["SetMembershipEdits"], True )
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/plane2", "planeSet", s["editScope2"] ),
+			source = s["editScope1"]["setPlane2"]["name"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.SetMembershipEdits is locked."
+		)
+
+	def testNonExistentLocation( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "planeSet" )
+		self.assertIsNone( self.__inspect( plane["out"], "/nothingHere", "planeSet" ) )
+
+	def testObjectSourceFallback( self ) :
+
+		# ObjectSource nodes should always return their `sets` plug as a source. Otherwise,
+		# creating a new set that doesn't yet exist would not be possible.
+
+		plane = GafferScene.Plane()
+		self.__assertExpectedResult(
+			self.__inspect( plane["out"], "/plane", "planeSet" ),
+			source = plane["sets"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True
+		)
+
+	def testDirtiedSignal( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "planeSet" )
+
+		editScope1 = Gaffer.EditScope()
+		editScope1.setup( plane["out"] )
+		editScope1["in"].setInput( plane["out"] )
+
+		editScope2 = Gaffer.EditScope()
+		editScope2.setup( editScope1["out"] )
+		editScope2["in"].setInput( editScope1["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.SetMembershipInspector(
+			editScope2["out"], settings["editScope"], "planeSet"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		# Changing the sets should dirty the inspector
+		plane["sets"].setValue( "newPlaneSet" )
+		self.assertEqual( len( cs ), 1 )
+
+		# Changing the transform should not
+		plane["transform"]["translate"]["x"].setValue( 10 )
+		self.assertEqual( len( cs ), 1 )
+
+		# Changing the EditScope should dirty the inspector
+		settings["editScope"].setInput( editScope1["enabled"] )
+		self.assertEqual( len( cs ), 2 )
+		settings["editScope"].setInput( editScope2["enabled"] )
+		self.assertEqual( len( cs ), 3 )
+		settings["editScope"].setInput( None )
+		self.assertEqual( len( cs ), 4 )
+
+	def testReadOnlyMetadataSignalling( self ) :
+
+		plane = GafferScene.Plane()
+		plane["sets"].setValue( "planeTest" )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( plane["out"] )
+		editScope["in"].setInput( plane["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.SetMembershipInspector(
+			editScope["out"], settings["editScope"], "planeSet"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, False )
+		self.assertEqual( len( cs ), 0 )  # Changes not relevant because we're not using the EditScope
+
+		settings["editScope"].setInput( editScope["enabled"] )
+		self.assertEqual( len( cs ), 1 )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		self.assertEqual( len( cs ), 2 )  # Change affects the result of `inspect().editable()`
+
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -56,6 +56,7 @@ from .ParameterInspectorTest import ParameterInspectorTest
 from .AttributeInspectorTest import AttributeInspectorTest
 from .HistoryPathTest import HistoryPathTest
 from .LightEditorTest import LightEditorTest
+from .SetMembershipInspectorTest import SetMembershipInspectorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1269,7 +1269,7 @@ _styleSheet = string.Template(
 		paint-alternating-row-colors-for-empty-area: 1;
 	}
 
-	*[gafferClass="GafferSceneUI.HierarchyView"] QTreeView::item {
+	*[gafferClass="GafferSceneUI.HierarchyView"], *[gafferClass="GafferSceneUI.LightEditor"] QTreeView::item {
 		height: 18px;
 		padding-top: 0px;
 		padding-bottom: 0px;

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1269,6 +1269,11 @@ _styleSheet = string.Template(
 		paint-alternating-row-colors-for-empty-area: 1;
 	}
 
+	*[gafferClass="GafferSceneUI.LightEditor"] QHeaderView::section {
+		height: 18px;
+		padding-left: 2px;
+	}
+
 	*[gafferClass="GafferSceneUI.HierarchyView"], *[gafferClass="GafferSceneUI.LightEditor"] QTreeView::item {
 		height: 18px;
 		padding-top: 0px;

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1280,6 +1280,12 @@ _styleSheet = string.Template(
 		padding-bottom: 0px;
 	}
 
+	*[gafferClass="GafferSceneUI._HistoryWindow"] QTreeView::item {
+		height: 18px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+	}
+
 	QTreeView::item {
 		padding-top: 2px;
 		padding-bottom: 2px;

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -356,6 +356,10 @@
 				"muteLightFadedHighlighted",
 				"unMuteLightFadedHighlighted",
 				"muteLightUndefined",
+				"setMember",
+				"setMemberHighlighted",
+				"setMemberFaded",
+				"setMemberFadedHighlighted",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -2765,7 +2765,7 @@
          x="10"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="sizeGuide" />
       <rect
          id="unMuteLight"
@@ -2839,6 +2839,38 @@
          x="408"
          y="2544"
          id="muteLightUndefined" />
+      <rect
+         id="setMember"
+         y="2544"
+         x="430"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="setMember" />
+      <rect
+         inkscape:label="setMemberHighlighted"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="450.95377"
+         y="2544"
+         id="setMemberHighlighted" />
+      <rect
+         inkscape:label="setMemberFaded"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="473"
+         y="2544"
+         id="setMemberFaded" />
+      <rect
+         id="setMemberFadedHighlighted"
+         y="2544.0928"
+         x="494.91803"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="setMemberFadedHighlighted" />
     </g>
     <g
        id="g6806"
@@ -8651,6 +8683,30 @@
    cx="394.00079"
    cy="2604.3616"
    r="5.5" />
+<circle
+   r="5.5"
+   cy="2604.3787"
+   cx="438.00079"
+   id="circle6245"
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+<circle
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   id="circle6249"
+   cx="459.00079"
+   cy="2604.3787"
+   r="5.5" />
+<circle
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   id="circle6251"
+   cx="481.00079"
+   cy="2604.3787"
+   r="5.5" />
+<circle
+   r="5.5"
+   cy="2604.3616"
+   cx="503.00079"
+   id="circle6253"
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 </g>
     <g
        id="g6430"

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -643,6 +643,16 @@ void RenderSets::attributes( CompoundObject::ObjectMap &attributes, const SceneP
 
 	if( !soloLightsSet().isEmpty() && lightsSet().match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) )
 	{
+		auto muteData = attributes.find( g_lightMuteAttributeName );
+		if( muteData != attributes.end() )
+		{
+			auto mute = runTimeCast<const BoolData>( muteData->second );
+			if( mute && mute->readable() )
+			{
+				return;
+			}
+		}
+
 		if( soloLightsSet().match( path ) & ( PathMatcher::ExactMatch | PathMatcher::AncestorMatch ) )
 		{
 			attributes[g_lightMuteAttributeName] = g_false;

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -179,6 +179,12 @@ GraphComponentPtr attributeEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, 
 // Set Membership
 // ==============
 
+ValuePlugPtr acquireSetEditsWrapper( Gaffer::EditScope &scope, const std::string &set, bool createIfNecessary )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::acquireSetEdits( &scope, set, createIfNecessary );
+}
+
 void setSetMembershipWrapper( Gaffer::EditScope &scope, const IECore::PathMatcher &paths, const std::string &set, EditScopeAlgo::SetMembership state )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -238,6 +244,7 @@ void bindEditScopeAlgo()
 	def( "removeAttributeEdit", &removeAttributeEditWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
 	def( "attributeEditReadOnlyReason", &attributeEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "path" ), arg( "attribute" ) ) );
 
+	def( "acquireSetEdits", &acquireSetEditsWrapper, ( arg( "scope" ), arg( "set" ), arg( "createIfNecessary" ) = true ) );
 	def( "setSetMembership", &setSetMembershipWrapper );
 	def( "getSetMembership", &getSetMembershipWrapper );
 	def( "setMembershipReadOnlyReason", &setMembershipReadOnlyReasonWrapper );

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -1,0 +1,285 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/SetMembershipInspector.h"
+
+#include "GafferScene/EditScopeAlgo.h"
+#include "GafferScene/ObjectSource.h"
+#include "GafferScene/SceneNode.h"
+#include "GafferScene/Set.h"
+#include "GafferScene/SetAlgo.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/ParallelAlgo.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Spreadsheet.h"
+#include "Gaffer/StringPlug.h"
+
+#include "boost/algorithm/string/join.hpp"
+
+using namespace boost::placeholders;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+namespace
+{
+
+const InternedString g_setMembershipContextVariableName( "setMembership:set" );
+
+// This uses the same strategy that ValuePlug uses for the hash cache,
+// using `plug->dirtyCount()` to invalidate previous cache entries when
+// a plug is dirtied.
+struct HistoryCacheKey
+{
+	HistoryCacheKey() {};
+	HistoryCacheKey( const ValuePlug *plug )
+		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
+	{
+	}
+
+	bool operator==( const HistoryCacheKey &rhs ) const
+	{
+		return
+			plug == rhs.plug &&
+			contextHash == rhs.contextHash &&
+			dirtyCount == rhs.dirtyCount
+		;
+	}
+
+	const ValuePlug *plug;
+	IECore::MurmurHash contextHash;
+	uint64_t dirtyCount;
+};
+
+size_t hash_value( const HistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, key.plug );
+	boost::hash_combine( result, key.contextHash );
+	boost::hash_combine( result, key.dirtyCount );
+	return result;
+}
+
+using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+HistoryCache g_historyCache(
+	// Getter
+	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		return SceneAlgo::history(
+			key.plug, Context::current()->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName )
+		);
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// Histories contain PlugPtrs, which could potentially be the sole
+		// owners. Destroying plugs can trigger dirty propagation, so as a
+		// precaution we destroy the history on the UI thread, where this would
+		// be OK.
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+}  // namespace
+
+SetMembershipInspector::SetMembershipInspector(
+	const GafferScene::ScenePlugPtr &scene,
+	const Gaffer::PlugPtr &editScope,
+	IECore::InternedString setName
+) :
+Inspector( "setMembership", setName.string(), editScope ),
+m_scene( scene ),
+m_setName( setName )
+{
+	m_scene->node()->plugDirtiedSignal().connect(
+		boost::bind( &SetMembershipInspector::plugDirtied, this, ::_1 )
+	);
+
+	Metadata::plugValueChangedSignal().connect( boost::bind( &SetMembershipInspector::plugMetadataChanged, this, ::_3, ::_4 ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &SetMembershipInspector::nodeMetadataChanged, this, ::_2, ::_3 ) );
+}
+
+GafferScene::SceneAlgo::History::ConstPtr SetMembershipInspector::history() const
+{
+	if( !m_scene->existsPlug()->getValue() )
+	{
+		return nullptr;
+	}
+
+	return g_historyCache.get( HistoryCacheKey( m_scene->objectPlug() ), Context::current()->canceller() );
+}
+
+IECore::ConstObjectPtr SetMembershipInspector::value( const GafferScene::SceneAlgo::History *history ) const
+{
+	const auto &path = history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	ConstPathMatcherDataPtr setMembers = history->scene->set( m_setName );
+
+	auto matchResult = (PathMatcher::Result)setMembers->readable().match( path );
+
+	return new IntData( matchResult );
+}
+
+Gaffer::ValuePlugPtr SetMembershipInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
+{
+	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );
+	if( !sceneNode || history->scene != sceneNode->outPlug() || !sceneNode->enabledPlug()->getValue() )
+	{
+		return nullptr;
+	}
+
+	if( const auto objectSource = runTimeCast<ObjectSource>( sceneNode ) )
+	{
+		return objectSource->setsPlug();
+	}
+	if( const auto setSource = runTimeCast<GafferScene::Set>( sceneNode ) )
+	{
+		const std::string setNamePattern = setSource->namePlug()->getValue();
+		if( !StringAlgo::matchMultiple( m_setName, setNamePattern ) )
+		{
+			return nullptr;
+		}
+
+		const FilterPlug *filterPlug = setSource->filterPlug();
+
+		Context::EditableScope setNameScope( history->context.get() );
+		setNameScope.set( g_setMembershipContextVariableName, &m_setName );
+
+		PathMatcher::Result filterResult = (PathMatcher::Result)filterPlug->match( history->scene.get() );
+
+		if( !( filterResult & ( PathMatcher::Result::ExactMatch | PathMatcher::Result::AncestorMatch ) ) )
+		{
+			return nullptr;
+		}
+
+		if( const auto spreadsheetSource = runTimeCast<Spreadsheet>( setSource->namePlug()->source<Plug>()->parent() ) )
+		{
+			if( const auto row = spreadsheetSource->rowsPlug()->row( m_setName ) )
+			{
+				return row->cellsPlug();
+			}
+		}
+
+		return setSource->namePlug();
+	}
+
+	return nullptr;
+}
+
+Inspector::EditFunctionOrFailure SetMembershipInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+{
+	const GraphComponent *readOnlyReason = EditScopeAlgo::setMembershipReadOnlyReason(
+		editScope,
+		m_setName.string(),
+		EditScopeAlgo::SetMembership::Added
+	);
+
+	if( readOnlyReason )
+	{
+		return boost::str(
+			boost::format( "%s is locked." ) % readOnlyReason->relativeName( readOnlyReason->ancestor<ScriptNode>() )
+		);
+	}
+	else
+	{
+		InternedString setName = m_setName;
+		return [
+			editScope = editScope,
+			setName,
+			context = history->context
+		] () {
+			Context::Scope scope( context.get() );
+			return EditScopeAlgo::acquireSetEdits( editScope, setName );
+		};
+	}
+}
+
+void SetMembershipInspector::plugDirtied( Gaffer::Plug *plug )
+{
+	if( plug == m_scene->setPlug() )
+	{
+		dirtiedSignal()( this );
+	}
+}
+
+void SetMembershipInspector::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug )
+{
+	if( !plug )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+	nodeMetadataChanged( key, plug->node() );
+}
+
+void SetMembershipInspector::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node )
+{
+	if( !node )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+
+	EditScope *scope = targetEditScope();
+	if( !scope )
+	{
+		return;
+	}
+
+	if(
+		MetadataAlgo::readOnlyAffectedByChange( scope, node, key ) ||
+		( MetadataAlgo::readOnlyAffectedByChange( key ) && scope->isAncestorOf( node ) )
+	)
+	{
+		// Might affect `EditScopeAlgo::setMembershipEditReadOnlyReason()`
+		// which we call in `editFunction()`.
+		/// \todo Can we ditch the signal processing and call `setMembershipEditReadOnlyReason()`
+		/// just-in-time from `editable()`? In the past that wasn't possible
+		/// because editability changed the appearance of the UI, but it isn't
+		/// doing that currently.
+		dirtiedSignal()( this );
+	}
+}

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -77,6 +77,17 @@ Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Resu
 	return result.acquireEdit();
 }
 
+bool editSetMembershipWrapper(
+	const GafferSceneUI::Private::SetMembershipInspector &inspector,
+	const GafferSceneUI::Private::Inspector::Result &inspection,
+	const GafferScene::ScenePlug::ScenePath &path,
+	GafferScene::EditScopeAlgo::SetMembership setMembership
+)
+{
+	ScopedGILRelease gilRelease;
+	return inspector.editSetMembership( &inspection, path, setMembership );
+}
+
 struct DirtiedSlotCaller
 {
 	void operator()( boost::python::object slot, InspectorPtr inspector )
@@ -154,5 +165,6 @@ void GafferSceneUIModule::bindInspector()
 				( arg( "scene" ), arg( "editScope" ), arg( "setName" ) )
 			)
 		)
+		.def( "editSetMembership", &editSetMembershipWrapper)
 	;
 }

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -41,6 +41,7 @@
 #include "GafferSceneUI/Private/Inspector.h"
 #include "GafferSceneUI/Private/AttributeInspector.h"
 #include "GafferSceneUI/Private/ParameterInspector.h"
+#include "GafferSceneUI/Private/SetMembershipInspector.h"
 
 #include "GafferBindings/PathBinding.h"
 #include "GafferBindings/SignalBinding.h"
@@ -147,4 +148,11 @@ void GafferSceneUIModule::bindInspector()
 		)
 	;
 
+	RefCountedClass<SetMembershipInspector, Inspector>( "SetMembershipInspector" )
+		.def(
+			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString>(
+				( arg( "scene" ), arg( "editScope" ), arg( "setName" ) )
+			)
+		)
+	;
 }

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -38,12 +38,12 @@
 
 #include "LightEditorBinding.h"
 
+#include "GafferSceneUI/Private/AttributeInspector.h"
 #include "GafferSceneUI/Private/Inspector.h"
+#include "GafferSceneUI/Private/SetMembershipInspector.h"
 
 #include "GafferScene/ScenePath.h"
 #include "GafferScene/ScenePlug.h"
-
-#include "GafferSceneUI/Private/AttributeInspector.h"
 
 #include "GafferUI/PathColumn.h"
 
@@ -355,6 +355,104 @@ CompoundDataPtr MuteColumn::m_muteUndefinedIconData = new CompoundData(
 
 StringDataPtr MuteColumn::m_muteBlankIconName = new StringData( "muteLightUndefined.png" );
 
+class SetMembershipColumn : public InspectorColumn
+{
+
+	public :
+		IE_CORE_DECLAREMEMBERPTR( SetMembershipColumn )
+
+		SetMembershipColumn( const GafferScene::ScenePlugPtr &scene, const Gaffer::PlugPtr editScope, const IECore::InternedString &setName, const std::string &columnName )
+			: InspectorColumn( new GafferSceneUI::Private::SetMembershipInspector( scene, editScope, setName ), columnName ), m_setName( setName )
+		{
+
+		}
+
+		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
+		{
+			CellData result = InspectorColumn::cellData( path, canceller );
+
+			auto scenePath = runTimeCast<const ScenePath>( &path );
+			if( !scenePath )
+			{
+				return result;
+			}
+
+			std::string toolTip;
+			if( auto toolTipData = runTimeCast<const StringData>( result.toolTip ) )
+			{
+				toolTip = toolTipData->readable();
+			}
+
+			if( auto value = runTimeCast<const IntData>( result.value ) )
+			{
+				if( value->readable() & PathMatcher::Result::ExactMatch )
+				{
+					result.icon = m_setMemberIconData;
+				}
+				else if( value->readable() & PathMatcher::Result::AncestorMatch )
+				{
+					ConstPathMatcherDataPtr setMembersData = scenePath->getScene()->set( m_setName );
+					const PathMatcher &setMembers = setMembersData->readable();
+
+					ScenePlug::ScenePath currentPath( scenePath->names() );
+					while( !currentPath.empty() )
+					{
+						if( setMembers.match( currentPath ) & PathMatcher::Result::ExactMatch )
+						{
+							result.icon = m_setMemberIconFadedData;
+							toolTip = "Inherited from : " + ScenePlug::pathToString( currentPath );
+							break;
+						}
+						currentPath.pop_back();
+					}
+				}
+			}
+
+			if( !result.icon )
+			{
+				result.icon = m_setMemberUndefinedIconData;
+			}
+
+			result.value = nullptr;
+			result.toolTip = new StringData( toolTip + ( toolTip.size() ? "\n\n" : "" ) + "Double-click to toggle" );
+
+			return result;
+		}
+
+		CellData headerData( const IECore::Canceller *canceller ) const override
+		{
+			return InspectorColumn::headerData( canceller );
+		}
+
+	private :
+		const IECore::InternedString m_setName;
+
+		static IECore::CompoundDataPtr m_setMemberIconData;
+		static IECore::CompoundDataPtr m_setMemberIconFadedData;
+		static IECore::CompoundDataPtr m_setMemberUndefinedIconData;
+};
+
+CompoundDataPtr SetMembershipColumn::m_setMemberIconData = new CompoundData(
+	{
+		{ InternedString( "state:normal" ), new StringData( "setMember.png" ) },
+		{ InternedString( "state:highlighted" ), new StringData( "setMemberHighlighted.png" ) }
+	}
+);
+
+CompoundDataPtr SetMembershipColumn::m_setMemberIconFadedData = new CompoundData(
+	{
+		{ InternedString( "state:normal" ), new StringData( "setMemberFaded.png" ) },
+		{ InternedString( "state:highlighted" ), new StringData( "setMemberFadedHighlighted.png" ) }
+	}
+);
+
+CompoundDataPtr SetMembershipColumn::m_setMemberUndefinedIconData = new CompoundData(
+	{
+		{ InternedString( "state:normal" ), new StringData( "muteLightUndefined.png" ) },
+		{ InternedString( "state:highlighted" ), new StringData( "setMemberFadedHighlighted.png" ) }
+	}
+);
+
 PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Canceller *canceller )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -393,6 +491,19 @@ void GafferSceneUIModule::bindLightEditor()
 			)
 		) )
 		.def( "inspector", &MuteColumn::inspector, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "headerData", &headerDataWrapper, ( arg_( "canceller" ) = object() ) )
+	;
+
+	IECorePython::RefCountedClass<SetMembershipColumn, InspectorColumn>( "_LightEditorSetMembershipColumn" )
+		.def( init<const GafferScene::ScenePlugPtr &, const Gaffer::PlugPtr &, const IECore::InternedString &, const std::string &>(
+			(
+				arg_( "scene" ),
+				arg_( "editScope" ),
+				arg_( "setName" ),
+				arg_( "columnName" )
+			)
+		) )
+		.def( "inspector", &SetMembershipColumn::inspector, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "headerData", &headerDataWrapper, ( arg_( "canceller" ) = object() ) )
 	;
 

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -283,10 +283,7 @@ class MuteColumn : public InspectorColumn
 					if( auto fullValue = a->member<BoolData>( "light:mute" ) )
 					{
 						result.icon = fullValue->readable() ? m_muteFadedIconData : m_unMuteFadedIconData;
-						result.toolTip = new StringData(
-							"Inherited from : " + ScenePlug::pathToString( currentPath ) + "\n\n"
-							"Double-click to toggle"
-						);
+						result.toolTip = new StringData( "Inherited from : " + ScenePlug::pathToString( currentPath ) );
 						break;
 					}
 					currentPath.pop_back();
@@ -308,6 +305,20 @@ class MuteColumn : public InspectorColumn
 			}
 
 			result.value = nullptr;
+			if( auto toolTipData = runTimeCast<const StringData>( result.toolTip ) )
+			{
+				std::string toolTip = toolTipData->readable();
+				size_t size = toolTip.size();
+				if( size < 6 || toolTip.substr( size - 6 ) != "toggle" )
+				{
+					toolTip += "\n\nDouble-click to toggle";
+					result.toolTip = new StringData( toolTip );
+				}
+			}
+			else
+			{
+				result.toolTip = new StringData( "Double-click to toggle" );
+			}
 
 			return result;
 		}


### PR DESCRIPTION
This adds a "Solo" column to the Light Editor that can be toggled on and off in the same way as the "Mute" column.

### Breaking changes ###

The "Mute" state of a light now takes precedence over "Solo" when both are activated. This is a breaking change over previous alpha releases ( starting in `1.2.0.0a1` ) only.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
