### PR TITLE
installDependencies : Clean extraction directory

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -34,12 +34,11 @@
 #
 ##########################################################################
 
-import os
+import pathlib
 import sys
 import argparse
 import hashlib
 import subprocess
-import glob
 import shutil
 
 if sys.version_info[0] < 3 :
@@ -83,7 +82,7 @@ args = parser.parse_args()
 sys.stderr.write( "Downloading dependencies \"%s\"\n" % args.archiveURL )
 archiveFileName, headers = urlretrieve( args.archiveURL )
 
-os.makedirs( args.dependenciesDir )
+pathlib.Path( args.dependenciesDir ).mkdir( parents = True )
 if platform != "windows":
 	subprocess.check_call( [ "tar", "xf", archiveFileName, "-C", args.dependenciesDir, "--strip-components=1" ] )
 else:
@@ -93,15 +92,11 @@ else:
 	)
 	# 7z (and zip extractors generally) don't have an equivalent of --strip-components=1
 	# Copy the files up one directory level to compensate
-	for p in glob.glob(
-		os.path.join(
-			args.dependenciesDir.replace( "/", "\\" ),
-			os.path.splitext( args.archiveURL.split( "/" )[-1] )[0],
-			"*"
-		)
-	):
-		shutil.move( p, args.dependenciesDir )
-
+	extractedPath = pathlib.Path( args.dependenciesDir ) / pathlib.Path( args.archiveURL ).stem
+	for p in extractedPath.glob( "*" ) :
+		shutil.move( str( p ), args.dependenciesDir )
+	
+	extractedPath.rmdir()
 
 # Tell the world
 


### PR DESCRIPTION
We were leaving behind the temporary extraction directory which got included in the release archive.

Note that the use of `str( p )` in `shutil.move()` is needed until Python 3.9, where a parsing bug is fixed : https://github.com/python/cpython/pull/15326

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
