### PR TITLE
Fix LightEditor toggle context scope

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
   - Fixed translation of `vector` typed outputs defined as `vector <name>` in an output definition.
   - Fixed translation of `shadow:enable` and `shadow:color` parameters on UsdLux lights, which were previously ignored.
 - BranchCreator : Fixed bug which could cause inconsistent hashes to be generated.
+- LightEditor : Fixed toggling values in cases where inherited light attributes were set by a script context variable without including a default.
 
 1.2.10.0 (relative to 1.2.9.0)
 ========

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -371,17 +371,18 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		nonEditable = [ i for i in inspections if not i.editable() ]
 
 		if len( nonEditable ) == 0 :
-			if not quickBoolean or not self.__toggleBoolean( inspectors, inspections ) :
-				edits = [ i.acquireEdit() for i in inspections ]
-				warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
-				# The plugs are either not boolean, boolean with mixed values,
-				# or attributes that don't exist and are not boolean. Show the popup.
-				self.__popup = GafferUI.PlugPopup( edits, warning = warnings )
+			with Gaffer.Context( self.getContext() ) as context :
+				if not quickBoolean or not self.__toggleBoolean( inspectors, inspections ) :
+					edits = [ i.acquireEdit() for i in inspections ]
+					warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
+					# The plugs are either not boolean, boolean with mixed values,
+					# or attributes that don't exist and are not boolean. Show the popup.
+					self.__popup = GafferUI.PlugPopup( edits, warning = warnings )
 
-				if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
-					self.__popup.plugValueWidget().setNameVisible( False )
+					if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
+						self.__popup.plugValueWidget().setNameVisible( False )
 
-				self.__popup.popup()
+					self.__popup.popup()
 
 		else :
 


### PR DESCRIPTION
Previously, we were not scoping the viewer context when attempting to toggle a boolean value automatically. Because the `__toggleBoolean()` method uses `fullAttributes()` to determine the new toggle value, it would not take the script context into account. This in turn caused things like the mute toggle to not work if one of a light's attributes did not provide a default value in a script context variable expression.

I think the fix in `LightEditor.py` is pretty straightforward, but I'm not entirely sure about the test case exercising it. I'll make comments inline about what I'm not certain of.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
