### PR TITLE
ArnoldColorManager : Use standard OpenColorIO menu format

### DIFF
--- a/python/GafferArnoldUI/ArnoldColorManagerUI.py
+++ b/python/GafferArnoldUI/ArnoldColorManagerUI.py
@@ -34,13 +34,10 @@
 #
 ##########################################################################
 
-import functools
-
 import PyOpenColorIO
 
-import IECore
-
 import Gaffer
+import GafferImageUI
 import GafferArnold
 
 def __parameterUserDefault( plug ) :
@@ -66,24 +63,16 @@ def __ocioConfig( plug ) :
 	except :
 		return None
 
-def __roles( config ) :
-
-	return [ r[0] for r in config.getRoles() ]
-
-def __colorSpaces( config ) :
-
-	return [ cs.getName() for cs in config.getColorSpaces() ]
-
 def __colorSpacePresetNames( plug ) :
 
 	config = __ocioConfig( plug )
 	if config is None :
 		return None
 
-	return IECore.StringVectorData(
-		[ "Roles/{}".format( x.replace( "_", " ").title() ) for x in __roles( config ) ] +
-		__colorSpaces( config ) + [ "None" ]
+	return GafferImageUI.OpenColorIOTransformUI.colorSpacePresetNames(
+		plug, config = config
 	)
+
 
 def __colorSpacePresetValues( plug ) :
 
@@ -91,7 +80,9 @@ def __colorSpacePresetValues( plug ) :
 	if config is None :
 		return None
 
-	return IECore.StringVectorData( __roles( config ) + __colorSpaces( config ) + [ "" ] )
+	return GafferImageUI.OpenColorIOTransformUI.colorSpacePresetValues(
+		plug, config = config
+	)
 
 def __colorSpacePlugValueWidget( plug ) :
 
@@ -134,6 +125,7 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __colorSpacePresetNames,
 			"presetValues", __colorSpacePresetValues,
 			"plugValueWidget:type", __colorSpacePlugValueWidget,
+			"openColorIO:includeRoles", True,
 
 		],
 
@@ -142,6 +134,7 @@ Gaffer.Metadata.registerNode(
 			"presetNames", __colorSpacePresetNames,
 			"presetValues", __colorSpacePresetValues,
 			"plugValueWidget:type", __colorSpacePlugValueWidget,
+			"openColorIO:includeRoles", True,
 
 		]
 

--- a/python/GafferImageUI/OpenColorIOTransformUI.py
+++ b/python/GafferImageUI/OpenColorIOTransformUI.py
@@ -44,9 +44,9 @@ import GafferImage
 
 import PyOpenColorIO
 
-def __colorSpaceMenuHelper( plug ) :
+def __colorSpaceMenuHelper( plug, config = None ) :
 
-	config = PyOpenColorIO.GetCurrentConfig()
+	config = PyOpenColorIO.GetCurrentConfig() if config is None else config
 	parameters = PyOpenColorIO.ColorSpaceMenuParameters( config )
 
 	categories = Gaffer.Metadata.value( plug, "openColorIO:categories" )
@@ -59,9 +59,9 @@ def __colorSpaceMenuHelper( plug ) :
 
 	return PyOpenColorIO.ColorSpaceMenuHelper( parameters )
 
-def colorSpacePresetNames( plug, noneLabel = "None" ) :
+def colorSpacePresetNames( plug, noneLabel = "None", config = None ) :
 
-	helper = __colorSpaceMenuHelper( plug )
+	helper = __colorSpaceMenuHelper( plug, config )
 	return IECore.StringVectorData(
 		[ noneLabel ] + [
 			"/".join(
@@ -72,9 +72,9 @@ def colorSpacePresetNames( plug, noneLabel = "None" ) :
 		]
 	)
 
-def colorSpacePresetValues( plug ) :
+def colorSpacePresetValues( plug, config = None ) :
 
-	helper = __colorSpaceMenuHelper( plug )
+	helper = __colorSpaceMenuHelper( plug, config )
 	return IECore.StringVectorData(
 		[ "" ] +
 		[ helper.getName( i ) for i in range( 0, helper.getNumColorSpaces() ) ]


### PR DESCRIPTION
This escaped the treatment in #5232 because it had its own duplicate menu code.
