### PR TITLE
RendererAlgo : Error if the camera is hidden

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
 - LightEditor : Adjustments made to the width of the "Name" column are now preserved when switching between sections.
 - Animation Editor : For protruding tangents the slope and scale controls are now disabled (non editable) and display constrained values.
 - Expression : `pathlib.Path` values may now be assigned to StringPlugs.
+- Render : An error is now emitted if the render camera is hidden, instead of rendering through a default camera instead (#5131).
 
 Fixes
 -----

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1691,6 +1691,10 @@ void outputCameras( const ScenePlug *scene, const IECore::CompoundObject *global
 		{
 			throw IECore::Exception( "Camera \"" + cameraOption->readable() + "\" is not in the camera set" );
 		}
+		if( !SceneAlgo::visible( scene, cameraPath ) )
+		{
+			throw IECore::Exception( "Camera \"" + cameraOption->readable() + "\" is hidden" );
+		}
 	}
 
 	const ScenePlug::ScenePath root;


### PR DESCRIPTION
If it's hidden, then it won't get exported to the renderer, and then there will be nothing to render through.

Fixes #5131.
