### PR TITLE
Windows Getting Started docs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Documentation
 -------------
 
  - Added more Python examples to the Scripting Reference "Common Operations" article.
+ - Added instructions for installing and configuring Gaffer on Windows to the "Getting Started" guide.
 
 Build
 -----

--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -40,6 +40,25 @@ To create the `ARNOLD_ROOT` environment variable in Linux:
     ```
 
 
+### Arnold in Windows ###
+
+> Note :
+> For this instruction, we will assume you have Arnold !ARNOLD_VERSION! installed to `!ARNOLD_PATH_WINDOWS!`.
+
+To create the `ARNOLD_ROOT` environment variable in Windows:
+
+1. Open the Command Prompt (Start > Windows System > Command Prompt).
+
+2. Run the command `setx ARNOLD_ROOT "!ARNOLD_PATH_WINDOWS!"`.
+
+3. In a new Command Prompt window, test that the variable is set:
+
+    ```powershell
+    C:\Users\user> echo %ARNOLD_ROOT%
+    # !ARNOLD_PATH_WINDOWS!
+    ```
+
+
 ### Arnold in macOS ###
 
 > Note :
@@ -89,6 +108,31 @@ To create the `DELIGHT` environment variable in Linux:
     ```shell
     user@desktop ~ $ echo $DELIGHT
     # !DELIGHT_PATH_LINUX!
+    ```
+
+
+### 3Delight in Windows ###
+
+> Important :
+> Gaffer currently requires __3Delight for Maya__ to be included as part of the 3Delight install for access to lights and shaders.
+
+> Tip :
+> The 3Delight installer typically configures the `DELIGHT` environment variable on Windows. So the steps below may not be required.
+
+> Note :
+> For this instruction, we will assume you have 3Delight !DELIGHT_VERSION! installed to `!DELIGHT_PATH_WINDOWS!`.
+
+To create the `DELIGHT` environment variable in Windows:
+
+1. Open the Command Prompt (Start > Windows System > Command Prompt).
+
+2. Run the command `setx DELIGHT "!DELIGHT_PATH_WINDOWS!"`.
+
+3. In a new Command Prompt window, test that the variable is set:
+
+    ```powershell
+    C:\Users\user> echo %DELIGHT%
+    # !DELIGHT_PATH_WINDOWS!
     ```
 
 

--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -3,7 +3,7 @@
 Gaffer is compatible with the following commercial and open-source third-party tools:
 
 - [Appleseed](http://appleseedhq.net/)
-- [Arnold](https://www.solidangle.com/arnold/)
+- [Arnold](https://www.arnoldrenderer.com/)
 - [3Delight](http://www.3delight.com/)
 - [Tractor](https://renderman.pixar.com/tractor)
 

--- a/doc/source/GettingStarted/InstallingGaffer/index.md
+++ b/doc/source/GettingStarted/InstallingGaffer/index.md
@@ -43,6 +43,9 @@ Gaffer is now installed to `C:\software\gaffer-!GAFFER_VERSION!-windows`.
 
 ## Installing in macOS ##
 
+> Note :
+> Pre-built versions of Gaffer are currently unavailable on macOS.
+
 To install Gaffer in macOS:
 
 1. Download the [latest macOS package of Gaffer](https://github.com/GafferHQ/gaffer/releases/download/!GAFFER_VERSION!/gaffer-!GAFFER_VERSION!-macos.tar.gz).

--- a/doc/source/GettingStarted/InstallingGaffer/index.md
+++ b/doc/source/GettingStarted/InstallingGaffer/index.md
@@ -5,7 +5,7 @@
 The Gaffer package is a self-contained directory, so you will need to manually install it, and later manually configure it, if necessary. Once extracted, the Gaffer directory contains the complete application, ready for use.
 
 > Note :
-> In keeping with Linux/macOS best practices, we will demonstrate how to install Gaffer in the `/opt/` directory. However, you could install it to any location on your file system to which you have write and execute access.
+> In keeping with Linux/macOS best practices, we will demonstrate how to install Gaffer in the `/opt/` directory. We also use `C:\software\` on Windows as an example installation path. However, you could install it to any location on your file system to which you have write and execute access.
 
 
 ## Installing in Linux ##
@@ -25,6 +25,21 @@ To install Gaffer in Linux:
 
 Gaffer is now installed to `/opt/gaffer-!GAFFER_VERSION!-linux`.
 
+
+## Installing in Windows ##
+
+To install Gaffer in Windows:
+
+1. Download the [latest Windows package of Gaffer](https://github.com/GafferHQ/gaffer/releases/download/!GAFFER_VERSION!/gaffer-!GAFFER_VERSION!-windows.zip).
+
+2. Extract the archive (for best performance, we suggest extracting with [7-Zip](https://www.7-zip.org/)).
+
+3. Move the extracted `gaffer-!GAFFER_VERSION!-windows` folder to the location you wish to install it under, such as `C:\software`.
+
+Gaffer is now installed to `C:\software\gaffer-!GAFFER_VERSION!-windows`.
+
+> Note :
+> Gaffer requires the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) to be installed on Windows. This needs to be [downloaded](https://aka.ms/vs/17/release/vc_redist.x64.exe) and installed before Gaffer can be [launched](../LaunchingGafferFirstTime/index.md).
 
 ## Installing in macOS ##
 

--- a/doc/source/GettingStarted/LaunchingGafferFirstTime/index.md
+++ b/doc/source/GettingStarted/LaunchingGafferFirstTime/index.md
@@ -5,7 +5,7 @@
 Once Gaffer has been installed, you will probably want to try it out right away before performing any additional configuration. To launch it, you can run its application file directly from the binary directory.
 
 > Note :
-> For these instructions, we will assume you have Gaffer installed to the `/opt/` directory. If you have installed it elsewhere, replace `/opt/` with the directory you installed it to.
+> For these instructions, we will assume you have Gaffer installed to the `/opt/` directory on Linux or macOS and `C:\software\` on Windows. If you have installed it elsewhere, replace `/opt/` or `C:\software\` with the directory you installed it to.
 
 > Caution :
 > When you run Gaffer from a terminal, its continued operation is dependent on that terminal window. If you close the terminal, it will also close Gaffer, and you may lose any unsaved data.
@@ -25,6 +25,26 @@ To launch Gaffer for the first time in Linux:
 
 Gaffer will launch in a new window.
 
+
+## Launching in Windows ##
+
+To launch Gaffer for the first time in Windows:
+
+1. Open the Command Prompt (Start > Windows System > Command Prompt).
+
+2. Navigate to the Gaffer binary directory and run the Gaffer application:
+    ```powershell
+    C:\Users\user> cd C:\software\gaffer-!GAFFER_VERSION!-windows\bin
+    C:\software\gaffer-!GAFFER_VERSION!-windows\bin> gaffer.cmd
+    ```
+
+Gaffer will launch in a new window.
+
+> Tip :
+> Gaffer can also be launched by browsing to `C:\software\gaffer-!GAFFER_VERSION!-windows\bin` in Windows Explorer and double-clicking on `gaffer.cmd`.
+
+> Note :
+> Gaffer requires the [Microsoft Visual C++ Redistributable](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) to be installed on Windows. If you see errors related to missing `VCRUNTIME` files such as `VCRUNTIME140.dll`, the redestributable will need to be [downloaded](https://aka.ms/vs/17/release/vc_redist.x64.exe) and installed before Gaffer can be launched.
 
 ## Launching in macOS ##
 

--- a/doc/source/GettingStarted/SettingUpGafferCommand/index.md
+++ b/doc/source/GettingStarted/SettingUpGafferCommand/index.md
@@ -49,6 +49,37 @@ To set up the `gaffer` command in Linux:
 You can now execute `gaffer` as a command from any directory in the terminal.
 
 
+## Setting up the "gaffer" command in Windows ##
+
+To set up the `gaffer` command in Windows:
+
+1. Right click on the Start menu and click on __System__.
+
+2. In the "Settings" window, click on __Advanced System Settings__.
+
+3. In the "System Properties" window, click on __Environment Variables__.
+
+4. The "Environment Variables" window contains two sections, one for the current user's environment variables and the other for system environment variables, which apply to all users. In the appropriate section, select the `Path` entry and click __Edit...__
+
+5. In the "Edit environment variable" window, click __New__ and specify the path to the Gaffer install's `bin` directory.
+
+    - `C:\software\gaffer-!GAFFER_VERSION!-windows\bin`
+
+6. Click __Ok__ to apply the edit, and __Ok__ again to dismiss the "Edit environment variable" window.
+
+7. In a new Command Prompt window, test that the `PATH` variable has been updated:
+
+    ```powershell
+    C:\Users\user> echo %PATH%
+    # C:\Windows\system32;C:\software\gaffer-!GAFFER_VERSION!-windows\bin
+    ```
+
+> Note :
+> Depending on your system configuration, the beginning of your `PATH` variable might not appear exactly as above. What's important is whether `C:\software\gaffer-!GAFFER_VERSION!-windows\bin` appears.
+
+You can now execute `gaffer` as a command from any directory in the command prompt.
+
+
 ## Setting up the "gaffer" command in macOS ##
 
 The default terminal in macOS is bash, so you will need to add to the `PATH` variable in the bash user config.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -301,12 +301,12 @@ texinfo_documents = [
 
 # Variables for string replacement functions
 
-arnold_version = '7.1.1.1'
+arnold_version = '7.1.4.2'
 arnold_path_linux = '/opt/solidangle/arnold-{0}'.format( arnold_version )
 arnold_path_osx = '/opt/solidangle/arnold-{0}'.format( arnold_version )
 arnold_path_windows = 'C:\\software\\arnold-{0}'.format( arnold_version )
 
-delight_version = '13.0.18'
+delight_version = '2.9.17'
 delight_path_linux = '/opt/3delight-{0}'.format( delight_version )
 delight_path_osx = '/opt/3delight-{0}'.format( delight_version )
 delight_path_windows = 'C:\\software\\3delight-{0}'.format( delight_version )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -304,10 +304,12 @@ texinfo_documents = [
 arnold_version = '7.1.1.1'
 arnold_path_linux = '/opt/solidangle/arnold-{0}'.format( arnold_version )
 arnold_path_osx = '/opt/solidangle/arnold-{0}'.format( arnold_version )
+arnold_path_windows = 'C:\\software\\arnold-{0}'.format( arnold_version )
 
 delight_version = '13.0.18'
 delight_path_linux = '/opt/3delight-{0}'.format( delight_version )
 delight_path_osx = '/opt/3delight-{0}'.format( delight_version )
+delight_path_windows = 'C:\\software\\3delight-{0}'.format( delight_version )
 
 tractor_version = '2.2'
 tractor_path_linux = '/opt/pixar/Tractor-{0}'.format( tractor_version )
@@ -366,9 +368,11 @@ def thirdPartySourceSubtitutions( app, docName, source) :
 	source[0] = source[0].replace( "!ARNOLD_VERSION!", arnold_version )
 	source[0] = source[0].replace( "!ARNOLD_PATH_LINUX!", arnold_path_linux )
 	source[0] = source[0].replace( "!ARNOLD_PATH_OSX!", arnold_path_osx )
+	source[0] = source[0].replace( "!ARNOLD_PATH_WINDOWS!", arnold_path_windows )
 	source[0] = source[0].replace( "!DELIGHT_VERSION!", delight_version )
 	source[0] = source[0].replace( "!DELIGHT_PATH_LINUX!", delight_path_linux )
 	source[0] = source[0].replace( "!DELIGHT_PATH_OSX!", delight_path_osx )
+	source[0] = source[0].replace( "!DELIGHT_PATH_WINDOWS!", delight_path_windows )
 	source[0] = source[0].replace( "!TRACTOR_VERSION!", tractor_version )
 	source[0] = source[0].replace( "!TRACTOR_PATH_LINUX!", tractor_path_linux )
 	source[0] = source[0].replace( "!TRACTOR_PATH_OSX!", tractor_path_osx )


### PR DESCRIPTION
This adds Windows equivalent instructions to the "Getting Started" documentation articles. I've used `C:\software` as the example install location, mostly for demonstration purposes and for lack of a more standard equivalent to `/opt` on Linux & macOS. 

As far as defining environment variables goes, for brevity I've used [setx](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setx) for things like `ARNOLD_ROOT` and `DELIGHT` as it seemed simpler to explain than listing each step of clicking through the UI. Though for updating `PATH`, I've suggested the UI approach as there seem to be numerous [pitfalls](https://stackoverflow.com/questions/19287379/how-do-i-add-to-the-windows-path-variable-using-setx-having-weird-problems) with using `setx` to append to existing environment variables. @ericmehl it would be good to get your thoughts on these as I'm no Windows power user...

This also includes a few small updates to the Arnold and 3Delight version numbers used in the docs, corrects an out of date Arnold link, and adds a note to the macOS install docs stating that builds are currently unavailable.