### PR TITLE
Documentation : Remove references to Appleseed

### DIFF
--- a/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
+++ b/doc/source/GettingStarted/ConfiguringGafferForThirdPartyTools/index.md
@@ -2,15 +2,15 @@
 
 Gaffer is compatible with the following commercial and open-source third-party tools:
 
-- [Appleseed](http://appleseedhq.net/)
 - [Arnold](https://www.arnoldrenderer.com/)
+- [Cycles](https://www.cycles-renderer.org/)
 - [3Delight](http://www.3delight.com/)
 - [Tractor](https://renderman.pixar.com/tractor)
 
-Gaffer comes with Appleseed, so it will require no additional configuration. For the rest of the tools in this list, you will need to set some additional environment variables.
+Gaffer comes with Cycles, so it will require no additional configuration. For the rest of the tools in this list, you will need to set some additional environment variables.
 
 > Tip :
-> If you do not use Appleseed in production, you can hide its nodes and presets from the UI by setting the `GAFFERAPPLESEED_HIDE_UI` environment variable to `1`. Even when set, Appleseed will still be available for OSL shader previews and example scenes.
+> If you do not use Cycles in production, you can hide its nodes and presets from the UI by setting the `GAFFERCYCLES_HIDE_UI` environment variable to `1`. Even when set, Cycles will still be available for OSL shader previews and example scenes.
 
 > Note :
 > For the following Linux instructions, we will assume you are using the bash shell and are familiar with terminal commands. Other shells will have comparable methods for setting environment variables.

--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/index.md
@@ -15,7 +15,7 @@ By the end of this tutorial you will have built a basic scene with Gaffer's robo
 - Using an interactive renderer
 
 > Note :
-> This tutorial uses Cycles, a free renderer included with Gaffer. While the Cycles-specific nodes described here can be substituted with equivalents from Arnold, Appleseed or 3Delight, we recommend that you complete this tutorial using Cycles before moving on to your preferred renderer.
+> This tutorial uses Cycles, a free renderer included with Gaffer. While the Cycles-specific nodes described here can be substituted with equivalents from Arnold or 3Delight, we recommend that you complete this tutorial using Cycles before moving on to your preferred renderer.
 
 
 ## Starting a new node graph ##


### PR DESCRIPTION
Remove a few references to Appleseed from the documentation text, replacing with Cycles where appropriate.