### PR TITLE
DotNodeGadget : Support context-sensitive labels

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - EditMenu : Fixed errors using "Duplicate with Inputs" with certain configurations of Dot node (#5309).
+- Dot : Fixed the display of context-sensitive `label` values.
 
 1.1.9.6 (relative to 1.1.9.5)
 =======

--- a/src/GafferUI/DotNodeGadget.cpp
+++ b/src/GafferUI/DotNodeGadget.cpp
@@ -186,7 +186,14 @@ void DotNodeGadget::updateLabel()
 		}
 		else
 		{
+			const auto script = dot->scriptNode();
+			const Context *context = script ? script->context() : nullptr;
+			Context::Scope scope( context );
 			m_label = dot->labelPlug()->getValue();
+			if( context )
+			{
+				m_label = context->substitute( m_label );
+			}
 		}
 	}
 	catch( const Gaffer::ProcessException &e )


### PR DESCRIPTION
Fixes #5330.
