### PR TITLE
Handle drags when the view is nearly parallel to a drag plane

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -58,6 +58,7 @@ Fixes
   - Fixed handling of points exactly at the density threshold.
 - ObjectSource, Group : Prevented the creation of locations with invalid names - `..`, `...` or anything containing `/` or a filter wildcard.
 - BranchCreator : Prevented the use of `...` and other filter wildcards in the `destination`.
+- TranslateTool : Fixed dragging in a plane parallel to an orthographic view. Translation in that case now behaves the same as dragging an axis.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -131,6 +131,7 @@ Breaking Changes
   - Removed support for deprecated `layout:widgetType` metadata. Use `plugValueWidget:type` metadata instead.
   - Removed `useTypeOnly` argument from `create()` function. Pass `typeMetadata = None` instead.
 - MeshTangents : Changed the edge used by `Mode::FirstEdge`.
+- Handle::AngularDrag : Fix mismatch between comment and implementation regarding the axis for zero rotation. The constructor arguments `axis0` and `axis1` were changed to `normal` and `axis0` respectively.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,7 @@ Improvements
 - VectorDataPlugValueWidget : Computation errors are now reflected by a red background colour.
 - VectorWarp : Added `Bilinear` filter, for faster but lower quality warping.
 - Dilate, Erode, Median, Resample, Resize, ImageTransform, Blur, VectorWarp : Improved performance significantly. For example, a Blur with a large radius is now almost 6x faster.
+- RotateTool : Added the ability to rotate an axis whose plane of rotation is parallel or nearly parallel to the view.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -91,6 +91,7 @@ API
 - Removed use of `RTLD_GLOBAL` for loading Python modules.
 - SceneAlgo : Added `validateName()` function.
 - Sampler : Added `visitPixels()` method, which provides an optimised method for accessing all pixels in a region.
+- Handle::AngularDrag : Added `isLinearDrag()` method.
 
 Breaking Changes
 ----------------

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -175,15 +175,15 @@ class GAFFERUI_API Handle : public Gadget
 		{
 
 			AngularDrag( bool processModifiers = true );
-			// Origin and axes are in gadget space. Rotations will be around
-			// axis0, with 0 rotation along axis1. Axes are assumed to be
+			// Origin, normal and axis0 are in gadget space. Rotations will be around
+			// normal, with 0 rotation along axis0. Axes are assumed to be
 			// orthogonal, but may have any length.
-			AngularDrag( const Gadget *gadget, const Imath::V3f &origin, const Imath::V3f &axis0, const Imath::V3f axis1, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
+			AngularDrag( const Gadget *gadget, const Imath::V3f &origin, const Imath::V3f &normal, const Imath::V3f &axis0, const DragDropEvent &dragBeginEvent, bool processModifiers = true );
 
 			// The axis of rotation in Gadget space.
-			const Imath::V3f &axis0() const;
+			const Imath::V3f &normal() const;
 			// The direction on which zero rotation lies.
-			const Imath::V3f &axis1() const;
+			const Imath::V3f &axis0() const;
 
 			// Rotation is in radians
 			float startRotation() const;
@@ -200,8 +200,8 @@ class GAFFERUI_API Handle : public Gadget
 				std::variant<std::monostate, PlanarDrag, LinearDrag> m_drag;
 				float m_rotation;
 
+				Imath::V3f m_normal;
 				Imath::V3f m_axis0;
-				Imath::V3f m_axis1;
 				float m_dragBeginRotation;
 
 				bool m_processModifiers;

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -189,6 +189,8 @@ class GAFFERUI_API Handle : public Gadget
 			float startRotation() const;
 			float updatedRotation( const DragDropEvent &event );
 
+			bool isLinearDrag() const;
+
 			private :
 
 				float closestRotation( const Imath::V2f &p, float targetRotation );

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -41,6 +41,8 @@
 #include "GafferUI/Gadget.h"
 #include "GafferUI/Style.h"
 
+#include <variant>
+
 namespace GafferUI
 {
 
@@ -190,7 +192,9 @@ class GAFFERUI_API Handle : public Gadget
 
 				float closestRotation( const Imath::V2f &p, float targetRotation );
 
-				PlanarDrag m_drag;
+				const Gadget *m_gadget;
+
+				std::variant<std::monostate, PlanarDrag, LinearDrag> m_drag;
 				float m_rotation;
 
 				Imath::V3f m_axis0;

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -158,6 +158,9 @@ class GAFFERUI_API Handle : public Gadget
 				bool m_preciseMotionEnabled;
 				Imath::V2f m_preciseMotionOrigin;
 
+				std::optional<LinearDrag> m_linearDrag;
+				Imath::V2f m_linearDragAxisMask;
+
 		};
 
 		// Returns the current scale factor needed to keep the handles

--- a/include/GafferUI/Handle.h
+++ b/include/GafferUI/Handle.h
@@ -151,6 +151,7 @@ class GAFFERUI_API Handle : public Gadget
 				Imath::V3f m_worldOrigin;
 				Imath::V3f m_worldAxis0;
 				Imath::V3f m_worldAxis1;
+				Imath::V3f m_worldPlaneNormal;
 				Imath::V2f m_dragBeginPosition;
 
 				bool m_processModifiers;

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -467,11 +467,7 @@ Imath::V2f Handle::PlanarDrag::updatedPosition( const DragDropEvent &event )
 		return V2f( linearPosition, linearPosition ) * m_linearDragAxisMask;
 	}
 
-	Plane3f worldPlane(
-		m_worldOrigin,
-		m_worldOrigin + m_worldAxis0,
-		m_worldOrigin + m_worldAxis1
-	);
+	Plane3f worldPlane( m_worldOrigin, m_worldPlaneNormal );
 	V3f worldIntersection( 0 );
 	worldPlane.intersect( worldLine, worldIntersection );
 
@@ -516,6 +512,7 @@ void Handle::PlanarDrag::init( const Gadget *gadget, const Imath::V3f &origin, c
 	m_worldOrigin = dragData.worldOrigin;
 	m_worldAxis0 = dragData.worldAxis0;
 	m_worldAxis1 = dragData.worldAxis1;
+	m_worldPlaneNormal = dragData.worldPlaneNormal;
 
 	if( abs( dragData.worldPlaneNormal.dot( dragData.worldLine.dir ) ) < g_planarToLinearDragThreshold )
 	{

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -671,6 +671,11 @@ float Handle::AngularDrag::updatedRotation( const DragDropEvent &event )
 	return rotation;
 }
 
+bool Handle::AngularDrag::isLinearDrag() const
+{
+	return std::holds_alternative<LinearDrag>( m_drag );
+}
+
 float Handle::AngularDrag::closestRotation( const V2f &p, float targetRotation )
 {
 	const float r = atan2( p.y, p.x );


### PR DESCRIPTION
This changes the behavior of `PlanarDrag` and `AngularDrag` to use a `LinearDrag` when the view is close to parallel to the plane being dragged. Previously, using Translate Tool and Rotate Tool would have no effect in such cases. 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
