### PR TITLE
SceneReader : Control cache policy via environment variables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,16 @@ Fixes
 
 - Gaffer module : Delayed loading of config files until the Gaffer module is completely defined.
 
+API
+---
+
+- SceneReader : Added environment variables to control cache policies.
+  - `GAFFERSCENE_SCENEREADER_OBJECT_CACHEPOLICY` controls the policy for objects.
+  - `GAFFERSCENE_SCENEREADER_SETNAMES_CACHEPOLICY` controls the policy for set names.
+  - `GAFFERSCENE_SCENEREADER_SET_CACHEPOLICY` controls the policy for sets.
+  - Default policies remain unchanged, but `Standard` policy may yield improved performance and
+    reduced memory usage for Alembic or USD files making heavy use of instancing.
+
 1.2.6.0 (relative to 1.2.5.0)
 =======
 

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -83,6 +83,8 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 
 	protected :
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 		/// \todo These methods defer to SceneInterface::hash() to do most of the work, but we could go further.
 		/// Currently we still hash in fileNamePlug() and refreshCountPlug() because we don't trust the current
 		/// implementation of SceneCache::hash() - it should hash the filename and modification time, but instead


### PR DESCRIPTION
This resurrects #3944, but this time providing environment variables to control the cache policies rather than hardcoding them. Since the main hesitation in getting #3944 merged was a lack of production testing, this new approach will allow opt-in testing, with no additional risk to those who don't opt in. I'm pretty hopeful that it won't take much testing to get this validated though, and we can change the default soon. My synthetic tests are showing substantial performance gains and reductions in memory usage.