### PR TITLE
Cycles SocketAlgo : Fix warning format arguments

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,11 @@
-1.1.x.x (relative to 1.1.9.0)
+1.1.9.x (relative to 1.1.9.0)
 =======
 
 Fixes
 -----
 
-- CompoundPlugValueWidget : Fixed errors when refreshing the widget. 
+- Cycles : Fixed crash triggered by unsupported shader parameters (#5147).
+- CompoundPlugValueWidget : Fixed errors when refreshing the widget.
 
 1.1.9.0 (relative to 1.1.8.0)
 =======

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -1793,5 +1793,37 @@ class RendererTest( GafferTest.TestCase ) :
 				"Invalid enum value \"missing\" for socket `subsurface_method` on node .*"
 			)
 
+	def testUnsupportedShaderParameters( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			attributes = renderer.attributes(
+				IECore.CompoundObject( {
+					"cycles:surface" : IECoreScene.ShaderNetwork(
+						shaders = {
+							"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface" ),
+							"coordinates" : IECoreScene.Shader( "texture_coordinate", "cycles:shader", { "ob_tfm" : imath.M44f() } ),
+						},
+						connections = [
+							( ( "coordinates", "normal" ), ( "output", "normal" ) )
+						],
+						output = "output"
+					)
+				} )
+			)
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].context, "Cycles::SocketAlgo" )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+		six.assertRegex(
+			self, mh.messages[0].message,
+			"Unsupported socket type `transform` for socket `ob_tfm` on node .*"
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -449,7 +449,7 @@ void setSocket( ccl::Node *node, const ccl::SocketType *socket, const IECore::Da
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
 				boost::format( "Unsupported socket type `%1%` for socket `%2%` on node `%3%`." )
-					% ccl::SocketType::type_name( socket->type ) % value->typeName() % socket->name % node->name
+					% ccl::SocketType::type_name( socket->type ) % socket->name % node->name
 			);
 			break;
 	}


### PR DESCRIPTION
There was one too many, which caused `boost::format()` to throw, subsequently crashing Gaffer.

I broke this in 8454f37c6d39ad1304bb3eb05dfb0feaaaaaf504, where I confidently stated that we didn't need to support transform sockets. But the `texture_coordinate` shader does have such a socket, called `ob_tfm`, which is how this problem surfaced. But I'm still not convinced we need to support it; I'm not sure how a user would use `ob_tfm` - maybe it's more of an implementation detail for Blender?

Fixes #5147.
