### PR TITLE
SpreadsheetUI : Fix editability when a child has an input

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 - Arnold : Moved `distance` shader to the `Shader/Utility` section of the node menu (previously in `Shader/Other`).
 - Graph Editor : Fixed a bug for some video drivers that led to a crash when using nodes with icons.
 - Node Editor : Removed `Gang/Ungang` menu options from output plugs.
+- SpreadsheetUI : Fixed bug which prevented the addition of new rows and columns when an existing plug had an input connection (#5248).
 
 1.2.3.0 (relative to 1.2.2.0)
 =======

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -239,7 +239,10 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _updateFromEditable( self ) :
 
-		editable = self._editable() and self.getPlug().getInput() is None
+		# Not using `_editable()` as it considers the whole plug to be non-editable if
+		# any child has an input connection, but that shouldn't prevent us adding new
+		# rows or columns.
+		editable = self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
 		self.__addRowButton.setEnabled( editable )
 		self.__addColumnButton.setEnabled( editable )
 


### PR DESCRIPTION
Refer to 7f7e265 and b694a48 for equivalent fixes to other widgets.

Fixes #5248.