### PR TITLE
Arnold Renderer : Fix translation of `vector <name>` outputs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.10.x (relative to 1.2.10.0)
 ========
 
+Fixes
+-----
+
+- Arnold : Fixed translation of `vector` typed outputs defined as `vector <name>` in an output definition.
 
 1.2.10.0 (relative to 1.2.9.0)
 ========

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -680,6 +680,7 @@ class RendererTest( GafferTest.TestCase ) :
 			( "C", "float" ),
 			( "D", "int" ),
 			( "E", "uint" ),
+			( "F", "vector" ),
 		] :
 
 			r.output(
@@ -703,6 +704,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"C FLOAT ieCoreArnold:filter:testC ieCoreArnold:display:testC",
 				"D INT ieCoreArnold:filter:testD ieCoreArnold:display:testD",
 				"E UINT ieCoreArnold:filter:testE ieCoreArnold:display:testE",
+				"F VECTOR ieCoreArnold:filter:testF ieCoreArnold:display:testF",
 			] ) )
 
 	def testOutputFilters( self ) :

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -635,7 +635,7 @@ class ArnoldOutput : public IECore::RefCounted
 						m_data = m_lpeName;
 						m_type = colorType;
 					}
-					else if( tokens[0] == "float" || tokens[0] == "int" || tokens[0] == "uint" )
+					else if( tokens[0] == "float" || tokens[0] == "int" || tokens[0] == "uint" || tokens[0] == "vector" )
 					{
 						// Cortex convention is `<type> <name>`. Arnold
 						// convention is `<name> <TYPE>`.


### PR DESCRIPTION
We want folks to use our standard `type name` convention, but because we didn't have `vector` support, they have been forced to use `<name> vector` syntax (the Arnold native syntax).
