### PR TITLE
SConstruct : Remove `gaffer` wrapper on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1352,7 +1352,7 @@ libraries = {
 	},
 
 	"scripts" : {
-		"additionalFiles" : [ "bin/gaffer", "bin/__gaffer.py" ],
+		"additionalFiles" : [ "bin/__gaffer.py" ],
 	},
 
 	"misc" : {
@@ -1377,8 +1377,7 @@ libraries = {
 
 }
 
-if env["PLATFORM"] == "win32" :
-	libraries["scripts"]["additionalFiles"].append( "bin/gaffer.cmd" )
+libraries["scripts"]["additionalFiles"].append( "bin/gaffer.cmd" if env["PLATFORM"] == "win32" else "bin/gaffer" )
 
 # Add on OpenGL libraries to definitions - these vary from platform to platform
 for library in ( "GafferUI", "GafferScene", "GafferSceneUI", "GafferImageUI" ) :


### PR DESCRIPTION
We were already not including the Windows-specific `gaffer.cmd` on Linux, this removes the corresponding `gaffer` launch wrapper on Windows.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
