### PR TITLE
DispatchDialogue : Fix mishandling of some exception types

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.1.1)
 =======
 
+Fixes
+-----
+
+- DispatchDialogue : Fixed `AttributeError: '__Implementation' object has no attribute 'message'` error.
+
 1.2.1.1 (relative to 1.2.1.0)
 =======
 

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -258,9 +258,8 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 			"".join( traceback.format_exception( *exceptionInfo ) )
 		)
 
-		# this works for RuntimeError, but is this safe for all exceptions?
 		excType, excValue, excTrace = exceptionInfo
-		if excValue and excValue.message:
+		if excValue and hasattr( excValue, "message" ) and excValue.message :
 			userFriendlyException = excValue.message.strip( "\n" ).split( "\n" )[-1]
 		else:
 			userFriendlyException = str( excType.__name__ )


### PR DESCRIPTION
Some exceptions don't have `message` implemented, and should use the fallback option of casting them to a string.

On example of such exception is `IECore.Exception`, which resulted in the following error:
`AttributeError: '__Implementation' object has no attribute 'message'`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
