### PR TITLE
Documentation : Remove release notes for versions < 1.0.0.0

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,10 @@ Fixes
 
 - Viewer : Fixed crash when visualising lights with a light filter intended for a different renderer.
 
+Documentation
+-------------
+
+- Removed release notes for versions prior to 1.0.0.0.
 
 1.3.1.0 (relative to 1.3.0.0)
 =======

--- a/doc/source/ReleaseNotes/generate.py
+++ b/doc/source/ReleaseNotes/generate.py
@@ -15,9 +15,14 @@ for line in changes :
 
 	m = re.match( r"^(Gaffer )?(([0-9]+\.){2,3}[0-9]+)", line )
 	if m :
-		versionIndex += ( "\n{}{}.md".format( " " * 4, m.group( 2 ) ) )
-		versionFile = open( m.group( 2 ) + ".md", "w" )
-		versionFile.write( m.group( 2 ) + "\n" )
+		versionString = m.group( 2 )
+		if versionString.startswith( "0." ) or versionString.count( "." ) != 3 :
+			# Ignore versions prior to 1.0.0.0
+			versionFile = None
+		else :
+			versionIndex += ( f"\n    {versionString}.md" )
+			versionFile = open( f"{versionString}.md", "w" )
+			versionFile.write( f"{versionString}\n" )
 		continue
 
 	if not versionFile :


### PR DESCRIPTION
They clutter up search results and provide more history than needed. This also fixes some Myst parser warnings which were coming from the older release notes and which cluttered up the CI annotations pane.
