### PR TITLE
Headers : Prefer `fmt::format` to `boost::format`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -748,6 +748,7 @@ baseLibEnv.Append(
 		"boost_regex$BOOST_LIB_SUFFIX",
 		"boost_chrono$BOOST_LIB_SUFFIX",
 		"tbb",
+		"fmt",
 		"Imath$IMATH_LIB_SUFFIX",
 		"IECore$CORTEX_LIB_SUFFIX",
 	],
@@ -966,11 +967,8 @@ libraries = {
 
 	"Gaffer" : {
 		"envAppends" : {
-			"LIBS" : [ "$HALF_LIBRARY", "fmt" ],
+			"LIBS" : [ "$HALF_LIBRARY" ],
 		},
-		"pythonEnvAppends" : {
-			"LIBS" : [ "fmt" ],
-		}
 	},
 
 	"GafferTest" : {
@@ -987,7 +985,7 @@ libraries = {
 	"GafferUI" : {
 		"envAppends" : {
 			## \todo Stop linking against `Iex`. It is only necessary on Windows Imath 2 builds.
-			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "fmt" ],
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "GafferUI", "GafferBindings" ],
@@ -1006,7 +1004,7 @@ libraries = {
 
 	"GafferDispatch" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "fmt" ],
+			"LIBS" : [ "Gaffer" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferDispatch" ],
@@ -1052,7 +1050,7 @@ libraries = {
 
 	"GafferScene" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "$HALF_LIBRARY", "fmt" ],
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "$HALF_LIBRARY" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],
@@ -1084,7 +1082,7 @@ libraries = {
 	"GafferImage" : {
 		"envAppends" : {
 			"CPPPATH" : [ "$BUILD_DIR/include/freetype2" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$IMATH_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$IMATH_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferImage", "GafferDispatch", "IECoreImage$CORTEX_LIB_SUFFIX", ],
@@ -1093,7 +1091,7 @@ libraries = {
 
 	"GafferImageTest" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX",  ],
+			"LIBS" : [ "Gaffer", "GafferImage", "OpenImageIO$OIIO_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferImage", "GafferImageTest" ],
@@ -1144,13 +1142,13 @@ libraries = {
 	"GafferArnold" : {
 		"envAppends" : {
 			"LIBPATH" : [ "$ARNOLD_ROOT/bin" ] if env["PLATFORM"] != "win32" else [ "$ARNOLD_ROOT/bin", "$ARNOLD_ROOT/lib" ],
-			"LIBS" : [ "Gaffer", "GafferScene", "GafferDispatch", "ai", "GafferVDB", "openvdb$VDB_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreArnold", "GafferOSL", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferScene", "GafferDispatch", "ai", "GafferVDB", "openvdb$VDB_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX", "IECoreArnold", "GafferOSL" ],
 			"CXXFLAGS" : [ "-DAI_ENABLE_DEPRECATION_WARNINGS" ],
 			"CPPPATH" : [ "$ARNOLD_ROOT/include" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBPATH" : [ "$ARNOLD_ROOT/bin" ] if env["PLATFORM"] != "win32" else [ "$ARNOLD_ROOT/bin", "$ARNOLD_ROOT/lib" ],
-			"LIBS" : [ "Gaffer", "GafferScene", "GafferBindings", "GafferVDB", "GafferDispatch", "GafferArnold", "GafferOSL", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreArnold", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferScene", "GafferBindings", "GafferVDB", "GafferDispatch", "GafferArnold", "GafferOSL", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreArnold" ],
 			"CXXFLAGS" : [ "-DAI_ENABLE_DEPRECATION_WARNINGS" ],
 			"CPPPATH" : [ "$ARNOLD_ROOT/include" ],
 		},
@@ -1268,7 +1266,7 @@ libraries = {
 		"envAppends" : {
 			"CXXFLAGS" : [ systemIncludeArgument, "$APPLESEED_ROOT/include", "-DAPPLESEED_ENABLE_IMATH_INTEROP" ],
 			"LIBPATH" : [ "$APPLESEED_ROOT/lib" ],
-			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "boost_thread$BOOST_LIB_SUFFIX", "fmt" ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "appleseed",  "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreAppleseed$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX", "boost_thread$BOOST_LIB_SUFFIX" ],
 			"CPPDEFINES" : [ "APPLESEED_USE_SSE" ] if platform.machine() != "arm64" else [],
 		},
 		"pythonEnvAppends" : {

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -38,7 +38,7 @@
 
 #include "IECore/SimpleTypedData.h"
 
-#include "boost/format.hpp"
+#include "fmt/format.h"
 
 namespace Gaffer
 {
@@ -115,7 +115,7 @@ inline const T &Context::Value::value() const
 	{
 		return *static_cast<const T *>( m_value );
 	}
-	throw IECore::Exception( boost::str( boost::format( "Context variable is not of type \"%s\"" ) % DataType::staticTypeName() ) );
+	throw IECore::Exception( fmt::format( "Context variable is not of type \"{}\"", DataType::staticTypeName() ) );
 }
 
 template<typename T>
@@ -145,9 +145,9 @@ void Context::Value::registerType()
 		const Value rehashed( name, static_cast<const ValueType *>( v.rawValue() ) );
 		if( v.hash() != rehashed.hash() )
 		{
-			throw IECore::Exception( boost::str(
-				boost::format( "Context variable \"%1%\" has an invalid hash" ) % name
-			) );
+			throw IECore::Exception(
+				fmt::format( "Context variable \"{}\" has an invalid hash", name.string() )
+			);
 		}
 	};
 }
@@ -201,7 +201,7 @@ inline const Context::Value &Context::internalGet( const IECore::InternedString 
 	const Value *result = internalGetIfExists( name );
 	if( !result )
 	{
-		throw IECore::Exception( boost::str( boost::format( "Context has no variable named \"%s\"" ) % name.value() ) );
+		throw IECore::Exception( fmt::format( "Context has no variable named \"{}\"", name.value() ) );
 	}
 
 #ifndef NDEBUG

--- a/include/Gaffer/ShufflePlug.inl
+++ b/include/Gaffer/ShufflePlug.inl
@@ -39,6 +39,8 @@
 #include "Gaffer/Node.h"
 #include "Gaffer/PlugAlgo.h"
 
+#include "fmt/format.h"
+
 #include <unordered_set>
 
 //////////////////////////////////////////////////////////////////////////
@@ -158,15 +160,13 @@ T ShufflesPlug::shuffle( const T &sourceContainer ) const
 							if( ! moveNames.insert( dstName ).second )
 							{
 								throw IECore::Exception(
-									boost::str(
-										boost::format(
-											"ShufflesPlug::shuffle : Destination plug \"%s\" shuffles from \"%s\" to \"%s\", " \
-											"cannot write from multiple sources to destination \"%s\"" )
-											% plug->destinationPlug()->relativeName( plug->node() ? plug->node()->parent() : nullptr )
-											% srcPattern
-											% dstPattern
-											% dstName
-								) );
+									fmt::format(
+										"ShufflesPlug::shuffle : Destination plug \"{}\" shuffles from \"{}\" to \"{}\", " \
+										"cannot write from multiple sources to destination \"{}\"",
+										plug->destinationPlug()->relativeName( plug->node() ? plug->node()->parent() : nullptr ),
+										srcPattern, dstPattern, dstName
+									)
+								);
 							}
 
 							if( dstReplace || ( destinationContainer.find( dstName ) == destinationContainer.end() ) )

--- a/include/Gaffer/TweakPlug.inl
+++ b/include/Gaffer/TweakPlug.inl
@@ -38,6 +38,8 @@
 
 #include "Gaffer/PlugAlgo.h"
 
+#include "fmt/format.h"
+
 namespace Gaffer
 {
 
@@ -82,7 +84,7 @@ bool TweakPlug::applyTweak(
 	if( !newData )
 	{
 		throw IECore::Exception(
-			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value plug has unsupported type \"%s\"" ) % name % valuePlug()->typeName() )
+			fmt::format( "Cannot apply tweak to \"{}\" : Value plug has unsupported type \"{}\"", name, valuePlug()->typeName() )
 		);
 	}
 
@@ -104,7 +106,7 @@ bool TweakPlug::applyTweak(
 	if( currentValue && currentValue->typeId() != newData->typeId() )
 	{
 		throw IECore::Exception(
-			boost::str( boost::format( "Cannot apply tweak to \"%s\" : Value of type \"%s\" does not match parameter of type \"%s\"" ) % name % currentValue->typeName() % newData->typeName() )
+			fmt::format( "Cannot apply tweak to \"{}\" : Value of type \"{}\" does not match parameter of type \"{}\"", name, currentValue->typeName(), newData->typeName() )
 		);
 	}
 
@@ -125,7 +127,7 @@ bool TweakPlug::applyTweak(
 		}
 		else if( !( mode == Gaffer::TweakPlug::Replace && missingMode == Gaffer::TweakPlug::MissingMode::IgnoreOrReplace) )
 		{
-			throw IECore::Exception( boost::str( boost::format( "Cannot apply tweak with mode %s to \"%s\" : This parameter does not exist" ) % modeToString( mode ) % name ) );
+			throw IECore::Exception( fmt::format( "Cannot apply tweak with mode {} to \"{}\" : This parameter does not exist", modeToString( mode ), name ) );
 		}
 	}
 

--- a/include/Gaffer/ValuePlug.inl
+++ b/include/Gaffer/ValuePlug.inl
@@ -34,7 +34,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/format.hpp"
+#include "fmt/format.h"
 
 namespace Gaffer
 {
@@ -51,17 +51,17 @@ boost::intrusive_ptr<const T> ValuePlug::getObjectValue( const IECore::MurmurHas
 			// This is quite a serious error, and it may occur when a calculation has already been cancelled,
 			// which could result in the exception that first cancelled the calculation being displayed, but
 			// not this error - print the error as a message as well as throwing an exception
-			std::string error = boost::str(
-				boost::format( "%1% : getValueInternal() returned NULL. This should be impossible, something has gone badly wrong internally to Gaffer." )
-				% fullName()
+			const std::string error = fmt::format(
+				"{} : getValueInternal() returned NULL. This should be impossible, something has gone badly wrong internally to Gaffer.",
+				fullName()
 			);
 			IECore::msg( IECore::Msg::Error, "ValuePlug::getObjectValue", error );
 			throw IECore::Exception( error );
 		}
 
-		throw IECore::Exception( boost::str(
-			boost::format( "%1% : getValueInternal() didn't return expected type (wanted %2% but got %3%). Is the hash being computed correctly?" )
-				% fullName() % T::staticTypeName() % value->typeName()
+		throw IECore::Exception( fmt::format(
+			"{} : getValueInternal() didn't return expected type (wanted {} but got {}). Is the hash being computed correctly?",
+			fullName(), T::staticTypeName(), value->typeName()
 		) );
 	}
 	return result;

--- a/include/GafferTest/Assert.h
+++ b/include/GafferTest/Assert.h
@@ -38,7 +38,7 @@
 
 #include "IECore/Exception.h"
 
-#include "boost/format.hpp"
+#include "fmt/format.h"
 
 namespace GafferTest
 {
@@ -46,9 +46,9 @@ namespace GafferTest
 #define GAFFERTEST_ASSERT( x ) \
 	if( !( x ) ) \
 	{ \
-		throw IECore::Exception( boost::str( \
-			boost::format( "Failed assertion \"%s\" : %s line %d" ) % #x % __FILE__ % __LINE__ \
-		) ); \
+		throw IECore::Exception( \
+			fmt::format( "Failed assertion \"{}\" : {} line {}", #x, __FILE__, __LINE__ ) \
+		); \
 	}
 
 #define GAFFERTEST_ASSERTEQUAL( x, y ) \
@@ -57,9 +57,9 @@ namespace GafferTest
 		const auto yy = y; /* only once */ \
 		if( xx != yy ) \
 		{ \
-			throw IECore::Exception( boost::str( \
-				boost::format( "Failed assertion \"%1% == %2%\" : %3% line %4%" ) % (xx) % (yy) % __FILE__ % __LINE__ \
-			) ); \
+			throw IECore::Exception( \
+				fmt::format( "Failed assertion \"{} == {}\" : {} line {}", (xx), (yy), __FILE__, __LINE__ ) \
+			); \
 		} \
 	}
 

--- a/src/GafferCortexModule/ParameterisedHolderBinding.h
+++ b/src/GafferCortexModule/ParameterisedHolderBinding.h
@@ -45,7 +45,7 @@
 
 #include "IECore/Parameter.h"
 
-#include "boost/format.hpp"
+#include "fmt/format.h"
 
 #include <memory>
 
@@ -68,10 +68,9 @@ class ParameterisedHolderWrapper : public BaseType
 			IECorePython::ScopedGILLock gilLock;
 			boost::python::dict scopeDict;
 			scopeDict["IECore"] = boost::python::import( "IECore" );
-			std::string toExecute = boost::str(
-				boost::format(
-					"IECore.ClassLoader.defaultLoader( \"%s\" ).load( \"%s\", %d )()\n"
-				) % searchPathEnvVar % className % classVersion
+			const std::string toExecute = fmt::format(
+				"IECore.ClassLoader.defaultLoader( \"{}\" ).load( \"{}\", {} )()\n",
+				searchPathEnvVar, className, classVersion
 			);
 			boost::python::object result = boost::python::eval( toExecute.c_str(), scopeDict, scopeDict );
 			return boost::python::extract<IECore::RunTimeTypedPtr>( result );

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1082,7 +1082,7 @@ void metadataToImageSpecAttributes( const CompoundData *metadata, ImageSpec &spe
 		{
 			IECore::msg(
 				IECore::Msg::Warning, "ImageWriter",
-				fmt::format( "Ignoring metadata \"{}\" because it conflicts with OpenImageIO.", it->first )
+				fmt::format( "Ignoring metadata \"{}\" because it conflicts with OpenImageIO.", it->first.string() )
 			);
 			continue;
 		}

--- a/src/GafferTest/ContextTest.cpp
+++ b/src/GafferTest/ContextTest.cpp
@@ -359,12 +359,12 @@ void GafferTest::testCopyEditableScope()
 	// the same data.
 
 	ContextPtr copy2 = new Context( *copy );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<int>( "a" ), &copy2->get<int>( "a" ) );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<int>( "b" ), &copy2->get<int>( "b" ) );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<int>( "c" ), &copy2->get<int>( "c" ) );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<int>( "d" ), &copy2->get<int>( "d" ) );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<int>( "e" ), &copy2->get<int>( "e" ) );
-	GAFFERTEST_ASSERTEQUAL( &copy->get<string>( "f" ), &copy2->get<string>( "f" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<int>( "a" ), (void *)&copy2->get<int>( "a" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<int>( "b" ), (void *)&copy2->get<int>( "b" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<int>( "c" ), (void *)&copy2->get<int>( "c" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<int>( "d" ), (void *)&copy2->get<int>( "d" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<int>( "e" ), (void *)&copy2->get<int>( "e" ) );
+	GAFFERTEST_ASSERTEQUAL( (void *)&copy->get<string>( "f" ), (void *)&copy2->get<string>( "f" ) );
 
 	// And the second copy should still be valid if the first
 	// one is destroyed.

--- a/src/GafferTestModule/LRUCacheTest.cpp
+++ b/src/GafferTestModule/LRUCacheTest.cpp
@@ -398,9 +398,9 @@ struct TestLRUCacheExceptions
 		Cache cache(
 			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
-				throw IECore::Exception( boost::str(
-					boost::format( "Get failed for %1%" ) % key
-				) );
+				throw IECore::Exception(
+					fmt::format( "Get failed for {}", key )
+				);
 				return 0;
 			},
 			1000
@@ -494,9 +494,9 @@ struct TestLRUCacheExceptions
 		Cache noErrorsCache(
 			[&calls]( int key, size_t &cost, const IECore::Canceller *canceller ) {
 				calls.push_back( key );
-				throw IECore::Exception( boost::str(
-					boost::format( "Get failed for %1%" ) % key
-				) );
+				throw IECore::Exception(
+					fmt::format( "Get failed for {}", key )
+				);
 				return 0;
 			},
 			1000,


### PR DESCRIPTION
Unlike the other formatting updates, this one targets `main` because it is a breaking change. We no longer include `boost/format.hpp` from any of our headers, so if anyone was relying on that their source will fail to compile. And we also now use `fmt::format` from various inlined functions, which requires linking to `libfmt` in any extensions that invoke those functions. Easy to adapt to, but not something we'd force on folks without a major version bump.