### PR TITLE
Channel PlugValueWidgets : Avoid unnecessary updates

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,15 @@
 1.2.x.x (relative to 1.2.0.1)
 =======
 
+Fixes
+-----
+
+- Viewer : Fixed flickering and empty menu in the channel selector for the image view.
+- RGBAChannelsPlugValueWidget, ChannelPlugValueWidget, ChannelMaskPlugValueWidget :
+  - Fixed unnecessary updates when channel data changed.
+ - RGBAChannelsPlugValueWidget
+  - Fixed bug that prevented errors being shown.
+
 1.2.0.1 (relative to 1.2.0.0)
 =======
 

--- a/python/GafferImageUI/ChannelMaskPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelMaskPlugValueWidget.py
@@ -66,7 +66,10 @@ class ChannelMaskPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _auxiliaryPlugs( self, plug ) :
 
-		return list( GafferImage.ImagePlug.RecursiveInputRange( plug.node() ) )
+		result = []
+		for imagePlug in GafferImage.ImagePlug.RecursiveInputRange( plug.node() ) :
+			result.extend( [ imagePlug["viewNames"], imagePlug["channelNames"] ] )
+		return result
 
 	@staticmethod
 	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
@@ -76,9 +79,9 @@ class ChannelMaskPlugValueWidget( GafferUI.PlugValueWidget ) :
 		for plug, imagePlugs in zip( plugs, auxiliaryPlugs ) :
 
 			availableChannels = set()
-			for imagePlug in imagePlugs :
-				for viewName in imagePlug.viewNames() :
-					availableChannels.update( imagePlug.channelNames( viewName = viewName ) )
+			for viewNamesPlug, channelNamesPlug in [ ( imagePlugs[i], imagePlugs[i+1] ) for i in range( 0, len( imagePlugs ), 2 ) ] :
+				for viewName in viewNamesPlug.getValue() :
+					availableChannels.update( channelNamesPlug.parent().channelNames( viewName = viewName ) )
 
 			result.append( { "value" : plug.getValue(), "availableChannels" : availableChannels } )
 

--- a/python/GafferImageUI/ChannelPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelPlugValueWidget.py
@@ -73,18 +73,18 @@ class ChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		name = Gaffer.Metadata.value( plug, "channelPlugValueWidget:imagePlugName" ) or "in"
 		imagePlug = plug.node().descendant( name )
-		return [ imagePlug ] if isinstance( imagePlug, GafferImage.ImagePlug ) else []
+		return [ imagePlug["viewNames"], imagePlug["channelNames"] ]
 
 	@staticmethod
 	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		result = []
 
-		for plug, imagePlugs in zip( plugs, auxiliaryPlugs ) :
+		for plug, ( viewNamesPlug, channelNamesPlug ) in zip( plugs, auxiliaryPlugs ) :
 
 			availableChannels = set()
-			for viewName in imagePlugs[0].viewNames() :
-				availableChannels.update( imagePlugs[0].channelNames( viewName = viewName ) )
+			for viewName in viewNamesPlug.getValue() :
+				availableChannels.update( channelNamesPlug.parent().channelNames( viewName = viewName ) )
 
 			result.append( { "value" : plug.getValue(), "availableChannels" : availableChannels } )
 

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -59,25 +59,27 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _auxiliaryPlugs( self, plug ) :
 
-		firstInputImage = next( GafferImage.ImagePlug.RecursiveInputRange( plug.node() ), None )
-		return [ firstInputImage ] if firstInputImage is not None else []
+		firstInputImage = next( GafferImage.ImagePlug.RecursiveInputRange( plug.node() ) )
+		return [ firstInputImage["viewNames"], firstInputImage["channelNames"] ]
 
 	@staticmethod
 	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
 		result = []
 
-		for plug, imagePlugs in zip( plugs, auxiliaryPlugs ) :
+		for plug, ( viewNamesPlug, channelNamesPlug ) in zip( plugs, auxiliaryPlugs ) :
 
 			availableChannels = set()
-			for viewName in imagePlugs[0].viewNames() :
-				availableChannels.update( imagePlugs[0].channelNames( viewName = viewName ) )
+			for viewName in viewNamesPlug.getValue() :
+				availableChannels.update( channelNamesPlug.parent().channelNames( viewName = viewName ) )
 
 			result.append( { "value" : plug.getValue(), "availableChannels" : availableChannels } )
 
 		return result
 
 	def _updateFromValues( self, values, exception ) :
+
+		self.__menuButton.setErrored( exception is not None )
 
 		self.__availableChannels = set().union( *[ v["availableChannels"] for v in values ] )
 		self.__currentValue = sole( v["value"] for v in values )
@@ -106,7 +108,6 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 				text = prefix + channels[0]
 
 		self.__menuButton.setText( text )
-		self.__menuButton.setErrored( exception is not None )
 
 	def _updateFromEditable( self ) :
 


### PR DESCRIPTION
We were using ImagePlugs as our auxiliary plugs as it was a convenient way of depending on both the `viewNames` and `channelNames` plugs. But this meant an update was triggered every time the `ImagePlug["channelData"]` plug was dirtied too, which was basically continuous when viewing an interactive render. This resulted in the channel selector in the ImageView flickering constantly, and the dropdown menu sometimes being empty because an update was pending. This is solved by declaring our dependencies more accurately, returning just the `viewNames` and `channelNames` plugs.

I've also deliberately removed the attempt to handle the lack of an ImagePlug in `_auxiliaryPlugs()` for RGBChannelsPlugValueWidget and ChannelPlugValueWidget, as there was no handling for the resulting empty lists in the subsequent `_valuesForUpdate()` methods. This matches the situation before we introduced asynchronous updates - we have always required the ImagePlug to exist and thrown if it doesn't.

Also moved error indicator code above the early out in `RGBAChannelsPlugValueWidget._updateFromValues()`, otherwise we'd never show the error state
