### PR TITLE
Small PlugValueWidget metadata improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -112,6 +112,7 @@ Breaking Changes
   - Replaced `affectsColorData()` with `affectsColorProcessor()` and `hashColorData()` with `hashColorProcessor()`.
   - Simplified implementation of pass-throughs when the color processor is a no-op. Derived classes may simply
     return an empty `ColorProcessorFunction`, and everything else is taken care of in the base class.
+- PlugValueWidget : Removed support for deprecated `layout:widgetType` metadata. Use `plugValueWidget:type` metadata instead.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -75,6 +75,7 @@ API
   - Added support for `layout:minimumWidth` metadata.
   - Tabs are now hidden if all their child plugs are hidden by `layout:visibilityActivator` metadata.
 - PlugValueWidget : Added `typeMetadata` argument to `create()` to use an alternative key to `plugValueWidget:type` when looking up widget type.
+- PresetsPlugValueWidget : Added `presetsPlugValueWidget:customWidgetType` metadata, to allow the type for the custom widget to be specified.
 - TabbedContainer : Added `setTabVisible()` and `getTabVisible()` methods.
 - Removed use of `RTLD_GLOBAL` for loading Python modules.
 - SceneAlgo : Added `validateName()` function.

--- a/Changes.md
+++ b/Changes.md
@@ -74,6 +74,7 @@ API
 - PlugLayout :
   - Added support for `layout:minimumWidth` metadata.
   - Tabs are now hidden if all their child plugs are hidden by `layout:visibilityActivator` metadata.
+- PlugValueWidget : Added `typeMetadata` argument to `create()` to use an alternative key to `plugValueWidget:type` when looking up widget type.
 - TabbedContainer : Added `setTabVisible()` and `getTabVisible()` methods.
 - Removed use of `RTLD_GLOBAL` for loading Python modules.
 - SceneAlgo : Added `validateName()` function.
@@ -112,7 +113,9 @@ Breaking Changes
   - Replaced `affectsColorData()` with `affectsColorProcessor()` and `hashColorData()` with `hashColorProcessor()`.
   - Simplified implementation of pass-throughs when the color processor is a no-op. Derived classes may simply
     return an empty `ColorProcessorFunction`, and everything else is taken care of in the base class.
-- PlugValueWidget : Removed support for deprecated `layout:widgetType` metadata. Use `plugValueWidget:type` metadata instead.
+- PlugValueWidget :
+  - Removed support for deprecated `layout:widgetType` metadata. Use `plugValueWidget:type` metadata instead.
+  - Removed `useTypeOnly` argument from `create()` function. Pass `typeMetadata = None` instead.
 
 Build
 -----

--- a/python/GafferImageUI/ImageWriterUI.py
+++ b/python/GafferImageUI/ImageWriterUI.py
@@ -186,6 +186,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 			"presetsPlugValueWidget:allowCustom", True,
+			"presetsPlugValueWidget:customWidgetType", "GafferUI.LayoutPlugValueWidget",
 
 		],
 		"layout.partName" : [

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -218,19 +218,22 @@ class PlugValueWidget( GafferUI.Widget ) :
 		return cls.__popupMenuSignal
 
 	## Returns a PlugValueWidget suitable for representing the specified plugs.
-	# The type of widget returned may be customised on a per-plug basis by a
-	# "plugValueWidget:type" metadata value, specifying the fully qualified
-	# python type name for a widget class. To suppress the creation of a widget,
-	# a value of "" may be registered - in this case None will be returned from
-	# create(). If useTypeOnly is True, then the metadata will be ignored and
-	# only the plug type will be taken into account in creating a PlugValueWidget.
+	# By default, the type of widget returned may be customised on a per-plug
+	# basis by a `plugValueWidget:type`` metadata value, specifying the fully
+	# qualified python type name for a widget class. To suppress the creation of
+	# a widget, a value of "" may be registered - in this case `None` will be
+	# returned from `create()``.
+	#
+	# Callers may pass an alternative metadata key to look up via the `typeMetadata`
+	# parameter. Passing `typeMetadata = None` bypasses any types registered via
+	# metadata and returns a default widget based on the plug type instead.
 	@classmethod
-	def create( cls, plugs, useTypeOnly=False ) :
+	def create( cls, plugs, typeMetadata = "plugValueWidget:type" ) :
 
 		if isinstance( plugs, Gaffer.Plug ) :
-			creators = { cls.__creator( plugs, useTypeOnly ) }
+			creators = { cls.__creator( plugs, typeMetadata ) }
 		else :
-			creators = { cls.__creator( p, useTypeOnly ) for p in plugs }
+			creators = { cls.__creator( p, typeMetadata ) for p in plugs }
 			# Not all PlugValueWidgets support multiple plugs, and some
 			# except in their constructors if passed a sequence type.
 			# Unwrap where possible.
@@ -912,12 +915,12 @@ class PlugValueWidget( GafferUI.Widget ) :
 	# Type registry internals
 
 	@classmethod
-	def __creator( cls, plug, useTypeOnly ) :
+	def __creator( cls, plug, typeMetadata ) :
 
 		# First try to create one using a creator registered for the specific plug.
-		if not useTypeOnly :
+		if typeMetadata :
 
-			widgetType = Gaffer.Metadata.value( plug, "plugValueWidget:type" )
+			widgetType = Gaffer.Metadata.value( plug, typeMetadata )
 
 			if widgetType is not None :
 				if widgetType == "" :

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -918,12 +918,6 @@ class PlugValueWidget( GafferUI.Widget ) :
 		if not useTypeOnly :
 
 			widgetType = Gaffer.Metadata.value( plug, "plugValueWidget:type" )
-			if widgetType is None :
-				widgetType = Gaffer.Metadata.value( plug, "layout:widgetType" )
-				if widgetType is not None :
-					warnings.warn( "The \"layout:widgetType\" metadata entry is deprecated, use \"plugValueWidget:type\" instead.", DeprecationWarning )
-					if widgetType == "None" :
-						return None
 
 			if widgetType is not None :
 				if widgetType == "" :

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -57,7 +57,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 		cont.addChild( self.__menuButton )
 
-		self.__customValuePlugWidget = GafferUI.PlugValueWidget.create( plugs, useTypeOnly=True )
+		self.__customValuePlugWidget = GafferUI.PlugValueWidget.create( plugs, typeMetadata = None )
 		if type( self.__customValuePlugWidget ) == GafferUI.ConnectionPlugValueWidget and len( self.getPlugs() ) and next( iter( self.getPlugs() ) ).children():
 			# If we couldn't find a meaningful plug widget type, and the plug has children, try using
 			# a layout widget to show child plugs when in "custom" mode

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -57,11 +57,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 		cont.addChild( self.__menuButton )
 
-		self.__customValuePlugWidget = GafferUI.PlugValueWidget.create( plugs, typeMetadata = None )
-		if type( self.__customValuePlugWidget ) == GafferUI.ConnectionPlugValueWidget and len( self.getPlugs() ) and next( iter( self.getPlugs() ) ).children():
-			# If we couldn't find a meaningful plug widget type, and the plug has children, try using
-			# a layout widget to show child plugs when in "custom" mode
-			self.__customValuePlugWidget = GafferUI.LayoutPlugValueWidget( plugs )
+		self.__customValuePlugWidget = GafferUI.PlugValueWidget.create( plugs, typeMetadata = "presetsPlugValueWidget:customWidgetType" )
 
 		cont.addChild( self.__customValuePlugWidget )
 

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1134,7 +1134,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 			)
 			self.__valueNode["presetValue"] = plug.createCounterpart( "presetValue", plug.Direction.In )
 			if hasattr( self.__plug, "getValue" ) :
-				plugValueWidget = GafferUI.PlugValueWidget.create( self.__valueNode["presetValue"], useTypeOnly = True )
+				plugValueWidget = GafferUI.PlugValueWidget.create( self.__valueNode["presetValue"], typeMetadata = None )
 
 		self.__editingColumn.append( plugValueWidget if plugValueWidget is not None else GafferUI.TextWidget() )
 

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -263,7 +263,7 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__button.clickedSignal().connect( Gaffer.WeakMethod( self.__clicked ), scoped = False )
 
 			if not isinstance( plug, Gaffer.BoolPlug ) :
-				plugValueWidget = GafferUI.PlugValueWidget.create( plug, useTypeOnly=True )
+				plugValueWidget = GafferUI.PlugValueWidget.create( plug, typeMetadata = None )
 				plugValueWidget.numericWidget().setFixedCharacterWidth( 5 )
 
 		self.__toggleValue = Gaffer.Metadata.value( plug, "togglePlugValueWidget:defaultToggleValue" )


### PR DESCRIPTION
This generalises a couple of things about the way we use metadata to determine the type of PlugValueWidget to create in the UI. It will allow me to use a PresetsPlugValueWidget as the primary UI for a new OCIO config plug, but also provide a file browser when `Custom` is chosen and a secondary widget is shown for entering paths directly.