### PR TITLE
PathListingWidget : Evaluate column headerData asynchronously

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - MatchPatternPathFilterWidget : Added the name of the property being filtered to the placeholder text.
 - OpenImageIOReader : The `availableFrames` plug no longer errors for a missing file sequence - instead it outputs an empty list.
 - PathListingWidget : Header data is now computed asynchronously, without locking the UI.
+- CollectScenes : Improved cancellation responsiveness for large lists of `rootNames`.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,9 @@ Fixes
 -----
 
 - Arnold : Fixed bug that caused `ai:volume:step_scale` to be ignored if `ai:volume_step` was set explicitly to `0.0`. This was different to the behaviour when `ai:volume_step` was not set at all.
-- LightEditor : Fixed hang caused by the `soloLights` set triggering on an upstream Python expression or ComputeNode (#5365).
+- LightEditor :
+  - Fixed hang caused by the `soloLights` set triggering on an upstream Python expression or ComputeNode (#5365).
+  - Fixed thread-safety bug that meant the LightEditor attempted to perform computes while the graph was being edited.
 - OSLImage : Fixed bug preventing channels / layers from being deleted using the right-click menu.
 - HierarchyView : Fixed crash triggered by layouts with two or more HierarchyViews (#5364).
 - Context : Fixed crash triggered by a reentrant call to `Context::set()` from within a slot connected to `Context::changedSignal()`.

--- a/Changes.md
+++ b/Changes.md
@@ -11,11 +11,13 @@ Improvements
 - ImageReader : Added `availableFrames` output plug, listing all the available frames in the current file sequence.
 - MatchPatternPathFilterWidget : Added the name of the property being filtered to the placeholder text.
 - OpenImageIOReader : The `availableFrames` plug no longer errors for a missing file sequence - instead it outputs an empty list.
+- PathListingWidget : Header data is now computed asynchronously, without locking the UI.
 
 Fixes
 -----
 
 - Arnold : Fixed bug that caused `ai:volume:step_scale` to be ignored if `ai:volume_step` was set explicitly to `0.0`. This was different to the behaviour when `ai:volume_step` was not set at all.
+- LightEditor : Fixed hang caused by the `soloLights` set triggering on an upstream Python expression or ComputeNode (#5365).
 - OSLImage : Fixed bug preventing channels / layers from being deleted using the right-click menu.
 - HierarchyView : Fixed crash triggered by layouts with two or more HierarchyViews (#5364).
 - Context : Fixed crash triggered by a reentrant call to `Context::set()` from within a slot connected to `Context::changedSignal()`.

--- a/src/GafferScene/CollectScenes.cpp
+++ b/src/GafferScene/CollectScenes.cpp
@@ -95,12 +95,14 @@ class RootTree : public IECore::Data
 
 		};
 
-		RootTree( const IECore::StringVectorData *roots )
+		RootTree( const IECore::StringVectorData *roots, const IECore::Canceller *canceller )
 			:	m_treeRoot( new Location( 0 ) )
 		{
 			ScenePlug::ScenePath path;
 			for( const auto &root : roots->readable() )
 			{
+				IECore::Canceller::check( canceller );
+
 				ScenePlug::stringToPath( root, path );
 				if( path.empty() )
 				{
@@ -415,7 +417,7 @@ void CollectScenes::compute( Gaffer::ValuePlug *output, const Gaffer::Context *c
 	{
 		ConstStringVectorDataPtr roots = rootNamesPlug()->getValue();
 		static_cast<ObjectPlug *>( output )->setValue(
-			new RootTree( roots.get() )
+			new RootTree( roots.get(), context->canceller() )
 		);
 		return;
 	}

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -438,7 +438,9 @@ class SetMembershipColumn : public InspectorColumn
 			{
 				auto scriptNode = sceneInput->ancestor<ScriptNode>();
 
-				Context::Scope contextScope( scriptNode->context() );
+				Context::EditableScope contextScope( scriptNode->context() );
+				contextScope.setCanceller( canceller );
+
 				ConstPathMatcherDataPtr setMembersData = m_scene->set( m_setName );
 				result.icon = setMembersData->readable().isEmpty() ? m_setEmpty : m_setHasMembers;
 			}

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -394,6 +394,7 @@ class PathModel : public QAbstractItemModel
 
 		PathModel( QTreeView *parent )
 			:	QAbstractItemModel( parent ),
+				m_headerDataState( State::Unrequested ),
 				m_rootItem( new Item( IECore::InternedString(), nullptr ) ),
 				m_flat( true ),
 				m_sortColumn( -1 ),
@@ -459,6 +460,9 @@ class PathModel : public QAbstractItemModel
 			}
 
 			m_rootItem = new Item( IECore::InternedString(), nullptr );
+			m_headerData.clear();
+			m_headerDataState = State::Unrequested;
+
 			endResetModel();
 		}
 
@@ -742,8 +746,16 @@ class PathModel : public QAbstractItemModel
 				return QVariant();
 			}
 
-			const CellVariants v = CellVariants( m_columns[section]->headerData() );
-			return v.variant( role );
+			if( dirtyIfUnrequested( m_headerDataState ) )
+			{
+				const_cast<PathModel *>( this )->scheduleUpdate();
+			}
+
+			if( section < (int)m_headerData.size() )
+			{
+				return m_headerData[section].variant( role );
+			}
+			return QVariant();
 		}
 
 		QModelIndex index( int row, int column, const QModelIndex &parentIndex = QModelIndex() ) const override
@@ -895,7 +907,9 @@ class PathModel : public QAbstractItemModel
 				[this] {
 					try
 					{
-						m_rootItem->update( this, Context::current()->canceller() );
+						const IECore::Canceller *canceller = Context::current()->canceller();
+						updateHeaderData( canceller );
+						m_rootItem->update( this, canceller );
 						queueEdit(
 							[this] () {
 								finaliseRecursiveExpansion();
@@ -1023,6 +1037,61 @@ class PathModel : public QAbstractItemModel
 			}
 
 			return false;
+		}
+
+		void updateHeaderData( const IECore::Canceller *canceller )
+		{
+			if( m_headerDataState != State::Dirty )
+			{
+				return;
+			}
+
+			std::vector<CellVariants> newHeaderData;
+			for( auto &column : m_columns )
+			{
+				newHeaderData.push_back( column->headerData( canceller ) );
+			}
+
+			if( m_headerData == newHeaderData )
+			{
+				m_headerDataState = State::Clean;
+				return;
+			}
+
+			queueEdit(
+
+				[this, newHeaderData = std::move( newHeaderData )] () mutable {
+
+					m_headerData.swap( newHeaderData );
+					m_headerDataState = State::Clean;
+					headerDataChanged( Qt::Horizontal, 0, m_headerData.size() - 1 );
+
+				}
+
+			);
+		}
+
+		// State transitions :
+		//
+		// - Unrequested->Dirty : When first queried.
+		// - Dirty->Clean : When updated.
+		// - Clean->Dirty : When path changes.
+		enum class State
+		{
+			// Initial state. Not yet requested by clients
+			// of the model, therefore not yet computed, and not
+			// in need of consideration during recursive updates.
+			Unrequested,
+			// Computed and up to date.
+			Clean,
+			// Stale data that needs recomputing.
+			Dirty
+		};
+
+		static bool dirtyIfUnrequested( std::atomic<State> &state )
+		{
+			State unrequested = State::Unrequested;
+			return state.compare_exchange_strong( unrequested, State::Dirty );
 		}
 
 		// A single item in the PathModel - stores a path and caches
@@ -1569,29 +1638,6 @@ class PathModel : public QAbstractItemModel
 				Item *m_parent;
 				int m_row;
 
-				// State transitions :
-				//
-				// - Unrequested->Dirty : When first queried.
-				// - Dirty->Clean : When updated.
-				// - Clean->Dirty : When path changes.
-				enum class State
-				{
-					// Initial state. Not yet requested by clients
-					// of the model, therefore not yet computed, and not
-					// in need of consideration during recursive updates.
-					Unrequested,
-					// Computed and up to date.
-					Clean,
-					// Stale data that needs recomputing.
-					Dirty
-				};
-
-				static bool dirtyIfUnrequested( std::atomic<State> &state )
-				{
-					State unrequested = State::Unrequested;
-					return state.compare_exchange_strong( unrequested, State::Dirty );
-				}
-
 				std::atomic<State> m_dataState;
 				std::vector<CellVariants> m_data;
 
@@ -1757,7 +1803,10 @@ class PathModel : public QAbstractItemModel
 		{
 			cancelUpdate();
 			m_rootItem->dirty( /* dirtyChildItems = */ false, /* dirtyData = */ true );
-			headerDataChanged( Qt::Horizontal, 0, m_columns.size() - 1 );
+			if( m_headerDataState == State::Clean )
+			{
+				m_headerDataState = State::Dirty;
+			}
 			scheduleUpdate();
 		}
 
@@ -1765,6 +1814,8 @@ class PathModel : public QAbstractItemModel
 
 		Gaffer::PathPtr m_rootPath;
 
+		std::vector<CellVariants> m_headerData;
+		mutable std::atomic<State> m_headerDataState;
 		Item::Ptr m_rootItem;
 		bool m_flat;
 		std::vector<GafferUI::PathColumnPtr> m_columns;


### PR DESCRIPTION
This does two things :

1. Prevents the UI from blocking waiting for `PathColumn.headerData()` to return. For most columns this doesn't matter, but some columns - such as the solo column in the LightEditor - have headers that depend on computes, which can be arbitrarily slow depending on the graph the user has constructed.
2. Fixes a GIL deadlock if `PathColumn.headerData()` waits for a Python compute on a secondary thread. This happened because PySide can cause Qt to call `PathModel::headerData()` while holding the GIL. The background updates we now use to evaluate the header happen on a thread without the GIL.

An easier fix would have been to put a `CheckedGILRelease` in `PathModel::headerData()`, but it seems worthwhile to make another thing asynchronous where we can.

Fixes #5365

I should note that I reproduced #5365 reliably, made my fix, observed it to be working reliably, and then went back and couldn't reproduce again _without_ my fix. @danieldresser-ie, since it seems to reproduce more reliably for you, it would be good if you could spend a bit of time verifying that I wasn't just getting lucky (although logically what I've done should be a fix).
