### PR TITLE
PythonExpressionEngine : Fix parsing of context lookups with subscripts

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
 
 - UVInspector : Removed display transform from UV wireframes and grid.
 - Viewer : Gamma is now applied after the display transform, not before.
+- Expression : Fixed parsing of Python expressions combining subscripts (`[]`) and `context` methods (#3088, #3613, #5250).
 
 API
 ---

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -262,6 +262,8 @@ class _Parser( ast.NodeVisitor ) :
 				contextName = self.__contextName( path )
 				if contextName :
 					self.contextReads.add( contextName )
+				else :
+					ast.NodeVisitor.generic_visit( self, node )
 
 	def visit_Call( self, node ) :
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -237,6 +237,23 @@ class ExpressionTest( GafferTest.TestCase ) :
 				c.setFrame( i )
 				self.assertEqual( s["n"]["sum"].getValue(), i )
 
+	def testContextGetFrameMethodInSubscript( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"d = { 1 : 2, 2 : 3 }; parent['n']['op1'] = d[int( context.getFrame() )]",
+			"python",
+		)
+
+		with Gaffer.Context() as c :
+			for i in ( 1, 2 ) :
+				c.setFrame( i )
+				self.assertEqual( s["n"]["op1"].getValue(), i + 1 )
+
 	def testContextGetMethod( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -269,6 +286,23 @@ class ExpressionTest( GafferTest.TestCase ) :
 		)
 
 		self.assertEqual( s["n"]["sum"].getValue(), 101 )
+
+	def testContextGetWithSubscript( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferTest.AddNode()
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression(
+			"parent['n']['op1'] = context.get( 'myArray' )[0]",
+			"python",
+		)
+
+		with Gaffer.Context() as c :
+			for i in ( 1, 2 ) :
+				c["myArray"] = IECore.IntVectorData( [ i ] )
+				self.assertEqual( s["n"]["op1"].getValue(), i )
 
 	def testDirtyPropagation( self ) :
 


### PR DESCRIPTION
We need to visit the `value` and `slice` child nodes of the `Subscript` AST node, because they may also contain context lookups.

I've targeted this to `main` as I'm a little wary of making changes to the parser, and there are easy workarounds that can be used in the meantime, as documented on the various issues.

Fixes #5250
Fixes #3613
Fixes #3088
