### PR TITLE
USDShader : Add new node for loading shaders from pxr::SdrRegistry

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- USDShader : Added a node for loading shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface` and `UsdUVTexture`.
+- USDShader : Added a node for loading shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface` and `UsdUVTexture`, which are now available in the `USD/Shader` section of the node menu.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.0.0)
 =======
 
+Features
+--------
+
+- USDShader : Added a node for loading shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface` and `UsdUVTexture`.
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -1352,7 +1352,7 @@ libraries = {
 
 	"GafferUSD" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX" ] + [ "${USD_LIB_PREFIX}" + x for x in ( [ "sdf", "arch", "tf", "vt" ] if not env["USD_MONOLITHIC"] else [ "usd_ms" ] ) ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX" ] + [ "${USD_LIB_PREFIX}" + x for x in ( [ "sdf", "arch", "tf", "vt", "ndr", "sdr" ] if not env["USD_MONOLITHIC"] else [ "usd_ms" ] ) ],
 			# USD includes "at least one deprecated or antiquated header", so we
 			# have to drop our usual strict warning levels.
 			"CXXFLAGS" : [ "-Wno-deprecated" if env["PLATFORM"] != "win32" else "/wd4996" ],

--- a/include/GafferUSD/USDShader.h
+++ b/include/GafferUSD/USDShader.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,18 +36,32 @@
 
 #pragma once
 
+#include "GafferUSD/Export.h"
+#include "GafferUSD/TypeIds.h"
+
+#include "GafferScene/Shader.h"
+
 namespace GafferUSD
 {
 
-enum TypeId
+class GAFFERUSD_API USDShader : public GafferScene::Shader
 {
 
-	USDLayerWriterTypeId = 110225,
-	USDAttributesTypeId = 110226,
-	USDShaderTypeId = 110227,
+	public :
 
-	LastTypeId = 110250,
+		explicit USDShader( const std::string &name=defaultName<USDShader>() );
+		~USDShader() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferUSD::USDShader, USDShaderTypeId, GafferScene::Shader );
+
+		void loadShader( const std::string &shaderName, bool keepExistingValues = false ) override;
+
+	protected :
+
+		IECore::ConstCompoundObjectPtr attributes( const Gaffer::Plug *output ) const override;
 
 };
+
+IE_CORE_DECLAREPTR( USDShader )
 
 } // namespace GafferUSD

--- a/python/GafferUSDTest/USDShaderTest.py
+++ b/python/GafferUSDTest/USDShaderTest.py
@@ -1,0 +1,262 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferUSD
+import GafferScene
+import GafferSceneTest
+
+class USDShaderTest( GafferSceneTest.SceneTestCase ) :
+
+	def __assertShaderLoads( self, name, expectedParameters, expectedOutputs ) :
+
+		shader = GafferUSD.USDShader()
+		shader.loadShader( name )
+		self.assertEqual( shader["name"].getValue(), name )
+
+		for parent, expected in {
+			shader["parameters"] : expectedParameters,
+			shader["out"] : expectedOutputs
+		}.items() :
+
+			allNames = set()
+			for name, plugType, defaultValue in expected :
+				with self.subTest( name = name ) :
+					self.assertIn( name, parent )
+					plug = parent[name]
+					self.assertIs( type( plug ), plugType )
+					self.assertEqual( plug.direction(), parent.direction() )
+					self.assertEqual( plug.getFlags(), Gaffer.Plug.Flags.Default )
+					if defaultValue is not None :
+						self.assertEqual( plug.defaultValue(), defaultValue )
+					else :
+						self.assertFalse( hasattr( plug, "defaultValue" ) )
+					allNames.add( name )
+
+			## \todo Assert that order is also what we expect, if we can get USD
+			# to preserve order in the first place.
+			# See https://github.com/PixarAnimationStudios/OpenUSD/pull/2497.
+			self.assertEqual( set( parent.keys() ), allNames )
+
+	def testLoadUsdPreviewSurface( self ) :
+
+		self.__assertShaderLoads(
+			"UsdPreviewSurface",
+			[
+				( "diffuseColor", Gaffer.Color3fPlug, imath.Color3f( 0.18 ) ),
+				( "emissiveColor", Gaffer.Color3fPlug, imath.Color3f( 0 ) ),
+				( "useSpecularWorkflow", Gaffer.IntPlug, 0 ),
+				( "specularColor", Gaffer.Color3fPlug, imath.Color3f( 0 ) ),
+				( "metallic", Gaffer.FloatPlug, 0 ),
+				( "roughness", Gaffer.FloatPlug, 0.5 ),
+				( "clearcoat", Gaffer.FloatPlug, 0 ),
+				( "clearcoatRoughness", Gaffer.FloatPlug, 0.009999999776482582 ),
+				( "opacity", Gaffer.FloatPlug, 1 ),
+				( "opacityThreshold", Gaffer.FloatPlug, 0 ),
+				( "ior", Gaffer.FloatPlug, 1.5 ),
+				( "normal", Gaffer.V3fPlug, imath.V3f( 0, 0, 1 ) ),
+				( "displacement", Gaffer.FloatPlug, 0 ),
+				( "occlusion", Gaffer.FloatPlug, 1 ),
+			],
+			[
+				( "surface", Gaffer.Plug, None ),
+				( "displacement", Gaffer.Plug, None ),
+			]
+		)
+
+	def testLoadUsdPrimvarReader( self ) :
+
+		self.__assertShaderLoads(
+			"UsdPrimvarReader_float",
+			[
+				( "varname", Gaffer.StringPlug, "" ),
+				( "fallback", Gaffer.FloatPlug, 0 ),
+			],
+			[
+				( "result", Gaffer.FloatPlug, 0 ),
+			]
+		)
+
+	def testLoadUsdUVTexture( self ) :
+
+		self.__assertShaderLoads(
+			"UsdUVTexture",
+			[
+				( "file", Gaffer.StringPlug, "" ),
+				( "st", Gaffer.V2fPlug, imath.V2f( 0 ) ),
+				( "wrapS", Gaffer.StringPlug, "useMetadata" ),
+				( "wrapT", Gaffer.StringPlug, "useMetadata" ),
+				( "fallback", Gaffer.Color4fPlug, imath.Color4f( 0, 0, 0, 1 ) ),
+				( "scale", Gaffer.Color4fPlug, imath.Color4f( 1 ) ),
+				( "bias", Gaffer.Color4fPlug, imath.Color4f( 0 ) ),
+				( "sourceColorSpace", Gaffer.StringPlug, "auto" ),
+			],
+			[
+				( "r", Gaffer.FloatPlug, 0 ),
+				( "g", Gaffer.FloatPlug, 0 ),
+				( "b", Gaffer.FloatPlug, 0 ),
+				( "a", Gaffer.FloatPlug, 0 ),
+				( "rgb", Gaffer.V3fPlug, imath.V3f( 0 ) ),
+			]
+		)
+
+	def testKeepExistingValues( self ) :
+
+		shader = GafferUSD.USDShader()
+		shader.loadShader( "UsdPrimvarReader_float" )
+
+		shader["parameters"]["fallback"].setValue( 1 )
+		shader.loadShader( "UsdPrimvarReader_float", keepExistingValues = True )
+		self.assertEqual( shader["parameters"]["fallback"].getValue(), 1 )
+
+		shader.loadShader( "UsdPrimvarReader_float", keepExistingValues = False )
+		self.assertEqual( shader["parameters"]["fallback"].getValue(), 0 )
+
+	def testLoadDifferentShader( self ) :
+
+		for keepExistingValues in [ True, False ] :
+			with self.subTest( keepExistingValues = keepExistingValues ) :
+
+				shader = GafferUSD.USDShader()
+				shader.loadShader( "UsdPreviewSurface" )
+				self.assertIn( "diffuseColor", shader["parameters"] )
+
+				shader.loadShader( "UsdPrimvarReader_float", keepExistingValues = keepExistingValues )
+				self.assertEqual( set( shader["parameters"].keys() ), { "varname", "fallback" } )
+
+	def testMissingShader( self ) :
+
+		shader = GafferUSD.USDShader()
+		with self.assertRaisesRegex( RuntimeError, "Shader \"missing\" not found in SdrRegistry" ) :
+			shader.loadShader( "missing" )
+
+	def testGeometricInterpretation( self ) :
+
+		for interpretation in [ "Normal", "Point", "Vector" ] :
+			with self.subTest( interpretation = interpretation ) :
+
+				shader = GafferUSD.USDShader()
+				shader.loadShader( "UsdPrimvarReader_{}".format( interpretation.lower() ) )
+
+				self.assertEqual(
+					shader["parameters"]["fallback"].interpretation(),
+					getattr( IECore.GeometricData.Interpretation, interpretation )
+				)
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferUSD.USDShader()
+		script["shader"].loadShader( "UsdPrimvarReader_float" )
+		script["shader"]["parameters"]["fallback"].setValue( 10 )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+		self.assertEqual( script2["shader"]["name"].getValue(), script["shader"]["name"].getValue() )
+		self.assertEqual( script2["shader"]["type"].getValue(), script["shader"]["type"].getValue() )
+		self.assertEqual( script2["shader"]["parameters"].keys(), script["shader"]["parameters"].keys() )
+		self.assertEqual( script2["shader"]["parameters"]["fallback"].getValue(), script["shader"]["parameters"]["fallback"].getValue() )
+
+	def testShaderNetwork( self ) :
+
+		uvReader = GafferUSD.USDShader( "uvReader" )
+		uvReader.loadShader( "UsdPrimvarReader_float2" )
+
+		transform2D = GafferUSD.USDShader( "transform2D" )
+		transform2D.loadShader( "UsdTransform2d" )
+		transform2D["parameters"]["in"].setInput( uvReader["out"]["result"] )
+		transform2D["parameters"]["scale"].setValue( imath.V2f( 2, 3 ) )
+
+		texture = GafferUSD.USDShader( "texture" )
+		texture.loadShader( "UsdUVTexture" )
+		texture["parameters"]["file"].setValue( "test.tx" )
+		texture["parameters"]["st"].setInput( transform2D["out"]["result"] )
+
+		surface = GafferUSD.USDShader( "surface" )
+		surface.loadShader( "UsdPreviewSurface" )
+		surface["parameters"]["diffuseColor"].setInput( texture["out"]["rgb"] )
+
+		shaderPlug = GafferScene.ShaderPlug()
+		shaderPlug.setInput( surface["out"]["surface"] )
+
+		network = shaderPlug.attributes()["surface"]
+		self.assertIsInstance( network, IECoreScene.ShaderNetwork )
+
+		self.assertEqual( network.getOutput(), ( "surface", "surface" ) )
+		self.assertEqual(
+			network.inputConnections( "surface" ),
+			[ ( ( "texture", "rgb" ), ( "surface", "diffuseColor" ) ) ]
+		)
+		self.assertEqual(
+			network.inputConnections( "texture" ),
+			[ ( ( "transform2D", "result" ), ( "texture", "st" ) ) ]
+		)
+		self.assertEqual(
+			network.inputConnections( "transform2D" ),
+			[ ( ( "uvReader", "result" ), ( "transform2D", "in" ) ) ]
+		)
+
+	def testUsdPreviewSurfaceAssignment( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		shader = GafferUSD.USDShader()
+		shader.loadShader( "UsdPreviewSurface" )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		shaderAssignment = GafferScene.ShaderAssignment()
+		shaderAssignment["in"].setInput( sphere["out"] )
+		shaderAssignment["filter"].setInput( sphereFilter["out"] )
+		shaderAssignment["shader"].setInput( shader["out"]["surface"] )
+
+		self.assertEqual( shaderAssignment["out"].attributes( "/sphere" ).keys(), [ "surface" ] )
+		self.assertIsInstance( shaderAssignment["out"].attributes( "/sphere" )["surface"], IECoreScene.ShaderNetwork )
+
+		shaderAssignment["shader"].setInput( shader["out"]["displacement"] )
+		self.assertEqual( shaderAssignment["out"].attributes( "/sphere" ).keys(), [ "displacement" ] )
+		self.assertIsInstance( shaderAssignment["out"].attributes( "/sphere" )["displacement"], IECoreScene.ShaderNetwork )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDTest/__init__.py
+++ b/python/GafferUSDTest/__init__.py
@@ -37,6 +37,7 @@
 from .ModuleTest import ModuleTest
 from .USDAttributesTest import USDAttributesTest
 from .USDLayerWriterTest import USDLayerWriterTest
+from .USDShaderTest import USDShaderTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferUSDUI/USDShaderUI.py
+++ b/python/GafferUSDUI/USDShaderUI.py
@@ -1,0 +1,199 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+from pxr import Sdr
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferSceneUI
+import GafferUSD
+
+def __sdrProperty( plug ) :
+
+	shaderName = plug.node()["name"].getValue()
+
+	sdrNode = Sdr.Registry().GetNodeByName( shaderName )
+	if plug.direction() == Gaffer.Plug.Direction.In :
+		return sdrNode.GetInput( plug.getName() )
+	else :
+		return sdrNode.GetOutput( plug.getName() )
+
+def __sdrMetadata( plug, name ) :
+
+	return __sdrProperty( plug ).GetMetadata().get( name )
+
+def __layoutIndex( plug ) :
+
+	# Usd carefully defines shader inputs in a sensible order
+	# in `shaderDefs.usda`, and then completely discards it
+	# during parsing, leaving us with parameters in a useless
+	# alphabetical order. Until that is sorted out, we manually
+	# match the intended order with our own metadata.
+	#
+	# See https://github.com/PixarAnimationStudios/OpenUSD/pull/2497.
+
+	shaderName = plug.node()["name"].getValue()
+	order = __propertyOrder.get( shaderName )
+	if order is None :
+		return None
+
+	return order.get( plug.getName() )
+
+def __widgetType( plug ) :
+
+	property = __sdrProperty( plug )
+	if property.GetWidget() not in ( "", "default" ) :
+		# The UsdPreviewSurface shaders don't provide any useful widget
+		# metadata, but we'd love to use it if they did, so alert
+		# ourselves if it appears in future.
+		IECore.msg(
+			IECore.Msg.Level.Warning, "USDShaderUI",
+			'Ignoring widget metadata "{}" on "{}"'.format(
+				property.GetWidget(), plug.fullName()
+			)
+		)
+
+	if property.GetOptions() :
+		return "GafferUI.PresetsPlugValueWidget"
+
+	# Fall back to metadata we provide ourselves.
+	return __widgetTypes.get(
+		"{}.{}".format( plug.node()["name"].getValue(), plug.getName() )
+	)
+
+def __presetNames( plug ) :
+
+	property = __sdrProperty( plug )
+	options = property.GetOptions()
+	if options :
+		return IECore.StringVectorData( [ o[0] for o in options ] )
+
+def __presetValues( plug ) :
+
+	property = __sdrProperty( plug )
+	options = property.GetOptions()
+	if options :
+		if len( options ) > 1 and all( o[1] == "" for o in options ) :
+			# USD's `_CreateSdrShaderProperty` method in `shaderDefUtils.cpp`
+			# always uses an empty string for the option value when converting
+			# from `allowedTokens`. Ignore that, and use the names as the values
+			# as intended by the author of `allowedTokens`.
+			return IECore.StringVectorData( [ o[0] for o in options ] )
+		else :
+			return IECore.StringVectorData( [ o[1] for o in options ] )
+
+def __noduleType( plug ) :
+
+	property = __sdrProperty( plug )
+	# `None` means "no opinion", so a nodule will be created based
+	# on the plug's type. `""` means "no nodule please".
+	return None if property.IsConnectable() else ""
+
+Gaffer.Metadata.registerNode(
+
+	GafferUSD.USDShader,
+
+	"description",
+	"""
+	Loads shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface`
+	and `UsdUVTexture`.
+	""",
+
+	plugs = {
+
+		"out" : [
+
+			"nodule:type", "GafferUI::CompoundNodule",
+
+		],
+
+		"parameters.*" : [
+
+			## \todo Get USD to actually provide help metadata. It's defined in a `doc`
+			# attribute in `shaderDefs.usda`, but not actually converted to Sdr by
+			# UsdShadeShaderDefUtils.
+			"description", functools.partial( __sdrMetadata, name = "help" ),
+			"layout:index", __layoutIndex,
+			"noduleLayout:index", __layoutIndex,
+			"plugValueWidget:type", __widgetType,
+			"presetNames", __presetNames,
+			"presetValues", __presetValues,
+			"nodule:type", __noduleType,
+
+		],
+
+		"out.*" : [
+
+			"description", functools.partial( __sdrMetadata, name = "help" ),
+			"layout:index", __layoutIndex,
+			"noduleLayout:index", __layoutIndex,
+
+		],
+
+	}
+)
+
+def __orderDict( names ) :
+
+	return dict( zip( names, range( 0, len( names ) ) ) )
+
+__propertyOrder = {
+
+	"UsdPreviewSurface" : __orderDict( [ "surface", "displacement", "diffuseColor", "emissiveColor", "useSpecularWorkflow", "specularColor", "metallic", "roughness", "clearcoat", "clearcoatRoughness", "opacity", "opacityThreshold", "ior", "normal", "displacement", "occlusion" ] ),
+	"UsdUVTexture" : __orderDict( [ "file", "st", "wrapS", "wrapT", "fallback", "scale", "bias", "sourceColorSpace", "r", "g", "b", "a", "rgb" ] ),
+	"UsdTransform2d" : __orderDict( [ "in", "rotation", "scale", "translation", "result" ] ),
+	"UsdPrimvarReader_int" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_float" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_float2" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_float3" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_float4" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_string" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_point" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_vector" : __orderDict( [ "varname", "fallback", "result" ] ),
+	"UsdPrimvarReader_normal" : __orderDict( [ "varname", "fallback", "result" ] ),
+
+}
+
+__widgetTypes = {
+
+	"UsdPreviewSurface.useSpecularWorkflow" : "GafferUI.BoolPlugValueWidget",
+	"UsdUVTexture.file" : "GafferUI.FileSystemPathPlugValueWidget",
+
+}

--- a/python/GafferUSDUI/__init__.py
+++ b/python/GafferUSDUI/__init__.py
@@ -36,5 +36,6 @@
 
 from . import USDAttributesUI
 from . import USDLayerWriterUI
+from . import USDShaderUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferUSDUI" )

--- a/src/GafferUSD/USDShader.cpp
+++ b/src/GafferUSD/USDShader.cpp
@@ -1,0 +1,356 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUSD/USDShader.h"
+
+#include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/PlugAlgo.h"
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreUSD/DataAlgo.h"
+#include "IECoreUSD/TypeTraits.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+
+#include "IECore/MessageHandler.h"
+
+#include "pxr/usd/sdf/types.h"
+#include "pxr/usd/sdf/valueTypeName.h"
+#include "pxr/usd/sdr/registry.h"
+#include "pxr/usd/sdr/shaderNode.h"
+#include "pxr/usd/sdr/shaderProperty.h"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace pxr;
+using namespace boost;
+using namespace Imath;
+using namespace IECore;
+using namespace GafferScene;
+using namespace GafferUSD;
+using namespace Gaffer;
+
+namespace
+{
+
+/// \todo This is an improved copy of a function in IECoreUSD/DataAlgo.cpp - move this
+/// one to IECoreUSD and expose it publicly.
+GeometricData::Interpretation interpretation( TfToken role )
+{
+	if( role == SdfValueRoleNames->Point )
+	{
+		return GeometricData::Point;
+	}
+	else if( role == SdfValueRoleNames->Vector )
+	{
+		return GeometricData::Vector;
+	}
+	else if( role == SdfValueRoleNames->Normal )
+	{
+		return GeometricData::Normal;
+	}
+	else if( role == SdfValueRoleNames->TextureCoordinate )
+	{
+		return GeometricData::UV;
+	}
+	else if( role == SdfValueRoleNames->Color )
+	{
+		return GeometricData::Color;
+	}
+	return GeometricData::None;
+}
+
+template<typename PlugType>
+Plug *loadTypedProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	using ValueType = typename PlugType::ValueType;
+	using USDValueType = typename IECoreUSD::CortexTypeTraits<ValueType>::USDType;
+
+	InternedString name = property.GetName().GetString();
+	PlugType *existingPlug = parent->getChild<PlugType>( name );
+
+	ValueType defaultValue = ValueType();
+	VtValue defaultVtValue = property.GetDefaultValue();
+	if( !defaultVtValue.IsHolding<USDValueType>() )
+	{
+		// Workaround for various UsdLuxLight `bool` inputs which somehow
+		// get reported with `int` default values.
+		defaultVtValue = defaultVtValue.Cast<USDValueType>();
+	}
+	if( !defaultVtValue.IsEmpty() )
+	{
+		defaultValue = IECoreUSD::DataAlgo::fromUSD( defaultVtValue.Get<USDValueType>() );
+	}
+
+	if( existingPlug && existingPlug->defaultValue() == defaultValue )
+	{
+		return existingPlug;
+	}
+
+	typename PlugType::Ptr plug = new PlugType( name, parent->direction(), defaultValue );
+	PlugAlgo::replacePlug( parent, plug );
+	return plug.get();
+}
+
+template<typename PlugType>
+Plug *loadCompoundNumericProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	InternedString name = property.GetName().GetString();
+	PlugType *existingPlug = parent->getChild<PlugType>( name );
+
+	IECore::GeometricData::Interpretation interpretation = ::interpretation( property.GetTypeAsSdfType().first.GetRole() );
+
+	using ValueType = typename PlugType::ValueType;
+	using USDValueType = typename IECoreUSD::CortexTypeTraits<ValueType>::USDType;
+
+	ValueType defaultValue( 0.0f );
+	VtValue defaultVtValue = property.GetDefaultValue();
+	if( !defaultVtValue.IsEmpty() )
+	{
+		defaultValue = IECoreUSD::DataAlgo::fromUSD( defaultVtValue.Get<USDValueType>() );
+	}
+
+	if(
+		existingPlug &&
+		existingPlug->defaultValue() == defaultValue &&
+		existingPlug->interpretation() == interpretation
+	)
+	{
+		return existingPlug;
+	}
+
+	typename PlugType::Ptr plug = new PlugType(
+		name, parent->direction(), defaultValue,
+		ValueType( std::numeric_limits<float>::lowest() ), ValueType( std::numeric_limits<float>::max() ),
+		Plug::Default, interpretation
+	);
+	PlugAlgo::replacePlug( parent, plug );
+	return plug.get();
+}
+
+Plug *loadAssetProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	InternedString name = property.GetName().GetString();
+	StringPlug *existingPlug = parent->getChild<StringPlug>( name );
+
+	string defaultValue;
+	VtValue defaultVtValue = property.GetDefaultValue();
+	if( !defaultVtValue.IsEmpty() )
+	{
+		defaultValue = defaultVtValue.Get<SdfAssetPath>().GetAssetPath();
+	}
+
+	if( existingPlug && existingPlug->defaultValue() == defaultValue )
+	{
+		return existingPlug;
+	}
+
+	StringPlugPtr plug = new StringPlug( name, parent->direction(), defaultValue );
+	PlugAlgo::replacePlug( parent, plug );
+	return plug.get();
+}
+
+Plug *loadTokenProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	// Sdr uses the `token` type to represent terminals, vstructs
+	// and unknown types. As I understand it, these don't carry values,
+	// so the Plug base class is the best way of representing them
+	// in Gaffer.
+	InternedString name = property.GetName().GetString();
+	Plug *existingPlug = parent->getChild<Plug>( name );
+
+	if( existingPlug && existingPlug->typeId() == Plug::staticTypeId() )
+	{
+		return existingPlug;
+	}
+
+	PlugPtr plug = new Plug( name, parent->direction() );
+	PlugAlgo::replacePlug( parent, plug );
+	return plug.get();
+}
+
+Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	const SdfValueTypeName type = property.GetTypeAsSdfType().first;
+	if( type == SdfValueTypeNames->Bool )
+	{
+		return loadTypedProperty<BoolPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Int )
+	{
+		return loadTypedProperty<IntPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Float )
+	{
+		return loadTypedProperty<FloatPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Float2 )
+	{
+		return loadCompoundNumericProperty<V2fPlug>( property, parent );
+	}
+	else if(
+		type == SdfValueTypeNames->Point3f ||
+		type == SdfValueTypeNames->Vector3f ||
+		type == SdfValueTypeNames->Normal3f ||
+		type == SdfValueTypeNames->Float3
+	)
+	{
+		return loadCompoundNumericProperty<V3fPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Color3f )
+	{
+		return loadCompoundNumericProperty<Color3fPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Float4 )
+	{
+		return loadCompoundNumericProperty<Color4fPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->String )
+	{
+		return loadTypedProperty<StringPlug>( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Asset )
+	{
+		return loadAssetProperty( property, parent );
+	}
+	else if( type == SdfValueTypeNames->Token )
+	{
+		return loadTokenProperty( property, parent );
+	}
+	else
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "USDShader",
+			fmt::format(
+				"Unable to load property \"{}\" of type \"{}\"",
+				property.GetName().GetString(), type.GetAsToken().GetString()
+			)
+		);
+		return nullptr;
+	}
+}
+
+const IECore::InternedString g_surface( "surface" );
+const IECore::InternedString g_displacement( "displacement" );
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( USDShader );
+
+USDShader::USDShader( const std::string &name )
+	:	GafferScene::Shader( name )
+{
+	addChild( new Plug( "out", Plug::Out ) );
+}
+
+USDShader::~USDShader()
+{
+}
+
+void USDShader::loadShader( const std::string &shaderName, bool keepExistingValues )
+{
+	SdrRegistry &registry = SdrRegistry::GetInstance();
+	SdrShaderNodeConstPtr shader = registry.GetShaderNodeByName( shaderName );
+
+	if( !shader )
+	{
+		throw Exception( fmt::format( "Shader \"{}\" not found in SdrRegistry", shaderName ) );
+	}
+
+	namePlug()->setValue( shaderName );
+	typePlug()->setValue( "surface" );
+
+	Plug *parametersPlug = this->parametersPlug()->source();
+
+	if( !keepExistingValues )
+	{
+		parametersPlug->clearChildren();
+		outPlug()->clearChildren();
+	}
+
+	std::unordered_set<const Plug *> validPlugs;
+	for( const auto &name : shader->GetInputNames() )
+	{
+		SdrShaderPropertyConstPtr property = shader->GetShaderInput( name );
+		validPlugs.insert( loadShaderProperty( *property, parametersPlug ) );
+	}
+
+	for( int i = parametersPlug->children().size() - 1; i >= 0; --i )
+	{
+		Plug *child = parametersPlug->getChild<Plug>( i );
+		if( validPlugs.find( child ) == validPlugs.end() )
+		{
+			parametersPlug->removeChild( child );
+		}
+	}
+
+	Plug *outPlug = this->outPlug();
+	for( const auto &name : shader->GetOutputNames() )
+	{
+		SdrShaderPropertyConstPtr property = shader->GetShaderOutput( name );
+		validPlugs.insert( loadShaderProperty( *property, outPlug ) );
+	}
+
+	for( int i = outPlug->children().size() - 1; i >= 0; --i )
+	{
+		Plug *child = outPlug->getChild<Plug>( i );
+		if( validPlugs.find( child ) == validPlugs.end() )
+		{
+			outPlug->removeChild( child );
+		}
+	}
+}
+
+IECore::ConstCompoundObjectPtr USDShader::attributes( const Gaffer::Plug *output ) const
+{
+	IECore::ConstCompoundObjectPtr result = Shader::attributes( output );
+	if( output->getName() == g_displacement )
+	{
+		// UsdPreviewSurface has separate surface and displacement outputs.
+		// Rename attribute for the displacement case.
+		if( auto network = result->member<IECoreScene::ShaderNetwork>( g_surface ) )
+		{
+			IECore::CompoundObjectPtr copy = result->copy();
+			// Cast OK as we never modify, and `copy` is returned as `const`.
+			copy->members()[g_displacement] = const_cast<IECoreScene::ShaderNetwork *>( network );
+			copy->members().erase( g_surface );
+			result = copy;
+		}
+	}
+	return result;
+}

--- a/src/GafferUSDModule/GafferUSDModule.cpp
+++ b/src/GafferUSDModule/GafferUSDModule.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferUSD/USDAttributes.h"
 #include "GafferUSD/USDLayerWriter.h"
+#include "GafferUSD/USDShader.h"
 
 #include "GafferDispatchBindings/TaskNodeBinding.h"
 
@@ -48,6 +49,7 @@ BOOST_PYTHON_MODULE( _GafferUSD )
 {
 
 	GafferBindings::DependencyNodeClass<USDAttributes>();
+	GafferBindings::DependencyNodeClass<USDShader>();
 	GafferDispatchBindings::TaskNodeClass<USDLayerWriter>();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -514,6 +514,28 @@ nodeMenu.append( "/VDB/Volume Scatter", GafferVDB.VolumeScatter, searchText = "V
 import GafferUSD
 import GafferUSDUI
 
+def __usdShaderCreator( shaderName ) :
+
+	node = GafferUSD.USDShader( name = shaderName )
+	node.loadShader( shaderName )
+	return node
+
+for menuPath, shader in [
+	[ "Preview Surface", "UsdPreviewSurface" ],
+	[ "UV Texture", "UsdUVTexture" ],
+	[ "Transform 2D", "UsdTransform2d" ],
+	[ "Primvar Reader/Int", "UsdPrimvarReader_int" ],
+	[ "Primvar Reader/Float", "UsdPrimvarReader_float" ],
+	[ "Primvar Reader/Float2", "UsdPrimvarReader_float2" ],
+	[ "Primvar Reader/Float3", "UsdPrimvarReader_float3" ],
+	[ "Primvar Reader/Float4", "UsdPrimvarReader_float4" ],
+	[ "Primvar Reader/String", "UsdPrimvarReader_string" ],
+	[ "Primvar Reader/Point", "UsdPrimvarReader_point" ],
+	[ "Primvar Reader/Vector", "UsdPrimvarReader_vector" ],
+	[ "Primvar Reader/Normal", "UsdPrimvarReader_normal" ],
+] :
+	nodeMenu.append( "/USD/Shader/{}".format( menuPath ), functools.partial( __usdShaderCreator, shader ), searchText = shader )
+
 nodeMenu.append( "/USD/Attributes", GafferUSD.USDAttributes, searchText = "USDAttributes" )
 nodeMenu.append( "/USD/Layer Writer", GafferUSD.USDLayerWriter, searchText = "USDLayerWriter" )
 


### PR DESCRIPTION
This provides the ability to load and assign the various UsdPreviewSurface shaders, and will form the foundations for loading UsdLuxLights in a future PR.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/7201a74b-d099-4ea5-91b4-a49dcee0eb41)

We have been debating whether or not we should be using the SdrRegistry or the SchemaRegistry for loading this stuff, and I came down on the side of the SdrRegistry for now because :

- The UsdPreviewSurface definitions are only registered with the SdrRegistry, not the SchemaRegistry.
- After building `arnold-usd`, I couldn't find any useful "bolt on" schemas that would be useful for extending a UsdLuxLight for Arnold.
- Nothing about the implementation of UsdShader is exposed publicly, so we can switch to loading from the schema registry in future if we want, without any visible change.