### PR TITLE
[5080] ImageReader/OpenImageIOReader fileValid plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -179,6 +179,10 @@ Build
 1.2.x.x (relative to 1.2.9.0)
 =======
 
+Improvements
+------------
+
+- OpenImageIOReader: Added 'fileValid' Bool plug that returns a value per frame whether that files exists or not.
 
 1.2.9.0 (relative to 1.2.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -46,6 +46,8 @@ Improvements
 - Dilate, Erode, Median, Resample, Resize, ImageTransform, Blur, VectorWarp : Improved performance significantly. For example, a Blur with a large radius is now almost 6x faster.
 - RotateTool : Added the ability to rotate an axis whose plane of rotation is parallel or nearly parallel to the view.
 - OptionQuery : Added support for querying generic `IECore::Object` values using an `ObjectPlug`.
+- ImageReader: promoted 'fileValid' from the internal OpenImageIOReader that reports per frame whether that files exists or not and works in conjunction with frame masks.
+- OpenImageIOReader: Added 'fileValid' Bool plug that returns a value per frame whether that files exists or not, takes into account the missingFrameMode.
 
 Fixes
 -----
@@ -178,12 +180,6 @@ Build
 
 1.2.x.x (relative to 1.2.9.0)
 =======
-
-Improvements
-------------
-
-- ImageReader: promoted 'fileValid' from the internal OpenImageIOReader that reports per frame whether that files exists or not.
-- OpenImageIOReader: Added 'fileValid' Bool plug that returns a value per frame whether that files exists or not.
 
 1.2.9.0 (relative to 1.2.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -182,6 +182,7 @@ Build
 Improvements
 ------------
 
+- ImageReader: promoted 'fileValid' from the internal OpenImageIOReader that reports per frame whether that files exists or not.
 - OpenImageIOReader: Added 'fileValid' Bool plug that returns a value per frame whether that files exists or not.
 
 1.2.9.0 (relative to 1.2.8.0)

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -129,6 +129,9 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 		Gaffer::IntVectorDataPlug *availableFramesPlug();
 		const Gaffer::IntVectorDataPlug *availableFramesPlug() const;
 
+		Gaffer::BoolPlug *fileValidPlug();
+		const Gaffer::BoolPlug *fileValidPlug() const;
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		static size_t supportedExtensions( std::vector<std::string> &extensions );

--- a/include/GafferImage/ImageReader.h
+++ b/include/GafferImage/ImageReader.h
@@ -195,6 +195,9 @@ class GAFFERIMAGE_API ImageReader : public ImageNode
 
 		static DefaultColorSpaceFunction &defaultColorSpaceFunction();
 
+		Gaffer::BoolPlug *intermediateFileValidPlug();
+		const Gaffer::BoolPlug *intermediateFileValidPlug() const;
+
 		static size_t g_firstChildIndex;
 
 };

--- a/include/GafferImage/OpenImageIOReader.h
+++ b/include/GafferImage/OpenImageIOReader.h
@@ -81,6 +81,9 @@ class GAFFERIMAGE_API OpenImageIOReader : public ImageNode
 		Gaffer::IntVectorDataPlug *availableFramesPlug();
 		const Gaffer::IntVectorDataPlug *availableFramesPlug() const;
 
+		Gaffer::BoolPlug *fileValidPlug();
+		const Gaffer::BoolPlug *fileValidPlug() const;
+
 		Gaffer::IntPlug *channelInterpretationPlug();
 		const Gaffer::IntPlug *channelInterpretationPlug() const;
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -298,8 +298,10 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		# so we can tell if BlackOutside is working.
 		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		with context :
+			self.assertEqual( reader["availableFrames"].getValue(), IECore.IntVectorData( [ 1, 3 , 5, 7 ] ) )
 			for i in range( 1, 11 ) :
 				context.setFrame( i )
+				self.assertEqual( reader["fileValid"].getValue(), i in ( 1, 3, 5, 7 ), "frame {}".format( i ) )
 				self.assertNotEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		def assertBlack() :

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -298,14 +298,14 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		# so we can tell if BlackOutside is working.
 		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
 		with context :
-			self.assertEqual( reader["availableFrames"].getValue(), IECore.IntVectorData( [ 1, 3 , 5, 7 ] ) )
 			for i in range( 1, 11 ) :
 				context.setFrame( i )
-				self.assertEqual( reader["fileValid"].getValue(), i in ( 1, 3, 5, 7 ), "frame {}".format( i ) )
 				self.assertNotEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
 
 		def assertBlack() :
 
+			# fileValid should always be true; aka black
+			self.assertTrue( reader["fileValid"].getValue() )
 			# format and data window still match
 			self.assertEqual( reader["out"]["format"].getValue(), oiio["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
@@ -318,6 +318,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		def assertMatch() :
 
+			self.assertEqual( reader["fileValid"].getValue(), oiio["fileValid"].getValue() )
 			self.assertEqual( reader["out"]["format"].getValue(), oiio["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
@@ -336,7 +337,9 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 				holdMetadata = reader["out"]["metadata"].getValue()
 				holdChannelNames = reader["out"]["channelNames"].getValue()
 				holdTile = reader["out"].channelData( "R", imath.V2i( 0 ) )
+				fileValid = reader["fileValid"].getValue()
 
+			self.assertEqual( reader["fileValid"].getValue(), fileValid )
 			self.assertEqual( reader["out"]["format"].getValue(), holdFormat )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), holdDataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), holdMetadata )

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -276,6 +276,42 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertTrue( GafferImage.BufferAlgo.empty( reader["out"]['dataWindow'].getValue() ) )
 			self.assertTrue( GafferImage.BufferAlgo.empty( oiio["out"]['dataWindow'].getValue() ) )
 
+	def testFileValid( self ):
+
+		testSequence = IECore.FileSequence( str( self.temporaryDirectory() / "incompleteSequence.####.exr" ) )
+		shutil.copyfile( self.fileName, testSequence.fileNameForFrame( 1001 ) )
+		shutil.copyfile( self.fileName, testSequence.fileNameForFrame( 1002 ) )
+		shutil.copyfile( self.fileName, testSequence.fileNameForFrame( 1004 ) )
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( pathlib.Path( testSequence.fileName ) )
+		reader["start"]["frame"].setValue( 1001 )
+		reader["end"]["frame"].setValue( 1005 )
+
+		context = Gaffer.Context( Gaffer.Context.current() )
+
+		# test with no frame mask set yet
+		with context :
+			for i in range( 1000, 1006 ) :
+				context.setFrame( i )
+				self.assertEqual( reader["fileValid"].getValue(), i in ( 1001, 1002, 1004 ) )
+
+		# test with frame mask set to hold with range 1001-1005
+		reader["start"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.ClampToFrame )
+		reader["end"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.ClampToFrame )
+		with context :
+			for i in range( 1000, 1006 ) :
+				context.setFrame( i )
+				self.assertEqual( reader["fileValid"].getValue(), i in ( 1000, 1001, 1002, 1004 ) )
+
+		# test with frame mask set to black with range 1001-1005
+		reader["start"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.BlackOutside )
+		reader["end"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.BlackOutside )
+		with context :
+			for i in range( 1000, 1006 ) :
+				context.setFrame( i )
+				self.assertEqual( reader["fileValid"].getValue(), i in (1000, 1001, 1002, 1004) )
+
 	def testFrameRangeMask( self ) :
 
 		testSequence = IECore.FileSequence( str( self.temporaryDirectory() / "incompleteSequence.####.exr" ) )
@@ -304,8 +340,6 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		def assertBlack() :
 
-			# fileValid should always be true; aka black
-			self.assertTrue( reader["fileValid"].getValue() )
 			# format and data window still match
 			self.assertEqual( reader["out"]["format"].getValue(), oiio["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
@@ -318,7 +352,6 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		def assertMatch() :
 
-			self.assertEqual( reader["fileValid"].getValue(), oiio["fileValid"].getValue() )
 			self.assertEqual( reader["out"]["format"].getValue(), oiio["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), oiio["out"]["dataWindow"].getValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), oiio["out"]["metadata"].getValue() )
@@ -337,9 +370,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 				holdMetadata = reader["out"]["metadata"].getValue()
 				holdChannelNames = reader["out"]["channelNames"].getValue()
 				holdTile = reader["out"].channelData( "R", imath.V2i( 0 ) )
-				fileValid = reader["fileValid"].getValue()
 
-			self.assertEqual( reader["fileValid"].getValue(), fileValid )
 			self.assertEqual( reader["out"]["format"].getValue(), holdFormat )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), holdDataWindow )
 			self.assertEqual( reader["out"]["metadata"].getValue(), holdMetadata )

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -298,25 +298,20 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		context = Gaffer.Context()
 		context.setFrame( 1 )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
-		with context:
-			self.assertFalse( reader["fileValid"].getValue() )
 		shutil.copyfile( self.fileName, testFile )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
-		reader['refreshCount'].setValue( reader['refreshCount'].getValue() + 1 )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		# changing missingFrameMode doesn't affect the fileValid plug
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
+		with context:
+			self.assertFalse( reader["fileValid"].getValue() )
+
+		# whereas refreshCount should affect the fileValid plug
+		reader['refreshCount'].setValue( reader['refreshCount'].getValue() + 1 )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
@@ -331,33 +326,21 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 
 		context = Gaffer.Context()
 
+		# frame 0 - missing
+		context.setFrame( 0 )
+
+		with context :
+			self.assertFalse( reader["fileValid"].getValue() )
+
 		# frame 1 - found
 		context.setFrame( 1 )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
 		# frame 2 - goes missing and then is found
 		context.setFrame( 2 )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
 		shutil.copyfile( self.offsetDataWindowFileName, testSequence.fileNameForFrame( 2 ) )
@@ -370,30 +353,12 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# frame 3: found
 		context.setFrame( 3 )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
 		# frame 4: missing
 		context.setFrame( 4 )
 
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
-		with context:
-			self.assertTrue( reader["fileValid"].getValue() )
-
-		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -293,48 +293,107 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		testFile = self.temporaryDirectory() / "single_file.exr"
 
 		reader = GafferImage.OpenImageIOReader()
-		reader["fileName"].setValue( pathlib.Path( testFile ) )
+		reader["fileName"].setValue( testFile )
 
 		context = Gaffer.Context()
 		context.setFrame( 1 )
 
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
 
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
+		with context:
+			self.assertFalse( reader["fileValid"].getValue() )
 		shutil.copyfile( self.fileName, testFile )
-		reader["refreshCount"].setValue( reader["refreshCount"].getValue() + 1 )
-
+		with context:
+			self.assertFalse( reader["fileValid"].getValue() )
+		reader['refreshCount'].setValue( reader['refreshCount'].getValue() + 1 )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+	def testFilesValid( self ):
 
 		testSequence = IECore.FileSequence( str( self.temporaryDirectory() / "incompleteSequence.####.exr" ) )
 		shutil.copyfile( self.fileName, testSequence.fileNameForFrame( 1 ) )
 		shutil.copyfile( self.offsetDataWindowFileName, testSequence.fileNameForFrame( 3 ) )
 
+		reader = GafferImage.OpenImageIOReader()
 		reader["fileName"].setValue( pathlib.Path( testSequence.fileName ) )
 
+		context = Gaffer.Context()
+
+		# frame 1 - found
+		context.setFrame( 1 )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		# frame 2 - goes missing and then is found
 		context.setFrame( 2 )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
-
 		shutil.copyfile( self.offsetDataWindowFileName, testSequence.fileNameForFrame( 2 ) )
-
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
-
-		reader["refreshCount"].setValue( reader["refreshCount"].getValue() + 1 )
-
+		reader['refreshCount'].setValue( reader['refreshCount'].getValue() + 1 )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
+		# frame 3: found
 		context.setFrame( 3 )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context:
 			self.assertTrue( reader["fileValid"].getValue() )
 
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		# frame 4: missing
 		context.setFrame( 4 )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
+		with context:
+			self.assertTrue( reader["fileValid"].getValue() )
+
+		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context:
 			self.assertFalse( reader["fileValid"].getValue() )
 

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -274,7 +274,10 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Whether or not the files exists and can be read into memory,
-			value calculated per frame if an image sequence.
+			value calculated per frame if an image sequence. MissingFrameMode
+			changes the behaviour, Error is the default behaviour, Black will
+			always returns true and hold will return true as long as the
+			nearest frame is valid.
 			""",
 
 			"layout:section", "Frames",

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -270,6 +270,17 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"fileValid" : [
+			"description",
+			"""
+			Whether or not the files exists and can be read into memory,
+			value calculated per frame if an image sequence.
+			""",
+
+			"layout:section", "Frames",
+
+		]
+
 	}
 
 )

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -274,10 +274,9 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Whether or not the files exists and can be read into memory,
-			value calculated per frame if an image sequence. MissingFrameMode
-			changes the behaviour, Error is the default behaviour, Black will
-			always returns true and hold will return true as long as the
-			nearest frame is valid.
+			value calculated per frame if an image sequence. Behaviour changes
+			if a frame mask of ClampToFrame or Black is selected, if outside
+			the frame mask fileValid will be set to True if the nearest frame is valid.
 			""",
 
 			"layout:section", "Frames",

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -132,7 +132,10 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Whether or not the files exists and can be read into memory,
-			value calculated per frame if an image sequence.
+			value calculated per frame if an image sequence. MissingFrameMode
+			changes the behaviour, Error is the default behaviour, Black will
+			always returns true and hold will return true as long as the
+			nearest frame is valid.
 			""",
 
 			"plugValueWidget:type", "",

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -133,9 +133,7 @@ Gaffer.Metadata.registerNode(
 			"""
 			Whether or not the files exists and can be read into memory,
 			value calculated per frame if an image sequence. MissingFrameMode
-			changes the behaviour, Error is the default behaviour, Black will
-			always returns true and hold will return true as long as the
-			nearest frame is valid.
+			does not change the behaviour of this plug.
 			""",
 
 			"plugValueWidget:type", "",

--- a/python/GafferImageUI/OpenImageIOReaderUI.py
+++ b/python/GafferImageUI/OpenImageIOReaderUI.py
@@ -127,6 +127,18 @@ Gaffer.Metadata.registerNode(
 			"Documented in ImageReader, where it is exposed to users."
 		],
 
+		"fileValid" : [
+
+			"description",
+			"""
+			Whether or not the files exists and can be read into memory,
+			value calculated per frame if an image sequence.
+			""",
+
+			"plugValueWidget:type", "",
+
+		]
+
 	}
 
 )

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -150,6 +150,7 @@ ImageReader::ImageReader( const std::string &name )
 	addChild( new IntVectorDataPlug( "availableFrames", Plug::Out, new IntVectorData, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new BoolPlug( "fileValid", Plug::Out, false, Plug::Default & ~Plug::Serialisable ) );
 
+	addChild( new BoolPlug( "__intermediateFileValid", Plug::In, false, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new AtomicCompoundDataPlug( "__intermediateMetadata", Plug::In, new CompoundData, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new StringPlug( "__intermediateColorSpace", Plug::Out, "", Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ImagePlug( "__intermediateImage", Plug::In, Plug::Default & ~Plug::Serialisable ) );
@@ -164,6 +165,7 @@ ImageReader::ImageReader( const std::string &name )
 	oiioReader->missingFrameModePlug()->setInput( missingFrameModePlug() );
 	oiioReader->channelInterpretationPlug()->setInput( channelInterpretationPlug() );
 	intermediateMetadataPlug()->setInput( oiioReader->outPlug()->metadataPlug() );
+	intermediateFileValidPlug()->setInput( oiioReader->fileValidPlug() );
 
 	ColorSpacePtr colorSpace = new ColorSpace( "__colorSpace" );
 	addChild( colorSpace );
@@ -289,54 +291,64 @@ const Gaffer::BoolPlug *ImageReader::fileValidPlug() const
 	return getChild<BoolPlug>( g_firstChildIndex + 8 );
 }
 
+Gaffer::BoolPlug *ImageReader::intermediateFileValidPlug()
+{
+	return getChild<BoolPlug>( g_firstChildIndex + 9 );
+}
+
+const Gaffer::BoolPlug *ImageReader::intermediateFileValidPlug() const
+{
+	return getChild<BoolPlug>( g_firstChildIndex + 9 );
+}
+
 AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 9 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 10 );
 }
 
 const AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 9 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 10 );
 }
 
 StringPlug *ImageReader::intermediateColorSpacePlug()
 {
-	return getChild<StringPlug>( g_firstChildIndex + 10 );
+	return getChild<StringPlug>( g_firstChildIndex + 11 );
 }
 
 const StringPlug *ImageReader::intermediateColorSpacePlug() const
 {
-	return getChild<StringPlug>( g_firstChildIndex + 10 );
+	return getChild<StringPlug>( g_firstChildIndex + 11 );
 }
 
 ImagePlug *ImageReader::intermediateImagePlug()
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 11 );
+	return getChild<ImagePlug>( g_firstChildIndex + 12 );
 }
 
 const ImagePlug *ImageReader::intermediateImagePlug() const
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 11 );
+	return getChild<ImagePlug>( g_firstChildIndex + 12 );
 }
 
 OpenImageIOReader *ImageReader::oiioReader()
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 12 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 13 );
 }
 
 const OpenImageIOReader *ImageReader::oiioReader() const
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 12 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 13 );
 }
 
 ColorSpace *ImageReader::colorSpace()
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 13 );
+	return getChild<ColorSpace>( g_firstChildIndex + 14 );
 }
 
 const ColorSpace *ImageReader::colorSpace() const
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 13 );
+	return getChild<ColorSpace>( g_firstChildIndex + 14 );
 }
 
 size_t ImageReader::supportedExtensions( std::vector<std::string> &extensions )
@@ -367,7 +379,7 @@ ImageReader::DefaultColorSpaceFunction &ImageReader::defaultColorSpaceFunction()
 void ImageReader::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
 {
 	ImageNode::affects( input, outputs );
-	if( input == fileNamePlug() || input == refreshCountPlug() || input == channelInterpretationPlug() )
+	if( input == intermediateFileValidPlug() )
 	{
 		outputs.push_back( fileValidPlug() );
 	}
@@ -407,11 +419,8 @@ void ImageReader::hash( const ValuePlug *output, const Context *context, IECore:
 	}
 	else if ( output == fileValidPlug() )
 	{
+		FrameMaskScope scope( context, this, /* clampBlack = */ true );
 		oiioReader()->fileValidPlug()->hash( h );
-		startModePlug()->hash( h );
-		startFramePlug()->hash( h );
-		endModePlug()->hash( h );
-		endFramePlug()->hash( h );
 	}
 }
 

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -148,6 +148,7 @@ ImageReader::ImageReader( const std::string &name )
 	addChild( new IntPlug( "channelInterpretation", Plug::In, (int)ChannelInterpretation::Default, /* min */ (int)ChannelInterpretation::Legacy, /* max */ (int)ChannelInterpretation::Specification ) );
 
 	addChild( new IntVectorDataPlug( "availableFrames", Plug::Out, new IntVectorData, Plug::Default & ~Plug::Serialisable ) );
+	addChild( new BoolPlug( "fileValid", Plug::Out, false, Plug::Default & ~Plug::Serialisable ) );
 
 	addChild( new AtomicCompoundDataPlug( "__intermediateMetadata", Plug::In, new CompoundData, Plug::Default & ~Plug::Serialisable ) );
 	addChild( new StringPlug( "__intermediateColorSpace", Plug::Out, "", Plug::Default & ~Plug::Serialisable ) );
@@ -172,6 +173,7 @@ ImageReader::ImageReader( const std::string &name )
 	intermediateImagePlug()->setInput( colorSpace->outPlug() );
 
 	availableFramesPlug()->setInput( oiioReader->availableFramesPlug() );
+	fileValidPlug()->setInput( oiioReader->fileValidPlug() );
 }
 
 ImageReader::~ImageReader()
@@ -278,54 +280,64 @@ const Gaffer::IntVectorDataPlug *ImageReader::availableFramesPlug() const
 	return getChild<IntVectorDataPlug>( g_firstChildIndex + 7 );
 }
 
+Gaffer::BoolPlug *ImageReader::fileValidPlug()
+{
+	return getChild<BoolPlug>( g_firstChildIndex + 8 );
+}
+
+const Gaffer::BoolPlug *ImageReader::fileValidPlug() const
+{
+	return getChild<BoolPlug>( g_firstChildIndex + 8 );
+}
+
 AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug()
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 8 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 9 );
 }
 
 const AtomicCompoundDataPlug *ImageReader::intermediateMetadataPlug() const
 {
-	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 8 );
+	return getChild<AtomicCompoundDataPlug>( g_firstChildIndex + 9 );
 }
 
 StringPlug *ImageReader::intermediateColorSpacePlug()
 {
-	return getChild<StringPlug>( g_firstChildIndex + 9 );
+	return getChild<StringPlug>( g_firstChildIndex + 10 );
 }
 
 const StringPlug *ImageReader::intermediateColorSpacePlug() const
 {
-	return getChild<StringPlug>( g_firstChildIndex + 9 );
+	return getChild<StringPlug>( g_firstChildIndex + 10 );
 }
 
 ImagePlug *ImageReader::intermediateImagePlug()
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 10 );
+	return getChild<ImagePlug>( g_firstChildIndex + 11 );
 }
 
 const ImagePlug *ImageReader::intermediateImagePlug() const
 {
-	return getChild<ImagePlug>( g_firstChildIndex + 10 );
+	return getChild<ImagePlug>( g_firstChildIndex + 11 );
 }
 
 OpenImageIOReader *ImageReader::oiioReader()
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 11 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 12 );
 }
 
 const OpenImageIOReader *ImageReader::oiioReader() const
 {
-	return getChild<OpenImageIOReader>( g_firstChildIndex + 11 );
+	return getChild<OpenImageIOReader>( g_firstChildIndex + 12 );
 }
 
 ColorSpace *ImageReader::colorSpace()
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 12 );
+	return getChild<ColorSpace>( g_firstChildIndex + 13 );
 }
 
 const ColorSpace *ImageReader::colorSpace() const
 {
-	return getChild<ColorSpace>( g_firstChildIndex + 12 );
+	return getChild<ColorSpace>( g_firstChildIndex + 13 );
 }
 
 size_t ImageReader::supportedExtensions( std::vector<std::string> &extensions )

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -1180,14 +1180,14 @@ void OpenImageIOReader::affects( const Gaffer::Plug *input, AffectedPlugsContain
 		outputs.push_back( availableFramesPlug() );
 	}
 
-	if( input == fileNamePlug() || input == refreshCountPlug() || input == missingFrameModePlug() || input == channelInterpretationPlug() )
+	if( input == fileNamePlug() || input == refreshCountPlug() || input == channelInterpretationPlug() )
 	{
-		outputs.push_back( tileBatchPlug() );
 		outputs.push_back( fileValidPlug() );
 	}
 
 	if( input == fileNamePlug() || input == refreshCountPlug() || input == missingFrameModePlug() || input == channelInterpretationPlug() )
 	{
+		outputs.push_back( tileBatchPlug() );
 		for( ValuePlug::Iterator it( outPlug() ); !it.done(); ++it )
 		{
 			outputs.push_back( it->get() );
@@ -1204,7 +1204,6 @@ void OpenImageIOReader::hash( const ValuePlug *output, const Context *context, I
 		refreshCountPlug()->hash( h );
 		channelInterpretationPlug()->hash( h );
 		hashFileName( context, h );
-		missingFrameModePlug()->hash( h );
 	}
 	else if( output == availableFramesPlug() )
 	{
@@ -1237,47 +1236,12 @@ void OpenImageIOReader::compute( ValuePlug *output, const Context *context ) con
 			return;
 		}
 
-		MissingFrameMode mode = (MissingFrameMode)missingFrameModePlug()->getValue();
 		ImageReader::ChannelInterpretation channelNaming = (ImageReader::ChannelInterpretation)channelInterpretationPlug()->getValue();
 
 		const std::string resolvedFileName = context->substitute( fileName );
 
 		FileHandleCache *cache = fileCache();
 		CacheEntry cacheEntry = cache->get( std::make_pair( resolvedFileName, channelNaming ) );
-
-		// if the cacheEntry file doesn't exist than let's check the missing frame mode
-		if ( !cacheEntry.file )
-		{
-			// missing frame mode set to black means we consider the file to exist
-			if( mode == OpenImageIOReader::Black )
-			{
-				static_cast<BoolPlug *>( output )->setValue( true );
-				return;
-			// if we're set to hold, let's find the nearest frame and make sure it's valid and can be loaded
-			} else if( mode == OpenImageIOReader::Hold ) {
-				ConstIntVectorDataPtr frameData = availableFramesPlug()->getValue();
-				const std::vector<int> &frames = frameData->readable();
-				if( frames.size() )
-				{
-					std::vector<int>::const_iterator fIt = std::lower_bound( frames.begin(), frames.end(), (int)context->getFrame() );
-
-					// decrement to get the previous frame, unless
-					// this is the first frame, in which case we
-					// hold to the beginning of the sequence
-					if( fIt != frames.begin() )
-					{
-						fIt--;
-					}
-
-					// setup a context with the new frame
-					Context::EditableScope holdScope( context );
-					holdScope.setFrame( *fIt );
-
-					const std::string resolvedFileNameHeld = holdScope.context()->substitute( fileName );
-					cacheEntry = cache->get( std::make_pair( resolvedFileNameHeld, channelNaming ) );
-				}
-			}
-		}
 
 		static_cast<BoolPlug *>( output )->setValue( bool( cacheEntry.file ) );
 	}


### PR DESCRIPTION
addresses issue https://github.com/GafferHQ/gaffer/issues/5080

- added a new plug to the OpenImageIOReader node called fileValid that allows you to query whether a frame exists and can be loaded
- promoted this plug to the ImageReader node so it can now be used in Gaffer to drive switches for missing frames
- added relevant unit tests for both nodes

### Related issues ###

n/a

### Dependencies ###

n/a

### Breaking changes ###

n/a

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
