### PR TITLE
Arnold `image` visualiser shader : Fix UV handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,7 +7,9 @@ Fixes
 - Tweak nodes : Fixed bugs which prevented the creation of new tweaks when an existing tweak had an input connection.
 - Preferences : Fixed bug which caused UI metadata to be serialised unnecessarily into `~/gaffer/startup/gui/preferences.py`.
 - OpenGL Texture shader : Fixed bug which allowed transparent regions to obscure objects behind them.
-- Viewer : Fixed Arnold selection bugs caused by the `ai:fis_filter` option.
+- Viewer :
+  - Fixed visualisation of Arnold `image` nodes with non-default UV Coordinates settings.
+  - Fixed Arnold selection bugs caused by the `ai:fis_filter` option.
 
 1.1.9.1 (relative to 1.1.9.0)
 =======

--- a/shaders/__viewer/__arnold_image.osl
+++ b/shaders/__viewer/__arnold_image.osl
@@ -49,7 +49,7 @@ shader __arnold_image
 	int tflip = 0,
 	float soffset = 0,
 	float toffset = 0,
-	int swapst = 0,
+	int swap_st = 0,
 
 	color multiply = 1,
 	color add = 0,
@@ -62,24 +62,26 @@ shader __arnold_image
 	output color out = 0
 )
 {
-	float uu = u * sscale;
-	float vv = v * tscale;
-
-	if( sflip > 0 )
-		uu = 1.0 - uu;
-	// Arnold / OSL have inverted v
-	if( tflip == 0 )
-		vv = 1.0 - vv;
+	float uu = u;
+	float vv = (1.0 - v);
 
 	uu += soffset;
 	vv += toffset;
 
-	if( swapst > 0 )
+	if( swap_st > 0 )
 	{
 		float tmp = uu;
-		uu == vv;
+		uu = vv;
 		vv = tmp;
 	}
+
+	if( sflip > 0 )
+		uu = 1.0 - uu;
+	if( tflip > 0 )
+		vv = 1.0 - vv;
+
+	uu *= sscale;
+	vv *= tscale;
 
 	color t = texture(
 		filename, uu, vv,


### PR DESCRIPTION
- Rename `swapst` to `swap_st`, so that it matches the name of the Arnold parameter and picks up the right values.
- Match order of transformations to Arnold. This includes interesting choices like offsetting _before_ swapping but scaling and flipping _after_.
- Fix `uu == vv` no-op (equality instead of assignment).

I found this little network very useful for testing the match :

<details>

```
import Gaffer
import GafferArnold
import GafferImage
import GafferOSL
import GafferScene
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 9, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 1, persistent=False )

__children = {}

__children["Plane"] = GafferScene.Plane( "Plane" )
parent.addChild( __children["Plane"] )
__children["Plane"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
parent.addChild( __children["ShaderAssignment"] )
__children["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Lambert"] = GafferArnold.ArnoldShader( "Lambert" )
parent.addChild( __children["Lambert"] )
__children["Lambert"].loadShader( "lambert" )
__children["Lambert"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["QuadLight"] = GafferArnold.ArnoldLight( "QuadLight" )
parent.addChild( __children["QuadLight"] )
__children["QuadLight"].loadShader( "quad_light" )
__children["QuadLight"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"] = GafferScene.Parent( "Parent" )
parent.addChild( __children["Parent"] )
__children["Parent"]["children"].addChild( GafferScene.ScenePlug( "child1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"]["children"].addChild( GafferScene.ScenePlug( "child2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Image"] = GafferArnold.ArnoldShader( "Image" )
parent.addChild( __children["Image"] )
__children["Image"].loadShader( "image" )
__children["Image"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ImageReader"] = GafferImage.ImageReader( "ImageReader" )
parent.addChild( __children["ImageReader"] )
__children["ImageReader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SpotLight"] = GafferArnold.ArnoldLight( "SpotLight" )
parent.addChild( __children["SpotLight"] )
__children["SpotLight"].loadShader( "spot_light" )
__children["SpotLight"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ShaderAssignment1"] = GafferScene.ShaderAssignment( "ShaderAssignment1" )
parent.addChild( __children["ShaderAssignment1"] )
__children["ShaderAssignment1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Gobo"] = GafferArnold.ArnoldShader( "Gobo" )
parent.addChild( __children["Gobo"] )
__children["Gobo"].loadShader( "gobo" )
__children["Gobo"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Plane"]["dimensions"].setValue( imath.V2f( 100, 100 ) )
__children["Plane"]["__uiPosition"].setValue( imath.V2f( -9.55000019, 5.49999952 ) )
__children["ShaderAssignment"]["in"].setInput( __children["Plane"]["out"] )
__children["ShaderAssignment"]["shader"].setInput( __children["Lambert"]["out"] )
__children["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( -9.55000019, -2.66406298 ) )
__children["Lambert"]["__uiPosition"].setValue( imath.V2f( -26.4499969, -2.66406322 ) )
__children["QuadLight"]["name"].setValue( 'quadLight' )
__children["QuadLight"]["transform"]["translate"].setValue( imath.V3f( 0, 0, 0.0220513344 ) )
__children["QuadLight"]["parameters"]["color"].setInput( __children["Image"]["out"] )
__children["QuadLight"]["parameters"]["exposure"].setValue( 4.0 )
__children["QuadLight"]["visualiserAttributes"]["lightDrawingMode"]["value"].setValue( 'wireframe' )
__children["QuadLight"]["__uiPosition"].setValue( imath.V2f( 23.1500015, 0.900000334 ) )
__children["Parent"]["in"].setInput( __children["ShaderAssignment"]["out"] )
__children["Parent"]["parent"].setValue( '/' )
__children["Parent"]["children"][0].setInput( __children["QuadLight"]["out"] )
__children["Parent"]["children"][1].setInput( __children["ShaderAssignment1"]["out"] )
__children["Parent"]["__uiPosition"].setValue( imath.V2f( -0.349147797, -21.8717175 ) )
__children["Image"]["parameters"]["filename"].setValue( '/home/john/dev/build/gaffer-1.2/resources/images/macaw.exr' )
__children["Image"]["__uiPosition"].setValue( imath.V2f( 5.4647913, 3.78201675 ) )
__children["ImageReader"]["fileName"].setValue( '${GAFFER_ROOT}/resources/images/macaw.exr' )
__children["ImageReader"]["__uiPosition"].setValue( imath.V2f( 61.2236633, 2.76368952 ) )
__children["SpotLight"]["name"].setValue( 'spotLight' )
__children["SpotLight"]["transform"]["translate"].setValue( imath.V3f( 2.63031411, 0, 1.99515831 ) )
__children["SpotLight"]["parameters"]["exposure"].setValue( 4.0 )
__children["SpotLight"]["__uiPosition"].setValue( imath.V2f( 39.1203537, 1.00615263 ) )
__children["ShaderAssignment1"]["in"].setInput( __children["SpotLight"]["out"] )
__children["ShaderAssignment1"]["shader"].setInput( __children["Gobo"]["out"] )
__children["ShaderAssignment1"]["__uiPosition"].setValue( imath.V2f( 39.1203537, -8.88081074 ) )
__children["Gobo"]["attributeSuffix"].setValue( 'gobo' )
__children["Gobo"]["parameters"]["slidemap"].setInput( __children["Image"]["out"] )
__children["Gobo"]["__uiPosition"].setValue( imath.V2f( 23.3626232, -8.88081074 ) )


del __children
```
</details>

The gobo is easy to check because you can see it at the same time as the projection. For the quad light texture, you can either toggle the Light Drawing Mode in the Visualiser tab, or you can take advantage of a weirdness in the Arnold viewport where the depth buffer arrives after the image - track away from the plane and briefly the plane will be drawn in front of the visualisation.