### PR TITLE
FloatSpline/ColorSpline : Add direction parameter

### DIFF
--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -1144,5 +1144,30 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		# Or should it raise an exception?  The current behaviour of leaving unsubstituted strings is probably
 		# not right.
 
+	def testActivatorMetadata( self ) :
+		c = Gaffer.Context()
+
+		s = self.compileShader( pathlib.Path( __file__ ).parent / "shaders" / "activatorMetadata.osl" )
+		n = GafferOSL.OSLShader()
+		n.loadShader( s )
+
+		parameters = n["parameters"]
+		for i in range( 5 ):
+			parameters["i"].setValue( i )
+			self.assertEqual( Gaffer.Metadata.value( parameters["test1"], "layout:activator" ), i > 2 )
+
+		self.assertEqual( Gaffer.Metadata.value( parameters["test2"], "layout:activator" ), False )
+		parameters["s"].setValue( "foo" )
+		self.assertEqual( Gaffer.Metadata.value( parameters["test2"], "layout:activator" ), True )
+
+		parameters["i"].setValue( 9 )
+		self.assertEqual( Gaffer.Metadata.value( parameters["test3"], "layout:visibilityActivator" ), False )
+		parameters["i2"].setValue( 8 )
+		self.assertEqual( Gaffer.Metadata.value( parameters["test3"], "layout:visibilityActivator" ), True )
+
+		self.assertEqual( Gaffer.Metadata.value( parameters["test4"], "layout:visibilityActivator" ), False )
+		parameters["c"].setValue( imath.Color3f( 0.2, 0.4, 0 ) )
+		self.assertEqual( Gaffer.Metadata.value( parameters["test4"], "layout:visibilityActivator" ), True )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/shaders/activatorMetadata.osl
+++ b/python/GafferOSLTest/shaders/activatorMetadata.osl
@@ -1,0 +1,65 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+surface activatorMetadata
+(
+	int i = 0,
+	int i2 = 0,
+	string s = "",
+	color c = 0,
+
+	int test1 = 0 [[
+		string enabledExpression = "i > 2"
+	]],
+	int test2 = 0 [[
+		string enabledExpression = "s == \"foo\""
+	]],
+	int test3 = 0 [[
+		string visibleExpression = "s == \"foo\" && i * i2 == 72"
+	]],
+	int test4 = 0 [[
+		string visibleExpression = "abs( c.r * c.g - 0.08 ) < 0.000001"
+	]],
+
+	// This spline isn't used, we just want to make sure that having plug types
+	// not understood by the activator expressions doesn't break anything
+	float splinePositions[] = { 0, 0, 1, 1 },
+	color splineValues[] = { 0, 0, 1, 1 },
+	string splineBasis = "catmull-rom",
+)
+{
+	Ci = emission();
+}

--- a/shaders/Pattern/ColorSpline.osl
+++ b/shaders/Pattern/ColorSpline.osl
@@ -43,11 +43,70 @@ shader ColorSpline
 	color splineValues[] = { 0, 0, 1, 1 },
 	string splineBasis = "catmull-rom",
 
-	float x = 0,
+	string direction = "custom" [[
+		string help = "Which direction the spline is applied in. U or V use the UVs, Diagonal or Radial use the UVs together with a start and end position. Custom uses the `x` input, which may be hooked up to any shader returning a float. When using UVs, the overrideUV plug maybe be connected in order to use custom UVs.",
+		string widget = "popup",
+		string options = "Custom:custom|U:u|V:v|Diagonal:diagonal|Radial:radial",
+		int connectable = 0,
+	]],
+
+	float x = 0 [[
+		string help = "The spline coordinate to use when direction is set to Custom.",
+		string visibleExpression = "direction == \"custom\"",
+	]],
+	point startPosition = 0 [[
+		string help = "Determines the start of a Diagonal spline, or the center of a Radial spline.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"diagonal\" || direction == \"radial\"",
+	]],
+	point endPosition = point( 1, 1, 0 ) [[
+		string help = "Determines the end of a Diagonal spline.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"diagonal\"",
+	]],
+	float radius = 1 [[
+		string help = "The size of the falloff in when direction is set to Radial.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"radial\"",
+	]],
+	point overrideUV = 0 [[
+		string help = "Connect to the nodule for this plug to override the UVs used when direction is set to U, V, Diagonal, or Radial. May be a 3 dimensional value for a 3 dimensional falloff.",
+		string widget = "null",
+	]],
 
 	output color c = 0
 
 )
 {
-	c = colorSpline( splinePositions, splineValues, splineBasis, x );
+	point uv = point( u, v, 0 );
+	if( isconnected( overrideUV ) )
+	{
+		uv = overrideUV;
+	}
+
+	float splineCoord;
+	if( direction == "custom" )
+	{
+		splineCoord = x;
+	}
+	else if( direction == "u" )
+	{
+		splineCoord = uv.x;
+	}
+	else if( direction == "v" )
+	{
+		splineCoord = uv.y;
+	}
+	else if( direction == "diagonal" )
+	{
+		vector disp = endPosition - startPosition;
+		splineCoord = dot( uv - startPosition, disp ) / dot( disp, disp );
+	}
+	else if( direction == "radial" )
+	{
+		vector disp = endPosition - startPosition;
+		splineCoord = length( uv - startPosition ) / radius;
+	}
+
+	c = colorSpline( splinePositions, splineValues, splineBasis, splineCoord );
 }

--- a/shaders/Pattern/FloatSpline.osl
+++ b/shaders/Pattern/FloatSpline.osl
@@ -43,11 +43,70 @@ shader FloatSpline
 	float splineValues[] = { 0, 0, 1, 1 },
 	string splineBasis = "catmull-rom",
 
-	float x = 0,
+	string direction = "custom" [[
+		string help = "Which direction the spline is applied in. U or V use the UVs, Diagonal or Radial use the UVs together with a start and end position. Custom uses the `x` input, which may be hooked up to any shader returning a float. When using UVs, the overrideUV plug maybe be connected in order to use custom UVs.",
+		string widget = "popup",
+		string options = "Custom:custom|U:u|V:v|Diagonal:diagonal|Radial:radial",
+		int connectable = 0,
+	]],
+
+	float x = 0 [[
+		string help = "The spline coordinate to use when direction is set to Custom.",
+		string visibleExpression = "direction == \"custom\"",
+	]],
+	point startPosition = 0 [[
+		string help = "Determines the start of a Diagonal spline, or the center of a Radial spline.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"diagonal\" || direction == \"radial\"",
+	]],
+	point endPosition = point( 1, 1, 0 ) [[
+		string help = "Determines the end of a Diagonal spline.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"diagonal\"",
+	]],
+	float radius = 1 [[
+		string help = "The size of the falloff in when direction is set to Radial.",
+		int gafferNoduleLayoutVisible = 0,
+		string visibleExpression = "direction == \"radial\"",
+	]],
+	point overrideUV = 0 [[
+		string help = "Connect to the nodule for this plug to override the UVs used when direction is set to U, V, Diagonal, or Radial. May be a 3 dimensional value for a 3 dimensional falloff.",
+		string widget = "null",
+	]],
 
 	output color c = 0
 
 )
 {
-	c = floatSpline( splinePositions, splineValues, splineBasis, x );
+	point uv = point( u, v, 0 );
+	if( isconnected( overrideUV ) )
+	{
+		uv = overrideUV;
+	}
+
+	float splineCoord;
+	if( direction == "custom" )
+	{
+		splineCoord = x;
+	}
+	else if( direction == "u" )
+	{
+		splineCoord = uv.x;
+	}
+	else if( direction == "v" )
+	{
+		splineCoord = uv.y;
+	}
+	else if( direction == "diagonal" )
+	{
+		vector disp = endPosition - startPosition;
+		splineCoord = dot( uv - startPosition, disp ) / dot( disp, disp );
+	}
+	else if( direction == "radial" )
+	{
+		vector disp = endPosition - startPosition;
+		splineCoord = length( uv - startPosition ) / radius;
+	}
+
+	c = floatSpline( splinePositions, splineValues, splineBasis, splineCoord );
 }

--- a/startup/GafferOSLUI/splineUIMetadata.py
+++ b/startup/GafferOSLUI/splineUIMetadata.py
@@ -1,0 +1,40 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+Gaffer.Metadata.registerValue( "osl:shader:Pattern/ColorSpline:direction", "userDefault", "v" )
+Gaffer.Metadata.registerValue( "osl:shader:Pattern/FloatSpline:direction", "userDefault", "v" )


### PR DESCRIPTION
I remember saying that just adding some shader parameters couldn't possibly require API changes, and this would have to be a piece of cake ... and you scoffing and saying I shouldn't tempt the gods.

Clearly you were right, because when we discussed this interface, we assumed that we could use activators, and we have not yet provided an API for activators for OSL shaders.

I think it would actually make a lot of sense to provide a way of setting up activators from Python, matching the convention of how we handle setting userDefaults on shader parameters from Python.

I've mocked this up in startup/GafferOSLUI/splineUIMetadata.py, and I think the user facing interface looks sort of reasonable ( and I like the idea of having a quick and dirty way to hook this up with a Python config without worrying about how to actually store functions in OSL files ), but actually implementing it is not reasonable.  As I've mocked it up here, we would need:
* GafferSceneUI.ShaderUI.__parameterActivator to match __parameterUserDefault ( so far so good )
* __parameterActivator would have to retrieve a metadata function without calling it ( ugh ), so it could call it itself with the appropriate node passed in ( ugh )
* that would require something specific to the Python Metadata wrapper that knows that the Python function stored inside a PythonValueFunction is a generic Python function that could take any arguments, not necessarily a function with no arguments matching the premise of Metadata::ValueFunction ( OK, this is awful, and almost certainly shouldn't be done ).

Maybe we just don't worry about this, and have an ugly UI?  But the whole point of this PR was kind of to present a friendly UI to someone who first glances at a FloatSpline ... I dunno.  If you can come up with some way of implementing a basic Python activator for OSL nodes, that might be enough of a general win to be worth implementing.

Oh, also:  after playing with it, I'm pretty unconvinced that it is worth sharing endPosition between Diagonal and Radial mode - it feel pretty unnatural to adjust the radius of radial mode by having to first line up one axis of the end position to match the start position, so that you can then dial the radius sort-of-directly.  I think it would probably be a lot better to have a radius control specific to Radial.