### PR TITLE
Reference : Maintain spline point addition/deletion across reload

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Reference : Fixed bug reloading a Reference after changing the number of points in a SplinePlug. The complete edited spline is now maintained across a reload. If the spline has not been edited, then the value is updated from the `.grf` file as before (#5170).
 - DispatchDialogue : Fixed `AttributeError: '__Implementation' object has no attribute 'message'` error.
 
 1.2.1.1 (relative to 1.2.1.0)


### PR DESCRIPTION
This is a very special-cased workaround, but I think that keeping it localised is the least risky option given that we want to roll this out in a patch release.

There perhaps might be a slightly less special-cased implementation available if `SplinePlug::setFrom()` and `SplinePlug::setInput()` automatically conformed the number of children, although the latter in particular doesn't seem easy to achieve. But even with those in place, we would _still_ need a special case of some sort, to create the "atomic value" experience we want users to have (whereby an edit to any point means that we ignore all points from the `.grf` file). So maybe this _would_ be a localised workaround even in an ideal world.

There might be an argument for instead completely replacing all the reload logic, and relying on serialisation instead. So we'd serialise the local edits, clear the children, load the file, and then replay the local edits on top. This would need some changes to the serialisation code to allow us to maintain connections to external plugs not included in the serialisation. But the benefit would be maintaining less code and having guaranteed consistency between save/load and reload. That is much broader in scope though, and too big of a change to make in a patch release.

Fixes #5170
