### PR TITLE
ColorProcessor/OpenColorIOTransform : Refactor for simplicity and performance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,9 @@ Improvements
     - Removed "Default" view.
     - Added menu options for changing the current Display.
     - Allowed the available views to be filtered using an `openColorIO:activeViews` metadata value registered on the View's `displayTransform.name` plug. Values should be space-separated names, optionally containing wildcards.
+  - OpenColorIOTransform :
+    - Improved performance.
+    - Improved detection of no-op transforms, such as when converting between colorspace aliases like `scene_linear` and `ACEScg`.
 - Seeds :
   - Renamed to Scatter.
   - Added sampling of primitive variables from the source mesh onto the scattered points, controlled using the new `primitiveVariables` plug.
@@ -55,6 +58,7 @@ API
 - ViewportGadget : A post-process shader can now be applied to any layer, not just the main one.
 - SceneGadget : Added `setLayer()` and `getLayer()` methods, which allow the destination `Gadget::Layer` to be specified.
 - TestCase : Added `ignoreMessage()` method, to register messages that should not be treated as test failures.
+- OpenColorIOTransform : Automated image pass-throughs when the `transform()` method returns a no-op. Derived classes no longer need to implement their own pass-through.
 - OpenColorIOTransformUI :
   - Added `noneLabel` argument to `colorSpacePresetNames()`.
   - Added support for `openColorIO:categories` and `openColorIO:includeRoles` metadata to `colorSpacePresetNames()`. These may be registered on a per-plug basis to control the colorspaces shown for that plug.
@@ -90,6 +94,11 @@ Breaking Changes
 - Seeds :
   - Renamed to Scatter.
   - Bugs fixes have made small changes to the point distribution.
+- ColorProcessor : Refactored virtual methods that must be implemented by derived classes :
+  - Replaced `processColorData()` with `colorProcessor()` method that returns a `ColorProcessorFunction`.
+  - Replaced `affectsColorData()` with `affectsColorProcessor()` and `hashColorData()` with `hashColorProcessor()`.
+  - Simplified implementation of pass-throughs when the color processor is a no-op. Derived classes may simply
+    return an empty `ColorProcessorFunction`, and everything else is taken care of in the base class.
 
 Build
 -----

--- a/include/GafferImage/OpenColorIOTransform.h
+++ b/include/GafferImage/OpenColorIOTransform.h
@@ -79,25 +79,6 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 	protected :
 
 		explicit OpenColorIOTransform( const std::string &name=defaultName<OpenColorIOTransform>(), bool withContextPlug=false );
-		/// Implemented to return true if hashTransform() has
-		/// an affect. Derived classed should implement
-		/// hashTransform() to return a default hash if the
-		/// node should be in a disabled state.
-		/// \todo: rework ColorProcessor so we can remove this.
-		bool enabled() const override;
-
-		/// Implemented to call affectsTransform() if the base class
-		/// does not affect the color data for this input. Derived
-		/// classes should implement affectsTransform() instead.
-		bool affectsColorData( const Gaffer::Plug *input ) const override;
-		/// Implemented to call hashTransform() after hashing the
-		/// affect of the base class. Derived classes should
-		/// implement hashTransform() instead.
-		void hashColorData( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		/// Implemented to fetch an OpenColorIO Processor from the
-		/// OpenColorIO Config and apply it to the output channels.
-		/// Derived classes should implement transform() instead.
-		void processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const override;
 
 		/// Derived classes must implement this to return true if the specified input
 		/// is used in transform().
@@ -110,6 +91,10 @@ class GAFFERIMAGE_API OpenColorIOTransform : public ColorProcessor
 		virtual OCIO_NAMESPACE::ConstTransformRcPtr transform() const = 0;
 
 	private :
+
+		bool affectsColorProcessor( const Gaffer::Plug *input ) const final;
+		void hashColorProcessor( const Gaffer::Context *context, IECore::MurmurHash &h ) const final;
+		ColorProcessorFunction colorProcessor( const Gaffer::Context *context ) const final;
 
 		OCIO_NAMESPACE::ConstContextRcPtr ocioContext( OCIO_NAMESPACE::ConstConfigRcPtr config ) const;
 

--- a/include/GafferImage/Saturation.h
+++ b/include/GafferImage/Saturation.h
@@ -57,10 +57,9 @@ class GAFFERIMAGE_API Saturation : public ColorProcessor
 
 	protected :
 
-		bool enabled() const override;
-		bool affectsColorData( const Gaffer::Plug *input ) const override;
-		void hashColorData( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
-		void processColorData( const Gaffer::Context *context, IECore::FloatVectorData *r, IECore::FloatVectorData *g, IECore::FloatVectorData *b ) const override;
+		bool affectsColorProcessor( const Gaffer::Plug *input ) const override;
+		void hashColorProcessor( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		ColorProcessorFunction colorProcessor( const Gaffer::Context *context ) const override;
 
 	private :
 

--- a/python/GafferImageTest/CDLTest.py
+++ b/python/GafferImageTest/CDLTest.py
@@ -100,7 +100,8 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 		o = GafferImage.CDL()
 		o["in"].setInput( n["out"] )
 
-		self.assertEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
+		self.assertImagesEqual( n["out"], o["out"] )
+		self.assertImageHashesEqual( n["out"], o["out"] )
 
 		o['slope'].setValue( imath.Color3f( 1, 2, 3 ) )
 
@@ -108,19 +109,13 @@ class CDLTest( GafferImageTest.ImageTestCase ) :
 
 		o["enabled"].setValue( False )
 
-		self.assertEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
-		self.assertEqual( n["out"]['format'].hash(), o["out"]['format'].hash() )
-		self.assertEqual( n["out"]['dataWindow'].hash(), o["out"]['dataWindow'].hash() )
-		self.assertEqual( n["out"]["metadata"].getValue(), o["out"]["metadata"].getValue() )
-		self.assertEqual( n["out"]['channelNames'].hash(), o["out"]['channelNames'].hash() )
+		self.assertImagesEqual( n["out"], o["out"] )
+		self.assertImageHashesEqual( n["out"], o["out"] )
 
 		o["enabled"].setValue( True )
 		o['slope'].setValue( o['slope'].defaultValue() )
-		self.assertEqual( GafferImage.ImageAlgo.image( n["out"] ), GafferImage.ImageAlgo.image( o["out"] ) )
-		self.assertEqual( n["out"]['format'].hash(), o["out"]['format'].hash() )
-		self.assertEqual( n["out"]['dataWindow'].hash(), o["out"]['dataWindow'].hash() )
-		self.assertEqual( n["out"]["metadata"].getValue(), o["out"]["metadata"].getValue() )
-		self.assertEqual( n["out"]['channelNames'].hash(), o["out"]['channelNames'].hash() )
+		self.assertImagesEqual( n["out"], o["out"] )
+		self.assertImageHashesEqual( n["out"], o["out"] )
 
 	def testImageHashPassThrough( self ) :
 

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -128,7 +128,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 
 		o["inputColorSpace"].setValue( "scene_linear" )
 		o["display"].setValue( "sRGB - Display" )
-		o["view"].setValue( "rec709" )
+		o["view"].setValue( "ACES 1.0 - SDR Video" )
 
 		self.assertNotEqual( GafferImage.ImageAlgo.imageHash( i["out"] ), GafferImage.ImageAlgo.imageHash( o["out"] ) )
 

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -53,7 +53,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 	groundTruth = GafferImageTest.ImageTestCase.imagesPath() / "checker_ocio_look.exr"
 	ocioConfig = GafferImageTest.ImageTestCase.openColorIOPath() / "context.ocio"
 
-	def test( self ) :
+	def testInvalidLook( self ) :
 
 		n = GafferImage.ImageReader()
 		n["fileName"].setValue( self.fileName )
@@ -64,10 +64,10 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		self.assertImageHashesEqual( n["out"], o["out"] )
 		self.assertImagesEqual( n["out"], o["out"] )
 
-		o["look"].setValue( "primary" )
+		o["look"].setValue( "nonexistent" )
 
-		self.assertRaises( AssertionError, lambda: self.assertImageHashesEqual( n["out"], o["out"] ) )
-		self.assertRaises( Exception, lambda: self.assertImagesEqual( n["out"], o["out"] ) )
+		with self.assertRaisesRegex( Gaffer.ProcessException, ".* The specified look, 'nonexistent', cannot be found.*" ) :
+			GafferImage.ImageAlgo.tiles( o["out"] )
 
 	def testPrimary( self ):
 

--- a/src/GafferImage/CDL.cpp
+++ b/src/GafferImage/CDL.cpp
@@ -131,17 +131,6 @@ bool CDL::affectsTransform( const Gaffer::Plug *input ) const
 
 void CDL::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if(
-		slopePlug()->isSetToDefault() &&
-		offsetPlug()->isSetToDefault() &&
-		powerPlug()->isSetToDefault() &&
-		saturationPlug()->isSetToDefault()
-	)
-	{
-		h = MurmurHash();
-		return;
-	}
-
 	slopePlug()->hash( h );
 	offsetPlug()->hash( h );
 	powerPlug()->hash( h );

--- a/src/GafferImage/ColorSpace.cpp
+++ b/src/GafferImage/ColorSpace.cpp
@@ -91,27 +91,16 @@ bool ColorSpace::affectsTransform( const Gaffer::Plug *input ) const
 
 void ColorSpace::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	std::string inSpace = inputSpacePlug()->getValue();
-	std::string outSpace = outputSpacePlug()->getValue();
-
-	if( inSpace == outSpace || inSpace.empty() || outSpace.empty() )
-	{
-		h = MurmurHash();
-		return;
-	}
-
 	inputSpacePlug()->hash( h );
 	outputSpacePlug()->hash( h );
 }
 
 OCIO_NAMESPACE::ConstTransformRcPtr ColorSpace::transform() const
 {
-	string inputSpace( inputSpacePlug()->getValue() );
-	string outputSpace( outputSpacePlug()->getValue() );
+	const string inputSpace = inputSpacePlug()->getValue();
+	const string outputSpace = outputSpacePlug()->getValue();
 
-	// no need to run the processor if we're not
-	// actually changing the color space.
-	if( ( inputSpace == outputSpace ) || inputSpace.empty() || outputSpace.empty() )
+	if( inputSpace.empty() || outputSpace.empty() )
 	{
 		return OCIO_NAMESPACE::ColorSpaceTransformRcPtr();
 	}

--- a/src/GafferImage/DisplayTransform.cpp
+++ b/src/GafferImage/DisplayTransform.cpp
@@ -97,19 +97,9 @@ bool DisplayTransform::affectsTransform( const Gaffer::Plug *input ) const
 
 void DisplayTransform::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	std::string colorSpace = inputColorSpacePlug()->getValue();
-	std::string display = displayPlug()->getValue();
-	std::string view = viewPlug()->getValue();
-
-	if( colorSpace.empty() || display.empty() || view.empty() )
-	{
-		h = MurmurHash();
-		return;
-	}
-
-	h.append( colorSpace );
-	h.append( display );
-	h.append( view );
+	inputColorSpacePlug()->hash( h );
+	displayPlug()->hash( h );
+	viewPlug()->hash( h );
 }
 
 OCIO_NAMESPACE::ConstTransformRcPtr DisplayTransform::transform() const
@@ -118,8 +108,7 @@ OCIO_NAMESPACE::ConstTransformRcPtr DisplayTransform::transform() const
 	std::string display = displayPlug()->getValue();
 	std::string view = viewPlug()->getValue();
 
-	// no need to run the processor if we don't
-	// have valid inputs
+	// Can't create a processor if we don't have valid inputs.
 	if( colorSpace.empty() || display.empty() || view.empty() )
 	{
 		return OCIO_NAMESPACE::ConstTransformRcPtr();

--- a/src/GafferImage/LUT.cpp
+++ b/src/GafferImage/LUT.cpp
@@ -121,12 +121,6 @@ bool LUT::affectsTransform( const Gaffer::Plug *input ) const
 
 void LUT::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	if( fileNamePlug()->getValue().empty() )
-	{
-		h = MurmurHash();
-		return;
-	}
-
 	fileNamePlug()->hash( h );
 	directionPlug()->hash( h );
 	interpolationPlug()->hash( h );

--- a/src/GafferImage/LookTransform.cpp
+++ b/src/GafferImage/LookTransform.cpp
@@ -87,37 +87,22 @@ bool LookTransform::affectsTransform( const Gaffer::Plug *input ) const
 
 void LookTransform::hashTransform( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
-	std::string look = lookPlug()->getValue();
-	if( look.empty() )
-	{
-		h = MurmurHash();
-		return;
-	}
-
 	lookPlug()->hash( h );
 	directionPlug()->hash( h );
 }
 
 OCIO_NAMESPACE::ConstTransformRcPtr LookTransform::transform() const
 {
-	OCIO_NAMESPACE::ConstConfigRcPtr config = OCIO_NAMESPACE::GetCurrentConfig();
-	OCIO_NAMESPACE::ConstColorSpaceRcPtr linearcs = config->getColorSpace( OCIO_NAMESPACE::ROLE_SCENE_LINEAR );
-	if (!linearcs)
-		throw IECore::Exception( "LookTransform: exception thrown during OCIO setup; ROLE_SCENE_LINEAR not defined." );
-
-	string colorSpace( linearcs->getName() );
-	string look( lookPlug()->getValue() );
-
-	// no need to run the processor if we're not actually changing the color space.
-	if( colorSpace.empty() || look.empty() )
+	const string look( lookPlug()->getValue() );
+	if( look.empty() )
 	{
 		return OCIO_NAMESPACE::ColorSpaceTransformRcPtr();
 	}
 
 	OCIO_NAMESPACE::LookTransformRcPtr transform = OCIO_NAMESPACE::LookTransform::Create();
-	transform->setSrc( colorSpace.c_str() );
+	transform->setSrc( OCIO_NAMESPACE::ROLE_SCENE_LINEAR );
 	transform->setLooks( look.c_str() );
-	transform->setDst( colorSpace.c_str() );
+	transform->setDst( OCIO_NAMESPACE::ROLE_SCENE_LINEAR );
 	transform->setDirection( directionPlug()->getValue() == Forward ? OCIO_NAMESPACE::TRANSFORM_DIR_FORWARD : OCIO_NAMESPACE::TRANSFORM_DIR_INVERSE );
 
 	return transform;


### PR DESCRIPTION
Derived classes now return a ColorProcessorFunction which is cached on an internal `__colorProcessor` plug. This simplifies the implementation of pass-throughs for no-op processors (they just return an empty ColorProcessorFunction and the rest is dealt with in the base class). It also means that we only create OCIO CPUProcessors once, instead of every tile. This gives a 25% reduction in runtime for a test applying a ColorSpace node. Tests with `gaffer stats -image -preCache` also show a significant reduction in hashing time - around 65%.

A side effect of this is that we have much better detection of no-op OCIO processors, so transforming between color-space aliases is now a perfect pass-through. That should fix the failing test in #5324, so I'd like to get this reviewed fairly quickly so I can rebase the other PR on top.