### PR TITLE
SetEditorBinding : Fix compilation on MacOS

### DIFF
--- a/src/GafferSceneUIModule/SetEditorBinding.cpp
+++ b/src/GafferSceneUIModule/SetEditorBinding.cpp
@@ -351,6 +351,8 @@ class SetPath : public Gaffer::Path
 
 };
 
+IE_CORE_DEFINERUNTIMETYPED( SetPath );
+
 SetPath::Ptr constructor1( ScenePlug &scene, Context &context, PathFilterPtr filter )
 {
 	return new SetPath( &scene, &context, filter );


### PR DESCRIPTION
The error was :

```
src/GafferSceneUIModule/SetEditorBinding.cpp:174:3: error: unused variable 'g_typeDescription' [-Werror,-Wunused-const-variable]
                IE_CORE_DECLARERUNTIMETYPEDEXTENSION( SetPath, GafferSceneUI::SetPathTypeId, Gaffer::Path );
                ^
/Users/john/dev/build/gaffer-1.2/include/IECore/RunTimeTyped.h:113:2: note: expanded from macro 'IE_CORE_DECLARERUNTIMETYPEDEXTENSION'
        IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( TYPE )
```

The problem is that `IE_CORE_DECLARERUNTIMETYPEDEXTENSION` declares a member variable that should be defined later by `IE_CORE_DEFINERUNTIMETYPED`, but we had omitted the second macro.

