### PR TITLE
CI : Upgrade actions to non-deprecated versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,9 +80,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: ilammy/msvc-dev-cmd@v1.10.0
+    - uses: ilammy/msvc-dev-cmd@v1.12.1
       with:
         sdk: 10.0.17763.0
 
@@ -228,7 +228,7 @@ jobs:
         echo "::remove-matcher owner=validateRelease::"
       if: matrix.publish
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.GAFFER_BUILD_NAME }}
         path: ${{ env.GAFFER_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}

--- a/.github/workflows/whitespaceCheck.yml
+++ b/.github/workflows/whitespaceCheck.yml
@@ -4,7 +4,7 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         # So that we get the branch for `base_ref`.
         fetch-depth: 0


### PR DESCRIPTION
GitHub plans to run all actions on Node 16 by Summer 2023, so this bumps a few versions to ones that claim compatibility.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
