### PR TITLE
Cycles : VDB volumes refactor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
   - Fixed error when `resize()` removed plugs with input connections.
   - Fixed error when `resize()` was used on an output plug.
 - CreateViews : Fixed loading of files saved from Gaffer 1.5+.
+- Cycles : OpenVDBs will now render and allow shader updates in a live render.
 
 1.4.13.0 (relative to 1.4.12.0)
 ========

--- a/include/GafferCycles/IECoreCyclesPreview/CameraAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/CameraAlgo.h
@@ -52,7 +52,7 @@ namespace CameraAlgo
 {
 
 /// Converts the specified IECoreScene::Camera into a ccl::Camera.
-IECORECYCLES_API ccl::Camera *convert( const IECoreScene::Camera *camera, const std::string &nodeName, ccl::Scene *scene = nullptr );
+IECORECYCLES_API ccl::Camera *convert( const IECoreScene::Camera *camera, const std::string &nodeName );
 
 } // namespace CameraAlgo
 

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import pathlib
 import math
 import time
 import unittest
@@ -43,6 +44,7 @@ import imath
 import IECore
 import IECoreScene
 import IECoreImage
+import IECoreVDB
 
 import GafferScene
 import GafferCycles
@@ -2741,6 +2743,79 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( testPixel.b, 0 )
 
 		del light, plane
+
+	def testVDB( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Cycles",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+		)
+
+		camera = renderer.camera(
+			"testCamera",
+			IECoreScene.Camera(
+				parameters = {
+					"resolution" : imath.V2i( 64, 64 ),
+				}
+			),
+			renderer.attributes( IECore.CompoundObject() )
+		)
+		camera.transform( imath.M44f().translate( imath.V3f( 0, 45, 150 ) ) )
+
+		renderer.option( "camera", IECore.StringData( "testCamera" ) )
+
+		renderer.output(
+			"testOutput",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testVDB",
+				}
+			)
+		)
+
+		renderer.object(
+			"/vdb",
+			IECoreVDB.VDBObject( pathlib.Path( __file__ ).parent / ".." / ".." / "GafferVDBTest" / "data" / "smoke.vdb" ), # todo - can't figure out how to load in a vdb...
+			renderer.attributes( IECore.CompoundObject ( {
+				"cycles:volume" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "principled_volume", "cycles:volume", { "density_attribute" : "density" } )
+					},
+					output = "output",
+				)
+			} ) )
+		)
+
+		renderer.light(
+			"/light",
+			None,
+			renderer.attributes( IECore.CompoundObject ( {
+				"cycles:light" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "background_light", "cycles:light", { "color" : imath.Color3f( 1, 1, 1 ) } ),
+					},
+					output = "output",
+				),
+			} ) )
+		)
+
+		renderer.render()
+		time.sleep( 2 )
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testVDB" )
+		self.assertIsInstance( image, IECoreImage.ImagePrimitive )
+
+		testPixel = self.__colorAtUV( image, imath.V2f( 0.5 ) )
+		self.assertGreater( testPixel.r, 0 )
+		self.assertGreater( testPixel.g, 0 )
+		self.assertGreater( testPixel.b, 0 )
+
+		del camera
+		del v
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesUI/CyclesAttributesUI.py
+++ b/python/GafferCyclesUI/CyclesAttributesUI.py
@@ -69,7 +69,7 @@ def __subdivisionSummary( plug ) :
 def __volumeSummary( plug ) :
 
 	info = []
-	for childName in ( "volumeClipping", "volumeStepSize", "volumeObjectSpace" ) :
+	for childName in ( "volumeClipping", "volumeStepSize", "volumeObjectSpace", "volumeVelocityScale", "volumePrecision" ) :
 		if plug[childName]["enabled"].getValue() :
 			info.append( IECore.CamelCase.toSpaced( childName ) + ( " On" if plug[childName]["value"].getValue() else " Off" ) )
 
@@ -338,6 +338,38 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Volume",
+
+		],
+
+		"attributes.volumeVelocityScale" : [
+
+			"description",
+			"""
+			Volume velocity scale to multiply with an existing velocity.
+			""",
+
+			"layout:section", "Volume",
+
+		],
+
+		"attributes.volumePrecision" : [
+
+			"description",
+			"""
+			Specifies volume data precision, lower values reduce
+			memory consumption at the cost of detail.
+			""",
+
+			"layout:section", "Volume",
+
+		],
+
+		"attributes.volumePrecision.value" : [
+
+			"preset:Full", "full",
+			"preset:Half", "half",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/src/GafferCycles/CyclesAttributes.cpp
+++ b/src/GafferCycles/CyclesAttributes.cpp
@@ -74,7 +74,9 @@ CyclesAttributes::CyclesAttributes( const std::string &name )
 	// Volume
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_clipping", new IECore::FloatData( 0.001f ), false, "volumeClipping" ) );
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_step_size", new IECore::FloatData( 0.0f ), false, "volumeStepSize" ) );
-	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_object_space", new IECore::BoolData( true ), false, "volumeObjectSpace" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_object_space", new IECore::BoolData( false ), false, "volumeObjectSpace" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_velocity_scale", new IECore::FloatData( 1.0f ), false, "volumeVelocityScale" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "cycles:volume_precision", new IECore::StringData( "full" ), false, "volumePrecision" ) );
 
 	// Asset name for cryptomatte
 	attributes->addChild( new Gaffer::NameValuePlug( "cycles:asset_name", new IECore::StringData( "" ), false, "assetName" ) );

--- a/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CameraAlgo.cpp
@@ -177,7 +177,7 @@ namespace CameraAlgo
 
 {
 
-ccl::Camera *convert( const IECoreScene::Camera *camera, const std::string &nodeName, ccl::Scene *scene )
+ccl::Camera *convert( const IECoreScene::Camera *camera, const std::string &nodeName )
 {
 	return convertCommon( camera, nodeName );
 }

--- a/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/CurvesAlgo.cpp
@@ -133,14 +133,14 @@ ccl::Hair *convertCommon( const IECoreScene::CurvesPrimitive *curve )
 	return hair;
 }
 
-ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::CurvesPrimitive *curve, const std::string &nodeName )
 {
 	ccl::Hair *hair = convertCommon( curve );
 	hair->name = ccl::ustring( nodeName.c_str() );
 	return hair;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::CurvesPrimitive *> &curves, const std::vector<float> &times, const int frameIdx, const std::string &nodeName )
 {
 	const int numSamples = curves.size();
 

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -41,6 +41,8 @@
 #include "IECore/SimpleTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "scene/image.h"
+#include "scene/image_vdb.h"
 // Cycles (for ustring)
 #include "util/param.h"
 #undef fmix // OpenImageIO's farmhash inteferes with IECore::MurmurHash
@@ -188,6 +190,19 @@ ccl::Attribute *convertTypedPrimitiveVariable( const std::string &name, const Pr
 	return attribute;
 }
 
+class IEVolumeLoader : public ccl::VDBImageLoader
+{
+	public:
+		IEVolumeLoader( const IECoreVDB::VDBObject *ieVolume, const string &gridName, const int precision_ )
+		: VDBImageLoader( gridName ), m_ieVolume( ieVolume )
+		{
+			grid = m_ieVolume->findGrid( gridName );
+			precision = precision_;
+		}
+
+		const IECoreVDB::VDBObject *m_ieVolume;
+};
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -200,7 +215,7 @@ namespace IECoreCycles
 namespace GeometryAlgo
 {
 
-ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName )
 {
 	const Registry &r = registry();
 	Registry::const_iterator it = r.find( object->typeId() );
@@ -208,10 +223,10 @@ ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeNam
 	{
 		return nullptr;
 	}
-	return it->second.converter( object, nodeName, scene );
+	return it->second.converter( object, nodeName );
 }
 
-ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName )
 {
 	if( samples.empty() )
 	{
@@ -236,11 +251,11 @@ ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, cons
 	}
 	if( it->second.motionConverter )
 	{
-		return it->second.motionConverter( samples, times, frameIdx, nodeName, scene );
+		return it->second.motionConverter( samples, times, frameIdx, nodeName );
 	}
 	else
 	{
-		return it->second.converter( samples.front(), nodeName, scene );
+		return it->second.converter( samples.front(), nodeName );
 	}
 }
 
@@ -374,6 +389,101 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	else if( name == "uv.tangent" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeVector )
 	{
 		attr->std = ccl::ATTR_STD_UV_TANGENT;
+	}
+}
+
+void convertVoxelGrids( const IECoreVDB::VDBObject *vdbObject, ccl::Volume *volume, ccl::Scene *scene, const float frame, const int precision )
+{
+	ccl::TypeDesc ctype;// = ccl::TypeDesc::TypeUnknown;
+
+	std::vector<std::string> gridNames = vdbObject->gridNames();
+
+	for( const std::string& gridName : gridNames )
+	{
+		ccl::AttributeStandard std = ccl::ATTR_STD_NONE;
+
+		if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_DENSITY ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_DENSITY;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_COLOR ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_COLOR;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_FLAME ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_FLAME;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_HEAT ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_HEAT;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_TEMPERATURE ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_TEMPERATURE;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_VELOCITY ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_VELOCITY;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_VELOCITY_X ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_VELOCITY_X;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_VELOCITY_Y ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_VELOCITY_Y;
+		}
+		else if( ccl::ustring( gridName.c_str() ) == ccl::Attribute::standard_name( ccl::ATTR_STD_VOLUME_VELOCITY_Z ) )
+		{
+			std = ccl::ATTR_STD_VOLUME_VELOCITY_Z;
+		}
+		else
+		{
+			openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridName );
+			if( grid->isType<openvdb::BoolGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeInt;
+			}
+			else if( grid->isType<openvdb::DoubleGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeFloat;
+			}
+			else if( grid->isType<openvdb::FloatGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeFloat;
+			}
+			else if( grid->isType<openvdb::Int32Grid>() )
+			{
+				ctype = ccl::TypeDesc::TypeInt;
+			}
+			else if( grid->isType<openvdb::Int64Grid>() )
+			{
+				ctype = ccl::TypeDesc::TypeInt;
+			}
+			else if( grid->isType<openvdb::Vec3DGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeVector;
+			}
+			else if( grid->isType<openvdb::Vec3IGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeVector;
+			}
+			else if( grid->isType<openvdb::Vec3SGrid>() )
+			{
+				ctype = ccl::TypeDesc::TypeVector;
+			}
+		}
+
+		ccl::Attribute *attr = ( std != ccl::ATTR_STD_NONE ) ?
+							volume->attributes.add( std ) :
+							volume->attributes.add( ccl::ustring( gridName.c_str() ), ctype, ccl::ATTR_ELEMENT_VOXEL );
+
+		ccl::ImageLoader *loader = new IEVolumeLoader( vdbObject, gridName, precision );
+		ccl::ImageParams params;
+		params.frame = frame;
+
+		attr->data_voxel() = scene->image_manager->add_image( loader, params, false );
 	}
 }
 

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -238,14 +238,14 @@ ccl::Mesh *convertCommon( const IECoreScene::MeshPrimitive *mesh )
 	return cmesh;
 }
 
-ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName )
 {
 	ccl::Mesh *cmesh = convertCommon( mesh );
 	cmesh->name = ccl::ustring( nodeName.c_str() );
 	return cmesh;
 }
 
-ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const std::vector<const IECoreScene::MeshPrimitive *> &meshes, const std::vector<float> &times, const int frameIdx, const std::string &nodeName )
 {
 	const int numSamples = meshes.size();
 

--- a/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/PointsAlgo.cpp
@@ -135,14 +135,14 @@ ccl::PointCloud *convertCommon( const IECoreScene::PointsPrimitive *points )
 	return pointcloud;
 }
 
-ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName )
 {
 	ccl::PointCloud *pointCloud = convertCommon( points );
 	pointCloud->name = ccl::ustring( nodeName.c_str() );
 	return pointCloud;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::PointsPrimitive *> &points, const std::vector<float> &times, const int frameIdx, const std::string &nodeName )
 {
 	const int numSamples = points.size();
 

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -99,14 +99,14 @@ ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere )
 	return pointcloud;
 }
 
-ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName )
 {
 	ccl::Geometry *result = convertCommon( sphere );
 	result->name = ccl::ustring( nodeName.c_str() );
 	return result;
 }
 
-ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
+ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName )
 {
 	ccl::Geometry *result = convertCommon( samples.front() );
 	result->name = ccl::ustring( nodeName.c_str() );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Refactored the VDB loading/rendering code for Cycles
- It now defers voxel grid creation into the scene-lock
- Shader modification now requires an expensive object rebuild, but now it reliably will update in a live render (this has been addressed)
- The unit-test I can't figure out how to load in a vdb, need help on that one

### Related issues ###

- https://github.com/GafferHQ/gaffer/pull/4815

### Dependencies ###

Not hard-dependencies, but I did apply this based on these two, so I am not sure how it'll go without them.
- https://github.com/GafferHQ/gaffer/pull/5101
- https://github.com/GafferHQ/gaffer/pull/5239
- https://projects.blender.org/blender/cycles/pulls/6 https://github.com/boberfly/dependencies/blob/cycles/Cycles/patches/volume_updates.patch

### Breaking changes ###

- GeometryAlgo now doesn't have a scene argument for the convert functions, as these were only for volumes and now scene is only needed in `convertVoxelGrids`

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.

### TODO ###

- I think we can do half-precision on vdb's, I'll add it to this when I figure that out. - Should be done now
- Unit-test needs fixing.