### PR TITLE
GafferUI : Remove Qt 4 support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1404,18 +1404,16 @@ def addQtLibrary( library, qtLibrary, pythonOnly = True ) :
 		if not pythonOnly:
 			libraries[library]["envAppends"].setdefault( "FRAMEWORKS", [] ).append( "Qt" + qtLibrary )
 	else :
-		prefix = "Qt" if int( env["QT_VERSION"] ) < 5 else "Qt${QT_VERSION}"
-		libraries[library]["pythonEnvAppends"]["LIBS"].append( prefix + qtLibrary )
+		libraries[library]["pythonEnvAppends"]["LIBS"].append( "Qt${QT_VERSION}" + qtLibrary )
 		if not pythonOnly:
-			libraries[library]["envAppends"]["LIBS"].append( prefix + qtLibrary )
+			libraries[library]["envAppends"]["LIBS"].append( "Qt${QT_VERSION}" + qtLibrary )
 
 for library in ( "GafferUI", ) :
 	addQtLibrary( library, "Core", False )
 	addQtLibrary( library, "Gui" )
 	addQtLibrary( library, "OpenGL" )
 	addQtLibrary( library, "Test" )
-	if int( env["QT_VERSION"] ) > 4 :
-		addQtLibrary( library, "Widgets" )
+	addQtLibrary( library, "Widgets" )
 
 # Add required libraries for Windows
 

--- a/python/GafferUI/InfoPathFilterWidget.py
+++ b/python/GafferUI/InfoPathFilterWidget.py
@@ -57,10 +57,7 @@ class InfoPathFilterWidget( GafferUI.PathFilterWidget ) :
 			filterButton.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ), scoped = False )
 
 			self.__filterText = GafferUI.TextWidget()
-
-			if hasattr( self.__filterText._qtWidget(), "setPlaceholderText" ) :
-				# setPlaceHolderText appeared in qt 4.7, nuke (6.3 at time of writing) is stuck on 4.6.
-				self.__filterText._qtWidget().setPlaceholderText( "Filter..." )
+			self.__filterText._qtWidget().setPlaceholderText( "Filter..." )
 
 			self.__filterText.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__filterEditingFinished ), scoped = False )
 			self.__filterText.textChangedSignal().connect( Gaffer.WeakMethod( self.__filterTextChanged ), scoped = False )

--- a/python/GafferUI/MatchPatternPathFilterWidget.py
+++ b/python/GafferUI/MatchPatternPathFilterWidget.py
@@ -61,10 +61,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 			)
 
 			self.__patternWidget = GafferUI.TextWidget()
-
-			if hasattr( self.__patternWidget._qtWidget(), "setPlaceholderText" ) :
-				# setPlaceHolderText appeared in qt 4.7, nuke (6.3 at time of writing) is stuck on 4.6.
-				self.__patternWidget._qtWidget().setPlaceholderText( "Filter..." )
+			self.__patternWidget._qtWidget().setPlaceholderText( "Filter..." )
 
 			self.__patternWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__patternEditingFinished ), scoped = False )
 			self.__patternWidget.textChangedSignal().connect( Gaffer.WeakMethod( self.__patternTextChanged ), scoped = False )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -227,9 +227,7 @@ class Menu( GafferUI.Widget ) :
 			self.__searchLine.textEdited.connect( Gaffer.WeakMethod( self.__updateSearchMenu ) )
 			self.__searchLine.returnPressed.connect( Gaffer.WeakMethod( self.__searchReturnPressed ) )
 			self.__searchLine.setObjectName( "gafferSearchField" )
-			if hasattr( self.__searchLine, "setPlaceholderText" ) :
-				# setPlaceHolderText appeared in qt 4.7, nuke (6.3 at time of writing) is stuck on 4.6.
-				self.__searchLine.setPlaceholderText( "Search..." )
+			self.__searchLine.setPlaceholderText( "Search..." )
 			if self.__lastAction :
 				self.__searchLine.setText( self.__lastAction.text() )
 				self.__searchMenu.setDefaultAction( self.__lastAction )

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -472,9 +472,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 
 		return newData
 
-	# Qt5 added a third argument we don't need, so we gobble it
-	# up with `*unused` to maintain compatibility with Qt4.
-	def __modelDataChanged( self, topLeft, bottomRight, *unused ) :
+	def __modelDataChanged( self, topLeft, bottomRight, roles ) :
 
 		if self.__propagatingDataChangesToSelection :
 			return


### PR DESCRIPTION
This was useless because a) we don't use Qt 4 and b) we removed Qt 4 support from PathListingWidget in b7bb1a998ad29684fc6fe664bf9be81b67cbf778, back in Gaffer 0.61.
