### PR TITLE
Build updates

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ Build
 -----
 
 - OpenEXR : Stopped linking unnecessarily to the `IlmImf` library.
+- Boost : Stopped linking unnecessarily to `iostreams`, `date_time`, `wave` and `system` libraries.
 
 1.2.x.x (relative to 1.2.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,11 @@ Breaking Changes
 - ImageReader : Renamed `None` preset to `Automatic`.
 - OpenColorIOTransform : Removed `availableColorSpaces()` and `availableRoles()` methods.
 
+Build
+-----
+
+- OpenEXR : Stopped linking unnecessarily to the `IlmImf` library.
+
 1.2.x.x (relative to 1.2.2.0)
 =======
 

--- a/SConstruct
+++ b/SConstruct
@@ -743,12 +743,8 @@ baseLibEnv = env.Clone()
 baseLibEnv.Append(
 
 	LIBS = [
-		"boost_iostreams$BOOST_LIB_SUFFIX",
 		"boost_filesystem$BOOST_LIB_SUFFIX",
-		"boost_date_time$BOOST_LIB_SUFFIX",
-		"boost_wave$BOOST_LIB_SUFFIX",
 		"boost_regex$BOOST_LIB_SUFFIX",
-		"boost_system$BOOST_LIB_SUFFIX",
 		"boost_chrono$BOOST_LIB_SUFFIX",
 		"tbb",
 		"Imath$OPENEXR_LIB_SUFFIX",

--- a/SConstruct
+++ b/SConstruct
@@ -425,6 +425,9 @@ for e in env["ENV_VARS_TO_IMPORT"].split() :
 	if e in os.environ :
 		env["ENV"][e] = os.environ[e]
 
+if env["BUILD_CACHEDIR"] != "" :
+	CacheDir( env["BUILD_CACHEDIR"] )
+
 ###########################################################################################
 # POSIX configuration
 ###########################################################################################
@@ -598,10 +601,6 @@ else:
 				"/Fd${TARGET}.pdb",
 			],
 		)
-
-
-if env["BUILD_CACHEDIR"] != "" :
-	CacheDir( env["BUILD_CACHEDIR"] )
 
 ###############################################################################################
 # Check for inkscape and sphinx

--- a/SConstruct
+++ b/SConstruct
@@ -384,12 +384,6 @@ env = Environment(
 	CPPDEFINES = [
 		( "BOOST_FILESYSTEM_VERSION", "3" ),
 		"BOOST_FILESYSTEM_NO_DEPRECATED",
-		# Boost has deprecated `boost/bind.hpp` in favour of
-		# `boost/bind/bind.hpp`, and we have updated our code accordingly. But
-		# `boost::python` and others are still using the deprecated header,
-		# so we define BOOST_BIND_GLOBAL_PLACEHOLDERS to silence the reams of
-		# warnings triggered by that.
-		"BOOST_BIND_GLOBAL_PLACEHOLDERS",
 	],
 
 	CPPPATH = [
@@ -790,6 +784,14 @@ with open( str( boostVersionHeader ) ) as f :
 if "BOOST_MAJOR_VERSION" not in baseLibEnv :
 	sys.stderr.write( "ERROR : unable to determine boost version from \"{}\".\n".format(  boostVersionHeader ) )
 	Exit( 1 )
+
+if ( int( baseLibEnv["BOOST_MAJOR_VERSION"] ), int( baseLibEnv["BOOST_MINOR_VERSION"] ) ) < ( 1, 80 ) :
+
+	# Older versions of boost deprecated `boost/bind.hpp` in favour of
+	# `boost/bind/bind.hpp`, but left `boost::python` and others still using the
+	# deprecated header, so we define BOOST_BIND_GLOBAL_PLACEHOLDERS to silence
+	# the reams of warnings triggered by that.
+	baseLibEnv.Append( CPPDEFINES = [ "BOOST_BIND_GLOBAL_PLACEHOLDERS" ] )
 
 ###############################################################################################
 # The basic environment for building python modules

--- a/SConstruct
+++ b/SConstruct
@@ -241,8 +241,8 @@ options.Add(
 )
 
 options.Add(
-	"OPENEXR_LIB_SUFFIX",
-	"The suffix used when locating the OpenEXR libraries.",
+	"IMATH_LIB_SUFFIX",
+	"The suffix used when locating the Imath library.",
 	"",
 )
 
@@ -748,7 +748,7 @@ baseLibEnv.Append(
 		"boost_regex$BOOST_LIB_SUFFIX",
 		"boost_chrono$BOOST_LIB_SUFFIX",
 		"tbb",
-		"Imath$OPENEXR_LIB_SUFFIX",
+		"Imath$IMATH_LIB_SUFFIX",
 		"IECore$CORTEX_LIB_SUFFIX",
 	],
 
@@ -986,7 +986,8 @@ libraries = {
 
 	"GafferUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "fmt" ],
+			## \todo Stop linking against `Iex`. It is only necessary on Windows Imath 2 builds.
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "fmt" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "GafferUI", "GafferBindings" ],
@@ -1051,7 +1052,7 @@ libraries = {
 
 	"GafferScene" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "$HALF_LIBRARY", "fmt" ],
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "$HALF_LIBRARY", "fmt" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],
@@ -1071,7 +1072,7 @@ libraries = {
 
 	"GafferSceneUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$OPENEXR_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferBindings", "GafferScene", "GafferUI", "GafferImageUI", "GafferSceneUI", "IECoreScene$CORTEX_LIB_SUFFIX" ],
@@ -1083,7 +1084,7 @@ libraries = {
 	"GafferImage" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$BUILD_DIR/include/freetype2" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$IMATH_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype", "fmt" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferImage", "GafferDispatch", "IECoreImage$CORTEX_LIB_SUFFIX", ],
@@ -1107,7 +1108,7 @@ libraries = {
 
 	"GafferImageUI" : {
 		"envAppends" : {
-			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferImage", "GafferUI", "OpenColorIO$OCIO_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "Iex$OPENEXR_LIB_SUFFIX" ],
+			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "Gaffer", "GafferImage", "GafferUI", "OpenColorIO$OCIO_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "Iex$IMATH_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"CPPPATH" : [ "$PYBIND11/include" ],
@@ -1201,11 +1202,11 @@ libraries = {
 	"GafferOSL" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],
-			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "Iex$OPENEXR_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferScene", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "Iex$IMATH_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"CPPPATH" : [ "$OSLHOME/include/OSL" ],
-			"LIBS" : [ "GafferBindings", "GafferScene", "GafferImage", "GafferOSL", "Iex$OPENEXR_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "GafferBindings", "GafferScene", "GafferImage", "GafferOSL", "Iex$IMATH_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"oslHeaders" : glob.glob( "shaders/*/*.h" ),
 		"oslShaders" : glob.glob( "shaders/*/*.osl" ),

--- a/SConstruct
+++ b/SConstruct
@@ -510,6 +510,19 @@ if env["PLATFORM"] != "win32" :
 			SHLINKFLAGS = [ "-Wl,-fatal_warnings" ],
 		)
 
+	# Address Sanitiser
+
+	if env["ASAN"] :
+		env.Append(
+			CXXFLAGS = [ "-fsanitize=address" ],
+			LINKFLAGS = [ "-fsanitize=address" ],
+		)
+		if "clang++" in os.path.basename( env["CXX"] ) :
+			env.Append(
+				CXXFLAGS = [ "-shared-libasan" ],
+				LINKFLAGS = [ "-shared-libasan" ],
+			)
+
 ###########################################################################################
 # Windows configuration
 ###########################################################################################
@@ -681,17 +694,6 @@ haveSphinx = conf.checkSphinx()
 if not conf.checkQtVersion() :
 	sys.stderr.write( "Qt not found\n" )
 	Exit( 1 )
-
-if env["ASAN"] :
-	env.Append(
-		CXXFLAGS = [ "-fsanitize=address" ],
-		LINKFLAGS = [ "-fsanitize=address" ],
-	)
-	if "clang++" in os.path.basename( env["CXX"] ) :
-		env.Append(
-			CXXFLAGS = [ "-shared-libasan" ],
-			LINKFLAGS = [ "-shared-libasan" ],
-		)
 
 ###############################################################################################
 # An environment for running commands with access to the applications we've built

--- a/SConstruct
+++ b/SConstruct
@@ -753,7 +753,6 @@ baseLibEnv.Append(
 		"boost_chrono$BOOST_LIB_SUFFIX",
 		"tbb",
 		"Imath$OPENEXR_LIB_SUFFIX",
-		"IlmImf$OPENEXR_LIB_SUFFIX",
 		"IECore$CORTEX_LIB_SUFFIX",
 	],
 

--- a/SConstruct
+++ b/SConstruct
@@ -746,7 +746,6 @@ baseLibEnv.Append(
 		"boost_iostreams$BOOST_LIB_SUFFIX",
 		"boost_filesystem$BOOST_LIB_SUFFIX",
 		"boost_date_time$BOOST_LIB_SUFFIX",
-		"boost_thread$BOOST_LIB_SUFFIX",
 		"boost_wave$BOOST_LIB_SUFFIX",
 		"boost_regex$BOOST_LIB_SUFFIX",
 		"boost_system$BOOST_LIB_SUFFIX",
@@ -1239,7 +1238,7 @@ libraries = {
 		"envAppends" : {
 			"CXXFLAGS" : [ systemIncludeArgument, "$APPLESEED_ROOT/include", "-DAPPLESEED_ENABLE_IMATH_INTEROP" ],
 			"LIBPATH" : [ "$APPLESEED_ROOT/lib" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "boost_thread$BOOST_LIB_SUFFIX", "fmt" ],
 			"CPPDEFINES" : [ "APPLESEED_USE_SSE" ] if platform.machine() != "arm64" else [],
 		},
 		"pythonEnvAppends" : {

--- a/config/ie/options
+++ b/config/ie/options
@@ -501,7 +501,7 @@ if "install" in sys.argv :
 # figure out the lib suffixes
 ##########################################################################
 
-OPENEXR_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenEXR", exrVersion )
+IMATH_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenEXR", exrVersion )
 OIIO_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenImageIO", oiioLibSuffix )
 OCIO_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenColorIO", ocioVersion )
 OSL_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenShadingLanguage", oslVersion )

--- a/src/Gaffer/ContextQuery.cpp
+++ b/src/Gaffer/ContextQuery.cpp
@@ -41,8 +41,6 @@
 
 #include "IECore/NullObject.h"
 
-#include "boost/bind.hpp"
-
 using namespace Imath;
 using namespace IECore;
 using namespace Gaffer;

--- a/src/GafferImageTestModule/GafferImageTestModule.cpp
+++ b/src/GafferImageTestModule/GafferImageTestModule.cpp
@@ -50,6 +50,7 @@
 #include "IECorePython/ScopedGILRelease.h"
 
 using namespace boost::python;
+using namespace boost::placeholders;
 using namespace Gaffer;
 using namespace GafferImage;
 using namespace GafferImageTest;

--- a/src/GafferScene/ShaderQuery.cpp
+++ b/src/GafferScene/ShaderQuery.cpp
@@ -45,8 +45,6 @@
 
 #include "IECoreScene/ShaderNetwork.h"
 
-#include "boost/bind.hpp"
-
 using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/GafferSceneUI/AttributeQueryUI.cpp
+++ b/src/GafferSceneUI/AttributeQueryUI.cpp
@@ -51,7 +51,7 @@
 #include "IECore/Exception.h"
 #include "IECore/NullObject.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -61,6 +61,8 @@
 #include <cassert>
 #include <functional>
 #include <iterator>
+
+using namespace boost::placeholders;
 
 namespace
 {

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -60,6 +60,7 @@
 
 using namespace std;
 using namespace boost::python;
+using namespace boost::placeholders;
 using namespace IECore;
 using namespace IECorePython;
 using namespace Gaffer;

--- a/src/GafferSceneUIModule/SetEditorBinding.cpp
+++ b/src/GafferSceneUIModule/SetEditorBinding.cpp
@@ -63,6 +63,7 @@
 #include "boost/container/flat_set.hpp"
 
 using namespace std;
+using namespace boost::placeholders;
 using namespace boost::python;
 using namespace IECore;
 using namespace IECorePython;

--- a/src/GafferVDB/PointsToLevelSet.cpp
+++ b/src/GafferVDB/PointsToLevelSet.cpp
@@ -45,6 +45,8 @@
 
 #include "IECoreScene/PointsPrimitive.h"
 
+#include "IECore/Version.h"
+
 #include "openvdb/openvdb.h"
 #include "openvdb/tools/ParticlesToLevelSet.h"
 
@@ -70,7 +72,7 @@ struct ParticleList
 	using PosType = openvdb::Vec3R;
 
 	ParticleList( const Primitive *points, const std::string &width, float widthScale, const std::string &velocity, float velocityScale )
-		:	m_positionView( points->variableIndexedView<V3fVectorData>( "P", PrimitiveVariable::Vertex, /* throwIfInvalid = */ true ).get() ),
+		:	m_positionView( points->variableIndexedView<V3fVectorData>( "P", PrimitiveVariable::Vertex, /* throwIfInvalid = */ true ).value() ),
 			m_widthView( points->variableIndexedView<FloatVectorData>( width, PrimitiveVariable::Vertex ) ),
 			m_widthScale( 0.5f * widthScale ), // VDB wants radius, so divide by two
 			m_velocityView( points->variableIndexedView<V3fVectorData>( velocity, PrimitiveVariable::Vertex ) ),
@@ -117,10 +119,17 @@ struct ParticleList
 
 	private :
 
+		template<typename T>
+#if CORTEX_COMPATIBILITY_VERSION >= 10005
+		using OptionalIndexedView = std::optional<PrimitiveVariable::IndexedView<T>>;
+#else
+		using OptionalIndexedView = boost::optional<PrimitiveVariable::IndexedView<T>>;
+#endif
+
 		PrimitiveVariable::IndexedView<V3f> m_positionView;
-		boost::optional<PrimitiveVariable::IndexedView<float>> m_widthView;
+		OptionalIndexedView<float> m_widthView;
 		float m_widthScale;
-		boost::optional<PrimitiveVariable::IndexedView<V3f>> m_velocityView;
+		OptionalIndexedView<V3f> m_velocityView;
 		float m_velocityScale;
 
 };


### PR DESCRIPTION
This prepares for an update to the dependencies provided by https://github.com/GafferHQ/dependencies/pull/229. It also builds and links successfully against the current dependencies, which will allow Image Engine to continue to make internal builds using Imath 2 etc. I've also tidied up a few other things in the SConstruct.