### PR TITLE
Cycles mesh normal fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 - LightEditor : Fixed toggling values in cases where inherited light attributes were set by a script context variable without including a default.
 - GLWidget : Fixed rare crash when showing a GLWidget for the first time.
 - BranchCreator : Fixed bug which could cause inconsistent hashes to be generated.
+- Cycles : Fixed rendering of meshes with faceted normals, which were previously being rendered as smooth. This applies to meshes without an `N` primitive variable, and meshes where `N` has `Uniform` or `FaceVarying` interpolation. Note that Cycles has no native support for `FaceVarying` interpolation so that in this case all faces are rendered faceted.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -26,7 +26,9 @@ Fixes
 - LightEditor : Fixed toggling values in cases where inherited light attributes were set by a script context variable without including a default.
 - GLWidget : Fixed rare crash when showing a GLWidget for the first time.
 - BranchCreator : Fixed bug which could cause inconsistent hashes to be generated.
-- Cycles : Fixed rendering of meshes with faceted normals, which were previously being rendered as smooth. This applies to meshes without an `N` primitive variable, and meshes where `N` has `Uniform` or `FaceVarying` interpolation. Note that Cycles has no native support for `FaceVarying` interpolation so that in this case all faces are rendered faceted.
+- Cycles :
+  - Fixed rendering of meshes with faceted normals, which were previously being rendered as smooth. This applies to meshes without an `N` primitive variable, and meshes where `N` has `Uniform` or `FaceVarying` interpolation. Note that Cycles has no native support for `FaceVarying` interpolation so that in this case all faces are rendered faceted.
+  - Fixed translation of Uniform `N` primitive variables. These are now available to be queried from the standard `Ng` attribute in Cycles.
 
 API
 ---

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -358,6 +358,11 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	{
 		attr->std = ccl::ATTR_STD_VERTEX_NORMAL;
 	}
+	else if( name == "N" && attr->element == ccl::ATTR_ELEMENT_FACE && attr->type == ccl::TypeDesc::TypeNormal )
+	{
+		attr->std = ccl::ATTR_STD_FACE_NORMAL;
+		attr->name = ccl::Attribute::standard_name( attr->std ); // Cycles calls this `Ng`.
+	}
 	else if( name == "uv" && attr->type == ccl::TypeFloat2 )
 	{
 		attr->std = ccl::ATTR_STD_UV;

--- a/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/MeshAlgo.cpp
@@ -71,6 +71,9 @@ namespace
 //  triangle-by-triangle basis using the `smooth` flag passed
 //  to `Mesh::add_triangle()`.
 // - Cycles does not support facevarying normals.
+//
+// Also see `convertPrimitiveVariable()` where we handle the tagging
+// of normal attributes with ATTR_STD_VERTEX_NORMAL and ATTR_STD_FACE_NORMAL.
 bool hasSmoothNormals( const IECoreScene::MeshPrimitive *mesh )
 {
 	auto it = mesh->variables.find( "N" );


### PR DESCRIPTION
This fixes the export of meshes without normals or with uniform normals so that they are rendered faceted as intended, rather than with default smoothing. It also "fixes" the rendering of meshes with FaceVarying normals by rendering them as faceted too (Cycles doesn't support FaceVarying normals, but we use them for things like the Cube node, where we always want faceting).

I'm hoping that this will fix the problem reported in a recent [thread](https://groups.google.com/u/1/g/gaffer-dev/c/zXDMaddaN4g) on gaffer-dev.