### PR TITLE
SConstruct : Fix include order on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -635,6 +635,19 @@ else:
 			],
 		)
 
+	# Reorder build commands so that `/external:I` includes come after `/I` includes.
+	# Otherwise we'll pick up the Gaffer includes from the build directory, and not
+	# the ones in the source tree.
+
+	for command, cxxFlags in [
+		( "CXXCOM", "$CXXFLAGS" ),
+		( "SHCXXCOM", "$SHCXXFLAGS" )
+	] :
+		if env[command].index( cxxFlags ) < env[command].index( "$_CCCOMCOM" ) :
+			# `$_CCCOMCOM` contains the preprocessor flags, including `/I`. Swap
+			# it with `cxxFlags`, which contains `/external:I`.
+			env[command] = env[command].replace( cxxFlags, "<>" ).replace( "$_CCCOMCOM", cxxFlags ).replace( "<>",  "$_CCCOMCOM" )
+
 ###############################################################################################
 # Check for inkscape and sphinx
 ###############################################################################################


### PR DESCRIPTION
MSVC seems to search include dirs in the order they are found on the command line, regardless of whether they are `/external:I` (system) or `/I` (regular) includes. This contrasts with GCC, which always searches regular includes before system includes. And unfortunately, the default SCons build commands place `$CXXFLAGS` before the include flags, so MSVC would find Gaffer's installed headers before it found the headers in the source tree, which are the ones we want. This reorders the build commands so that sanity can prevail.
