### PR TITLE
Cycles crash fix (1.2 version)

### DIFF
--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -1818,8 +1818,8 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].context, "Cycles::SocketAlgo" )
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
-		six.assertRegex(
-			self, mh.messages[0].message,
+		self.assertRegex(
+			mh.messages[0].message,
 			"Unsupported socket type `transform` for socket `ob_tfm` on node .*"
 		)
 

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -46,6 +46,8 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "util/vector.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
+#include "fmt/format.h"
+
 using namespace std;
 using namespace Imath;
 using namespace IECore;
@@ -448,8 +450,10 @@ void setSocket( ccl::Node *node, const ccl::SocketType *socket, const IECore::Da
 		default:
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported socket type `%1%` for socket `%2%` on node `%3%`." )
-					% ccl::SocketType::type_name( socket->type ) % socket->name % node->name
+				fmt::format(
+					"Unsupported socket type `{}` for socket `{}` on node `{}`.",
+					ccl::SocketType::type_name( socket->type ), socket->name, node->name
+				)
 			);
 			break;
 	}

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -79,8 +79,10 @@ void setNumericSocket( ccl::Node *node, const ccl::SocketType &socket, const IEC
 		default :
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported type `%1%` for socket `%2%` on node `%3%" )
-					% value->typeName() % socket.name % node->name
+				fmt::format(
+					"Unsupported type `{}` for socket `{}` on node `{}",
+					value->typeName(), socket.name, node->name
+				)
 			);
 			break;
 	}
@@ -105,8 +107,10 @@ void setFloat2Socket( ccl::Node *node, const ccl::SocketType &socket, const IECo
 		default :
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported type `%1%` for socket `%2%` on node `%3%" )
-					% value->typeName() % socket.name % node->name
+				fmt::format(
+					"Unsupported type `{}` for socket `{}` on node `{}",
+					value->typeName(), socket.name, node->name
+				)
 			);
 			break;
 	}
@@ -136,8 +140,10 @@ void setFloat2ArraySocket( ccl::Node *node, const ccl::SocketType &socket, const
 		default :
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported type `%1%` for socket `%2%` on node `%3%" )
-					% value->typeName() % socket.name % node->name
+				fmt::format(
+					"Unsupported type `{}` for socket `{}` on node `{}",
+					value->typeName(), socket.name, node->name
+				)
 			);
 			break;
 	}
@@ -169,8 +175,10 @@ void setFloat3Socket( ccl::Node *node, const ccl::SocketType &socket, const IECo
 		default :
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported type `%1%` for socket `%2%` on node `%3%" )
-					% value->typeName() % socket.name % node->name
+				fmt::format(
+					"Unsupported type `{}` for socket `{}` on node `{}",
+					value->typeName(), socket.name, node->name
+				)
 			);
 			break;
 	}
@@ -207,8 +215,10 @@ void setFloat3ArraySocket( ccl::Node *node, const ccl::SocketType &socket, const
 		default :
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Unsupported type `%1%` for socket `%2%` on node `%3%" )
-					% value->typeName() % socket.name % node->name
+				fmt::format(
+					"Unsupported type `{}` for socket `{}` on node `{}",
+					value->typeName(), socket.name, node->name
+				)
 			);
 			break;
 	}
@@ -227,8 +237,10 @@ void setArraySocket( ccl::Node *node, const ccl::SocketType &socket, const Data 
 	{
 		IECore::msg(
 			IECore::Msg::Warning, "Cycles::SocketAlgo::setSocket",
-			boost::format( "Unsupported data type `%1%` for socket `%2%` on node %3%" )
-				% value->typeName() % socket.name % node->name
+			fmt::format(
+				"Unsupported data type `{}` for socket `{}` on node {}",
+				value->typeName(), socket.name, node->name
+			)
 		);
 	}
 }
@@ -257,8 +269,10 @@ void setEnumSocket( ccl::Node *node, const ccl::SocketType &socket, const IECore
 		{
 			IECore::msg(
 				IECore::Msg::Warning, "Cycles::SocketAlgo",
-				boost::format( "Invalid enum value \"%1%\" for socket `%2%` on node %3%" )
-					% name % socket.name % node->name
+				fmt::format(
+					"Invalid enum value \"{}\" for socket `{}` on node {}",
+					name, socket.name, node->name
+				)
 			);
 		}
 	}
@@ -282,8 +296,10 @@ void setStringSocket( ccl::Node *node, const ccl::SocketType &socket, const IECo
 	{
 		IECore::msg(
 			IECore::Msg::Warning, "Cycles::SocketAlgo",
-			boost::format( "Unsupported data type `%1%` for socket `%2%` on node %3% (expected StringData or InternedStringData)." )
-				% value->typeName() % socket.name % node->name
+			fmt::format(
+				"Unsupported data type `{}` for socket `{}` on node {} (expected StringData or InternedStringData).",
+				value->typeName(), socket.name, node->name
+			)
 		);
 	}
 }


### PR DESCRIPTION
As for #5151, this fixes a Cycles rendering crash. But this time I've indulged in a bit of `fmt::format()` instead of `boost::format()` - I intend for us to replace all `boost::format()` usage over time.