### PR TITLE
GraphComponent : Allow `:` in names

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -83,6 +83,7 @@ Fixes
 - PresetsPlugValueWidget : Fixed label update for context-sensitive presets.
 - PlugValueWidget : Fixed value update when auxiliary plugs depend on the context but the primary plugs do not.
 - Cycles : Fixed handling of `cycles:shader:volume_sampling_method` and `cycles:shader:volume_interpolation_method` attributes, which were being ignored previously.
+- OptionQuery : Fixed bug which allowed duplicate queries to be added in the UI.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -91,6 +91,7 @@ API
   - Added an `oldName` argument to `nameChangedSignal()` slot signature.
   - Added a `nameChanged()` protected virtual method, which can be overridden to receive notifications of name changes before
     they are made public by `nameChangedSignal()`.
+  - Colon (`:`) is now an allowed character in names.
 - View : Added DisplayTransform add-on class which can be used to add colourspace management to any View.
 - ViewportGadget : A post-process shader can now be applied to any layer, not just the main one.
 - SceneGadget : Added `setLayer()` and `getLayer()` methods, which allow the destination `Gadget::Layer` to be specified.

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -215,10 +215,11 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 			for path in paths :
 				attr = node["in"].fullAttributes( path ) if useFullAttr else node["in"].attributes( path )
 				attributes.update( attr )
+			existingTweaks = { tweak["name"].getValue() for tweak in node["tweaks"] }
 
 		attributes = collections.OrderedDict( sorted( attributes.items() ) )
 
-		for key, value in [ ( k, v ) for k, v in attributes.items() if k.replace( ':', '_' ) not in node["tweaks"] ] :
+		for key, value in attributes.items() :
 			result.append(
 				"/" + key,
 				{
@@ -226,7 +227,8 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 						Gaffer.WeakMethod( self.__addTweak ),
 						key,
 						value
-					)
+					),
+					"active" : key not in existingTweaks
 				}
 			)
 
@@ -245,8 +247,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		else :
 			plug = Gaffer.TweakPlug( name, plugTypeOrValue() )
 
-		if name :
-			plug.setName( name.replace( ':', '_' ) )
+		plug.setName( "tweak0" )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -382,7 +382,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 
 		n = Gaffer.GraphComponent()
 
-		for name in ( "0", "0a", "@A", "a.A", ".", "A:", "a|", "a(" ) :
+		for name in ( "0", "0a", "@A", "a.A", ".", "A!", "a|", "a(" ) :
 			self.assertRaises( Exception, n.setName, name )
 			self.assertRaises( Exception, Gaffer.GraphComponent, name )
 
@@ -1190,6 +1190,21 @@ class GraphComponentTest( GafferTest.TestCase ) :
 				( "Method", "NameTracker", "newName" ),
 				( "Slot", "NameTracker", "newName" ),
 		] )
+
+	def testColonInName( self ) :
+
+		g = Gaffer.GraphComponent( "test:a" )
+		self.assertEqual( g.getName(), "test:a" )
+
+		g.setName( "test:a:b" )
+		self.assertEqual( g.getName(), "test:a:b" )
+
+		p = Gaffer.GraphComponent()
+		p.addChild( g )
+		self.assertIn( "test:a:b", p )
+		self.assertTrue( p["test:a:b"].isSame( g ) )
+		self.assertTrue( p.getChild( "test:a:b" ).isSame( g ) )
+		self.assertTrue( p.descendant( "test:a:b" ).isSame( g ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/ContextVariableTweaksUI.py
+++ b/python/GafferUI/ContextVariableTweaksUI.py
@@ -176,8 +176,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		else :
 			plug = Gaffer.TweakPlug( name, plugTypeOrValue() )
 
-		if name :
-			plug.setName( name.replace( ':', '_' ) )
+		plug.setName( "tweak0" )
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().addChild( plug )

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -63,7 +63,7 @@ using namespace std;
 namespace
 {
 
-// Equivalent to checking a regex match against "^[A-Za-z_]+[A-Za-z_0-9]*",
+// Equivalent to checking a regex match against "^[A-Za-z_:]+[A-Za-z_:0-9]*",
 // but significantly quicker.
 //
 /// \todo Relax restrictions to only disallow '.' and `/'? We originally had
@@ -80,7 +80,7 @@ bool validName( const std::string &name )
 	if(
 		!(f >= 'A' && f <= 'Z') &&
 		!(f >= 'a' && f <= 'z' ) &&
-		f != '_'
+		f != '_' && f != ':'
 	)
 	{
 		return false;
@@ -92,7 +92,7 @@ bool validName( const std::string &name )
 			!(c >= 'A' && c <= 'Z') &&
 			!(c >= 'a' && c <= 'z' ) &&
 			!(c >= '0' && c <= '9' ) &&
-			c != '_'
+			c != '_' && c != ':'
 		)
 		{
 			return false;


### PR DESCRIPTION
For some upcoming UsdLux work we need to be able to create plugs representing UsdLuxLight parameters, some of which have `:` in their names (e.g. `shaping:focus`). Rather than introduce some mangling scheme to squeeze that past Gaffer's existing naming restrictions, it's simpler to lift our restrictions. The history of this is that before Gaffer was even in its infancy, I was using `node.plugName` syntax in Python to access plugs, but soon grew tired of avoiding Python keywords in plug names, and adopted the `node["plugName"]` syntax we use now. The naming restrictions were needed for the original syntax, but there's no need for them any more.

After loosening the naming, I went looking for places we had previously mangled names, intending to remove the mangling. But it turned out that in those cases it was better to give the plugs more generic names anyway. So that's what I've done in the subsequent commits.