### PR TITLE
Wrapper : Reintroduce `LC_NUMERIC=C`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,13 @@
 1.2.x.x (relative to 1.2.0.2)
 =======
 
+Fixes
+-----
+
+- Locale :
+  - Reintroduced `LC_NUMERIC=C` environment variable assignment to wrapper. This was removed in `1.2.0.0` but is still necessary due to a [bug in Cortex](https://github.com/ImageEngine/cortex/issues/1338).
+  - Fixed serialisation of `.gfr` files in locales with non-default numeric formatting (#5158).
+
 Documentation
 -------------
 

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -50,6 +50,12 @@ if [[ $1 == -psn_0_* ]] ; then
 	shift
 fi
 
+# Work around https://github.com/ImageEngine/cortex/issues/1338, which
+# causes bad serialisations in certain locales.
+##########################################################################
+
+export LC_NUMERIC=C
+
 # Find where this script is located, resolving any symlinks that were used
 # to invoke it. Set GAFFER_ROOT based on the script location.
 ##########################################################################


### PR DESCRIPTION
I removed this in e323014e1d3980cb065a5cfc780a0c1ad04f0b48 after verifying that the OCIO bug it worked around was now fixed properly. But what I didn't realise is that we have our _own_ equivalent bug in https://github.com/ImageEngine/cortex/issues/1338. So I'm reverting the change until we have time to fix properly in Cortex.

Fixes #5158
