### PR TITLE
SConstruct : Verify preferred encoding

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -159,6 +159,8 @@ jobs:
     - name: Build Gaffer
       run: |
        scons -j 2 build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+      env:
+        PYTHONUTF8: 1
 
     - name: Test
       # Tests should complete in well under an hour. If they don't it's most likely because
@@ -202,7 +204,8 @@ jobs:
           with open( os.environ["GITHUB_ENV"], "a" ) as f :
             print( "Setting $ARNOLD_ROOT to '%s'" % arnoldRoot )
             f.write( 'ARNOLD_ROOT=%s\n' % arnoldRoot )
-
+      env:
+        PYTHONUTF8: 1
       shell: python
 
     - name: Build Docs and Package
@@ -214,6 +217,8 @@ jobs:
         echo "::add-matcher::./.github/workflows/main/problemMatchers/sphinx.json"
         scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
         echo "::remove-matcher owner=sphinx::"
+      env:
+        PYTHONUTF8: 1
       if: matrix.publish
 
     - name: Validate

--- a/SConstruct
+++ b/SConstruct
@@ -40,17 +40,20 @@ import os
 import re
 import sys
 import glob
+import locale
 import platform
 import shutil
 import subprocess
 import distutils.dir_util
 
-if os.name == "nt":
-	import _locale
-	_locale._getdefaultlocale_backup = _locale._getdefaultlocale
-	_locale._getdefaultlocale = (lambda *args: (_locale._getdefaultlocale_backup()[0], 'utf8'))
+EnsureSConsVersion( 3, 0, 2 ) # Substfile is a default builder as of 3.0.2
 
-EnsureSConsVersion( 3, 0, 2 )  # Substfile is a default builder as of 3.0.2
+if locale.getpreferredencoding() != "UTF-8" :
+	# The `Substfile` builder uses `open()` without specifying an encoding, and
+	# so gets Python's default encoding. Unless this is `UTF-8`, any `.py` files
+	# containing unicode characters will be corrupted during installation.
+	sys.stderr.write( "ERROR : Preferred encoding must be 'UTF-8'. Set PYTHONUTF8 environment variable before running `scons`.\n" )
+	Exit( 1 )
 
 ###############################################################################################
 # Version


### PR DESCRIPTION
This defaults to something very unhelpful on Windows, hence the previous workaround that monkey-patched in the UTF8 encoding. That workaround was sufficient in Python 3.7, but does not work in Python 3.10, which is what my SCons install happens to use. I've been unable to find a similar hack for 3.10, and since setting PYTHONUTF8 is so straightforward, it seems reasonable to ask everyone building on Windows to do that, regardless of Python version. This also gives us a little bit of a safety net on Linux, where the preferred encoding has always been UTF8 so far, but plausibly could differ on someone's machine somewhere.

