### PR TITLE
GafferCycles : Fix linking on MacOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1266,7 +1266,7 @@ libraries = {
 				( "CCL_NAMESPACE_END", "}" ),
 				( "WITH_OSL", "1" ),
 			],
-			"FRAMEWORKS" : [ "Foundation", "Metal" ],
+			"FRAMEWORKS" : [ "Foundation", "Metal", "IOKit" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBPATH" : [ "$CYCLES_ROOT/lib" ],


### PR DESCRIPTION
Cycles 3.3 and above requires linking to the IOKit framework to determine Mac GPU core counts.

https://archive.blender.org/developer/D15257