### PR TITLE
Playback and Orientation hot keys

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
   - Added <kbd>Ctrl</kbd>+<kbd>Right</kbd> hotkey toggle for forward playback.
   - Added <kbd>Ctrl</kbd>+<kbd>Left</kbd> hotkey toggle for backward playback.
   - Pressing either of <kbd>Right</kbd> or <kbd>Left</kbd> will also stop playback.
+- Transform Tools : Added <kbd>O</kbd> shortcut to cycle through the orientation modes.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 1.2.x.x (relative to 1.2.1.1)
 =======
 
+Improvements
+------------
+
+- Playback :
+  - Added <kbd>Ctrl</kbd>+<kbd>Right</kbd> hotkey toggle for forward playback.
+  - Added <kbd>Ctrl</kbd>+<kbd>Left</kbd> hotkey toggle for backward playback.
+  - Pressing either of <kbd>Right</kbd> or <kbd>Left</kbd> will also stop playback.
+
 Fixes
 -----
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -52,6 +52,9 @@ Undo                                 | {kbd}`Ctrl` + {kbd}`Z`
 Redo                                 | {kbd}`Ctrl` + {kbd}`Shift` + {kbd}`Z`
 Step one frame forward               | {kbd}`→`
 Step one frame backward              | {kbd}`←`
+Play forward                         | {kbd}`Ctrl` + {kbd}`→`
+Play backward                        | {kbd}`Ctrl` + {kbd}`←`
+Stop playback                        | {kbd}`→`, {kbd}`←`, {kbd}`Ctrl` + {kbd}`→`, {kbd}`Ctrl` + {kbd}`←`
 Fullscreen mode                      | {kbd}`F11`
 Hide tabs of current panel           | {kbd}`Ctrl` + {kbd}`T`
 Maximise current panel               | {kbd}`Space`

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -219,6 +219,7 @@ Pause processing                     | {kbd}`Escape`
 Selection Tool                       | {kbd}`Q`
 Translate Tool                       | {kbd}`W`
 Rotate Tool                          | {kbd}`E`
+Cycle Transform Tool Orientation     | {kbd}`O`
 Scale Tool                           | {kbd}`R`
 Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -240,6 +240,18 @@ class Viewer( GafferUI.NodeSetEditor ) :
 						t["active"].setValue( False )
 				return True
 
+			# \todo The Viewer should not need to know about `TransformTool` and orientations.
+			# This can be made more general by adding metadata to plugs such as
+			# `viewer:cyclePresetShortcut` and acting on that instead of this one special case.
+			if event.key == "O" and t["active"].getValue() and "orientation" in t :
+				orientation = Gaffer.NodeAlgo.currentPreset( t["orientation"] )
+				presets = Gaffer.NodeAlgo.presets( t["orientation"] )
+
+				Gaffer.NodeAlgo.applyPreset(
+					t["orientation"],
+					presets[ ( presets.index( orientation ) + 1 ) % len( presets ) ]
+				)
+
 		return False
 
 	def __contextMenu( self, widget ) :


### PR DESCRIPTION
This adds three new hotkeys :
- `Ctrl+Right` toggles playback forward
- `Ctrl+Left` toggles playback backward
- `Right` and `Left` will both stop playback
- `O` to cycle the orientation mode for transform tools

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
