### PR TITLE
NumericPlugValueWidget fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Instancer : Fixed bug that could cause the `scene:path` context variable to be leaked into the evaluation of `propotypes.set` in rare circumstances.
+- NumericPlugValueWidget : Fixed bug causing the cursor position to be reset to the end if the number of digits in the plug value changed while incrementing/decrementing with the keyboard up/down arrow keys.
 
 1.2.9.0 (relative to 1.2.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,10 @@ Fixes
 -----
 
 - Instancer : Fixed bug that could cause the `scene:path` context variable to be leaked into the evaluation of `propotypes.set` in rare circumstances.
-- NumericPlugValueWidget : Fixed bug causing the cursor position to be reset to the end if the number of digits in the plug value changed while incrementing/decrementing with the keyboard up/down arrow keys.
+- NumericPlugValueWidget (#5335) :
+  - Fixed bug causing the cursor position to be reset to the end if the number of digits in the plug value changed while incrementing/decrementing with the keyboard up/down arrow keys.
+  - Fixed bug causing the cursor position to be reset to the end when incrementing an animated plug.
+  - Fixed intermittent `---` values when drag-changing an animated plug value.
 
 1.2.9.0 (relative to 1.2.8.0)
 =======

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -84,6 +84,14 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _updateFromValues( self, values, exception ) :
 
+		if len( values ) == 0 and exception is None and self.getPlugs() :
+			# Placeholder update for a pending background compute. If we're animated,
+			# we don't want to use a `---` placeholder because it messes up editing for
+			# the user. Animation is quick enough to compute that there is no need
+			# for a placeholder anyway, so we'll just wait for the final update.
+			if all( Gaffer.Animation.isAnimated( p ) for p in self.getPlugs() ) :
+				return
+
 		# Update value and error state.
 
 		value = sole( values )

--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -289,10 +289,10 @@ class NumericWidget( GafferUI.TextWidget ) :
 		text = self.__valueToString( value )
 		dragBeginOrEnd = reason in ( self.ValueChangedReason.DragBegin, self.ValueChangedReason.DragEnd )
 
-		if text == self.getText() and not dragBeginOrEnd :
-			# early out if the text hasn't changed. we never early out if the reason is
-			# drag start or drag end, as we want to maintain matching pairs so things
-			# make sense to client code.
+		if self.getText() and self.__numericType( text ) == self.getValue() and not dragBeginOrEnd :
+			# early out if the value, after text formatting, hasn't changed. we never
+			# early out if the reason is drag start or drag end, as we want to maintain
+			# matching pairs so things make sense to client code.
 			return
 
 		self.setText( text )


### PR DESCRIPTION
This fixes a few issues with using `NumericPlugValueWidget`.

- Incrementing the value of an animated plug with the keyboard up / down arrows would always reset the cursor to the end, making it unusable on animated plugs.
- Drag-changing the value of an animated plug would result in intermittent "---" values. The final value seems to always be set properly, but it causes flickering in the UI.
- Using the increment / decrement keyboard shortcuts. If the plug value was changed with the keyboard shortcuts in a way such that the number of digits in the value changed and the cursor was at or adjacent to a digit place that was removed,
it would be reset to the end. For example, decrementing the value of `100` at the 10's place would reset the cursor to the end.

Fixes #5335 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
