### PR TITLE
SceneGadget fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,7 +15,7 @@ Fixes
 -----
 
 - Backups : Fixed error when a backup file contained characters that couldn't be represented using the current locale. This could be triggered by a separate bug in OpenShadingLanguage that caused the locale to be changed unnecessarily (#5048).
-
+- Viewer : Fixed potential crash when destroying a raytraced viewport.
 - Cyles :
   - Fixed crashes caused by providing unsupported data types in shader parameters.
   - Fixed support for Color4f values on colour shader parameters. This can be useful when loading non-standard USD files.

--- a/Changes.md
+++ b/Changes.md
@@ -15,7 +15,9 @@ Fixes
 -----
 
 - Backups : Fixed error when a backup file contained characters that couldn't be represented using the current locale. This could be triggered by a separate bug in OpenShadingLanguage that caused the locale to be changed unnecessarily (#5048).
-- Viewer : Fixed potential crash when destroying a raytraced viewport.
+- Viewer :
+  - Fixed crash when switching from Cycles to OpenGL rendering (#5051).
+  - Fixed potential crash when destroying a raytraced viewport.
 - Cyles :
   - Fixed crashes caused by providing unsupported data types in shader parameters.
   - Fixed support for Color4f values on colour shader parameters. This can be useful when loading non-standard USD files.

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -631,6 +631,27 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			gw._qtWidget().setFixedWidth( 200 + ( i % 2 ) * 200 )
 			self.waitForIdle( 100 )
 
+	def testSetRenderer( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["s"] = GafferScene.Sphere()
+
+		sg = GafferSceneUI.SceneGadget()
+		sg.setMinimumExpansionDepth( 1 )
+		sg.setScene( s["s"]["out"] )
+
+		with GafferUI.Window() as w :
+			gw = GafferUI.GadgetWidget( sg )
+
+		w.setVisible( True )
+		self.waitForIdle( 1000 )
+
+		for i in range( 0, 5 ) :
+			sg.setRenderer( self.renderer )
+			self.waitForRender( sg )
+			sg.setRenderer( "OpenGL" )
+			self.waitForRender( sg )
+
 	def setUp( self ) :
 
 		GafferUITest.TestCase.setUp( self )


### PR DESCRIPTION
This fixes a couple of potential crashes in the raytraced viewer. What's a little odd in that the main crash was reported in #5051 on Windows, and I reproduced it on Windows. I couldn't reproduce it on Linux, but ASAN showed the problem. So I fixed the bugs on Linux and verified using ASAN. All good. Then I went back to Windows, and couldn't reproduce the original crash, _even without my fix_! So, I'm pretty sure I've fixed #5051, but am not able to verify 100%. If anyone is still able to reproduce on Windows, perhaps they could try this PR.