### PR TITLE
Context : Fix crash triggered by re-entrant call to `set()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,8 @@ Fixes
 
 - Arnold : Fixed bug that caused `ai:volume:step_scale` to be ignored if `ai:volume_step` was set explicitly to `0.0`. This was different to the behaviour when `ai:volume_step` was not set at all.
 - OSLImage : Fixed bug preventing channels / layers from being deleted using the right-click menu.
+- HierarchyView : Fixed crash triggered by layouts with two or more HierarchyViews (#5364).
+- Context : Fixed crash triggered by a reentrant call to `Context::set()` from within a slot connected to `Context::changedSignal()`.
 
 API
 ---

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -357,10 +357,9 @@ class GAFFER_API Context : public IECore::RefCounted
 		};
 
 		// Sets a variable and emits `changedSignal()` as appropriate. Does not
-		// manage ownership in any way. Returns true if the value was assigned,
-		// and false if the value was not (due to it being equal to the
-		// previously stored value).
-		bool internalSet( const IECore::InternedString &name, const Value &value );
+		// manage ownership in any way. If ownership is required, the caller must
+		// update `m_allocMap` appropriately _before_ calling `internalSet()`.
+		void internalSet( const IECore::InternedString &name, const Value &value );
 		// Throws if variable doesn't exist.
 		const Value &internalGet( const IECore::InternedString &name ) const;
 		// Returns nullptr if variable doesn't exist.

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -312,10 +312,8 @@ void Context::set( const IECore::InternedString &name, const IECore::Data *value
 {
 	// We copy the value so that the client can't invalidate this context by changing it.
 	ConstDataPtr copy = value->copy();
-	if( internalSet( name, Value( name, copy.get() ) ) )
-	{
-		m_allocMap[name] = copy;
-	}
+	m_allocMap[name] = copy;
+	internalSet( name, Value( name, copy.get() ) );
 }
 
 IECore::DataPtr Context::getAsData( const IECore::InternedString &name ) const


### PR DESCRIPTION
We were updating `m_allocMap` (which maintains ownership) _after_ assigning to `m_map` (which deals in raw pointers) and emitting `changedSignal()`. This meant we were in an inconsistent internal state at the point we triggered arbitrary observer code via slots connected to the signal. If a slot set the _same_ variable again, we'd end up with the raw pointer from the second call to `set()`, but with the owning pointer for the first call. Hence we were referencing a dangling pointer and subsequent attempts at accessing it would crash.

The solution is to store to `m_allocMap` _before_ calling `internalSet()`, so everything is in sync when we emit the signal.

This fixes crashes triggered by the interaction between multiple HierarchyViews synchronising via `ContextAlgo::set/getVisibleSet()`, as described in (#5364). I'm still not 100% sure how that was leading to a re-entrant call, but it seems worth fixing this at the lowest level possible, and "no signalling without consistent internal state" is a rule to live by anyway.
