### PR TITLE
Arnold CameraAlgo : Fix screen window for Lentil cameras

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.10.x (relative to 1.2.10.1)
 ========
 
+Fixes
+-----
+
+- Arnold : Fixed screen window export for Lentil cameras.
 
 1.2.10.1 (relative to 1.2.10.0)
 ========

--- a/src/IECoreArnold/CameraAlgo.cpp
+++ b/src/IECoreArnold/CameraAlgo.cpp
@@ -190,7 +190,7 @@ Imath::Box2f screenWindow( const IECoreScene::Camera *camera )
 {
 	Imath::Box2f result = camera->frustum();
 
-	if( camera->getProjection() == "perspective" )
+	if( camera->getProjection() == "perspective" || camera->getProjection() == "lentil_camera" )
 	{
 		// Normalise so that Arnold's NDC space goes from 0-1 across the aperture.
 		// This is helpful when using Arnold `uv_remap` shaders.


### PR DESCRIPTION
This is something of a blind fix based on discussion on gaffer-dev, since I don't have Lentil to test with. But I did check the other blocks where we deal with perspective cameras and determined that they were all setting parameters that don't exist in Lentil, so I hope this is the only spot that needs touching. And this won't affect anything for Arnold's standard cameras, so should be pretty safe.