### PR TITLE
Arnold 7.2 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,9 +178,9 @@ jobs:
         import sys
         import os
 
-        for arnoldVersion in [ "7.1.1.0" ] :
+        for arnoldVersion in [ "7.1.1.0", "7.2.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
-          os.environ["ARNOLD_ROOT"] =  arnoldRoot
+          os.environ["ARNOLD_ROOT"] = arnoldRoot
 
           subprocess.check_call(
             [

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Features
 --------
 
+- Arnold : Added support for Arnold 7.2.
 - PointsToLevelSet : Added a new node for converting points primitives into OpenVDB level sets.
 
 Improvements

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Features
 Improvements
 ------------
 
+- ArnoldOptions : Exposed Arnold 7.2.1.0's Global Light Sampling feature via a new `lightSamples` plug.
 - Shader : Added support for shading input connections to splines.  After double clicking on a spline to open the editor, you may select a control point, and then drag an input to the value control.  Works in GafferImage, GafferObject and Arnold.  Supports a max of 32 values in the spline.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - ArnoldOptions : Exposed Arnold 7.2.1.0's Global Light Sampling feature via a new `lightSamples` plug.
+- ArnoldAttributes : Added `shadowAutoBumpVisibility` plug, since Arnold 7.2.1.0 now correctly implements this feature.
 - Shader : Added support for shading input connections to splines.  After double clicking on a spline to open the editor, you may select a control point, and then drag an input to the value control.  Works in GafferImage, GafferObject and Arnold.  Supports a max of 32 values in the spline.
 
 Fixes

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -75,6 +75,7 @@ def __autoBumpVisibilitySummary( plug ) :
 	for childName, label in (
 
 		( "camera", "Camera" ),
+		( "shadow", "Shadow" ),
 		( "diffuseReflection", "DiffRefl" ),
 		( "specularReflection", "SpecRefl" ),
 		( "diffuseTransmission", "DiffTrans" ),
@@ -350,6 +351,19 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Displacement.Auto Bump Visibility",
 			"label", "Camera",
+
+		],
+
+		"attributes.shadowAutoBumpVisibility" : [
+
+			"description",
+			"""
+			Whether or not the autobump is visible to shadow
+			rays.
+			""",
+
+			"layout:section", "Displacement.Auto Bump Visibility",
+			"label", "Shadow",
 
 		],
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -69,6 +69,8 @@ def __samplingSummary( plug ) :
 		info.append( "SSS %d" % plug["giSSSSamples"]["value"].getValue() )
 	if plug["giVolumeSamples"]["enabled"].getValue() :
 		info.append( "Volume %d" % plug["giVolumeSamples"]["value"].getValue() )
+	if plug["lightSamples"]["enabled"].getValue() :
+		info.append( "Light %d" % plug["lightSamples"]["value"].getValue() )
 	if plug["aaSeed"]["enabled"].getValue() :
 		info.append( "Seed {0}".format( plug["aaSeed"]["value"].getValue() ) )
 	if plug["aaSampleClamp"]["enabled"].getValue() :
@@ -423,6 +425,30 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "Volume Samples",
+
+		],
+
+		"options.lightSamples" : [
+
+			"description",
+			"""
+			Specifies a fixed number of light samples to be taken at each
+			shading point. This enables "Global Light Sampling", which provides
+			significantly improved performance for scenes containing large numbers
+			of lights. In this mode, the `samples` setting on each light is ignored,
+			and instead the fixed number of samples is distributed among all the
+			lights according to their contribution at the shading point.
+
+			A value of `0` disables Global Light Sampling, reverting to the original
+			per-light sampling algorithm.
+
+			> Note : Global Light Sampling currently has limitations. See
+			> https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_user_guide_ac_render_settings_ac_lights_settings_html
+			> for more details.
+			""",
+
+			"layout:section", "Sampling",
+			"label", "Light Samples",
 
 		],
 

--- a/python/IECoreArnoldTest/MeshAlgoTest.py
+++ b/python/IECoreArnoldTest/MeshAlgoTest.py
@@ -129,9 +129,13 @@ class MeshAlgoTest( unittest.TestCase ) :
 				IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ), imath.V3f( -1, 0, 0 ) ] ), IECore.IntVectorData( [0]* 8 + [1]* 8 )
 		)
 
+		mNoNormals = m.copy()
+		del mNoNormals["N"]
+
 		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
+			self.assertTrue( arnold.AiNodeGetBool( n, "smoothing" ) )
 
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( normals.contents ), 4 )
@@ -140,6 +144,7 @@ class MeshAlgoTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetVec( normals, i ), arnold.AtVector( 1, 0, 0 ) )
 
 			n = IECoreArnold.NodeAlgo.convert( mFaceVaryingIndexed, universe, "testMesh2" )
+			self.assertTrue( arnold.AiNodeGetBool( n, "smoothing" ) )
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			normalIndices = arnold.AiNodeGetArray( n, "nidxs" )
 
@@ -149,12 +154,16 @@ class MeshAlgoTest( unittest.TestCase ) :
 					arnold.AtVector( *refNormals[i//4] ) )
 
 			n = IECoreArnold.NodeAlgo.convert( mVertexIndexed, universe, "testMesh3" )
+			self.assertTrue( arnold.AiNodeGetBool( n, "smoothing" ) )
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			normalIndices = arnold.AiNodeGetArray( n, "nidxs" )
 			for i in range( 0, 36 ) :
 				s = [0, (i // 2)%2, 1][i // 12]
 				self.assertEqual( arnold.AiArrayGetVec( normals, arnold.AiArrayGetInt( normalIndices, i ) ),
 					arnold.AtVector( -1 if s else 1, 0, 0 ) )
+
+			n = IECoreArnold.NodeAlgo.convert( mNoNormals, universe, "testMesh4" )
+			self.assertFalse( arnold.AiNodeGetBool( n, "smoothing" ) )
 
 	def testVertexPrimitiveVariables( self ) :
 

--- a/src/GafferArnold/ArnoldAttributes.cpp
+++ b/src/GafferArnold/ArnoldAttributes.cpp
@@ -66,6 +66,7 @@ ArnoldAttributes::ArnoldAttributes( const std::string &name )
 
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:disp_autobump", new IECore::BoolData( false ), false, "autoBump" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:autobump_visibility:camera", new IECore::BoolData( true ), false, "cameraAutoBumpVisibility" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "ai:autobump_visibility:shadow", new IECore::BoolData( false ), false, "shadowAutoBumpVisibility" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:autobump_visibility:diffuse_reflect", new IECore::BoolData( false ), false, "diffuseReflectionAutoBumpVisibility" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:autobump_visibility:specular_reflect", new IECore::BoolData( false ), false, "specularReflectionAutoBumpVisibility" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "ai:autobump_visibility:diffuse_transmit", new IECore::BoolData( false ), false, "diffuseTransmissionAutoBumpVisibility" ) );

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -62,6 +62,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_transmission_samples", new IECore::IntData( 2 ), false, "giTransmissionSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_sss_samples", new IECore::IntData( 2 ), false, "giSSSSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:GI_volume_samples", new IECore::IntData( 2 ), false, "giVolumeSamples" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:light_samples", new IECore::IntData( 0 ), false, "lightSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:AA_seed", new IECore::IntData( 1 ), false, "aaSeed" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:AA_sample_clamp", new IECore::FloatData( 10 ), false, "aaSampleClamp" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:AA_sample_clamp_affects_aovs", new IECore::BoolData( false ), false, "aaSampleClampAffectsAOVs" ) );

--- a/src/IECoreArnold/MeshAlgo.cpp
+++ b/src/IECoreArnold/MeshAlgo.cpp
@@ -231,6 +231,10 @@ AtNode *convertCommon( const IECoreScene::MeshPrimitive *mesh, AtUniverse *unive
 
 	AtNode *result = AiNode( universe, g_polymeshArnoldString, AtString( nodeName.c_str() ), parentNode );
 
+	// This defaults to `false` in Arnold 7.1 and lower, and to `true` in Arnold 7.2 and greater.
+	// Set to `false` so we have a common baseline in all versions.
+	AiNodeSetBool( result, g_smoothingArnoldString, false );
+
 	const std::vector<int> &verticesPerFace = mesh->verticesPerFace()->readable();
 	AiNodeSetArray(
 		result,

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -929,6 +929,7 @@ IECore::InternedString g_volumeVisibilityAttributeName( "ai:visibility:volume" )
 IECore::InternedString g_subsurfaceVisibilityAttributeName( "ai:visibility:subsurface" );
 
 IECore::InternedString g_cameraVisibilityAutoBumpAttributeName( "ai:autobump_visibility:camera" );
+IECore::InternedString g_shadowVisibilityAutoBumpAttributeName( "ai:autobump_visibility:shadow" );
 IECore::InternedString g_diffuseReflectVisibilityAutoBumpAttributeName( "ai:autobump_visibility:diffuse_reflect" );
 IECore::InternedString g_specularReflectVisibilityAutoBumpAttributeName( "ai:autobump_visibility:specular_reflect" );
 IECore::InternedString g_diffuseTransmitVisibilityAutoBumpAttributeName( "ai:autobump_visibility:diffuse_transmit" );
@@ -1555,6 +1556,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				autoBump = attributeValue<bool>( g_dispAutoBumpAttributeName, attributes, false );
 				autoBumpVisibility = AI_RAY_CAMERA;
 				updateVisibility( autoBumpVisibility, g_cameraVisibilityAutoBumpAttributeName, AI_RAY_CAMERA, attributes );
+				updateVisibility( autoBumpVisibility, g_shadowVisibilityAutoBumpAttributeName, AI_RAY_SHADOW, attributes );
 				updateVisibility( autoBumpVisibility, g_diffuseReflectVisibilityAutoBumpAttributeName, AI_RAY_DIFFUSE_REFLECT, attributes );
 				updateVisibility( autoBumpVisibility, g_specularReflectVisibilityAutoBumpAttributeName, AI_RAY_SPECULAR_REFLECT, attributes );
 				updateVisibility( autoBumpVisibility, g_diffuseTransmitVisibilityAutoBumpAttributeName, AI_RAY_DIFFUSE_TRANSMIT, attributes );


### PR DESCRIPTION
This exposes new user-facing features from Arnold 7.2, and works around a breaking change in `polymesh.smoothing`.

The one remaining thing I'd like to do for Arnold 7.2 is to use the new `AiSetSystemHandlers()` function to disable Arnold's signal handlers and our own instead. But it'll take me a while to figure out the best way of adding our own handler, without the pitfalls of the Arnold one, and I figured users would appreciate the features in a quicker timeframe.