### PR TITLE
Add -category argument to TestRunner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
             testRunner: su testUser -c
+            testArguments: -category standard
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
             sconsCacheMegabytes: 2500
@@ -63,7 +64,7 @@ jobs:
             publish: true
             containerImage:
             testRunner: Invoke-Expression
-            testArguments: GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
+            testArguments: -category standard GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
             sconsCacheMegabytes: 400
 
     runs-on: ${{ matrix.os }}

--- a/Changes.md
+++ b/Changes.md
@@ -150,6 +150,7 @@ Breaking Changes
 - DisplayTransform :
   - The `inputSpace` default value is now interpreted as the working space rather than as an invalid space. This means that a node without `inputSpace` specified is no longer a pass-through as it was before.
   - The `display` and `view` default values are now interpreted as the default defined by the current OpenColorIO config, rather than as invalid values. This means that a node without `display` or `view` specified is no longer a pass-through as it was before.
+- gaffer test : Replaced -performanceOnly flag with -category argument which may be set to "performance" for the same as the old "-performanceOnly", or "standard" for the converse.
 
 Build
 -----

--- a/apps/test/test-1.py
+++ b/apps/test/test-1.py
@@ -93,10 +93,10 @@ class test( Gaffer.Application ) :
 					defaultValue = 1,
 				),
 
-				IECore.BoolParameter(
-					name = "performanceOnly",
-					description = "Skips tests that don't compute performance metrics.",
-					defaultValue = False,
+				IECore.StringParameter(
+					name = "category",
+					description = 'If set, restricts tests to only a certain category. Currently supported categories are "performance" and "standard" (where standard means any test that is not a performance test).',
+					defaultValue = "",
 				),
 
 				IECore.FileNameParameter(
@@ -142,8 +142,8 @@ class test( Gaffer.Application ) :
 				testCase = unittest.defaultTestLoader.loadTestsFromName( name )
 				testSuite.addTest( testCase )
 
-			if args["performanceOnly"].value :
-				GafferTest.TestRunner.filterPerformanceTests( testSuite )
+			if args["category"].value :
+				GafferTest.TestRunner.filterTestCategory( testSuite, args["category"].value )
 
 			testRunner = GafferTest.TestRunner( previousResultsFile = args["previousOutputFile"].value )
 			if args["stopOnFailure"].value :

--- a/python/GafferTest/TestRunner.py
+++ b/python/GafferTest/TestRunner.py
@@ -135,18 +135,28 @@ class TestRunner( unittest.TextTestRunner ) :
 
 	# Adds a skip decorator to all non-performance-related tests.
 	@staticmethod
-	def filterPerformanceTests( test ) :
+	def filterTestCategory( test, category ) :
+		if category == "":
+			return
 
 		if isinstance( test, unittest.TestSuite ) :
 			for t in test :
-				TestRunner.filterPerformanceTests( t )
+				TestRunner.filterTestCategory( t, category )
 		elif isinstance( test, unittest.TestCase ) :
 			testMethod = getattr( test, test._testMethodName )
-			if not getattr( testMethod, "performanceTestMethod", False  ) :
-				setattr(
-					test, test._testMethodName,
-					unittest.skip( "Not a performance test" )( testMethod )
-				)
+			isPerf = getattr( testMethod, "performanceTestMethod", False )
+			if category == "performance":
+				if not isPerf:
+					setattr(
+						test, test._testMethodName,
+						unittest.skip( "Not a performance test" )( testMethod )
+					)
+			else:
+				if isPerf:
+					setattr(
+						test, test._testMethodName,
+						unittest.skip( "Skipping performance test" )( testMethod )
+					)
 
 	def _makeResult( self ) :
 


### PR DESCRIPTION
As discussed, replace -performanceOnly with a more flexible argument.

Since we haven't decided yet whether to set release builds to `-category standard`, I tried setting up a temp build with it set for comparison purposes ... we'll see if I botched that syntax.