### PR TITLE
OSLImage delete channels / layers via UI

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 -----
 
 - Arnold : Fixed bug that caused `ai:volume:step_scale` to be ignored if `ai:volume_step` was set explicitly to `0.0`. This was different to the behaviour when `ai:volume_step` was not set at all.
+- OSLImage : Fixed bug preventing channels / layers from being deleted using the right-click menu.
 
 API
 ---

--- a/python/GafferOSLUI/OSLImageUI.py
+++ b/python/GafferOSLUI/OSLImageUI.py
@@ -218,6 +218,7 @@ Gaffer.Metadata.registerNode(
 		],
 		"channels.*" : [
 
+			"deletable", True,
 			# Although the parameters plug is positioned
 			# as we want above, we must also register
 			# appropriate values for each individual parameter,


### PR DESCRIPTION
This does just what it claims to do, making OSLImage channels deletable from the right-click menu.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
