### PR TITLE
Arnold config : Add default color manager

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Improvements
     - Improved detection of no-op transforms, such as when converting between colorspace aliases like `scene_linear` and `ACEScg`.
   - ColorSpace : Defaulted the input and output space to the current working space.
   - DisplayTransform : Defaulted the input space to the current working space, and the display and view to the defaults defined by the current OpenColorIO config.
+  - ArnoldColorManager : Improved defaults to match Gaffer's current OpenColorIO configuration.
 - Seeds :
   - Renamed to Scatter.
   - Added sampling of primitive variables from the source mesh onto the scattered points, controlled using the new `primitiveVariables` plug.

--- a/python/GafferArnoldUI/ArnoldColorManagerUI.py
+++ b/python/GafferArnoldUI/ArnoldColorManagerUI.py
@@ -55,7 +55,7 @@ def __ocioConfig( plug ) :
 		with context :
 			if plug.node()["__shader"]["name"].getValue() != "color_manager_ocio" :
 				return None
-			config = plug.node()["parameters"]["config"].getValue()
+			config = context.substitute( plug.node()["parameters"]["config"].getValue() )
 		if not config :
 			return PyOpenColorIO.GetCurrentConfig()
 		else :

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferImage
@@ -65,3 +67,28 @@ for node, plug in [
 	( GafferImage.ImageWriter, "colorSpace" ),
 ] :
 	Gaffer.Metadata.registerValue( node, plug, "openColorIO:includeRoles", True )
+
+# Set up Arnold colour manager with metadata that integrates with our OCIO configs.
+
+with IECore.IgnoredExceptions( ImportError ) :
+
+	import GafferArnold
+
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "userDefault", "${ocio:config}" )
+
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "preset:$OCIO", "" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "preset:ACES 1.3 - CG Config", "ocio://cg-config-v1.0.0_aces-v1.3_ocio-v2.1" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "preset:ACES 1.3 - Studio Config", "ocio://studio-config-v1.0.0_aces-v1.3_ocio-v2.1" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "preset:Legacy (Gaffer 1.2)", "${GAFFER_ROOT}/openColorIO/config.ocio" )
+
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "presetsPlugValueWidget:allowCustom", True )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "presetsPlugValueWidget:customWidgetType", "GafferUI.FileSystemPathPlugValueWidget" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "fileSystemPath:extensions", "ocio" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "path:leaf", True )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.config", "path:valid", True )
+
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.color_space_linear", "userDefault", "${ocio:workingSpace}" )
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.color_space_linear", "preset:Working Space", "${ocio:workingSpace}" )
+
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldColorManager, "parameters.color_space_narrow", "userDefault", "matte_paint" )


### PR DESCRIPTION
This translates Gaffer's context-based OCIO config into an Arnold `color_manager_ocio`, taking effect only if the scene doesn't already specify a color manager. This completes the planned OCIO work for Gaffer 1.3, as specified in #5215.