### PR TITLE
EditScopeAlgo : Use `fmt::format`

### DIFF
--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -1152,7 +1152,7 @@ ConstObjectPtr optionValue( const ScenePlug *scene, const std::string &option )
 			return registeredOption->second;
 		}
 
-		throw IECore::Exception( boost::str( boost::format( "Option \"%s\" does not exist" ) % option ) );
+		throw IECore::Exception( fmt::format( "Option \"{}\" does not exist", option ) );
 	}
 
 	return result;
@@ -1197,7 +1197,7 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireOptionEdit( Gaffer::EditScope *sco
 			);
 			if( !optionValue )
 			{
-				throw IECore::Exception( boost::str( boost::format( "Option \"%s\" cannot be tweaked" ) % option ) );
+				throw IECore::Exception( fmt::format( "Option \"{}\" cannot be tweaked", option ) );
 			}
 		}
 	};


### PR DESCRIPTION
This replaces a couple errant uses of `boost::format` that snuck in after reviving a dormant PR #4907.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
