### PR TITLE
FilterAlgo.cpp : Fix missing fmt include

### DIFF
--- a/src/GafferImage/FilterAlgo.cpp
+++ b/src/GafferImage/FilterAlgo.cpp
@@ -41,6 +41,8 @@
 
 #include "OpenImageIO/filter.h"
 
+#include "fmt/format.h"
+
 #include <climits>
 
 


### PR DESCRIPTION
`FilterAlgo.cpp` was missing a `fmt` include call, which was causing the build to fail at IE.

I'm not entirely sure why it's working for GafferHQ, but my guess is that one of the other headers being included happen to also be including `fmt` in a public way.

I assume that we don't need to update the `Changes` file for this one, but let me know if that's not the case.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
