### PR TITLE
CI : Specify metacity display on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Install toolchain (Linux)
       run: |
         Xvfb :99 -screen 0 1280x1024x24 &
-        metacity&
+        metacity --display :99.0 &
         useradd -m testUser
         echo LD_PRELOAD=libSegFault.so >> $GITHUB_ENV
         # The Docker container configures bash shells such that they enable the


### PR DESCRIPTION
`DISPLAY: ":99.0"` was removed from the overall env in bca21f5 in order to reduce side effects on Windows, unfortunately this introduced side effects on Linux as metacity no longer knew to use our Xvfb display server. This change specifies the display when running metacity which ensures the documentation screengrabs are made at the desired resolution, and fixes the timing related issues noticed in the Gaffer 1.0+ documentation builds where screengrabs were being made before the desired widget was visible.

Spotted this while looking into the root cause of some of the screengrab issues mentioned in #4989. It seems to explain most of the issues, so I'm keen to see what happens here on CI.