### PR TITLE
CompoundPlugValueWidget : Fix error when deleting widgets in python 3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.1.x.x (relative to 1.1.9.0)
+=======
+
+Fixes
+-----
+
+- CompoundPlugValueWidget : Fixed errors when refreshing the widget. 
+
 1.1.9.0 (relative to 1.1.8.0)
 =======
 

--- a/python/GafferCortexUI/CompoundPlugValueWidget.py
+++ b/python/GafferCortexUI/CompoundPlugValueWidget.py
@@ -196,7 +196,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# ditch child uis we don't need any more
 		childPlugs = self._childPlugs()
-		for childPlug in self.__childPlugUIs.keys() :
+		for childPlug in list( self.__childPlugUIs.keys() ) :
 			if childPlug not in childPlugs :
 				del self.__childPlugUIs[childPlug]
 


### PR DESCRIPTION
In python 3, deleting elements from a dictionary should not iterate over the `keys()`, given that it will update during execution, returning a `RuntimeError: dictionary changed size during iteration` exception.

### Related issues ###

We were getting this sort of error messages at IE:

```
"/software/apps/gaffer/1.1.9.0/cent7.x86_64/cortex/10.4/gaffer/py3/python/GafferCortexUI/CompoundPlugValueWidget.py", line 199, in __updateChildPlugUIs
    for childPlug in self.__childPlugUIs.keys() :
RuntimeError: dictionary changed size during iteration
```

### Dependencies ###

- None

### Breaking changes ###

- None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
