### PR TITLE
BranchCreator : Fix atomic initialisation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - Arnold
   - Fixed translation of `vector` typed outputs defined as `vector <name>` in an output definition.
   - Fixed translation of `shadow:enable` and `shadow:color` parameters on UsdLux lights, which were previously ignored.
+- BranchCreator : Fixed bug which could cause inconsistent hashes to be generated.
 
 1.2.10.0 (relative to 1.2.9.0)
 ========

--- a/src/GafferScene/BranchCreator.cpp
+++ b/src/GafferScene/BranchCreator.cpp
@@ -209,7 +209,7 @@ class BranchCreator::BranchesData : public IECore::Data
 		static void hash( const BranchCreator *branchCreator, const Context *context, IECore::MurmurHash &h )
 		{
 			// See `SceneAlgo::matchingPathsHash()` for documentation of this hashing strategy.
-			std::atomic<uint64_t> h1, h2;
+			std::atomic<uint64_t> h1( 0 ), h2( 0 );
 			auto f = [branchCreator, &h1, &h2]( const GafferScene::ScenePlug *scene, const GafferScene::ScenePlug::ScenePath &path )
 			{
 				IECore::MurmurHash h;


### PR DESCRIPTION
You can't rely on atomics to be default-initialised until C++20, which as we all know - living in the VFX industry in 2023 - is several years in the future.