### PR TITLE
DisplayTransformUI : Fix view presets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.3.x.x (relative to 1.3.0.0)
 =======
 
+Fixes
+-----
+
+- DisplayTransform : Fixed missing `view` presets when `display` is at the default value (#5392).
 
 1.3.0.0 (relative to 1.2.10.0)
 =======

--- a/python/GafferImageUI/DisplayTransformUI.py
+++ b/python/GafferImageUI/DisplayTransformUI.py
@@ -63,7 +63,7 @@ def __viewPresetNames( plug ) :
 def __viewPresetValues( plug ) :
 
 	config = GafferImage.OpenColorIOAlgo.currentConfig()
-	display = plug.parent()["display"].getValue()
+	display = plug.parent()["display"].getValue() or config.getDefaultDisplay()
 
 	return IECore.StringVectorData( [ "" ] + list( config.getViews( display ) ) )
 


### PR DESCRIPTION
We weren't accounting for the fallback from `display == ""` to the default display.

Fixes #5392.
