### PR TITLE
RendererAlgo : Fix hash update in `object|transformSamples()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.1.9.x (relative to 1.1.9.3)
 =======
 
+Fixes
+-----
+
+- Viewer : Fixed bugs which could prevent an object from being updated if its computation was previously interrupted.
+
 1.1.9.3 (relative to 1.1.9.2)
 =======
 
@@ -8,7 +13,6 @@ Fixes
 -----
 
 - ImageReader : Made error message more descriptive when trying to access a channel that doesn't exist.
-
 
 1.1.9.2 (relative to 1.1.9.1)
 =======

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -147,5 +147,56 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( len( samples ), 1 )
 			self.assertEqual( samples[0], coordinateSystem["out"].object( "/coordinateSystem" ) )
 
+	def testObjectSamplesHash( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["type"].setValue( sphere.Type.Primitive )
+
+		with Gaffer.Context() as c :
+
+			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
+
+			h1 = IECore.MurmurHash()
+			samples1 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h1 )
+			self.assertEqual( samples1[0].radius(), 1 )
+			self.assertNotEqual( h1, IECore.MurmurHash() )
+
+			sphere["radius"].setValue( 2 )
+			h2 = IECore.MurmurHash( h1 )
+			samples2 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h2 )
+			self.assertEqual( samples2[0].radius(), 2 )
+			self.assertNotEqual( h2, IECore.MurmurHash() )
+			self.assertNotEqual( h2, h1 )
+
+			h3 = IECore.MurmurHash( h2 )
+			samples3 = GafferScene.Private.RendererAlgo.objectSamples( sphere["out"]["object"], [ 1.0 ], h3 )
+			self.assertIsNone( samples3 ) # Hash matched, so no samples generated
+			self.assertEqual( h3, h2 )
+
+	def testTransformSamplesHash( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		with Gaffer.Context() as c :
+
+			c["scene:path"] = IECore.InternedStringVectorData( [ "sphere" ] )
+
+			h1 = IECore.MurmurHash()
+			samples1 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h1 )
+			self.assertEqual( samples1[0].translation().x, 0 )
+			self.assertNotEqual( h1, IECore.MurmurHash() )
+
+			sphere["transform"]["translate"]["x"].setValue( 2 )
+			h2 = IECore.MurmurHash( h1 )
+			samples2 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h2 )
+			self.assertEqual( samples2[0].translation().x, 2 )
+			self.assertNotEqual( h2, IECore.MurmurHash() )
+			self.assertNotEqual( h2, h1 )
+
+			h3 = IECore.MurmurHash( h2 )
+			samples3 = GafferScene.Private.RendererAlgo.transformSamples( sphere["out"]["transform"], [ 1.0 ], h3 )
+			self.assertIsNone( samples3 ) # Hash matched, so no samples generated
+			self.assertEqual( h3, h2 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -336,12 +336,18 @@ object capturedObjectCapturedLinks( const CapturingRenderer::CapturedObject &o, 
 	}
 }
 
-list objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, const std::vector<float> &sampleTimes, bool copy )
+object objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, const std::vector<float> &sampleTimes, IECore::MurmurHash *hash, bool copy )
 {
+	bool result;
 	std::vector<IECore::ConstObjectPtr> samples;
 	{
 		IECorePython::ScopedGILRelease gilRelease;
-		GafferScene::Private::RendererAlgo::objectSamples( &objectPlug, sampleTimes, samples );
+		result = GafferScene::Private::RendererAlgo::objectSamples( &objectPlug, sampleTimes, samples, hash );
+	}
+
+	if( !result )
+	{
+		return object();
 	}
 
 	list pythonSamples;
@@ -355,6 +361,29 @@ list objectSamplesWrapper( const Gaffer::ObjectPlug &objectPlug, const std::vect
 		{
 			pythonSamples.append( boost::const_pointer_cast<IECore::Object>( s ) );
 		}
+	}
+
+	return pythonSamples;
+}
+
+object transformSamplesWrapper( const Gaffer::M44fPlug &transformPlug, const std::vector<float> &sampleTimes, IECore::MurmurHash *hash )
+{
+	bool result;
+	std::vector<M44f> samples;
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		result = GafferScene::Private::RendererAlgo::transformSamples( &transformPlug, sampleTimes, samples, hash );
+	}
+
+	if( !result )
+	{
+		return object();
+	}
+
+	list pythonSamples;
+	for( auto &s : samples )
+	{
+		pythonSamples.append( s );
 	}
 
 	return pythonSamples;
@@ -404,7 +433,8 @@ void GafferSceneModule::bindRender()
 
 			scope rendererAlgomoduleScope( rendererAlgoModule );
 
-			def( "objectSamples", &objectSamplesWrapper, ( arg( "objectPlug" ), arg( "sampleTimes" ), arg( "_copy" ) = true ) );
+			def( "objectSamples", &objectSamplesWrapper, ( arg( "objectPlug" ), arg( "sampleTimes" ), arg( "hash" ) = object(), arg( "_copy" ) = true ) );
+			def( "transformSamples", &transformSamplesWrapper, ( arg( "transformPlug" ), arg( "sampleTimes" ), arg( "hash" ) = object() ) );
 
 			class_<GafferScene::Private::RendererAlgo::RenderSets, boost::noncopyable>( "RenderSets" )
 				.def( init<const ScenePlug *>() )


### PR DESCRIPTION
We must only write to the output `hash` _after_ successfully filling the sample buffer. Otherwise, if the sampling throws, we hit the `return false` early-out code path on the next call. This caused the RenderController to fail to update an object at all if its previous update was cancelled.