### PR TITLE
OpenImageIOReader : More descriptive error for invalid channel name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,12 @@
 1.1.9.x (relative to 1.1.9.2)
 =======
 
+Fixes
+-----
+
+- ImageReader : Made error message more descriptive when trying to access a channel that doesn't exist.
+
+
 1.1.9.2 (relative to 1.1.9.1)
 =======
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -99,6 +99,13 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertNotEqual( h1, h2 )
 
+	def testChannelMissing( self ) :
+		n = GafferImage.ImageReader()
+		n["fileName"].setValue( self.largeFileName )
+
+		with six.assertRaisesRegex( self, RuntimeError, 'OpenImageIOReader : No channel named "doesNotExist"' ):
+			n["out"].channelData( "doesNotExist", imath.V2i( 0 ) )
+
 	def testColorSpaceOverride( self ) :
 
 		exrReader = GafferImage.ImageReader()

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -718,7 +718,12 @@ class File
 			}
 			else
 			{
-				ChannelMapEntry channelMapEntry = view.channelMap.at( channelName );
+				auto findIt = view.channelMap.find( channelName );
+				if( findIt == view.channelMap.end() )
+				{
+					throw IECore::Exception( "OpenImageIOReader : No channel named \"" + channelName + "\"" );
+				}
+				ChannelMapEntry channelMapEntry = findIt->second;
 				batchIndex = tileBatchIndex( view, channelMapEntry.subImage, tileOrigin );
 				batchSubIndex = tileBatchSubIndex( view, channelMapEntry.channelIndex, tileOrigin );
 			}


### PR DESCRIPTION
I've gone ahead and implemented this as requested, because it was easy to do.

But conceptually, I'm not entirely convinced that it's the right approach after considering it further. I was under the impression that accessing a plug in a context that isn't permitted is usually undefined behaviour ... it's easy to catch in this case, but in general, I was under the impression that it was allowed to result in a segfault.

I'm wondering how this error was encountered ... if it's through wrappers like channelData, and channelData is supposed to be a safe way of interacting, maybe channelData should be checking if the channel is in channelNames 