### PR TITLE
GLWidget : Make _makeCurrent safe

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
   - Fixed translation of `vector` typed outputs defined as `vector <name>` in an output definition.
   - Fixed translation of `shadow:enable` and `shadow:color` parameters on UsdLux lights, which were previously ignored.
 - LightTool : Fixed bug causing non-settable plugs to be enabled, such as plugs with an expression as input or those using the default spreadsheet row for their value. This generated the error `ERROR : EventSignalCombiner : Cannot set value for plug {plug} except during computation.`
+- GLWidget : Fixed rare crash when showing a GLWidget for the first time.
 
 API
 ---

--- a/config/ie/options
+++ b/config/ie/options
@@ -463,9 +463,6 @@ if usdIncludePath:
 if usdLibPath:
 	LOCATE_DEPENDENCY_LIBPATH.insert(0, usdLibPath)
 
-# ImageEngine is now using a monolithic build of USD
-USD_MONOLITHIC = True
-
 ##########################################################################
 # get compiler and other build tools set up
 ##########################################################################

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -172,14 +172,21 @@ class GLWidget( GafferUI.Widget ) :
 			return False
 
 		self._qtWidget().viewport().makeCurrent()
+
+		# We need to call the init method after a GL context has been
+		# created, this is true either in __draw or after we call makeCurrent().
+		# Calling it in all these circumstances does mean we call init() way more
+		# than needed, but it's safe.
+		IECoreGL.init( True )
+
 		return True
 
 	def __draw( self ) :
 
-		# we need to call the init method after a GL context has been
-		# created, and this seems like the only place that is guaranteed.
-		# calling it here does mean we call init() way more than needed,
-		# but it's safe.
+		# We need to call the init method after a GL context has been
+		# created, this is true either in __draw or after we call makeCurrent().
+		# Calling it in all these circumstances does mean we call init() way more
+		# than needed, but it's safe.
 		IECoreGL.init( True )
 
 		if self.__multisample:

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -73,8 +73,14 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
+#include "OpenEXR/ImathMatrixAlgo.h"
+#include "OpenEXR/ImathSphere.h"
+#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathSphere.h"
+#endif
 
 #include "fmt/format.h"
 


### PR DESCRIPTION
Restoring __framebufferValid ( which was removed here: https://github.com/GafferHQ/gaffer/commit/f99db60db120f92b8c5dbc6e42b6f643def36d54 ) does seem to fix the problem, but it doesn't seem like a particularly direct solution: we need to make sure that IECoreGL::init is called before we try and use GL, so I've gone with just having a flag that we set when we call init ... feels pretty clear and reliable? I could switch back to __framebufferValid if you prefer.

It seems like there might also be a question of whether we should be calling viewport().makeCurrent() when we return false ... currently I am, just because that's what the old code did.

