### PR TITLE
SceneReader : Make `boundHash()` savvy to USD scenegraph instancing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.4.0)
 =======
 
+Improvements
+------------
+
+- SceneReader : Improved performance when computing bounds for complex USD stages containing scenegraph instancing.
+
 1.2.4.0 (relative to 1.2.3.0)
 =======
 

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -210,10 +210,15 @@ void SceneReader::hashBound( const ScenePath &path, const Gaffer::Context *conte
 	else
 	{
 		// Deliberately not using `childBoundsPlug()->hash()`
-		// here because `fileName/path` uniquely identifies the
-		// result, and is quicker to compute.
-		fileNamePlug()->hash( h );
-		h.append( &path.front(), path.size() );
+		// here because `HierarchyHash` also uniquely identifies the
+		// result, and is quicker to compute (at least in all current
+		// SceneInterface implementations). In current implementations,
+		// `HierarchyHash` is equivalent to hashing `fileName` and `path`
+		// but with one big improvement : USDScene and LinkedScene can
+		// account for scenegraph instancing and save us from repeating
+		// the bounding box computation for _every_ instance. This is
+		// a _big_ performance win for complex scenes.
+		s->hash( SceneInterface::HierarchyHash, context->getTime(), h );
 	}
 
 	if( path.size() == 0 )


### PR DESCRIPTION
This avoids us computing the same bounding box redundantly for each instance in USD. This gives a 4x speedup in `testUSDInstanceBoundsPerformance`, but greater speedups are possible in larger scenes containing heavier use of instancing.

