### PR TITLE
Name-change handling improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Fixes
 API
 ---
 
+- GraphComponent : Added an `oldName` argument to `nameChangedSignal()` slot signature.
 - View : Added DisplayTransform add-on class which can be used to add colourspace management to any View.
 - ViewportGadget : A post-process shader can now be applied to any layer, not just the main one.
 - SceneGadget : Added `setLayer()` and `getLayer()` methods, which allow the destination `Gadget::Layer` to be specified.
@@ -51,6 +52,7 @@ Breaking Changes
 ----------------
 
 - Appleseed : Removed Appleseed support. We suggest Cycles as an actively maintained open-source alternative.
+- GraphComponent : Changed slot signature for `nameChangedSignal()`.
 - GLWidget :
   - A GL context is no longer available in `_resize()`.
   - Removed `BufferOptions.Double`.

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Fixes
 - Viewer : Gamma is now applied after the display transform, not before.
 - Expression : Fixed parsing of Python expressions combining subscripts (`[]`) and `context` methods (#3088, #3613, #5250).
 - ConnectionCreatorWrapper : Fixed bug which forced PlugAdder derived classes to implement `updateDragEndPoint()` unnecessarily.
+- Plug : Fixed bug which caused stale values to be retrieved from the cache for plugs that had been renamed.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -34,7 +34,10 @@ Fixes
 API
 ---
 
-- GraphComponent : Added an `oldName` argument to `nameChangedSignal()` slot signature.
+- GraphComponent :
+  - Added an `oldName` argument to `nameChangedSignal()` slot signature.
+  - Added a `nameChanged()` protected virtual method, which can be overridden to receive notifications of name changes before
+    they are made public by `nameChangedSignal()`.
 - View : Added DisplayTransform add-on class which can be used to add colourspace management to any View.
 - ViewportGadget : A post-process shader can now be applied to any layer, not just the main one.
 - SceneGadget : Added `setLayer()` and `getLayer()` methods, which allow the destination `Gadget::Layer` to be specified.

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -233,6 +233,13 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public Signals::T
 
 	protected :
 
+		/// Called by `setName()` immediately prior to emitting
+		/// `nameChangedSignal()`. This provides an opportunity to respond to
+		/// the change before outside observers are notified. Implementations
+		/// should call the base class implementation before doing their own
+		/// work.
+		virtual void nameChanged( IECore::InternedString oldName );
+
 		/// Called just /before/ the parent of this GraphComponent is
 		/// changed to newParent. This is an opportunity to do things
 		/// in preparation for the new relationship - currently it allows

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -87,6 +87,7 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public Signals::T
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::GraphComponent, GraphComponentTypeId, IECore::RunTimeTyped );
 
 		using UnarySignal = Signals::Signal<void (GraphComponent *), Signals::CatchingCombiner<void>>;
+		using NameChangedSignal = Signals::Signal<void (GraphComponent *, IECore::InternedString), Signals::CatchingCombiner<void>>;
 		using BinarySignal = Signals::Signal<void (GraphComponent *, GraphComponent *), Signals::CatchingCombiner<void>>;
 		using ChildrenReorderedSignal = Signals::Signal<void (GraphComponent *, const std::vector<size_t> &originalIndices ), Signals::CatchingCombiner<void>>;
 
@@ -109,8 +110,9 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public Signals::T
 		/// Returns the relative path name from the specified ancestor to this component.
 		/// Passing nullptr for ancestor yields the same result as calling fullName().
 		std::string relativeName( const GraphComponent *ancestor ) const;
-		/// A signal which is emitted whenever a name is changed.
-		UnarySignal &nameChangedSignal();
+		/// A signal which is emitted whenever a name is changed. The old name is passed
+		/// as an argument to the slot.
+		NameChangedSignal &nameChangedSignal();
 		/// Returns T::staticTypeName() without namespace prefixes, for use as the
 		/// default name in GraphComponent constructors.
 		template<typename T>

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -227,6 +227,7 @@ class GAFFER_API Plug : public GraphComponent
 
 	protected :
 
+		void nameChanged( IECore::InternedString oldName ) override;
 		void parentChanging( Gaffer::GraphComponent *newParent ) override;
 		void parentChanged( Gaffer::GraphComponent *oldParent ) override;
 		void childrenReordered( const std::vector<size_t> &oldIndices ) override;
@@ -246,7 +247,7 @@ class GAFFER_API Plug : public GraphComponent
 
 	private :
 
-		static void propagateDirtinessForParentChange( Plug *plugToDirty );
+		static void propagateDirtinessAtLeaves( Plug *plugToDirty );
 
 		void setFlagsInternal( unsigned flags );
 

--- a/include/GafferBindings/GraphComponentBinding.h
+++ b/include/GafferBindings/GraphComponentBinding.h
@@ -110,6 +110,28 @@ class GraphComponentWrapper : public IECorePython::RunTimeTypedWrapper<WrappedTy
 			return WrappedType::acceptsParent( potentialParent );
 		}
 
+		void nameChanged( IECore::InternedString oldName ) override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "_nameChanged" );
+					if( f )
+					{
+						f( oldName.string() );
+						return;
+					}
+				}
+				catch( const boost::python::error_already_set &e )
+				{
+					IECorePython::ExceptionAlgo::translatePythonException();
+				}
+			}
+			WrappedType::nameChanged( oldName );
+		}
+
 		void parentChanging( Gaffer::GraphComponent *newParent ) override
 		{
 			if( this->isSubclassed() )

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -680,7 +680,7 @@ class _ImagesPath( Gaffer.Path ) :
 		del self.__nameChangedConnections[child]
 		self._emitPathChanged()
 
-	def __nameChanged( self, child ) :
+	def __nameChanged( self, child, oldName ) :
 
 		self._emitPathChanged()
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -296,6 +296,6 @@ class _HistoryWindow( GafferUI.Window ) :
 
 				node = node.parent()
 
-	def __nodeNameChanged( self, node ) :
+	def __nodeNameChanged( self, node, oldName ) :
 
 		self.__path._emitPathChanged()

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -711,5 +711,34 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 
 		self.assertEqual( raised.exception.plug(), thrower["out"] )
 
+	def testUsePlugNameInCompute( self ) :
+
+		class NameSensitiveComputeNode( Gaffer.ComputeNode ) :
+
+			def __init__( self, name="PassThrough" ) :
+
+				Gaffer.ComputeNode.__init__( self, name )
+
+				self.plug = Gaffer.StringPlug( "out", Gaffer.Plug.Direction.Out )
+				self.addChild( self.plug )
+
+			# No need to override `hash()`, because the base class includes
+			# the plug name in the hash anyway.
+
+			def compute( self, plug, context ) :
+
+				plug.setValue( plug.getName() )
+
+		IECore.registerRunTimeTyped( NameSensitiveComputeNode )
+
+		n = NameSensitiveComputeNode()
+		h1 = n.plug.hash()
+		self.assertEqual( n.plug.getValue(), "out" )
+
+		n.plug.setName( "out2" )
+		h2 = n.plug.hash()
+		self.assertNotEqual( h2, h1 )
+		self.assertEqual( n.plug.getValue(), "out2" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -123,7 +123,7 @@ class _AnimationPathFilter( Gaffer.PathFilter ) :
 		# when an AnimationNode is involved.
 		self.changedSignal()( self )
 
-	def __nameChanged( self, graphComponent ) :
+	def __nameChanged( self, graphComponent, oldName ) :
 
 		self.changedSignal()( self )
 

--- a/python/GafferUI/ButtonPlugValueWidget.py
+++ b/python/GafferUI/ButtonPlugValueWidget.py
@@ -74,7 +74,7 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__updateLabel()
 
-	def __nameChanged( self, plug ) :
+	def __nameChanged( self, plug, oldName ) :
 
 		self.__updateLabel()
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -155,7 +155,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__menuButton.setText( editScope.getName() if editScope is not None else "None" )
 
-	def __editScopeNameChanged( self, editScope ) :
+	def __editScopeNameChanged( self, editScope, oldName ) :
 
 		self.__updateMenuButton( editScope )
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -580,7 +580,7 @@ class GraphEditor( GafferUI.Editor ) :
 
 		self.titleChangedSignal()( self )
 
-	def __rootNameChanged( self, root ) :
+	def __rootNameChanged( self, root, oldName ) :
 
 		self.titleChangedSignal()( self )
 

--- a/python/GafferUI/NodeSetEditor.py
+++ b/python/GafferUI/NodeSetEditor.py
@@ -268,7 +268,7 @@ class NodeSetEditor( GafferUI.Editor ) :
 
 		self.__nodeSetChangedSignal( self )
 
-	def __nameChanged( self, node ) :
+	def __nameChanged( self, node, oldName ) :
 
 		self.titleChangedSignal()( self )
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -789,7 +789,7 @@ class _PlugListing( GafferUI.Widget ) :
 		self.__updateChildNameChangedConnection( child )
 		self.__updatePathLazily()
 
-	def __childNameChanged( self, child ) :
+	def __childNameChanged( self, child, oldName ) :
 
 		selection = self.getSelection()
 		self.__updatePath()

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -126,7 +126,7 @@ void validateName( const InternedString &name )
 struct GraphComponent::MemberSignals : boost::noncopyable
 {
 
-	UnarySignal nameChangedSignal;
+	NameChangedSignal nameChangedSignal;
 	BinarySignal childAddedSignal;
 	BinarySignal childRemovedSignal;
 	BinarySignal parentChangedSignal;
@@ -243,8 +243,9 @@ const IECore::InternedString &GraphComponent::setName( const IECore::InternedStr
 
 void GraphComponent::setNameInternal( const IECore::InternedString &name )
 {
+	const InternedString oldName = m_name;
 	m_name = name;
-	MemberSignals::emitLazily( m_signals.get(), &MemberSignals::nameChangedSignal, this );
+	MemberSignals::emitLazily( m_signals.get(), &MemberSignals::nameChangedSignal, this, oldName );
 }
 
 const IECore::InternedString &GraphComponent::getName() const
@@ -274,7 +275,7 @@ std::string GraphComponent::relativeName( const GraphComponent *ancestor ) const
 	return fullName;
 }
 
-GraphComponent::UnarySignal &GraphComponent::nameChangedSignal()
+GraphComponent::NameChangedSignal &GraphComponent::nameChangedSignal()
 {
 	return signals()->nameChangedSignal;
 }

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -245,6 +245,7 @@ void GraphComponent::setNameInternal( const IECore::InternedString &name )
 {
 	const InternedString oldName = m_name;
 	m_name = name;
+	nameChanged( oldName );
 	MemberSignals::emitLazily( m_signals.get(), &MemberSignals::nameChangedSignal, this, oldName );
 }
 
@@ -652,6 +653,10 @@ GraphComponent::BinarySignal &GraphComponent::parentChangedSignal()
 GraphComponent::ChildrenReorderedSignal &GraphComponent::childrenReorderedSignal()
 {
 	return signals()->childrenReorderedSignal;
+}
+
+void GraphComponent::nameChanged( IECore::InternedString oldName )
+{
 }
 
 void GraphComponent::parentChanging( Gaffer::GraphComponent *newParent )

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -243,6 +243,7 @@ const IECore::InternedString &GraphComponent::setName( const IECore::InternedStr
 
 void GraphComponent::setNameInternal( const IECore::InternedString &name )
 {
+	DirtyPropagationScope dirtyPropagationScope;
 	const InternedString oldName = m_name;
 	m_name = name;
 	nameChanged( oldName );

--- a/src/Gaffer/Plug.cpp
+++ b/src/Gaffer/Plug.cpp
@@ -565,6 +565,12 @@ PlugPtr Plug::createCounterpart( const std::string &name, Direction direction ) 
 	return result;
 }
 
+void Plug::nameChanged( IECore::InternedString oldName )
+{
+	GraphComponent::nameChanged( oldName );
+	propagateDirtinessAtLeaves( this );
+}
+
 void Plug::parentChanging( Gaffer::GraphComponent *newParent )
 {
 	// When a plug is removed from a node, we need to propagate dirtiness for
@@ -576,7 +582,7 @@ void Plug::parentChanging( Gaffer::GraphComponent *newParent )
 	// deferred until after `parentChanged()`, when the operation is complete.
 	if( node() )
 	{
-		propagateDirtinessForParentChange( this );
+		propagateDirtinessAtLeaves( this );
 	}
 
 	// This method manages the connections between plugs when
@@ -663,7 +669,7 @@ void Plug::parentChanged( Gaffer::GraphComponent *oldParent )
 	{
 		// If a plug has been added to a node, we need to
 		// propagate dirtiness.
-		propagateDirtinessForParentChange( this );
+		propagateDirtinessAtLeaves( this );
 	}
 }
 
@@ -702,7 +708,7 @@ void Plug::childrenReordered( const std::vector<size_t> &oldIndices )
 	}
 }
 
-void Plug::propagateDirtinessForParentChange( Plug *plugToDirty )
+void Plug::propagateDirtinessAtLeaves( Plug *plugToDirty )
 {
 	// When a plug is reparented, we need to take into account
 	// all the descendants it brings with it, so we recurse to
@@ -711,7 +717,7 @@ void Plug::propagateDirtinessForParentChange( Plug *plugToDirty )
 	{
 		for( Plug::Iterator it( plugToDirty ); !it.done(); ++it )
 		{
-			propagateDirtinessForParentChange( it->get() );
+			propagateDirtinessAtLeaves( it->get() );
 		}
 	}
 	else

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -267,6 +267,21 @@ struct UnarySlotCaller
 	}
 };
 
+struct NameChangedSlotCaller
+{
+	void operator()( boost::python::object slot, GraphComponentPtr g, IECore::InternedString oldName )
+	{
+		try
+		{
+			slot( g, oldName.string() );
+		}
+		catch( const error_already_set &e )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
+	}
+};
+
 struct BinarySlotCaller
 {
 
@@ -353,6 +368,7 @@ void GafferModule::bindGraphComponent()
 	;
 
 	SignalClass<GraphComponent::UnarySignal, DefaultSignalCaller<GraphComponent::UnarySignal>, UnarySlotCaller>( "UnarySignal" );
+	SignalClass<GraphComponent::NameChangedSignal, DefaultSignalCaller<GraphComponent::NameChangedSignal>, NameChangedSlotCaller>( "NameChangedSignal" );
 	SignalClass<GraphComponent::BinarySignal, DefaultSignalCaller<GraphComponent::BinarySignal>, BinarySlotCaller>( "BinarySignal" );
 	SignalClass<GraphComponent::ChildrenReorderedSignal, DefaultSignalCaller<GraphComponent::ChildrenReorderedSignal>, ChildrenReorderedSlotCaller>( "BinarySignal" );
 


### PR DESCRIPTION
Improvements to assist in work I'm doing on a generic Collect node, for which I should have a PR coming fairly soon.

@ivanimanishi, it'd be worth you taking a quick look at https://github.com/GafferHQ/gaffer/commit/d4ad78c98a21f8e7b2f8e24846a70f592fae528b to determine the scale of the impact of the breaking change on the IE codebase. The adjustment is pretty straightforward - you can just add an `*unused` argument to any `nameChanged` Python slots and they should continue to work in both old and new Gaffer. But if you have a lot of such call sites it might take a bit of time to get done. @masterkeech, I believe there is only a single Python source file affected at Cinesite, but you might like to perform your own check.