### PR TITLE
Arnold ShaderNetworkAlgo : Improve UsdUVTexture support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.0.2)
 =======
 
+Improvements
+------------
+
+- USD : Added translation of UsdUVTexture's `scale`, `bias` and `fallback` parameters to Arnold.
+
 Fixes
 -----
 


### PR DESCRIPTION
We couldn't support these parameters before because Cortex wasn't loading the `float4` type. But since https://github.com/ImageEngine/cortex/commit/e08e467a37140a9d2f49e24aad2f53d8515800f2 we have been loading `float4` as `Color4` so this is now possible.