### PR TITLE
Expression : Accept `pathlib.Path` for StringPlug assignments

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - PathListingWidget : Added support for columns that can automatically stretch to make use of available space.
 - LightEditor : Adjustments made to the width of the "Name" column are now preserved when switching between sections.
 - Animation Editor : For protruding tangents the slope and scale controls are now disabled (non editable) and display constrained values.
+- Expression : `pathlib.Path` values may now be assigned to StringPlugs.
 
 Fixes
 -----
@@ -34,6 +35,7 @@ Fixes
   - Fixed handling of colour array parameters.
 - Layouts : Fixed bug applying window size and position from saved layouts (#5042).
 - Light Editor : Fixed tooltips that were missing the "Double-click to toggle" hint. [^2]
+- ArnoldTextureBake : Fixed Windows path handling bug.
 
 API
 ---

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -39,6 +39,7 @@ import re
 import ast
 import functools
 import inspect
+import pathlib
 import imath
 
 import IECore
@@ -95,7 +96,10 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 				parentDict = parentDict[p]
 			r = parentDict.get( plugPathSplit[-1], IECore.NullObject.defaultNullObject() )
 			try:
-				result.append( r )
+				if isinstance( r, pathlib.Path ) :
+					result.append( r.as_posix() )
+				else :
+					result.append( r )
 			except:
 				raise TypeError( "Unsupported type for result \"%s\" for expression output \"%s\"" % ( str( r ), plugPath ) )
 

--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -384,7 +384,7 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 		self["__IndexFileExpression"].setExpression( inspect.cleandoc(
 			"""
 			import pathlib
-			parent["__indexFilePath"] = str( pathlib.Path( parent["bakeDirectory"] ) / ( "BAKE_FILE_INDEX_%i.####.txt" % context.get("BAKE_WEDGE:index", 0 ) ) )
+			parent["__indexFilePath"] = pathlib.Path( parent["bakeDirectory"] ) / ( "BAKE_FILE_INDEX_%i.####.txt" % context.get("BAKE_WEDGE:index", 0 ) )
 			"""
 		), "python" )
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1584,5 +1584,15 @@ class ExpressionTest( GafferTest.TestCase ) :
 		self.assertEqual( script["reference"]["IntPlug"].getValue(), 99 )
 		self.assertEqual( script["reference"]["FloatPlug"].getValue(), 2.5 )
 
+	def testPathForStringPlug( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.StringInOutNode()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( 'import pathlib; parent["node"]["in"] = pathlib.Path.cwd()' )
+
+		self.assertEqual( script["node"]["in"].getValue(), pathlib.Path.cwd().as_posix() )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This means users don't need to think about whether to use `str()` (no!) or `as_posix()` (yes!), as it is done for them.