### PR TITLE
CatalogueUI : Make ImageListing Widget Public

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,11 @@ Fixes
 - NodeEditor : Reverted change that prevented a plug being unlocked if static `readOnly` metadata was registered against it.
 - EditMenu : Fixed errors using "Duplicate with Inputs" with certain configurations of Dot node (#5309).
 
+API
+---
+
+- CatalogueUI : Made ImageListing widget public so it can be customized using the API.
+
 1.2.7.0 (relative to 1.2.6.0)
 =======
 

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -429,7 +429,7 @@ Gaffer.Metadata.registerNode(
 			from the catalogue node.
 			""",
 
-			"plugValueWidget:type", "GafferImageUI.CatalogueUI._ImageListing",
+			"plugValueWidget:type", "GafferImageUI.CatalogueUI.ImageListing",
 			"label", "",
 			"layout:section", "Images",
 
@@ -690,10 +690,10 @@ class _ImagesPath( Gaffer.Path ) :
 			self._emitPathChanged()
 
 ##########################################################################
-# _ImageListing
+# ImageListing
 ##########################################################################
 
-class _ImageListing( GafferUI.PlugValueWidget ) :
+class ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
@@ -729,7 +729,7 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 			)
 			self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
 
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) as self.__buttonRow :
 
 				addButton = GafferUI.Button( image = "pathChooser.png", hasFrame = False, toolTip = "Load image" )
 				addButton.clickedSignal().connect( Gaffer.WeakMethod( self.__addClicked ), scoped = False )
@@ -768,6 +768,12 @@ class _ImageListing( GafferUI.PlugValueWidget ) :
 		Gaffer.Metadata.plugValueChangedSignal( plug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataValueChanged ), scoped = False )
 
 		self.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenu ), scoped = False )
+
+	def buttonRow( self ):
+
+		# Convenience method to get the button row list container to make
+		# it easier to add additional buttons to the Image Listing widget
+		return self.__buttonRow
 
 	def getToolTip( self ) :
 

--- a/startup/GafferImageUI/catalogueUICompatibility.py
+++ b/startup/GafferImageUI/catalogueUICompatibility.py
@@ -1,0 +1,39 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImageUI
+
+GafferImageUI.CatalogueUI._ImageListing = GafferImageUI.CatalogueUI.ImageListing


### PR DESCRIPTION
As per the discussion in https://github.com/GafferHQ/gaffer/pull/5316, I have made the ImageListing widget public with a config to ensure the private method points to the new public method and added a way to access the button list container.

Api
---
- CatalogueUI : Make ImageListing widget public so it can be customized using the API

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
