### PR TITLE
LightFilterVisualiser : Support USD lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,16 @@
 1.3.x.x (relative to 1.3.1.0)
 =======
 
+Improvements
+------------
+
+- Viewer : Added visualisation of light filters for USD lights.
+
+Fixes
+-----
+
+- Viewer : Fixed crash when visualising lights with a light filter intended for a different renderer.
+
 
 1.3.1.0 (relative to 1.3.0.0)
 =======

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -132,6 +132,17 @@ Visualisations LightFilterVisualiser::allVisualisations( const IECore::CompoundO
 		boost::split( tokens, attributeName, boost::is_any_of(":") );
 		const IECoreScene::ShaderNetwork *lightShaderNetwork = attributes->member<IECoreScene::ShaderNetwork>( tokens.front() + ":light" );
 
+		// If the light is a USD light, the renderer-specific `lightShaderNetwork` won't be valid
+		if( !lightShaderNetwork )
+		{
+			lightShaderNetwork = attributes->member<IECoreScene::ShaderNetwork>( "light" );
+		}
+
+		if( !lightShaderNetwork )
+		{
+			continue;
+		}
+
 		// It's possible that we found a light filter defined in world space
 		// that isn't assigned to a light just yet. If we found a filter in
 		// light space it must have a valid light shader, though.


### PR DESCRIPTION
This adds support for visualising light filters on USD lights. It also fixes a crash that would occur when trying to visualise a light filter intended for one renderer on a light for a different renderer.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
