### PR TITLE
Gaffer : Fix exports for nodes which were once templated

### DIFF
--- a/include/Gaffer/ContextProcessor.h
+++ b/include/Gaffer/ContextProcessor.h
@@ -45,7 +45,7 @@ namespace Gaffer
 /// The ContextProcessor provides a base class to simplify the creation of nodes
 /// which evaluate their inputs using a modified context to that provided for the output
 /// evaluation - time warps being one good example.
-class IECORE_EXPORT ContextProcessor : public ComputeNode
+class GAFFER_API ContextProcessor : public ComputeNode
 {
 
 	public :

--- a/include/Gaffer/ContextVariables.h
+++ b/include/Gaffer/ContextVariables.h
@@ -43,7 +43,7 @@
 namespace Gaffer
 {
 
-class IECORE_EXPORT ContextVariables : public ContextProcessor
+class GAFFER_API ContextVariables : public ContextProcessor
 {
 
 	public :

--- a/include/Gaffer/DeleteContextVariables.h
+++ b/include/Gaffer/DeleteContextVariables.h
@@ -42,7 +42,7 @@
 namespace Gaffer
 {
 
-class IECORE_EXPORT DeleteContextVariables : public ContextProcessor
+class GAFFER_API DeleteContextVariables : public ContextProcessor
 {
 
 	public :

--- a/include/Gaffer/Loop.h
+++ b/include/Gaffer/Loop.h
@@ -44,7 +44,7 @@
 namespace Gaffer
 {
 
-class IECORE_EXPORT Loop : public ComputeNode
+class GAFFER_API Loop : public ComputeNode
 {
 
 	public :

--- a/include/Gaffer/NameSwitch.h
+++ b/include/Gaffer/NameSwitch.h
@@ -43,7 +43,7 @@ namespace Gaffer
 
 class StringPlug;
 
-class IECORE_EXPORT NameSwitch : public Switch
+class GAFFER_API NameSwitch : public Switch
 {
 
 	public :

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -43,7 +43,7 @@
 namespace Gaffer
 {
 
-class IECORE_EXPORT Switch : public ComputeNode
+class GAFFER_API Switch : public ComputeNode
 {
 
 	public :

--- a/include/Gaffer/TimeWarp.h
+++ b/include/Gaffer/TimeWarp.h
@@ -42,7 +42,7 @@
 namespace Gaffer
 {
 
-class IECORE_EXPORT TimeWarp : public ContextProcessor
+class GAFFER_API TimeWarp : public ContextProcessor
 {
 
 	public :


### PR DESCRIPTION
When these were templated, we needed to give them visibility everywhere, as the templates were instantiated in and exported from multiple libraries. But they are no longer templated so we can use the regular `GAFFER_API` visibility to export them only from `libGaffer`.
