### PR TITLE
Build : Import Imath symbols

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -532,6 +532,7 @@ else:
 		CXXFLAGS = [
 			"/nologo",  # Suppress startup banner
 			"/DOPENEXR_DLL",  # Link to dynamic OpenEXR library
+			"/DIMATH_DLL",  # Link to dynamic Imath library
 			"/DNOMINMAX",  # Suppress compiler definition of `min` and `max`
 			"/D__PRETTY_FUNCTION__=__FUNCSIG__",
 			"/DBOOST_ALL_DYN_LINK",


### PR DESCRIPTION
This fixes a build error with OpenEXR / Imath version 3.x where Imath was split into a separate project from OpenEXR.

This is needed to build with Gaffer dependencies starting with version `7.0.0`.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
