### PR TITLE
SceneGadget : Destroy camera before renderer

### DIFF
--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -218,6 +218,7 @@ SceneGadget::~SceneGadget()
 	// Then destroy controller and renderer before our OutputBuffer is
 	// destroyed, because the renderer might send pixels to it during shutdown.
 	m_controller.reset();
+	m_camera.reset();
 	m_renderer.reset();
 }
 


### PR DESCRIPTION
It's an unfortunate requirent of the Renderer API that all ObjectInterfaces must be destroyed before the Renderer they came from. By not destroying the camera before the renderer, we ended up calling `AiNodeDestroy()` _after_ `AiUniverseDestroy()`, which has already implicitly destroyed all the nodes. That caused crashes when shutting down the Arnold renderer in the Viewer.

This bug was introduced in #5120, ironically when fixing a Cycles shutdown crash. Since that hasn't been released yet, we don't need a specific mention of this latest fix in Changes.md.
