### PR TITLE
Apply `clang-tidy modernize-use-override`

### DIFF
--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -203,7 +203,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 
 				IE_CORE_DECLARERUNTIMETYPEDEXTENSION( Inspector::HistoryPath, HistoryPathTypeId, Path );
 
-				~HistoryPath();
+				~HistoryPath() override;
 
 				void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr) const override;
 				IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override;

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -424,7 +424,7 @@ class UVOrientedQuadPrimitive : public IECoreGL::QuadPrimitive
 			addVertexAttribute( "uv", uvData );
 		}
 
-		~UVOrientedQuadPrimitive()
+		~UVOrientedQuadPrimitive() override
 		{
 
 		}


### PR DESCRIPTION
This catches a few missing overrides that crept in since the last time, and somehow evaded `-Wsuggest-override`.
