### PR TITLE
SceneReader : Use GlobalScope for accessing input plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.6.0)
 =======
 
+Improvements
+------------
+
+- SceneReader : Removed `scene:path` and `scene:setName` variables from context used to evaluate `fileName`, `refreshCount` and `tags` plugs. This prevents logical impossibilities like changing the file per location, and also reduces pressure on the hash cache.
+
 Fixes
 -----
 

--- a/include/GafferScene/SceneReader.h
+++ b/include/GafferScene/SceneReader.h
@@ -125,9 +125,11 @@ class GAFFERSCENE_API SceneReader : public SceneNode
 			IECoreScene::ConstSceneInterfacePtr pathScene;
 		};
 		mutable tbb::enumerable_thread_specific<LastScene> m_lastScene;
-		// Returns the SceneInterface for the current filename (in the current Context)
-		// and specified path, using m_lastScene to accelerate the lookups.
-		IECoreScene::ConstSceneInterfacePtr scene( const ScenePath &path ) const;
+		// Returns the SceneInterface for the current filename and specified
+		// path, using `m_lastScene` to accelerate the lookups. If `refreshCount`
+		// or `tags` are provided, they are filled from `refreshCountPlug()` and
+		// `tagsPlug()` respectively.
+		IECoreScene::ConstSceneInterfacePtr scene( const ScenePath &path, const Gaffer::Context *context, int *refreshCount = nullptr, std::string *tags = nullptr ) const;
 
 		static const double g_frameRate;
 		static size_t g_firstPlugIndex;

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -218,13 +218,14 @@ void SceneReader::hashBound( const ScenePath &path, const Gaffer::Context *conte
 {
 	SceneNode::hashBound( path, context, parent, h );
 
-	ConstSceneInterfacePtr s = scene( path );
+	int refreshCount = 0;
+	ConstSceneInterfacePtr s = scene( path, context, &refreshCount );
 	if( !s )
 	{
 		return;
 	}
 
-	refreshCountPlug()->hash( h );
+	h.append( refreshCount );
 
 	if( s->hasBound() )
 	{
@@ -252,7 +253,7 @@ void SceneReader::hashBound( const ScenePath &path, const Gaffer::Context *conte
 
 Imath::Box3f SceneReader::computeBound( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	ConstSceneInterfacePtr s = scene( path, context );
 	if( !s )
 	{
 		return Box3f();
@@ -285,13 +286,14 @@ void SceneReader::hashTransform( const ScenePath &path, const Gaffer::Context *c
 {
 	SceneNode::hashTransform( path, context, parent, h );
 
-	ConstSceneInterfacePtr s = scene( path );
+	int refreshCount = 0;
+	ConstSceneInterfacePtr s = scene( path, context, &refreshCount );
 	if( !s )
 	{
 		return;
 	}
 
-	refreshCountPlug()->hash( h );
+	h.append( refreshCount );
 	s->hash( SceneInterface::TransformHash, timeAsDouble( context ), h );
 
 	if( path.size() == 1 )
@@ -302,7 +304,7 @@ void SceneReader::hashTransform( const ScenePath &path, const Gaffer::Context *c
 
 Imath::M44f SceneReader::computeTransform( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	ConstSceneInterfacePtr s = scene( path, context );
 	if( !s )
 	{
 		return M44f();
@@ -325,7 +327,8 @@ Imath::M44f SceneReader::computeTransform( const ScenePath &path, const Gaffer::
 
 void SceneReader::hashAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	int refreshCount = 0;
+	ConstSceneInterfacePtr s = scene( path, context, &refreshCount );
 	if( !s )
 	{
 		h = parent->attributesPlug()->defaultValue()->Object::hash();
@@ -334,13 +337,13 @@ void SceneReader::hashAttributes( const ScenePath &path, const Gaffer::Context *
 
 	SceneNode::hashAttributes( path, context, parent, h );
 
-	refreshCountPlug()->hash( h );
+	h.append( refreshCount );
 	s->hash( SceneInterface::AttributesHash, timeAsDouble( context ), h );
 }
 
 IECore::ConstCompoundObjectPtr SceneReader::computeAttributes( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	ConstSceneInterfacePtr s = scene( path, context );
 	if( !s )
 	{
 		return parent->attributesPlug()->defaultValue();
@@ -388,8 +391,8 @@ IECore::ConstCompoundObjectPtr SceneReader::computeAttributes( const ScenePath &
 
 void SceneReader::hashObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-
-	ConstSceneInterfacePtr s = scene( path );
+	int refreshCount = 0;
+	ConstSceneInterfacePtr s = scene( path, context, &refreshCount );
 	if( !s || !s->hasObject() )
 	{
 		// no object
@@ -399,13 +402,13 @@ void SceneReader::hashObject( const ScenePath &path, const Gaffer::Context *cont
 
 	SceneNode::hashObject( path, context, parent, h );
 
-	refreshCountPlug()->hash( h );
+	h.append( refreshCount );
 	s->hash( SceneInterface::ObjectHash, timeAsDouble( context ), h );
 }
 
 IECore::ConstObjectPtr SceneReader::computeObject( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	ConstSceneInterfacePtr s = scene( path, context );
 	if( !s || !s->hasObject() )
 	{
 		return parent->objectPlug()->defaultValue();
@@ -416,7 +419,8 @@ IECore::ConstObjectPtr SceneReader::computeObject( const ScenePath &path, const 
 
 void SceneReader::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	int refreshCount = 0; string tags;
+	ConstSceneInterfacePtr s = scene( path, context, &refreshCount, &tags );
 	if( !s )
 	{
 		h = parent->childNamesPlug()->defaultValue()->Object::hash();
@@ -425,17 +429,16 @@ void SceneReader::hashChildNames( const ScenePath &path, const Gaffer::Context *
 
 	SceneNode::hashChildNames( path, context, parent, h );
 
-	refreshCountPlug()->hash( h );
-
-	// append a hash of the tags plug, as restricting the tags can affect the hierarchy
-	tagsPlug()->hash( h );
+	h.append( refreshCount );
+	h.append( tags );
 
 	s->hash( SceneInterface::ChildNamesHash, timeAsDouble( context ), h );
 }
 
 IECore::ConstInternedStringVectorDataPtr SceneReader::computeChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( path );
+	string tagsString;
+	ConstSceneInterfacePtr s = scene( path, context, nullptr, &tagsString );
 	if( !s )
 	{
 		return parent->childNamesPlug()->defaultValue();
@@ -449,7 +452,6 @@ IECore::ConstInternedStringVectorDataPtr SceneReader::computeChildNames( const S
 
 	// filter out any which don't have the right tags
 
-	std::string tagsString = tagsPlug()->getValue();
 	if( !tagsString.empty() )
 	{
 		Tokenizer tagsTokenizer( tagsString, boost::char_separator<char>( " " ) );
@@ -506,7 +508,7 @@ void SceneReader::hashSetNames( const Gaffer::Context *context, const ScenePlug 
 
 IECore::ConstInternedStringVectorDataPtr SceneReader::computeSetNames( const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr s = scene( ScenePath() );
+	ConstSceneInterfacePtr s = scene( ScenePath(), context );
 	if( !s )
 	{
 		return parent->setNamesPlug()->defaultValue();
@@ -533,6 +535,8 @@ IECore::ConstInternedStringVectorDataPtr SceneReader::computeSetNames( const Gaf
 void SceneReader::hashSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
 {
 	SceneNode::hashSet( setName, context, parent, h );
+
+	ScenePlug::GlobalScope globalScope( context );
 	fileNamePlug()->hash( h );
 	refreshCountPlug()->hash( h );
 	h.append( setName );
@@ -571,7 +575,7 @@ static void loadSetWalk( const SceneInterface *s, const InternedString &setName,
 
 IECore::ConstPathMatcherDataPtr SceneReader::computeSet( const IECore::InternedString &setName, const Gaffer::Context *context, const ScenePlug *parent ) const
 {
-	ConstSceneInterfacePtr rootScene = scene( ScenePath() );
+	ConstSceneInterfacePtr rootScene = scene( ScenePath(), context );
 	if( !rootScene )
 	{
 		return outPlug()->setPlug()->defaultValue();
@@ -620,12 +624,23 @@ void SceneReader::plugSet( Gaffer::Plug *plug )
 	}
 }
 
-ConstSceneInterfacePtr SceneReader::scene( const ScenePath &path ) const
+ConstSceneInterfacePtr SceneReader::scene( const ScenePath &path, const Gaffer::Context *context, int *refreshCount, std::string *tags ) const
 {
+	ScenePlug::GlobalScope globalScope( context );
+
 	std::string fileName = fileNamePlug()->getValue();
 	if( !fileName.size() )
 	{
 		return nullptr;
+	}
+
+	if( refreshCount )
+	{
+		*refreshCount = refreshCountPlug()->getValue();
+	}
+	if( tags )
+	{
+		*tags = tagsPlug()->getValue();
 	}
 
 	LastScene &lastScene = m_lastScene.local();


### PR DESCRIPTION
This prevents impossible setups like requesting a different filename for each location. It also reduces pressure on the hash cache in the common case that the filename is provided by an expression input (which would previously have been hashed once for every value of `scene:path`).

We originally tried this in #1745, but abandoned it due to concerns that the additional context creation overhead offset any benefits. But Context creation performance has been significantly improved since then. I tested this on the Moana island asset, _without_ an expression driving the `fileName` - the worst case situation where there can be no benefit from the GlobalScope. This demonstrated that the additional overhead of constructing the GlobalScope is now neglibible.
