### PR TITLE
SConstruct : Always build gafferVars

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2073,6 +2073,9 @@ if haveSphinx and haveInkscape :
 	docEnv.Depends( docs, docGraphicsCommands )
 	docEnv.Depends( docs, "build" )
 	docVars = docCommandEnv.Command( "doc/source/gafferVars.json", "doc/source/gafferVars.py", generateDocs )
+	# Always build gafferVars otherwise an incorrect version could be retrieved from the cache
+	docEnv.AlwaysBuild( docVars )
+	docEnv.NoCache( docVars )
 	docEnv.Depends( docs, docVars )
 	if resources is not None :
 		docEnv.Depends( docs, resources )


### PR DESCRIPTION
We've seen a few [cases](https://www.gafferhq.org/documentation/1.2.0.1/index.html) [recently](https://www.gafferhq.org/documentation/1.2.0.2/index.html) where `1.2.x.x` docs are building claiming a version number of `1.3.0.0`. It seems the culprit here is `docs/source/gafferVars.json` being retrieved from the cache with the wrong version. This PR disables caching on gafferVars and sets it to always build. 

For local docs rebuilds, Sphinx seems smart enough to ignore the updated file if the contents hasn't changed, so I don't think this should introduce issues there.