### PR TITLE
PlugValueWidgetTest : Fix handling of background updates

### DIFF
--- a/python/GafferUITest/PlugValueWidgetTest.py
+++ b/python/GafferUITest/PlugValueWidgetTest.py
@@ -50,12 +50,14 @@ class PlugValueWidgetTest( GafferUITest.TestCase ) :
 	@staticmethod
 	def waitForUpdate( widget ) :
 
-		# Updates are done lazily, so we need to flush any pending updates.
-		widget._PlugValueWidget__callUpdateFromValues.flush( widget )
-		# And updates for computed values are done in the background, so we
-		# need to wait until they're done.
-		if any( isinstance( p, Gaffer.ValuePlug ) and Gaffer.PlugAlgo.dependsOnCompute( p ) for p in widget.getPlugs() ) :
-			with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as handler :
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as handler :
+
+			# Updates are done lazily, so we need to flush any pending updates.
+			widget._PlugValueWidget__callUpdateFromValues.flush( widget )
+
+			# And updates for computed values are done in the background, so we
+			# need to wait until they're done.
+			if any( isinstance( p, Gaffer.ValuePlug ) and Gaffer.PlugAlgo.dependsOnCompute( p ) for p in widget.getPlugs() ) :
 				handler.assertCalled()
 
 	def testContext( self ) :


### PR DESCRIPTION
We need to scope `handler` before calling `flush()` because otherwise thread timings could mean that the background update had been attempted before the handler was scoped, in which case `assertCalled()` timed out and the test failed. This caused errors like the following in CI :

```
======================================================================
Error: FAIL: testErrorHandling (GafferUITest.BoolPlugValueWidgetTest.BoolPlugValueWidgetTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferTest/ParallelAlgoTest.py", line 82, in assertCalled
    f = self.__queue.get( block = True, timeout = timeout )
  File "/__w/gaffer/gaffer/build/lib/python3.7/queue.py", line 178, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/python/GafferUITest/BoolPlugValueWidgetTest.py", line 94, in testErrorHandling
    GafferUITest.PlugValueWidgetTest.waitForUpdate( w )
  File "/__w/gaffer/gaffer/build/python/GafferUITest/PlugValueWidgetTest.py", line 59, in waitForUpdate
    handler.assertCalled()
  File "/__w/gaffer/gaffer/build/python/GafferTest/ParallelAlgoTest.py", line 84, in assertCalled
    raise AssertionError( "UIThread call not made within {} seconds".format( timeout ) )
AssertionError: UIThread call not made within 30.0 seconds
```
