### PR TITLE
Cycles : Correct setting of background light's lightgroup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - DisplayTransform : Fixed missing `view` presets when `display` is at the default value (#5392).
+- Cycles : The background light's lightgroup is now being set correctly as well as adding a way to set a lightgroup from CyclesOptions when a CyclesBackground is being used instead.
 
 1.3.0.0 (relative to 1.2.10.0)
 =======

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -302,6 +302,9 @@ def __backgroundSummary( plug ) :
 	if plug["bgTransparentRoughnessThreshold"]["enabled"].getValue() :
 		info.append( "Roughness Threshold {}".format( plug["bgTransparentRoughnessThreshold"]["value"].getValue() ) )
 
+	if plug["bgLightgroup"]["enabled"].getValue() :
+		info.append( "Lightgroup {}".format( plug["bgLightgroup"]["value"].getValue() ) )
+
 	for childName in ( "Camera", "Diffuse", "Glossy", "Transmission", "Shadow", "Scatter" ) :
 		if plug["bg" + childName + "Visibility"]["enabled"].getValue() :
 			info.append( IECore.CamelCase.toSpaced( childName ) + ( " On" if plug["bg" + childName + "Visibility"]["value"].getValue() else " Off" ) )
@@ -1306,6 +1309,20 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Background",
 			"label", "Scatter Visible",
+
+		],
+
+		"options.bgLightgroup" : [
+
+			"description",
+			"""
+			The background lightgroup name. This will only be set if a
+			CyclesBackground is used instead of a background light,
+			otherwise it will use the lightgroup name from the light itself.
+			""",
+
+			"layout:section", "Background",
+			"label", "Lightgroup",
 
 		],
 

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -144,6 +144,8 @@ CyclesOptions::CyclesOptions( const std::string &name )
 
 	options->addChild( new Gaffer::NameValuePlug( "cycles:background:volume_step_size", new IECore::FloatData( 0.1f ), false, "volumeStepSize" ) );
 
+	options->addChild( new Gaffer::NameValuePlug( "cycles:background:lightgroup", new IECore::StringData( "" ), false, "bgLightgroup" ) );
+
 	// Film
 	options->addChild( new Gaffer::NameValuePlug( "cycles:film:exposure", new IECore::FloatData( 1.0f ), false, "exposure" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:film:pass_alpha_threshold", new IECore::FloatData( 0.5f ), false, "passAlphaThreshold" ) );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- The lightgroup name wasn't being set on background lights properly
- Added the lightgroup option on CyclesOptions for if CyclesBackground is being used instead of a background light
- From what Brecht has said on their roadmap, they will allow more than one background light and lightgroup name each, so we should re-visit this for when that happens
- Added a unit-test to verify that the lightgroup is being picked up

### Related issues ###

- NA

### Dependencies ###

- NA

### Breaking changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
