### PR TITLE
EditMenu : Don't rely on plug order in `duplicateWithInputs`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.1.9.x (relative to 1.1.9.6)
 =======
 
+Fixes
+-----
+
+- EditMenu : Fixed errors using "Duplicate with Inputs" with certain configurations of Dot node (#5309).
+
 1.1.9.6 (relative to 1.1.9.5)
 =======
 

--- a/python/GafferUI/EditMenu.py
+++ b/python/GafferUI/EditMenu.py
@@ -239,8 +239,10 @@ def duplicateWithInputs( menu ) :
 						dest.setInput( source.getInput() )
 					return
 
-			for i in range( 0, len( source.children() ) ) :
-				duplicateInputs( source[i], dest[i] )
+			for sourceChild in source.children() :
+				destChild = dest.getChild( sourceChild.getName() )
+				if destChild is not None :
+					duplicateInputs( sourceChild, destChild )
 
 		for i in range( 0, len( newNodes ) ) :
 			duplicateInputs(


### PR DESCRIPTION
@ericmehl, the reason why we associate the top-level source/dest via index is well documented in this function, and definitely necessary. But I don't see any reason we would need to do that for the child plugs on those nodes, so hopefully this fix makes sense?