### PR TITLE
SceneReader : Check `setNames` before loading a set

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- SceneReader : Removed `scene:path` and `scene:setName` variables from context used to evaluate `fileName`, `refreshCount` and `tags` plugs. This prevents logical impossibilities like changing the file per location, and also reduces pressure on the hash cache.
+- SceneReader :
+  - Removed `scene:path` and `scene:setName` variables from context used to evaluate `fileName`, `refreshCount` and `tags` plugs. This prevents logical impossibilities like changing the file per location, and also reduces pressure on the hash cache.
+  - Improved performance when USD files are queried for sets which don't exist. This can be a substantial improvement when a complex USD file without sets is used within a node graph which adds many sets downstream.
 
 Fixes
 -----

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -712,6 +712,38 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			sceneReader["out"].bound( "/" )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testUSDEmptySetsPerformance( self ) :
+
+		# This creates a node graph where the SceneReader will be asked to load
+		# sets that it doesn't provide, because it is connected in to a Group
+		# where other inputs _are_ providing sets. If we're not smart about it,
+		# this can cause us to recurse the entire USD stage trying to load a set
+		# that isn't even in `SceneReader.out.setNames`.
+
+		sceneReader = GafferScene.SceneReader()
+		sceneReader["fileName"].setValue( self.__createInstancedComposition( 1000, 100 ) )
+
+		cube = GafferScene.Cube()
+		cube["sets"].setValue( "setA setB setC setD setE setF" )
+
+		light = GafferSceneTest.TestLight()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( sceneReader["out"] )
+		group["in"][1].setInput( cube["out"] )
+		group["in"][2].setInput( light["out"] )
+
+		self.assertTrue(
+			{ "setA", "setB", "setC", "defaultLights" }.issubset(
+				{ str( n ) for n in group["out"].setNames() }
+			)
+		)
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			for name in group["out"].setNames() :
+				group["out"].set( name )
+
 	def testUSDTimeCodeAccuracy( self ) :
 
 		# Write a sample on all integer frames up to 100000.


### PR DESCRIPTION
Otherwise `IECoreUSD::USDScene` will do a full stage traversal looking for set members, only to return with nothing. This can represent a huge overhead when many sets exist in the Gaffer scene, but not in the USD file. This reduces the runtime for `testUSDEmptySetsPerformance` by greater than 85%. I suspect it will have an even greater impact on the production scene I'm currently testing.

I did consider moving this check to `USDScene::readSet()` itself, but decided against for a few reasons :

- `readSet()` can be called at any level of the hierarchy, so we would either need a special case for the root (the only case Gaffer cares about), or we would need storage for the set names at each location (to cater to the general case).
- If we need to store things somewhere, using Gaffer's single unified cache is preferable to an invisible cache somewhere else.
- The same issue applies for `AlembicScene`, so this way we get to kill two birds with one stone.
