### PR TITLE
Cycles : Correct tagging of tangent primitive variables to allow normal maps to render properly.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.1.9.x (relative to 1.1.9.4)
 =======
 
+Fixes
+-----
+
+- Cycles : Correct tagging of tangent primitive variables to allow normal maps to render properly.
+
 1.1.9.4 (relative to 1.1.9.3)
 =======
 

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -40,6 +40,8 @@
 
 #include "IECore/SimpleTypedData.h"
 
+#include "boost/algorithm/string/predicate.hpp"
+
 IECORE_PUSH_DEFAULT_VISIBILITY
 // Cycles (for ustring)
 #include "util/param.h"
@@ -351,6 +353,14 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	else if( name == "uv" && attr->type == ccl::TypeFloat2 )
 	{
 		attr->std = ccl::ATTR_STD_UV;
+	}
+	else if( boost::ends_with( name, "tangent_sign" ) && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeFloat )
+	{
+		attr->std = ccl::ATTR_STD_UV_TANGENT_SIGN;
+	}
+	else if( boost::ends_with( name, "tangent" ) && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeVector )
+	{
+		attr->std = ccl::ATTR_STD_UV_TANGENT;
 	}
 }
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Tangents need to exist and be tagged correctly for Cycles to use these with normal maps
- For these to function properly the user needs to do a few steps:

1. Create a `MeshTangents` node for a given UV, and name it with the name of the UV with `.tangent` on the end eg. `uv.tangent`
2. Create a primitive variable of type float + FaceVarying and name it based on the UV name with `.tangent_sign` on the end eg. `uv.tangent_sign` (I use `PrimitiveVariables` + `ResamplePrimitiveVariables` nodes)
3. Plug a tangent-space `cyclesImageTexture` into a `cyclesNormalMap` node, and plug that into a `cyclesPrincipledShader`'s `normal` socket.

I am not sure exactly on the specifics of `tangent_sign` but it is needed for it to render.
![Old](https://user-images.githubusercontent.com/5601445/233605980-2b6a18a6-59d1-4cc0-914c-8deec70f6cfd.png)
![New](https://user-images.githubusercontent.com/5601445/233606010-8b4f9c04-9a6f-43c7-8a6e-e4ea34b58a7a.png)


### Related issues ###

- It came up again in the Discord from a user

### Dependencies ###

- NA

### Breaking changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.

Todo: Get the proper MikkTSpace code into place again, now that it is bundled with Cycles 3.5 and have it implicitly be created in the absence of tangent and tangent_sign primitive variables. This will be targetting for Gaffer 1.3.x probably.