### PR TITLE
HierarchyView : Add "Frame Selection" to context menu

### DIFF
--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -299,6 +299,7 @@ Fully collapse selected location    | {kbd}`Shift` + {kbd}`←`
 Copy selected paths                 | {kbd}`Ctrl` + {kbd}`C`
 Edit source node of selection       | {kbd}`Alt` + {kbd}`E`
 Edit tweaks node for selection      | {kbd}`Alt` + {kbd}`Shift` + {kbd}`E`
+Frame selection                     | {kbd}`F`
 
 ## Python Editor ##
 

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -214,6 +214,14 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 				"shortCut" : "Ctrl+C"
 			}
 		)
+		menuDefinition.append(
+			"Frame Selection",
+			{
+				"command" : Gaffer.WeakMethod( self.__frameSelectedPaths ),
+				"active" : not selection.isEmpty(),
+				"shortCut" : "F"
+			}
+		)
 
 		self.__contextMenu = GafferUI.Menu( menuDefinition )
 		self.__contextMenu.popup( widget )


### PR DESCRIPTION
Follow-up to #5383 adding `Frame Selection` to the HierarchyView right-click menu and an entry to the Controls And Shortcuts documentation page.