### PR TITLE
Documentation : Fix non-consecutive header increases

### DIFF
--- a/doc/source/GettingStarted/SettingUpGafferCommand/index.md
+++ b/doc/source/GettingStarted/SettingUpGafferCommand/index.md
@@ -6,7 +6,7 @@ After you have installed Gaffer, it will remain a collection of files and direct
 > For these instructions, we will assume you have Gaffer installed to the `/opt/` directory. If you have installed it elsewhere, replace `/opt/` with the directory you installed it to.
 
 
-### Environment variables ###
+## Environment variables ##
 
 An environment variable is simply a value, such as a string, number, boolean, or location that your terminal is aware of. For instance, when you ran the `tar` command to extract the downloaded Gaffer package, the `tar` command was not located in your `~/Downloads` directory, but actually in `/usr/bin/`. Whenever you open your terminal, several folders are added to your terminal's `PATH` environment variable, which provides it with a list of locations in the file system from which it can source commands.
 

--- a/doc/source/GettingStarted/index.md
+++ b/doc/source/GettingStarted/index.md
@@ -5,7 +5,7 @@
 Here you can find information and instructions about how to install and configure Gaffer.
 
 
-### Quick installation ###
+## Quick installation ##
 
 - [Installing Gaffer](InstallingGaffer/index.md)
 - [Launching Gaffer for the First Time](LaunchingGafferFirstTime/index.md)
@@ -13,7 +13,7 @@ Here you can find information and instructions about how to install and configur
 After you have installed Gaffer, we recommend that you familiarize yourself with the application and its basic concepts by following the [Assembling the Gaffer Bot](TutorialAssemblingTheGafferBot/index.md) tutorial.
 
 
-### Complete installation ###
+## Complete installation ##
 
 - [Setting Up the "gaffer" Command](SettingUpGafferCommand/index.md)
 - [Configuring Gaffer for Third-Party Tools](ConfiguringGafferForThirdPartyTools/index.md)


### PR DESCRIPTION
These headers are already rendered as `<h2>` elements in the HTML, so changing the markdown should have no visible effect other than to silence the warnings reported on CI.