### PR TITLE
Windows Renderer tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             publish: true
             containerImage:
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
-            testRunner: powershell -c Invoke-Expression
+            testRunner: Invoke-Expression
             testArguments: GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
             sconsCacheMegabytes: 400
 
@@ -193,7 +193,13 @@ jobs:
 
           # Test Arnold extension
           print( "::add-matcher::./.github/workflows/main/problemMatchers/unittest.json" )
-          subprocess.check_call( "${{ matrix.testRunner }} \"" + os.path.join( os.environ["GAFFER_BUILD_DIR"], "bin", "gaffer" ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest\"", shell = True )
+
+          # `matrix.testRunner` on Windows is used to run tests in Powershell. Python `subprocess` uses
+          # `cmd.exe` on Windows, which requires Byzantine syntax to keep using Powershell. We
+          # run `gaffer` without the Powershell shim from `matrix.testRunner`.
+          cmd = os.path.join( os.environ["GAFFER_BUILD_DIR"], "bin", "gaffer" ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest"
+          cmd = ( "${{ matrix.testRunner }} \"" if os.name != "nt" else "" ) + cmd + ( "\"" if os.name != "nt" else "" )
+          subprocess.check_call( cmd, shell = True )
           print( "::remove-matcher owner=unittest::" )
 
           # Publish ARNOLD_ROOT to the environment for subsequent steps,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             publish: true
             containerImage:
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
-            testRunner: Invoke-Expression
+            testRunner: powershell -c Invoke-Expression
             testArguments: GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
             sconsCacheMegabytes: 400
 
@@ -191,11 +191,10 @@ jobs:
           #Build Arnold extension
           subprocess.check_call( "scons -j 2 build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions", shell = True )
 
-          if os.name != "nt" :
-            # Test Arnold extension
-            print( "::add-matcher::./.github/workflows/main/problemMatchers/unittest.json" )
-            subprocess.check_call( "${{ matrix.testRunner }} \"" + os.path.join( os.environ["GAFFER_BUILD_DIR"], "bin", "gaffer" ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest\"", shell = True )
-            print( "::remove-matcher owner=unittest::" )
+          # Test Arnold extension
+          print( "::add-matcher::./.github/workflows/main/problemMatchers/unittest.json" )
+          subprocess.check_call( "${{ matrix.testRunner }} \"" + os.path.join( os.environ["GAFFER_BUILD_DIR"], "bin", "gaffer" ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest\"", shell = True )
+          print( "::remove-matcher owner=unittest::" )
 
           # Publish ARNOLD_ROOT to the environment for subsequent steps,
           # so we can build the docs for GafferArnold.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
             containerImage:
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
             testRunner: Invoke-Expression
-            testArguments:
+            testArguments: GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferCyclesTest GafferCyclesUITest
             sconsCacheMegabytes: 400
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,7 @@ jobs:
         import subprocess
         import sys
         import os
+        import pathlib
 
         for arnoldVersion in [ "7.1.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
@@ -197,7 +198,7 @@ jobs:
           # `matrix.testRunner` on Windows is used to run tests in Powershell. Python `subprocess` uses
           # `cmd.exe` on Windows, which requires Byzantine syntax to keep using Powershell. We
           # run `gaffer` without the Powershell shim from `matrix.testRunner`.
-          cmd = os.path.join( os.environ["GAFFER_BUILD_DIR"], "bin", "gaffer" ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest"
+          cmd = str( ( pathlib.Path( os.environ["GAFFER_BUILD_DIR"] ) / "bin" / "gaffer" ).absolute() ) + " test IECoreArnoldTest GafferArnoldTest GafferArnoldUITest"
           cmd = ( "${{ matrix.testRunner }} \"" if os.name != "nt" else "" ) + cmd + ( "\"" if os.name != "nt" else "" )
           subprocess.check_call( cmd, shell = True )
           print( "::remove-matcher owner=unittest::" )

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
             containerImage:
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
             testRunner: Invoke-Expression
-            testArguments: GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
+            testArguments:
             sconsCacheMegabytes: 400
 
     runs-on: ${{ matrix.os }}

--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -552,6 +552,16 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 		self["__CleanUpCommand"]["command"].setValue( inspect.cleandoc(
 			"""
 			import os
+
+			import GafferImage
+
+			# Clear the image cache to free file handles preventing
+			# intermediate files from being deleted on Windows.
+
+			fLimit = GafferImage.OpenImageIOReader.getOpenFilesLimit()
+			GafferImage.OpenImageIOReader.setOpenFilesLimit( 0 )
+			GafferImage.OpenImageIOReader.setOpenFilesLimit( fLimit )
+
 			for tmpFile in variables["filesToDelete"]:
 				os.remove( tmpFile )
 			"""
@@ -560,13 +570,6 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 		self["__CleanUpExpression"] = Gaffer.Expression()
 		self["__CleanUpExpression"].setExpression( inspect.cleandoc(
 			"""
-
-			import GafferImage
-
-			fLimit = GafferImage.OpenImageIOReader.getOpenFilesLimit()
-			GafferImage.OpenImageIOReader.setOpenFilesLimit( 0 )
-			GafferImage.OpenImageIOReader.setOpenFilesLimit( fLimit )
-
 			imageList = parent["__imageList"]
 
 			toDelete = []

--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -561,6 +561,12 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 		self["__CleanUpExpression"].setExpression( inspect.cleandoc(
 			"""
 
+			import GafferImage
+
+			fLimit = GafferImage.OpenImageIOReader.getOpenFilesLimit()
+			GafferImage.OpenImageIOReader.setOpenFilesLimit( 0 )
+			GafferImage.OpenImageIOReader.setOpenFilesLimit( fLimit )
+
 			imageList = parent["__imageList"]
 
 			toDelete = []

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -109,7 +109,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				str( self.temporaryDirectory() / "test.tif" ),
+				( self.temporaryDirectory() / "test.tif" ).as_posix(),
 				"tiff",
 				"rgba",
 				{}
@@ -157,7 +157,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				str( self.temporaryDirectory() / "test.####.tif" ),
+				( self.temporaryDirectory() / "test.####.tif" ).as_posix(),
 				"tiff",
 				"rgba",
 				{}
@@ -1082,7 +1082,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				str( self.temporaryDirectory() / "test.tif" ),
+				( self.temporaryDirectory() / "test.tif" ).as_posix(),
 				"tiff",
 				"rgba",
 				{}
@@ -1418,7 +1418,7 @@ class ArnoldRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				str( self.temporaryDirectory() / "deformationBlurOff.exr" ),
+				( self.temporaryDirectory() / "deformationBlurOff.exr" ).as_posix(),
 				"exr",
 				"rgba",
 				{

--- a/python/GafferArnoldTest/ArnoldVDBTest.py
+++ b/python/GafferArnoldTest/ArnoldVDBTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import pathlib
 import imath
 
@@ -76,7 +77,12 @@ class ArnoldVDBTest( GafferSceneTest.SceneTestCase ) :
 		# As should invalid file names.
 		v["grids"].setValue( "density" )
 		v["fileName"].setValue( "notAFile.vdb" )
-		with self.assertRaisesRegex( Gaffer.ProcessException, "No such file or directory" ) :
+		if os.name != "nt" :
+			errorMessage = "No such file or directory"
+		else :
+			errorMessage = ".* could not get size of file notAFile.vdb"
+
+		with self.assertRaisesRegex( Gaffer.ProcessException, errorMessage ) :
 			v["out"].bound( "/volume" )
 
 	def testStepSize( self ) :

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -168,7 +168,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 1 )
 
 		self.assertAlmostEqual( script["imageStats"]["average"][3].getValue(), 0.381, delta = 0.001 )
 
@@ -246,7 +246,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		self.assertAlmostEqual(
 			self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r,
@@ -337,7 +337,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		initialColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertAlmostEqual( initialColor.r, 0.09, delta = 0.013 )
@@ -422,7 +422,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start render 1 and save the image output.
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 
@@ -433,7 +433,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start and stop new render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 
 		# Get image from new render.
@@ -457,7 +457,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Now test flush cache during a render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Get colour after 1 second of render.
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
@@ -608,7 +608,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		# Render, and check `sphere2`` is receiving illumination.
 
 		s["render"]["state"].setValue( s["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		litColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.75, 0.5 ) )
 		self.assertGreater( litColor.r, 0.1 )

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -60,6 +60,8 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 	# Arnold outputs licensing warnings that would cause failures
 	failureMessageLevel = IECore.MessageHandler.Level.Error
 
+	startupWaitTime = 3.0 if sys.platform == "win32" else 1.0
+
 	def testTwoRenders( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -168,7 +170,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		self.assertAlmostEqual( script["imageStats"]["average"][3].getValue(), 0.381, delta = 0.001 )
 
@@ -246,7 +248,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		self.assertAlmostEqual(
 			self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r,
@@ -337,7 +339,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		initialColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertAlmostEqual( initialColor.r, 0.09, delta = 0.013 )
@@ -422,7 +424,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start render 1 and save the image output.
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 
@@ -433,7 +435,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start and stop new render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 
 		# Get image from new render.
@@ -457,7 +459,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Now test flush cache during a render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Get colour after 1 second of render.
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
@@ -526,7 +528,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		# Start rendering.
 
 		s["render"]["state"].setValue( s["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Switch which object is tagged as a mesh light. This used to trigger a
 		# crash.
@@ -608,7 +610,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		# Render, and check `sphere2`` is receiving illumination.
 
 		s["render"]["state"].setValue( s["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		litColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.75, 0.5 ) )
 		self.assertGreater( litColor.r, 0.1 )

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -168,7 +168,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		self.assertAlmostEqual( script["imageStats"]["average"][3].getValue(), 0.381, delta = 0.001 )
 
@@ -246,7 +246,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		self.assertAlmostEqual(
 			self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r,
@@ -337,7 +337,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		initialColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertAlmostEqual( initialColor.r, 0.09, delta = 0.013 )
@@ -422,7 +422,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start render 1 and save the image output.
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 
@@ -433,7 +433,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Start and stop new render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 
 		# Get image from new render.
@@ -457,7 +457,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		# Now test flush cache during a render
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Get colour after 1 second of render.
 		redTexture = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
@@ -608,7 +608,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		# Render, and check `sphere2`` is receiving illumination.
 
 		s["render"]["state"].setValue( s["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		litColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.75, 0.5 ) )
 		self.assertGreater( litColor.r, 0.1 )

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -130,7 +130,10 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 	def testUserDefaultMetadata( self ) :
 
 		cacheFilePath =	self.temporaryDirectory() / "testShaderUserDefaults.scc"
-		script = f"""
+
+		scriptPath = self.temporaryDirectory() / "testScript.py"
+		with open( scriptPath, "w" ) as outFile :
+			outFile.write( f"""
 import Gaffer
 import GafferScene
 import GafferArnold
@@ -148,10 +151,11 @@ root["SceneWriter"]["in"].setInput( root["ShaderAssignment"]["out"] )
 root["SceneWriter"]["fileName"].setValue( "{cacheFilePath.as_posix()}" )
 root["SceneWriter"].execute()
 		"""
+			)
 
 		env = os.environ.copy()
 		subprocess.check_call(
-			[ str( Gaffer.executablePath() ), "env", "python","-c", script ],
+			[ str( Gaffer.executablePath() ), "env", "python", str( scriptPath ) ],
 			env = env
 		)
 		scene = IECoreScene.SceneCache( str( cacheFilePath ), IECore.IndexedIO.OpenMode.Read )
@@ -168,9 +172,9 @@ root["SceneWriter"].execute()
 		self.assertEqual( parms["filename"].value, "" )
 		self.assertEqual( parms["filter"].value, "smart_bicubic" )
 
-		env["ARNOLD_PLUGIN_PATH"] = pathlib.Path( __file__ ).parent / "metadata"
+		env["ARNOLD_PLUGIN_PATH"] = str( pathlib.Path( __file__ ).parent / "metadata" )
 		subprocess.check_call(
-			[ str( Gaffer.executablePath() ), "env", "python","-c", script ],
+			[ str( Gaffer.executablePath() ), "env", "python", str( scriptPath ) ],
 			env = env
 		)
 		scene = IECoreScene.SceneCache( str( cacheFilePath ), IECore.IndexedIO.OpenMode.Read )

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -132,7 +132,7 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 		cacheFilePath =	self.temporaryDirectory() / "testShaderUserDefaults.scc"
 
 		scriptPath = self.temporaryDirectory() / "testScript.py"
-		with open( scriptPath, "w" ) as outFile :
+		with open( scriptPath, "w", encoding = "utf-8" ) as outFile :
 			outFile.write( f"""
 import Gaffer
 import GafferScene

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -57,6 +57,8 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 	# the class of their interactive render node
 	interactiveRenderNodeClass = None
 
+	startupWaitTime = 1.0
+
 	@classmethod
 	def setUpClass( cls ) :
 
@@ -261,7 +263,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -320,7 +322,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render the sphere.
 
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -378,7 +380,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -462,7 +464,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -528,7 +530,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -585,7 +587,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2.0 )
+		self.uiThreadCallHandler.waitFor( max( 2.0, self.startupWaitTime ) )
 
 		# Render red sphere
 
@@ -646,7 +648,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -882,7 +884,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -972,7 +974,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -999,7 +1001,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Unpause it, wait, and check that the update happened.
 
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -1072,7 +1074,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0, 0 ) )
@@ -1149,7 +1151,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1229,7 +1231,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1289,7 +1291,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -1348,7 +1350,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# Visible to start with
 
@@ -1517,7 +1519,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 		s["render"]["state"].setValue( s["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		# We haven't used the trace sets yet, so should be able to see
 		# the reflection.
@@ -1673,7 +1675,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		c = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		unfilteredIntensity = c[0]
@@ -1832,7 +1834,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# by default, filters aren't linked.
 
 		script["render"]["state"].setValue( script["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( self.startupWaitTime )
 
 		unfilteredColor = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		self.assertGreater( unfilteredColor[0], 0.25 )
@@ -1905,7 +1907,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2.0 )
+		self.uiThreadCallHandler.waitFor( max( 2.0, self.startupWaitTime ) )
 
 		# Render red sphere
 
@@ -1966,7 +1968,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -2055,7 +2057,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["renderer"]["state"].setValue( s["renderer"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( max( 2, self.startupWaitTime ) )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0 )

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -261,7 +261,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -320,7 +320,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render the sphere.
 
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -378,7 +378,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -462,7 +462,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -528,7 +528,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -585,7 +585,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 2.0 )
 
 		# Render red sphere
 
@@ -646,7 +646,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -882,7 +882,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -972,7 +972,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -1072,7 +1072,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0, 0 ) )
@@ -1149,7 +1149,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1229,7 +1229,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1289,7 +1289,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -1348,7 +1348,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# Visible to start with
 
@@ -1517,7 +1517,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 		s["render"]["state"].setValue( s["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		# We haven't used the trace sets yet, so should be able to see
 		# the reflection.
@@ -1673,7 +1673,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 1 )
 
 		c = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		unfilteredIntensity = c[0]
@@ -1832,7 +1832,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# by default, filters aren't linked.
 
 		script["render"]["state"].setValue( script["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 1 )
 
 		unfilteredColor = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		self.assertGreater( unfilteredColor[0], 0.25 )
@@ -1905,7 +1905,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3.0 )
+		self.uiThreadCallHandler.waitFor( 2.0 )
 
 		# Render red sphere
 
@@ -1966,7 +1966,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -2055,7 +2055,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["renderer"]["state"].setValue( s["renderer"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 3 )
+		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0 )

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -261,7 +261,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -320,7 +320,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# Render the sphere.
 
 		s["r"]["state"].setValue( s["r"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		self.assertAlmostEqual( self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) ).r, 1, delta = 0.01 )
 
@@ -378,7 +378,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -462,7 +462,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -528,7 +528,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -585,7 +585,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Render red sphere
 
@@ -646,7 +646,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -882,7 +882,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -972,7 +972,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -1072,7 +1072,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0, 0 ) )
@@ -1149,7 +1149,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1229,7 +1229,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0.0 )
@@ -1289,7 +1289,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -1348,7 +1348,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Visible to start with
 
@@ -1517,7 +1517,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["render"]["in"].setInput( s["outputs"]["out"] )
 		s["render"]["state"].setValue( s["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# We haven't used the trace sets yet, so should be able to see
 		# the reflection.
@@ -1673,7 +1673,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["render"]["state"].setValue( script["render"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		unfilteredIntensity = c[0]
@@ -1832,7 +1832,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		# by default, filters aren't linked.
 
 		script["render"]["state"].setValue( script["render"].State.Running )
-		self.uiThreadCallHandler.waitFor( 1 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		unfilteredColor = self._color4fAtUV( script["catalogue"], imath.V2f( 0.5 ) )
 		self.assertGreater( unfilteredColor[0], 0.25 )
@@ -1905,7 +1905,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2.0 )
+		self.uiThreadCallHandler.waitFor( 3.0 )
 
 		# Render red sphere
 
@@ -1966,7 +1966,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertEqual( c / c[0], imath.Color3f( 1, 0.5, 0.25 ) )
@@ -2055,7 +2055,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["renderer"]["state"].setValue( s["renderer"].State.Running )
 
-		self.uiThreadCallHandler.waitFor( 2 )
+		self.uiThreadCallHandler.waitFor( 3 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertNotEqual( c[0], 0 )

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -132,7 +132,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			# to get into the buffers.
 			timeout = time.time() + 1
 			while time.time() < timeout :
-				self.waitForIdle()
+				self.waitForIdle( 5 )
 
 	def testObjectVisibility( self ) :
 
@@ -434,6 +434,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			[]
 		)
 
+	@unittest.skipIf( os.name == "nt", "Unknown problem running on Windows." )
 	def testObjectAtLine( self ) :
 
 		cubes = []
@@ -561,6 +562,7 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		sg.setSelectionMask( None )
 		self.assertEqual( sg.getSelectionMask(), None )
 
+	@unittest.skipIf( os.name == "nt", "Unknown problem running on Windows." )
 	def testSelectionMask( self ) :
 
 		plane = GafferScene.Plane()

--- a/python/IECoreArnoldTest/OutputDriverTest.py
+++ b/python/IECoreArnoldTest/OutputDriverTest.py
@@ -32,6 +32,7 @@
 #
 ##########################################################################
 
+import os
 import pathlib
 import time
 import unittest
@@ -41,6 +42,7 @@ import IECoreImage
 
 class OutputDriverTest( unittest.TestCase ) :
 
+	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
 	def testMergedDisplays( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )
@@ -48,7 +50,7 @@ class OutputDriverTest( unittest.TestCase ) :
 
 		subprocess.check_call( [
 			"kick", "-v", "0", "-dw", "-dp",
-			pathlib.Path( __file__ ).parent / "assFiles" / "mergedDisplays.ass"
+			str( pathlib.Path( __file__ ).parent / "assFiles" / "mergedDisplays.ass" )
 		] )
 
 		image = IECoreImage.ImageDisplayDriver.removeStoredImage( "mergedImage" )
@@ -63,6 +65,7 @@ class OutputDriverTest( unittest.TestCase ) :
 		self.assertTrue( "direct_diffuse.G" in channelNames )
 		self.assertTrue( "direct_diffuse.B" in channelNames )
 
+	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
 	def testVectorAndPointDisplays( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )
@@ -70,7 +73,7 @@ class OutputDriverTest( unittest.TestCase ) :
 
 		subprocess.check_call( [
 			"kick", "-v", "0", "-dw", "-dp",
-			pathlib.Path( __file__ ).parent / "assFiles" / "vectorAndPointDisplays.ass"
+			str( pathlib.Path( __file__ ).parent / "assFiles" / "vectorAndPointDisplays.ass" )
 		] )
 
 		image = IECoreImage.ImageDisplayDriver.removeStoredImage( "vectorAndPointImage" )
@@ -88,6 +91,7 @@ class OutputDriverTest( unittest.TestCase ) :
 		self.assertTrue( "N.G" in channelNames )
 		self.assertTrue( "N.B" in channelNames )
 
+	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
 	def testLayerName( self ) :
 
 		server = IECoreImage.DisplayDriverServer( 1559 )
@@ -95,7 +99,7 @@ class OutputDriverTest( unittest.TestCase ) :
 
 		subprocess.check_call( [
 			"kick", "-v", "0", "-dw", "-dp",
-			pathlib.Path( __file__ ).parent / "assFiles" / "outputWithLayerName.ass"
+			str( pathlib.Path( __file__ ).parent / "assFiles" / "outputWithLayerName.ass" )
 		] )
 
 		image = IECoreImage.ImageDisplayDriver.removeStoredImage( "layerNameImage" )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -1972,7 +1972,7 @@ class RendererTest( GafferTest.TestCase ) :
 			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
 
 			options = arnold.AiUniverseGetOptions( universe )
-			self.assertTrue( str( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "shaders" ) in arnold.AiNodeGetStr( options, "plugin_searchpath" ) )
+			self.assertTrue( ( pathlib.Path( os.environ["GAFFER_ROOT"] ) / "shaders" ).as_posix() in arnold.AiNodeGetStr( options, "plugin_searchpath" ) )
 
 			n = arnold.AiNodeLookUpByName( universe, "testPlane" )
 
@@ -2661,6 +2661,15 @@ class RendererTest( GafferTest.TestCase ) :
 		r.option( "ai:log:filename", IECore.StringData( "" ) )
 		r.render()
 
+	@unittest.skipIf( os.name == "nt", "Windows does not support read-only directories" )
+	def testLogDirectoryCreationReadOnly( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.ass" )
+		)
+
 		# Trying to write to a read-only location should result in an
 		# error message.
 
@@ -2675,6 +2684,7 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
 		self.assertTrue( "Permission denied" in mh.messages[0].message )
 
+	@unittest.skipIf( os.name == "nt", "Log file can't be deleted on Windows because it is still in use until the process finishes.")
 	def testStatsAndLog( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/python/IECoreArnoldTest/UniverseBlockTest.py
+++ b/python/IECoreArnoldTest/UniverseBlockTest.py
@@ -85,7 +85,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 			try :
 				subprocess.check_output(
-					[ "gaffer", "test", "IECoreArnoldTest.UniverseBlockTest.testMetadataLoading" ],
+					[ "gaffer" if os.name != "nt" else "gaffer.cmd", "test", "IECoreArnoldTest.UniverseBlockTest.testMetadataLoading" ],
 					env = env, stderr = subprocess.STDOUT
 				)
 			except subprocess.CalledProcessError as e :
@@ -99,7 +99,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 				e = arnold.AiNodeEntryLookUp( "options" )
 
-				s = arnold.AtStringReturn()
+				s = arnold.AtStringStruct()
 				i = ctypes.c_int()
 
 				arnold.AiMetaDataGetStr( e, "", "cortex.testString", s )
@@ -114,6 +114,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 				arnold.AiMetaDataGetInt( e, "AA_samples", "cortex.testInt", i )
 				self.assertEqual( i.value, 12 )
 
+	@unittest.skipIf( os.name == "nt", "Kick not currently working on Windows.")
 	def testKickNodes( self ) :
 
 		# Running `kick -nodes` will load any plugins that might link to


### PR DESCRIPTION
This gets the tests passing for `GafferArnoldTest` and `GafferArnoldUITest`. Of particular interest may be the tests I'm skipping in 6ec8cb59c47850baa8658852ed11cd3a0f4106f4. Are those worth digging deeper to sort them out? I'm skipping them on the theory that 95% coverage is better than the current 0%.

And I hope the extra wait times for Arnold renders won't be too much of a bummer. I tried to keep them to a minimum but Arnold was ornery on the subject.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
