### PR TITLE
Widget: Expose the top level Gaffer Widget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.x.x (relative to 1.2.6.0)
 =======
 
+API
+---
+
+- Widget : Exposed the top level Gaffer widget to the api so deriving classes from GafferUI.Widget sub classes is easier.
 
 1.2.6.0 (relative to 1.2.5.0)
 =======

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -128,6 +128,8 @@ class Widget( Gaffer.Signals.Trackable, metaclass = _WidgetMetaclass ) :
 
 		assert( isinstance( topLevelWidget, ( QtWidgets.QWidget, Widget ) ) )
 
+		self.__gafferWidget = None
+
 		if isinstance( topLevelWidget, QtWidgets.QWidget ) :
 			assert( Widget.__qtWidgetOwners.get( topLevelWidget ) is None )
 			self.__qtWidget = topLevelWidget
@@ -669,6 +671,13 @@ class Widget( Gaffer.Signals.Trackable, metaclass = _WidgetMetaclass ) :
 	def _postConstructor( self ) :
 
 		pass
+
+	## Returns the top level GafferUI widget. If the
+	# top level widget set is a native qt widget
+	# will return None
+	def _gafferWidget( self ) :
+
+		return self.__gafferWidget
 
 	## Returns the top level QWidget instance used to implement
 	# the GafferUI.Widget functionality.


### PR DESCRIPTION
When we derive from a GafferUI Widget class we may want to access the top level Gaffer widget so we can inject additional widgets into the already created UI. By exposing the top level GafferUI.Widget this allows us to do that from more than just the QtWidget which may not be as reliable.

Api
---
- Widget: Expose the top level Gaffer widget to the api so deriving classes from GafferUI.Widget sub classes is easier

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
