### PR TITLE
Gaffer : Disable constructor implicit conversions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -61,6 +61,7 @@ Breaking Changes
 - OpenColorIO : Changed default config.
 - Subprocess32 : Removed Python module.
 - Six : Removed Python module.
+- Gaffer : Class constructors are now declared explicit disabling implicit conversions.
 
 Build
 -----

--- a/include/Gaffer/Action.h
+++ b/include/Gaffer/Action.h
@@ -110,7 +110,7 @@ class GAFFER_API Action : public IECore::RunTimeTyped
 
 	protected :
 
-		Action( bool cancelBackgroundTasks = true );
+		explicit Action( bool cancelBackgroundTasks = true );
 		~Action() override;
 
 		/// Must be implemented by derived classes to

--- a/include/Gaffer/ApplicationRoot.h
+++ b/include/Gaffer/ApplicationRoot.h
@@ -52,7 +52,7 @@ class GAFFER_API ApplicationRoot : public GraphComponent
 
 	public :
 
-		ApplicationRoot( const std::string &name = defaultName<ApplicationRoot>() );
+		explicit ApplicationRoot( const std::string &name = defaultName<ApplicationRoot>() );
 		~ApplicationRoot() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::ApplicationRoot, ApplicationRootTypeId, GraphComponent );

--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -56,7 +56,7 @@ class GAFFER_API ArrayPlug : public Plug
 		/// but this may change in the future. It is strongly
 		/// recommended that ArrayPlug children are only accessed
 		/// through numeric indexing and never via names.
-		ArrayPlug(
+		explicit ArrayPlug(
 			const std::string &name = defaultName<ArrayPlug>(),
 			Direction direction = In,
 			PlugPtr element = nullptr,

--- a/include/Gaffer/Backdrop.h
+++ b/include/Gaffer/Backdrop.h
@@ -51,7 +51,7 @@ class GAFFER_API Backdrop : public Node
 
 	public :
 
-		Backdrop( const std::string &name=defaultName<Backdrop>() );
+		explicit Backdrop( const std::string &name=defaultName<Backdrop>() );
 		~Backdrop() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Backdrop, BackdropTypeId, Node );

--- a/include/Gaffer/Box.h
+++ b/include/Gaffer/Box.h
@@ -53,7 +53,7 @@ class GAFFER_API Box : public SubGraph
 
 	public :
 
-		Box( const std::string &name=defaultName<Box>() );
+		explicit Box( const std::string &name=defaultName<Box>() );
 		~Box() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Box, BoxTypeId, SubGraph );

--- a/include/Gaffer/BoxIO.h
+++ b/include/Gaffer/BoxIO.h
@@ -141,7 +141,7 @@ class GAFFER_API BoxIO : public Node
 
 	protected :
 
-		BoxIO( Plug::Direction direction, const std::string &name=defaultName<BoxIO>() );
+		explicit BoxIO( Plug::Direction direction, const std::string &name=defaultName<BoxIO>() );
 
 		Gaffer::Plug *inPlugInternal();
 		const Gaffer::Plug *inPlugInternal() const;

--- a/include/Gaffer/BoxIn.h
+++ b/include/Gaffer/BoxIn.h
@@ -46,7 +46,7 @@ class GAFFER_API BoxIn : public BoxIO
 
 	public :
 
-		BoxIn( const std::string &name=defaultName<BoxIn>() );
+		explicit BoxIn( const std::string &name=defaultName<BoxIn>() );
 		~BoxIn() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::BoxIn, BoxInTypeId, BoxIO );

--- a/include/Gaffer/BoxOut.h
+++ b/include/Gaffer/BoxOut.h
@@ -48,7 +48,7 @@ class GAFFER_API BoxOut : public BoxIO
 
 	public :
 
-		BoxOut( const std::string &name=defaultName<BoxOut>() );
+		explicit BoxOut( const std::string &name=defaultName<BoxOut>() );
 		~BoxOut() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::BoxOut, BoxOutTypeId, BoxIO );

--- a/include/Gaffer/BoxPlug.h
+++ b/include/Gaffer/BoxPlug.h
@@ -66,7 +66,7 @@ class GAFFER_API BoxPlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( BoxPlug<T>, ValuePlug );
 
-		BoxPlug(
+		explicit BoxPlug(
 			const std::string &name = defaultName<BoxPlug>(),
 			Direction direction=In,
 			T defaultValue = T(),

--- a/include/Gaffer/ChildSet.h
+++ b/include/Gaffer/ChildSet.h
@@ -48,7 +48,7 @@ class GAFFER_API ChildSet : public Gaffer::Set
 
 	public :
 
-		ChildSet( GraphComponentPtr parent );
+		explicit ChildSet( GraphComponentPtr parent );
 		~ChildSet() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::ChildSet, ChildSetTypeId, Gaffer::Set );

--- a/include/Gaffer/CompoundDataPlug.h
+++ b/include/Gaffer/CompoundDataPlug.h
@@ -56,7 +56,7 @@ class GAFFER_API CompoundDataPlug : public Gaffer::ValuePlug
 
 	public :
 
-		CompoundDataPlug(
+		explicit CompoundDataPlug(
 			const std::string &name = defaultName<CompoundDataPlug>(),
 			Direction direction=In,
 			unsigned flags = Default

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -67,7 +67,7 @@ class GAFFER_API CompoundNumericPlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( CompoundNumericPlug<T>, ValuePlug );
 
-		CompoundNumericPlug(
+		explicit CompoundNumericPlug(
 			const std::string &name = defaultName<CompoundNumericPlug>(),
 			Direction direction=In,
 			T defaultValue = T( 0 ),

--- a/include/Gaffer/CompoundPathFilter.h
+++ b/include/Gaffer/CompoundPathFilter.h
@@ -52,7 +52,7 @@ class GAFFER_API CompoundPathFilter : public Gaffer::PathFilter
 
 		using Filters = std::vector<PathFilterPtr>;
 
-		CompoundPathFilter( IECore::CompoundDataPtr userData = nullptr );
+		explicit CompoundPathFilter( IECore::CompoundDataPtr userData = nullptr );
 		~CompoundPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::CompoundPathFilter, CompoundPathFilterTypeId, PathFilter );

--- a/include/Gaffer/ComputeNode.h
+++ b/include/Gaffer/ComputeNode.h
@@ -57,7 +57,7 @@ class GAFFER_API ComputeNode : public DependencyNode
 
 	public :
 
-		ComputeNode( const std::string &name=defaultName<ComputeNode>() );
+		explicit ComputeNode( const std::string &name=defaultName<ComputeNode>() );
 		~ComputeNode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ComputeNode, ComputeNodeTypeId, DependencyNode );

--- a/include/Gaffer/Container.h
+++ b/include/Gaffer/Container.h
@@ -50,7 +50,7 @@ class IECORE_EXPORT Container : public Base
 
 		IE_CORE_DECLAREMEMBERPTR( Container );
 
-		Container( const std::string &name=GraphComponent::defaultName<Container>() );
+		explicit Container( const std::string &name=GraphComponent::defaultName<Container>() );
 		~Container() override;
 
 		//! @name RunTimeTyped interface

--- a/include/Gaffer/ContextMonitor.h
+++ b/include/Gaffer/ContextMonitor.h
@@ -65,7 +65,7 @@ class GAFFER_API ContextMonitor : public Monitor
 
 		/// Statistics are only collected for the root and its
 		/// descendants.
-		ContextMonitor( const GraphComponent *root = nullptr );
+		explicit ContextMonitor( const GraphComponent *root = nullptr );
 		~ContextMonitor() override;
 
 		IE_CORE_DECLAREMEMBERPTR( ContextMonitor )

--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -52,7 +52,7 @@ class IECORE_EXPORT ContextProcessor : public ComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ContextProcessor, ContextProcessorTypeId, ComputeNode );
 
-		ContextProcessor( const std::string &name=GraphComponent::defaultName<ContextProcessor>() );
+		explicit ContextProcessor( const std::string &name=GraphComponent::defaultName<ContextProcessor>() );
 		~ContextProcessor() override;
 
 		/// \undoable

--- a/include/Gaffer/ContextQuery.h
+++ b/include/Gaffer/ContextQuery.h
@@ -51,7 +51,7 @@ namespace Gaffer
 class GAFFER_API ContextQuery : public Gaffer::ComputeNode
 {
 	public:
-		ContextQuery( const std::string &name = defaultName<ContextQuery>() );
+		explicit ContextQuery( const std::string &name = defaultName<ContextQuery>() );
 		~ContextQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ContextQuery, ContextQueryTypeId, Gaffer::ComputeNode );

--- a/include/Gaffer/ContextVariableTweaks.h
+++ b/include/Gaffer/ContextVariableTweaks.h
@@ -49,7 +49,7 @@ class GAFFER_API ContextVariableTweaks : public ContextProcessor
 
 	public :
 
-		ContextVariableTweaks( const std::string &name=defaultName<ContextVariableTweaks>() );
+		explicit ContextVariableTweaks( const std::string &name=defaultName<ContextVariableTweaks>() );
 		~ContextVariableTweaks() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ContextVariableTweaks, ContextVariableTweaksTypeId, ContextProcessor );

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -50,7 +50,7 @@ class IECORE_EXPORT ContextVariables : public ContextProcessor
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ContextVariables, ContextVariablesTypeId, ContextProcessor );
 
-		ContextVariables( const std::string &name=GraphComponent::defaultName<ContextVariables>() );
+		explicit ContextVariables( const std::string &name=GraphComponent::defaultName<ContextVariables>() );
 		~ContextVariables() override;
 
 		CompoundDataPlug *variablesPlug();

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -49,7 +49,7 @@ class IECORE_EXPORT DeleteContextVariables : public ContextProcessor
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::DeleteContextVariables, DeleteContextVariablesTypeId, ContextProcessor );
 
-		DeleteContextVariables( const std::string &name=GraphComponent::defaultName<DeleteContextVariables>() );
+		explicit DeleteContextVariables( const std::string &name=GraphComponent::defaultName<DeleteContextVariables>() );
 		~DeleteContextVariables() override;
 
 		StringPlug *variablesPlug();

--- a/include/Gaffer/DependencyNode.h
+++ b/include/Gaffer/DependencyNode.h
@@ -54,7 +54,7 @@ class GAFFER_API DependencyNode : public Node
 
 	public :
 
-		DependencyNode( const std::string &name=defaultName<DependencyNode>() );
+		explicit DependencyNode( const std::string &name=defaultName<DependencyNode>() );
 		~DependencyNode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::DependencyNode, DependencyNodeTypeId, Node );

--- a/include/Gaffer/Dot.h
+++ b/include/Gaffer/Dot.h
@@ -51,7 +51,7 @@ class GAFFER_API Dot : public DependencyNode
 
 	public :
 
-		Dot( const std::string &name=defaultName<Dot>() );
+		explicit Dot( const std::string &name=defaultName<Dot>() );
 		~Dot() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Dot, DotTypeId, DependencyNode );

--- a/include/Gaffer/EditScope.h
+++ b/include/Gaffer/EditScope.h
@@ -69,7 +69,7 @@ class GAFFER_API EditScope : public Box
 
 	public :
 
-		EditScope( const std::string &name=defaultName<EditScope>() );
+		explicit EditScope( const std::string &name=defaultName<EditScope>() );
 		~EditScope() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::EditScope, EditScopeTypeId, Box );

--- a/include/Gaffer/Expression.h
+++ b/include/Gaffer/Expression.h
@@ -52,7 +52,7 @@ class GAFFER_API Expression : public ComputeNode
 
 	public :
 
-		Expression( const std::string &name=defaultName<Expression>() );
+		explicit Expression( const std::string &name=defaultName<Expression>() );
 		~Expression() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Expression, ExpressionTypeId, ComputeNode );

--- a/include/Gaffer/FileSequencePathFilter.h
+++ b/include/Gaffer/FileSequencePathFilter.h
@@ -66,7 +66,7 @@ class GAFFER_API FileSequencePathFilter : public PathFilter
 			All = Files | SequentialFiles | Sequences,
 		};
 
-		FileSequencePathFilter( Keep mode = Concise, IECore::CompoundDataPtr userData = nullptr );
+		explicit FileSequencePathFilter( Keep mode = Concise, IECore::CompoundDataPtr userData = nullptr );
 		~FileSequencePathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::FileSequencePathFilter, FileSequencePathFilterTypeId, Gaffer::PathFilter );

--- a/include/Gaffer/FileSystemPath.h
+++ b/include/Gaffer/FileSystemPath.h
@@ -60,7 +60,7 @@ class GAFFER_API FileSystemPath : public Path
 
 	public :
 
-		FileSystemPath( PathFilterPtr filter = nullptr, bool includeSequences = false );
+		explicit FileSystemPath( PathFilterPtr filter = nullptr, bool includeSequences = false );
 		FileSystemPath( const std::string &path, PathFilterPtr filter = nullptr, bool includeSequences = false );
 		FileSystemPath( const std::filesystem::path &path, PathFilterPtr filter = nullptr, bool includeSequences = false );
 		FileSystemPath( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = nullptr, bool includeSequences = false );

--- a/include/Gaffer/GraphComponent.h
+++ b/include/Gaffer/GraphComponent.h
@@ -81,7 +81,7 @@ class GAFFER_API GraphComponent : public IECore::RunTimeTyped, public Signals::T
 
 	public :
 
-		GraphComponent( const std::string &name=GraphComponent::defaultName<GraphComponent>() );
+		explicit GraphComponent( const std::string &name=GraphComponent::defaultName<GraphComponent>() );
 		~GraphComponent() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( Gaffer::GraphComponent, GraphComponentTypeId, IECore::RunTimeTyped );

--- a/include/Gaffer/HiddenFilePathFilter.h
+++ b/include/Gaffer/HiddenFilePathFilter.h
@@ -52,7 +52,7 @@ class GAFFER_API HiddenFilePathFilter : public PathFilter
 
 	public :
 
-		HiddenFilePathFilter( IECore::CompoundDataPtr userData = nullptr );
+		explicit HiddenFilePathFilter( IECore::CompoundDataPtr userData = nullptr );
 		~HiddenFilePathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::HiddenFilePathFilter, HiddenFilePathFilterTypeId, Gaffer::PathFilter );

--- a/include/Gaffer/LeafPathFilter.h
+++ b/include/Gaffer/LeafPathFilter.h
@@ -51,7 +51,7 @@ class GAFFER_API LeafPathFilter : public Gaffer::PathFilter
 		/// one or more of the patterns (using StringAlgo match()).
 		/// If leafOnly is true then directories will always be passed
 		/// through.
-		LeafPathFilter( IECore::CompoundDataPtr userData = nullptr );
+		explicit LeafPathFilter( IECore::CompoundDataPtr userData = nullptr );
 		~LeafPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::LeafPathFilter, LeafPathFilterTypeId, PathFilter );

--- a/include/Gaffer/Loop.h
+++ b/include/Gaffer/Loop.h
@@ -51,7 +51,7 @@ class IECORE_EXPORT Loop : public ComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Loop, LoopTypeId, ComputeNode );
 
-		Loop( const std::string &name=GraphComponent::defaultName<Loop>() );
+		explicit Loop( const std::string &name=GraphComponent::defaultName<Loop>() );
 		~Loop() override;
 
 		/// \undoable

--- a/include/Gaffer/MatchPatternPathFilter.h
+++ b/include/Gaffer/MatchPatternPathFilter.h
@@ -54,7 +54,7 @@ class GAFFER_API MatchPatternPathFilter : public Gaffer::PathFilter
 		/// one or more of the patterns (using StringAlgo match()).
 		/// If leafOnly is true then directories will always be passed
 		/// through.
-		MatchPatternPathFilter( const std::vector<IECore::StringAlgo::MatchPattern> &patterns, IECore::InternedString propertyName = "name", bool leafOnly = true, IECore::CompoundDataPtr userData = nullptr );
+		explicit MatchPatternPathFilter( const std::vector<IECore::StringAlgo::MatchPattern> &patterns, IECore::InternedString propertyName = "name", bool leafOnly = true, IECore::CompoundDataPtr userData = nullptr );
 		~MatchPatternPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::MatchPatternPathFilter, MatchPatternPathFilterTypeId, PathFilter );

--- a/include/Gaffer/Monitor.h
+++ b/include/Gaffer/Monitor.h
@@ -65,10 +65,10 @@ class GAFFER_API Monitor : public IECore::RefCounted
 
 				/// Constructs a Scope where the monitor has the specified
 				/// active state. If monitor is null, the scope is a no-op.
-				Scope( const MonitorPtr &monitor, bool active = true );
+				explicit Scope( const MonitorPtr &monitor, bool active = true );
 				/// Constructs a Scope where each of `monitors` has the
 				/// specified `active` state.
-				Scope( const MonitorSet &monitors, bool active = true );
+				explicit Scope( const MonitorSet &monitors, bool active = true );
 				/// Returns to the previously active set of monitors.
 				~Scope();
 

--- a/include/Gaffer/NameSwitch.h
+++ b/include/Gaffer/NameSwitch.h
@@ -50,7 +50,7 @@ class IECORE_EXPORT NameSwitch : public Switch
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::NameSwitch, NameSwitchTypeId, Switch );
 
-		NameSwitch( const std::string &name=GraphComponent::defaultName<NameSwitch>() );
+		explicit NameSwitch( const std::string &name=GraphComponent::defaultName<NameSwitch>() );
 		~NameSwitch() override;
 
 		void setup( const Plug *plug );

--- a/include/Gaffer/NameValuePlug.h
+++ b/include/Gaffer/NameValuePlug.h
@@ -111,7 +111,7 @@ class GAFFER_API NameValuePlug : public Gaffer::ValuePlug
 		// Bare constructor required for compatibility with old CompoundDataPlug::MemberPlug constructor.
 		// Deprecated, and dangerous, since if you don't manually construct child plugs in the expected order of
 		// "name", "value", and optionally "enabled" then you will get a crash.
-		NameValuePlug(
+		explicit NameValuePlug(
 			const std::string &name=defaultName<NameValuePlug>(),
 			Direction direction=In,
 			unsigned flags=Default

--- a/include/Gaffer/Node.h
+++ b/include/Gaffer/Node.h
@@ -68,7 +68,7 @@ class GAFFER_API Node : public GraphComponent
 
 	public :
 
-		Node( const std::string &name=defaultName<Node>() );
+		explicit Node( const std::string &name=defaultName<Node>() );
 		~Node() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Node, NodeTypeId, GraphComponent );

--- a/include/Gaffer/NumericPlug.h
+++ b/include/Gaffer/NumericPlug.h
@@ -54,7 +54,7 @@ class GAFFER_API NumericPlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( NumericPlug<T>, ValuePlug );
 
-		NumericPlug(
+		explicit NumericPlug(
 			const std::string &name = defaultName<NumericPlug>(),
 			Direction direction=In,
 			T defaultValue = T(),

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -77,9 +77,9 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 
 		using Names = std::vector<IECore::InternedString>;
 
-		Path( PathFilterPtr filter = nullptr );
-		Path( const std::string &path, PathFilterPtr filter = nullptr );
-		Path( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = nullptr );
+		explicit Path( PathFilterPtr filter = nullptr );
+		explicit Path( const std::string &path, PathFilterPtr filter = nullptr );
+		explicit Path( const Names &names, const IECore::InternedString &root = "/", PathFilterPtr filter = nullptr );
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::Path, PathTypeId, IECore::RunTimeTyped );
 

--- a/include/Gaffer/PathFilter.h
+++ b/include/Gaffer/PathFilter.h
@@ -59,7 +59,7 @@ class GAFFER_API PathFilter : public IECore::RunTimeTyped
 
 	public :
 
-		PathFilter( IECore::CompoundDataPtr userData = nullptr );
+		explicit PathFilter( IECore::CompoundDataPtr userData = nullptr );
 		~PathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::PathFilter, PathFilterTypeId, IECore::RunTimeTyped );

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -141,7 +141,7 @@ class GAFFER_API Plug : public GraphComponent
 			All = Dynamic | Serialisable | AcceptsInputs | Cacheable | AcceptsDependencyCycles
 		};
 
-		Plug( const std::string &name=defaultName<Plug>(), Direction direction=In, unsigned flags=Default );
+		explicit Plug( const std::string &name=defaultName<Plug>(), Direction direction=In, unsigned flags=Default );
 		~Plug() override;
 
 		template<typename T=Plug, Plug::Direction D=Plug::Invalid>

--- a/include/Gaffer/Preferences.h
+++ b/include/Gaffer/Preferences.h
@@ -47,7 +47,7 @@ class GAFFER_API Preferences : public Node
 
 	public :
 
-		Preferences( const std::string &name=defaultName<Preferences>() );
+		explicit Preferences( const std::string &name=defaultName<Preferences>() );
 		~Preferences() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Preferences, PreferencesTypeId, Node );

--- a/include/Gaffer/Random.h
+++ b/include/Gaffer/Random.h
@@ -50,7 +50,7 @@ class GAFFER_API Random : public ComputeNode
 
 	public :
 
-		Random( const std::string &name=defaultName<Random>() );
+		explicit Random( const std::string &name=defaultName<Random>() );
 		~Random() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Random, RandomTypeId, ComputeNode );

--- a/include/Gaffer/RandomChoice.h
+++ b/include/Gaffer/RandomChoice.h
@@ -49,7 +49,7 @@ class GAFFER_API RandomChoice : public ComputeNode
 
 	public :
 
-		RandomChoice( const std::string &name=defaultName<RandomChoice>() );
+		explicit RandomChoice( const std::string &name=defaultName<RandomChoice>() );
 		~RandomChoice() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::RandomChoice, RandomChoiceTypeId, ComputeNode );

--- a/include/Gaffer/Reference.h
+++ b/include/Gaffer/Reference.h
@@ -50,7 +50,7 @@ class GAFFER_API Reference : public SubGraph
 
 	public :
 
-		Reference( const std::string &name=defaultName<Reference>() );
+		explicit Reference( const std::string &name=defaultName<Reference>() );
 		~Reference() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Reference, ReferenceTypeId, SubGraph );

--- a/include/Gaffer/ScriptNode.h
+++ b/include/Gaffer/ScriptNode.h
@@ -79,7 +79,7 @@ class GAFFER_API ScriptNode : public Node
 
 	public :
 
-		ScriptNode( const std::string &name=defaultName<Node>() );
+		explicit ScriptNode( const std::string &name=defaultName<Node>() );
 		~ScriptNode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::ScriptNode, ScriptNodeTypeId, Node );

--- a/include/Gaffer/ShufflePlug.h
+++ b/include/Gaffer/ShufflePlug.h
@@ -55,7 +55,7 @@ class GAFFER_API ShufflePlug : public ValuePlug
 
 		ShufflePlug( const std::string &source, const std::string &destination, bool deleteSource=false, bool enabled=true, bool replaceDestination=true );
 		/// Primarily used for serialisation.
-		ShufflePlug( const std::string &name = defaultName<ShufflePlug>(), Direction direction=In, unsigned flags = Default );
+		explicit ShufflePlug( const std::string &name = defaultName<ShufflePlug>(), Direction direction=In, unsigned flags = Default );
 
 		StringPlug *sourcePlug();
 		const StringPlug *sourcePlug() const;

--- a/include/Gaffer/SplinePlug.h
+++ b/include/Gaffer/SplinePlug.h
@@ -126,7 +126,7 @@ class GAFFER_API SplinePlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( SplinePlug<T>, ValuePlug );
 
-		SplinePlug(
+		explicit SplinePlug(
 			const std::string &name = defaultName<SplinePlug>(),
 			Direction direction=In,
 			const T &defaultValue = T(),

--- a/include/Gaffer/Spreadsheet.h
+++ b/include/Gaffer/Spreadsheet.h
@@ -50,7 +50,7 @@ class GAFFER_API Spreadsheet : public ComputeNode
 
 	public :
 
-		Spreadsheet( const std::string &name=defaultName<Spreadsheet>() );
+		explicit Spreadsheet( const std::string &name=defaultName<Spreadsheet>() );
 		~Spreadsheet() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Spreadsheet, SpreadsheetTypeId, ComputeNode );

--- a/include/Gaffer/StandardSet.h
+++ b/include/Gaffer/StandardSet.h
@@ -82,7 +82,7 @@ class GAFFER_API StandardSet : public Gaffer::Set
 
 	public :
 
-		StandardSet( bool removeOrphans = false );
+		explicit StandardSet( bool removeOrphans = false );
 		~StandardSet() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Gaffer::StandardSet, StandardSetTypeId, Gaffer::Set );

--- a/include/Gaffer/StringPlug.h
+++ b/include/Gaffer/StringPlug.h
@@ -91,7 +91,7 @@ class GAFFER_API StringPlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::StringPlug, StringPlugTypeId, ValuePlug );
 
-		StringPlug(
+		explicit StringPlug(
 			const std::string &name = defaultName<StringPlug>(),
 			Direction direction=In,
 			const std::string &defaultValue = "",

--- a/include/Gaffer/SubGraph.h
+++ b/include/Gaffer/SubGraph.h
@@ -46,7 +46,7 @@ class GAFFER_API SubGraph : public DependencyNode
 
 	public :
 
-		SubGraph( const std::string &name=defaultName<SubGraph>() );
+		explicit SubGraph( const std::string &name=defaultName<SubGraph>() );
 		~SubGraph() override;
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::SubGraph, SubGraphTypeId, DependencyNode );

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -50,7 +50,7 @@ class IECORE_EXPORT Switch : public ComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::Switch, SwitchTypeId, ComputeNode );
 
-		Switch( const std::string &name=GraphComponent::defaultName<Switch>() );
+		explicit Switch( const std::string &name=GraphComponent::defaultName<Switch>() );
 		~Switch() override;
 
 		/// Sets up the switch to work with the specified plug type.

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -49,7 +49,7 @@ class IECORE_EXPORT TimeWarp : public ContextProcessor
 
 		GAFFER_NODE_DECLARE_TYPE( Gaffer::TimeWarp, TimeWarpTypeId, ContextProcessor );
 
-		TimeWarp( const std::string &name=GraphComponent::defaultName<TimeWarp>() );
+		explicit TimeWarp( const std::string &name=GraphComponent::defaultName<TimeWarp>() );
 		~TimeWarp() override;
 
 		FloatPlug *speedPlug();

--- a/include/Gaffer/Transform2DPlug.h
+++ b/include/Gaffer/Transform2DPlug.h
@@ -46,7 +46,7 @@ class GAFFER_API Transform2DPlug : public ValuePlug
 
 	public :
 
-		Transform2DPlug(
+		explicit Transform2DPlug(
 			const std::string &name = defaultName<Transform2DPlug>(),
 			Direction direction=In,
 			const Imath::V2f &defaultTranslate = Imath::V2f( 0 ),

--- a/include/Gaffer/TransformPlug.h
+++ b/include/Gaffer/TransformPlug.h
@@ -47,7 +47,7 @@ class GAFFER_API TransformPlug : public ValuePlug
 
 	public :
 
-		TransformPlug(
+		explicit TransformPlug(
 			const std::string &name = defaultName<TransformPlug>(),
 			Direction direction=In,
 			const Imath::V3f &defaultTranslate = Imath::V3f( 0 ),

--- a/include/Gaffer/TweakPlug.h
+++ b/include/Gaffer/TweakPlug.h
@@ -78,7 +78,7 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 		TweakPlug( const std::string &tweakName, Gaffer::ValuePlugPtr valuePlug, Mode mode = Replace, bool enabled = true );
 		TweakPlug( const std::string &tweakName, const IECore::Data *value, Mode mode = Replace, bool enabled = true );
 		/// Primarily used for serialisation.
-		TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name=defaultName<TweakPlug>(), Direction direction=In, unsigned flags=Default );
+		explicit TweakPlug( Gaffer::ValuePlugPtr valuePlug, const std::string &name=defaultName<TweakPlug>(), Direction direction=In, unsigned flags=Default );
 
 		Gaffer::StringPlug *namePlug();
 		const Gaffer::StringPlug *namePlug() const;

--- a/include/Gaffer/TypedObjectPlug.h
+++ b/include/Gaffer/TypedObjectPlug.h
@@ -68,7 +68,7 @@ class IECORE_EXPORT TypedObjectPlug : public ValuePlug
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( TypedObjectPlug<T>, ValuePlug );
 
 		/// A copy of defaultValue is taken - it must not be null.
-		TypedObjectPlug(
+		explicit TypedObjectPlug(
 			const std::string &name,
 			Direction direction = In,
 			ConstValuePtr defaultValue = new ValueType,

--- a/include/Gaffer/TypedPlug.h
+++ b/include/Gaffer/TypedPlug.h
@@ -54,7 +54,7 @@ class IECORE_EXPORT TypedPlug : public ValuePlug
 
 		GAFFER_PLUG_DECLARE_TEMPLATE_TYPE( TypedPlug<T>, ValuePlug );
 
-		TypedPlug(
+		explicit TypedPlug(
 			const std::string &name = defaultName<TypedPlug>(),
 			Direction direction=In,
 			const T &defaultValue = T(),

--- a/include/Gaffer/UndoScope.h
+++ b/include/Gaffer/UndoScope.h
@@ -71,7 +71,7 @@ class GAFFER_API UndoScope : DirtyPropagationScope
 		/// can be used by UI elements to compress a series of individual
 		/// editing events such as an interactively updated drag into
 		/// a single item on the undo stack.
-		UndoScope( ScriptNodePtr script, State state=Enabled, const std::string &mergeGroup=std::string() );
+		explicit UndoScope( ScriptNodePtr script, State state=Enabled, const std::string &mergeGroup=std::string() );
 		~UndoScope();
 
 	private :

--- a/include/Gaffer/VTuneMonitor.h
+++ b/include/Gaffer/VTuneMonitor.h
@@ -49,7 +49,7 @@ class GAFFER_API VTuneMonitor : public Monitor
 
 	public :
 
-		VTuneMonitor( bool monitorHashProcess = false );
+		explicit VTuneMonitor( bool monitorHashProcess = false );
 		~VTuneMonitor() override;
 
 		IE_CORE_DECLAREMEMBERPTR( VTuneMonitor )

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -57,7 +57,7 @@ class GAFFER_API ValuePlug : public Plug
 	public :
 
 		/// Constructs a ValuePlug which can be used as a parent for other ValuePlugs.
-		ValuePlug( const std::string &name=defaultName<ValuePlug>(), Direction direction=In, unsigned flags=Default );
+		explicit ValuePlug( const std::string &name=defaultName<ValuePlug>(), Direction direction=In, unsigned flags=Default );
 		~ValuePlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( Gaffer::ValuePlug, ValuePlugTypeId, Plug );

--- a/include/GafferArnold/ArnoldAOVShader.h
+++ b/include/GafferArnold/ArnoldAOVShader.h
@@ -51,7 +51,7 @@ class GAFFERARNOLD_API ArnoldAOVShader : public GafferScene::GlobalShader
 
 	public :
 
-		ArnoldAOVShader( const std::string &name=defaultName<ArnoldAOVShader>() );
+		explicit ArnoldAOVShader( const std::string &name=defaultName<ArnoldAOVShader>() );
 		~ArnoldAOVShader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldAOVShader, ArnoldAOVShaderTypeId, GafferScene::GlobalShader );

--- a/include/GafferArnold/ArnoldAtmosphere.h
+++ b/include/GafferArnold/ArnoldAtmosphere.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldAtmosphere : public GafferScene::GlobalShader
 
 	public :
 
-		ArnoldAtmosphere( const std::string &name=defaultName<ArnoldAtmosphere>() );
+		explicit ArnoldAtmosphere( const std::string &name=defaultName<ArnoldAtmosphere>() );
 		~ArnoldAtmosphere() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldAtmosphere, ArnoldAtmosphereTypeId, GafferScene::GlobalShader );

--- a/include/GafferArnold/ArnoldAttributes.h
+++ b/include/GafferArnold/ArnoldAttributes.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldAttributes : public GafferScene::Attributes
 
 	public :
 
-		ArnoldAttributes( const std::string &name=defaultName<ArnoldAttributes>() );
+		explicit ArnoldAttributes( const std::string &name=defaultName<ArnoldAttributes>() );
 		~ArnoldAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldAttributes, ArnoldAttributesTypeId, GafferScene::Attributes );

--- a/include/GafferArnold/ArnoldBackground.h
+++ b/include/GafferArnold/ArnoldBackground.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldBackground : public GafferScene::GlobalShader
 
 	public :
 
-		ArnoldBackground( const std::string &name=defaultName<ArnoldBackground>() );
+		explicit ArnoldBackground( const std::string &name=defaultName<ArnoldBackground>() );
 		~ArnoldBackground() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldBackground, ArnoldBackgroundTypeId, GafferScene::GlobalShader );

--- a/include/GafferArnold/ArnoldCameraShaders.h
+++ b/include/GafferArnold/ArnoldCameraShaders.h
@@ -53,7 +53,7 @@ class GAFFERARNOLD_API ArnoldCameraShaders : public GafferScene::Shader
 
 	public :
 
-		ArnoldCameraShaders( const std::string &name=defaultName<ArnoldCameraShaders>() );
+		explicit ArnoldCameraShaders( const std::string &name=defaultName<ArnoldCameraShaders>() );
 		~ArnoldCameraShaders() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldCameraShaders, ArnoldCameraShadersTypeId, GafferScene::Shader );

--- a/include/GafferArnold/ArnoldColorManager.h
+++ b/include/GafferArnold/ArnoldColorManager.h
@@ -54,7 +54,7 @@ class GAFFERARNOLD_API ArnoldColorManager : public GafferScene::GlobalsProcessor
 
 	public :
 
-		ArnoldColorManager( const std::string &name=defaultName<ArnoldColorManager>() );
+		explicit ArnoldColorManager( const std::string &name=defaultName<ArnoldColorManager>() );
 		~ArnoldColorManager() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldColorManager, ArnoldColorManagerTypeId, GafferScene::GlobalsProcessor );

--- a/include/GafferArnold/ArnoldDisplacement.h
+++ b/include/GafferArnold/ArnoldDisplacement.h
@@ -56,7 +56,7 @@ class GAFFERARNOLD_API ArnoldDisplacement : public GafferScene::Shader
 
 	public :
 
-		ArnoldDisplacement( const std::string &name=defaultName<ArnoldDisplacement>() );
+		explicit ArnoldDisplacement( const std::string &name=defaultName<ArnoldDisplacement>() );
 		~ArnoldDisplacement() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldDisplacement, ArnoldDisplacementTypeId, GafferScene::Shader );

--- a/include/GafferArnold/ArnoldImager.h
+++ b/include/GafferArnold/ArnoldImager.h
@@ -50,7 +50,7 @@ class GAFFERARNOLD_API ArnoldImager : public GafferScene::GlobalsProcessor
 
 	public :
 
-		ArnoldImager( const std::string &name=defaultName<ArnoldImager>() );
+		explicit ArnoldImager( const std::string &name=defaultName<ArnoldImager>() );
 		~ArnoldImager() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldImager, ArnoldImagerTypeId, GafferScene::GlobalsProcessor );

--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -54,7 +54,7 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldLight, ArnoldLightTypeId, GafferScene::Light );
 
-		ArnoldLight( const std::string &name=defaultName<ArnoldLight>() );
+		explicit ArnoldLight( const std::string &name=defaultName<ArnoldLight>() );
 		~ArnoldLight() override;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;

--- a/include/GafferArnold/ArnoldLightFilter.h
+++ b/include/GafferArnold/ArnoldLightFilter.h
@@ -53,7 +53,7 @@ class GAFFERARNOLD_API ArnoldLightFilter : public GafferScene::LightFilter
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldLightFilter, ArnoldLightFilterTypeId, GafferScene::LightFilter );
 
-		ArnoldLightFilter( const std::string &name=defaultName<ArnoldLightFilter>() );
+		explicit ArnoldLightFilter( const std::string &name=defaultName<ArnoldLightFilter>() );
 		~ArnoldLightFilter() override;
 
 };

--- a/include/GafferArnold/ArnoldMeshLight.h
+++ b/include/GafferArnold/ArnoldMeshLight.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldMeshLight : public GafferScene::FilteredSceneProces
 
 	public :
 
-		ArnoldMeshLight( const std::string &name=defaultName<ArnoldMeshLight>() );
+		explicit ArnoldMeshLight( const std::string &name=defaultName<ArnoldMeshLight>() );
 		~ArnoldMeshLight() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldMeshLight, ArnoldMeshLightTypeId, FilteredSceneProcessor );

--- a/include/GafferArnold/ArnoldOptions.h
+++ b/include/GafferArnold/ArnoldOptions.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldOptions : public GafferScene::Options
 
 	public :
 
-		ArnoldOptions( const std::string &name=defaultName<ArnoldOptions>() );
+		explicit ArnoldOptions( const std::string &name=defaultName<ArnoldOptions>() );
 		~ArnoldOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldOptions, ArnoldOptionsTypeId, GafferScene::Options );

--- a/include/GafferArnold/ArnoldRender.h
+++ b/include/GafferArnold/ArnoldRender.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API ArnoldRender : public GafferScene::Render
 
 	public :
 
-		ArnoldRender( const std::string &name=defaultName<ArnoldRender>() );
+		explicit ArnoldRender( const std::string &name=defaultName<ArnoldRender>() );
 		~ArnoldRender() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldRender, ArnoldRenderTypeId, GafferScene::Render );

--- a/include/GafferArnold/ArnoldShader.h
+++ b/include/GafferArnold/ArnoldShader.h
@@ -50,7 +50,7 @@ class GAFFERARNOLD_API ArnoldShader : public GafferScene::Shader
 
 	public :
 
-		ArnoldShader( const std::string &name=defaultName<ArnoldShader>() );
+		explicit ArnoldShader( const std::string &name=defaultName<ArnoldShader>() );
 		~ArnoldShader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldShader, ArnoldShaderTypeId, GafferScene::Shader );

--- a/include/GafferArnold/ArnoldVDB.h
+++ b/include/GafferArnold/ArnoldVDB.h
@@ -51,7 +51,7 @@ class GAFFERARNOLD_API ArnoldVDB : public GafferScene::ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::ArnoldVDB, ArnoldVDBTypeId, GafferScene::ObjectSource );
 
-		ArnoldVDB( const std::string &name=defaultName<ArnoldVDB>() );
+		explicit ArnoldVDB( const std::string &name=defaultName<ArnoldVDB>() );
 		~ArnoldVDB() override;
 
 		Gaffer::StringPlug *fileNamePlug();

--- a/include/GafferArnold/InteractiveArnoldRender.h
+++ b/include/GafferArnold/InteractiveArnoldRender.h
@@ -49,7 +49,7 @@ class GAFFERARNOLD_API InteractiveArnoldRender : public GafferScene::Interactive
 
 	public :
 
-		InteractiveArnoldRender( const std::string &name=defaultName<InteractiveArnoldRender>() );
+		explicit InteractiveArnoldRender( const std::string &name=defaultName<InteractiveArnoldRender>() );
 		~InteractiveArnoldRender() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferArnold::InteractiveArnoldRender, InteractiveArnoldRenderTypeId, GafferScene::InteractiveRender );

--- a/include/GafferCortex/CompoundParameterHandler.h
+++ b/include/GafferCortex/CompoundParameterHandler.h
@@ -51,7 +51,7 @@ class GAFFERCORTEX_API CompoundParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( CompoundParameterHandler );
 
-		CompoundParameterHandler( IECore::CompoundParameterPtr parameter );
+		explicit CompoundParameterHandler( IECore::CompoundParameterPtr parameter );
 		~CompoundParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCortex/DateTimeParameterHandler.h
+++ b/include/GafferCortex/DateTimeParameterHandler.h
@@ -57,7 +57,7 @@ class GAFFERCORTEX_API DateTimeParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( DateTimeParameterHandler );
 
-		DateTimeParameterHandler( IECore::DateTimeParameterPtr parameter );
+		explicit DateTimeParameterHandler( IECore::DateTimeParameterPtr parameter );
 		~DateTimeParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCortex/ExecutableOpHolder.h
+++ b/include/GafferCortex/ExecutableOpHolder.h
@@ -58,7 +58,7 @@ class GAFFERCORTEX_API ExecutableOpHolder : public ParameterisedHolderTaskNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferCortex::ExecutableOpHolder, ExecutableOpHolderTypeId, ParameterisedHolderTaskNode );
 
-		ExecutableOpHolder( const std::string &name=defaultName<ExecutableOpHolder>() );
+		explicit ExecutableOpHolder( const std::string &name=defaultName<ExecutableOpHolder>() );
 
 		void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false ) override;
 

--- a/include/GafferCortex/NumericParameterHandler.h
+++ b/include/GafferCortex/NumericParameterHandler.h
@@ -57,7 +57,7 @@ class GAFFERCORTEX_API NumericParameterHandler : public ParameterHandler
 		using ParameterType = IECore::NumericParameter<T>;
 		using PlugType = Gaffer::NumericPlug<T>;
 
-		NumericParameterHandler( typename ParameterType::Ptr parameter );
+		explicit NumericParameterHandler( typename ParameterType::Ptr parameter );
 		~NumericParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCortex/ObjectParameterHandler.h
+++ b/include/GafferCortex/ObjectParameterHandler.h
@@ -56,7 +56,7 @@ class GAFFERCORTEX_API ObjectParameterHandler : public ParameterHandler
 
 		IE_CORE_DECLAREMEMBERPTR( ObjectParameterHandler );
 
-		ObjectParameterHandler( IECore::ObjectParameter::Ptr parameter );
+		explicit ObjectParameterHandler( IECore::ObjectParameter::Ptr parameter );
 		~ObjectParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCortex/OpHolder.h
+++ b/include/GafferCortex/OpHolder.h
@@ -57,7 +57,7 @@ class GAFFERCORTEX_API OpHolder : public ParameterisedHolderComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferCortex::OpHolder, OpHolderTypeId, ParameterisedHolderComputeNode );
 
-		OpHolder( const std::string &name=defaultName<OpHolder>() );
+		explicit OpHolder( const std::string &name=defaultName<OpHolder>() );
 
 		void setParameterised( IECore::RunTimeTypedPtr parameterised, bool keepExistingValues=false ) override;
 

--- a/include/GafferCortex/ParameterisedHolder.h
+++ b/include/GafferCortex/ParameterisedHolder.h
@@ -66,7 +66,7 @@ class GAFFERCORTEX_API ParameterisedHolder : public BaseType
 		IECORE_RUNTIMETYPED_DECLARETEMPLATE( ParameterisedHolder<BaseType>, BaseType );
 		IE_CORE_DECLARERUNTIMETYPEDDESCRIPTION( ParameterisedHolder<BaseType> );
 
-		ParameterisedHolder( const std::string &name=Gaffer::GraphComponent::defaultName<ParameterisedHolder>() );
+		explicit ParameterisedHolder( const std::string &name=Gaffer::GraphComponent::defaultName<ParameterisedHolder>() );
 		~ParameterisedHolder() override;
 
 		/// May be overridden by derived classes, but they must call the base class implementation

--- a/include/GafferCortex/TypedParameterHandler.h
+++ b/include/GafferCortex/TypedParameterHandler.h
@@ -57,7 +57,7 @@ class GAFFERCORTEX_API TypedParameterHandler : public ParameterHandler
 		using ParameterType = IECore::TypedParameter<T>;
 		using PlugType = typename Gaffer::PlugType<T>::Type;
 
-		TypedParameterHandler( typename ParameterType::Ptr parameter );
+		explicit TypedParameterHandler( typename ParameterType::Ptr parameter );
 		~TypedParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCortex/VectorTypedParameterHandler.h
+++ b/include/GafferCortex/VectorTypedParameterHandler.h
@@ -55,7 +55,7 @@ class GAFFERCORTEX_API VectorTypedParameterHandler : public ParameterHandler
 		using DataType = typename ParameterType::ObjectType;
 		using PlugType = Gaffer::TypedObjectPlug<DataType>;
 
-		VectorTypedParameterHandler( typename ParameterType::Ptr parameter );
+		explicit VectorTypedParameterHandler( typename ParameterType::Ptr parameter );
 		~VectorTypedParameterHandler() override;
 
 		IECore::Parameter *parameter() override;

--- a/include/GafferCycles/CyclesAttributes.h
+++ b/include/GafferCycles/CyclesAttributes.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesAttributes : public GafferScene::Attributes
 
 	public :
 
-		CyclesAttributes( const std::string &name=defaultName<CyclesAttributes>() );
+		explicit CyclesAttributes( const std::string &name=defaultName<CyclesAttributes>() );
 		~CyclesAttributes() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesAttributes, CyclesAttributesTypeId, GafferScene::Attributes );

--- a/include/GafferCycles/CyclesBackground.h
+++ b/include/GafferCycles/CyclesBackground.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesBackground : public GafferScene::GlobalShader
 
 	public :
 
-		CyclesBackground( const std::string &name=defaultName<CyclesBackground>() );
+		explicit CyclesBackground( const std::string &name=defaultName<CyclesBackground>() );
 		~CyclesBackground() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesBackground, CyclesBackgroundTypeId, GafferScene::GlobalShader );

--- a/include/GafferCycles/CyclesLight.h
+++ b/include/GafferCycles/CyclesLight.h
@@ -53,7 +53,7 @@ class GAFFERCYCLES_API CyclesLight : public GafferScene::Light
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesLight, CyclesLightTypeId, GafferScene::Light );
 
-		CyclesLight( const std::string &name=defaultName<CyclesLight>() );
+		explicit CyclesLight( const std::string &name=defaultName<CyclesLight>() );
 		~CyclesLight() override;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;

--- a/include/GafferCycles/CyclesMeshLight.h
+++ b/include/GafferCycles/CyclesMeshLight.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesMeshLight : public GafferScene::FilteredSceneProces
 
 	public :
 
-		CyclesMeshLight( const std::string &name=defaultName<CyclesMeshLight>() );
+		explicit CyclesMeshLight( const std::string &name=defaultName<CyclesMeshLight>() );
 		~CyclesMeshLight() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferCycles::CyclesMeshLight, CyclesMeshLightTypeId, FilteredSceneProcessor );

--- a/include/GafferCycles/CyclesOptions.h
+++ b/include/GafferCycles/CyclesOptions.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesOptions : public GafferScene::Options
 
 	public :
 
-		CyclesOptions( const std::string &name=defaultName<CyclesOptions>() );
+		explicit CyclesOptions( const std::string &name=defaultName<CyclesOptions>() );
 		~CyclesOptions() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesOptions, CyclesOptionsTypeId, GafferScene::Options );

--- a/include/GafferCycles/CyclesRender.h
+++ b/include/GafferCycles/CyclesRender.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesRender : public GafferScene::Render
 
 	public :
 
-		CyclesRender( const std::string &name=defaultName<CyclesRender>() );
+		explicit CyclesRender( const std::string &name=defaultName<CyclesRender>() );
 		~CyclesRender() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesRender, CyclesRenderTypeId, GafferScene::Render );

--- a/include/GafferCycles/CyclesShader.h
+++ b/include/GafferCycles/CyclesShader.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API CyclesShader : public GafferScene::Shader
 
 	public :
 
-		CyclesShader( const std::string &name=defaultName<CyclesShader>() );
+		explicit CyclesShader( const std::string &name=defaultName<CyclesShader>() );
 		~CyclesShader() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::CyclesShader, CyclesShaderTypeId, GafferScene::Shader );

--- a/include/GafferCycles/InteractiveCyclesRender.h
+++ b/include/GafferCycles/InteractiveCyclesRender.h
@@ -49,7 +49,7 @@ class GAFFERCYCLES_API InteractiveCyclesRender : public GafferScene::Interactive
 
 	public :
 
-		InteractiveCyclesRender( const std::string &name=defaultName<InteractiveCyclesRender>() );
+		explicit InteractiveCyclesRender( const std::string &name=defaultName<InteractiveCyclesRender>() );
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferCycles::InteractiveCyclesRender, InteractiveCyclesRenderTypeId, GafferScene::InteractiveRender );
 

--- a/include/GafferDelight/DelightAttributes.h
+++ b/include/GafferDelight/DelightAttributes.h
@@ -49,7 +49,7 @@ class GAFFERDELIGHT_API DelightAttributes : public GafferScene::Attributes
 
 	public :
 
-		DelightAttributes( const std::string &name=defaultName<DelightAttributes>() );
+		explicit DelightAttributes( const std::string &name=defaultName<DelightAttributes>() );
 		~DelightAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDelight::DelightAttributes, DelightAttributesTypeId, GafferScene::Attributes );

--- a/include/GafferDelight/DelightOptions.h
+++ b/include/GafferDelight/DelightOptions.h
@@ -49,7 +49,7 @@ class GAFFERDELIGHT_API DelightOptions : public GafferScene::Options
 
 	public :
 
-		DelightOptions( const std::string &name=defaultName<DelightOptions>() );
+		explicit DelightOptions( const std::string &name=defaultName<DelightOptions>() );
 		~DelightOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDelight::DelightOptions, DelightOptionsTypeId, GafferScene::Options );

--- a/include/GafferDelight/DelightRender.h
+++ b/include/GafferDelight/DelightRender.h
@@ -49,7 +49,7 @@ class GAFFERDELIGHT_API DelightRender : public GafferScene::Render
 
 	public :
 
-		DelightRender( const std::string &name=defaultName<DelightRender>() );
+		explicit DelightRender( const std::string &name=defaultName<DelightRender>() );
 		~DelightRender() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDelight::DelightRender, DelightRenderTypeId, GafferScene::Render );

--- a/include/GafferDelight/InteractiveDelightRender.h
+++ b/include/GafferDelight/InteractiveDelightRender.h
@@ -49,7 +49,7 @@ class GAFFERDELIGHT_API InteractiveDelightRender : public GafferScene::Interacti
 
 	public :
 
-		InteractiveDelightRender( const std::string &name=defaultName<InteractiveDelightRender>() );
+		explicit InteractiveDelightRender( const std::string &name=defaultName<InteractiveDelightRender>() );
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDelight::InteractiveDelightRender, InteractiveDelightRenderTypeId, GafferScene::InteractiveRender );
 

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -100,7 +100,7 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 {
 	public :
 
-		Dispatcher( const std::string &name=defaultName<Dispatcher>() );
+		explicit Dispatcher( const std::string &name=defaultName<Dispatcher>() );
 		~Dispatcher() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDispatch::Dispatcher, DispatcherTypeId, Gaffer::Node );

--- a/include/GafferDispatch/TaskNode.h
+++ b/include/GafferDispatch/TaskNode.h
@@ -117,7 +117,7 @@ class GAFFERDISPATCH_API TaskNode : public Gaffer::DependencyNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferDispatch::TaskNode, TaskNodeTypeId, Gaffer::DependencyNode );
 
-		TaskNode( const std::string &name=defaultName<TaskNode>() );
+		explicit TaskNode( const std::string &name=defaultName<TaskNode>() );
 		~TaskNode() override;
 
 		/// Plug type used to represent tasks within the

--- a/include/GafferImage/Blur.h
+++ b/include/GafferImage/Blur.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API Blur : public FlatImageProcessor
 {
 	public :
 
-		Blur( const std::string &name=defaultName<Blur>() );
+		explicit Blur( const std::string &name=defaultName<Blur>() );
 		~Blur() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Blur, BlurTypeId, FlatImageProcessor );

--- a/include/GafferImage/CDL.h
+++ b/include/GafferImage/CDL.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API CDL : public OpenColorIOTransform
 
 	public :
 
-		CDL( const std::string &name=defaultName<CDL>() );
+		explicit CDL( const std::string &name=defaultName<CDL>() );
 		~CDL() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CDL, CDLTypeId, OpenColorIOTransform );

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -65,7 +65,7 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Catalogue, CatalogueTypeId, ImageNode );
 
-		Catalogue( const std::string &name = defaultName<Catalogue>() );
+		explicit Catalogue( const std::string &name = defaultName<Catalogue>() );
 		~Catalogue() override;
 
 		/// Plug type used to represent an image in the catalogue.

--- a/include/GafferImage/ChannelDataProcessor.h
+++ b/include/GafferImage/ChannelDataProcessor.h
@@ -51,7 +51,7 @@ class GAFFERIMAGE_API ChannelDataProcessor : public ImageProcessor
 
 	public :
 
-		ChannelDataProcessor( const std::string &name=defaultName<ChannelDataProcessor>(), bool premultiplyPlug = false );
+		explicit ChannelDataProcessor( const std::string &name=defaultName<ChannelDataProcessor>(), bool premultiplyPlug = false );
 		~ChannelDataProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ChannelDataProcessor, ChannelDataProcessorTypeId, ImageProcessor );

--- a/include/GafferImage/Checkerboard.h
+++ b/include/GafferImage/Checkerboard.h
@@ -58,7 +58,7 @@ class GAFFERIMAGE_API Checkerboard : public FlatImageSource
 
 	public :
 
-		Checkerboard( const std::string &name=defaultName<Checkerboard>() );
+		explicit Checkerboard( const std::string &name=defaultName<Checkerboard>() );
 		~Checkerboard() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Checkerboard, CheckerboardTypeId, FlatImageSource );

--- a/include/GafferImage/Clamp.h
+++ b/include/GafferImage/Clamp.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API Clamp : public ChannelDataProcessor
 
 	public :
 
-		Clamp( const std::string &name=defaultName<Clamp>() );
+		explicit Clamp( const std::string &name=defaultName<Clamp>() );
 		~Clamp() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Clamp, ClampTypeId, ChannelDataProcessor );

--- a/include/GafferImage/CollectImages.h
+++ b/include/GafferImage/CollectImages.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API CollectImages : public ImageProcessor
 
 	public :
 
-		CollectImages( const std::string &name=defaultName<CollectImages>() );
+		explicit CollectImages( const std::string &name=defaultName<CollectImages>() );
 		~CollectImages() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CollectImages, CollectImagesTypeId, ImageProcessor );

--- a/include/GafferImage/ColorProcessor.h
+++ b/include/GafferImage/ColorProcessor.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API ColorProcessor : public ImageProcessor
 
 	public :
 
-		ColorProcessor( const std::string &name=defaultName<ColorProcessor>() );
+		explicit ColorProcessor( const std::string &name=defaultName<ColorProcessor>() );
 		~ColorProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ColorProcessor, ColorProcessorTypeId, ImageProcessor );

--- a/include/GafferImage/ColorSpace.h
+++ b/include/GafferImage/ColorSpace.h
@@ -54,7 +54,7 @@ class GAFFERIMAGE_API ColorSpace : public OpenColorIOTransform
 
 	public :
 
-		ColorSpace( const std::string &name=defaultName<ColorSpace>() );
+		explicit ColorSpace( const std::string &name=defaultName<ColorSpace>() );
 		~ColorSpace() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ColorSpace, ColorSpaceTypeId, OpenColorIOTransform );

--- a/include/GafferImage/Constant.h
+++ b/include/GafferImage/Constant.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API Constant : public FlatImageSource
 
 	public :
 
-		Constant( const std::string &name=defaultName<Constant>() );
+		explicit Constant( const std::string &name=defaultName<Constant>() );
 		~Constant() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Constant, ConstantTypeId, FlatImageSource );

--- a/include/GafferImage/CopyChannels.h
+++ b/include/GafferImage/CopyChannels.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API CopyChannels : public FlatImageProcessor
 
 	public :
 
-		CopyChannels( const std::string &name=defaultName<CopyChannels>() );
+		explicit CopyChannels( const std::string &name=defaultName<CopyChannels>() );
 		~CopyChannels() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CopyChannels, CopyChannelsTypeId, FlatImageProcessor );

--- a/include/GafferImage/CopyImageMetadata.h
+++ b/include/GafferImage/CopyImageMetadata.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API CopyImageMetadata : public MetadataProcessor
 
 	public :
 
-		CopyImageMetadata( const std::string &name=defaultName<CopyImageMetadata>() );
+		explicit CopyImageMetadata( const std::string &name=defaultName<CopyImageMetadata>() );
 		~CopyImageMetadata() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CopyImageMetadata, CopyImageMetadataTypeId, MetadataProcessor );

--- a/include/GafferImage/CopyViews.h
+++ b/include/GafferImage/CopyViews.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API CopyViews : public ImageProcessor
 
 	public :
 
-		CopyViews( const std::string &name=defaultName<CopyViews>() );
+		explicit CopyViews( const std::string &name=defaultName<CopyViews>() );
 		~CopyViews() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CopyViews, CopyViewsTypeId, ImageProcessor );

--- a/include/GafferImage/CreateViews.h
+++ b/include/GafferImage/CreateViews.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API CreateViews : public ImageNode
 
 	public :
 
-		CreateViews( const std::string &name=defaultName<CreateViews>() );
+		explicit CreateViews( const std::string &name=defaultName<CreateViews>() );
 		~CreateViews() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::CreateViews, CreateViewsTypeId, ImageNode );

--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API Crop : public ImageProcessor
 {
 	public :
 
-		Crop( const std::string &name=defaultName<Crop>() );
+		explicit Crop( const std::string &name=defaultName<Crop>() );
 		~Crop() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Crop, CropTypeId, ImageProcessor );

--- a/include/GafferImage/DeepHoldout.h
+++ b/include/GafferImage/DeepHoldout.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API DeepHoldout : public ImageProcessor
 
 	public :
 
-		DeepHoldout( const std::string &name=defaultName<DeepHoldout>() );
+		explicit DeepHoldout( const std::string &name=defaultName<DeepHoldout>() );
 		~DeepHoldout() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepHoldout, DeepHoldoutTypeId, ImageProcessor );

--- a/include/GafferImage/DeepMerge.h
+++ b/include/GafferImage/DeepMerge.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API DeepMerge : public ImageProcessor
 
 	public :
 
-		DeepMerge( const std::string &name=defaultName<DeepMerge>() );
+		explicit DeepMerge( const std::string &name=defaultName<DeepMerge>() );
 		~DeepMerge() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepMerge, DeepMergeTypeId, ImageProcessor );

--- a/include/GafferImage/DeepRecolor.h
+++ b/include/GafferImage/DeepRecolor.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API DeepRecolor : public ImageProcessor
 
 	public :
 
-		DeepRecolor( const std::string &name=defaultName<DeepRecolor>() );
+		explicit DeepRecolor( const std::string &name=defaultName<DeepRecolor>() );
 		~DeepRecolor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepRecolor, DeepRecolorTypeId, ImageProcessor );

--- a/include/GafferImage/DeepSampleCounts.h
+++ b/include/GafferImage/DeepSampleCounts.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API DeepSampleCounts : public ImageProcessor
 
 	public :
 
-		DeepSampleCounts( const std::string &name=defaultName<DeepSampleCounts>() );
+		explicit DeepSampleCounts( const std::string &name=defaultName<DeepSampleCounts>() );
 		~DeepSampleCounts() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepSampleCounts, DeepSampleCountsTypeId, ImageProcessor );

--- a/include/GafferImage/DeepSampler.h
+++ b/include/GafferImage/DeepSampler.h
@@ -52,7 +52,7 @@ class GAFFERIMAGE_API DeepSampler : public Gaffer::ComputeNode
 
 	public :
 
-		DeepSampler( const std::string &name=defaultName<DeepSampler>() );
+		explicit DeepSampler( const std::string &name=defaultName<DeepSampler>() );
 		~DeepSampler() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepSampler, DeepSamplerTypeId, ComputeNode );

--- a/include/GafferImage/DeepState.h
+++ b/include/GafferImage/DeepState.h
@@ -56,7 +56,7 @@ class GAFFERIMAGE_API DeepState : public ImageProcessor
 		};
 
 
-		DeepState( const std::string &name=defaultName<DeepState>() );
+		explicit DeepState( const std::string &name=defaultName<DeepState>() );
 		~DeepState() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepState, DeepStateTypeId, ImageProcessor );

--- a/include/GafferImage/DeepToFlat.h
+++ b/include/GafferImage/DeepToFlat.h
@@ -56,7 +56,7 @@ class GAFFERIMAGE_API DeepToFlat : public ImageProcessor
 			None
 		};
 
-		DeepToFlat( const std::string &name=defaultName<DeepToFlat>() );
+		explicit DeepToFlat( const std::string &name=defaultName<DeepToFlat>() );
 		~DeepToFlat() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeepToFlat, DeepToFlatTypeId, ImageProcessor );

--- a/include/GafferImage/DeleteChannels.h
+++ b/include/GafferImage/DeleteChannels.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API DeleteChannels : public ImageProcessor
 			Keep = 1
 		};
 
-		DeleteChannels( const std::string &name=defaultName<DeleteChannels>() );
+		explicit DeleteChannels( const std::string &name=defaultName<DeleteChannels>() );
 		~DeleteChannels() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeleteChannels, DeleteChannelsTypeId, ImageProcessor );

--- a/include/GafferImage/DeleteImageMetadata.h
+++ b/include/GafferImage/DeleteImageMetadata.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API DeleteImageMetadata : public MetadataProcessor
 
 	public :
 
-		DeleteImageMetadata( const std::string &name=defaultName<DeleteImageMetadata>() );
+		explicit DeleteImageMetadata( const std::string &name=defaultName<DeleteImageMetadata>() );
 		~DeleteImageMetadata() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeleteImageMetadata, DeleteImageMetadataTypeId, MetadataProcessor );

--- a/include/GafferImage/DeleteViews.h
+++ b/include/GafferImage/DeleteViews.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API DeleteViews : public ImageProcessor
 			Keep = 1
 		};
 
-		DeleteViews( const std::string &name=defaultName<DeleteViews>() );
+		explicit DeleteViews( const std::string &name=defaultName<DeleteViews>() );
 		~DeleteViews() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DeleteViews, DeleteViewsTypeId, ImageProcessor );

--- a/include/GafferImage/Dilate.h
+++ b/include/GafferImage/Dilate.h
@@ -46,7 +46,7 @@ class GAFFERIMAGE_API Dilate : public RankFilter
 
 	public :
 
-		Dilate( const std::string &name=defaultName<Dilate>() );
+		explicit Dilate( const std::string &name=defaultName<Dilate>() );
 		~Dilate() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Dilate, DilateTypeId, RankFilter );

--- a/include/GafferImage/Display.h
+++ b/include/GafferImage/Display.h
@@ -57,7 +57,7 @@ class GAFFERIMAGE_API Display : public ImageNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Display, DisplayTypeId, ImageNode );
 
-		Display( const std::string &name = defaultName<Display>() );
+		explicit Display( const std::string &name = defaultName<Display>() );
 		~Display() override;
 
 		/// Sets the driver used to provide the

--- a/include/GafferImage/DisplayTransform.h
+++ b/include/GafferImage/DisplayTransform.h
@@ -53,7 +53,7 @@ class GAFFERIMAGE_API DisplayTransform : public OpenColorIOTransform
 
 	public :
 
-		DisplayTransform( const std::string &name=defaultName<DisplayTransform>() );
+		explicit DisplayTransform( const std::string &name=defaultName<DisplayTransform>() );
 		~DisplayTransform() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::DisplayTransform, DisplayTransformTypeId, OpenColorIOTransform );

--- a/include/GafferImage/Empty.h
+++ b/include/GafferImage/Empty.h
@@ -47,7 +47,7 @@ class GAFFERIMAGE_API Empty : public ImageNode
 
 	public :
 
-		Empty( const std::string &name=defaultName<Empty>() );
+		explicit Empty( const std::string &name=defaultName<Empty>() );
 		~Empty() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Empty, EmptyTypeId, ImageNode );

--- a/include/GafferImage/Erode.h
+++ b/include/GafferImage/Erode.h
@@ -46,7 +46,7 @@ class GAFFERIMAGE_API Erode : public RankFilter
 
 	public :
 
-		Erode( const std::string &name=defaultName<Erode>() );
+		explicit Erode( const std::string &name=defaultName<Erode>() );
 		~Erode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Erode, ErodeTypeId, RankFilter );

--- a/include/GafferImage/FlatImageProcessor.h
+++ b/include/GafferImage/FlatImageProcessor.h
@@ -52,7 +52,7 @@ class GAFFERIMAGE_API FlatImageProcessor : public ImageProcessor
 
 		/// Constructs with a single input ImagePlug named "in". Use inPlug()
 		/// to access this plug.
-		FlatImageProcessor( const std::string &name=defaultName<FlatImageProcessor>() );
+		explicit FlatImageProcessor( const std::string &name=defaultName<FlatImageProcessor>() );
 
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use

--- a/include/GafferImage/FlatImageSource.h
+++ b/include/GafferImage/FlatImageSource.h
@@ -50,7 +50,7 @@ class GAFFERIMAGE_API FlatImageSource : public ImageNode
 
 	public :
 
-		FlatImageSource( const std::string &name=defaultName<FlatImageSource>() );
+		explicit FlatImageSource( const std::string &name=defaultName<FlatImageSource>() );
 
 		~FlatImageSource() override;
 

--- a/include/GafferImage/FlatToDeep.h
+++ b/include/GafferImage/FlatToDeep.h
@@ -62,7 +62,7 @@ class GAFFERIMAGE_API FlatToDeep : public ImageProcessor
 			Channel,
 		};
 
-		FlatToDeep( const std::string &name=defaultName<FlatToDeep>() );
+		explicit FlatToDeep( const std::string &name=defaultName<FlatToDeep>() );
 		~FlatToDeep() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::FlatToDeep, FlatToDeepTypeId, ImageProcessor );

--- a/include/GafferImage/FormatPlug.h
+++ b/include/GafferImage/FormatPlug.h
@@ -64,7 +64,7 @@ class GAFFERIMAGE_API FormatPlug : public Gaffer::ValuePlug
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferImage::FormatPlug, FormatPlugTypeId, Gaffer::ValuePlug );
 
-		FormatPlug(
+		explicit FormatPlug(
 			const std::string &name = defaultName<FormatPlug>(),
 			Direction direction=In,
 			Format defaultValue = Format(),

--- a/include/GafferImage/FormatQuery.h
+++ b/include/GafferImage/FormatQuery.h
@@ -51,7 +51,7 @@ namespace GafferImage
 struct GAFFERIMAGE_API FormatQuery : Gaffer::ComputeNode
 {
 
-	FormatQuery( std::string const& name = defaultName< FormatQuery >() );
+	explicit FormatQuery( std::string const& name = defaultName< FormatQuery >() );
 	~FormatQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferImage::FormatQuery, FormatQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferImage/Grade.h
+++ b/include/GafferImage/Grade.h
@@ -54,7 +54,7 @@ class GAFFERIMAGE_API Grade : public ChannelDataProcessor
 
 	public :
 
-		Grade( const std::string &name=defaultName<Grade>() );
+		explicit Grade( const std::string &name=defaultName<Grade>() );
 		~Grade() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Grade, GradeTypeId, ChannelDataProcessor );

--- a/include/GafferImage/ImageMetadata.h
+++ b/include/GafferImage/ImageMetadata.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API ImageMetadata : public MetadataProcessor
 
 	public :
 
-		ImageMetadata( const std::string &name=defaultName<ImageMetadata>() );
+		explicit ImageMetadata( const std::string &name=defaultName<ImageMetadata>() );
 		~ImageMetadata() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageMetadata, ImageMetadataTypeId, MetadataProcessor );

--- a/include/GafferImage/ImageNode.h
+++ b/include/GafferImage/ImageNode.h
@@ -52,7 +52,7 @@ class GAFFERIMAGE_API ImageNode : public Gaffer::ComputeNode
 
 	public :
 
-		ImageNode( const std::string &name=defaultName<ImageNode>() );
+		explicit ImageNode( const std::string &name=defaultName<ImageNode>() );
 		~ImageNode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageNode, ImageNodeTypeId, Gaffer::ComputeNode );

--- a/include/GafferImage/ImagePlug.h
+++ b/include/GafferImage/ImagePlug.h
@@ -82,7 +82,7 @@ class GAFFERIMAGE_API ImagePlug : public Gaffer::ValuePlug
 
 	public :
 
-		ImagePlug( const std::string &name=defaultName<ImagePlug>(), Direction direction=In, unsigned flags=Default );
+		explicit ImagePlug( const std::string &name=defaultName<ImagePlug>(), Direction direction=In, unsigned flags=Default );
 		~ImagePlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferImage::ImagePlug, ImagePlugTypeId, ValuePlug );

--- a/include/GafferImage/ImageProcessor.h
+++ b/include/GafferImage/ImageProcessor.h
@@ -60,7 +60,7 @@ class GAFFERIMAGE_API ImageProcessor : public ImageNode
 
 		/// Constructs with a single input ImagePlug named "in". Use inPlug()
 		/// to access this plug.
-		ImageProcessor( const std::string &name=defaultName<ImageProcessor>() );
+		explicit ImageProcessor( const std::string &name=defaultName<ImageProcessor>() );
 
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -60,7 +60,7 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 
 	public :
 
-		ImageReader( const std::string &name=defaultName<ImageReader>() );
+		explicit ImageReader( const std::string &name=defaultName<ImageReader>() );
 		~ImageReader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageReader, ImageReaderTypeId, ImageNode );

--- a/include/GafferImage/ImageSampler.h
+++ b/include/GafferImage/ImageSampler.h
@@ -56,7 +56,7 @@ class GAFFERIMAGE_API ImageSampler : public Gaffer::ComputeNode
 
 	public :
 
-		ImageSampler( const std::string &name=defaultName<ImageSampler>() );
+		explicit ImageSampler( const std::string &name=defaultName<ImageSampler>() );
 		~ImageSampler() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageSampler, ImageSamplerTypeId, ComputeNode );

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -54,7 +54,7 @@ class GAFFERIMAGE_API ImageStats : public Gaffer::ComputeNode
 
 	public :
 
-		ImageStats( const std::string &name=defaultName<ImageStats>() );
+		explicit ImageStats( const std::string &name=defaultName<ImageStats>() );
 		~ImageStats() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageStats, ImageStatsTypeId, Gaffer::ComputeNode );

--- a/include/GafferImage/ImageTransform.h
+++ b/include/GafferImage/ImageTransform.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API ImageTransform : public FlatImageProcessor
 {
 	public :
 
-		ImageTransform( const std::string &name=defaultName<ImageTransform>() );
+		explicit ImageTransform( const std::string &name=defaultName<ImageTransform>() );
 		~ImageTransform() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageTransform, ImageTransformTypeId, FlatImageProcessor );

--- a/include/GafferImage/ImageWriter.h
+++ b/include/GafferImage/ImageWriter.h
@@ -69,7 +69,7 @@ class GAFFERIMAGE_API ImageWriter : public GafferDispatch::TaskNode
 			Tile = 1
 		};
 
-		ImageWriter( const std::string &name=defaultName<ImageWriter>() );
+		explicit ImageWriter( const std::string &name=defaultName<ImageWriter>() );
 		~ImageWriter() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageWriter, ImageWriterTypeId, TaskNode );

--- a/include/GafferImage/LUT.h
+++ b/include/GafferImage/LUT.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API LUT : public OpenColorIOTransform
 
 	public :
 
-		LUT( const std::string &name=defaultName<LUT>() );
+		explicit LUT( const std::string &name=defaultName<LUT>() );
 		~LUT() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::LUT, LUTTypeId, OpenColorIOTransform );

--- a/include/GafferImage/LookTransform.h
+++ b/include/GafferImage/LookTransform.h
@@ -46,7 +46,7 @@ class GAFFERIMAGE_API LookTransform : public OpenColorIOTransform
 
 	public :
 
-		LookTransform( const std::string &name=defaultName<LookTransform>() );
+		explicit LookTransform( const std::string &name=defaultName<LookTransform>() );
 		~LookTransform() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::LookTransform, LookTransformTypeId, OpenColorIOTransform );

--- a/include/GafferImage/Median.h
+++ b/include/GafferImage/Median.h
@@ -46,7 +46,7 @@ class GAFFERIMAGE_API Median : public RankFilter
 
 	public :
 
-		Median( const std::string &name=defaultName<Median>() );
+		explicit Median( const std::string &name=defaultName<Median>() );
 		~Median() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Median, MedianTypeId, RankFilter );

--- a/include/GafferImage/Merge.h
+++ b/include/GafferImage/Merge.h
@@ -60,7 +60,7 @@ class GAFFERIMAGE_API Merge : public FlatImageProcessor
 
 	public :
 
-		Merge( const std::string &name=defaultName<Merge>() );
+		explicit Merge( const std::string &name=defaultName<Merge>() );
 		~Merge() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Merge, MergeTypeId, FlatImageProcessor );

--- a/include/GafferImage/MetadataProcessor.h
+++ b/include/GafferImage/MetadataProcessor.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API MetadataProcessor : public ImageProcessor
 
 	public :
 
-		MetadataProcessor( const std::string &name=defaultName<MetadataProcessor>() );
+		explicit MetadataProcessor( const std::string &name=defaultName<MetadataProcessor>() );
 		~MetadataProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::MetadataProcessor, MetadataProcessorTypeId, ImageProcessor );

--- a/include/GafferImage/Mirror.h
+++ b/include/GafferImage/Mirror.h
@@ -48,7 +48,7 @@ class GAFFERIMAGE_API Mirror : public FlatImageProcessor
 
 	public :
 
-		Mirror( const std::string &name=defaultName<Mirror>() );
+		explicit Mirror( const std::string &name=defaultName<Mirror>() );
 		~Mirror() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Mirror, MirrorTypeId, FlatImageProcessor );

--- a/include/GafferImage/Mix.h
+++ b/include/GafferImage/Mix.h
@@ -53,7 +53,7 @@ class GAFFERIMAGE_API Mix : public ImageProcessor
 
 	public :
 
-		Mix( const std::string &name=defaultName<Mix>() );
+		explicit Mix( const std::string &name=defaultName<Mix>() );
 		~Mix() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Mix, MixTypeId, ImageProcessor );

--- a/include/GafferImage/Offset.h
+++ b/include/GafferImage/Offset.h
@@ -47,7 +47,7 @@ class GAFFERIMAGE_API Offset : public ImageProcessor
 {
 	public :
 
-		Offset( const std::string &name=defaultName<Offset>() );
+		explicit Offset( const std::string &name=defaultName<Offset>() );
 		~Offset() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Offset, OffsetTypeId, ImageProcessor );

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -78,7 +78,7 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 
 	protected :
 
-		OpenColorIOTransform( const std::string &name=defaultName<OpenColorIOTransform>(), bool withContextPlug=false );
+		explicit OpenColorIOTransform( const std::string &name=defaultName<OpenColorIOTransform>(), bool withContextPlug=false );
 		/// Implemented to return true if hashTransform() has
 		/// an affect. Derived classed should implement
 		/// hashTransform() to return a default hash if the

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -56,7 +56,7 @@ class GAFFERIMAGE_API OpenImageIOReader : public ImageNode
 
 	public :
 
-		OpenImageIOReader( const std::string &name=defaultName<OpenImageIOReader>() );
+		explicit OpenImageIOReader( const std::string &name=defaultName<OpenImageIOReader>() );
 		~OpenImageIOReader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::OpenImageIOReader, OpenImageIOReaderTypeId, ImageNode );

--- a/include/GafferImage/Premultiply.h
+++ b/include/GafferImage/Premultiply.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API Premultiply : public ChannelDataProcessor
 
 	public :
 
-		Premultiply( const std::string &name=defaultName<Premultiply>() );
+		explicit Premultiply( const std::string &name=defaultName<Premultiply>() );
 		~Premultiply() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Premultiply, PremultiplyTypeId, ChannelDataProcessor );

--- a/include/GafferImage/Ramp.h
+++ b/include/GafferImage/Ramp.h
@@ -58,7 +58,7 @@ class GAFFERIMAGE_API Ramp : public FlatImageSource
 
 	public :
 
-		Ramp( const std::string &name=defaultName<Ramp>() );
+		explicit Ramp( const std::string &name=defaultName<Ramp>() );
 		~Ramp() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Ramp, RampTypeId, FlatImageSource );

--- a/include/GafferImage/RankFilter.h
+++ b/include/GafferImage/RankFilter.h
@@ -77,7 +77,7 @@ class GAFFERIMAGE_API RankFilter : public FlatImageProcessor
 			DilateRank
 		};
 
-		RankFilter( const std::string &name=defaultName<RankFilter>(), Mode mode=MedianRank );
+		explicit RankFilter( const std::string &name=defaultName<RankFilter>(), Mode mode=MedianRank );
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;

--- a/include/GafferImage/Rectangle.h
+++ b/include/GafferImage/Rectangle.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API Rectangle : public Shape
 
 	public :
 
-		Rectangle( const std::string &name=defaultName<Rectangle>() );
+		explicit Rectangle( const std::string &name=defaultName<Rectangle>() );
 		~Rectangle() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Rectangle, RectangleTypeId, Shape );

--- a/include/GafferImage/Resample.h
+++ b/include/GafferImage/Resample.h
@@ -60,7 +60,7 @@ class GAFFERIMAGE_API Resample : public FlatImageProcessor
 {
 	public :
 
-		Resample( const std::string &name=defaultName<Resample>() );
+		explicit Resample( const std::string &name=defaultName<Resample>() );
 		~Resample() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Resample, ResampleTypeId, FlatImageProcessor );

--- a/include/GafferImage/Resize.h
+++ b/include/GafferImage/Resize.h
@@ -57,7 +57,7 @@ class GAFFERIMAGE_API Resize : public FlatImageProcessor
 {
 	public :
 
-		Resize( const std::string &name=defaultName<Resize>() );
+		explicit Resize( const std::string &name=defaultName<Resize>() );
 		~Resize() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Resize, ResizeTypeId, FlatImageProcessor );

--- a/include/GafferImage/Saturation.h
+++ b/include/GafferImage/Saturation.h
@@ -47,7 +47,7 @@ class GAFFERIMAGE_API Saturation : public ColorProcessor
 
 	public :
 
-		Saturation( const std::string &name=defaultName<Saturation>() );
+		explicit Saturation( const std::string &name=defaultName<Saturation>() );
 		~Saturation() override;
 
 		Gaffer::FloatPlug *saturationPlug();

--- a/include/GafferImage/SelectView.h
+++ b/include/GafferImage/SelectView.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API SelectView : public ImageProcessor
 
 	public :
 
-		SelectView( const std::string &name=defaultName<SelectView>() );
+		explicit SelectView( const std::string &name=defaultName<SelectView>() );
 		~SelectView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::SelectView, SelectViewTypeId, ImageProcessor );

--- a/include/GafferImage/Shape.h
+++ b/include/GafferImage/Shape.h
@@ -55,7 +55,7 @@ class GAFFERIMAGE_API Shape : public FlatImageProcessor
 
 	public :
 
-		Shape( const std::string &name=defaultName<Shape>() );
+		explicit Shape( const std::string &name=defaultName<Shape>() );
 		~Shape() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Shape, ShapeTypeId, FlatImageProcessor );

--- a/include/GafferImage/Shuffle.h
+++ b/include/GafferImage/Shuffle.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API Shuffle : public ImageProcessor
 
 	public :
 
-		Shuffle( const std::string &name=defaultName<Shuffle>() );
+		explicit Shuffle( const std::string &name=defaultName<Shuffle>() );
 		~Shuffle() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Shuffle, ShuffleTypeId, ImageProcessor );

--- a/include/GafferImage/Text.h
+++ b/include/GafferImage/Text.h
@@ -56,7 +56,7 @@ class GAFFERIMAGE_API Text : public Shape
 
 	public :
 
-		Text( const std::string &name=defaultName<Text>() );
+		explicit Text( const std::string &name=defaultName<Text>() );
 		~Text() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Text, TextTypeId, Shape );

--- a/include/GafferImage/Unpremultiply.h
+++ b/include/GafferImage/Unpremultiply.h
@@ -49,7 +49,7 @@ class GAFFERIMAGE_API Unpremultiply : public ChannelDataProcessor
 
 	public :
 
-		Unpremultiply( const std::string &name=defaultName<Unpremultiply>() );
+		explicit Unpremultiply( const std::string &name=defaultName<Unpremultiply>() );
 		~Unpremultiply() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Unpremultiply, UnpremultiplyTypeId, ChannelDataProcessor );

--- a/include/GafferImage/VectorWarp.h
+++ b/include/GafferImage/VectorWarp.h
@@ -45,7 +45,7 @@ class GAFFERIMAGE_API VectorWarp : public Warp
 {
 	public :
 
-		VectorWarp( const std::string &name=defaultName<Warp>() );
+		explicit VectorWarp( const std::string &name=defaultName<Warp>() );
 		~VectorWarp() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::VectorWarp, VectorWarpTypeId, Warp );

--- a/include/GafferImage/Warp.h
+++ b/include/GafferImage/Warp.h
@@ -60,7 +60,7 @@ class GAFFERIMAGE_API Warp : public FlatImageProcessor
 {
 	public :
 
-		Warp( const std::string &name=defaultName<Warp>() );
+		explicit Warp( const std::string &name=defaultName<Warp>() );
 		~Warp() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::Warp, WarpTypeId, FlatImageProcessor );

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -84,7 +84,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 	public :
 
-		ImageView( const std::string &name = defaultName<ImageView>() );
+		explicit ImageView( const std::string &name = defaultName<ImageView>() );
 		~ImageView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImageUI::ImageView, ImageViewTypeId, GafferUI::View );

--- a/include/GafferOSL/ClosurePlug.h
+++ b/include/GafferOSL/ClosurePlug.h
@@ -55,7 +55,7 @@ class GAFFEROSL_API ClosurePlug : public Gaffer::Plug
 
 	public :
 
-		ClosurePlug( const std::string &name=defaultName<ClosurePlug>(), Direction direction=In, unsigned flags=Default );
+		explicit ClosurePlug( const std::string &name=defaultName<ClosurePlug>(), Direction direction=In, unsigned flags=Default );
 		~ClosurePlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferOSL::ClosurePlug, ClosurePlugTypeId, Plug );

--- a/include/GafferOSL/OSLCode.h
+++ b/include/GafferOSL/OSLCode.h
@@ -52,7 +52,7 @@ class GAFFEROSL_API OSLCode : public OSLShader
 
 	public :
 
-		OSLCode( const std::string &name=defaultName<OSLCode>() );
+		explicit OSLCode( const std::string &name=defaultName<OSLCode>() );
 		~OSLCode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferOSL::OSLCode, OSLCodeTypeId, OSLShader );

--- a/include/GafferOSL/OSLImage.h
+++ b/include/GafferOSL/OSLImage.h
@@ -54,7 +54,7 @@ class GAFFEROSL_API OSLImage : public GafferImage::ImageProcessor
 
 	public :
 
-		OSLImage( const std::string &name=defaultName<OSLImage>() );
+		explicit OSLImage( const std::string &name=defaultName<OSLImage>() );
 		~OSLImage() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferOSL::OSLImage, OSLImageTypeId, GafferImage::ImageProcessor );

--- a/include/GafferOSL/OSLLight.h
+++ b/include/GafferOSL/OSLLight.h
@@ -56,7 +56,7 @@ class GAFFEROSL_API OSLLight : public GafferScene::Light
 
 		GAFFER_NODE_DECLARE_TYPE( GafferOSL::OSLLight, OSLLightTypeId, GafferScene::Light );
 
-		OSLLight( const std::string &name=defaultName<OSLLight>() );
+		explicit OSLLight( const std::string &name=defaultName<OSLLight>() );
 		~OSLLight() override;
 
 		Gaffer::StringPlug *shaderNamePlug();

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -56,7 +56,7 @@ class GAFFEROSL_API OSLObject : public GafferScene::Deformer
 
 	public :
 
-		OSLObject( const std::string &name=defaultName<OSLObject>() );
+		explicit OSLObject( const std::string &name=defaultName<OSLObject>() );
 		~OSLObject() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferOSL::OSLObject, OSLObjectTypeId, GafferScene::Deformer );

--- a/include/GafferOSL/OSLShader.h
+++ b/include/GafferOSL/OSLShader.h
@@ -51,7 +51,7 @@ class GAFFEROSL_API OSLShader : public GafferScene::Shader
 
 	public :
 
-		OSLShader( const std::string &name=defaultName<OSLShader>() );
+		explicit OSLShader( const std::string &name=defaultName<OSLShader>() );
 		~OSLShader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferOSL::OSLShader, OSLShaderTypeId, GafferScene::Shader );

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -53,7 +53,7 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 
 		IE_CORE_DECLAREMEMBERPTR( ShadingEngine )
 
-		ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork );
+		explicit ShadingEngine( const IECoreScene::ShaderNetwork *shaderNetwork );
 
 		// Fast version that takes ownership of network instead of copying
 		ShadingEngine( IECoreScene::ShaderNetworkPtr &&shaderNetwork );

--- a/include/GafferScene/AimConstraint.h
+++ b/include/GafferScene/AimConstraint.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API AimConstraint : public Constraint
 
 	public :
 
-		AimConstraint( const std::string &name=defaultName<AimConstraint>() );
+		explicit AimConstraint( const std::string &name=defaultName<AimConstraint>() );
 		~AimConstraint() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::AimConstraint, AimConstraintTypeId, Constraint );

--- a/include/GafferScene/AttributeProcessor.h
+++ b/include/GafferScene/AttributeProcessor.h
@@ -57,7 +57,7 @@ class GAFFERSCENE_API AttributeProcessor : public FilteredSceneProcessor
 
 		/// Constructs with a single input ScenePlug named "in". Use inPlug()
 		/// to access this plug.
-		AttributeProcessor( const std::string &name );
+		explicit AttributeProcessor( const std::string &name );
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.

--- a/include/GafferScene/AttributeQuery.h
+++ b/include/GafferScene/AttributeQuery.h
@@ -52,7 +52,7 @@ namespace GafferScene
 
 struct GAFFERSCENE_API AttributeQuery : Gaffer::ComputeNode
 {
-	AttributeQuery( const std::string& name = defaultName< AttributeQuery >() );
+	explicit AttributeQuery( const std::string& name = defaultName< AttributeQuery >() );
 	~AttributeQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferScene::AttributeQuery, AttributeQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/AttributeTweaks.h
+++ b/include/GafferScene/AttributeTweaks.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API AttributeTweaks : public AttributeProcessor
 
 	public :
 
-		AttributeTweaks( const std::string &name=defaultName<AttributeTweaks>() );
+		explicit AttributeTweaks( const std::string &name=defaultName<AttributeTweaks>() );
 		~AttributeTweaks() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::AttributeTweaks, AttributeTweaksTypeId, AttributeProcessor );

--- a/include/GafferScene/AttributeVisualiser.h
+++ b/include/GafferScene/AttributeVisualiser.h
@@ -56,7 +56,7 @@ class GAFFERSCENE_API AttributeVisualiser : public AttributeProcessor
 
 	public :
 
-		AttributeVisualiser( const std::string &name=defaultName<AttributeVisualiser>() );
+		explicit AttributeVisualiser( const std::string &name=defaultName<AttributeVisualiser>() );
 		~AttributeVisualiser() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::AttributeVisualiser, AttributeVisualiserTypeId, AttributeProcessor );

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API Attributes : public AttributeProcessor
 
 	public :
 
-		Attributes( const std::string &name=defaultName<Attributes>() );
+		explicit Attributes( const std::string &name=defaultName<Attributes>() );
 		~Attributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Attributes, AttributesTypeId, AttributeProcessor );

--- a/include/GafferScene/BoundQuery.h
+++ b/include/GafferScene/BoundQuery.h
@@ -60,7 +60,7 @@ struct GAFFERSCENE_API BoundQuery : Gaffer::ComputeNode
 		Relative = 0x02
 	};
 
-	BoundQuery( std::string const& name = defaultName< BoundQuery >() );
+	explicit BoundQuery( std::string const& name = defaultName< BoundQuery >() );
 	~BoundQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferScene::BoundQuery, BoundQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/BranchCreator.h
+++ b/include/GafferScene/BranchCreator.h
@@ -93,7 +93,7 @@ class GAFFERSCENE_API BranchCreator : public FilteredSceneProcessor
 
 	protected :
 
-		BranchCreator( const std::string &name=defaultName<BranchCreator>() );
+		explicit BranchCreator( const std::string &name=defaultName<BranchCreator>() );
 
 		/// Implemented for mappingPlug().
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/Camera.h
+++ b/include/GafferScene/Camera.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API Camera : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Camera, CameraTypeId, ObjectSource );
 
-		Camera( const std::string &name=defaultName<Camera>() );
+		explicit Camera( const std::string &name=defaultName<Camera>() );
 		~Camera() override;
 
 		Gaffer::StringPlug *projectionPlug();

--- a/include/GafferScene/CameraTweaks.h
+++ b/include/GafferScene/CameraTweaks.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API CameraTweaks : public ObjectProcessor
 
 	public :
 
-		CameraTweaks( const std::string &name=defaultName<CameraTweaks>() );
+		explicit CameraTweaks( const std::string &name=defaultName<CameraTweaks>() );
 		~CameraTweaks() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CameraTweaks, CameraTweaksTypeId, ObjectProcessor );

--- a/include/GafferScene/ClippingPlane.h
+++ b/include/GafferScene/ClippingPlane.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API ClippingPlane : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ClippingPlane, ClippingPlaneTypeId, ObjectSource );
 
-		ClippingPlane( const std::string &name=defaultName<ClippingPlane>() );
+		explicit ClippingPlane( const std::string &name=defaultName<ClippingPlane>() );
 		~ClippingPlane() override;
 
 	protected :

--- a/include/GafferScene/ClosestPointSampler.h
+++ b/include/GafferScene/ClosestPointSampler.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API ClosestPointSampler : public PrimitiveSampler
 
 	public :
 
-		ClosestPointSampler( const std::string &name = defaultName<ClosestPointSampler>() );
+		explicit ClosestPointSampler( const std::string &name = defaultName<ClosestPointSampler>() );
 		~ClosestPointSampler() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ClosestPointSampler, ClosestPointSamplerTypeId, PrimitiveSampler );

--- a/include/GafferScene/CollectPrimitiveVariables.h
+++ b/include/GafferScene/CollectPrimitiveVariables.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API CollectPrimitiveVariables : public ObjectProcessor
 
 	public :
 
-		CollectPrimitiveVariables( const std::string &name=defaultName<CollectPrimitiveVariables>() );
+		explicit CollectPrimitiveVariables( const std::string &name=defaultName<CollectPrimitiveVariables>() );
 		~CollectPrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CollectPrimitiveVariables, CollectPrimitiveVariablesTypeId, ObjectProcessor );

--- a/include/GafferScene/CollectScenes.h
+++ b/include/GafferScene/CollectScenes.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API CollectScenes : public SceneProcessor
 
 	public :
 
-		CollectScenes( const std::string &name=defaultName<CollectScenes>() );
+		explicit CollectScenes( const std::string &name=defaultName<CollectScenes>() );
 		~CollectScenes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CollectScenes, CollectScenesTypeId, SceneProcessor );

--- a/include/GafferScene/CollectTransforms.h
+++ b/include/GafferScene/CollectTransforms.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API CollectTransforms : public AttributeProcessor
 
 	public :
 
-		CollectTransforms( const std::string &name=defaultName<CollectTransforms>() );
+		explicit CollectTransforms( const std::string &name=defaultName<CollectTransforms>() );
 		~CollectTransforms() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CollectTransforms, CollectTransformsTypeId, AttributeProcessor );

--- a/include/GafferScene/Constraint.h
+++ b/include/GafferScene/Constraint.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API Constraint : public SceneElementProcessor
 
 	public :
 
-		Constraint( const std::string &name=defaultName<Constraint>() );
+		explicit Constraint( const std::string &name=defaultName<Constraint>() );
 		~Constraint() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Constraint, ConstraintTypeId, SceneElementProcessor );

--- a/include/GafferScene/CoordinateSystem.h
+++ b/include/GafferScene/CoordinateSystem.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API CoordinateSystem : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CoordinateSystem, CoordinateSystemTypeId, ObjectSource );
 
-		CoordinateSystem( const std::string &name=defaultName<CoordinateSystem>() );
+		explicit CoordinateSystem( const std::string &name=defaultName<CoordinateSystem>() );
 		~CoordinateSystem() override;
 
 	protected :

--- a/include/GafferScene/CopyAttributes.h
+++ b/include/GafferScene/CopyAttributes.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API CopyAttributes : public FilteredSceneProcessor
 
 	public :
 
-		CopyAttributes( const std::string &name=defaultName<CopyAttributes>() );
+		explicit CopyAttributes( const std::string &name=defaultName<CopyAttributes>() );
 		~CopyAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CopyAttributes, CopyAttributesTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/CopyOptions.h
+++ b/include/GafferScene/CopyOptions.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API CopyOptions : public GafferScene::GlobalsProcessor
 
 	public :
 
-		CopyOptions( const std::string &name=defaultName<CopyOptions>() );
+		explicit CopyOptions( const std::string &name=defaultName<CopyOptions>() );
 		~CopyOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CopyOptions, CopyOptionsTypeId, GlobalsProcessor );

--- a/include/GafferScene/CopyPrimitiveVariables.h
+++ b/include/GafferScene/CopyPrimitiveVariables.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API CopyPrimitiveVariables : public Deformer
 
 	public :
 
-		CopyPrimitiveVariables( const std::string &name=defaultName<CopyPrimitiveVariables>() );
+		explicit CopyPrimitiveVariables( const std::string &name=defaultName<CopyPrimitiveVariables>() );
 		~CopyPrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CopyPrimitiveVariables, CopyPrimitiveVariablesTypeId, Deformer );

--- a/include/GafferScene/Cryptomatte.h
+++ b/include/GafferScene/Cryptomatte.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API Cryptomatte : public GafferImage::FlatImageProcessor
 {
 
 	public:
-		Cryptomatte(const std::string &name = defaultName<Cryptomatte>());
+		explicit Cryptomatte(const std::string &name = defaultName<Cryptomatte>());
 		~Cryptomatte() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION(GafferScene::Cryptomatte, CryptomatteTypeId, GafferImage::FlatImageProcessor);

--- a/include/GafferScene/Cube.h
+++ b/include/GafferScene/Cube.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API Cube : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Cube, CubeTypeId, ObjectSource );
 
-		Cube( const std::string &name=defaultName<Cube>() );
+		explicit Cube( const std::string &name=defaultName<Cube>() );
 		~Cube() override;
 
 		Gaffer::V3fPlug *dimensionsPlug();

--- a/include/GafferScene/CurveSampler.h
+++ b/include/GafferScene/CurveSampler.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API CurveSampler : public PrimitiveSampler
 
 	public :
 
-		CurveSampler( const std::string &name = defaultName<CurveSampler>() );
+		explicit CurveSampler( const std::string &name = defaultName<CurveSampler>() );
 		~CurveSampler() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CurveSampler, CurveSamplerTypeId, PrimitiveSampler );

--- a/include/GafferScene/CustomAttributes.h
+++ b/include/GafferScene/CustomAttributes.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API CustomAttributes : public GafferScene::Attributes
 
 	public :
 
-		CustomAttributes( const std::string &name=defaultName<CustomAttributes>() );
+		explicit CustomAttributes( const std::string &name=defaultName<CustomAttributes>() );
 		~CustomAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CustomAttributes,CustomAttributesTypeId, Attributes );

--- a/include/GafferScene/CustomOptions.h
+++ b/include/GafferScene/CustomOptions.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API CustomOptions : public GafferScene::Options
 
 	public :
 
-		CustomOptions( const std::string &name=defaultName<CustomOptions>() );
+		explicit CustomOptions( const std::string &name=defaultName<CustomOptions>() );
 		~CustomOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::CustomOptions, CustomOptionsTypeId, Options );

--- a/include/GafferScene/Deformer.h
+++ b/include/GafferScene/Deformer.h
@@ -65,7 +65,7 @@ class GAFFERSCENE_API Deformer : public ObjectProcessor
 
 		/// Constructs with a single input ScenePlug named "in". Use inPlug()
 		/// to access this plug.
-		Deformer( const std::string &name );
+		explicit Deformer( const std::string &name );
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.

--- a/include/GafferScene/DeleteAttributes.h
+++ b/include/GafferScene/DeleteAttributes.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API DeleteAttributes : public AttributeProcessor
 
 	public :
 
-		DeleteAttributes( const std::string &name=defaultName<DeleteAttributes>() );
+		explicit DeleteAttributes( const std::string &name=defaultName<DeleteAttributes>() );
 		~DeleteAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteAttributes, DeleteAttributesTypeId, AttributeProcessor );

--- a/include/GafferScene/DeleteCurves.h
+++ b/include/GafferScene/DeleteCurves.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API DeleteCurves : public Deformer
 
 	public :
 
-		DeleteCurves( const std::string &name = defaultName<DeleteCurves>() );
+		explicit DeleteCurves( const std::string &name = defaultName<DeleteCurves>() );
 		~DeleteCurves() override;
 
 		Gaffer::StringPlug *curvesPlug();

--- a/include/GafferScene/DeleteFaces.h
+++ b/include/GafferScene/DeleteFaces.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API DeleteFaces : public Deformer
 
 	public :
 
-		DeleteFaces( const std::string &name = defaultName<DeleteFaces>() );
+		explicit DeleteFaces( const std::string &name = defaultName<DeleteFaces>() );
 		~DeleteFaces() override;
 
 		Gaffer::StringPlug *facesPlug();

--- a/include/GafferScene/DeleteGlobals.h
+++ b/include/GafferScene/DeleteGlobals.h
@@ -60,7 +60,7 @@ class GAFFERSCENE_API DeleteGlobals : public GlobalsProcessor
 
 	public :
 
-		DeleteGlobals( const std::string &name=defaultName<DeleteGlobals>() );
+		explicit DeleteGlobals( const std::string &name=defaultName<DeleteGlobals>() );
 		~DeleteGlobals() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteGlobals, DeleteGlobalsTypeId, GlobalsProcessor );

--- a/include/GafferScene/DeleteObject.h
+++ b/include/GafferScene/DeleteObject.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API DeleteObject : public FilteredSceneProcessor
 
 	public :
 
-		DeleteObject( const std::string &name=defaultName<DeleteObject>() );
+		explicit DeleteObject( const std::string &name=defaultName<DeleteObject>() );
 		~DeleteObject() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteObject, DeleteObjectTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/DeleteOptions.h
+++ b/include/GafferScene/DeleteOptions.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API DeleteOptions : public DeleteGlobals
 
 	public :
 
-		DeleteOptions( const std::string &name=defaultName<DeleteOptions>() );
+		explicit DeleteOptions( const std::string &name=defaultName<DeleteOptions>() );
 		~DeleteOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteOptions, DeleteOptionsTypeId, DeleteGlobals );

--- a/include/GafferScene/DeleteOutputs.h
+++ b/include/GafferScene/DeleteOutputs.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API DeleteOutputs : public DeleteGlobals
 
 	public :
 
-		DeleteOutputs( const std::string &name=defaultName<DeleteOutputs>() );
+		explicit DeleteOutputs( const std::string &name=defaultName<DeleteOutputs>() );
 		~DeleteOutputs() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteOutputs, DeleteOutputsTypeId, DeleteGlobals );

--- a/include/GafferScene/DeletePoints.h
+++ b/include/GafferScene/DeletePoints.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API DeletePoints : public Deformer
 
 	public :
 
-		DeletePoints( const std::string &name = defaultName<DeletePoints>() );
+		explicit DeletePoints( const std::string &name = defaultName<DeletePoints>() );
 		~DeletePoints() override;
 
 		Gaffer::StringPlug *pointsPlug();

--- a/include/GafferScene/DeletePrimitiveVariables.h
+++ b/include/GafferScene/DeletePrimitiveVariables.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API DeletePrimitiveVariables : public PrimitiveVariableProcess
 
 	public :
 
-		DeletePrimitiveVariables( const std::string &name=defaultName<DeletePrimitiveVariables>() );
+		explicit DeletePrimitiveVariables( const std::string &name=defaultName<DeletePrimitiveVariables>() );
 		~DeletePrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeletePrimitiveVariables, DeletePrimitiveVariablesTypeId, PrimitiveVariableProcessor );

--- a/include/GafferScene/DeleteSets.h
+++ b/include/GafferScene/DeleteSets.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API DeleteSets : public SceneProcessor
 
 	public :
 
-		DeleteSets( const std::string &name=defaultName<DeleteSets>() );
+		explicit DeleteSets( const std::string &name=defaultName<DeleteSets>() );
 		~DeleteSets() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::DeleteSets, DeleteSetsTypeId, SceneProcessor );

--- a/include/GafferScene/Duplicate.h
+++ b/include/GafferScene/Duplicate.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Duplicate : public BranchCreator
 
 	public :
 
-		Duplicate( const std::string &name=defaultName<Duplicate>() );
+		explicit Duplicate( const std::string &name=defaultName<Duplicate>() );
 		~Duplicate() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Duplicate, DuplicateTypeId, BranchCreator );

--- a/include/GafferScene/Encapsulate.h
+++ b/include/GafferScene/Encapsulate.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API Encapsulate : public FilteredSceneProcessor
 
 	public :
 
-		Encapsulate( const std::string &name=defaultName<Encapsulate>() );
+		explicit Encapsulate( const std::string &name=defaultName<Encapsulate>() );
 		~Encapsulate() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Encapsulate, EncapsulateTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/ExistenceQuery.h
+++ b/include/GafferScene/ExistenceQuery.h
@@ -51,7 +51,7 @@ namespace GafferScene
 
 struct GAFFERSCENE_API ExistenceQuery : Gaffer::ComputeNode
 {
-	ExistenceQuery( const std::string& name = defaultName< ExistenceQuery >() );
+	explicit ExistenceQuery( const std::string& name = defaultName< ExistenceQuery >() );
 	~ExistenceQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferScene::ExistenceQuery, ExistenceQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/ExternalProcedural.h
+++ b/include/GafferScene/ExternalProcedural.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API ExternalProcedural : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ExternalProcedural, ExternalProceduralTypeId, ObjectSource );
 
-		ExternalProcedural( const std::string &name=defaultName<ExternalProcedural>() );
+		explicit ExternalProcedural( const std::string &name=defaultName<ExternalProcedural>() );
 		~ExternalProcedural() override;
 
 		Gaffer::StringPlug *fileNamePlug();

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -59,7 +59,7 @@ class GAFFERSCENE_API Filter : public Gaffer::ComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Filter, FilterTypeId, Gaffer::ComputeNode );
 
-		Filter( const std::string &name=defaultName<Filter>() );
+		explicit Filter( const std::string &name=defaultName<Filter>() );
 		~Filter() override;
 
 		Gaffer::BoolPlug *enabledPlug() override;

--- a/include/GafferScene/FilterPlug.h
+++ b/include/GafferScene/FilterPlug.h
@@ -58,7 +58,7 @@ class GAFFERSCENE_API FilterPlug : public Gaffer::IntPlug
 
 	public :
 
-		FilterPlug(
+		explicit FilterPlug(
 			const std::string &name = defaultName<FilterPlug>(),
 			Direction direction = In,
 			unsigned flags = Default

--- a/include/GafferScene/FilterProcessor.h
+++ b/include/GafferScene/FilterProcessor.h
@@ -57,7 +57,7 @@ class GAFFERSCENE_API FilterProcessor : public Filter
 
 		/// Constructs with a single input filter plug named "in". Use inPlug()
 		/// to access this plug.
-		FilterProcessor( const std::string &name=defaultName<FilterProcessor>() );
+		explicit FilterProcessor( const std::string &name=defaultName<FilterProcessor>() );
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.

--- a/include/GafferScene/FilterQuery.h
+++ b/include/GafferScene/FilterQuery.h
@@ -55,7 +55,7 @@ class GAFFERSCENE_API FilterQuery : public Gaffer::ComputeNode
 
 	public :
 
-		FilterQuery( const std::string &name=defaultName<FilterQuery>() );
+		explicit FilterQuery( const std::string &name=defaultName<FilterQuery>() );
 		~FilterQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::FilterQuery, FilterQueryTypeId, ComputeNode );

--- a/include/GafferScene/FilterResults.h
+++ b/include/GafferScene/FilterResults.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API FilterResults : public Gaffer::ComputeNode
 
 	public :
 
-		FilterResults( const std::string &name=defaultName<FilterResults>() );
+		explicit FilterResults( const std::string &name=defaultName<FilterResults>() );
 		~FilterResults() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::FilterResults, FilterResultsTypeId, ComputeNode );

--- a/include/GafferScene/FilteredSceneProcessor.h
+++ b/include/GafferScene/FilteredSceneProcessor.h
@@ -55,7 +55,7 @@ class GAFFERSCENE_API FilteredSceneProcessor : public SceneProcessor
 
 	public :
 
-		FilteredSceneProcessor( const std::string &name=defaultName<FilteredSceneProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
+		explicit FilteredSceneProcessor( const std::string &name=defaultName<FilteredSceneProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
 		~FilteredSceneProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::FilteredSceneProcessor, FilteredSceneProcessorTypeId, SceneProcessor );

--- a/include/GafferScene/FramingConstraint.h
+++ b/include/GafferScene/FramingConstraint.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API FramingConstraint : public SceneElementProcessor
 
 	public :
 
-		FramingConstraint( const std::string &name=defaultName<FramingConstraint>() );
+		explicit FramingConstraint( const std::string &name=defaultName<FramingConstraint>() );
 		~FramingConstraint() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::FramingConstraint, FramingConstraintTypeId, SceneElementProcessor );

--- a/include/GafferScene/FreezeTransform.h
+++ b/include/GafferScene/FreezeTransform.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API FreezeTransform : public FilteredSceneProcessor
 
 	public :
 
-		FreezeTransform( const std::string &name=defaultName<FreezeTransform>() );
+		explicit FreezeTransform( const std::string &name=defaultName<FreezeTransform>() );
 		~FreezeTransform() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::FreezeTransform, FreezeTransformTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/GlobalShader.h
+++ b/include/GafferScene/GlobalShader.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API GlobalShader : public GlobalsProcessor
 
 	public :
 
-		GlobalShader( const std::string &name=defaultName<GlobalShader>() );
+		explicit GlobalShader( const std::string &name=defaultName<GlobalShader>() );
 		~GlobalShader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::GlobalShader, GlobalShaderTypeId, GlobalsProcessor );

--- a/include/GafferScene/GlobalsProcessor.h
+++ b/include/GafferScene/GlobalsProcessor.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API GlobalsProcessor : public SceneProcessor
 
 	public :
 
-		GlobalsProcessor( const std::string &name=defaultName<GlobalsProcessor>() );
+		explicit GlobalsProcessor( const std::string &name=defaultName<GlobalsProcessor>() );
 		~GlobalsProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::GlobalsProcessor, GlobalsProcessorTypeId, SceneProcessor );

--- a/include/GafferScene/Grid.h
+++ b/include/GafferScene/Grid.h
@@ -57,7 +57,7 @@ class GAFFERSCENE_API Grid : public SceneNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Grid, GridTypeId, SceneNode );
 
-		Grid( const std::string &name=defaultName<Grid>() );
+		explicit Grid( const std::string &name=defaultName<Grid>() );
 		~Grid() override;
 
 		Gaffer::StringPlug *namePlug();

--- a/include/GafferScene/Group.h
+++ b/include/GafferScene/Group.h
@@ -55,7 +55,7 @@ class GAFFERSCENE_API Group : public SceneProcessor
 
 	public :
 
-		Group( const std::string &name=defaultName<Group>() );
+		explicit Group( const std::string &name=defaultName<Group>() );
 		~Group() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Group, GroupTypeId, SceneProcessor );

--- a/include/GafferScene/ImageToPoints.h
+++ b/include/GafferScene/ImageToPoints.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API ImageToPoints : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ImageToPoints, ImageToPointsTypeId, ObjectSource );
 
-		ImageToPoints( const std::string &name=defaultName<ImageToPoints>() );
+		explicit ImageToPoints( const std::string &name=defaultName<ImageToPoints>() );
 		~ImageToPoints() override;
 
 		GafferImage::ImagePlug *imagePlug();

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -58,7 +58,7 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 				GAFFER_PLUG_DECLARE_TYPE( ContextVariablePlug, InstancerContextVariablePlugTypeId, Gaffer::ValuePlug );
 
-				ContextVariablePlug(
+				explicit ContextVariablePlug(
 					const std::string &name = defaultName<ContextVariablePlug>(),
 					Direction direction=In,
 					bool defaultEnable = true,

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -59,7 +59,7 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 
 	public :
 
-		InteractiveRender( const std::string &name=defaultName<InteractiveRender>() );
+		explicit InteractiveRender( const std::string &name=defaultName<InteractiveRender>() );
 		~InteractiveRender() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::InteractiveRender, GafferScene::InteractiveRenderTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/Isolate.h
+++ b/include/GafferScene/Isolate.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API Isolate : public FilteredSceneProcessor
 
 	public :
 
-		Isolate( const std::string &name=defaultName<Isolate>() );
+		explicit Isolate( const std::string &name=defaultName<Isolate>() );
 		~Isolate() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Isolate, IsolateTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/Light.h
+++ b/include/GafferScene/Light.h
@@ -52,7 +52,7 @@ class GAFFERSCENE_API Light : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Light, LightTypeId, ObjectSource );
 
-		Light( const std::string &name=defaultName<Light>() );
+		explicit Light( const std::string &name=defaultName<Light>() );
 		~Light() override;
 
 		Gaffer::Plug *parametersPlug();

--- a/include/GafferScene/LightFilter.h
+++ b/include/GafferScene/LightFilter.h
@@ -72,7 +72,7 @@ class GAFFERSCENE_API LightFilter : public ObjectSource
 
 	protected :
 
-		LightFilter( GafferScene::ShaderPtr shader, const std::string &name=defaultName<LightFilter>() );
+		explicit LightFilter( GafferScene::ShaderPtr shader, const std::string &name=defaultName<LightFilter>() );
 
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;

--- a/include/GafferScene/LightToCamera.h
+++ b/include/GafferScene/LightToCamera.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API LightToCamera : public SceneElementProcessor
 
 	public :
 
-		LightToCamera( const std::string &name=defaultName<LightToCamera>() );
+		explicit LightToCamera( const std::string &name=defaultName<LightToCamera>() );
 		~LightToCamera() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::LightToCamera, LightToCameraTypeId, SceneElementProcessor );

--- a/include/GafferScene/LocaliseAttributes.h
+++ b/include/GafferScene/LocaliseAttributes.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API LocaliseAttributes : public AttributeProcessor
 
 	public :
 
-		LocaliseAttributes( const std::string &name=defaultName<LocaliseAttributes>() );
+		explicit LocaliseAttributes( const std::string &name=defaultName<LocaliseAttributes>() );
 		~LocaliseAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::LocaliseAttributes, LocaliseAttributesTypeId, AttributeProcessor );

--- a/include/GafferScene/MapOffset.h
+++ b/include/GafferScene/MapOffset.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API MapOffset : public ObjectProcessor
 
 	public :
 
-		MapOffset( const std::string &name=defaultName<MapOffset>() );
+		explicit MapOffset( const std::string &name=defaultName<MapOffset>() );
 		~MapOffset() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MapOffset, MapOffsetTypeId, ObjectProcessor );

--- a/include/GafferScene/MapProjection.h
+++ b/include/GafferScene/MapProjection.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API MapProjection : public ObjectProcessor
 
 	public :
 
-		MapProjection( const std::string &name=defaultName<MapProjection>() );
+		explicit MapProjection( const std::string &name=defaultName<MapProjection>() );
 		~MapProjection() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MapProjection, MapProjectionTypeId, ObjectProcessor );

--- a/include/GafferScene/MergeScenes.h
+++ b/include/GafferScene/MergeScenes.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API MergeScenes : public SceneProcessor
 
 	public :
 
-		MergeScenes( const std::string &name=defaultName<MergeScenes>() );
+		explicit MergeScenes( const std::string &name=defaultName<MergeScenes>() );
 		~MergeScenes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MergeScenes, MergeScenesTypeId, SceneProcessor );

--- a/include/GafferScene/MeshDistortion.h
+++ b/include/GafferScene/MeshDistortion.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API MeshDistortion : public ObjectProcessor
 
 	public :
 
-		MeshDistortion( const std::string &name=defaultName<MeshDistortion>() );
+		explicit MeshDistortion( const std::string &name=defaultName<MeshDistortion>() );
 		~MeshDistortion() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshDistortion, MeshDistortionTypeId, ObjectProcessor );

--- a/include/GafferScene/MeshSegments.h
+++ b/include/GafferScene/MeshSegments.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API MeshSegments : public ObjectProcessor
 
 	public :
 
-		MeshSegments( const std::string &name=defaultName<MeshSegments>() );
+		explicit MeshSegments( const std::string &name=defaultName<MeshSegments>() );
 		~MeshSegments() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshSegments, MeshSegmentsTypeId, ObjectProcessor );

--- a/include/GafferScene/MeshSplit.h
+++ b/include/GafferScene/MeshSplit.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API MeshSplit : public BranchCreator
 
 	public :
 
-		MeshSplit( const std::string &name=defaultName<MeshSplit>() );
+		explicit MeshSplit( const std::string &name=defaultName<MeshSplit>() );
 		~MeshSplit() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshSplit, MeshSplitTypeId, BranchCreator );

--- a/include/GafferScene/MeshTangents.h
+++ b/include/GafferScene/MeshTangents.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API MeshTangents : public ObjectProcessor
 
 	public :
 
-		MeshTangents( const std::string &name=defaultName<MeshTangents>() );
+		explicit MeshTangents( const std::string &name=defaultName<MeshTangents>() );
 		~MeshTangents() override;
 
 		enum Mode

--- a/include/GafferScene/MeshToPoints.h
+++ b/include/GafferScene/MeshToPoints.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API MeshToPoints : public Deformer
 
 	public :
 
-		MeshToPoints( const std::string &name=defaultName<MeshToPoints>() );
+		explicit MeshToPoints( const std::string &name=defaultName<MeshToPoints>() );
 		~MeshToPoints() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshToPoints, MeshToPointsTypeId, Deformer );

--- a/include/GafferScene/MeshType.h
+++ b/include/GafferScene/MeshType.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API MeshType : public ObjectProcessor
 
 	public :
 
-		MeshType( const std::string &name=defaultName<MeshType>() );
+		explicit MeshType( const std::string &name=defaultName<MeshType>() );
 		~MeshType() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshType, MeshTypeTypeId, ObjectProcessor );

--- a/include/GafferScene/MotionPath.h
+++ b/include/GafferScene/MotionPath.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API MotionPath : public FilteredSceneProcessor
 
 	public :
 
-		MotionPath( const std::string &name=defaultName<MotionPath>() );
+		explicit MotionPath( const std::string &name=defaultName<MotionPath>() );
 		~MotionPath() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MotionPath, MotionPathTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/ObjectProcessor.h
+++ b/include/GafferScene/ObjectProcessor.h
@@ -61,7 +61,7 @@ class GAFFERSCENE_API ObjectProcessor : public FilteredSceneProcessor
 
 		/// Constructs with a single input ScenePlug named "in". Use inPlug()
 		/// to access this plug.
-		ObjectProcessor( const std::string &name );
+		explicit ObjectProcessor( const std::string &name );
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.

--- a/include/GafferScene/ObjectToScene.h
+++ b/include/GafferScene/ObjectToScene.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API ObjectToScene : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ObjectToScene, ObjectToSceneTypeId, ObjectSource );
 
-		ObjectToScene( const std::string &name=defaultName<ObjectToScene>() );
+		explicit ObjectToScene( const std::string &name=defaultName<ObjectToScene>() );
 		~ObjectToScene() override;
 
 		Gaffer::ObjectPlug *objectPlug();

--- a/include/GafferScene/OpenGLAttributes.h
+++ b/include/GafferScene/OpenGLAttributes.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API OpenGLAttributes : public GafferScene::Attributes
 
 	public :
 
-		OpenGLAttributes( const std::string &name=defaultName<OpenGLAttributes>() );
+		explicit OpenGLAttributes( const std::string &name=defaultName<OpenGLAttributes>() );
 		~OpenGLAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::OpenGLAttributes, OpenGLAttributesTypeId, Attributes );

--- a/include/GafferScene/OpenGLRender.h
+++ b/include/GafferScene/OpenGLRender.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API OpenGLRender : public Render
 
 	public :
 
-		OpenGLRender( const std::string &name=defaultName<OpenGLRender>() );
+		explicit OpenGLRender( const std::string &name=defaultName<OpenGLRender>() );
 		~OpenGLRender() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::OpenGLRender, OpenGLRenderTypeId, Render );

--- a/include/GafferScene/OpenGLShader.h
+++ b/include/GafferScene/OpenGLShader.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API OpenGLShader : public GafferScene::Shader
 
 	public :
 
-		OpenGLShader( const std::string &name=defaultName<OpenGLShader>() );
+		explicit OpenGLShader( const std::string &name=defaultName<OpenGLShader>() );
 		~OpenGLShader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::OpenGLShader, OpenGLShaderTypeId, GafferScene::Shader );

--- a/include/GafferScene/OptionQuery.h
+++ b/include/GafferScene/OptionQuery.h
@@ -54,7 +54,7 @@ namespace GafferScene
 class GAFFERSCENE_API OptionQuery : public Gaffer::ComputeNode
 {
 	public :
-		OptionQuery( const std::string& name = defaultName< OptionQuery >() );
+		explicit OptionQuery( const std::string& name = defaultName< OptionQuery >() );
 		~OptionQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::OptionQuery, OptionQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/Options.h
+++ b/include/GafferScene/Options.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API Options : public GlobalsProcessor
 
 	public :
 
-		Options( const std::string &name=defaultName<Options>() );
+		explicit Options( const std::string &name=defaultName<Options>() );
 		~Options() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Options, OptionsTypeId, GlobalsProcessor );

--- a/include/GafferScene/Orientation.h
+++ b/include/GafferScene/Orientation.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API Orientation : public ObjectProcessor
 
 	public :
 
-		Orientation( const std::string &name=defaultName<Orientation>() );
+		explicit Orientation( const std::string &name=defaultName<Orientation>() );
 		~Orientation() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Orientation, OrientationTypeId, ObjectProcessor );

--- a/include/GafferScene/Outputs.h
+++ b/include/GafferScene/Outputs.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API Outputs : public GlobalsProcessor
 
 	public :
 
-		Outputs( const std::string &name=defaultName<Outputs>() );
+		explicit Outputs( const std::string &name=defaultName<Outputs>() );
 		~Outputs() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Outputs, OutputsTypeId, GlobalsProcessor );

--- a/include/GafferScene/Parameters.h
+++ b/include/GafferScene/Parameters.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Parameters : public ObjectProcessor
 
 	public :
 
-		Parameters( const std::string &name=defaultName<Parameters>() );
+		explicit Parameters( const std::string &name=defaultName<Parameters>() );
 		~Parameters() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Parameters, ParametersTypeId, ObjectProcessor );

--- a/include/GafferScene/Parent.h
+++ b/include/GafferScene/Parent.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Parent : public BranchCreator
 
 	public :
 
-		Parent( const std::string &name=defaultName<Parent>() );
+		explicit Parent( const std::string &name=defaultName<Parent>() );
 		~Parent() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Parent, ParentTypeId, BranchCreator );

--- a/include/GafferScene/ParentConstraint.h
+++ b/include/GafferScene/ParentConstraint.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API ParentConstraint : public Constraint
 
 	public :
 
-		ParentConstraint( const std::string &name=defaultName<ParentConstraint>() );
+		explicit ParentConstraint( const std::string &name=defaultName<ParentConstraint>() );
 		~ParentConstraint() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ParentConstraint, ParentConstraintTypeId, Constraint );

--- a/include/GafferScene/PathFilter.h
+++ b/include/GafferScene/PathFilter.h
@@ -51,7 +51,7 @@ class GAFFERSCENE_API PathFilter : public Filter
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PathFilter, PathFilterTypeId, Filter );
 
-		PathFilter( const std::string &name=defaultName<PathFilter>() );
+		explicit PathFilter( const std::string &name=defaultName<PathFilter>() );
 		~PathFilter() override;
 
 		Gaffer::StringVectorDataPlug *pathsPlug();

--- a/include/GafferScene/Plane.h
+++ b/include/GafferScene/Plane.h
@@ -51,7 +51,7 @@ class GAFFERSCENE_API Plane : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Plane, PlaneTypeId, ObjectSource );
 
-		Plane( const std::string &name=defaultName<Plane>() );
+		explicit Plane( const std::string &name=defaultName<Plane>() );
 		~Plane() override;
 
 		Gaffer::V2fPlug *dimensionsPlug();

--- a/include/GafferScene/PointConstraint.h
+++ b/include/GafferScene/PointConstraint.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API PointConstraint : public Constraint
 
 	public :
 
-		PointConstraint( const std::string &name=defaultName<PointConstraint>() );
+		explicit PointConstraint( const std::string &name=defaultName<PointConstraint>() );
 		~PointConstraint() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PointConstraint, PointConstraintTypeId, Constraint );

--- a/include/GafferScene/PointsType.h
+++ b/include/GafferScene/PointsType.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API PointsType : public ObjectProcessor
 
 	public :
 
-		PointsType( const std::string &name=defaultName<PointsType>() );
+		explicit PointsType( const std::string &name=defaultName<PointsType>() );
 		~PointsType() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PointsType, PointsTypeTypeId, ObjectProcessor );

--- a/include/GafferScene/PrimitiveSampler.h
+++ b/include/GafferScene/PrimitiveSampler.h
@@ -73,7 +73,7 @@ class GAFFERSCENE_API PrimitiveSampler : public Deformer
 
 	protected :
 
-		PrimitiveSampler( const std::string &name = defaultName<PrimitiveSampler>() );
+		explicit PrimitiveSampler( const std::string &name = defaultName<PrimitiveSampler>() );
 
 		/// SamplingFunction
 		/// ================

--- a/include/GafferScene/PrimitiveVariableExists.h
+++ b/include/GafferScene/PrimitiveVariableExists.h
@@ -51,7 +51,7 @@ class GAFFERSCENE_API PrimitiveVariableExists : public Gaffer::ComputeNode
 
 	public :
 
-		PrimitiveVariableExists( const std::string &name=defaultName<PrimitiveVariableExists>() );
+		explicit PrimitiveVariableExists( const std::string &name=defaultName<PrimitiveVariableExists>() );
 		~PrimitiveVariableExists() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PrimitiveVariableExists, PrimitiveVariableExistsTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/PrimitiveVariableProcessor.h
+++ b/include/GafferScene/PrimitiveVariableProcessor.h
@@ -58,7 +58,7 @@ class GAFFERSCENE_API PrimitiveVariableProcessor : public SceneElementProcessor
 
 	public :
 
-		PrimitiveVariableProcessor( const std::string &name=defaultName<PrimitiveVariableProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
+		explicit PrimitiveVariableProcessor( const std::string &name=defaultName<PrimitiveVariableProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
 		~PrimitiveVariableProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PrimitiveVariableProcessor, PrimitiveVariableProcessorTypeId, SceneElementProcessor );

--- a/include/GafferScene/PrimitiveVariableQuery.h
+++ b/include/GafferScene/PrimitiveVariableQuery.h
@@ -51,7 +51,7 @@ namespace GafferScene
 
 struct GAFFERSCENE_API PrimitiveVariableQuery : Gaffer::ComputeNode
 {
-	PrimitiveVariableQuery( const std::string& name = defaultName< PrimitiveVariableQuery >() );
+	explicit PrimitiveVariableQuery( const std::string& name = defaultName< PrimitiveVariableQuery >() );
 	~PrimitiveVariableQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferScene::PrimitiveVariableQuery, PrimitiveVariableQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/PrimitiveVariables.h
+++ b/include/GafferScene/PrimitiveVariables.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API PrimitiveVariables : public ObjectProcessor
 
 	public :
 
-		PrimitiveVariables( const std::string &name=defaultName<PrimitiveVariables>() );
+		explicit PrimitiveVariables( const std::string &name=defaultName<PrimitiveVariables>() );
 		~PrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::PrimitiveVariables, PrimitiveVariablesTypeId, ObjectProcessor );

--- a/include/GafferScene/Prune.h
+++ b/include/GafferScene/Prune.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API Prune : public FilteredSceneProcessor
 
 	public :
 
-		Prune( const std::string &name=defaultName<Prune>() );
+		explicit Prune( const std::string &name=defaultName<Prune>() );
 		~Prune() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Prune, PruneTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/Rename.h
+++ b/include/GafferScene/Rename.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Rename : public FilteredSceneProcessor
 
 	public :
 
-		Rename( const std::string &name=defaultName<Rename>() );
+		explicit Rename( const std::string &name=defaultName<Rename>() );
 		~Rename() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Rename, RenameTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 
 	public :
 
-		Render( const std::string &name=defaultName<Render>() );
+		explicit Render( const std::string &name=defaultName<Render>() );
 		~Render() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Render, GafferScene::RenderTypeId, GafferDispatch::TaskNode );

--- a/include/GafferScene/ResamplePrimitiveVariables.h
+++ b/include/GafferScene/ResamplePrimitiveVariables.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API ResamplePrimitiveVariables : public PrimitiveVariableProce
 
 	public :
 
-		ResamplePrimitiveVariables( const std::string &name = defaultName<ResamplePrimitiveVariables>() );
+		explicit ResamplePrimitiveVariables( const std::string &name = defaultName<ResamplePrimitiveVariables>() );
 		~ResamplePrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ResamplePrimitiveVariables, ResamplePrimitiveVariablesTypeId, PrimitiveVariableProcessor );

--- a/include/GafferScene/ReverseWinding.h
+++ b/include/GafferScene/ReverseWinding.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API ReverseWinding : public ObjectProcessor
 
 	public :
 
-		ReverseWinding( const std::string &name=defaultName<ReverseWinding>() );
+		explicit ReverseWinding( const std::string &name=defaultName<ReverseWinding>() );
 		~ReverseWinding() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ReverseWinding, ReverseWindingTypeId, ObjectProcessor );

--- a/include/GafferScene/SceneElementProcessor.h
+++ b/include/GafferScene/SceneElementProcessor.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API SceneElementProcessor : public FilteredSceneProcessor
 
 	public :
 
-		SceneElementProcessor( const std::string &name=defaultName<SceneElementProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
+		explicit SceneElementProcessor( const std::string &name=defaultName<SceneElementProcessor>(), IECore::PathMatcher::Result filterDefault = IECore::PathMatcher::EveryMatch );
 		~SceneElementProcessor() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneElementProcessor, SceneElementProcessorTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/SceneFilterPathFilter.h
+++ b/include/GafferScene/SceneFilterPathFilter.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API SceneFilterPathFilter : public Gaffer::PathFilter
 
 	public :
 
-		SceneFilterPathFilter( FilterPtr sceneFilter, IECore::CompoundDataPtr userData = nullptr );
+		explicit SceneFilterPathFilter( FilterPtr sceneFilter, IECore::CompoundDataPtr userData = nullptr );
 		~SceneFilterPathFilter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferScene::SceneFilterPathFilter, SceneFilterPathFilterTypeId, Gaffer::PathFilter );

--- a/include/GafferScene/SceneNode.h
+++ b/include/GafferScene/SceneNode.h
@@ -52,7 +52,7 @@ class GAFFERSCENE_API SceneNode : public Gaffer::ComputeNode
 
 	public :
 
-		SceneNode( const std::string &name=defaultName<SceneNode>() );
+		explicit SceneNode( const std::string &name=defaultName<SceneNode>() );
 		~SceneNode() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneNode, SceneNodeTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -61,7 +61,7 @@ class GAFFERSCENE_API ScenePath : public Gaffer::Path
 
 	public :
 
-		ScenePath( ScenePlugPtr scene, Gaffer::ContextPtr context, Gaffer::PathFilterPtr filter = nullptr );
+		explicit ScenePath( ScenePlugPtr scene, Gaffer::ContextPtr context, Gaffer::PathFilterPtr filter = nullptr );
 		ScenePath( ScenePlugPtr scene, Gaffer::ContextPtr context, const std::string &path, Gaffer::PathFilterPtr filter = nullptr );
 		ScenePath( ScenePlugPtr scene, Gaffer::ContextPtr context, const Names &names, const IECore::InternedString &root = "/", Gaffer::PathFilterPtr filter = nullptr );
 

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -55,7 +55,7 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 
 	public :
 
-		ScenePlug( const std::string &name=defaultName<ScenePlug>(), Direction direction=In, unsigned flags=Default );
+		explicit ScenePlug( const std::string &name=defaultName<ScenePlug>(), Direction direction=In, unsigned flags=Default );
 		~ScenePlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferScene::ScenePlug, ScenePlugTypeId, ValuePlug );

--- a/include/GafferScene/SceneProcessor.h
+++ b/include/GafferScene/SceneProcessor.h
@@ -60,7 +60,7 @@ class GAFFERSCENE_API SceneProcessor : public SceneNode
 
 		/// Constructs with a single input ScenePlug named "in". Use inPlug()
 		/// to access this plug.
-		SceneProcessor( const std::string &name=defaultName<SceneProcessor>() );
+		explicit SceneProcessor( const std::string &name=defaultName<SceneProcessor>() );
 		/// Constructs with an ArrayPlug called "in". Use inPlug() as a
 		/// convenience for accessing the first child in the array, and use
 		/// inPlugs() to access the array itself.

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -58,7 +58,7 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 
 	public :
 
-		SceneReader( const std::string &name=defaultName<SceneReader>() );
+		explicit SceneReader( const std::string &name=defaultName<SceneReader>() );
 		~SceneReader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneReader, SceneReaderTypeId, SceneNode )

--- a/include/GafferScene/SceneWriter.h
+++ b/include/GafferScene/SceneWriter.h
@@ -54,7 +54,7 @@ class GAFFERSCENE_API SceneWriter : public GafferDispatch::TaskNode
 
 	public :
 
-		SceneWriter( const std::string &name=defaultName<SceneWriter>() );
+		explicit SceneWriter( const std::string &name=defaultName<SceneWriter>() );
 		~SceneWriter() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SceneWriter, SceneWriterTypeId, GafferDispatch::TaskNode );

--- a/include/GafferScene/Seeds.h
+++ b/include/GafferScene/Seeds.h
@@ -47,7 +47,7 @@ class GAFFERSCENE_API Seeds : public BranchCreator
 
 	public :
 
-		Seeds( const std::string &name=defaultName<Seeds>() );
+		explicit Seeds( const std::string &name=defaultName<Seeds>() );
 		~Seeds() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Seeds, SeedsTypeId, BranchCreator );

--- a/include/GafferScene/Set.h
+++ b/include/GafferScene/Set.h
@@ -57,7 +57,7 @@ class GAFFERSCENE_API Set : public FilteredSceneProcessor
 
 	public :
 
-		Set( const std::string &name=defaultName<Set>() );
+		explicit Set( const std::string &name=defaultName<Set>() );
 		~Set() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Set, SetTypeId, FilteredSceneProcessor );

--- a/include/GafferScene/SetFilter.h
+++ b/include/GafferScene/SetFilter.h
@@ -58,7 +58,7 @@ class GAFFERSCENE_API SetFilter : public Filter
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SetFilter, SetFilterTypeId, Filter );
 
-		SetFilter( const std::string &name=defaultName<SetFilter>() );
+		explicit SetFilter( const std::string &name=defaultName<SetFilter>() );
 		~SetFilter() override;
 
 		Gaffer::StringPlug *setExpressionPlug();

--- a/include/GafferScene/SetQuery.h
+++ b/include/GafferScene/SetQuery.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API SetQuery : public Gaffer::ComputeNode
 
 	public :
 
-		SetQuery( const std::string &name=defaultName<SetQuery>() );
+		explicit SetQuery( const std::string &name=defaultName<SetQuery>() );
 		~SetQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SetQuery, SetQueryTypeId, ComputeNode );

--- a/include/GafferScene/SetVisualiser.h
+++ b/include/GafferScene/SetVisualiser.h
@@ -64,7 +64,7 @@ class GAFFERSCENE_API SetVisualiser : public AttributeProcessor
 
 	public :
 
-		SetVisualiser( const std::string &name=defaultName<SetVisualiser>() );
+		explicit SetVisualiser( const std::string &name=defaultName<SetVisualiser>() );
 		~SetVisualiser() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SetVisualiser, SetVisualiserTypeId, AttributeProcessor );

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -68,7 +68,7 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 
 	public :
 
-		Shader( const std::string &name=defaultName<Shader>() );
+		explicit Shader( const std::string &name=defaultName<Shader>() );
 		~Shader() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Shader, ShaderTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/ShaderAssignment.h
+++ b/include/GafferScene/ShaderAssignment.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API ShaderAssignment : public AttributeProcessor
 
 	public :
 
-		ShaderAssignment( const std::string &name=defaultName<ShaderAssignment>() );
+		explicit ShaderAssignment( const std::string &name=defaultName<ShaderAssignment>() );
 		~ShaderAssignment() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShaderAssignment, ShaderAssignmentTypeId, AttributeProcessor );

--- a/include/GafferScene/ShaderPlug.h
+++ b/include/GafferScene/ShaderPlug.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API ShaderPlug : public Gaffer::Plug
 
 	public :
 
-		ShaderPlug( const std::string &name=defaultName<ShaderPlug>(), Direction direction=In, unsigned flags=Default );
+		explicit ShaderPlug( const std::string &name=defaultName<ShaderPlug>(), Direction direction=In, unsigned flags=Default );
 		~ShaderPlug() override;
 
 		GAFFER_PLUG_DECLARE_TYPE( GafferScene::ShaderPlug, ShaderPlugTypeId, Plug );

--- a/include/GafferScene/ShaderQuery.h
+++ b/include/GafferScene/ShaderQuery.h
@@ -51,7 +51,7 @@ namespace GafferScene
 class GAFFERSCENE_API ShaderQuery : public Gaffer::ComputeNode
 {
 	public:
-		ShaderQuery( const std::string &name = defaultName<ShaderQuery>() );
+		explicit ShaderQuery( const std::string &name = defaultName<ShaderQuery>() );
 		~ShaderQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShaderQuery, ShaderQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/ShaderTweaks.h
+++ b/include/GafferScene/ShaderTweaks.h
@@ -51,7 +51,7 @@ class GAFFERSCENE_API ShaderTweaks : public AttributeProcessor
 
 	public :
 
-		ShaderTweaks( const std::string &name=defaultName<ShaderTweaks>() );
+		explicit ShaderTweaks( const std::string &name=defaultName<ShaderTweaks>() );
 		~ShaderTweaks() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShaderTweaks, ShaderTweaksTypeId, AttributeProcessor );

--- a/include/GafferScene/ShuffleAttributes.h
+++ b/include/GafferScene/ShuffleAttributes.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API ShuffleAttributes : public AttributeProcessor
 
 	public :
 
-		ShuffleAttributes( const std::string &name=defaultName<ShuffleAttributes>() );
+		explicit ShuffleAttributes( const std::string &name=defaultName<ShuffleAttributes>() );
 		~ShuffleAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShuffleAttributes, ShuffleAttributesTypeId, AttributeProcessor );

--- a/include/GafferScene/ShufflePrimitiveVariables.h
+++ b/include/GafferScene/ShufflePrimitiveVariables.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API ShufflePrimitiveVariables : public Deformer
 
 	public :
 
-		ShufflePrimitiveVariables( const std::string &name=defaultName<ShufflePrimitiveVariables>() );
+		explicit ShufflePrimitiveVariables( const std::string &name=defaultName<ShufflePrimitiveVariables>() );
 		~ShufflePrimitiveVariables() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShufflePrimitiveVariables, ShufflePrimitiveVariablesTypeId, Deformer );

--- a/include/GafferScene/Sphere.h
+++ b/include/GafferScene/Sphere.h
@@ -50,7 +50,7 @@ class GAFFERSCENE_API Sphere : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Sphere, SphereTypeId, ObjectSource );
 
-		Sphere( const std::string &name=defaultName<Sphere>() );
+		explicit Sphere( const std::string &name=defaultName<Sphere>() );
 		~Sphere() override;
 
 		enum Type

--- a/include/GafferScene/StandardAttributes.h
+++ b/include/GafferScene/StandardAttributes.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API StandardAttributes : public Attributes
 
 	public :
 
-		StandardAttributes( const std::string &name=defaultName<StandardAttributes>() );
+		explicit StandardAttributes( const std::string &name=defaultName<StandardAttributes>() );
 		~StandardAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::StandardAttributes, StandardAttributesTypeId, Attributes );

--- a/include/GafferScene/StandardOptions.h
+++ b/include/GafferScene/StandardOptions.h
@@ -47,7 +47,7 @@ class GAFFERSCENE_API StandardOptions : public Options
 
 	public :
 
-		StandardOptions( const std::string &name=defaultName<StandardOptions>() );
+		explicit StandardOptions( const std::string &name=defaultName<StandardOptions>() );
 		~StandardOptions() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::StandardOptions, StandardOptionsTypeId, Options );

--- a/include/GafferScene/SubTree.h
+++ b/include/GafferScene/SubTree.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API SubTree : public SceneProcessor
 
 	public :
 
-		SubTree( const std::string &name=defaultName<SubTree>() );
+		explicit SubTree( const std::string &name=defaultName<SubTree>() );
 		~SubTree() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::SubTree, SubTreeTypeId, SceneProcessor );

--- a/include/GafferScene/Text.h
+++ b/include/GafferScene/Text.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Text : public ObjectSource
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Text, TextTypeId, ObjectSource );
 
-		Text( const std::string &name=defaultName<Text>() );
+		explicit Text( const std::string &name=defaultName<Text>() );
 		~Text() override;
 
 		Gaffer::StringPlug *textPlug();

--- a/include/GafferScene/Transform.h
+++ b/include/GafferScene/Transform.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Transform : public SceneElementProcessor
 
 	public :
 
-		Transform( const std::string &name=defaultName<Transform>() );
+		explicit Transform( const std::string &name=defaultName<Transform>() );
 		~Transform() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Transform, TransformTypeId, SceneElementProcessor );

--- a/include/GafferScene/TransformQuery.h
+++ b/include/GafferScene/TransformQuery.h
@@ -59,7 +59,7 @@ struct GAFFERSCENE_API TransformQuery : Gaffer::ComputeNode
 		Relative = 0x02
 	};
 
-	TransformQuery( std::string const& name = defaultName< TransformQuery >() );
+	explicit TransformQuery( std::string const& name = defaultName< TransformQuery >() );
 	~TransformQuery() override;
 
 	GAFFER_NODE_DECLARE_TYPE( GafferScene::TransformQuery, TransformQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/UDIMQuery.h
+++ b/include/GafferScene/UDIMQuery.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API UDIMQuery : public Gaffer::ComputeNode
 
 	public :
 
-		UDIMQuery( const std::string &name=defaultName<UDIMQuery>() );
+		explicit UDIMQuery( const std::string &name=defaultName<UDIMQuery>() );
 		~UDIMQuery() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::UDIMQuery, UDIMQueryTypeId, Gaffer::ComputeNode );

--- a/include/GafferScene/UVSampler.h
+++ b/include/GafferScene/UVSampler.h
@@ -46,7 +46,7 @@ class GAFFERSCENE_API UVSampler : public PrimitiveSampler
 
 	public :
 
-		UVSampler( const std::string &name = defaultName<UVSampler>() );
+		explicit UVSampler( const std::string &name = defaultName<UVSampler>() );
 		~UVSampler() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferScene::UVSampler, UVSamplerTypeId, PrimitiveSampler );

--- a/include/GafferScene/Unencapsulate.h
+++ b/include/GafferScene/Unencapsulate.h
@@ -48,7 +48,7 @@ class GAFFERSCENE_API Unencapsulate : public BranchCreator
 
 	public :
 
-		Unencapsulate( const std::string &name=defaultName<Unencapsulate>() );
+		explicit Unencapsulate( const std::string &name=defaultName<Unencapsulate>() );
 		~Unencapsulate() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Unencapsulate, UnencapsulateTypeId, BranchCreator );

--- a/include/GafferScene/UnionFilter.h
+++ b/include/GafferScene/UnionFilter.h
@@ -49,7 +49,7 @@ class GAFFERSCENE_API UnionFilter : public FilterProcessor
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::UnionFilter, UnionFilterTypeId, FilterProcessor );
 
-		UnionFilter( const std::string &name=defaultName<UnionFilter>() );
+		explicit UnionFilter( const std::string &name=defaultName<UnionFilter>() );
 		~UnionFilter() override;
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;

--- a/include/GafferScene/Wireframe.h
+++ b/include/GafferScene/Wireframe.h
@@ -53,7 +53,7 @@ class GAFFERSCENE_API Wireframe : public Deformer
 
 	public :
 
-		Wireframe( const std::string &name=defaultName<Wireframe>() );
+		explicit Wireframe( const std::string &name=defaultName<Wireframe>() );
 		~Wireframe() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::Wireframe, WireframeTypeId, Deformer );

--- a/include/GafferSceneUI/CameraTool.h
+++ b/include/GafferSceneUI/CameraTool.h
@@ -55,7 +55,7 @@ class GAFFERSCENEUI_API CameraTool : public GafferSceneUI::SelectionTool
 
 	public :
 
-		CameraTool( SceneView *view, const std::string &name = defaultName<CameraTool>() );
+		explicit CameraTool( SceneView *view, const std::string &name = defaultName<CameraTool>() );
 		~CameraTool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::CameraTool, CameraToolTypeId, GafferSceneUI::SelectionTool );

--- a/include/GafferSceneUI/CropWindowTool.h
+++ b/include/GafferSceneUI/CropWindowTool.h
@@ -57,7 +57,7 @@ class GAFFERSCENEUI_API CropWindowTool : public GafferUI::Tool
 
 	public :
 
-		CropWindowTool( GafferUI::View *view, const std::string &name = defaultName<CropWindowTool>() );
+		explicit CropWindowTool( GafferUI::View *view, const std::string &name = defaultName<CropWindowTool>() );
 
 		~CropWindowTool() override;
 

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -59,7 +59,7 @@ class GAFFERSCENEUI_API RotateTool : public TransformTool
 
 	public :
 
-		RotateTool( SceneView *view, const std::string &name = defaultName<RotateTool>() );
+		explicit RotateTool( SceneView *view, const std::string &name = defaultName<RotateTool>() );
 		~RotateTool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::RotateTool, RotateToolTypeId, TransformTool );

--- a/include/GafferSceneUI/ScaleTool.h
+++ b/include/GafferSceneUI/ScaleTool.h
@@ -50,7 +50,7 @@ class GAFFERSCENEUI_API ScaleTool : public TransformTool
 
 	public :
 
-		ScaleTool( SceneView *view, const std::string &name = defaultName<ScaleTool>() );
+		explicit ScaleTool( SceneView *view, const std::string &name = defaultName<ScaleTool>() );
 		~ScaleTool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::ScaleTool, ScaleToolTypeId, TransformTool );

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -71,7 +71,7 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 
 	public :
 
-		SceneView( const std::string &name = defaultName<SceneView>() );
+		explicit SceneView( const std::string &name = defaultName<SceneView>() );
 		~SceneView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::SceneView, SceneViewTypeId, GafferUI::View );

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -53,7 +53,7 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 
 	public :
 
-		SelectionTool( SceneView *view, const std::string &name = defaultName<SelectionTool>() );
+		explicit SelectionTool( SceneView *view, const std::string &name = defaultName<SelectionTool>() );
 
 		~SelectionTool() override;
 

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -56,7 +56,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 	public :
 
-		ShaderView( const std::string &name = defaultName<ShaderView>() );
+		explicit ShaderView( const std::string &name = defaultName<ShaderView>() );
 		~ShaderView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::ShaderView, ShaderViewTypeId, GafferImageUI::ImageView );

--- a/include/GafferSceneUI/TranslateTool.h
+++ b/include/GafferSceneUI/TranslateTool.h
@@ -51,7 +51,7 @@ class GAFFERSCENEUI_API TranslateTool : public TransformTool
 
 	public :
 
-		TranslateTool( SceneView *view, const std::string &name = defaultName<TranslateTool>() );
+		explicit TranslateTool( SceneView *view, const std::string &name = defaultName<TranslateTool>() );
 		~TranslateTool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::TranslateTool, TranslateToolTypeId, TransformTool );

--- a/include/GafferSceneUI/UVView.h
+++ b/include/GafferSceneUI/UVView.h
@@ -61,7 +61,7 @@ class GAFFERSCENEUI_API UVView : public GafferUI::View
 
 	public :
 
-		UVView( const std::string &name = defaultName<UVView>() );
+		explicit UVView( const std::string &name = defaultName<UVView>() );
 		~UVView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::UVView, UVViewTypeId, View );

--- a/include/GafferUI/AuxiliaryNodeGadget.h
+++ b/include/GafferUI/AuxiliaryNodeGadget.h
@@ -48,7 +48,7 @@ class GAFFERUI_API AuxiliaryNodeGadget : public StandardNodeGadget
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::AuxiliaryNodeGadget, AuxiliaryNodeGadgetTypeId, StandardNodeGadget );
 
-		AuxiliaryNodeGadget( Gaffer::NodePtr node );
+		explicit AuxiliaryNodeGadget( Gaffer::NodePtr node );
 		~AuxiliaryNodeGadget() override;
 
 		Imath::Box3f bound() const override;

--- a/include/GafferUI/BackdropNodeGadget.h
+++ b/include/GafferUI/BackdropNodeGadget.h
@@ -49,7 +49,7 @@ class GAFFERUI_API BackdropNodeGadget : public NodeGadget
 
 	public :
 
-		BackdropNodeGadget( Gaffer::NodePtr node );
+		explicit BackdropNodeGadget( Gaffer::NodePtr node );
 		~BackdropNodeGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::BackdropNodeGadget, BackdropNodeGadgetTypeId, NodeGadget );

--- a/include/GafferUI/ButtonEvent.h
+++ b/include/GafferUI/ButtonEvent.h
@@ -66,7 +66,7 @@ struct GAFFERUI_API ButtonEvent : public ModifiableEvent
 		All = Left | Middle | Right
 	};
 
-	ButtonEvent(
+	explicit ButtonEvent(
 		Buttons button_ = None,
 		Buttons buttons_ = None,
 		const IECore::LineSegment3f &Line=IECore::LineSegment3f(),

--- a/include/GafferUI/CompoundNodule.h
+++ b/include/GafferUI/CompoundNodule.h
@@ -52,7 +52,7 @@ class GAFFERUI_API CompoundNodule : public Nodule
 
 	public :
 
-		CompoundNodule( Gaffer::PlugPtr plug );
+		explicit CompoundNodule( Gaffer::PlugPtr plug );
 		~CompoundNodule() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::CompoundNodule, CompoundNoduleTypeId, Nodule );

--- a/include/GafferUI/CompoundNumericNodule.h
+++ b/include/GafferUI/CompoundNumericNodule.h
@@ -51,7 +51,7 @@ class GAFFERUI_API CompoundNumericNodule : public StandardNodule
 
 	public :
 
-		CompoundNumericNodule( Gaffer::PlugPtr plug );
+		explicit CompoundNumericNodule( Gaffer::PlugPtr plug );
 		~CompoundNumericNodule() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::CompoundNumericNodule, CompoundNumericNoduleTypeId, StandardNodule );

--- a/include/GafferUI/ConnectionCreator.h
+++ b/include/GafferUI/ConnectionCreator.h
@@ -55,7 +55,7 @@ class GAFFERUI_API ConnectionCreator : public Gadget
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::ConnectionCreator, ConnectionCreatorTypeId, Gadget );
 
-		ConnectionCreator( const std::string &name=defaultName<ConnectionCreator>() );
+		explicit ConnectionCreator( const std::string &name=defaultName<ConnectionCreator>() );
 		~ConnectionCreator() override;
 
 		/// May be called by the recipient of a drag to figure out if this

--- a/include/GafferUI/ContainerGadget.h
+++ b/include/GafferUI/ContainerGadget.h
@@ -54,7 +54,7 @@ class GAFFERUI_API ContainerGadget : public Gadget
 
 	public :
 
-		ContainerGadget( const std::string &name=defaultName<ContainerGadget>() );
+		explicit ContainerGadget( const std::string &name=defaultName<ContainerGadget>() );
 		~ContainerGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::ContainerGadget, ContainerGadgetTypeId, Gadget );

--- a/include/GafferUI/DotNodeGadget.h
+++ b/include/GafferUI/DotNodeGadget.h
@@ -57,7 +57,7 @@ class GAFFERUI_API DotNodeGadget : public StandardNodeGadget
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::DotNodeGadget, DotNodeGadgetTypeId, StandardNodeGadget );
 
-		DotNodeGadget( Gaffer::NodePtr node );
+		explicit DotNodeGadget( Gaffer::NodePtr node );
 		~DotNodeGadget() override;
 
 		Imath::Box3f bound() const override;

--- a/include/GafferUI/DragDropEvent.h
+++ b/include/GafferUI/DragDropEvent.h
@@ -48,7 +48,7 @@ IE_CORE_FORWARDDECLARE( Gadget )
 struct GAFFERUI_API DragDropEvent : public ButtonEvent
 {
 
-	DragDropEvent(
+	explicit DragDropEvent(
 		Buttons button = None,
 		Buttons buttons = None,
 		const IECore::LineSegment3f &Line=IECore::LineSegment3f(),

--- a/include/GafferUI/FPSGadget.h
+++ b/include/GafferUI/FPSGadget.h
@@ -49,7 +49,7 @@ class GAFFERUI_API FPSGadget : public Gadget
 
 	public :
 
-		FPSGadget( Imath::V3f defaultPosition = Imath::V3f( 5.0f, 50.0f, 0.0f ) );
+		explicit FPSGadget( Imath::V3f defaultPosition = Imath::V3f( 5.0f, 50.0f, 0.0f ) );
 		~FPSGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::FPSGadget, FPSGadgetTypeId, Gadget );

--- a/include/GafferUI/Frame.h
+++ b/include/GafferUI/Frame.h
@@ -48,7 +48,7 @@ class GAFFERUI_API Frame : public IndividualContainer
 
 	public :
 
-		Frame( GadgetPtr child );
+		explicit Frame( GadgetPtr child );
 		~Frame() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::Frame, FrameTypeId, IndividualContainer );

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -85,7 +85,7 @@ class GAFFERUI_API Gadget : public Gaffer::GraphComponent
 
 	public :
 
-		Gadget( const std::string &name=defaultName<Gadget>() );
+		explicit Gadget( const std::string &name=defaultName<Gadget>() );
 		~Gadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::Gadget, GadgetTypeId, Gaffer::GraphComponent );

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -91,7 +91,7 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 		/// Creates a graph showing the children of root, optionally
 		/// filtered by the specified set. Nodes are only displayed if
 		/// they are both a child of root and a member of filter.
-		GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter = nullptr );
+		explicit GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter = nullptr );
 
 		~GraphGadget() override;
 

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -65,7 +65,7 @@ class GAFFERUI_API Handle : public Gadget
 
 	protected :
 
-		Handle( const std::string &name=defaultName<Handle>() );
+		explicit Handle( const std::string &name=defaultName<Handle>() );
 
 		// Implemented to call renderHandle() after applying
 		// the raster scale.

--- a/include/GafferUI/ImageGadget.h
+++ b/include/GafferUI/ImageGadget.h
@@ -61,7 +61,7 @@ class GAFFERUI_API ImageGadget : public Gadget
 		/// Images are searched for on the paths defined by
 		/// the GAFFERUI_IMAGE_PATHS environment variable.
 		/// Throws if the file cannot be loaded.
-		ImageGadget( const std::string &fileName );
+		explicit ImageGadget( const std::string &fileName );
 		/// A copy of the image is taken.
 		ImageGadget( const IECoreImage::ConstImagePrimitivePtr image );
 		~ImageGadget() override;

--- a/include/GafferUI/IndividualContainer.h
+++ b/include/GafferUI/IndividualContainer.h
@@ -49,7 +49,7 @@ class GAFFERUI_API IndividualContainer : public ContainerGadget
 
 	public :
 
-		IndividualContainer( GadgetPtr child=nullptr );
+		explicit IndividualContainer( GadgetPtr child=nullptr );
 		~IndividualContainer() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::IndividualContainer, IndividualContainerTypeId, ContainerGadget );

--- a/include/GafferUI/KeyEvent.h
+++ b/include/GafferUI/KeyEvent.h
@@ -55,7 +55,7 @@ namespace GafferUI
 /// A class to represent events involving keyboard keys.
 struct GAFFERUI_API KeyEvent : public ModifiableEvent
 {
-	KeyEvent(
+	explicit KeyEvent(
 		const char *k = "a",
 		Modifiers m = ModifiableEvent::None
 	)

--- a/include/GafferUI/LinearContainer.h
+++ b/include/GafferUI/LinearContainer.h
@@ -70,7 +70,7 @@ class GAFFERUI_API LinearContainer : public ContainerGadget
 			Decreasing
 		};
 
-		LinearContainer( const std::string &name=defaultName<LinearContainer>(), Orientation orientation=X,
+		explicit LinearContainer( const std::string &name=defaultName<LinearContainer>(), Orientation orientation=X,
 			Alignment alignment=Centre, float spacing = 0.0f, Direction=Increasing );
 
 		~LinearContainer() override;

--- a/include/GafferUI/ModifiableEvent.h
+++ b/include/GafferUI/ModifiableEvent.h
@@ -60,7 +60,7 @@ struct GAFFERUI_API ModifiableEvent : public Event
 		All = Shift | Control | Alt
 	};
 
-	ModifiableEvent( Modifiers m = None ) : modifiers( m ) {};
+	explicit ModifiableEvent( Modifiers m = None ) : modifiers( m ) {};
 
 	/// The state of the modifier keys.
 	Modifiers modifiers;

--- a/include/GafferUI/NameGadget.h
+++ b/include/GafferUI/NameGadget.h
@@ -48,7 +48,7 @@ class GAFFERUI_API NameGadget : public TextGadget
 
 	public :
 
-		NameGadget( Gaffer::GraphComponentPtr object );
+		explicit NameGadget( Gaffer::GraphComponentPtr object );
 		~NameGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::NameGadget, NameGadgetTypeId, TextGadget );

--- a/include/GafferUI/NodeGadget.h
+++ b/include/GafferUI/NodeGadget.h
@@ -103,7 +103,7 @@ class GAFFERUI_API NodeGadget : public Gadget
 
 	protected :
 
-		NodeGadget( Gaffer::NodePtr node );
+		explicit NodeGadget( Gaffer::NodePtr node );
 
 		/// Creating a static one of these is a convenient way of registering a NodeGadget type.
 		template<class T>

--- a/include/GafferUI/Nodule.h
+++ b/include/GafferUI/Nodule.h
@@ -87,7 +87,7 @@ class GAFFERUI_API Nodule : public ConnectionCreator
 
 	protected :
 
-		Nodule( Gaffer::PlugPtr plug );
+		explicit Nodule( Gaffer::PlugPtr plug );
 
 		/// Creating a static one of these is a convenient way of registering a Nodule type.
 		template<class T>

--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -81,7 +81,7 @@ class GAFFERUI_API NoduleLayout : public Gadget
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::NoduleLayout, NoduleLayoutTypeId, Gadget );
 
-		NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedString section = IECore::InternedString() );
+		explicit NoduleLayout( Gaffer::GraphComponentPtr parent, IECore::InternedString section = IECore::InternedString() );
 		~NoduleLayout() override;
 
 		/// \todo These do not need to be virtual, since this is

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -73,7 +73,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 			Default = Interactive,
 		};
 
-		PathColumn( SizeMode sizeMode = Default );
+		explicit PathColumn( SizeMode sizeMode = Default );
 
 		/// Returns the current column size mode.
 		SizeMode getSizeMode() const;

--- a/include/GafferUI/PlugGadget.h
+++ b/include/GafferUI/PlugGadget.h
@@ -58,7 +58,7 @@ class GAFFERUI_API PlugGadget : public ContainerGadget
 
 	public :
 
-		PlugGadget( Gaffer::PlugPtr plug );
+		explicit PlugGadget( Gaffer::PlugPtr plug );
 		~PlugGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::PlugGadget, PlugGadgetTypeId, Gadget );

--- a/include/GafferUI/Pointer.h
+++ b/include/GafferUI/Pointer.h
@@ -57,7 +57,7 @@ class GAFFERUI_API Pointer : public IECore::RefCounted
 		IE_CORE_DECLAREMEMBERPTR( Pointer )
 
 		/// A copy of the image is taken.
-		Pointer( const IECoreImage::ImagePrimitive *image, const Imath::V2i &hotspot = Imath::V2i( -1 ) );
+		explicit Pointer( const IECoreImage::ImagePrimitive *image, const Imath::V2i &hotspot = Imath::V2i( -1 ) );
 		/// Images are loaded from the paths specified by the
 		/// GAFFERUI_IMAGE_PATHS environment variable.
 		Pointer( const std::string &fileName, const Imath::V2i &hotspot = Imath::V2i( -1 ) );

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -55,7 +55,7 @@ class GAFFERUI_API RotateHandle : public Handle
 
 	public :
 
-		RotateHandle( Style::Axes axes );
+		explicit RotateHandle( Style::Axes axes );
 		~RotateHandle() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::RotateHandle, RotateHandleTypeId, Handle );

--- a/include/GafferUI/ScaleHandle.h
+++ b/include/GafferUI/ScaleHandle.h
@@ -47,7 +47,7 @@ class GAFFERUI_API ScaleHandle : public Handle
 
 	public :
 
-		ScaleHandle( Style::Axes axes );
+		explicit ScaleHandle( Style::Axes axes );
 		~ScaleHandle() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::ScaleHandle, ScaleHandleTypeId, Handle );

--- a/include/GafferUI/SpacerGadget.h
+++ b/include/GafferUI/SpacerGadget.h
@@ -46,7 +46,7 @@ class GAFFERUI_API SpacerGadget : public Gadget
 
 	public :
 
-		SpacerGadget( const Imath::Box3f &size );
+		explicit SpacerGadget( const Imath::Box3f &size );
 		~SpacerGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::SpacerGadget, SpacerGadgetTypeId, Gadget );

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -76,7 +76,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 			InvalidEdge
 		};
 
-		StandardNodeGadget( Gaffer::NodePtr node );
+		explicit StandardNodeGadget( Gaffer::NodePtr node );
 		~StandardNodeGadget() override;
 
 		Nodule *nodule( const Gaffer::Plug *plug ) override;

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -56,7 +56,7 @@ class GAFFERUI_API StandardNodule : public Nodule
 
 	public :
 
-		StandardNodule( Gaffer::PlugPtr plug );
+		explicit StandardNodule( Gaffer::PlugPtr plug );
 		~StandardNodule() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::StandardNodule, StandardNoduleTypeId, Nodule );

--- a/include/GafferUI/TextGadget.h
+++ b/include/GafferUI/TextGadget.h
@@ -49,7 +49,7 @@ class GAFFERUI_API TextGadget : public Gadget
 
 	public :
 
-		TextGadget( const std::string &text );
+		explicit TextGadget( const std::string &text );
 		~TextGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::TextGadget, TextGadgetTypeId, Gadget );

--- a/include/GafferUI/Tool.h
+++ b/include/GafferUI/Tool.h
@@ -76,7 +76,7 @@ class GAFFERUI_API Tool : public Gaffer::Node
 
 	public :
 
-		Tool( View *view, const std::string &name = defaultName<Tool>() );
+		explicit Tool( View *view, const std::string &name = defaultName<Tool>() );
 		~Tool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferUI::Tool, ToolTypeId, Gaffer::Node );

--- a/include/GafferUI/TranslateHandle.h
+++ b/include/GafferUI/TranslateHandle.h
@@ -47,7 +47,7 @@ class GAFFERUI_API TranslateHandle : public Handle
 
 	public :
 
-		TranslateHandle( Style::Axes axes );
+		explicit TranslateHandle( Style::Axes axes );
 		~TranslateHandle() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::TranslateHandle, TranslateHandleTypeId, Handle );

--- a/include/GafferUI/ViewportGadget.h
+++ b/include/GafferUI/ViewportGadget.h
@@ -63,7 +63,7 @@ class GAFFERUI_API ViewportGadget : public Gadget
 
 		using UnarySignal = Gaffer::Signals::Signal<void (ViewportGadget *), Gaffer::Signals::CatchingCombiner<void>>;
 
-		ViewportGadget( GadgetPtr primaryChild = nullptr );
+		explicit ViewportGadget( GadgetPtr primaryChild = nullptr );
 		~ViewportGadget() override;
 
 		GAFFER_GRAPHCOMPONENT_DECLARE_TYPE( GafferUI::ViewportGadget, ViewportGadgetTypeId, Gadget );

--- a/include/GafferUSD/USDAttributes.h
+++ b/include/GafferUSD/USDAttributes.h
@@ -49,7 +49,7 @@ class GAFFERUSD_API USDAttributes : public GafferScene::Attributes
 
 	public :
 
-		USDAttributes( const std::string &name=defaultName<USDAttributes>() );
+		explicit USDAttributes( const std::string &name=defaultName<USDAttributes>() );
 		~USDAttributes() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferUSD::USDAttributes, USDAttributesTypeId, GafferScene::Attributes );

--- a/include/GafferUSD/USDLayerWriter.h
+++ b/include/GafferUSD/USDLayerWriter.h
@@ -55,7 +55,7 @@ class GAFFERUSD_API USDLayerWriter : public GafferDispatch::TaskNode
 
 	public :
 
-		USDLayerWriter( const std::string &name=defaultName<USDLayerWriter>() );
+		explicit USDLayerWriter( const std::string &name=defaultName<USDLayerWriter>() );
 		~USDLayerWriter() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferUSD::USDLayerWriter, USDLayerWriterTypeId, GafferDispatch::TaskNode );

--- a/include/GafferVDB/LevelSetOffset.h
+++ b/include/GafferVDB/LevelSetOffset.h
@@ -52,7 +52,7 @@ class GAFFERVDB_API LevelSetOffset : public GafferScene::Deformer
 
 	public :
 
-		LevelSetOffset(const std::string &name = defaultName<LevelSetOffset>() );
+		explicit LevelSetOffset(const std::string &name = defaultName<LevelSetOffset>() );
 		~LevelSetOffset() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetOffset, LevelSetOffsetTypeId, GafferScene::Deformer );

--- a/include/GafferVDB/LevelSetToMesh.h
+++ b/include/GafferVDB/LevelSetToMesh.h
@@ -52,7 +52,7 @@ class GAFFERVDB_API LevelSetToMesh : public GafferScene::Deformer
 
 	public :
 
-		LevelSetToMesh( const std::string &name=defaultName<LevelSetToMesh>() );
+		explicit LevelSetToMesh( const std::string &name=defaultName<LevelSetToMesh>() );
 		~LevelSetToMesh() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferVDB::LevelSetToMesh, LevelSetToMeshTypeId, GafferScene::Deformer );

--- a/include/GafferVDB/MeshToLevelSet.h
+++ b/include/GafferVDB/MeshToLevelSet.h
@@ -56,7 +56,7 @@ class GAFFERVDB_API MeshToLevelSet : public GafferScene::ObjectProcessor
 
 	public :
 
-		MeshToLevelSet( const std::string &name=defaultName<MeshToLevelSet>() );
+		explicit MeshToLevelSet( const std::string &name=defaultName<MeshToLevelSet>() );
 		~MeshToLevelSet() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferVDB::MeshToLevelSet, MeshToLevelSetTypeId, GafferScene::ObjectProcessor );

--- a/include/GafferVDB/PointsGridToPoints.h
+++ b/include/GafferVDB/PointsGridToPoints.h
@@ -56,7 +56,7 @@ class GAFFERVDB_API PointsGridToPoints : public GafferScene::ObjectProcessor
 
 	public :
 
-		PointsGridToPoints( const std::string &name=defaultName<PointsGridToPoints>() );
+		explicit PointsGridToPoints( const std::string &name=defaultName<PointsGridToPoints>() );
 		~PointsGridToPoints() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferVDB::PointsGridToPoints, PointsGridToPointsTypeId, GafferScene::ObjectProcessor );

--- a/include/GafferVDB/PointsToLevelSet.h
+++ b/include/GafferVDB/PointsToLevelSet.h
@@ -56,7 +56,7 @@ class GAFFERVDB_API PointsToLevelSet : public GafferScene::ObjectProcessor
 
 	public :
 
-		PointsToLevelSet( const std::string &name=defaultName<PointsToLevelSet>() );
+		explicit PointsToLevelSet( const std::string &name=defaultName<PointsToLevelSet>() );
 		~PointsToLevelSet() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferVDB::PointsToLevelSet, PointsToLevelSetTypeId, GafferScene::ObjectProcessor );

--- a/include/GafferVDB/SphereLevelSet.h
+++ b/include/GafferVDB/SphereLevelSet.h
@@ -54,7 +54,7 @@ class GAFFERVDB_API SphereLevelSet : public GafferScene::ObjectSource
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferVDB::SphereLevelSet, GafferVDB::SphereLevelSetTypeId, ObjectSource );
 
-		SphereLevelSet( const std::string &name=defaultName<SphereLevelSet>() );
+		explicit SphereLevelSet( const std::string &name=defaultName<SphereLevelSet>() );
 		~SphereLevelSet() override;
 
 		Gaffer::StringPlug *gridPlug();

--- a/include/IECoreArnold/UniverseBlock.h
+++ b/include/IECoreArnold/UniverseBlock.h
@@ -56,7 +56,7 @@ class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 		/// Constructs with a uniquely owned universe if `writable == true`, and
 		/// a potentially shared universe otherwise. The latter is useful for
 		/// making queries via the `AiNodeEntry` API.
-		UniverseBlock( bool writable );
+		explicit UniverseBlock( bool writable );
 		/// Releases the universe created by the constructor.
 		~UniverseBlock();
 

--- a/include/IECoreDelight/ParameterList.h
+++ b/include/IECoreDelight/ParameterList.h
@@ -59,7 +59,7 @@ class IECOREDELIGHT_API ParameterList
 
 		ParameterList();
 		ParameterList( std::initializer_list<NSIParam_t> parameters );
-		ParameterList( const IECore::CompoundDataMap &values );
+		explicit ParameterList( const IECore::CompoundDataMap &values );
 
 		~ParameterList();
 


### PR DESCRIPTION
Many classes in Gaffer have implicit conversions as the constructors are not declared `explicit`.

This can cause function overloads that take instances of the classes as parameters to be considered ambiguous. e.g.

```
void foo( std::string const& ) { ... }
void foo( Gaffer::StringPlug const& ) { ... }
std::string str;
foo( str ); // <- this function call is ambiguous as there is an implicit conversion from std::string to Gaffer::StringPlug
foo( "" ); // <- this function call is not ambiguous as two implicit conversions are required for the Gaffer::StringPlug overload.
```

To prevent these implicit conversions all classes with a single constructor argument are now declared `explicit`

### Breaking changes ###

This could be considered an API change

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
