### PR TITLE
ie/options : Fixed when running SCons with python 3

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -62,6 +62,7 @@ def getOption( name, default ) :
 
 ## \todo: this is duplicated from ./installAll but can we centralize it instead?
 def gafferVersionFromScons() :
+	import re
 
 	sconsFile = "SConstruct"
 	versionVars = ["gafferMilestoneVersion", "gafferMajorVersion", "gafferMinorVersion", "gafferPatchVersion"]


### PR DESCRIPTION
Recent changes again broke install at IE when using python 3.

Specifically, the removal `import re` from inside a function definition in the config file triggered the same problem as the one described in c61dc4de5918406863ab09e4ca8d0cfa08ff22a8, this time because `re` was not visible inside that function anymore, even though it was imported at the top of the file.

There is no need to alter the `Changes` file, as it only affects IE installs.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
