### PR TITLE
Application : Clamp thread count at hardware concurrency.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Arnold : Fixed screen window export for Lentil cameras.
+- Application : Fixed the `-threads` argument to clamp the number of threads to the number of available hardware cores (#5403).
 
 1.2.10.1 (relative to 1.2.10.0)
 ========


### PR DESCRIPTION
This fixes deadlocks caused by worker threads not being able to join a `tbb::task_arena`, because by default they are constructed to only allow the same number of workers as cores. Fixes #5403.

Also added support for specifying negative thread counts, to reserve some cores for other applications.
