### PR TITLE
Gaffer module : Move config loading after all name definitions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.x.x (relative to 1.2.6.0)
 =======
 
+Fixes
+-----
+
+- Gaffer module : Moved config loading after all name definitions
 
 1.2.6.0 (relative to 1.2.5.0)
 =======

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -60,8 +60,6 @@ from .Monitor import Monitor
 from . import NodeAlgo
 from . import ExtensionAlgo
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )
-
 # Class-level non-UI metadata registration
 Metadata.registerValue( Reference, "childNodesAreReadOnly", True )
 
@@ -80,3 +78,5 @@ def executablePath( absolute = True ) :
 		return rootPath() / "bin" / executable
 
 	return executable
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )


### PR DESCRIPTION
Moves the line loading startup config files for the Gaffer module to the end of the file, so all name definitions can be changed by those configs.

### Related issues ###

The previous implementation prevented us from overriding the `executablePath()` definition via a module config file.
See #5313 

### Dependencies ###

None

### Breaking changes ###

None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
