### PR TITLE
SConstruct : PyBind is now required by GafferImage python module

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1089,6 +1089,7 @@ libraries = {
 			"LIBS" : [ "Gaffer", "GafferDispatch", "Iex$IMATH_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "OpenColorIO$OCIO_LIB_SUFFIX", "freetype" ],
 		},
 		"pythonEnvAppends" : {
+			"CPPPATH" : [ "$PYBIND11/include" ],
 			"LIBS" : [ "GafferBindings", "GafferImage", "GafferDispatch", "IECoreImage$CORTEX_LIB_SUFFIX", ],
 		},
 	},


### PR DESCRIPTION
With src/GafferImageModule/OpenColorIOAlgoBinding.cpp now using pybind, it makes sense this is needed - not sure why it doesn't fail on CI without it.