### PR TITLE
Wrapper : Remove `LC_NUMERIC` override

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,11 @@ Fixes
   - Fixed handling of colour array parameters.
 - Layouts : Fixed bug applying window size and position from saved layouts (#5042).
 
+Breaking Changes
+----------------
+
+- Locale : Removed `LC_NUMERIC=C` environment variable assignment from wrapper. This was a workaround for an OpenColorIO bug that has since been fixed.
+
 [^1]: Changes inherited from 1.x. Can be omitted from the release notes for the final release of 1.2.
 [^2]: Changes made to features introduced in 1.2.0.0ax. Can be omitted from the release notes for the final release of 1.2.
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -50,12 +50,6 @@ if [[ $1 == -psn_0_* ]] ; then
 	shift
 fi
 
-# Work around OCIO bug that causes parsing to fail for certain locales.
-# See https://github.com/imageworks/OpenColorIO/issues/297
-##########################################################################
-
-export LC_NUMERIC=C
-
 # Find where this script is located, resolving any symlinks that were used
 # to invoke it. Set GAFFER_ROOT based on the script location.
 ##########################################################################


### PR DESCRIPTION
This was only needed to workaround an OpenColorIO bug that was fixed in OCIO 2.1.1.
