### PR TITLE
Animation gadget draw tangents with constrained scale using fixed raster space length

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - USD : Added translation of UsdUVTexture's `scale`, `bias` and `fallback` parameters to Arnold.
+- AnimationGadget : Curves using cubic interpolation whose tangents have constrained scale are now displayed with fixed raster space length to ensure that tangent manipulator handles are always accessible.
 
 Fixes
 -----
@@ -15,6 +16,11 @@ Fixes
 - Tweak nodes : Fixed bugs which prevented the creation of new tweaks when an existing tweak had an input connection.
 - Preferences : Fixed bug which caused UI metadata to be serialised unnecessarily into `~/gaffer/startup/gui/preferences.py`.
 - OpenGL Texture shader : Fixed bug which allowed transparent regions to obscure objects behind them.
+
+API
+---
+
+- Animation : Added `constrainedLength` metadata that specifies the fixed raster space length used for display of tangents whose scale is constrained.
 
 Documentation
 -------------

--- a/include/GafferUI/AnimationGadget.h
+++ b/include/GafferUI/AnimationGadget.h
@@ -104,6 +104,7 @@ class GAFFERUI_API AnimationGadget : public Gadget
 		void frame();
 
 		void plugDirtied( Gaffer::Plug *plug );
+		void metadataValueChanged( IECore::InternedString target, IECore::InternedString key );
 
 		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );
 		bool buttonRelease( GadgetPtr gadget, const ButtonEvent &event );

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -90,6 +90,8 @@ Gaffer.Metadata.registerValue( "Animation.TieMode.Manual", "description", "Tange
 Gaffer.Metadata.registerValue( "Animation.TieMode.Slope", "description", "Tangent slopes are kept equal." )
 Gaffer.Metadata.registerValue( "Animation.TieMode.Scale", "description", "Tangent slopes are kept equal and scales are kept proportional." )
 
+Gaffer.Metadata.registerValue( "Animation.Tangent", "constrainedLength", 60.0 )
+
 # PlugValueWidget popup menu for setting keys
 ##########################################################################
 

--- a/src/GafferUI/AnimationGadget.cpp
+++ b/src/GafferUI/AnimationGadget.cpp
@@ -562,6 +562,8 @@ AnimationGadget::AnimationGadget()
 	m_visiblePlugs->memberAcceptanceSignal().connect( boost::bind( &AnimationGadget::plugSetAcceptor, this, ::_1, ::_2 ) );
 	m_visiblePlugs->memberAddedSignal().connect( boost::bind( &AnimationGadget::visiblePlugAdded, this, ::_1, ::_2 ) );
 	m_visiblePlugs->memberRemovedSignal().connect( boost::bind( &AnimationGadget::visiblePlugRemoved, this, ::_1, ::_2 ) );
+
+	Gaffer::Metadata::valueChangedSignal().connect( boost::bind( &AnimationGadget::metadataValueChanged, this, ::_1, ::_2 ) );
 }
 
 AnimationGadget::~AnimationGadget()
@@ -850,6 +852,14 @@ const Gaffer::StandardSet *AnimationGadget::editablePlugs() const
 void AnimationGadget::plugDirtied( Gaffer::Plug *plug )
 {
 	dirty( DirtyType::Render );
+}
+
+void AnimationGadget::metadataValueChanged( IECore::InternedString target, IECore::InternedString key )
+{
+	if( ( target == g_metadataTangent ) && ( key == g_metadataConstrainedLength ) )
+	{
+		dirty( DirtyType::Render );
+	}
 }
 
 std::string AnimationGadget::getToolTip( const IECore::LineSegment3f &line ) const


### PR DESCRIPTION
Animation curves using cubic interpolation will have tangents whose scale is constrained. When these tangents point upwards or downwards the length of the tangent increases dramatically so that the manipulator handle at the tip of the tangent is often far offscreen preventing the user from being able to manipulate the tangent or the curve's shape.

Such tangents are now drawn with a fixed raster space length (similar to other DCC e.g maya) so the tangent manipulator handle is always accessible and can be manipulated.

The fixed raster space length used is read from metadata with target `Animation.Tangent` and key `constrainedLength`.

When the metadata is not registered or has a value of zero this new drawing behaviour is disabled and the constrained tangents are drawn with their actual length.

A default value of 60 is registered for this metadata.

These changes do not affect the actual shape of the curves or affect the actual position of constained tangents. These changes purely affect how constrained tangents are drawn in the animation gadget.

### Related issues ###

none

### Dependencies ###

none

### Breaking changes ###

none

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
