### PR TITLE
Scons : Make encoding check more flexible

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -45,10 +45,11 @@ import platform
 import shutil
 import subprocess
 import distutils.dir_util
+import codecs
 
 EnsureSConsVersion( 3, 0, 2 ) # Substfile is a default builder as of 3.0.2
 
-if locale.getpreferredencoding() != "UTF-8" :
+if codecs.lookup( locale.getpreferredencoding() ).name != "utf-8" :
 	# The `Substfile` builder uses `open()` without specifying an encoding, and
 	# so gets Python's default encoding. Unless this is `UTF-8`, any `.py` files
 	# containing unicode characters will be corrupted during installation.


### PR DESCRIPTION
After upgrading my system Python to 3.11.4 I found that it reports my encoding as `utf-8` instead of `UTF-8`.

I don't know if this really qualifies as a bug fix, but I figured it will be better to get it early in the current chain than later. Happy to retarget to 1.3 if that's desirable.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
