### PR TITLE
3Delight : Insert default `uvCoord` shader

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - 3Delight :
   - Moved shaders to `3Delight/Shader` menu and removed outdated shaders from the menu.
   - Shaders (including light shaders) are only loaded from the `osl` subdirectory of the 3Delight installation.
+  - Primitive variables named `uv` are now automatically renamed `st` for compatibility with the `uvCoord` shader's expectation.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
   - Moved shaders to `3Delight/Shader` menu and removed outdated shaders from the menu.
   - Shaders (including light shaders) are only loaded from the `osl` subdirectory of the 3Delight installation.
   - Primitive variables named `uv` are now automatically renamed `st` for compatibility with the `uvCoord` shader's expectation.
+  - Added a default `uvCoord` shader during internal shader network preprocessing to shader parameters that do not have an input connection.
 
 Fixes
 -----

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -208,7 +208,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 		self.assertEqual( mesh["nvertices"], [ 4, 4 ] )
 		self.assertEqual(
-			mesh["uv"],
+			mesh["st"],
 			[
 				imath.V2f( 0, 0 ),
 				imath.V2f( 0.5, 0 ),
@@ -218,7 +218,10 @@ class RendererTest( GafferTest.TestCase ) :
 				imath.V2f( 1, 1 )
 			]
 		)
-		self.assertEqual( mesh["uv.indices"], [ 0, 1, 4, 3, 1, 2, 5, 4 ] )
+		self.assertEqual( mesh["st.indices"], [ 0, 1, 4, 3, 1, 2, 5, 4 ] )
+
+		self.assertNotIn( "uv.indices", mesh )
+		self.assertNotIn( "uv", mesh )
 
 	def testAnimatedMesh( self ) :
 

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -974,6 +974,80 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 		self.assertEqual( shader["splineBasis"], "linear" )
 
+	def testUVCoordShaderInserted( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.nsi" ),
+		)
+
+		s = IECoreScene.ShaderNetwork(
+			{
+				"output" : IECoreScene.Shader( "testShader", "surface", { "uvCoord" : IECore.FloatVectorData() } )
+			},
+			output = "output"
+		)
+
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		a = r.attributes( IECore.CompoundObject( { "osl:surface": s } ) )
+
+		r.object( "object", m, a )
+
+		r.render()
+		del r
+
+		nsi = self.__parseDict( self.temporaryDirectory() / "test.nsi" )
+
+		shaders = { k: v for k, v in nsi.items() if nsi[k]["nodeType"] == "shader" }
+
+		self.assertEqual( len( shaders ), 2 )
+
+		testShader = next( k for k, v in shaders.items() if v["shaderfilename"] == "testShader" )
+		uvShader = next( k for k, v in shaders.items() if pathlib.Path( v["shaderfilename"] ).name == "uvCoord.oso" )
+
+		self.assertEqual( len( nsi[testShader]["uvCoord"] ), 1 )
+		self.assertEqual( self.__connectionSource( nsi[testShader]["uvCoord"][0], nsi ), nsi[uvShader] )
+
+	def testUVCoordShaderNotInserted( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.nsi" ),
+		)
+
+		s = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader( "testShader", "surface", { "uvCoord" : IECore.FloatVectorData() } ),
+				"input" : IECoreScene.Shader( "testUVShader" )
+			},
+			connections = [
+				( ( "input", "" ), ( "output", "uvCoord" ) )
+			],
+			output = "output"
+		)
+
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		a = r.attributes( IECore.CompoundObject( { "osl:surface": s } ) )
+
+		r.object( "object", m, a )
+
+		r.render()
+		del r
+
+		nsi = self.__parseDict( self.temporaryDirectory() / "test.nsi" )
+
+		shaders = { k: v for k, v in nsi.items() if nsi[k]["nodeType"] == "shader" }
+
+		self.assertEqual( len( shaders ), 2 )
+
+		testShader = next( k for k, v in shaders.items() if v["shaderfilename"] == "testShader" )
+		uvShader = next( k for k, v in shaders.items() if v["shaderfilename"] == "testUVShader" )
+
+		self.assertEqual( len( nsi[testShader]["uvCoord"] ), 1 )
+		self.assertEqual( self.__connectionSource( nsi[testShader]["uvCoord"][0], nsi ), nsi[uvShader] )
+
 	# Helper methods used to check that NSI files we write contain what we
 	# expect. The 3delight API only allows values to be set, not queried,
 	# so we build a simple dictionary-based node graph for now.
@@ -987,7 +1061,14 @@ class RendererTest( GafferTest.TestCase ) :
 		if len( cSplit ) == 1 :
 			return nsi[cSplit[0][1:-1]]  # remove <>
 
-		return nsi[cSplit[0][1:-1]][cSplit[1]]
+		nodeName = cSplit[0][1:-1]
+		parameterName = cSplit[1]
+
+		if parameterName not in nsi[nodeName] :
+			# Shaders don't list their outputs as parameters, just return the node
+			return nsi[nodeName]
+
+		return nsi[nodeName][parameterName]
 
 	def __parseDict( self, nsiFile ) :
 
@@ -1051,6 +1132,11 @@ class RendererTest( GafferTest.TestCase ) :
 				if arraySplit is not None and pType != "float[2]" :
 					pLength = int( arraySplit.groupdict()["arrayLength"] )
 					pType = arraySplit.groupdict()["varType"]
+
+				if pLength == 0 :
+					tokens.popleft()  # Opening `[`
+					tokens.popleft()  # Closing	`]`
+					continue  # And we're done
 
 				numComponents = { "v": 3, "color": 3, "doublematrix": 16, "float[2]": 2 }.get( pType, 1 )
 				numElements = pLength * numComponents * pSize

--- a/src/IECoreDelight/NodeAlgo.cpp
+++ b/src/IECoreDelight/NodeAlgo.cpp
@@ -86,13 +86,15 @@ Registry &registry()
 
 void addPrimitiveVariableParameters( const char *name, const IECoreScene::PrimitiveVariable &value, const IECore::IntVectorData *vertexIndices, ParameterList &parameterList, ParameterList *indicesParameterList )
 {
-	NSIParam_t p = parameterList.parameter( name, value.data.get(), false );
+	const char *conformedName = strcmp( name, "uv" ) == 0 ? "st" : name;
+
+	NSIParam_t p = parameterList.parameter( conformedName, value.data.get(), false );
 	if( p.type == NSITypeInvalid )
 	{
 		return;
 	}
 
-	if( strcmp( name, "P" ) == 0 )
+	if( strcmp( conformedName, "P" ) == 0 )
 	{
 		// Work around sloppy use of geometric interpretation
 		p.type = NSITypePoint;
@@ -137,7 +139,7 @@ void addPrimitiveVariableParameters( const char *name, const IECoreScene::Primit
 	{
 		if( indicesParameterList )
 		{
-			const string indicesName = name + string( ".indices" );
+			const string indicesName = conformedName + string( ".indices" );
 			indicesParameterList->add( {
 				indicesParameterList->allocate( indicesName ),
 				indices->readable().data(),


### PR DESCRIPTION
This adds a default `uvCoord` shader to 3Delight shaders that expect UV coordinates and don't already have a connection.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
