### PR TITLE
Plug/ValuePlug : Allow interleaving edit/compute within DirtyPropagationScopes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -57,6 +57,7 @@ Fixes
 - Expression : Fixed parsing of Python expressions combining subscripts (`[]`) and `context` methods (#3088, #3613, #5250).
 - ConnectionCreatorWrapper : Fixed bug which forced PlugAdder derived classes to implement `updateDragEndPoint()` unnecessarily.
 - Plug : Fixed bug which caused stale values to be retrieved from the cache for plugs that had been renamed.
+- ValuePlug : Fixed results when graph edits and computes are interleaved within a DirtyPropagationScope (#1971).
 - OpenColorIOTransform : Fixed error processing deep image tiles containing no samples.
 - Seeds :
   - Fixed duplicate points at triangle edges.

--- a/include/Gaffer/Plug.h
+++ b/include/Gaffer/Plug.h
@@ -245,6 +245,16 @@ class GAFFER_API Plug : public GraphComponent
 		/// connected to the signal.
 		virtual void dirty();
 
+		/// Makes any pending calls to `dirty()` that would otherwise be
+		/// delayed by a DirtyPropagationScope. May be called by plugs
+		/// that wish to allow edits and computes to be interleaved within
+		/// a single DirtyPropagationScope, requiring caches to be invalidated
+		/// before the scope is closed.
+		///
+		/// > Note : Never calls `plugDirtiedSignal()` - that is always
+		/// > deferred until the DirtyPropagationScope closes.
+		static void flushDirtyPropagationScope();
+
 	private :
 
 		static void propagateDirtinessAtLeaves( Plug *plugToDirty );

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -740,5 +740,14 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		self.assertNotEqual( h2, h1 )
 		self.assertEqual( n.plug.getValue(), "out2" )
 
+	def testInterleavedEditsAndComputes( self ) :
+
+		n = GafferTest.AddNode()
+
+		with Gaffer.DirtyPropagationScope() :
+			for i in range( 0, 100 ) :
+				n["op1"].setValue( i )
+				self.assertEqual( n["sum"].getValue(), i )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -235,6 +235,8 @@ class ValuePlug::HashProcess : public Process
 			// one per context, computed by ComputeNode::hash(). Pull the value from our cache, or compute it
 			// using a HashProcess instance.
 
+			Plug::flushDirtyPropagationScope(); // Ensure any pending calls to `dirty()` are made before we look up `m_dirtyCount`.
+
 			const ComputeNode *computeNode = IECore::runTimeCast<const ComputeNode>( p->node() );
 			const ThreadState &threadState = ThreadState::current();
 			const Context *currentContext = threadState.context();
@@ -313,7 +315,6 @@ class ValuePlug::HashProcess : public Process
 					// HashCacheMode::Legacy
 					HashProcessKey legacyProcessKey( processKey );
 					legacyProcessKey.dirtyCount = g_legacyGlobalDirtyCount + DIRTY_COUNT_RANGE_MAX + 1;
-
 					return threadData.cache.get( legacyProcessKey, currentContext->canceller() );
 				}
 			}


### PR DESCRIPTION
This means calling `ValuePlug::dirty()` before the scope closes, so that the hash cache is invalidated before the compute is performed.

This was first requested way back in 2017 in issue #1971, where the use case was edit/compute loops in the PythonEditor. It has become a high priority more recently though, as it turned out we were actually interleaving edits and computes in the TransformTools, and noticed incorrect results while working on the LightTool in #5218. The problem was as follows, and is demonstrated in `testMultipleSelectionWithEditScope` :

1. We push a dirty propagation scope using UndoScope.
2. We create a transform edit for `/cube1`, which dirties some plugs, incrementing their dirty count.
3. We create a transform edit for `/cube`, but as part of doing that we need to compute the _current_ transform. This "bakes" that transform into the (hash) cache, keyed by the current dirty count.
4. We propagate dirtiness for this new transform edit, but don't increment the dirty count again, because we've already visited those plugs in step 2.
5. After closing the scope, we query the transform for `/cube` and end up with the cached value from step 3. This is incorrect, because it isn't accounting for the edits made subsequently.

The problem is demonstrated even more simply by `ComputeNodeTest.testInterleavedEditsAndComputes`.

There is an overhead to calling `flushDirtyPropagationScope()` for each `getValue()` call, and it is measurable in `ValuePlugTest.testCacheOverhead()`. But taking into account the performance improvements made in #5362, we still come out with an %18 reduction in runtime even with the overhead.

Fixes #1971
