### PR TITLE
LightTool : Fix plugs with inputs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 - Arnold
   - Fixed translation of `vector` typed outputs defined as `vector <name>` in an output definition.
   - Fixed translation of `shadow:enable` and `shadow:color` parameters on UsdLux lights, which were previously ignored.
+- LightTool : Fixed bug causing non-settable plugs to be enabled, such as plugs with an expression as input or those using the default spreadsheet row for their value. This generated the error `ERROR : EventSignalCombiner : Cannot set value for plug {plug} except during computation.`
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - USDShader : Added a node for loading shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface` and `UsdUVTexture`, which are now available in the `USD/Shader` section of the node menu.
 
+Improvements
+------------
+
+- LightTool : Added support for editing animated plugs.
+
 Fixes
 -----
 

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -47,6 +47,7 @@
 #include "GafferUI/ImageGadget.h"
 #include "GafferUI/StandardStyle.h"
 
+#include "Gaffer/Animation.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameValuePlug.h"
@@ -142,6 +143,19 @@ Plug *activeValuePlug( Plug *sourcePlug )
 		return tweakPlug->valuePlug();
 	}
 	return sourcePlug;
+}
+
+void setValueOrAddKey( FloatPlug *plug, float time, float value )
+{
+	if( Animation::isAnimated( plug ) )
+	{
+		Animation::CurvePlug *curve = Animation::acquire( plug );
+		curve->insertKey( time, value );
+	}
+	else
+	{
+		plug->setValue( value );
+	}
 }
 
 const char *constantFragSource()
@@ -791,7 +805,9 @@ class SpotLightHandle : public LightToolHandle
 					}
 
 					// Clamp each individual cone angle as well
-					coneFloatPlug->setValue(
+					setValueOrAddKey(
+						coneFloatPlug,
+						m_view->getContext()->getTime(),
 						conePlugAngle(
 							clampHandleAngle(
 								originalConeHandleAngle + angleDelta,
@@ -812,7 +828,9 @@ class SpotLightHandle : public LightToolHandle
 					}
 
 					// Clamp each individual cone angle as well
-					penumbraFloatPlug->setValue(
+					setValueOrAddKey(
+						penumbraFloatPlug,
+						m_view->getContext()->getTime(),
 						penumbraPlugAngle(
 							clampHandleAngle(
 								originalPenumbraHandleAngle.value() + angleDelta,


### PR DESCRIPTION
This add the ability to use the Light Tool with plugs that are animated. It also disables handles for plugs that can't be edited, such as plugs driven by an expression or whose current input is a spreadsheet default plug.

Should the `inspectionEditable()` code be moved to `Inspection` in some way, so clients don't have to know to make those extra checks?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
