### PR TITLE
QuadLight Handle

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.1.0)
 =======
 
+Features
+--------
+
+- LightTool : Added manipulator for quad lights.
+
 Improvements
 ------------
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -263,6 +263,17 @@ Adjust, snapping to rounded increments              | Hold {kbd}`Ctrl` during ac
 Target mode (Translate and Rotate only)             | Hold {kbd}`V` then {{leftClick}} on target geometry
 
 
+### Light Tool ###
+
+> Note :
+> For the following controls and shortcuts, the Light Tool must be active
+
+Action                                        | Control or shortcut
+----------------------------------------------|--------------------
+Adjust, fine precision                        | Hold {kbd}`Shift` during action
+Constrain to aspect ratio (Quad lights only)  | Hold {kbd}`Ctrl` during action
+
+
 ### 2D images ###
 
 Action                               | Control or shortcut

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -817,7 +817,7 @@ class SpotLightHandle : public LightToolHandle
 		SpotLightHandle(
 			const std::string &attributePattern,
 			HandleType handleType,
-			SceneViewPtr view,
+			const SceneView *view,
 			const float zRotation,
 			const std::string &name = "SpotLightHandle"
 		) :
@@ -1627,7 +1627,7 @@ class SpotLightHandle : public LightToolHandle
 		ParameterInspectorPtr m_coneAngleInspector;
 		ParameterInspectorPtr m_penumbraAngleInspector;
 
-		SceneViewPtr m_view;
+		const SceneView *m_view;
 
 		const float m_zRotation;
 

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -2096,8 +2096,18 @@ class QuadLightHandle : public LightToolHandle
 
 		bool allInspectionsEnabled() const
 		{
-			/// \todo Implement me
 			bool enabled = true;
+			for( auto &[widthInspection, originalWidth, heightInspection, originalHeight] : m_inspections )
+			{
+				if( m_handleType & HandleType::Width )
+				{
+					enabled &= widthInspection ? widthInspection->editable() : false;
+				}
+				if( m_handleType & HandleType::Height )
+				{
+					enabled &= heightInspection ? heightInspection->editable() : false;
+				}
+			}
 
 			return enabled;
 		}

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -2462,6 +2462,11 @@ void LightTool::metadataChanged( InternedString key )
 
 void LightTool::updateHandleInspections()
 {
+	if( m_dragging )
+	{
+		return;
+	}
+
 	auto scene = scenePlug()->getInput<ScenePlug>();
 	scene = scene ? scene->getInput<ScenePlug>() : scene;
 	if( !scene )

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1003,30 +1003,6 @@ class SpotLightHandle : public LightToolHandle
 			return {m_penumbraAngleInspector.get()};
 		}
 
-		bool mouseMove( const ButtonEvent &event )
-		{
-			if( m_drag || !m_coneAngleInspector || handleScenePath()->isEmpty() )
-			{
-				return false;
-			}
-
-			const auto &[coneInspection, coneHandleAngle, penumbraInspection, penumbraHandleAngle] = spotLightHandleAngles();
-
-			const float angle = m_handleType == HandleType::Cone ? coneHandleAngle : penumbraHandleAngle.value();
-
-			const M44f r = M44f().rotate( V3f( 0, degreesToRadians( angle ), 0 ) );
-			const Line3f rayLine(
-				V3f( 0 ),
-				V3f( 0, 0, m_visualiserScale * m_frustumScale * -10.f ) * r
-			);
-			const V3f dragPoint = rayLine.closestPointTo( Line3f( event.line.p0, event.line.p1 ) );
-			m_arcRadius = dragPoint.length();
-
-			dirty( DirtyType::Render );
-
-			return false;
-		}
-
 	protected :
 
 		void renderHandle( const Style *style, Style::State state ) const override
@@ -1336,6 +1312,30 @@ class SpotLightHandle : public LightToolHandle
 		}
 
 	private :
+
+		bool mouseMove( const ButtonEvent &event )
+		{
+			if( m_drag || !m_coneAngleInspector || handleScenePath()->isEmpty() )
+			{
+				return false;
+			}
+
+			const auto &[coneInspection, coneHandleAngle, penumbraInspection, penumbraHandleAngle] = spotLightHandleAngles();
+
+			const float angle = m_handleType == HandleType::Cone ? coneHandleAngle : penumbraHandleAngle.value();
+
+			const M44f r = M44f().rotate( V3f( 0, degreesToRadians( angle ), 0 ) );
+			const Line3f rayLine(
+				V3f( 0 ),
+				V3f( 0, 0, m_visualiserScale * m_frustumScale * -10.f ) * r
+			);
+			const V3f dragPoint = rayLine.closestPointTo( Line3f( event.line.p0, event.line.p1 ) );
+			m_arcRadius = dragPoint.length();
+
+			dirty( DirtyType::Render );
+
+			return false;
+		}
 
 		void dragBegin( const DragDropEvent &event ) override
 		{

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1213,7 +1213,7 @@ class SpotLightHandle : public LightToolHandle
 
 			IECoreGL::GroupPtr group = new IECoreGL::Group;
 
-			const bool highlighted = state == Style::State::HighlightedState || m_drag;
+			const bool highlighted = state == Style::State::HighlightedState;
 
 			// Line along cone. Use a cylinder because GL_LINE with width > 1
 			// are not reliably selected.


### PR DESCRIPTION
This adds handles for manipulating quad light width and height in the 3d viewport.

Handle are included for width and height individually as well as corner handles for both values at the same time. Holding the Control key during a drag will constrain the dimensions to maintain the aspect ratio at the start of the drag.

The code is still in draft state, especially the commit history which I'll tidy up and maybe merge down to one commit once we're happy with the behavior.

It's ready for usability testing for now.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
