### PR TITLE
Arnold Renderer : Fix `step_size` handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,13 @@
 1.2.x.x (relative to 1.2.8.0)
 =======
 
+> Caution : A bug fix in the handling of the `ai:volume:step_scale` attribute may change the appearance of Arnold volume renders.
+
+Fixes
+-----
+
+- Arnold : Fixed bug that caused `ai:volume:step_scale` to be ignored if `ai:volume_step` was set explicitly to `0.0`. This was different to the behaviour when `ai:volume_step` was not set at all.
+
 1.2.8.0 (relative to 1.2.7.0)
 =======
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3589,6 +3589,9 @@ class RendererTest( GafferTest.TestCase ) :
 		self.__testVDB( stepSize = 0.1, stepScale = None, expectedSize = 0.1, expectedScale = 1.0 )
 		self.__testVDB( stepSize = None, stepScale = None, expectedSize = 0.0, expectedScale = 1.0 )
 		self.__testVDB( stepSize = 1.0, stepScale = 0.5, expectedSize = 0.5, expectedScale = 1.0 )
+		self.__testVDB( stepSize = 10.0, stepScale = 0.5, expectedSize = 5.0, expectedScale = 1.0 )
+		self.__testVDB( stepSize = 0.0, stepScale = 10, expectedSize = 0.0, expectedScale = 10 )
+		self.__testVDB( stepSize = 0.0, stepScale = None, expectedSize = 0.0, expectedScale = 1.0 )
 
 	def testCameraAttributes( self ) :
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1750,11 +1750,16 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					AiNodeSetFlt( node, g_velocityOutlierThresholdArnoldString, velocityOutlierThreshold.value() );
 				}
 
-				if ( stepSize )
+				// Arnold only applies `step_scale` when `step_size == 0` (auto), which we think is highly
+				// confusing. So when `step_size` is non-zero, we bake `step_scale` into it, so that the
+				// scale still has an effect.
+
+				const float stepValue = stepSize.value_or( 0.0f );
+				if( stepValue > 0.0f )
 				{
-					AiNodeSetFlt( node, g_stepSizeArnoldString, stepSize.value() * stepScale.value_or( 1.0f ) );
+					AiNodeSetFlt( node, g_stepSizeArnoldString, stepValue * stepScale.value_or( 1.0f ) );
 				}
-				else if ( stepScale )
+				else if( stepScale )
 				{
 					AiNodeSetFlt( node, g_stepScaleArnoldString, stepScale.value() );
 				}


### PR DESCRIPTION
We were completely ignoring `step_scale` if `step_size` was explicitly set to `0.0` (meaning auto). This was different to the results when `step_size` was left unspecified, despite it ostensibly defaulting to `0.0`! This is nasty, because it thwarts attepts at render optimisation, and it takes some fairly detailed reading of the Arnold stats to detect the problem.

Because this fix can change the appearance of Arnold renders, we should carefully consider where it belongs. The possible hardline stances are :

- This is a bugfix and should go into `1.1.9.x`.
- This is a behaviour change and should go into `1.3.0.0`.

I've taken a middle ground by putting it into `1.2.x.x` and adding a caution to the release notes. I definitely don't think it's suitable for `1.1.9.x` because shows in that phase of "warts and all" version lock won't want _any_ changes to images. I could be persuaded pretty easily to move to `1.3`, but I know of shows starting up in `1.2` that could benefit from the increased clarity when optimising their renders.

The original bug dates back to PR #2634, which contains some useful information on our original intentions and the reasons for them, which I've distilled into the new comment in the source code. I've also verified that the Arnold behaviour hasn't changed from what we observed back then.
