### PR TITLE
VisibleSet : Improve control of visibility of siblings and ancestors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -46,7 +46,9 @@ Improvements
 - Dilate, Erode, Median, Resample, Resize, ImageTransform, Blur, VectorWarp : Improved performance significantly. For example, a Blur with a large radius is now almost 6x faster.
 - RotateTool : Added the ability to rotate an axis whose plane of rotation is parallel or nearly parallel to the view.
 - OptionQuery : Added support for querying generic `IECore::Object` values using an `ObjectPlug`.
-- SceneView : Ancestors and siblings of locations included in the Visible Set are no longer drawn while their ancestors are collapsed.
+- SceneView :
+  - Ancestors and siblings of locations included in the Visible Set are no longer drawn while their ancestors are collapsed.
+  - Added red wireframe colour to the bounding box of locations excluded from the Visible Set.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -104,6 +104,7 @@ API
 - Sampler : Added `visitPixels()` method, which provides an optimised method for accessing all pixels in a region.
 - Handle::AngularDrag : Added `isLinearDrag()` method.
 - Widget : Added per-widget control over colour display transforms via new `setDisplayTransform()`, `getDisplayTransform()` and `displayTransform()` methods.
+- VisibleSet : Added `VisibleSet::Visibility` struct containing `drawMode` and `descendantsVisible` members.
 
 Breaking Changes
 ----------------
@@ -152,6 +153,7 @@ Breaking Changes
   - The `inputSpace` default value is now interpreted as the working space rather than as an invalid space. This means that a node without `inputSpace` specified is no longer a pass-through as it was before.
   - The `display` and `view` default values are now interpreted as the default defined by the current OpenColorIO config, rather than as invalid values. This means that a node without `display` or `view` specified is no longer a pass-through as it was before.
 - gaffer test : Replaced `-performanceOnly` flag with `-category` argument which may be set to `performance` for the same as the old `-performanceOnly`, or `standard` for the converse.
+- VisibleSet : Renamed `VisibleSet::match()` to `visibility()` and changed return type.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,7 @@ Improvements
 - SceneView :
   - Ancestors and siblings of locations included in the Visible Set are no longer drawn while their ancestors are collapsed.
   - Added red wireframe colour to the bounding box of locations excluded from the Visible Set.
+- HierarchyView : Added support for inclusion and exclusion of leaf level locations to the Visible Set.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -46,6 +46,7 @@ Improvements
 - Dilate, Erode, Median, Resample, Resize, ImageTransform, Blur, VectorWarp : Improved performance significantly. For example, a Blur with a large radius is now almost 6x faster.
 - RotateTool : Added the ability to rotate an axis whose plane of rotation is parallel or nearly parallel to the view.
 - OptionQuery : Added support for querying generic `IECore::Object` values using an `ObjectPlug`.
+- SceneView : Ancestors and siblings of locations included in the Visible Set are no longer drawn while their ancestors are collapsed.
 
 Fixes
 -----

--- a/include/GafferScene/Private/IECoreScenePreview/Placeholder.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Placeholder.h
@@ -51,9 +51,20 @@ class GAFFERSCENE_API Placeholder : public IECoreScene::VisibleRenderable
 
 	public :
 
-		Placeholder( const Imath::Box3f &bound = Imath::Box3f() );
+		enum Mode
+		{
+			/// A standard collapsed location
+			Default = 0,
+			/// A location that has been excluded from the VisibleSet
+			Excluded = 1,
+		};
+
+		Placeholder( const Imath::Box3f &bound = Imath::Box3f(), const Placeholder::Mode mode = Placeholder::Mode::Default );
 
 		IE_CORE_DECLAREEXTENSIONOBJECT( IECoreScenePreview::Placeholder, GafferScene::PreviewPlaceholderTypeId, IECoreScene::VisibleRenderable );
+
+		void setMode( Mode mode );
+		Mode getMode() const;
 
 		void setBound( const Imath::Box3f &bound );
 		const Imath::Box3f &getBound() const;
@@ -64,7 +75,7 @@ class GAFFERSCENE_API Placeholder : public IECoreScene::VisibleRenderable
 	private :
 
 		static const unsigned int m_ioVersion;
-
+		Mode m_mode;
 		Imath::Box3f m_bound;
 
 };

--- a/include/GafferScene/VisibleSet.h
+++ b/include/GafferScene/VisibleSet.h
@@ -63,10 +63,36 @@ struct GAFFERSCENE_API VisibleSet
 	PathMatcher inclusions;
 	PathMatcher exclusions;
 
-	/// Returns the result of a match made against the VisibleSet.
-	/// ExactMatch : The location should be rendered.
-	/// DescendantMatch : Some (but not necessarily all) descendants of the location should be rendered (but this location shouldn't be unless ExactMatch is also set).
-	PathMatcher::Result match( const std::vector<InternedString> &path, const size_t minimumExpansionDepth = 0 ) const;
+	struct Visibility
+	{
+		/// The draw mode of a location as defined by the VisibleSet.
+		enum DrawMode
+		{
+			/// The location is not visible.
+			None = 0,
+			/// The location is visible and will be drawn. If the location has descendants then their combined bounding
+			/// box will also be drawn when `descendantsVisible` is false.
+			Visible = 1,
+			/// The location is visible, but only ever drawn as a bounding box as it is excluded from the VisibleSet.
+			ExcludedBounds = 2,
+		};
+
+		Visibility( DrawMode drawMode = DrawMode::None, bool descendantsVisible = false )
+			: drawMode( drawMode ), descendantsVisible( descendantsVisible )
+		{
+		}
+
+		bool operator == ( const Visibility &rhs ) const
+		{
+			return drawMode == rhs.drawMode && descendantsVisible == rhs.descendantsVisible;
+		}
+
+		DrawMode drawMode;
+		bool descendantsVisible;
+	};
+
+	/// Returns the Visibility of a path tested against the VisibleSet.
+	Visibility visibility( const std::vector<InternedString> &path, const size_t minimumExpansionDepth = 0 ) const;
 
 	bool operator == ( const VisibleSet &rhs ) const;
 	bool operator != ( const VisibleSet &rhs ) const;

--- a/python/GafferSceneTest/IECoreScenePreviewTest/PlaceholderTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/PlaceholderTest.py
@@ -50,6 +50,7 @@ class PlaceholderTest( GafferTest.TestCase ) :
 		o = IECore.Object.create( "IECoreScenePreview::Placeholder" )
 		self.assertIsInstance( o, GafferScene.Private.IECoreScenePreview.Placeholder )
 		self.assertEqual( o.getBound(), imath.Box3f() )
+		self.assertEqual( o.getMode(), GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Default )
 
 	def testBound( self ) :
 
@@ -67,23 +68,48 @@ class PlaceholderTest( GafferTest.TestCase ) :
 			imath.Box3f( imath.V3f( 2, 3, 4 ), imath.V3f( 5, 6, 7 ) )
 		)
 
+	def testMode( self ) :
+
+		o = GafferScene.Private.IECoreScenePreview.Placeholder()
+		self.assertEqual(
+			o.getMode(),
+			GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Default
+		)
+
+		o.setMode( GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded )
+		self.assertEqual(
+			o.getMode(),
+			GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded
+		)
+
+		o2 = GafferScene.Private.IECoreScenePreview.Placeholder( mode = GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded )
+		self.assertEqual(
+			o2.getMode(),
+			GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded
+		)
+
 	def testCopy( self ) :
 
 		o = GafferScene.Private.IECoreScenePreview.Placeholder(
-			imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) )
+			imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ),
+			GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded,
 		)
 		o2 = o.copy()
 		self.assertEqual( o.getBound(), o2.getBound() )
+		self.assertEqual( o.getMode(), o2.getMode() )
 		self.assertEqual( o, o2 )
 
 		o2.setBound( imath.Box3f( imath.V3f( 2, 3, 4 ), imath.V3f( 5, 6, 7 ) ) )
 		self.assertNotEqual( o.getBound(), o2.getBound() )
+		o2.setMode( GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Default )
+		self.assertNotEqual( o.getMode(), o2.getMode() )
 		self.assertNotEqual( o, o2 )
 
 	def testSerialisation( self ) :
 
 		o = GafferScene.Private.IECoreScenePreview.Placeholder(
-			imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) )
+			imath.Box3f( imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ),
+			GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded
 		)
 
 		m = IECore.MemoryIndexedIO( IECore.CharVectorData(), [], IECore.IndexedIO.OpenMode.Write )
@@ -93,6 +119,7 @@ class PlaceholderTest( GafferTest.TestCase ) :
 		o2 = IECore.Object.load( m2, "o" )
 
 		self.assertEqual( o.getBound(), o2.getBound() )
+		self.assertEqual( o.getMode(), o2.getMode() )
 		self.assertEqual( o, o2 )
 
 if __name__ == "__main__":

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -1320,6 +1320,131 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( renderer.capturedObject( "/group/plane" ).numAttributeEdits(), 3 )
 
+	def testExcludedLocationsHaveNoObject( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( group["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 10 )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v = GafferScene.VisibleSet()
+		v.exclusions.addPath( "/group/plane" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v.exclusions = IECore.PathMatcher( [ "/group" ] )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNone( renderer.capturedObject( "/group/sphere" ) )
+
+		controller.setVisibleSet( GafferScene.VisibleSet() )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+	def testExcludedLocationBoundsVisibility( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( group["out"], Gaffer.Context(), renderer )
+		controller.setMinimumExpansionDepth( 10 )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v = GafferScene.VisibleSet()
+		v.exclusions.addPath( "/group/plane" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v.expansions.addPath( "/group" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane/__unexpandedChildren__" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v.expansions.removePath( "/group" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v.exclusions = IECore.PathMatcher( [ "/group" ] )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNone( renderer.capturedObject( "/group/sphere" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/__unexpandedChildren__" ) )
+
+		controller.setVisibleSet( GafferScene.VisibleSet() )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+	def testIncludeLocation( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( group["out"], Gaffer.Context(), renderer )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v = GafferScene.VisibleSet()
+		v.inclusions.addPath( "/group/plane" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNone( renderer.capturedObject( "/group/sphere" ) )
+
+		v.inclusions = IECore.PathMatcher( [ "/group" ] )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
+
+		controller.setVisibleSet( GafferScene.VisibleSet() )
+		controller.update()
+
+		self.assertIsNone( renderer.capturedObject( "/group/plane" ) )
+		self.assertIsNone( renderer.capturedObject( "/group/sphere" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderControllerTest.py
+++ b/python/GafferSceneTest/RenderControllerTest.py
@@ -1410,6 +1410,32 @@ class RenderControllerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertIsNotNone( renderer.capturedObject( "/group/plane" ) )
 		self.assertIsNotNone( renderer.capturedObject( "/group/sphere" ) )
 
+	def testExcludedLocationPlaceholderMode( self ) :
+
+		plane = GafferScene.Plane()
+		sphere = GafferScene.Sphere()
+		group = GafferScene.Group()
+		group["in"][0].setInput( plane["out"] )
+		group["in"][1].setInput( sphere["out"] )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer()
+		controller = GafferScene.RenderController( group["out"], Gaffer.Context(), renderer )
+		controller.update()
+
+		self.assertEqual( renderer.capturedObject( "/group/__unexpandedChildren__" ).capturedSamples()[0].getMode(), GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Default )
+
+		v = GafferScene.VisibleSet()
+		v.exclusions.addPath( "/group" )
+		controller.setVisibleSet( v )
+		controller.update()
+
+		self.assertEqual( renderer.capturedObject( "/group/__unexpandedChildren__" ).capturedSamples()[0].getMode(), GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Excluded )
+
+		controller.setVisibleSet( GafferScene.VisibleSet() )
+		controller.update()
+
+		self.assertEqual( renderer.capturedObject( "/group/__unexpandedChildren__" ).capturedSamples()[0].getMode(), GafferScene.Private.IECoreScenePreview.Placeholder.Mode.Default )
+
 	def testIncludeLocation( self ) :
 
 		plane = GafferScene.Plane()

--- a/src/GafferScene/IECoreGLPreview/ProceduralVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/ProceduralVisualiser.cpp
@@ -72,6 +72,14 @@ class BoundVisualiser : public ObjectVisualiser
 			group->getState()->add( new IECoreGL::Primitive::DrawSolid( false ) );
 			group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
 
+			if( const IECoreScenePreview::Placeholder *placeholder = IECore::runTimeCast<const IECoreScenePreview::Placeholder>( object ) )
+			{
+				if( placeholder->getMode() == IECoreScenePreview::Placeholder::Mode::Excluded )
+				{
+					group->getState()->add( new IECoreGL::WireframeColorStateComponent( Color4f( 0.3, 0.18, 0.18, 1 ) ) );
+				}
+			}
+
 			IECore::V3fVectorDataPtr pData = new IECore::V3fVectorData;
 			IECore::IntVectorDataPtr vertsPerCurveData = new IECore::IntVectorData;
 			vector<V3f> &p = pData->writable();

--- a/src/GafferScene/IECoreScenePreview/Placeholder.cpp
+++ b/src/GafferScene/IECoreScenePreview/Placeholder.cpp
@@ -46,9 +46,19 @@ using namespace IECoreScenePreview;
 const unsigned int Placeholder::m_ioVersion = 0;
 IE_CORE_DEFINEOBJECTTYPEDESCRIPTION( Placeholder );
 
-Placeholder::Placeholder( const Imath::Box3f &bound )
-	:	m_bound( bound )
+Placeholder::Placeholder( const Imath::Box3f &bound, const Placeholder::Mode mode )
+	:	 m_mode( mode ), m_bound( bound )
 {
+}
+
+void Placeholder::setMode( Mode mode )
+{
+	m_mode = mode;
+}
+
+Placeholder::Mode Placeholder::getMode() const
+{
+	return m_mode;
 }
 
 void Placeholder::setBound( const Imath::Box3f &bound )
@@ -78,19 +88,23 @@ bool Placeholder::isEqualTo( const IECore::Object *other ) const
 		return false;
 	}
 
-	return m_bound == static_cast<const Placeholder *>( other )->m_bound;
+	const Placeholder *placeholder = static_cast<const Placeholder *>( other );
+	return m_bound == placeholder->m_bound && m_mode == placeholder->m_mode;
 }
 
 void Placeholder::hash( IECore::MurmurHash &h ) const
 {
 	VisibleRenderable::hash( h );
 	h.append( m_bound );
+	h.append( m_mode );
 }
 
 void Placeholder::copyFrom( const IECore::Object *other, IECore::Object::CopyContext *context )
 {
 	VisibleRenderable::copyFrom( other, context );
-	m_bound = static_cast<const Placeholder *>( other )->m_bound;
+	const Placeholder *placeholder = static_cast<const Placeholder *>( other );
+	m_bound = placeholder->m_bound;
+	m_mode = placeholder->m_mode;
 }
 
 void Placeholder::save( IECore::Object::SaveContext *context ) const
@@ -99,6 +113,7 @@ void Placeholder::save( IECore::Object::SaveContext *context ) const
 
 	IndexedIOPtr container = context->container( staticTypeName(), m_ioVersion );
 	container->write( "bound", m_bound.min.getValue(), 6 );
+	container->write( "mode", m_mode );
 }
 
 void Placeholder::load( IECore::Object::LoadContextPtr context )
@@ -109,10 +124,14 @@ void Placeholder::load( IECore::Object::LoadContextPtr context )
 	ConstIndexedIOPtr container = context->container( staticTypeName(), v );
 	float *b = m_bound.min.getValue();
 	container->read( "bound", b, 6 );
+	unsigned int mode = 0;
+	container->read( "mode", mode );
+	m_mode = Mode( mode );
 }
 
 void Placeholder::memoryUsage( IECore::Object::MemoryAccumulator &accumulator ) const
 {
 	VisibleRenderable::memoryUsage( accumulator );
 	accumulator.accumulate( sizeof( m_bound ) );
+	accumulator.accumulate( sizeof( m_mode ) );
 }

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -439,10 +439,16 @@ class RenderController::SceneGraph
 
 			// VisibleSet
 
+			const auto currentDrawMode = m_drawMode;
 			if( ( m_dirtyComponents & VisibleSetComponent ) && updateVisibleSet( path, controller->m_visibleSet, controller->m_minimumExpansionDepth ) )
 			{
 				m_changedComponents |= VisibleSetComponent;
-				m_dirtyComponents |= ObjectComponent;
+
+				// An object update is only required on change of draw mode for this location.
+				if( currentDrawMode != m_drawMode )
+				{
+					m_dirtyComponents |= ObjectComponent;
+				}
 			}
 
 			// Object

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -545,7 +545,7 @@ class RenderController::SceneGraph
 			{
 				// Create bounding box if needed
 				Box3f bound;
-				if( ( m_drawMode == VisibleSet::Visibility::Visible && !m_expanded && m_children.size() ) || m_drawMode == VisibleSet::Visibility::ExcludedBounds )
+				if( ( m_drawMode == VisibleSet::Visibility::Visible && !m_descendantsVisible && m_children.size() ) || m_drawMode == VisibleSet::Visibility::ExcludedBounds )
 				{
 					bound = controller->m_scene->boundPlug()->getValue();
 				}
@@ -604,7 +604,7 @@ class RenderController::SceneGraph
 
 		bool expanded() const
 		{
-			return m_expanded;
+			return m_descendantsVisible;
 		}
 
 		const std::vector<std::unique_ptr<SceneGraph>> &children()
@@ -630,7 +630,7 @@ class RenderController::SceneGraph
 			clearObject();
 			m_attributesHash = m_lightLinksHash = m_transformHash = m_childNamesHash = IECore::MurmurHash();
 			m_cleared = true;
-			m_expanded = false;
+			m_descendantsVisible = false;
 			m_drawMode = VisibleSet::Visibility::None;
 			m_boundInterface = nullptr;
 			m_dirtyComponents = AllComponents;
@@ -972,11 +972,11 @@ class RenderController::SceneGraph
 		{
 			const auto visibility = visibleSet.visibility( path, minimumExpansionDepth );
 
-			if( visibility.descendantsVisible == m_expanded && visibility.drawMode == m_drawMode )
+			if( visibility.descendantsVisible == m_descendantsVisible && visibility.drawMode == m_drawMode )
 			{
 				return false;
 			}
-			m_expanded = visibility.descendantsVisible;
+			m_descendantsVisible = visibility.descendantsVisible;
 			m_drawMode = visibility.drawMode;
 
 			return true;
@@ -1117,7 +1117,7 @@ class RenderController::SceneGraph
 		std::vector<std::unique_ptr<SceneGraph>> m_children;
 
 		IECoreScenePreview::Renderer::ObjectInterfacePtr m_boundInterface;
-		bool m_expanded;
+		bool m_descendantsVisible;
 		VisibleSet::Visibility::DrawMode m_drawMode;
 
 		// Tracks work which needs to be done on

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -959,15 +959,15 @@ class RenderController::SceneGraph
 
 		bool updateExpansion( const ScenePlug::ScenePath &path, const GafferScene::VisibleSet &visibleSet, size_t minimumExpansionDepth )
 		{
-			/// \todo We also include DescendantMatch here to ensure the ancestors of visible paths are also visible,
-			/// ideally we'd avoid expanding those ancestors and instead render only the ExactMatch.
-			const bool expanded = visibleSet.match( path, minimumExpansionDepth ) & ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch );
+			/// \todo We expand based on the descendant visibility to ensure the ancestors of visible paths are expanded,
+			/// ideally we'd avoid drawing those ancestors and instead render only the visible locations.
+			const auto visibility = visibleSet.visibility( path, minimumExpansionDepth );
 
-			if( expanded == m_expanded )
+			if( visibility.descendantsVisible == m_expanded )
 			{
 				return false;
 			}
-			m_expanded = expanded;
+			m_expanded = visibility.descendantsVisible;
 			return true;
 		}
 

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -546,7 +546,10 @@ class RenderController::SceneGraph
 
 				if( !bound.isEmpty() )
 				{
-					IECoreScenePreview::PlaceholderPtr placeholder = new IECoreScenePreview::Placeholder( bound );
+					IECoreScenePreview::PlaceholderPtr placeholder = new IECoreScenePreview::Placeholder(
+						bound,
+						m_drawMode == VisibleSet::Visibility::ExcludedBounds ? IECoreScenePreview::Placeholder::Mode::Excluded : IECoreScenePreview::Placeholder::Mode::Default
+					);
 
 					std::string boundName;
 					ScenePlug::pathToString( path, boundName );

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -536,11 +536,24 @@ void GafferSceneModule::bindRender()
 			.def( "parameters", (IECore::CompoundData *(Geometry::*)())&Geometry::parameters, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		;
 
-		IECorePython::RunTimeTypedClass<Placeholder>()
-			.def( init<const Box3f &>( arg( "bound" ) = Box3f() ) )
-			.def( "setBound", &Placeholder::setBound )
-			.def( "getBound", &Placeholder::getBound, return_value_policy<copy_const_reference>() )
-		;
+		IECorePython::RunTimeTypedClass<Placeholder> placeholderClass( "Placeholder" );
+		{
+			scope s = placeholderClass;
+
+			enum_<Placeholder::Mode>( "Mode" )
+				.value( "Default", Placeholder::Default )
+				.value( "Excluded", Placeholder::Excluded )
+			;
+
+			placeholderClass
+				.def( init<const Box3f &, const Placeholder::Mode>( ( arg( "bound" ) = Box3f(), arg( "mode" ) = Placeholder::Mode::Default ) ) )
+				.def( "setMode", &Placeholder::setMode )
+				.def( "getMode", &Placeholder::getMode )
+				.def( "setBound", &Placeholder::setBound )
+				.def( "getBound", &Placeholder::getBound, return_value_policy<copy_const_reference>() )
+			;
+
+		}
 
 		scope capturingRendererScope = IECorePython::RefCountedClass<CapturingRenderer, Renderer>( "CapturingRenderer" )
 			.def( init<Renderer::RenderType, const std::string &, const IECore::MessageHandlerPtr &>( ( arg( "renderType" ) = Renderer::RenderType::Interactive, arg( "fileName" ) = "", arg( "messageHandler") = IECore::MessageHandlerPtr() ) ) )

--- a/src/GafferSceneUIModule/HierarchyViewBinding.cpp
+++ b/src/GafferSceneUIModule/HierarchyViewBinding.cpp
@@ -529,15 +529,6 @@ class InclusionsColumn : public PathColumn
 				return result;
 			}
 
-			Context::EditableScope scope( m_context.get() );
-			scope.setCanceller( canceller );
-
-			if( scenePath->getScene()->childNames( scenePath->names() )->readable().empty() )
-			{
-				// To limit the amount of duplicate information presented we don't provide custom cellData to leaf locations
-				return result;
-			}
-
 			const auto visibleSet = ContextAlgo::getVisibleSet( m_context.get() );
 			const auto inclusionsMatch = visibleSet.inclusions.match( scenePath->names() );
 			const auto locationExcluded = visibleSet.exclusions.match( scenePath->names() ) & (IECore::PathMatcher::Result::ExactMatch | IECore::PathMatcher::Result::AncestorMatch);
@@ -627,14 +618,6 @@ class InclusionsColumn : public PathColumn
 			auto scenePath = IECore::runTimeCast<const ScenePath>( &path );
 			if( !scenePath )
 			{
-				return false;
-			}
-
-			Context::EditableScope scope( m_context.get() );
-
-			if( scenePath->getScene()->childNames( scenePath->names() )->readable().empty() )
-			{
-				// Leaf locations are not treated as clickable, user interaction should occur at the parent location
 				return false;
 			}
 
@@ -776,15 +759,6 @@ class ExclusionsColumn : public PathColumn
 				return result;
 			}
 
-			Context::EditableScope scope( m_context.get() );
-			scope.setCanceller( canceller );
-
-			if( scenePath->getScene()->childNames( scenePath->names() )->readable().empty() )
-			{
-				// To limit the amount of duplicate information presented we don't provide custom cellData to leaf locations
-				return result;
-			}
-
 			auto visibleSet = ContextAlgo::getVisibleSet( m_context.get() );
 			auto exclusionsMatch = visibleSet.exclusions.match( scenePath->names() );
 
@@ -847,14 +821,6 @@ class ExclusionsColumn : public PathColumn
 			auto scenePath = IECore::runTimeCast<const ScenePath>( &path );
 			if( !scenePath )
 			{
-				return false;
-			}
-
-			Context::EditableScope scope( m_context.get() );
-
-			if( scenePath->getScene()->childNames( scenePath->names() )->readable().empty() )
-			{
-				// Leaf locations are not treated as clickable, user interaction should occur at the parent location
 				return false;
 			}
 


### PR DESCRIPTION
This refines the VisibleSet behaviour introduced in Gaffer 1.2. These changes improve the result returned by `VisibleSet::match()` replacing the returned `PathMatcher::Result` with a new `VisibleSet::Result`. 

The RenderController has been updated to draw based on the `VisibleSet::Result`, which allows for improved control over visibility of siblings and ancestors of locations included in the VisibleSet. Previously, when a location was included in the VisibleSet the bounds of its siblings and ancestors would also always be visible. With these changes scene locations can be included in the VisibleSet, and their siblings and ancestors will only be drawn when expanded via the usual methods. This also allows us to better support inclusion and exclusion at the leaf level, so the Hierarchy View inclusion and exclusion columns now permit user interaction at that level.

Now that `VisibleSet::Result` can identify when the bounds of an excluded location should be visible (all of its ancestors are expanded or meet the Viewer's minimum expansion depth), we tint those excluded bounding box wireframes red in the Viewer. This is intended as a hint that those particular bounds cannot be expanded without first removing the exclusion. This colouring has been kept fairly subtle, maintaining a similar level of relative contrast as the standard bounding box wireframe colour. This may prove to be too subtle, but given the intent of excluding a location from the VisibleSet is to prevent its objects from drawing in the Viewer, it doesn't seem appropriate to make excluded bounds stand out more than regular bounds...