### PR TITLE
Fix loading of `GafferOSLUI` and `GafferVDBUI` on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ API
 ---
 
 - NoduleLayout : Added a warning message when a required custom gadget has not been registered.
+- GafferUITest.TestCase : Added testing of NodeGadgets to `assertNodeUIsHaveExpectedLifetime()`.
 
 1.2.2.0 (relative to 1.2.1.1)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - OSLObject/OSLImage : Fixed missing `+` buttons in GraphEditor on Windows (#5222).
+- Viewer : Fixed missing VDB visualisations on Windows (#5223).
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.2.0)
 =======
 
+API
+---
+
+- NoduleLayout : Added a warning message when a required custom gadget has not been registered.
+
 1.2.2.0 (relative to 1.2.1.1)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.2.0)
 =======
 
+Fixes
+-----
+
+- OSLObject/OSLImage : Fixed missing `+` buttons in GraphEditor on Windows (#5222).
+
 API
 ---
 

--- a/python/GafferOSLUI/__init__.py
+++ b/python/GafferOSLUI/__init__.py
@@ -36,6 +36,16 @@
 
 from ._GafferOSLUI import *
 
+import os
+import ctypes
+if os.name == "nt" :
+	# Because `_GafferOSLUI.pyd` currently doesn't require any symbols
+	# from `GafferOSLUI.dll`, the Windows linker omits the latter. Load
+	# it explicitly, because it contains custom gadget registrations
+	# that we need.
+	ctypes.CDLL( "GafferOSLUI.dll" )
+del os, ctypes
+
 from . import OSLShaderUI
 from . import OSLImageUI
 from . import OSLObjectUI

--- a/python/GafferUITest/TestCase.py
+++ b/python/GafferUITest/TestCase.py
@@ -160,8 +160,12 @@ class TestCase( GafferTest.TestCase ) :
 			weakNodeUI = weakref.ref( nodeUI )
 			weakScript = weakref.ref( script )
 
-			del window, nodeUI
+			nodeGadget = GafferUI.NodeGadget.create( script["node"] )
+			weakNodeGadget = weakref.ref( nodeGadget )
+
+			del window, nodeUI, nodeGadget
 			self.assertIsNone( weakNodeUI() )
+			self.assertIsNone( weakNodeGadget() )
 
 			del script
 			self.assertIsNone( weakScript() )

--- a/python/GafferVDBUI/__init__.py
+++ b/python/GafferVDBUI/__init__.py
@@ -36,6 +36,16 @@
 
 from ._GafferVDBUI import *
 
+import os
+import ctypes
+if os.name == "nt" :
+	# Because `_GafferVDBUI.pyd` currently doesn't require any symbols
+	# from `GafferVDBUI.dll`, the Windows linker omits the latter. Load
+	# it explicitly, because it contains a custom visualiser registration
+	# that we need.
+	ctypes.CDLL( "GafferVDBUI.dll" )
+del os, ctypes
+
 from . import LevelSetToMeshUI
 from . import MeshToLevelSetUI
 from . import LevelSetOffsetUI

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -53,6 +53,8 @@
 #include "boost/container/flat_set.hpp"
 #include "boost/regex.hpp"
 
+#include "fmt/format.h"
+
 using namespace std;
 using namespace boost::placeholders;
 using namespace IECore;
@@ -109,6 +111,7 @@ GadgetPtr createCustomGadget( const InternedString &gadgetType, GraphComponentPt
 	const CustomGadgetCreatorMap::const_iterator it = m.find( gadgetType );
 	if( it == m.end() )
 	{
+		IECore::msg( IECore::Msg::Warning, "NoduleLayout", fmt::format( "No custom gadget \"{}\" registered for `{}`", gadgetType.string(), parent->fullName() ) );
 		return nullptr;
 	}
 	return it->second( parent );
@@ -640,7 +643,7 @@ void NoduleLayout::updateNoduleLayout()
 			{
 				gadget = Nodule::create( const_cast<Plug *>( boost::get<const Plug *>( item ) ) ); /// \todo Fix cast
 			}
-			else
+			else if( !gadgetType.string().empty() )
 			{
 				gadget = createCustomGadget( gadgetType, m_parent.get() );
 			}


### PR DESCRIPTION
This restores the missing UI elements reported in #5222 and #5223.