### PR TITLE
Backups : Fix bug loading non-ASCII backups if locale was changed

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,11 +14,18 @@ Improvements
 Fixes
 -----
 
+- Backups : Fixed error when a backup file contained characters that couldn't be represented using the current locale. This could be triggered by a separate bug in OpenShadingLanguage that caused the locale to be changed unnecessarily (#5048).
+
 - Cyles :
   - Fixed crashes caused by providing unsupported data types in shader parameters.
   - Fixed support for Color4f values on colour shader parameters. This can be useful when loading non-standard USD files.
   - Fixed support for V[23]i values on vector shader parameters.
   - Fixed handling of colour array parameters.
+
+API
+---
+
+- TestCase : Added `scopedLocale()` method.
 
 1.1.8.0 (relative to 1.1.7.0)
 =======

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import contextlib
+import locale
 import os
 import sys
 import unittest
@@ -134,6 +136,17 @@ class TestCase( unittest.TestCase ) :
 			self.__temporaryDirectory = tempfile.mkdtemp( prefix = "gafferTest" )
 
 		return self.__temporaryDirectory
+
+	## Returns a context manager that sets the locale
+	# on enter and restores it on exit.
+	@staticmethod
+	@contextlib.contextmanager
+	def scopedLocale( l, category = locale.LC_CTYPE ) :
+
+		previousLocale = locale.getlocale( category )
+		locale.setlocale( category, l )
+		yield
+		locale.setlocale( category, previousLocale )
 
 	## Attempts to ensure that the hashes for a node
 	# are reasonable by jiggling around input values

--- a/python/GafferUI/Backups.py
+++ b/python/GafferUI/Backups.py
@@ -41,6 +41,7 @@ import IECore
 from Qt import QtCore
 
 import collections
+import io
 import os
 import re
 import stat
@@ -163,7 +164,7 @@ class Backups( object ) :
 		]
 		ignorePatterns = [ re.compile( x ) for x in ignorePatterns ]
 
-		with open( backupFileName ) as backupFile, open( scriptFileName ) as scriptFile :
+		with io.open( backupFileName, encoding = "utf-8" ) as backupFile, io.open( scriptFileName, encoding = "utf-8" ) as scriptFile :
 
 			backupLines = backupFile.readlines()
 			scriptLines = scriptFile.readlines()

--- a/python/GafferUITest/BackupsTest.py
+++ b/python/GafferUITest/BackupsTest.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 ##########################################################################
 #
 #  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
@@ -204,6 +206,26 @@ class BackupsTest( GafferUITest.TestCase ) :
 
 		b.backup( s )
 		assertBackupsReadOnly()
+
+	def testNonASCIIRecoveryFile( self ) :
+
+		a = Gaffer.ApplicationRoot()
+
+		b = GafferUI.Backups.acquire( a )
+		b.settings()["fileName"].setValue( "${script:directory}/${script:name}-backup${backup:number}.gfr" )
+		b.settings()["files"].setValue( 3 )
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() + "/test.gfr" )
+		s.save()
+
+		s["node"] = GafferTest.StringInOutNode()
+		s["node"]["in"].setValue( "Ä, Ö, and Ü." )
+
+		b.backup( s )
+
+		with self.scopedLocale( "C" ) :
+			self.assertEqual( b.recoveryFile( s ), self.temporaryDirectory() + "/test-backup0.gfr" )
 
 	def __assertFilesEqual( self, f1, f2 ) :
 


### PR DESCRIPTION
If we don't specify the encoding to `open()`, then Python chooses a default encoding which is platform-specific. On Linux, this is generally UTF-8 but is unfortunately sensistive to a bug in OpenShadingLanguage which changes the locale when loading a shader (see #5048). On Windows, UTF-8 is not even the default encoding, so the new test case may have failed even without the explicit choice of locale. This is described pretty well in [PEP 597](https://peps.python.org/pep-0597).

The solution is simply to specify the encoding when opening the file, via the `encoding` argument to `open()`. But that argument only exists in Python 3, so we must use `io.open()` instead, to bridge the gap until we drop Python 3 support. Eventually, we can even drop the `encoding` argument entirely, because [PEP 686](https://peps.python.org/pep-0686/) makes UTF-8 the default on all platforms, and is adopted in Python 3.15.
