### PR TITLE
ImageGadget : Fix active tile indicator bugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,7 +39,9 @@ Fixes
 -----
 
 - UVInspector : Removed display transform from UV wireframes and grid.
-- Viewer : Gamma is now applied after the display transform, not before.
+- Viewer :
+  - Gamma is now applied after the display transform, not before.
+  - Fixed image viewer's active tile indicators from becoming stuck when a computation was cancelled.
 - Expression : Fixed parsing of Python expressions combining subscripts (`[]`) and `context` methods (#3088, #3613, #5250).
 - ConnectionCreatorWrapper : Fixed bug which forced PlugAdder derived classes to implement `updateDragEndPoint()` unnecessarily.
 - Plug : Fixed bug which caused stale values to be retrieved from the cache for plugs that had been renamed.


### PR DESCRIPTION
The active tile indicator would remain "stuck" if an exception (either `Cancelled` or `ProcessException`) was thrown. This would give the user the misleading impression that certain tiles were being worked on when they were not.

Replacement for #4011, which is now out of sync with the current state of things. I had hesitated to merge it because it was made "under protest", but I continue to believe that this is the right fix. Without it :

- When reverting to a cached image, the indicators remain stuck on, suggesting to the user that processing is happening when it is not.
- When cancelling and restarting a computation with new parameters, the indicators remain stuck on, suggesting to the user that processing is happening on tiles where it is not. Their attention is therefore in the wrong place looking for the next update.
