### PR TITLE
Cycles : Improved GPU support when Cycles is compiled with GPU devices.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - USDShader : Added a node for loading shaders from USD's `SdrRegistry`. This includes shaders such as `UsdPreviewSurface` and `UsdUVTexture`, which are now available in the `USD/Shader` section of the node menu.
 
+Improvements
+------------
+
+- Cycles : Improved GPU support when Cycles is compiled with GPU devices.
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -1304,7 +1304,7 @@ libraries = {
 				"IECoreScene$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreVDB$CORTEX_LIB_SUFFIX",
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL",
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
-				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
+				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew", "extern_hipew",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
 				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex", "openpgl",
 			],
@@ -1322,7 +1322,7 @@ libraries = {
 			"LIBS" : [
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferBindings", "GafferCycles",
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
-				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
+				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew", "extern_hipew",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
 				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex", "openpgl",
 			],
@@ -1462,6 +1462,15 @@ for library in ( "GafferUI", ) :
 	addQtLibrary( library, "Test" )
 	addQtLibrary( library, "Widgets" )
 
+# Add required libraries for Linux
+
+if env["PLATFORM"] != "win32" and env["PLATFORM"] != "darwin" :
+
+	for library in ( "GafferCycles", ) :
+
+		libraries[library].setdefault( "envAppends", {} )
+		libraries[library]["envAppends"].setdefault( "LIBS", [] ).extend( [ "dl" ] )
+
 # Add required libraries for Windows
 
 if env["PLATFORM"] == "win32" :
@@ -1470,6 +1479,13 @@ if env["PLATFORM"] == "win32" :
 
 		libraries[library].setdefault( "envAppends", {} )
 		libraries[library]["envAppends"].setdefault( "LIBS", [] ).extend( [ "Advapi32" ] )
+	
+	for library in ( "GafferCycles", ) :
+
+		libraries[library].setdefault( "envAppends", {} )
+		libraries[library]["envAppends"].setdefault( "LIBS", [] ).extend( [ "Advapi32", "Version" ] )
+		libraries[library].setdefault( "pythonEnvAppends", {} )
+		libraries[library]["pythonEnvAppends"].setdefault( "LIBS", [] ).extend( [ "Advapi32", "Version" ] )
 
 # Optionally add vTune requirements
 

--- a/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
+++ b/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
@@ -60,6 +60,6 @@ IECORECYCLES_API int patchVersion();
 /// Returns a string of the form "major.minor.patch"
 IECORECYCLES_API const std::string &versionString();
 /// Returns a vector of ccl::devices
-IECORECYCLES_API const std::vector<ccl::DeviceInfo> &devices();
+IECORECYCLES_API std::vector<ccl::DeviceInfo> &devices();
 
 }

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -47,6 +47,18 @@ def __sessionSummary( plug ) :
 	if plug["device"]["enabled"].getValue() :
 		info.append( "Device(s) {}".format( plug["device"]["value"].getValue() ) )
 
+	if plug["useDeviceFallback"]["enabled"].getValue() :
+		info.append( "Device Fallback {}".format( plug["useDeviceFallback"]["value"].getValue() ) )
+
+	if plug["peerMemory"]["enabled"].getValue() :
+		info.append( "Peer-Memory {}".format( plug["peerMemory"]["value"].getValue() ) )
+
+	if plug["useHardwareRT"]["enabled"].getValue() :
+		info.append( "Hardware Raytracing {}".format( plug["useHardwareRT"]["value"].getValue() ) )
+
+	if plug["kernelOptimizationLevel"]["enabled"].getValue() :
+		info.append( "Kernel Optimization Level {}".format( plug["kernelOptimizationLevel"]["value"].getValue() ) )
+
 	if plug["shadingSystem"]["enabled"].getValue() :
 		info.append( "Shading System {}".format( plug["shadingSystem"]["value"].getValue() ) )
 
@@ -367,6 +379,7 @@ def __devicesPreset() :
 	hipIndex = 0
 	optixIndex = 0
 	metalIndex = 0
+	oneapiIndex = 0
 
 	for device in GafferCycles.devices :
 
@@ -385,6 +398,9 @@ def __devicesPreset() :
 		elif device["type"] == "METAL" :
 			index = metalIndex
 			metalIndex += 1
+		elif device["type"] == "ONEAPI" :
+			index = oneapiIndex
+			oneapiIndex += 1
 		Gaffer.Metadata.registerValue(
 			GafferCycles.CyclesOptions,
 			"options.device.value",
@@ -398,18 +414,26 @@ def __devicesPreset() :
 			"CPU %s:%02i" % ( device["type"], index )
 			)
 
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:First CUDA", "CUDA:00" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:First OptiX", "OPTIX:00" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:First HIP", "HIP:00" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:First Metal", "METAL:00" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:First OneAPI", "ONEAPI:00" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:All CUDA", "CUDA:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:All OptiX", "OPTIX:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:All HIP", "HIP:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:All Metal", "METAL:*" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:All OneAPI", "ONEAPI:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and all CUDA", "CPU CUDA:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and all OptiX", "CPU OPTIX:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and all HIP", "CPU HIP:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and all Metal", "CPU METAL:*" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and all OneAPI", "CPU ONEAPI:*" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and first CUDA found", "CPU CUDA:00" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and first OptiX found", "CPU OPTIX:00" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and first HIP found", "CPU HIP:00" )
 	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and first Metal found", "CPU METAL:00" )
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.device.value", "preset:CPU and first OneAPI found", "CPU ONEAPI:00" )
 
 Gaffer.Metadata.registerNode(
 
@@ -457,9 +481,9 @@ Gaffer.Metadata.registerNode(
 
 				CPU CUDA:00
 
-			To render on the first and second OpenCL device:
+			To render on the first and second HIP device:
 
-				OPENCL:00 OPENCL:01
+				HIP:00 HIP:01
 
 			To render on every OptiX device found:
 
@@ -472,6 +496,88 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Session",
 			"label", "Device(s)",
+
+		],
+
+		"options.useDeviceFallback" : [
+
+			"description",
+			"""
+			When a device like a GPU that is specified but cannot be found in the system,
+			this option will fallback to the CPU for rendering instead of erroring out.
+
+			If the OSL shadingsystem is specified on a device which doesn't support it,
+			it'll also revert to CPU instead of erroring out.
+			""",
+
+			"layout:section", "Session",
+			"label", "Device Fallback",
+
+		],
+
+		"options.peerMemory" : [
+
+			"description",
+			"""
+			Distribute memory across devices.
+
+			Make more room for large scenes to fit by distributing memory across interconnected devices
+			(e.g. via NVLink) rather than duplicating it.
+			""",
+
+			"layout:section", "Session",
+			"label", "Peer-Memory",
+
+		],
+
+		"options.useHardwareRT" : [
+
+			"description",
+			"""
+			Hardware Raytracing (experimental for Metal and HIP)
+
+			Metal RT for ray tracing uses less memory for scenes which use curves extensively, and can give better
+			performance in specific cases. However this support is experimental and some scenes may render incorrectly.
+
+			HIP RT enables AMD hardware ray tracing on RDNA2 and above, with shader fallback on older cards.
+			This feature is experimental and some scenes may render incorrectly.
+
+			OneAPI (Embree on GPU) enables the use of hardware ray tracing on Intel GPUs,
+			providing better overall performance.
+			""",
+
+			"layout:section", "Session",
+			"label", "Use Hardware Raytracing",
+
+		],
+
+		"options.kernelOptimizationLevel" : [
+
+			"description",
+			"""
+			Kernel Optimization.
+
+			Kernels can be optimized based on scene content. Optimized kernels are requested at the start of a render.
+			If optimized kernels are not available, rendering will proceed using generic kernels until the optimized set
+			is available in the cache. This can result in additional CPU usage for a brief time (tens of seconds).
+
+			Off - Disable kernel optimization. Slowest rendering, no extra background CPU usage.
+			Intersection only - Optimize only intersection kernels. Faster rendering, negligible extra background CPU usage.
+			Full - Optimize all kernels. Fastest rendering, may result in extra background CPU usage.
+			""",
+
+			"layout:section", "Session",
+			"label", "Kernel Optimisation",
+
+		],
+
+		"options.kernelOptimizationLevel.value" : [
+
+			"preset:Off", "OFF",
+			"preset:Intersection only", "INTERSECT",
+			"preset:Full", "FULL",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -57,6 +57,10 @@ CyclesOptions::CyclesOptions( const std::string &name )
 
 	// Device
 	options->addChild( new Gaffer::NameValuePlug( "cycles:device", new IECore::StringData( "CPU" ), false, "device" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:device:use_fallback", new IECore::BoolData( false ), false, "useDeviceFallback" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:device:peer_memory", new IECore::BoolData( false ), false, "peerMemory" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:device:use_hardwarert", new IECore::BoolData( false ), false, "useHardwareRT" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:device:kernel_optimization_level", new IECore::StringData( "FULL" ), false, "kernelOptimizationLevel" ) );
 
 	// Session and scene
 	options->addChild( new Gaffer::NameValuePlug( "cycles:shadingsystem", new IECore::StringData( "OSL" ), false, "shadingSystem" ) );

--- a/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
@@ -83,11 +83,7 @@ bool init()
 	ccl::util_logging_verbosity_set( 0 );
 
 	// Get devices
-	ccl::vector<ccl::DeviceInfo> devices = ccl::Device::available_devices( ccl::DEVICE_MASK_CPU | ccl::DEVICE_MASK_HIP | ccl::DEVICE_MASK_CUDA | ccl::DEVICE_MASK_METAL
-#ifdef WITH_OPTIX
-	| ccl::DEVICE_MASK_OPTIX
-#endif
-	);
+	ccl::vector<ccl::DeviceInfo> devices = ccl::Device::available_devices();
 	devices.push_back( ccl::Device::get_multi_device( devices, 0, true ) );
 
 	for( auto device : devices )
@@ -118,7 +114,7 @@ const std::string &versionString()
 	return cyclesVersion;
 }
 
-const std::vector<ccl::DeviceInfo> &devices()
+std::vector<ccl::DeviceInfo> &devices()
 {
 	return cyclesDevices;
 }


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Improved GPU support when Cycles is compiled with GPU devices
- The code checks if the device supports OSL instead of disabling it for all devices that are not the CPU
- Peer-memory can be enabled/disabled
- Hardware-Raytracing toggle for Metal, HIP (AMD) and oneAPI (Intel) are supported if Cycles 3.6.0 is used with Embree 4 and HIP-RT
- Kernel-optimisation levels for Metal
- Device fallback option added and defaulted to off, now when a device cannot be found it'll error out - setting this to true will revert back to the previous behaviour of using the CPU
- Better error and warning reporting, and info reporting on what devices will be rendered on

### Related issues ###

- Testing with https://github.com/GafferHQ/gaffer/pull/5101 but this patch should work without it, the `hasOSLShader()` was updated to check the shaders in the cache and not the scene, as the scene wouldn't have the shaders yet or it may have a stale cache of the scene pointer

### Dependencies ###

- Regular Cycles 3.5.0 will work fine, but for GPU support outside of Metal, a custom compiled Cycles 3.6.0 + OptiX + Embree 4 + HIP-RT needs to be used for maximum GPU oomph

### Breaking changes ###

- If a GPU device is specified but not found, it'll error out and not revert to CPU by default - shouldn't break anyone's scripts as only the CPU has been used so far...
- Not breaking but square_samples I removed as this was pre-CyclesX and is dead code removal
- Need to check if `external_cuew` and `external_hipew` break macOS @murraystevenson 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
