### PR TITLE
Fix compilation with Clang

### DIFF
--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -105,7 +105,7 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 				// variable. But computes can only depend on plugs,
 				// so we transfer the name into this private plug
 				// each time it changes.
-				void nameChanged();
+				void nameChanged( IECore::InternedString oldName ) override;
 
 				Gaffer::StringPlug *namePlug();
 				const Gaffer::StringPlug *namePlug() const;

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -162,7 +162,7 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 
 		class NetworkBuilder;
 
-		void nameChanged();
+		void nameChanged( IECore::InternedString oldName ) override;
 		void nodeMetadataChanged( IECore::InternedString key );
 
 		// We want to use the node name when computing the shader, so that we

--- a/include/GafferUI/DotNodeGadget.h
+++ b/include/GafferUI/DotNodeGadget.h
@@ -73,7 +73,7 @@ class GAFFERUI_API DotNodeGadget : public StandardNodeGadget
 		Gaffer::Node *upstreamNode();
 
 		void plugDirtied( const Gaffer::Plug *plug );
-		void nameChanged( const Gaffer::GraphComponent *graphComponent );
+		void nodeNameChanged( const Gaffer::GraphComponent *graphComponent );
 		void updateUpstreamNameChangedConnection();
 		void updateLabel();
 

--- a/include/GafferUI/NameGadget.h
+++ b/include/GafferUI/NameGadget.h
@@ -55,7 +55,7 @@ class GAFFERUI_API NameGadget : public TextGadget
 
 	private :
 
-		void nameChanged( Gaffer::GraphComponentPtr object );
+		void graphComponentNameChanged( Gaffer::GraphComponentPtr object );
 
 };
 

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -669,8 +669,6 @@ Catalogue::Image::Image( const std::string &name, Direction direction, unsigned 
 	addChild( new StringPlug( "description" ) );
 	addChild( new IntPlug( "outputIndex" ) );
 	addChild( new StringPlug( "__name", Plug::In, name, Plug::Default & ~Plug::Serialisable ) );
-
-	nameChangedSignal().connect( boost::bind( &Image::nameChanged, this ) );
 }
 
 Gaffer::StringPlug *Catalogue::Image::fileNamePlug()
@@ -754,7 +752,7 @@ Gaffer::PlugPtr Catalogue::Image::createCounterpart( const std::string &name, Di
 	return new Image( name, direction, getFlags() );
 }
 
-void Catalogue::Image::nameChanged()
+void Catalogue::Image::nameChanged( IECore::InternedString oldName )
 {
 	if( !getInput() )
 	{

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -765,7 +765,6 @@ Shader::Shader( const std::string &name )
 	nodeColorPlug()->setFlags( Plug::Serialisable | Plug::AcceptsInputs, false );
 	addChild( new CompoundObjectPlug( "__outAttributes", Plug::Out, new IECore::CompoundObject ) );
 
-	nameChangedSignal().connect( boost::bind( &Shader::nameChanged, this ) );
 	Metadata::nodeValueChangedSignal( this ).connect( boost::bind( &Shader::nodeMetadataChanged, this, ::_2 ) );
 }
 
@@ -1046,7 +1045,7 @@ IECore::DataPtr Shader::parameterValue( const Gaffer::Plug *parameterPlug ) cons
 	return nullptr;
 }
 
-void Shader::nameChanged()
+void Shader::nameChanged( IECore::InternedString oldName )
 {
 	nodeNamePlug()->setValue( getName() );
 }

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -76,7 +76,7 @@ DotNodeGadget::DotNodeGadget( Gaffer::NodePtr node )
 	setContents( new SpacerGadget( Box3f( V3f( -0.25 ), V3f( 0.25 ) ) ) );
 
 	node->plugDirtiedSignal().connect( boost::bind( &DotNodeGadget::plugDirtied, this, ::_1 ) );
-	node->nameChangedSignal().connect( boost::bind( &DotNodeGadget::nameChanged, this, ::_1 ) );
+	node->nameChangedSignal().connect( boost::bind( &DotNodeGadget::nodeNameChanged, this, ::_1 ) );
 
 	dragEnterSignal().connect( boost::bind( &DotNodeGadget::dragEnter, this, ::_2 ) );
 	dropSignal().connect( boost::bind( &DotNodeGadget::drop, this, ::_2 ) );
@@ -150,7 +150,7 @@ void DotNodeGadget::plugDirtied( const Gaffer::Plug *plug )
 	}
 }
 
-void DotNodeGadget::nameChanged( const Gaffer::GraphComponent *graphComponent )
+void DotNodeGadget::nodeNameChanged( const Gaffer::GraphComponent *graphComponent )
 {
 	updateLabel();
 }
@@ -160,7 +160,7 @@ void DotNodeGadget::updateUpstreamNameChangedConnection()
 	m_upstreamNameChangedConnection.disconnect();
 	if( Node *n = upstreamNode() )
 	{
-		m_upstreamNameChangedConnection = n->nameChangedSignal().connect( boost::bind( &DotNodeGadget::nameChanged, this, ::_1 ) );
+		m_upstreamNameChangedConnection = n->nameChangedSignal().connect( boost::bind( &DotNodeGadget::nodeNameChanged, this, ::_1 ) );
 	}
 }
 

--- a/src/GafferUI/NameGadget.cpp
+++ b/src/GafferUI/NameGadget.cpp
@@ -47,14 +47,14 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( NameGadget );
 NameGadget::NameGadget( Gaffer::GraphComponentPtr object )
 	:	TextGadget( object->getName() )
 {
-	object->nameChangedSignal().connect( boost::bind( &NameGadget::nameChanged, this, ::_1 ) );
+	object->nameChangedSignal().connect( boost::bind( &NameGadget::graphComponentNameChanged, this, ::_1 ) );
 }
 
 NameGadget::~NameGadget()
 {
 }
 
-void NameGadget::nameChanged( Gaffer::GraphComponentPtr object )
+void NameGadget::graphComponentNameChanged( Gaffer::GraphComponentPtr object )
 {
 	setText( object->getName() );
 }


### PR DESCRIPTION
This was broken by 4e2786af7dfa0e2a823d890ab6d8e522ddc696ab, where we introduced a `GraphComponent::nameChanged()` virtual method which conflicted with several pre-existing methods with the same name.

In the case of Catalogue and Shader we can override the new virtual function instead of connecting to signals. In the case of NameGadget and DotNodeGadget we just rename the functions so they don't conflict.
