### PR TITLE
StandardStyle : Avoid buggy blend mode change

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 -----
 
 - Arnold : Moved `distance` shader to the `Shader/Utility` section of the node menu (previously in `Shader/Other`).
+- Graph Editor : Fixed a bug for some video drivers that led to a crash when using nodes with icons.
 
 1.2.3.0 (relative to 1.2.2.0)
 =======

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1130,7 +1130,16 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 
 	// As the image is already pre-multiplied we need to change our blend mode.
 	glEnable( GL_BLEND );
-	glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
+	if( !IECoreGL::Selector::currentSelector() )
+	{
+		// Some users have reported crashes that were traced back to this call
+		// when used on the GL_R32UI data type the `IDRender` selection mode
+		// uses. The `IDRender` buffer would get corrupted with values that
+		// didn't correspond to actual gadgets.
+		// Don't change it when rendering the selection pass since
+		// blending should not be applied to an integer buffer anyways.
+		glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
+	}
 
 	glEnable( GL_TEXTURE_2D );
 	glActiveTexture( GL_TEXTURE0 );


### PR DESCRIPTION
This fixes a bug affecting some video drivers which would crash Gaffer when using nodes that have an icon, such as the Box and Reference nodes.

It seems that changing the blend mode as we do here caused the `IDRender` buffer to get corrupted values. That would cause 
`GafferUI::ViewportGadget::gadgetsAtInternal()` to get `HitRecord` items with names that didn't correspond to an actual gadget. Trying to use the name as an index into a vector or similar reference then led to a crash

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
