### PR TITLE
Caribou nuke pr

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 
 - DelightOptions : Added new options for modern 3Delight, as of version `2.9.39`.
 - ShaderQuery and ShaderTweaks : Added a filter for shader parameter names in the shader browser (#5293).
+- ImageReader : Added `availableFrames` output plug, listing all the available frames in the current file sequence.
 - MatchPatternPathFilterWidget : Added the name of the property being filtered to the placeholder text.
 - OpenImageIOReader : The `availableFrames` plug no longer errors for a missing file sequence - instead it outputs an empty list.
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - DelightOptions : Added new options for modern 3Delight, as of version `2.9.39`.
 - ShaderQuery and ShaderTweaks : Added a filter for shader parameter names in the shader browser (#5293).
 - MatchPatternPathFilterWidget : Added the name of the property being filtered to the placeholder text.
+- OpenImageIOReader : The `availableFrames` plug no longer errors for a missing file sequence - instead it outputs an empty list.
 
 Fixes
 -----

--- a/config/ie/options
+++ b/config/ie/options
@@ -463,7 +463,7 @@ if targetApp == "maya" :
 		usdIncludePath = os.path.join( mayaUsdReg["location"], mayaMajorVersion, "mayausd", "USD{}".format( mayaPythonMajorVersion ), "include" )
 		usdLibPath = os.path.join( mayaUsdReg["location"], mayaMajorVersion, "mayausd", "USD{}".format( mayaPythonMajorVersion ), "lib" )
 
-elif targetApp in ( "houdini", "nuke" ) :
+elif targetApp in ( "houdini", ) :
 	# Both nuke and houdini provide USD in their distribution.
 	# However, nuke doesn't provide includes, and the libs don't have python support, which prevents us from using them.
 	# And houdini has a mangled boost install which includes an "h" prefix which also messes up the GafferUSD build

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -124,6 +124,9 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 		Gaffer::IntPlug *channelInterpretationPlug();
 		const Gaffer::IntPlug *channelInterpretationPlug() const;
 
+		Gaffer::IntVectorDataPlug *availableFramesPlug();
+		const Gaffer::IntVectorDataPlug *availableFramesPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -863,5 +863,17 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			# data window when comparing
 			self.assertImagesEqual( multiPartReader["out"], singlePartReader["out"], metadataBlacklist = [ "openexr:chunkCount" ], ignoreChannelNamesOrder = True, ignoreDataWindow = True )
 
+	def testSerialisation( self ) :
+
+		script1 = Gaffer.ScriptNode()
+		script1["reader"] = GafferImage.ImageReader()
+
+		serialisation = script1.serialise( filter = Gaffer.StandardSet( { script1["reader"] } ) )
+		self.assertNotIn( "setInput", serialisation ) # Check we don't serialise internal connections
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( serialisation )
+		self.assertIsInstance( script2["reader"], GafferImage.ImageReader )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -64,6 +64,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 	unsupportedMultipartFileName = GafferImageTest.ImageTestCase.imagesPath() / "unsupportedMultipart.exr"
 	multipartDefaultChannelsFileName = GafferImageTest.ImageTestCase.imagesPath() / "multipartDefaultChannels.exr"
 	multipartDefaultChannelsOverlapFileName = GafferImageTest.ImageTestCase.imagesPath() / "multipartDefaultChannelsOverlap.exr"
+	missingFileName = GafferImageTest.ImageTestCase.imagesPath() / "missing.####.exr"
 
 	def testInternalImageSpaceConversion( self ) :
 
@@ -281,6 +282,10 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( self.fileName )
 		self.assertEqual( reader["availableFrames"].getValue(), IECore.IntVectorData( [] ) )
 		reader["fileName"].setValue( pathlib.Path( testSequence.fileNameForFrame( 1 ) ) )
+		self.assertEqual( reader["availableFrames"].getValue(), IECore.IntVectorData( [] ) )
+
+		# missing image sequence, empty available frames
+		reader["fileName"].setValue( self.missingFileName )
 		self.assertEqual( reader["availableFrames"].getValue(), IECore.IntVectorData( [] ) )
 
 	def testMissingFrameMode( self ) :

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -41,6 +41,8 @@ import GafferUI
 import GafferImage
 from . import OpenColorIOTransformUI
 
+from GafferUI.PlugValueWidget import sole
+
 Gaffer.Metadata.registerNode(
 
 	GafferImage.ImageReader,
@@ -249,6 +251,36 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"availableFrames" : [
+
+			"description",
+			"""
+			A list of the available frames for the current file sequence.
+			Empty when the input `fileName` is not a file sequence.
+			""",
+
+			"layout:section", "Frames",
+			"plugValueWidget:type", "GafferImageUI.ImageReaderUI._AvailableFramesPlugValueWidget",
+
+		],
+
 	}
 
 )
+
+class _AvailableFramesPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		self.__textWidget = GafferUI.TextWidget( editable = False )
+		GafferUI.PlugValueWidget.__init__( self, self.__textWidget, plug, **kw )
+
+	def _updateFromValues( self, values, exception ) :
+
+		value = sole( values )
+		if value is None :
+			self.__textWidget.setText( "---" )
+		else :
+			self.__textWidget.setText( str( IECore.frameListFromList( list( value ) ) ) )
+
+		self.__textWidget.setErrored( exception is not None )

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -146,6 +146,8 @@ ImageReader::ImageReader( const std::string &name )
 
 	addChild( new IntPlug( "channelInterpretation", Plug::In, (int)ChannelInterpretation::Default, /* min */ (int)ChannelInterpretation::Legacy, /* max */ (int)ChannelInterpretation::Specification ) );
 
+	addChild( new IntVectorDataPlug( "availableFrames", Plug::Out, new IntVectorData, Plug::Default & ~Plug::Serialisable ) );
+
 	addChild( new AtomicCompoundDataPlug( "__intermediateMetadata", Plug::In, new CompoundData, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new StringPlug( "__intermediateColorSpace", Plug::Out, "", Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ImagePlug( "__intermediateImage", Plug::In, Plug::Default & ~Plug::Serialisable ) );
@@ -169,6 +171,8 @@ ImageReader::ImageReader( const std::string &name )
 	colorSpace->outputSpacePlug()->setValue( config->getColorSpace( OCIO_NAMESPACE::ROLE_SCENE_LINEAR )->getName() );
 	colorSpace->processUnpremultipliedPlug()->setValue( true );
 	intermediateImagePlug()->setInput( colorSpace->outPlug() );
+
+	availableFramesPlug()->setInput( oiioReader->availableFramesPlug() );
 }
 
 ImageReader::~ImageReader()
@@ -265,54 +269,64 @@ const IntPlug *ImageReader::channelInterpretationPlug() const
 	return getChild<IntPlug>( g_firstChildIndex + 6 );
 }
 
+Gaffer::IntVectorDataPlug *ImageReader::availableFramesPlug()
+{
+	return getChild<IntVectorDataPlug>( g_firstChildIndex + 7 );
+}
+
+const Gaffer::IntVectorDataPlug *ImageReader::availableFramesPlug() const
+{
+	return getChild<IntVectorDataPlug>( g_firstChildIndex + 7 );
+}
+
 AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 7 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 8 );
 }
 
 const AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 7 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 8 );
 }
 
 StringPlug *ImageReader::intermediateColorSpacePlug()
 {
-	return getChild<StringPlug>( g_firstChildIndex + 8 );
+	return getChild<StringPlug>( g_firstChildIndex + 9 );
 }
 
 const StringPlug *ImageReader::intermediateColorSpacePlug() const
 {
-	return getChild<StringPlug>( g_firstChildIndex + 8 );
+	return getChild<StringPlug>( g_firstChildIndex + 9 );
 }
 
 ImagePlug *ImageReader::intermediateImagePlug()
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 9 );
+	return getChild<ImagePlug>( g_firstChildIndex + 10 );
 }
 
 const ImagePlug *ImageReader::intermediateImagePlug() const
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 9 );
+	return getChild<ImagePlug>( g_firstChildIndex + 10 );
 }
 
 OpenImageIOReader *ImageReader::oiioReader()
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 10 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 11 );
 }
 
 const OpenImageIOReader *ImageReader::oiioReader() const
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 10 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 11 );
 }
 
 ColorSpace *ImageReader::colorSpace()
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 11 );
+	return getChild<ColorSpace>( g_firstChildIndex + 12 );
 }
 
 const ColorSpace *ImageReader::colorSpace() const
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 11 );
+	return getChild<ColorSpace>( g_firstChildIndex + 12 );
 }
 
 size_t ImageReader::supportedExtensions( std::vector<std::string> &extensions )

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -1212,7 +1212,17 @@ void OpenImageIOReader::compute( ValuePlug *output, const Context *context ) con
 	if( output == availableFramesPlug() )
 	{
 		FileSequencePtr fileSequence = nullptr;
-		IECore::ls( fileNamePlug()->getValue(), fileSequence, /* minSequenceSize */ 1 );
+		// In case the image sequence is simply missing, the availableFrames should be set to 0
+		// that allows, in practice, tool building on the ImageReader to gracefully handle that case
+		// when running template workflows.
+		try
+		{
+			IECore::ls( fileNamePlug()->getValue(), fileSequence, /* minSequenceSize */ 1 );
+		}
+		catch( const std::exception & )
+		{
+			// Fall through to `setToDefault()`.
+		}
 
 		if( fileSequence )
 		{


### PR DESCRIPTION
- GafferImage::OpenImageIOReader: Avoid to throw when computing `availableFrames` plug value for missing file sequence.

### Related issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

- List any other unmerged PRs that thi
### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
