### PR TITLE
Build : Link to `fmt` library

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1013,7 +1013,7 @@ libraries = {
 
 	"GafferScene" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "Half" ],
+			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "Half", "fmt" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],

--- a/src/GafferScene/Rename.cpp
+++ b/src/GafferScene/Rename.cpp
@@ -48,11 +48,8 @@
 
 #include "tbb/enumerable_thread_specific.h"
 
-/// \todo Add the latest `fmtlib` to GafferHQ/dependencies
-/// and get it from there. We don't want to rely on OpenImageIO
-/// here, especially not its implementation details.
-#define FMT_HEADER_ONLY
-#include "OpenImageIO/detail/fmt/format.h"
+#include "fmt/args.h"
+#include "fmt/format.h"
 
 #include <regex>
 #include <unordered_set>


### PR DESCRIPTION
This will be needed after the [new dependencies](https://github.com/GafferHQ/dependencies/pull/226) build is released, which adds the headers separately that OpenImageIO leaves out.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
