### PR TITLE
IECoreScene config : Set SharedSceneInterface limit to 2000 files

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - EditScope : Hid the `BoxIn.name` and `BoxOut.name` plugs from the NodeEditor, since it is not editable and the name is _always_ `in` or `out` respectively.
+- Limits : Increased soft file handle limit (`RLIMIT_NOFILE`) to match the hard limit (Linux only).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - EditScope : Hid the `BoxIn.name` and `BoxOut.name` plugs from the NodeEditor, since it is not editable and the name is _always_ `in` or `out` respectively.
 - Limits : Increased soft file handle limit (`RLIMIT_NOFILE`) to match the hard limit (Linux only).
+- SceneReader : Increased the default limit for the number of open files to 2000 (or 25% of the file handle limit, whichever is lowest).
 
 Fixes
 -----

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -52,8 +52,17 @@ signal.signal( signal.SIGINT, signal.SIG_DFL )
 warnings.simplefilter( "default", DeprecationWarning )
 
 import IECore
-from Gaffer._Gaffer import _nameProcess
 
+# Increase the soft limit for file handles as high as we can - we need everything we can get for
+# opening models, textures etc.
+if os.name != "nt" :
+	import resource
+	softFileLimit, hardFileLimit = resource.getrlimit( resource.RLIMIT_NOFILE )
+	if softFileLimit < hardFileLimit :
+		resource.setrlimit( resource.RLIMIT_NOFILE, ( hardFileLimit, hardFileLimit ) )
+		IECore.msg( IECore.Msg.Level.Info, "Gaffer", "Increased file handle limit to {}".format( hardFileLimit ) )
+
+from Gaffer._Gaffer import _nameProcess
 _nameProcess()
 
 helpText = """Usage :

--- a/startup/GafferScene/sharedSceneInterfaces.py
+++ b/startup/GafferScene/sharedSceneInterfaces.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+
+import IECoreScene
+
+# Cortex default limit is 200, which is not sufficient for many real production
+# use cases, and the cost of re-opening large USD assemblies is too high to
+# want to do it more than once.
+
+maxScenes = 2000
+if os.name != "nt" :
+	import resource
+	maxScenes = max(
+		200,
+		min( maxScenes, resource.getrlimit( resource.RLIMIT_NOFILE )[0] // 4 )
+	)
+
+IECoreScene.SharedSceneInterfaces.setMaxScenes( maxScenes )


### PR DESCRIPTION
This is the limit which controls how many files the SceneReader will keep open concurrently. Setting it too low has two downsides :

- Runtime cost of reopening files as the cache is thrashed. This can be significant, particularly for large USD assemblies where stage composition is expensive.
- We currently have a bug when the same USD file is opened twice - the hashes for instanced locations may be swapped around, resulting in `IOException` errors where we try to read non-existent children. Fixing this is a priority, but it is nasty enough that in the meantime, all mitigations are worthwhile.

No doubt we could have a healthy debate about precisely what the default should be. My thought process was this :

- 200 is definitely too low. It thrashes for current production scenes in several studios.
- Image Engine uses a default of 500, which is sufficient for the production scenes I've been looking at recently, but doesn't leave a _lot_ of headroom.
- Cinesite has recently gone nuclear and bumped to 20000, effectively guaranteeing that Gaffer will never _ever_ close a cache file. This seems too high for a universal default, since we don't know what `ulimit` might be in effect in other studios.
- `ulimit` on my stock CentOS install is 65535.
- A factor of 10x increase is significant enough to be worthwhile, and gives reasonably headroom in current known production use cases. But still seems conservative enough to not cause problems in (reasonable) unknown environments.
