### PR TITLE
Isolate : Keep light filters too when `keepLights` is on

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ Improvements
   - Added a "Disable Edit" command to the right-click menu, to easily disable tweaks in EditScopes (shortcut <kbd>D</kbd>).
   - Added a "Remove Attribute" command to the right-click menu, to delete attributes using the EditScope (shortcut <kbd>Delete</kbd>).
   - Adjustments made to the width of the "Name" column are now preserved when switching between sections.
+- Isolate : The `keepLights` setting now also keeps light filters.
 - AttributeTweaks : Added `Remove` mode.
 - PathListingWidget : Added support for columns that can automatically stretch to make use of available space.
 - Animation Editor : For protruding tangents the slope and scale controls are now disabled (non editable) and display constrained values.
@@ -159,6 +160,7 @@ Breaking Changes
 - Dispatcher : the `jobDirectory()` Python binding now returns a `pathlib.Path`, or `None` if it is empty.
 - `Context::EditableScope`, `ImagePlug::ChannelDataScope`, `ScenePlug::PathScope/SetScope` : Removed deprecated functions which didn't take pointers and required duplication of data.
 - ViewportGadget : Removed deprecated `gadgetsAt()` signature.
+- Isolate : The `keepLights` setting now also keeps light filters.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -129,6 +129,7 @@ API
 - GafferTest : Added ObjectPlug overloads for `repeatGetValue()` and `parallelGetValue()`.
 - SceneTestCase : Added `assertParallelGetValueComputesObjectOnce()`. This can be used to check that expensive computes are using an appropriate cache policy.
 - Gaffer ( Python module ) : Added `rootPath()` and `executablePath()` methods.
+- TestLightFilter : Added new node to GafferSceneTest, to aid in testing of scenarios involving LightFilters.
 
 Breaking Changes
 ----------------

--- a/include/GafferSceneTest/TestLightFilter.h
+++ b/include/GafferSceneTest/TestLightFilter.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,46 +34,31 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef GAFFERSCENETEST_TESTLIGHTFILTER_H
+#define GAFFERSCENETEST_TESTLIGHTFILTER_H
 
-#include "GafferSceneTest/ContextSanitiser.h"
-#include "GafferSceneTest/CompoundObjectSource.h"
-#include "GafferSceneTest/ScenePlugTest.h"
-#include "GafferSceneTest/TestLight.h"
-#include "GafferSceneTest/TestLightFilter.h"
-#include "GafferSceneTest/TestShader.h"
-#include "GafferSceneTest/TraverseScene.h"
+#include "GafferSceneTest/Export.h"
+#include "GafferSceneTest/TypeIds.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferScene/LightFilter.h"
 
-#include "IECorePython/ScopedGILRelease.h"
-
-using namespace boost::python;
-using namespace GafferSceneTest;
-
-static void traverseSceneWrapper( const GafferScene::ScenePlug *scenePlug )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	traverseScene( scenePlug );
-}
-
-BOOST_PYTHON_MODULE( _GafferSceneTest )
+namespace GafferSceneTest
 {
 
-	IECorePython::RefCountedClass<ContextSanitiser, Gaffer::Monitor>( "ContextSanitiser" )
-		.def( init<>() )
-	;
+class GAFFERSCENETEST_API TestLightFilter : public GafferScene::LightFilter
+{
 
-	GafferBindings::DependencyNodeClass<CompoundObjectSource>();
-	GafferBindings::NodeClass<TestShader>();
-	GafferBindings::NodeClass<TestLight>();
-	GafferBindings::NodeClass<TestLightFilter>();
+	public :
 
-	def( "traverseScene", &traverseSceneWrapper );
-	def( "connectTraverseSceneToPlugDirtiedSignal", &connectTraverseSceneToPlugDirtiedSignal );
-	def( "connectTraverseSceneToContextChangedSignal", &connectTraverseSceneToContextChangedSignal );
-	def( "connectTraverseSceneToPreDispatchSignal", &connectTraverseSceneToPreDispatchSignal );
+		GAFFER_NODE_DECLARE_TYPE( GafferSceneTest::TestLightFilter, TestLightFilterTypeId, GafferScene::LightFilter );
 
-	def( "testManyStringToPathCalls", &testManyStringToPathCalls );
+		TestLightFilter( const std::string &name=defaultName<TestLightFilter>() );
+		~TestLightFilter() override;
 
-}
+};
+
+IE_CORE_DECLAREPTR( TestLightFilter )
+
+} // namespace GafferSceneTest
+
+#endif // GAFFERSCENETEST_TESTLIGHTFILTER_H

--- a/include/GafferSceneTest/TypeIds.h
+++ b/include/GafferSceneTest/TypeIds.h
@@ -46,6 +46,7 @@ enum TypeId
 	CompoundObjectSourceTypeId = 110701,
 	TestShaderTypeId = 110702,
 	TestLightTypeId = 110703,
+	TestLightFilterTypeId = 110704,
 
 	LastTypeId = 110749
 };

--- a/python/GafferSceneTest/IsolateTest.py
+++ b/python/GafferSceneTest/IsolateTest.py
@@ -325,15 +325,21 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		# - group
 		#    - light
 		#    - camera
+		#    - lightFilter
 		#    - model1
 		#       - sphere
 		#       - light
-		#	 - model2
+		#       - lightFilter
+		#    - model2
 		#       - sphere
 		#       - light
+		#       - lightFilter
 
 		light = GafferSceneTest.TestLight()
 		light["sets"].setValue( "lightsAndSpheres" )
+
+		lightFilter = GafferSceneTest.TestLightFilter()
+		lightFilter["sets"].setValue( "lightsAndSpheres" )
 
 		sphere = GafferScene.Sphere()
 		sphere["sets"].setValue( "lightsAndSpheres" )
@@ -343,18 +349,21 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		model1 = GafferScene.Group()
 		model1["in"][0].setInput( sphere["out"] )
 		model1["in"][1].setInput( light["out"] )
+		model1["in"][2].setInput( lightFilter["out"] )
 		model1["name"].setValue( "model1" )
 
 		model2 = GafferScene.Group()
 		model2["in"][0].setInput( sphere["out"] )
 		model2["in"][1].setInput( light["out"] )
+		model2["in"][2].setInput( lightFilter["out"] )
 		model2["name"].setValue( "model2" )
 
 		group = GafferScene.Group()
 		group["in"][0].setInput( light["out"] )
-		group["in"][1].setInput( camera["out"] )
-		group["in"][2].setInput( model1["out"] )
-		group["in"][3].setInput( model2["out"] )
+		group["in"][1].setInput( lightFilter["out"] )
+		group["in"][2].setInput( camera["out"] )
+		group["in"][3].setInput( model1["out"] )
+		group["in"][4].setInput( model2["out"] )
 
 		self.assertSceneValid( group["out"] )
 
@@ -371,19 +380,25 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertTrue( isolate["out"].exists( "/group/model1/sphere" ) )
 		self.assertTrue( isolate["out"].exists( "/group/model1/light" ) )
+		self.assertTrue( isolate["out"].exists( "/group/model1/lightFilter" ) )
 		self.assertTrue( isolate["out"].exists( "/group/model1" ) )
 
 		self.assertFalse( isolate["out"].exists( "/group/model2/sphere" ) )
+		self.assertFalse( isolate["out"].exists( "/group/model2/light" ) )
+		self.assertFalse( isolate["out"].exists( "/group/model2/lightFilter" ) )
 		self.assertFalse( isolate["out"].exists( "/group/model2" ) )
 
 		self.assertFalse( isolate["out"].exists( "/group/light" ) )
+		self.assertFalse( isolate["out"].exists( "/group/lightFilter" ) )
 		self.assertFalse( isolate["out"].exists( "/group/camera" ) )
 
 		self.assertEqual( isolate["out"].set( "__lights" ).value.paths(), [ "/group/model1/light" ] )
+		self.assertEqual( isolate["out"].set( "__lightFilters" ).value.paths(), [ "/group/model1/lightFilter" ] )
 		self.assertEqual( isolate["out"].set( "__cameras" ).value.paths(), [] )
-		self.assertEqual( isolate["out"].set( "lightsAndSpheres" ).value, IECore.PathMatcher( [ "/group/model1/sphere", "/group/model1/light" ] ) )
+		self.assertEqual( isolate["out"].set( "lightsAndSpheres" ).value, IECore.PathMatcher( [ "/group/model1/sphere", "/group/model1/light", "/group/model1/lightFilter" ] ) )
 
 		self.assertNotEqual( isolate["out"].setHash( "__lights" ), group["out"].setHash( "__lights" ) )
+		self.assertNotEqual( isolate["out"].setHash( "__lightFilters" ), group["out"].setHash( "__lightFilters" ) )
 		self.assertNotEqual( isolate["out"].setHash( "__cameras" ), group["out"].setHash( "__cameras" ) )
 
 		# Keep lights
@@ -395,13 +410,19 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( isolate["out"].exists( "/group/camera" ) )
 
 		self.assertEqual( isolate["out"].set( "__lights" ), group["out"].set( "__lights" ) )
+		self.assertEqual( isolate["out"].set( "__lightFilters" ), group["out"].set( "__lightFilters" ) )
 		self.assertEqual( isolate["out"].set( "__cameras" ).value.paths(), [] )
 		self.assertEqual(
 			isolate["out"].set("lightsAndSpheres" ).value,
-			IECore.PathMatcher( [ "/group/model1/sphere" ] + group["out"].set( "__lights" ).value.paths() )
+			IECore.PathMatcher(
+				[ "/group/model1/sphere" ] +
+				group["out"].set( "__lights" ).value.paths() +
+				group["out"].set( "__lightFilters" ).value.paths()
+			)
 		)
 
 		self.assertEqual( isolate["out"].setHash( "__lights" ), group["out"].setHash( "__lights" ) )
+		self.assertEqual( isolate["out"].setHash( "__lightFilters" ), group["out"].setHash( "__lightFilters" ) )
 		self.assertNotEqual( isolate["out"].setHash( "__cameras" ), group["out"].setHash( "__cameras" ) )
 
 		# Keep cameras too
@@ -416,10 +437,15 @@ class IsolateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( isolate["out"].set( "__cameras" ), group["out"].set( "__cameras" ) )
 		self.assertEqual(
 			isolate["out"].set("lightsAndSpheres" ).value,
-			IECore.PathMatcher( [ "/group/model1/sphere" ] + group["out"].set( "__lights" ).value.paths() )
+			IECore.PathMatcher(
+				[ "/group/model1/sphere" ] +
+				group["out"].set( "__lights" ).value.paths() +
+				group["out"].set( "__lightFilters" ).value.paths()
+			)
 		)
 
 		self.assertEqual( isolate["out"].setHash( "__lights" ), group["out"].setHash( "__lights" ) )
+		self.assertEqual( isolate["out"].setHash( "__lightFilters" ), group["out"].setHash( "__lightFilters" ) )
 		self.assertEqual( isolate["out"].setHash( "__cameras" ), group["out"].setHash( "__cameras" ) )
 
 	def testKeepLightsAndCamerasHashing( self ):

--- a/python/GafferSceneUI/IsolateUI.py
+++ b/python/GafferSceneUI/IsolateUI.py
@@ -83,8 +83,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Keeps all lights, regardless of other settings. This is
-			useful when isolating an asset but wanting to render it
+			Keeps all lights and light filters, regardless of other settings.
+			This is useful when isolating an asset but wanting to render it
 			using a light rig located elsewhere in the scene.
 			""",
 

--- a/src/GafferSceneTest/TestLightFilter.cpp
+++ b/src/GafferSceneTest/TestLightFilter.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,46 +34,21 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
-
-#include "GafferSceneTest/ContextSanitiser.h"
-#include "GafferSceneTest/CompoundObjectSource.h"
-#include "GafferSceneTest/ScenePlugTest.h"
-#include "GafferSceneTest/TestLight.h"
 #include "GafferSceneTest/TestLightFilter.h"
+
 #include "GafferSceneTest/TestShader.h"
-#include "GafferSceneTest/TraverseScene.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-#include "IECorePython/ScopedGILRelease.h"
-
-using namespace boost::python;
+using namespace Gaffer;
+using namespace GafferScene;
 using namespace GafferSceneTest;
 
-static void traverseSceneWrapper( const GafferScene::ScenePlug *scenePlug )
+GAFFER_NODE_DEFINE_TYPE( TestLightFilter );
+
+TestLightFilter::TestLightFilter( const std::string &name )
+	:	GafferScene::LightFilter( new Shader(), name )
 {
-	IECorePython::ScopedGILRelease gilRelease;
-	traverseScene( scenePlug );
 }
 
-BOOST_PYTHON_MODULE( _GafferSceneTest )
+TestLightFilter::~TestLightFilter()
 {
-
-	IECorePython::RefCountedClass<ContextSanitiser, Gaffer::Monitor>( "ContextSanitiser" )
-		.def( init<>() )
-	;
-
-	GafferBindings::DependencyNodeClass<CompoundObjectSource>();
-	GafferBindings::NodeClass<TestShader>();
-	GafferBindings::NodeClass<TestLight>();
-	GafferBindings::NodeClass<TestLightFilter>();
-
-	def( "traverseScene", &traverseSceneWrapper );
-	def( "connectTraverseSceneToPlugDirtiedSignal", &connectTraverseSceneToPlugDirtiedSignal );
-	def( "connectTraverseSceneToContextChangedSignal", &connectTraverseSceneToContextChangedSignal );
-	def( "connectTraverseSceneToPreDispatchSignal", &connectTraverseSceneToPreDispatchSignal );
-
-	def( "testManyStringToPathCalls", &testManyStringToPathCalls );
-
 }


### PR DESCRIPTION
This was proposed by a user at Cinesite recently, and it seems entirely reasonable to me; if the intent of `keepLights` is to keep the lighting, then we also need to keep the light filters or the rendered image will not be the same. I've made it as a PR targeting 1.2.0.0 rather than 1.1.x though, because I'm a little uneasy about including such a behaviour change in a minor release. I'm also a little uneasy about trying to squeeze one last thing until 1.2 goes final though. And you could reasonably make the argument that this is a bugfix and as such could go into _any_ version. So, all that is open to debate...opinions welcome.