### PR TITLE
OpenColorIO Viewer menu improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,8 @@ Improvements
     - Organised colorspaces into submenus by family.
     - Removed unwanted title-casing, so that names are now displayed verbatim.
     - Added control over the presence of roles by registering `openColorIO:includeRoles` metadata to the relevant plugs.
+  - Improved View display transform menu :
+    - Ordered menu items to match the order in the OpenColorIO config.
 - VectorDataPlugValueWidget : Computation errors are now reflected by a red background colour.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -65,14 +65,15 @@ Breaking Changes
 Build
 -----
 
-- OpenEXR : Stopped linking unnecessarily to the `IlmImf` library.
 - Boost :
   - Updated to version 1.80.0.
   - Stopped linking unnecessarily to `iostreams`, `date_time`, `wave` and `system` libraries.
 - Cortex : Updated to version 10.5.0.0.
 - Imath : Added version 3.1.7.
 - Minizip : Added version 3.0.9.
-- OpenEXR : Updated to version 3.1.7.
+- OpenEXR :
+  - Updated to version 3.1.7.
+  - Stopped linking unnecessarily to the `IlmImf` library.
 - OpenColorIO : Updated to version 2.2.1.
 - PyBind11 : Updated to version 2.10.4.
 - PySide : Updated to version 5.15.8.

--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ API
 - Color4fVectorDataPlug : Added a plug type for storing arrays of `Color4f`.
 - TypedObjectPlug : Added default value for `direction` and `defaultValue` constructor arguments.
 - VectorDataWidget : Added `setErrored()` and `getErrored()` methods to control an error state. Errors are reflected by a red background colour.
+- PlugLayout : Added support for `layout:minimumWidth` metadata.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -15,7 +15,7 @@ Improvements
   - Improved colorspace menus :
     - Organised colorspaces into submenus by family.
     - Removed unwanted title-casing, so that names are now displayed verbatim.
-    - Removed Roles submenu, which is deemed unsuitable by the OpenColorIO UX working group. It may be reintroduced by registering `openColorIO:includeRoles` metadata to the relevant plugs.
+    - Added control over the presence of roles by registering `openColorIO:includeRoles` metadata to the relevant plugs.
 - VectorDataPlugValueWidget : Computation errors are now reflected by a red background colour.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,8 @@ Improvements
   - Improved View display transform menu :
     - Ordered menu items to match the order in the OpenColorIO config.
     - Removed "Default" view.
+    - Added menu options for changing the current Display.
+    - Allowed the available views to be filtered using an `openColorIO:activeViews` metadata value registered on the View's `displayTransform.name` plug. Values should be space-separated names, optionally containing wildcards.
 - VectorDataPlugValueWidget : Computation errors are now reflected by a red background colour.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
     - Added control over the presence of roles by registering `openColorIO:includeRoles` metadata to the relevant plugs.
   - Improved View display transform menu :
     - Ordered menu items to match the order in the OpenColorIO config.
+    - Removed "Default" view.
 - VectorDataPlugValueWidget : Computation errors are now reflected by a red background colour.
 
 Fixes

--- a/doc/source/Reference/ScriptingReference/Metadata/index.md
+++ b/doc/source/Reference/ScriptingReference/Metadata/index.md
@@ -30,7 +30,8 @@ Name                              | Purpose                                     
 `layout:section`                  | Specifies the section the plug belongs in     | `TabName.SectionName`
 `layout:section:<name>:collapsed` | Specifies whether the section is collapsed    | `True` (collapsed), `False` (expanded)
 `layout:accessory`                | Places widget on same line as previous widget | `True`
-
+`layout:width`                    | Specifies a fixed width for the widget        | `100`
+`layout:minimumWidth`             | Specifies a minimum width for the widget      | `100`
 
 GraphEditor layout
 ------------------

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -238,6 +238,7 @@ class GAFFERUI_API View::DisplayTransform : public Gaffer::Node
 		using DisplayTransformCreator = std::function<IECoreGL::Shader::SetupPtr ()>;
 
 		static void registerDisplayTransform( const std::string &name, DisplayTransformCreator creator );
+		static void deregisterDisplayTransform( const std::string &name );
 		static std::vector<std::string> registeredDisplayTransforms();
 
 	private :

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -403,8 +403,13 @@ class PlugLayout( GafferUI.Widget ) :
 		width = self.__itemMetadataValue( plug, "width" )
 		if width is not None :
 			result._qtWidget().setFixedWidth( width )
-			if result._qtWidget().layout() is not None :
-				result._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
+
+		minimumWidth = self.__itemMetadataValue( plug, "minimumWidth" )
+		if minimumWidth is not None :
+			result._qtWidget().setMinimumWidth( minimumWidth )
+
+		if result._qtWidget().layout() is not None and ( width is not None or minimumWidth is not None ) :
+			result._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
 
 		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and self.__itemMetadataValue( plug, "label" ) != "" :
 			result = GafferUI.PlugWidget( result )

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -109,7 +109,6 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"label", "",
-			"layout:width", 100,
 
 			"presetNames", lambda plug : IECore.StringVectorData( GafferUI.View.DisplayTransform.registeredDisplayTransforms() ),
 			"presetValues", lambda plug : IECore.StringVectorData( GafferUI.View.DisplayTransform.registeredDisplayTransforms() ),

--- a/src/GafferUIModule/ViewBinding.cpp
+++ b/src/GafferUIModule/ViewBinding.cpp
@@ -168,6 +168,8 @@ void bindView()
 		.def( init<View *>() )
 		.def( "registerDisplayTransform", &registerDisplayTransformWrapper )
 		.staticmethod( "registerDisplayTransform" )
+		.def( "deregisterDisplayTransform", &View::DisplayTransform::deregisterDisplayTransform )
+		.staticmethod( "deregisterDisplayTransform" )
 		.def( "registeredDisplayTransforms", &registeredDisplayTransformsWrapper )
 		.staticmethod( "registeredDisplayTransforms" )
 	;

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import copy
 import functools
 import imath
 
@@ -83,9 +84,7 @@ def __processor( view ) :
 	d.setDisplay( defaultDisplay )
 	d.setView( view )
 
-	# \todo : Should be `context = copy.deepcopy( config.getCurrentContext() )`
-	# once https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1575 gets merged into OCIO2.1.2
-	context = OCIO.Context( searchPaths = list( config.getCurrentContext().getSearchPaths() ), workingDir = config.getCurrentContext().getWorkingDir(), environmentMode = config.getCurrentContext().getEnvironmentMode(), stringVars = dict( config.getCurrentContext().getStringVars() ) )
+	context = copy.deepcopy( config.getCurrentContext() )
 	gafferContext = Gaffer.Context.current()
 	for variable in preferences["displayColorSpace"]["context"] :
 		if variable["enabled"].getValue() :

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -134,7 +134,84 @@ def __registerViewerDisplayTransforms() :
 
 __registerViewerDisplayTransforms()
 
+class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
+		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plugs, **kw )
+
+		self.__currentValue = ""
+
+	def _updateFromValues( self, values, exception ) :
+
+		if exception is not None :
+			self.__menuButton.setText( "" )
+			self.__currentValue = ""
+		else :
+			assert( len( values ) == 1 )
+			self.__currentValue = values[0]
+			# Only show the View name, because the Display name is more of
+			# a "set once and forget" affair. The menu shows both for when
+			# you need to check.
+			self.__menuButton.setText( self.__currentValue.partition( "/" )[-1] )
+
+		self.__menuButton.setErrored( exception is not None )
+
+	def _updateFromEditable( self ) :
+
+		self.__menuButton.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		activeViews = Gaffer.Metadata.value( self.getPlug(), "openColorIO:activeViews" ) or "*"
+
+		# View section
+
+		result.append( "/__ViewDivider__", { "divider" : True, "label" : "View" } )
+
+		displayToViews = {}
+
+		currentDisplay, currentView = self.__currentValue.split( "/" )
+		for displayTransform in GafferUI.View.DisplayTransform.registeredDisplayTransforms() :
+			display, view = displayTransform.split( "/" )
+			if not IECore.StringAlgo.matchMultiple( view, activeViews ) :
+				continue
+			displayToViews.setdefault( display, [] ).append( view )
+			if display != currentDisplay :
+				continue
+			result.append(
+				f"/{view}", {
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), f"{currentDisplay}/{view}" ),
+					"checkBox" : view == currentView
+				}
+			)
+
+		# Display section
+
+		result.append( "/__DisplayDivider__", { "divider" : True, "label" : "Display" } )
+
+		for display, views in displayToViews.items() :
+			newValue = "{}/{}".format( display, currentView if currentView in views else views[0] )
+			result.append(
+				f"/{display}", {
+					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), newValue ),
+					"checkBox" : display == currentDisplay
+				}
+			)
+
+		return result
+
+	def __setValue( self, value, unused ) :
+
+		self.getPlug().setValue( value )
+
+GafferImageUI._OpenColorIODisplayTransformPlugValueWidget = DisplayTransformPlugValueWidget
+Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "plugValueWidget:type", "GafferImageUI._OpenColorIODisplayTransformPlugValueWidget" )
 Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "userDefault", "{}/{}".format( defaultDisplay, config.getDefaultView( defaultDisplay ) ) )
+Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "layout:minimumWidth", 150 )
 
 # Add "Roles" submenus to various colorspace plugs. The OCIO UX guidelines suggest we
 # shouldn't do this, but they do seem like they might be useful, and historically they

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -105,6 +105,17 @@ def __setDisplayTransform() :
 
 __setDisplayTransform()
 
+# And connect to `plugSet()` to update `GafferUI.DisplayTransform` again when the user modifies something.
+
+def __plugSet( plug ) :
+
+	if plug.relativeName( plug.node() ) != "displayColorSpace" :
+		return
+
+	__setDisplayTransform()
+
+preferences.plugSetSignal().connect( __plugSet, scoped = False )
+
 # Register with `GafferUI.View.DisplayTransform` for use in the Viewer.
 
 def __displayTransformCreator( view ) :
@@ -120,26 +131,9 @@ def __registerViewerDisplayTransforms() :
 			functools.partial( __displayTransformCreator, name )
 		)
 
-	GafferUI.View.DisplayTransform.registerDisplayTransform(
-		"Default",
-		functools.partial( __displayTransformCreator, preferences["displayColorSpace"]["view"].getValue() )
-	)
-
 __registerViewerDisplayTransforms()
 
-# And connect to `plugSet()` to update everything again when the user modifies something.
-
-def __plugSet( plug ) :
-
-	if plug.relativeName( plug.node() ) != "displayColorSpace" :
-		return
-
-	__registerViewerDisplayTransforms()
-	__setDisplayTransform()
-
-preferences.plugSetSignal().connect( __plugSet, scoped = False )
-
-Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "userDefault", "Default" )
+Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "userDefault", config.getDefaultView( defaultDisplay ) )
 
 # Add "Roles" submenus to various colorspace plugs. The OCIO UX guidelines suggest we
 # shouldn't do this, but they do seem like they might be useful, and historically they


### PR DESCRIPTION
A bunch of improvements to the Viewer's display transform menu as requested in #5215 :

- Expose choice of OCIO display.
- Remove "Default" view.
- Sort views in order defined by OCIO config.
- Add metadata to control what views are visible.
- Don't clip long view names.

Rather than present all permutations of display and view in a single menu, or waste real estate with two separate toolbar fields, I've laid the menu out like this :

![image](https://user-images.githubusercontent.com/1133871/233389595-443e518f-88c9-4f3f-8051-f780df5d1962.png)

Views come first because I assume that's what you'd be changing most often. Only views for the current display are listed. Display can be changed from the section below, automatically maintaining the current view where it also exists for the new display. 

Out of necessity, this also includes all the commits from #5263 - I'll rebase when that is reviewed and merged.