### PR TITLE
StandardLightVisualiser : Fix crash visualising portals

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.2.x.x (relative to 1.2.0.0)
+=======
+
+Fixes
+-----
+
+- Viewer : Fixed crash displaying Arnold quad lights in portal mode.
+
 1.2.0.0 (relative to 1.1.9.0)
 =======
 

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -534,7 +534,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		if( parameter<bool>( metadataTarget, shaderParameters, "portalParameter", false ) )
 		{
 			// Because we don't support variable size lights, we keep a fixed hatching scale
-			geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( quadPortal( size, muted ) ) );
+			geometry->addChild( const_pointer_cast<IECoreGL::Renderable>( quadPortal( size, /* hatchingScale = */ 1.0f, muted ) ) );
 		}
 		else
 		{


### PR DESCRIPTION
This was introduced by 832d0a87a3dfa73a6c53617e2b239c4a047fd9aa, where `bool muted` was accidentally passed to the `float hatchingScale` argument of `quadPortal()`, causing the space between hatch lines to be zero, and the hatch line generation to run until it ran out of memory.
