### PR TITLE
Viewport hide objects

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
   - Fixed bug causing the cursor position to be reset to the end if the number of digits in the plug value changed while incrementing/decrementing with the keyboard up/down arrow keys.
   - Fixed bug causing the cursor position to be reset to the end when incrementing an animated plug.
   - Fixed intermittent `---` values when drag-changing an animated plug value.
+- EditScopes : Fixed bug where the enabled state of `AttributeEdits`, `OptionEdits` and `SetMembershipEdits` did not have any effect. This fix will only apply to newly created `AttributeEdits`, `OptionEdits` and `SetMembershipEdits`.
 
 1.2.9.0 (relative to 1.2.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.x.x (relative to 1.2.9.0)
 =======
 
+Improvements
+------------
+
+- EditScopeUI : Added the ability to turn off visibility of selected objects in the viewer using the <kbd>Ctrl</kbd>+<kbd>H</kbd> shortcut.
+
 Fixes
 -----
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -227,25 +227,26 @@ Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
 
 ### 3D scenes ###
 
-Action                                               | Control or shortcut
------------------------------------------------------|--------------------
-Tumble                                               | {kbd}`Alt` + {{leftClick}} and drag
-Tumble, fine precision                               | Hold {kbd}`Shift` during action
-Select objects                                       | {{leftClick}} and drag marquee, then release
-Add/remove object from selection                     | {kbd}`Ctrl` + {{leftClick}}
-Add objects to selection                             | {kbd}`Shift` + {{leftClick}} and drag marquee, then release
-Deselect objects                                     | {kbd}`Ctrl` + {{leftClick}} and drag marquee, then release
-Expand selection                                     | {kbd}`↓`
-Fully expand selection                               | {kbd}`Shift` + {kbd}`↓`
-Collapse selection                                   | {kbd}`↑`
-Edit source node of selection                        | {kbd}`Alt` + {kbd}`E`
-Edit tweaks node for selection                       | {kbd}`Alt` + {kbd}`Shift` + {kbd}`E`
-Fit clipping planes to scene                         | {{rightClick}} > *Clipping Planes* > *Fit To Scene*
-Fit clipping planes to selection                     | {{rightClick}} > *Clipping Planes* > *Fit To Selection*<br>or<br>{kbd}`Ctrl` + {kbd}`K`
-Frame view, and fit clipping planes                  | {kbd}`Ctrl` + {kbd}`F`
-Reset clipping planes                                | {{rightClick}} > *Clipping Planes* > *Default*
-Toggle Inspector                                     | {kbd}`I`
-Prune selected objects from current EditScope        | {kbd}`Ctrl` + {kbd}`Delete`<br>or<br>{kbd}`Ctrl` + {kbd}`Backspace`
+Action                                                           | Control or shortcut
+-----------------------------------------------------------------|--------------------
+Tumble                                                           | {kbd}`Alt` + {{leftClick}} and drag
+Tumble, fine precision                                           | Hold {kbd}`Shift` during action
+Select objects                                                   | {{leftClick}} and drag marquee, then release
+Add/remove object from selection                                 | {kbd}`Ctrl` + {{leftClick}}
+Add objects to selection                                         | {kbd}`Shift` + {{leftClick}} and drag marquee, then release
+Deselect objects                                                 | {kbd}`Ctrl` + {{leftClick}} and drag marquee, then release
+Expand selection                                                 | {kbd}`↓`
+Fully expand selection                                           | {kbd}`Shift` + {kbd}`↓`
+Collapse selection                                               | {kbd}`↑`
+Edit source node of selection                                    | {kbd}`Alt` + {kbd}`E`
+Edit tweaks node for selection                                   | {kbd}`Alt` + {kbd}`Shift` + {kbd}`E`
+Fit clipping planes to scene                                     | {{rightClick}} > *Clipping Planes* > *Fit To Scene*
+Fit clipping planes to selection                                 | {{rightClick}} > *Clipping Planes* > *Fit To Selection*<br>or<br>{kbd}`Ctrl` + {kbd}`K`
+Frame view, and fit clipping planes                              | {kbd}`Ctrl` + {kbd}`F`
+Reset clipping planes                                            | {{rightClick}} > *Clipping Planes* > *Default*
+Toggle Inspector                                                 | {kbd}`I`
+Prune selected objects from current EditScope                    | {kbd}`Ctrl` + {kbd}`Delete`<br>or<br>{kbd}`Ctrl` + {kbd}`Backspace`
+Turn off visibility for selected objects from current EditScope  | {kbd}`Ctrl` + {kbd}`H`
 
 ### Transform tools ###
 

--- a/python/GafferSceneTest/EditScopeAlgoTest.py
+++ b/python/GafferSceneTest/EditScopeAlgoTest.py
@@ -73,6 +73,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( GafferScene.EditScopeAlgo.getPruned( scope, "/group/cube" ) )
 		self.assertEqual( len( list( GafferScene.SceneProcessor.Range( scope ) ) ), 1 )
 		self.assertEqual( scope["PruningEdits"]["paths"].getValue(), IECore.StringVectorData( [ "/group/plane" ] ) )
+		self.assertEqual( scope["PruningEdits"]["Prune"]["enabled"].getInput(), scope["PruningEdits"]["enabled"] )
 		self.assertFalse( GafferScene.SceneAlgo.exists( scope["out"], "/group/plane" ) )
 		self.assertTrue( GafferScene.SceneAlgo.exists( scope["out"], "/group/cube" ) )
 
@@ -162,6 +163,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertIsInstance( edit, GafferScene.EditScopeAlgo.TransformEdit )
 		self.assertTrue( GafferScene.EditScopeAlgo.hasTransformEdit( editScope, "/plane" ) )
 		self.assertIsNotNone( GafferScene.EditScopeAlgo.acquireTransformEdit( editScope, "/plane", createIfNecessary = False ) )
+		self.assertEqual( editScope["TransformEdits"]["Transform"]["enabled"].getInput(), editScope["TransformEdits"]["enabled"] )
 		self.assertEqual( editScope["out"].transform( "/plane" ), imath.M44f() )
 		edit.translate.setValue( imath.V3f( 2, 3, 4 ) )
 		self.assertEqual( editScope["out"].transform( "/plane" ), imath.M44f().translate( imath.V3f( 2, 3, 4 ) ) )
@@ -318,6 +320,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( edit["mode"].getValue(), Gaffer.TweakPlug.Mode.Replace )
 		self.assertEqual( edit["value"].getValue(), imath.Color3f( 0 ) )
 		self.assertEqual( edit["enabled"].getValue(), False )
+		self.assertEqual( editScope["LightEdits"]["ShaderTweaks"]["enabled"].getInput(), editScope["LightEdits"]["enabled"] )
 
 		edit["enabled"].setValue( True )
 		edit["value"].setValue( imath.Color3f( 1 ) )
@@ -667,6 +670,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( edit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
 		self.assertEqual( edit["value"].getValue(), 1.0 )
 		self.assertEqual( edit["enabled"].getValue(), False )
+		self.assertEqual( editScope["AttributeEdits"]["AttributeTweaks"]["enabled"].getInput(), editScope["AttributeEdits"]["enabled"] )
 
 		edit["enabled"].setValue( True )
 		edit["value"].setValue( 2.0 )
@@ -1084,6 +1088,9 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		GafferScene.EditScopeAlgo.setSetMembership( scope, IECore.PathMatcher( ["/group/cube"] ), "A", membership.Added )
 
+		self.assertEqual( scope["SetMembershipEdits"]["Set"]["enabled"].getInput(), scope["SetMembershipEdits"]["enabled"] )
+		self.assertEqual( scope["SetMembershipEdits"]["Set1"]["enabled"].getInput(), scope["SetMembershipEdits"]["enabled"] )
+
 		for path, set, status in (
 			( "/group/plane", "A", membership.Unchanged ),
 			( "/group/plane", "B", membership.Unchanged ),
@@ -1272,6 +1279,7 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( edit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
 		self.assertEqual( edit["value"].getValue(), 10 )
 		self.assertEqual( edit["enabled"].getValue(), False )
+		self.assertEqual( editScope["OptionEdits"]["OptionTweaks"]["enabled"].getInput(), editScope["OptionEdits"]["enabled"] )
 
 		edit["enabled"].setValue( True )
 		edit["value"].setValue( 20 )

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -87,6 +87,7 @@ namespace
 /// in clients of history related APIs such as `AttributeInspector`.
 using CreatableRegistry = std::unordered_map<std::string, const IECore::DataPtr>;
 CreatableRegistry g_attributeRegistry {
+	{ "scene:visible", new BoolData( true ) },
 	{ "gl:visualiser:scale", new IECore::FloatData( 1.0f ) },
 	{ "gl:visualiser:maxTextureResolution", new IECore::IntData( 512 ) },
 	{ "gl:visualiser:frustum", new IECore::StringData( "whenSelected" ) },

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -684,7 +684,7 @@ SceneProcessorPtr attributeProcessor( const std::string &name )
 	result->addChild( attributeTweaks );
 	attributeTweaks->inPlug()->setInput( result->inPlug() );
 	attributeTweaks->filterPlug()->setInput( pathFilter->outPlug() );
-	attributeTweaks->enabledPlug()->setValue( result->enabledPlug() );
+	attributeTweaks->enabledPlug()->setInput( result->enabledPlug() );
 	attributeTweaks->localisePlug()->setValue( true );
 	attributeTweaks->ignoreMissingPlug()->setValue( true );
 
@@ -902,6 +902,7 @@ SceneProcessorPtr setMembershipProcessor()
 	addSet->filterPlug()->setInput( addPathFilter->outPlug() );
 	addSet->namePlug()->setInput( spreadsheet->enabledRowNamesPlug() );
 	addSet->modePlug()->setValue( GafferScene::Set::Mode::Add );
+	addSet->enabledPlug()->setInput( result->enabledPlug() );
 	addSet->setVariablePlug()->setValue( "setMembership:set" );
 
 	GafferScene::SetPtr removeSet = new GafferScene::Set();
@@ -910,6 +911,7 @@ SceneProcessorPtr setMembershipProcessor()
 	removeSet->filterPlug()->setInput( removePathFilter->outPlug() );
 	removeSet->namePlug()->setInput( spreadsheet->enabledRowNamesPlug() );
 	removeSet->modePlug()->setValue( GafferScene::Set::Mode::Remove );
+	removeSet->enabledPlug()->setInput( result->enabledPlug() );
 	removeSet->setVariablePlug()->setValue( "setMembership:set" );
 
 	auto rowsPlug = static_cast<Spreadsheet::RowsPlug *>(
@@ -1102,7 +1104,7 @@ SceneProcessorPtr optionProcessor( const std::string &name )
 	OptionTweaksPtr optionTweaks = new OptionTweaks;
 	result->addChild( optionTweaks );
 	optionTweaks->inPlug()->setInput( result->inPlug() );
-	optionTweaks->enabledPlug()->setValue( result->enabledPlug() );
+	optionTweaks->enabledPlug()->setInput( result->enabledPlug() );
 	optionTweaks->ignoreMissingPlug()->setValue( true );
 
 	PlugAlgo::promoteWithName( optionTweaks->tweaksPlug(), "edits" );

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -226,3 +226,4 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 # Add catalogue hotkeys to viewers, eg: up/down navigation
 GafferUI.Editor.instanceCreatedSignal().connect( GafferImageUI.CatalogueUI.addCatalogueHotkeys, scoped = False )
 GafferUI.Editor.instanceCreatedSignal().connect( GafferSceneUI.EditScopeUI.addPruningActions, scoped = False )
+GafferUI.Editor.instanceCreatedSignal().connect( GafferSceneUI.EditScopeUI.addVisibilityActions, scoped = False )


### PR DESCRIPTION
This adds a new shortcut to the 3d viewer, Ctrl + H, to turn off visibility of the selected objects.

It also fixes a bug that left the enabled plug of some of the edit scope processors disconnected from their parent node. These should be connected to ensure disabled state is propagated.

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
