### PR TITLE
Add compatibility with OSL 1.12

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1245,8 +1245,8 @@ libraries = {
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL",
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
-				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
-				"Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3",
+				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
+				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3"
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : [

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -54,6 +54,7 @@
 
 #include "OSL/oslcomp.h"
 #include "OSL/oslexec.h"
+#include "OSL/rendererservices.h"
 
 #include "OpenImageIO/errorhandler.h"
 

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -52,6 +52,7 @@
 #include "OSL/oslclosure.h"
 #include "OSL/oslexec.h"
 #include "OSL/oslversion.h"
+#include "OSL/rendererservices.h"
 
 #include "OpenImageIO/ustring.h"
 


### PR DESCRIPTION
This contains the `#include` fixes from #5094, plus a linking fix for GafferCycles.