### PR TITLE
PathListingWidget : Remove `expandNonLeaf`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -91,6 +91,7 @@ Breaking Changes
 - ImageReader : Renamed `None` preset to `Automatic`.
 - OpenColorIOTransform : Removed `availableColorSpaces()` and `availableRoles()` methods.
 - OpenColorIO : Changed default config.
+- PathListingWidget : Removed `expandNonLeaf` argument from `setSelection()` and `setSelectedPaths()` methods.
 - Subprocess32 : Removed Python module.
 - Six : Removed Python module.
 - Gaffer : Class constructors are now declared explicit disabling implicit conversions.

--- a/python/GafferCortexUI/FileIndexedIOPathPreview.py
+++ b/python/GafferCortexUI/FileIndexedIOPathPreview.py
@@ -104,7 +104,7 @@ class FileIndexedIOPathPreview( GafferUI.DeferredPathPreview ) :
 		with Gaffer.Signals.BlockedConnection( self.__pathListingSelectionChangedConnection ) :
 			## \todo This functionality might be nice in the PathChooserWidget. We could
 			# maybe even use a PathChooserWidget here anyway.
-			self.__pathListing.setSelection( IECore.PathMatcher( [ str( pathCopy ) ] ), expandNonLeaf=False )
+			self.__pathListing.setSelection( IECore.PathMatcher( [ str( pathCopy ) ] ) )
 			# expand as people type forwards
 			if len( pathCopy ) > len( self.__prevPath ) :
 				self.__pathListing.setPathExpanded( pathCopy, True )

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -238,7 +238,7 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 
 		selection = ContextAlgo.getSelectedPaths( self.getContext() )
 		with Gaffer.Signals.BlockedConnection( self.__selectionChangedConnection ) :
-			self.__pathListing.setSelection( selection, scrollToFirst=True, expandNonLeaf=False )
+			self.__pathListing.setSelection( selection, scrollToFirst=True )
 
 GafferUI.Editor.registerType( "HierarchyView", HierarchyView )
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -300,7 +300,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		selectedPaths = ContextAlgo.getSelectedPaths( self.getContext() )
 		with Gaffer.Signals.BlockedConnection( self.__selectionChangedConnection ) :
 			selection = [selectedPaths] + ( [IECore.PathMatcher()] * ( len( self.__pathListing.getColumns() ) - 1 ) )
-			self.__pathListing.setSelection( selection, scrollToFirst=True, expandNonLeaf=False )
+			self.__pathListing.setSelection( selection, scrollToFirst=True )
 
 	def __buttonDoubleClick( self, pathListing, event ) :
 
@@ -573,7 +573,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			for p in selection :
 				p.clear()
 			selection[columnIndex].addPath( str( cellPath ) )
-			pathListing.setSelection( selection, expandNonLeaf = False, scrollToFirst = False )
+			pathListing.setSelection( selection, scrollToFirst = False )
 
 		menuDefinition = IECore.MenuDefinition()
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -333,7 +333,7 @@ class PathListingWidget( GafferUI.Widget ) :
 	## Sets the currently selected paths. Accepts a single `IECore.PathMatcher`
 	# for `Row` and `Rows` modes, and a list of `IECore.PathMatcher`, one for
 	# each column, for `Cell` and `Cells` modes.
-	def setSelection( self, paths, scrollToFirst=True, expandNonLeaf=True ) :
+	def setSelection( self, paths, scrollToFirst=True ) :
 
 		if self.__rowSelectionMode() :
 			assert( isinstance( paths, IECore.PathMatcher ) )
@@ -354,7 +354,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			) :
 				raise ValueError( "More than one cell selected" )
 
-		self.__setSelectionInternal( paths, scrollToFirst, expandNonLeaf )
+		self.__setSelectionInternal( paths, scrollToFirst )
 
 	## Returns an `IECore.PathMatcher` object containing the currently selected
 	# paths for `Row` or `Rows` modes, and a list of `IECore.PathMatcher`
@@ -379,7 +379,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		)
 
 	## \deprecated
-	def setSelectedPaths( self, pathOrPaths, scrollToFirst=True, expandNonLeaf=True ) :
+	def setSelectedPaths( self, pathOrPaths, scrollToFirst=True ) :
 
 		paths = pathOrPaths
 		if isinstance( pathOrPaths, Gaffer.Path ) :
@@ -387,7 +387,7 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		self.setSelection(
 			IECore.PathMatcher( [ str( path ) for path in paths ] ),
-			scrollToFirst, expandNonLeaf
+			scrollToFirst
 		)
 
 	## \deprecated Use getSelectedPaths() instead.
@@ -417,13 +417,13 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		return self.__dragPointer
 
-	def __setSelectionInternal( self, paths, scrollToFirst=True, expandNonLeaf=True ) :
+	def __setSelectionInternal( self, paths, scrollToFirst=True ) :
 
 		paths = paths if isinstance( paths, list ) else [paths] * len( self.getColumns() )
 
 		_GafferUI._pathListingWidgetSetSelection(
 			GafferUI._qtAddress( self._qtWidget() ),
-			paths, scrollToFirst, expandNonLeaf
+			paths, scrollToFirst
 		)
 
 	def __getSelectionInternal( self ) :
@@ -593,7 +593,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			else :
 				selection = [IECore.PathMatcher()] * len( self.getColumns() )
 
-			self.__setSelectionInternal( selection, scrollToFirst=False, expandNonLeaf=False )
+			self.__setSelectionInternal( selection, scrollToFirst=False )
 			return True
 
 		return False
@@ -782,7 +782,7 @@ class PathListingWidget( GafferUI.Widget ) :
 				) :
 					selection[i].addPaths( newPaths )
 
-			self.__setSelectionInternal( selection, scrollToFirst=False, expandNonLeaf=False )
+			self.__setSelectionInternal( selection, scrollToFirst=False )
 			self.__lastSelectedIndex = QtCore.QPersistentModelIndex( index )
 
 	def __toggleSelect( self, index ) :
@@ -809,7 +809,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		# for doing keyboard-based expansion, and we can make use
 		# of if in our Shift-click range selection.
 		self._qtWidget().setCurrentIndex( index )
-		self.__setSelectionInternal( selection, scrollToFirst=False, expandNonLeaf=False )
+		self.__setSelectionInternal( selection, scrollToFirst=False )
 
 		self.__lastSelectedIndex = QtCore.QPersistentModelIndex( index )
 
@@ -822,7 +822,7 @@ class PathListingWidget( GafferUI.Widget ) :
 			paths = IECore.PathMatcher( [ path ] )
 		elif self.__cellSelectionMode :
 			paths = [ IECore.PathMatcher( [ path ] ) if i == index.column() else IECore.PathMatcher() for i in range( 0, len( self.getColumns() ) ) ]
-		self.setSelection( paths, scrollToFirst=False, expandNonLeaf=False )
+		self.setSelection( paths, scrollToFirst=False )
 
 		self.__lastSelectedIndex = QtCore.QPersistentModelIndex( index )
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -889,7 +889,7 @@ class _PlugListing( GafferUI.Widget ) :
 
 		selection = self.__pathListing.getPath().copy()
 		selection[:] = self.__dragItem.fullName().split( "." )
-		self.__pathListing.setSelectedPaths( [ selection ], scrollToFirst = False, expandNonLeaf = False )
+		self.__pathListing.setSelectedPaths( [ selection ], scrollToFirst = False )
 
 		return True
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -351,13 +351,13 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertTrue( w.getExpansion().isEmpty() )
 
 		s = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
-		w.setSelection( s, expandNonLeaf = False, scrollToFirst = False )
+		w.setSelection( s, scrollToFirst = False )
 		self.assertEqual( w.getSelection(), s )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertTrue( w.getExpansion().isEmpty() )
 
 		s.addPath( "/3/5" )
-		w.setSelection( s, expandNonLeaf = False, scrollToFirst = True )
+		w.setSelection( s, scrollToFirst = True )
 		self.assertEqual( w.getSelection(), s )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3" ] ) )
@@ -391,83 +391,22 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 
 		s1 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
 		s2 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
-		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = False )
+		w.setSelection( [ s1, s2 ], scrollToFirst = False )
 		self.assertEqual( w.getSelection(), [ s1, s2 ] )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertTrue( w.getExpansion().isEmpty() )
 
 		s1.addPath( "/3/5" )
-		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = True )
+		w.setSelection( [ s1, s2 ], scrollToFirst = True )
 		self.assertEqual( w.getSelection(), [ s1, s2 ] )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3" ] ) )
 
 		s2.addPath( "/4/6" )
-		w.setSelection( [ s1, s2 ], expandNonLeaf = False, scrollToFirst = True )
+		w.setSelection( [ s1, s2 ], scrollToFirst = True )
 		self.assertEqual( w.getSelection(), [ s1, s2 ] )
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/3", "/4" ] ) )
-
-	def testRowSelectionExpansion( self ) :
-
-		d = {}
-		for i in range( 0, 10 ) :
-			dd = {}
-			for j in range( 0, 10 ) :
-				dd[str(j)] = j
-			d[str(i)] = dd
-
-		p = Gaffer.DictPath( d, "/" )
-
-		w = GafferUI.PathListingWidget(
-			p,
-			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
-			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
-		)
-		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
-
-		self.assertTrue( w.getSelection().isEmpty() )
-		self.assertTrue( w.getExpansion().isEmpty() )
-
-		s = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
-		w.setSelection( s, expandNonLeaf = True, scrollToFirst = False )
-		self.assertEqual( w.getSelection(), s )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
-		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/1", "/2", "/9" ] ) )
-
-	def testCellSelectionExpansion( self ) :
-
-		d = {}
-		for i in range( 0, 10 ) :
-			dd = {}
-			for j in range( 0, 10 ) :
-				dd[str(j)] = j
-			d[str(i)] = dd
-
-		p = Gaffer.DictPath( d, "/" )
-
-		w = GafferUI.PathListingWidget(
-			p,
-			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
-			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
-		)
-		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
-
-		# The default widget has multiple columns preset for file browsing,
-		# just use two to simply testing.
-		c = [ w.defaultNameColumn, w.StandardColumn( "h", "a" ) ]
-		w.setColumns( c )
-		self.assertEqual( w.getColumns(), c )
-
-		self.assertEqual( w.getSelection(), [IECore.PathMatcher()] * 2 )
-		self.assertTrue( w.getExpansion().isEmpty() )
-
-		s1 = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5" ] )
-		s2 = IECore.PathMatcher( [ "/1", "/3", "/4", "/9", "/4/6" ] )
-		w.setSelection( [ s1, s2 ], expandNonLeaf = True, scrollToFirst = False )
-		self.assertEqual( w.getSelection(), [ s1, s2 ] )
-		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
-		self.assertEqual( w.getExpansion(), IECore.PathMatcher( [ "/1", "/2", "/3", "/4", "/9" ] ) )
 
 	def testSelectionSignalFrequency( self ) :
 
@@ -585,7 +524,7 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( w.getPathExpanded( pa ), False )
 		self.assertEqual( w.getPathExpanded( pae ), False )
 
-		w.setSelectedPaths( [ pa ], expandNonLeaf = False )
+		w.setSelectedPaths( [ pa ] )
 		self.assertEqual( w.getPathExpanded( pa ), False )
 		self.assertEqual( w.getPathExpanded( pae ), False )
 


### PR DESCRIPTION
While revisiting the logic in `PathModel::updateExpansion()` we proposed the removal of `expandNonLeaf` as it is rarely used and hard to understand. 

The intent is to replace this behaviour with a `F` shortcut in the Hierarchy View to expand and frame selected locations. 