### PR TITLE
Cycles : Update to 3.5.0

### DIFF
--- a/python/GafferCyclesUI/CyclesAttributesUI.py
+++ b/python/GafferCyclesUI/CyclesAttributesUI.py
@@ -86,7 +86,7 @@ def __objectSummary( plug ) :
 def __shaderSummary( plug ) :
 
 	info = []
-	for childName in ( "useMis", "useTransparentShadow", "heterogeneousVolume", "volumeSamplingMethod", "volumeInterpolationMethod", "volumeStepRate", "displacementMethod" ) :
+	for childName in ( "emissionSamplingMethod", "useTransparentShadow", "heterogeneousVolume", "volumeSamplingMethod", "volumeInterpolationMethod", "volumeStepRate", "displacementMethod" ) :
 		if plug[childName]["enabled"].getValue() :
 			info.append( IECore.CamelCase.toSpaced( childName ) + ( " On" if plug[childName]["value"].getValue() else " Off" ) )
 
@@ -354,16 +354,26 @@ Gaffer.Metadata.registerNode(
 
 		# Shader
 
-		"attributes.useMis" : [
+		"attributes.emissionSamplingMethod" : [
 
 			"description",
 			"""
-			Use multiple importance sampling for this material,
-			disabling may reduce overall noise for large
-			objects that emit little light compared to other light sources.
+			Sampling strategy for emissive surfaces.
 			""",
 
 			"layout:section", "Shader",
+
+		],
+
+		"attributes.emissionSamplingMethod.value" : [
+
+			"preset:None", "none",
+			"preset:Auto", "auto",
+			"preset:Front", "front",
+			"preset:Back", "back",
+			"preset:Front-Back", "front_back",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -829,6 +829,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.useLightTree" : [
+
+			"description",
+			"""
+			Sample multiple lights more efficiently based on estimated contribution at every shading point.
+			""",
+
+			"layout:section", "Sampling",
+
+		],
+
 		# Ray Depth
 
 		"options.minBounce" : [

--- a/src/GafferCycles/CyclesAttributes.cpp
+++ b/src/GafferCycles/CyclesAttributes.cpp
@@ -82,7 +82,7 @@ CyclesAttributes::CyclesAttributes( const std::string &name )
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:asset_name", new IECore::StringData( "" ), false, "assetName" ) );
 
 	// Shader-specific
-	attributes->addChild( new Gaffer::NameValuePlug( "cycles:shader:use_mis", new IECore::BoolData( true ), false, "useMis" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "cycles:shader:emission_sampling_method", new IECore::StringData( "auto" ), false, "emissionSamplingMethod" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:shader:use_transparent_shadow", new IECore::BoolData( true ), false, "useTransparentShadow" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:shader:heterogeneous_volume", new IECore::BoolData( true ), false, "heterogeneousVolume" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:shader:volume_sampling_method", new IECore::StringData( "multiple_importance" ), false, "volumeSamplingMethod" ) );

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -108,6 +108,7 @@ CyclesOptions::CyclesOptions( const std::string &name )
 
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:start_sample", new IECore::IntData( 0 ), false, "startSample" ) );
 
+	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_light_tree", new IECore::BoolData( true ), false, "useLightTree" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:light_sampling_threshold", new IECore::FloatData( 0.05f ), false, "lightSamplingThreshold" ) );
 
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_adaptive_sampling", new IECore::BoolData( false ), false, "useAdaptiveSampling" ) );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Update Cycles to 3.5.0
- Minor API changes to emission sampling being an InternedString enum of choices over just a boolean MIS setting
- Disk light API update
- Removed client-side `normalize` emulation for the now-landed `normalize` for lights

### Related issues ###

- NA

### Dependencies ###

- [Cycles update 3.5.0](https://github.com/GafferHQ/dependencies/pull/230)

### Breaking changes ###

- Any `cycles:shader:use_mis` attributes will need to be removed and/or replaced with `cycles:shader:emission_sampling` but it shouldn't break anything. Should we make an update script for this?

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
