### PR TITLE
CompoundEditor : Call `setGeometry()` conditional

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -1414,15 +1414,6 @@ def _restoreWindowState( gafferWindow, boundData ) :
 	if not window :
 		return
 
-	# If we don't clear the full-screen flag then restoring geometry won't
-	# work, as its overridden by the full-screen state.  Doing it conditionally
-	# improves fullscreen - fullscreen layout transitions (avoids pointless
-	# re-scale animations), but does mean that we don't properly restore the
-	# non-fullscreen size of the window and it will keep that of the first
-	# fullscreen layout loaded. Seems a reasonable trade-off though.
-	if not ( boundData["fullScreen"] and window.windowState() == QtCore.Qt.WindowFullScreen ) :
-		window.setWindowState( QtCore.Qt.WindowNoState )
-
 	targetScreen = QtWidgets.QApplication.primaryScreen()
 
 	if boundData["screen"] > -1 :
@@ -1431,21 +1422,19 @@ def _restoreWindowState( gafferWindow, boundData ) :
 			targetScreen = screens[ boundData["screen"] ]
 			window.setScreen( targetScreen )
 
-	screenGeom = targetScreen.availableGeometry()
-	window.setGeometry(
-		( boundData["bound"].min()[0] * screenGeom.width() ) + screenGeom.x(),
-		( ( 1.0 - boundData["bound"].max()[1] ) * screenGeom.height() ) + screenGeom.y(),
-		( boundData["bound"].size()[0] * screenGeom.width() ),
-		( boundData["bound"].size()[1] * screenGeom.height() )
-	)
-
 	if boundData["fullScreen"] :
 		window.setWindowState( QtCore.Qt.WindowFullScreen )
 	elif boundData["maximized"] and sys.platform != "darwin" :
 		window.setWindowState( QtCore.Qt.WindowMaximized )
 	else :
 		window.setWindowState( QtCore.Qt.WindowNoState )
-
+		screenGeom = targetScreen.availableGeometry()
+		window.setGeometry(
+			( boundData["bound"].min()[0] * screenGeom.width() ) + screenGeom.x(),
+			( ( 1.0 - boundData["bound"].max()[1] ) * screenGeom.height() ) + screenGeom.y(),
+			( boundData["bound"].size()[0] * screenGeom.width() ),
+			( boundData["bound"].size()[1] * screenGeom.height() )
+		)
 
 def _reprDict( d ) :
 


### PR DESCRIPTION
On Windows, maximizing the window in the layout was inconsistent :
1. On startup `maximized` was respected.
2. Opening a script, `maximized` was disrespected. It would resize the window to a consistent size - but not the size requested by the layout, I believe. It also showed itself as maximized on the window controls, requiring a restore + maximize click combo to get the window maximized again.

This solution solves the problem on Windows, but needs testing on Linux and MacOS.

Fixes #5042

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
