### PR TITLE
CI : Update to GafferHQ/dependencies 7.0.0a3

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -48,7 +48,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/7.0.0a2/gafferDependencies-7.0.0a2-{platform}.{extension}".format(
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/7.0.0a3/gafferDependencies-7.0.0a3-{platform}.{extension}".format(
 	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )

--- a/Changes.md
+++ b/Changes.md
@@ -117,6 +117,7 @@ Breaking Changes
 - PlugValueWidget :
   - Removed support for deprecated `layout:widgetType` metadata. Use `plugValueWidget:type` metadata instead.
   - Removed `useTypeOnly` argument from `create()` function. Pass `typeMetadata = None` instead.
+- MeshTangents : Changed the edge used by `Mode::FirstEdge`.
 
 Build
 -----
@@ -126,6 +127,7 @@ Build
   - Stopped linking unnecessarily to `iostreams`, `date_time`, `wave` and `system` libraries.
 - Cortex : Updated to version 10.5.0.0.
 - Imath : Added version 3.1.7.
+- MaterialX : Added version 1.38.4.
 - Minizip : Added version 3.0.9.
 - OpenEXR :
   - Updated to version 3.1.7.
@@ -136,6 +138,8 @@ Build
 - PyBind11 : Updated to version 2.10.4.
 - PySide : Updated to version 5.15.8.
 - Qt : Updated to version 5.15.8.
+- USD : Updated to version 23.05.
+- Xerces : Removed.
 - ZLib : Added version 1.2.13.
 
 1.2.x.x (relative to 1.2.7.0)

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -123,6 +123,7 @@ prependToPath "$GAFFER_ROOT/fonts" IECORE_FONT_PATHS
 prependToPath "$HOME/gaffer/ops:$GAFFER_ROOT/ops" IECORE_OP_PATHS
 
 prependToPath "$GAFFER_ROOT/resources/IECoreUSD" PXR_PLUGINPATH_NAME
+prependToPath "$GAFFER_ROOT/materialX" PXR_MTLX_STDLIB_SEARCH_PATHS
 
 prependToPath "$HOME/gaffer/opPresets:$GAFFER_ROOT/opPresets" IECORE_OP_PRESET_PATHS
 prependToPath "$HOME/gaffer/procedurals:$GAFFER_ROOT/procedurals" IECORE_PROCEDURAL_PATHS

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -16,6 +16,7 @@ call :prependToPath "%GAFFER_ROOT%\fonts" IECORE_FONT_PATHS
 call :prependToPath "%GAFFER_ROOT%\ops" IECORE_OP_PATHS
 
 call :prependToPath "%GAFFER_ROOT%\resources\IECoreUSD" PXR_PLUGINPATH_NAME
+call :prependToPath "%GAFFER_ROOT%\materialX" PXR_MTLX_STDLIB_SEARCH_PATHS
 
 call :prependToPath "%USERPROFILE%\gaffer\opPresets;%GAFFER_ROOT%\opPresets" IECORE_OP_PRESET_PATHS
 call :prependToPath "%USERPROFILE%\gaffer\procedurals;%GAFFER_ROOT%\procedurals" IECORE_PROCEDURAL_PATHS

--- a/python/GafferSceneTest/MeshTangentsTest.py
+++ b/python/GafferSceneTest/MeshTangentsTest.py
@@ -135,10 +135,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( tangent.data ), 3 )
 		self.assertEqual( len( biTangent.data ), 3 )
 
-		for v, v1 in zip( tangent.data, [imath.V3f( 1, 0, 0 ), imath.V3f( -1, 0, 0 ), imath.V3f( 0, -1, 0 ) ] ):
+		for v, v1 in zip( tangent.data, [ imath.V3f( 1, 0, 0 ), imath.V3f( -1, 0, 0 ), imath.V3f( 1, -1, 0 ).normalized() ] ) :
 			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
 
-		for v, v1 in zip( biTangent.data, [imath.V3f( 0, -1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( -1, 0, 0 ) ] ):
+		for v, v1 in zip( biTangent.data, [ imath.V3f( 0, -1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( -1, -1, 0 ).normalized() ] ) :
 			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
 
 	def testModeTwoEdges( self ) :


### PR DESCRIPTION
This brings the Cortex update needed to merge #5295, and also adds initial MaterialX support to the USD build. @ericmehl, if you could upload the Windows variant of the dependencies package today, that would be brilliant.