### PR TITLE
PathListingWidget : Ensure columns can resize while header is hidden

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 - DispatchDialogue : Fixed `AttributeError: '__Implementation' object has no attribute 'message'` error.
 - Catalogue : Fixed errors caused by empty image selections.
 - MultiLineStringPlugValueWidget : Fixed bug handling <kbd>Esc</kbd>.
+- PathListingWidget : Fixed issue with columns set to automatically stretch not resizing if column headers are hidden.
 
 Documentation
 -------------

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -846,6 +846,8 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 		QtWidgets.QTreeView.__init__( self )
 
+		# Our `sizeHint()` depends on the header's size, so we need to
+		# ask for a geometry update any time it changes.
 		self.header().geometriesChanged.connect( self.updateGeometry )
 		self.header().sectionResized.connect( self.__sectionResized )
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -846,7 +846,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 		QtWidgets.QTreeView.__init__( self )
 
-		self.header().geometriesChanged.connect( self.__geometriesChanged )
+		self.header().geometriesChanged.connect( self.updateGeometry )
 		self.header().sectionResized.connect( self.__sectionResized )
 
 		# Disable Qt's stretchLastSection behaviour as it will claim any available space in the header
@@ -903,6 +903,12 @@ class _TreeView( QtWidgets.QTreeView ) :
 				return True
 
 		return QtWidgets.QTreeView.event( self, event )
+
+	def resizeEvent( self, event ) :
+
+		self.__geometriesChanged()
+
+		QtWidgets.QTreeView.resizeEvent( self, event )
 
 	def lastVisibleIndex( self, parentIndex = None ) :
 
@@ -1107,14 +1113,12 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 	def __geometriesChanged( self ) :
 
-		self.updateGeometry()
-
 		viewportWidth = self.viewport().width()
 		if viewportWidth == self.__previousViewportWidth :
 			# We're only interested in changes to width
 			return
 
-		if self.header().length() <= self.__previousViewportWidth or self.header().length() < viewportWidth :
+		if self.__previousViewportWidth == 0 or self.header().length() <= self.__previousViewportWidth or self.header().length() < viewportWidth :
 			# We use the previous viewport width to help determine whether the columns should be resized,
 			# if the columns fit within the previous width, then we should maintain that relationship and
 			# resize to fit the new width. If the columns are narrower than the current viewport width,
@@ -1128,7 +1132,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 	def __resizeStretchColumns( self ) :
 
 		header = self.header()
-		availableWidth = header.width()
+		availableWidth = self.viewport().width()
 		stretchColumnWidth = 0
 		columnsToStretch = []
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -906,7 +906,18 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 	def resizeEvent( self, event ) :
 
-		self.__geometriesChanged()
+		viewportWidth = self.viewport().width()
+		if viewportWidth != self.__previousViewportWidth :
+			if self.__previousViewportWidth == 0 or self.header().length() <= self.__previousViewportWidth or self.header().length() < viewportWidth :
+				# We use the previous viewport width to help determine whether the columns should be resized,
+				# if the columns fit within the previous width, then we should maintain that relationship and
+				# resize to fit the new width. If the columns are narrower than the current viewport width,
+				# then we resize to make use of the newly available space.
+				self.__updatingGeometry = True
+				self.__resizeStretchColumns()
+				self.__updatingGeometry = False
+
+			self.__previousViewportWidth = viewportWidth
 
 		QtWidgets.QTreeView.resizeEvent( self, event )
 
@@ -1110,24 +1121,6 @@ class _TreeView( QtWidgets.QTreeView ) :
 		self.__recalculatingColumnWidths = True
 		header.resizeSection( lastColumn, adjustedWidth )
 		self.__recalculatingColumnWidths = False
-
-	def __geometriesChanged( self ) :
-
-		viewportWidth = self.viewport().width()
-		if viewportWidth == self.__previousViewportWidth :
-			# We're only interested in changes to width
-			return
-
-		if self.__previousViewportWidth == 0 or self.header().length() <= self.__previousViewportWidth or self.header().length() < viewportWidth :
-			# We use the previous viewport width to help determine whether the columns should be resized,
-			# if the columns fit within the previous width, then we should maintain that relationship and
-			# resize to fit the new width. If the columns are narrower than the current viewport width,
-			# then we resize to make use of the newly available space.
-			self.__updatingGeometry = True
-			self.__resizeStretchColumns()
-			self.__updatingGeometry = False
-
-		self.__previousViewportWidth = viewportWidth
 
 	def __resizeStretchColumns( self ) :
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -857,7 +857,6 @@ class _TreeView( QtWidgets.QTreeView ) :
 		self.__lastColumnWidth = 0
 
 		self.__recalculatingColumnWidths = False
-		self.__updatingGeometry = False
 
 		# we track the previous viewport width to aid in determining whether stretchable columns should
 		# be resized when the viewport width changes
@@ -913,10 +912,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 				# if the columns fit within the previous width, then we should maintain that relationship and
 				# resize to fit the new width. If the columns are narrower than the current viewport width,
 				# then we resize to make use of the newly available space.
-				self.__updatingGeometry = True
 				self.__resizeStretchColumns()
-				self.__updatingGeometry = False
-
 			self.__previousViewportWidth = viewportWidth
 
 		QtWidgets.QTreeView.resizeEvent( self, event )
@@ -1078,7 +1074,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 	def __sectionResized( self, index, oldWidth, newWidth ) :
 
-		if self.__recalculatingColumnWidths or self.__updatingGeometry :
+		if self.__recalculatingColumnWidths :
 			# we're only interested in resizing being done by the user
 			return
 


### PR DESCRIPTION
This is a fix for the UI Editor `_PlugListing` column truncation noticed this week.  This addresses the issue while avoiding sending the :rabbit2: too far down the :hole: . I've left a todo for further work worth investigating as part of improving macOS support.