### PR TITLE
Collect : Add new node for collecting arbitrary values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 - Arnold : Fixed screen window export for Lentil cameras.
 - Application : Fixed the `-threads` argument to clamp the number of threads to the number of available hardware cores (#5403).
 - CompareFloat, CompareColor, CompareVector : Worked around crashes in OSL's batched shading system (#5430).
+- PlugValueWidget : Fixed search for auxiliary plugs of output plugs. In this case, the inputs are now searched instead of the outputs.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ API
 ---
 
 - ThreadMonitor : Added new class for tracking the threads used to perform processes.
+- PlugAlgo : Added `findSource()` method.
 
 Documentation
 -------------

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - LightTool : Added manipulator for quad lights.
+- Collect : Added a utility node for collecting the values of arbitrary inputs across a range of contexts.
 
 Improvements
 ------------

--- a/include/Gaffer/Collect.h
+++ b/include/Gaffer/Collect.h
@@ -1,0 +1,119 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/Export.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
+#include "Gaffer/TypeIds.h"
+
+namespace Gaffer
+{
+
+class GAFFER_API Collect : public ComputeNode
+{
+
+	public :
+
+		Collect( const std::string &name = defaultName<Collect>() );
+		~Collect() override;
+
+		GAFFER_NODE_DECLARE_TYPE( Gaffer::Collect, CollectTypeId, ComputeNode );
+
+		StringPlug *contextVariablePlug();
+		const StringPlug *contextVariablePlug() const;
+
+		StringPlug *indexContextVariablePlug();
+		const StringPlug *indexContextVariablePlug() const;
+
+		StringVectorDataPlug *contextValuesPlug();
+		const StringVectorDataPlug *contextValuesPlug() const;
+
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
+
+		ValuePlug *inPlug();
+		const ValuePlug *inPlug() const;
+
+		ValuePlug *outPlug();
+		const ValuePlug *outPlug() const;
+
+		ObjectPlug *enabledValuesPlug();
+		const ObjectPlug *enabledValuesPlug() const;
+
+		bool canAddInput( const ValuePlug *prototype ) const;
+		ValuePlug *addInput( const ValuePlug *prototype );
+		void removeInput( ValuePlug *inputPlug );
+
+		ValuePlug *outputPlugForInput( const ValuePlug *inputPlug );
+		const ValuePlug *outputPlugForInput( const ValuePlug *inputPlug ) const;
+
+		ValuePlug *inputPlugForOutput( const ValuePlug *outputPlug );
+		const ValuePlug *inputPlugForOutput( const ValuePlug *outputPlug ) const;
+
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context) const override;
+
+		ValuePlug::CachePolicy hashCachePolicy( const ValuePlug *output ) const override;
+		ValuePlug::CachePolicy computeCachePolicy( const ValuePlug *output ) const override;
+
+	private :
+
+		// We collect the values for all output plugs in a single compute and cache
+		// them in a CompoundObject on this internal plug, indexing them by plug name.
+		// This provides greater ValuePlug cache coherency when multiple inputs depend
+		// on the same upstream computes (for instance, when they are each collecting
+		// a property of the same scene location).
+		CompoundObjectPlug *collectionPlug();
+		const CompoundObjectPlug *collectionPlug() const;
+
+		void inputAdded( GraphComponent *input );
+		void inputRemoved( GraphComponent *input );
+		void inputNameChanged( GraphComponent *input, IECore::InternedString oldName );
+
+		std::unordered_map<GraphComponent *, Signals::ScopedConnection> m_inputNameChangedConnections;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+}  // namespace Gaffer

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -72,6 +72,11 @@ GAFFER_API bool dependsOnCompute( const ValuePlug *plug );
 template<typename Predicate>
 std::invoke_result_t<Predicate, Plug *> findDestination( Plug *plug, Predicate &&predicate );
 
+/// Visits the plug and its inputs, returing the first `predicate( plug )` result which
+/// evaluates to `true`.
+template<typename Predicate>
+std::invoke_result_t<Predicate, Plug *> findSource( Plug *plug, Predicate &&predicate );
+
 /// Conversion to and from `IECore::Data`
 /// =====================================
 

--- a/include/Gaffer/PlugAlgo.inl
+++ b/include/Gaffer/PlugAlgo.inl
@@ -84,4 +84,20 @@ std::invoke_result_t<Predicate, Plug *> findDestination( Plug *plug, Predicate &
 	return std::invoke_result_t<Predicate, Plug *>();
 }
 
+template<typename Predicate>
+std::invoke_result_t<Predicate, Plug *> findSource( Plug *plug, Predicate &&predicate )
+{
+	while( plug )
+	{
+		if( auto source = predicate( plug ) )
+		{
+			return source;
+		}
+		plug = plug->getInput();
+	}
+
+	// Typically a null pointer.
+	return std::invoke_result_t<Predicate, Plug *>();
+}
+
 } // namespace Gaffer::PlugAlgo

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -151,6 +151,7 @@ enum TypeId
 	HiddenFilePathFilterTypeId = 110105,
 	Color4fVectorDataPlugTypeId = 110106,
 	OptionalValuePlugTypeId = 110107,
+	CollectTypeId = 110108,
 
 	LastTypeId = 110159,
 

--- a/python/GafferTest/CollectTest.py
+++ b/python/GafferTest/CollectTest.py
@@ -1,0 +1,387 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+
+import Gaffer
+import GafferTest
+
+class CollectTest( GafferTest.TestCase ) :
+
+	def testAddInput( self ) :
+
+		node = Gaffer.Collect()
+
+		for inputPlugType, outputPlugType in [
+			( Gaffer.BoolPlug, Gaffer.BoolVectorDataPlug ),
+			( Gaffer.IntPlug, Gaffer.IntVectorDataPlug ),
+			( Gaffer.FloatPlug, Gaffer.FloatVectorDataPlug ),
+			( Gaffer.StringPlug, Gaffer.StringVectorDataPlug ),
+			( Gaffer.V2iPlug, Gaffer.V2iVectorDataPlug ),
+			( Gaffer.V3iPlug, Gaffer.V3iVectorDataPlug ),
+			( Gaffer.V2fPlug, Gaffer.V2fVectorDataPlug ),
+			( Gaffer.V3fPlug, Gaffer.V3fVectorDataPlug ),
+			( Gaffer.Color3fPlug, Gaffer.Color3fVectorDataPlug ),
+			( Gaffer.Color4fPlug, Gaffer.Color4fVectorDataPlug ),
+			( Gaffer.M33fPlug, Gaffer.M33fVectorDataPlug ),
+			( Gaffer.M44fPlug, Gaffer.M44fVectorDataPlug ),
+			( Gaffer.AtomicCompoundDataPlug, Gaffer.ObjectVectorPlug ),
+			( Gaffer.CompoundObjectPlug, Gaffer.ObjectVectorPlug ),
+		] :
+
+			with self.subTest( inputPlugType = inputPlugType ) :
+
+				examplePlug = inputPlugType( defaultValue = inputPlugType.ValueType() )
+				self.assertTrue( node.canAddInput( examplePlug ) )
+
+				input = node.addInput( examplePlug )
+				self.assertIsInstance( input, inputPlugType )
+				self.assertTrue( input.parent().isSame( node["in"] ) )
+				self.assertFalse( input.isSame( examplePlug ) )
+
+				self.assertIsNone( input.getInput() )
+				self.assertIsNone( examplePlug.getInput() )
+
+				output = node.outputPlugForInput( input )
+				self.assertIsInstance( output, outputPlugType )
+				self.assertTrue( output.parent().isSame( node["out"] ) )
+
+				self.assertTrue( node.outputPlugForInput( input ).isSame( output ) )
+				self.assertTrue( node.inputPlugForOutput( output ).isSame( input ) )
+
+		for unsupportedPlug in [
+			Gaffer.NameValuePlug(),
+			Gaffer.SplineffPlug( defaultValue = Gaffer.SplineDefinitionff() ),
+		] :
+			with self.subTest( inputPlugType = type( unsupportedPlug ) ) :
+				self.assertFalse( node.canAddInput( unsupportedPlug ) )
+				with self.assertRaisesRegex( RuntimeError, "Unsupported plug type" ) :
+					node.addInput( unsupportedPlug )
+
+	def testRemoveInput( self ) :
+
+		collect = Gaffer.Collect()
+		input = collect.addInput( Gaffer.IntPlug() )
+		output = collect.outputPlugForInput( input )
+		self.assertEqual( len( collect["in"] ), 1 )
+		self.assertEqual( len( collect["out"] ), 1 )
+
+		collect.removeInput( input )
+		self.assertEqual( len( collect["in"] ), 0 )
+		self.assertEqual( len( collect["out"] ), 0 )
+		self.assertIsNone( input.parent() )
+		self.assertIsNone( output.parent() )
+
+	def testCollectStrings( self ) :
+
+		source = GafferTest.StringInOutNode()
+		source["in"].setValue( "${collectionVariable}" )
+
+		collect = Gaffer.Collect()
+		collect["contextVariable"].setValue( "collectionVariable" )
+		collect["contextValues"].setValue( IECore.StringVectorData( [ "a", "b", "c", "d", "e" ] ) )
+
+		input = collect.addInput( source["out"] )
+		input.setInput( source["out"] )
+		output = collect.outputPlugForInput( input )
+
+		self.assertEqual( output.getValue(), IECore.StringVectorData( [ "a", "b", "c", "d", "e" ] ) )
+		self.assertEqual( collect["enabledValues"].getValue(), IECore.StringVectorData( [ "a", "b", "c", "d", "e" ] ) )
+
+		collect["enabled"].setValue( False )
+		self.assertEqual( output.getValue(), IECore.StringVectorData() )
+		self.assertEqual( collect["enabledValues"].getValue(), IECore.StringVectorData() )
+
+	def testCollectColors( self ) :
+
+		random = Gaffer.RandomChoice()
+		random.setup( Gaffer.Color3fPlug() )
+		random["seedVariable"].setValue( "collectionVariable" )
+		random["choices"]["values"].setValue(
+			IECore.Color3fVectorData( [
+				imath.Color3f( 1, 0, 0 ),
+				imath.Color3f( 0, 1, 0 ),
+				imath.Color3f( 0, 0, 1 ),
+			] )
+		)
+		random["choices"]["weights"].setValue( IECore.FloatVectorData( [ 1, 1, 1 ] ) )
+
+		collect = Gaffer.Collect()
+		collect["contextVariable"].setValue( "collectionVariable" )
+		collect["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 100 ) ] ) )
+
+		input = collect.addInput( random["out"] )
+		input.setInput( random["out"] )
+		output = collect.outputPlugForInput( input )
+
+		colors = output.getValue()
+		self.assertEqual( len( colors ), 100 )
+		uniqueColors = { str( c ) for c in colors }
+		self.assertEqual( len( uniqueColors ), 3 )
+
+	def testCollectObjects( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["collect"] = Gaffer.Collect()
+		script["collect"]["contextVariable"].setValue( "collectionVariable" )
+		script["collect"]["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 10 ) ] ) )
+
+		script["collect"].addInput( Gaffer.CompoundObjectPlug( "object", defaultValue = IECore.CompoundObject() ) )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			"parent['collect']['in']['object'] = IECore.CompoundObject( { 'v' : IECore.StringData( context['collectionVariable'] ) } )"
+		)
+
+		self.assertEqual(
+			script["collect"]["out"]["object"].getValue(),
+			IECore.ObjectVector( [ IECore.CompoundObject( { "v" : IECore.StringData( str( x ) ) } ) for x in range( 0, 10 ) ] )
+		)
+
+	def testCollectManyBools( self ) :
+
+		# Exposes the need for the `OutputTraits<BoolPlug>` specialisation.
+
+		collect = Gaffer.Collect()
+		collect["contextVariable"].setValue( "collectionVariable" )
+		collect["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 10000 ) ] ) )
+
+		input = collect.addInput( Gaffer.BoolPlug( "test", defaultValue = True ) )
+		output = collect.outputPlugForInput( input )
+
+		self.assertEqual( output.getValue(), IECore.BoolVectorData( [ True ] * 10000 ) )
+
+	def testAffects( self ) :
+
+		collect = Gaffer.Collect()
+		in1 = collect.addInput( Gaffer.V3fPlug() )
+		in2 = collect.addInput( Gaffer.V3fPlug() )
+
+		def assertAffects( input ) :
+
+			# All inputs affect the internal collection plug.
+
+			dependents = set( collect.affects( input ) )
+			self.assertEqual( dependents, { collect["__collection"] } )
+
+			# Which in turn affects all outputs.
+
+			dependents = set( collect.affects( collect["__collection"] ) )
+			self.assertEqual( dependents, { collect["enabledValues"] } | set( Gaffer.ValuePlug.Range( collect["out"] ) ) )
+
+		assertAffects( in1["x"] )
+		assertAffects( in1["y"] )
+		assertAffects( in1["z"] )
+		assertAffects( in2["x"] )
+		assertAffects( in2["y"] )
+		assertAffects( in2["z"] )
+		assertAffects( collect["contextVariable"] )
+		assertAffects( collect["indexContextVariable"] )
+		assertAffects( collect["contextValues"] )
+
+	def testEnabledPlug( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["collect"] = Gaffer.Collect()
+		self.assertTrue( script["collect"].enabledPlug().isSame( script["collect"]["enabled"] ) )
+
+		script["collect"]["contextVariable"].setValue( "collectionVariable" )
+		script["collect"]["indexContextVariable"].setValue( "indexVariable" )
+		script["collect"]["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 10 ) ] ) )
+
+		script["collect"].addInput( Gaffer.IntPlug( "value" ) )
+		script["collect"].addInput( Gaffer.IntPlug( "index" ) )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			"i = int( context['collectionVariable'] );"
+			"parent['collect']['in']['value'] = i;"
+			"parent['collect']['in']['index'] = context['indexVariable'];"
+			"parent['collect']['enabled'] = i % 2;"
+		)
+
+		self.assertEqual(
+			script["collect"]["out"]["value"].getValue(),
+			IECore.IntVectorData( [ 1, 3, 5, 7, 9 ] )
+		)
+		self.assertEqual(
+			script["collect"]["out"]["index"].getValue(),
+			IECore.IntVectorData( [ 1, 3, 5, 7, 9 ] )
+		)
+		self.assertEqual(
+			script["collect"]["enabledValues"].getValue(),
+			IECore.StringVectorData( [ str( x ) for x in range( 0, 10 ) if x % 2 ] )
+		)
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["uninitialised"] = Gaffer.Collect()
+		script["initialised"] = Gaffer.Collect()
+
+		script["initialised"].addInput( Gaffer.StringPlug( "a", defaultValue = "default" ) )
+		script["initialised"].addInput( Gaffer.CompoundObjectPlug( "b", defaultValue = IECore.CompoundObject() ) )
+		# We're trying to eliminate `Dynamic` from the API, but while it still exists, we want
+		# to demonstrate that it doesn't matter whether it is on or off when it comes to
+		# Collect node serialisation.
+		script["initialised"].addInput( Gaffer.IntPlug( "c", defaultValue = 2, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		serialisation = script.serialise()
+		self.assertEqual( serialisation.count( "addChild" ), 2 ) # One for each node, but none for the inputs and ouputs
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( serialisation )
+
+		self.assertEqual( len( script2["uninitialised"]["in"] ), 0 )
+		self.assertEqual( len( script2["uninitialised"]["out"] ), 0 )
+
+		self.assertEqual( script2["initialised"]["in"].keys(), [ "a", "b", "c" ] )
+		self.assertEqual( script2["initialised"]["out"].keys(), [ "a", "b", "c" ] )
+		self.assertIsInstance( script2["initialised"]["in"]["a"], Gaffer.StringPlug )
+		self.assertEqual( script2["initialised"]["in"]["a"].defaultValue(), "default" )
+		self.assertIsInstance( script2["initialised"]["out"]["a"], Gaffer.StringVectorDataPlug )
+		self.assertIsInstance( script2["initialised"]["in"]["b"], Gaffer.CompoundObjectPlug )
+		self.assertEqual( script2["initialised"]["in"]["b"].defaultValue(), IECore.CompoundObject() )
+		self.assertIsInstance( script2["initialised"]["out"]["b"], Gaffer.ObjectVectorPlug )
+		self.assertIsInstance( script2["initialised"]["in"]["c"], Gaffer.IntPlug )
+		self.assertEqual( script2["initialised"]["in"]["c"].defaultValue(), 2 )
+		self.assertIsInstance( script2["initialised"]["out"]["c"], Gaffer.IntVectorDataPlug )
+
+	def testChangingCollectionType( self ) :
+
+		collect = Gaffer.Collect()
+		collect["contextVariable"].setValue( "collectionVariable" )
+		collect["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 10 ) ] ) )
+
+		input = collect.addInput( Gaffer.IntPlug( "test", defaultValue = 0 ) )
+		output = collect.outputPlugForInput( input )
+
+		self.assertEqual( output.getValue(), IECore.IntVectorData( [ 0 ] * 10 ) )
+
+		collect.removeInput( input )
+
+		input = collect.addInput( Gaffer.FloatPlug( "test", defaultValue = 0 ) )
+		output = collect.outputPlugForInput( input )
+
+		self.assertEqual( output.getValue(), IECore.FloatVectorData( [ 0 ] * 10 ) )
+
+	def testChangingCollectionValue( self ) :
+
+		collect = Gaffer.Collect()
+		collect["contextVariable"].setValue( "collectionVariable" )
+		collect["contextValues"].setValue( IECore.StringVectorData( [ str( x ) for x in range( 0, 10 ) ] ) )
+
+		input = collect.addInput( Gaffer.IntPlug( "test", defaultValue = 0 ) )
+		output = collect.outputPlugForInput( input )
+		self.assertEqual( output.getValue(), IECore.IntVectorData( [ 0 ] * 10 ) )
+
+		input.setValue( 1 )
+		self.assertEqual( output.getValue(), IECore.IntVectorData( [ 1 ] * 10 ) )
+
+	def testPlugAccessors( self ) :
+
+		collect = Gaffer.Collect()
+		input = collect.addInput( Gaffer.IntPlug( "test" ) )
+		output = collect.outputPlugForInput( input )
+		self.assertTrue( output.parent().isSame( collect["out"] ) )
+		self.assertEqual( output.getName(), input.getName() )
+		self.assertTrue( collect.inputPlugForOutput( output ).isSame( input ) )
+
+		with self.assertRaisesRegex( RuntimeError, "`IntPlug` is not an output of `Collect`" ) :
+			collect.inputPlugForOutput( Gaffer.IntPlug() )
+
+		with self.assertRaisesRegex( RuntimeError, "`test` is not an output of `Collect`" ) :
+			collect.inputPlugForOutput( Gaffer.IntPlug( "test" ) )
+
+		with self.assertRaisesRegex( RuntimeError, "`IntPlug` is not an input of `Collect`" ) :
+			collect.outputPlugForInput( Gaffer.IntPlug() )
+
+		with self.assertRaisesRegex( RuntimeError, "`test` is not an input of `Collect`" ) :
+			collect.outputPlugForInput( Gaffer.IntPlug( "test" ) )
+
+	def testRenameInput( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["collect"] = Gaffer.Collect()
+		script["collect"]["contextValues"].setValue( IECore.StringVectorData( [ "one" ] ) )
+
+		input1 = script["collect"].addInput( Gaffer.IntPlug( "a", defaultValue = 1 ) )
+		output1 = script["collect"].outputPlugForInput( input1 )
+
+		input2 = script["collect"].addInput( Gaffer.IntPlug( "b", defaultValue = 2 ) )
+		output2 = script["collect"].outputPlugForInput( input2 )
+
+		def assertPreconditions() :
+
+			self.assertEqual( input1.getName(), "a" )
+			self.assertEqual( output1.getName(), "a" )
+			self.assertEqual( output1.getValue(), IECore.IntVectorData( [ 1 ] ) )
+
+			self.assertEqual( input2.getName(), "b" )
+			self.assertEqual( output2.getName(), "b" )
+			self.assertEqual( output2.getValue(), IECore.IntVectorData( [ 2 ] ) )
+
+		assertPreconditions()
+
+		with Gaffer.UndoScope( script ) :
+			input1.setName( "b" )
+
+		def assertPostconditions() :
+
+			self.assertEqual( input1.getName(), "b1" )
+			self.assertEqual( output1.getName(), "b1" )
+			self.assertEqual( output1.getValue(), IECore.IntVectorData( [ 1 ] ) )
+
+			self.assertEqual( input2.getName(), "b" )
+			self.assertEqual( output2.getName(), "b" )
+			self.assertEqual( output2.getValue(), IECore.IntVectorData( [ 2 ] ) )
+
+		assertPostconditions()
+
+		script.undo()
+		assertPreconditions()
+
+		script.redo()
+		assertPostconditions()
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1013,5 +1013,28 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 			Gaffer.PlugAlgo.findDestination( None, lambda plug : plug )
 		)
 
+	def testFindSource( self ) :
+
+		self.assertIsNone( Gaffer.PlugAlgo.findSource( None, lambda plug : plug ) )
+		self.assertIsNone( Gaffer.PlugAlgo.findSource( Gaffer.IntPlug(), lambda plug : None ) )
+
+		node = GafferTest.AddNode()
+		self.assertTrue(
+			Gaffer.PlugAlgo.findSource( node["op1"], lambda plug : plug ).isSame( node["op1"] )
+		)
+
+		node2 = GafferTest.MultiplyNode()
+		node["op1"].setInput( node2["product"] )
+
+		self.assertTrue(
+			Gaffer.PlugAlgo.findSource( node["op1"], lambda plug : plug ).isSame( node["op1"] )
+		)
+
+		self.assertTrue(
+			Gaffer.PlugAlgo.findSource(
+				node["op1"], lambda plug : plug if isinstance( plug.node(), GafferTest.MultiplyNode ) else None
+			).isSame( node2["product"] )
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -158,6 +158,7 @@ from .HiddenFilePathFilterTest import HiddenFilePathFilterTest
 from .ContextVariableTweaksTest import ContextVariableTweaksTest
 from .OptionalValuePlugTest import OptionalValuePlugTest
 from .ThreadMonitorTest import ThreadMonitorTest
+from .CollectTest import CollectTest
 
 from .IECorePreviewTest import *
 

--- a/python/GafferUI/CollectUI.py
+++ b/python/GafferUI/CollectUI.py
@@ -1,0 +1,395 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+from ._TableView import _TableView
+
+from Qt import QtCore
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.Collect,
+
+	"description",
+	"""
+	Collects arbitrary input values across a range of contexts, outputting
+	arrays containing the values collected across that range.
+	""",
+
+	"layout:section:Settings.Inputs:collapsed", False,
+
+	plugs = {
+
+		"contextVariable" : [
+
+			"description",
+			"""
+			The context variable used to vary the values of the inputs being
+			collected. This should be used in the node network upstream of the
+			inputs.
+			""",
+
+			"noduleLayout:visible", False,
+
+		],
+
+		"indexContextVariable" : [
+
+			"description",
+			"""
+			The context variable used to specify the index being collected. This
+			may be used in the node network upstream of the inputs.
+			""",
+
+			"noduleLayout:visible", False,
+
+		],
+
+		"contextValues" : [
+
+			"description",
+			"""
+			The values of the context variable. Collection will be performed once
+			for each context value.
+			""",
+
+			"nodule:type", "",
+
+		],
+
+		"enabled" : [
+
+			"description",
+			"""
+			Enables or disables collection. This may be varied based on the
+			context variable, so that collection may be disabled in some
+			contexts but not others. Only values for enabled contexts are
+			included in the output arrays.
+			""",
+
+			"layout:section", "Settings",
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"in" : [
+
+			"description",
+			"""
+			Container of inputs to be collected from. Inputs may be added by
+			calling `collectNode.addInput( plug )` or using the UI. Each input
+			provides a corresponding output parented under the `out` plug.
+			""",
+
+			"plugValueWidget:type", "GafferUI.LayoutPlugValueWidget",
+
+			"layout:section", "Settings.Inputs",
+
+			"layout:customWidget:footer:widgetType", "GafferUI.CollectUI._InputFooter",
+			"layout:customWidget:footer:index", -1,
+
+			"nodule:type", "GafferUI::CompoundNodule",
+			"noduleLayout:spacing", 0.2,
+			"noduleLayout:customGadget:addButton:gadgetType", "GafferUI.CollectUI._InputAdder",
+
+		],
+
+		"in.*" : [
+
+			"description",
+			lambda plug : f"""An input value to be collected once in each context, with an array of the results
+			being provided by `out.{plug.getName()}`.""",
+
+			"renameable", True,
+
+		],
+
+		"enabledValues" : [
+
+			"description",
+			"""
+			Outputs an array of the context values for which collection was enabled by the `enabled` plug.
+			""",
+
+			# We show the value for this plug in the `_OutputPlugValueWidget`.
+			"plugValueWidget:type", "",
+			"noduleLayout:index", 0,
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			Container of array outputs corresponding to the inputs provided by the `in` plug.
+			""",
+
+			"plugValueWidget:type", "GafferUI.CollectUI._OutputPlugValueWidget",
+			"layout:section", "Results",
+
+			"nodule:type", "GafferUI::CompoundNodule",
+			"noduleLayout:spacing", 0.2,
+			"noduleLayout:index", 1,
+
+		],
+
+		"out.*" : [
+
+			"description",
+			lambda plug : f"""An array of all the results collected from `in.{plug.getName()}`.""",
+
+		],
+
+	}
+)
+
+##########################################################################
+# _InputFooter
+##########################################################################
+
+class _InputFooter( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug ) :
+
+		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
+
+		GafferUI.PlugValueWidget.__init__( self, row, plug )
+
+		with row :
+
+			GafferUI.Spacer( imath.V2i( GafferUI.PlugWidget.labelWidth(), 1 ) )
+
+			self.__menuButton = GafferUI.MenuButton(
+				image = "plus.png",
+				hasFrame = False,
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
+			)
+
+			GafferUI.Spacer( imath.V2i( 1 ), imath.V2i( 999999, 1 ), parenting = { "expand": True } )
+
+		self.__menuButton.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
+		self.__menuButton.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ), scoped = False )
+		self.__menuButton.dropSignal().connect( Gaffer.WeakMethod( self.__drop ), scoped = False )
+
+	def _updateFromEditable( self ) :
+
+		self.__menuButton.setEnabled(
+			self.getPlug().getInput() is None and not Gaffer.MetadataAlgo.readOnly( self.getPlug() )
+		)
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		for item in [
+			Gaffer.BoolPlug,
+			Gaffer.FloatPlug,
+			Gaffer.IntPlug,
+			"NumericDivider",
+			Gaffer.StringPlug,
+			"StringDivider",
+			Gaffer.V2iPlug,
+			Gaffer.V3iPlug,
+			Gaffer.V2fPlug,
+			Gaffer.V3fPlug,
+			"VectorDivider",
+			Gaffer.Color3fPlug,
+			Gaffer.Color4fPlug,
+			"ColorDivider",
+			Gaffer.M33fPlug,
+			Gaffer.M44fPlug,
+		] :
+			if isinstance( item, str ) :
+				result.append( "/" + item, { "divider": True } )
+			else :
+				result.append(
+					"/" + item.__name__.replace( "Plug", "" ),
+					{
+						"command" : functools.partial( Gaffer.WeakMethod( self.__addInput ), item ),
+					}
+				)
+
+		return result
+
+	def __dragEnter( self, widget, event ) :
+
+		if not isinstance( event.data, Gaffer.ValuePlug ) :
+			return False
+
+		if not self.getPlug().node().canAddInput( event.data ) :
+			return False
+
+		self.__menuButton.setHighlighted( True )
+		return True
+
+	def __dragLeave( self, widget, event ) :
+
+		self.__menuButton.setHighlighted( False )
+		return True
+
+	def __drop( self, widget, event ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().node().addInput( event.data )
+
+		self.__menuButton.setHighlighted( False )
+		return True
+
+	def __addInput( self, plugType ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+
+			node = self.getPlug().node()
+			node.addInput( plugType() )
+
+##########################################################################
+# _InputAdder
+##########################################################################
+
+class _InputAdder( GafferUI.PlugAdder ) :
+
+	def __init__( self, plug ) :
+
+		GafferUI.PlugAdder.__init__( self )
+
+		self.__node = plug.node()
+
+	def canCreateConnection( self, endpoint ) :
+
+		if not GafferUI.PlugAdder.canCreateConnection( self, endpoint ) :
+			return False
+
+		return endpoint.direction() == Gaffer.Plug.Direction.Out and self.__node.canAddInput( endpoint )
+
+	def createConnection( self, endpoint ) :
+
+		with Gaffer.UndoScope( self.__node.scriptNode() ) :
+			input = self.__node.addInput( endpoint )
+			input.setInput( endpoint )
+
+GafferUI.NoduleLayout.registerCustomGadget( "GafferUI.CollectUI._InputAdder", _InputAdder )
+
+##########################################################################
+# _OutputPlugValueWidget
+##########################################################################
+
+class _OutputPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		self.__vectorDataWidget = GafferUI.VectorDataWidget(
+			editable = False,
+			horizontalScrollMode = GafferUI.ScrollMode.Automatic
+		)
+
+		self.__busyWidget = GafferUI.BusyWidget( size = 18 )
+		# Sneak into the corner of the table view.
+		self.__busyWidget._qtWidget().setParent( self.__vectorDataWidget._qtWidget() )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__vectorDataWidget, plugs, **kw )
+
+	def hasLabel( self ) :
+
+		return True
+
+	def _auxiliaryPlugs( self, plug ) :
+
+		node = plug.node()
+		if isinstance( node, Gaffer.Collect ) :
+			return [ node["enabledValues"] ]
+
+	@staticmethod
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
+
+		return [
+			{
+				"enabledValues" : enabledValuesPlug.getValue(),
+				"outputs" : [ c.getValue() for c in plug.children() ],
+			}
+			for plug, ( enabledValuesPlug, ) in zip( plugs, auxiliaryPlugs )
+		]
+
+	def _updateFromValues( self, values, exception ) :
+
+		if values :
+			self.__vectorDataWidget.setHeader(
+				[ "Context" ] + [ IECore.CamelCase.toSpaced( c.getName() ) for c in self.getPlug().children() ]
+			)
+			self.__vectorDataWidget.setData( [ values[0]["enabledValues"] ] + values[0]["outputs"] )
+
+		self.__busyWidget.setVisible( exception is None and not values )
+		self.__vectorDataWidget.setErrored( exception is not None )
+
+##########################################################################
+# Delete menu items. We can't use the usual `deletable` metadata because
+# we need to call `removeInput()` to synchronise deletion of the input
+# and output plugs.
+##########################################################################
+
+def __plugPopupMenu( menuDefinition, plug ) :
+
+	node = plug.node()
+	if not isinstance( node, Gaffer.Collect ) or plug.parent() not in { node["in"], node["out"] } :
+		return
+
+	if len( menuDefinition.items() ) :
+		menuDefinition.append( "/DeleteDivider", { "divider" : True } )
+
+	menuDefinition.append( "/Delete", { "command" : functools.partial( __deletePlug, plug ), "active" : not Gaffer.MetadataAlgo.readOnly( plug ) } )
+
+def __deletePlug( plug ) :
+
+	with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+		input = plug if plug.direction() == Gaffer.Plug.Direction.In else plug.node().inputPlugForOutput( plug )
+		plug.node().removeInput( input )
+
+GafferUI.PlugValueWidget.popupMenuSignal().connect(
+	lambda menuDefinition, plugValueWidget : __plugPopupMenu( menuDefinition, plugValueWidget.getPlug() ),
+	scoped = False
+)
+
+GafferUI.GraphEditor.plugContextMenuSignal().connect(
+	lambda graphEditor, plug, menuDefinition : __plugPopupMenu( menuDefinition, plug ),
+	scoped = False
+)

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -695,7 +695,10 @@ class PlugValueWidget( GafferUI.Widget ) :
 		self.__auxiliaryPlugs = []
 		auxiliaryNodes = set()
 		for plug in self.__plugs :
-			auxiliaryPlugs = Gaffer.PlugAlgo.findDestination( plug, lambda plug : self._auxiliaryPlugs( plug ) ) or []
+			if plug.direction() == Gaffer.Plug.Direction.In :
+				auxiliaryPlugs = Gaffer.PlugAlgo.findDestination( plug, lambda plug : self._auxiliaryPlugs( plug ) ) or []
+			else :
+				auxiliaryPlugs = Gaffer.PlugAlgo.findSource( plug, lambda plug : self._auxiliaryPlugs( plug ) ) or []
 			self.__auxiliaryPlugs.append( auxiliaryPlugs )
 			auxiliaryNodes.update( [ plug.node() for plug in auxiliaryPlugs ] )
 			# > Note : Which `auxiliaryPlugs` we find depends on the output connections

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -303,6 +303,7 @@ from . import BoxOutUI
 from . import NameSwitchUI
 from . import EditScopeUI
 from . import ContextVariableTweaksUI
+from . import CollectUI
 
 # backwards compatibility
 ## \todo Remove me

--- a/src/Gaffer/Collect.cpp
+++ b/src/Gaffer/Collect.cpp
@@ -1,0 +1,647 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/Collect.h"
+
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/PlugAlgo.h"
+#include "Gaffer/TypedObjectPlug.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/TypeTraits.h"
+
+#include "boost/bind.hpp"
+
+#include "tbb/blocked_range.h"
+#include "tbb/parallel_for.h"
+#include "tbb/parallel_reduce.h"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace tbb;
+using namespace IECore;
+using namespace Gaffer;
+
+namespace
+{
+
+// Miscellaneous utilities
+// =======================
+
+template<typename T>
+void filterVector( vector<T> &v, const vector<unsigned char> &f )
+{
+	size_t newIndex = 0;
+	for( size_t oldIndex = 0; oldIndex < v.size(); ++oldIndex )
+	{
+		if( f[oldIndex] )
+		{
+			if( newIndex != oldIndex )
+			{
+				v[newIndex] = std::move( v[oldIndex] );
+			}
+			++newIndex;
+		}
+	}
+	v.resize( newIndex );
+	v.shrink_to_fit();
+}
+
+void filterVectors( CompoundObject *compoundObject, const vector<unsigned char> &filter )
+{
+	for( auto &[name, value] : compoundObject->members() )
+	{
+		if( auto o = runTimeCast<ObjectVector>( value.get() ) )
+		{
+			filterVector( o->members(), filter );
+		}
+		else
+		{
+			if( auto d = runTimeCast<UCharVectorData>( value.get() ) )
+			{
+				// See `OutputTraits<BoolPlug>`.
+				value = new BoolVectorData( vector<bool>( d->readable().begin(), d->readable().end() ) );
+			}
+
+			IECore::dispatch(
+				static_cast<Data *>( value.get() ),
+				[&] ( auto *data ) {
+					using DataType = remove_pointer_t<decltype( data )>;
+					if constexpr ( TypeTraits::IsVectorTypedData<DataType>::value )
+					{
+						filterVector( data->writable(), filter );
+					}
+				}
+			);
+		}
+	}
+}
+
+using IntRange = blocked_range<int>;
+const IECore::InternedString g_enabledOutputs( "__enabledOutputs__" );
+
+// Type-based plug dispatch
+// ========================
+//
+// We need to be able to deal with many types of input plug, which
+// we do by calling generic lambdas after downcasting to the specific
+// type we are dealing with.
+
+// If `plug` is a supported type, downcasts it to its true type and
+// calls `functor( plug, args )`. Otherwise, does nothing.
+template<typename F>
+void dispatchPlugFunction( const ValuePlug *plug, F &&functor )
+{
+	switch( (int)plug->typeId() )
+	{
+		case BoolPlugTypeId :
+			functor( static_cast<const BoolPlug *>( plug ) );
+			break;
+		case IntPlugTypeId :
+			functor( static_cast<const IntPlug *>( plug ) );
+			break;
+		case FloatPlugTypeId :
+			functor( static_cast<const FloatPlug *>( plug ) );
+			break;
+		case StringPlugTypeId :
+			functor( static_cast<const StringPlug *>( plug ) );
+			break;
+		case V2iPlugTypeId :
+			functor( static_cast<const V2iPlug *>( plug ) );
+			break;
+		case V3iPlugTypeId :
+			functor( static_cast<const V3iPlug *>( plug ) );
+			break;
+		case V2fPlugTypeId :
+			functor( static_cast<const V2fPlug *>( plug ) );
+			break;
+		case V3fPlugTypeId :
+			functor( static_cast<const V3fPlug *>( plug ) );
+			break;
+		case Color3fPlugTypeId :
+			functor( static_cast<const Color3fPlug *>( plug ) );
+			break;
+		case Color4fPlugTypeId :
+			functor( static_cast<const Color4fPlug *>( plug ) );
+			break;
+		case M33fPlugTypeId :
+			functor( static_cast<const M33fPlug *>( plug ) );
+			break;
+		case M44fPlugTypeId :
+			functor( static_cast<const M44fPlug *>( plug ) );
+			break;
+		case IntVectorDataPlugTypeId :
+			functor( static_cast<const IntVectorDataPlug *>( plug ) );
+			break;
+		case AtomicCompoundDataPlugTypeId :
+			functor( static_cast<const AtomicCompoundDataPlug *>( plug ) );
+			break;
+		case CompoundObjectPlugTypeId :
+			functor( static_cast<const CompoundObjectPlug *>( plug ) );
+			break;
+		case ObjectVectorPlugTypeId :
+			functor( static_cast<const ObjectVectorPlug *>( plug ) );
+			break;
+		default :
+			break;
+	}
+}
+
+// OutputTraits
+// ============
+//
+// Depending on the type of input plug we are collecting from, we will
+// need a different type of output plug to store an array of the collected
+// values. The OutputTraits template abstracts this away for us.
+
+// By default we collect into an appropriate VectorTypedData object,
+// with some careful handling to use GeometricTypedData where necessary.
+template<typename InputPlugType>
+struct OutputTraits
+{
+	using ContainerType = vector<typename InputPlugType::ValueType>;
+	using ObjectType = std::conditional_t<
+		IECore::TypeTraits::IsVec<typename ContainerType::value_type>::value,
+		IECore::GeometricTypedData<ContainerType>,
+		IECore::TypedData<ContainerType>
+	>;
+	using PlugType = TypedObjectPlug<ObjectType>;
+	static ContainerType &container( ObjectType &object ) { return object.writable(); }
+	static typename InputPlugType::ValueType collect( const InputPlugType *input ) { return input->getValue(); }
+};
+
+// CompoundData inputs are collected into an ObjectVector object.
+template<typename T>
+struct OutputTraits<TypedObjectPlug<T>>
+{
+	using ObjectType = ObjectVector;
+	using ContainerType = ObjectVector::MemberContainer;
+	using PlugType = ObjectVectorPlug;
+	static ContainerType &container( ObjectType &object ) { return object.members(); }
+	static ObjectPtr collect( const TypedObjectPlug<T> *input ) {
+		// Cast is OK because we're storing into a container that becomes const
+		// immediately after returning from compute. We never modify the value.
+		return boost::const_pointer_cast<T>( input->getValue() );
+	}
+};
+
+// BoolPlug inputs are subject to the `vector<bool>` fiasco. We can't write concurrently to
+// individual elements of a `vector<bool>`, because they're proxies that mix multiple values
+// into a single byte. So we write to a temporary UCharVectorData and then convert to
+// BoolVectorData in `filterVectors()`.
+template<>
+struct OutputTraits<BoolPlug>
+{
+	using ObjectType = UCharVectorData;
+	using ContainerType = UCharVectorData::ValueType;
+	using PlugType = BoolVectorDataPlug;
+	static ContainerType &container( ObjectType &object ) { return object.writable(); }
+	static bool collect( const BoolPlug *input ) { return input->getValue(); }
+};
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( Collect );
+
+size_t Collect::g_firstPlugIndex = 0;
+
+Collect::Collect( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "contextVariable", Plug::In, "collect:value" ) );
+	addChild( new StringPlug( "indexContextVariable", Plug::In, "collect:index" ) );
+	addChild( new StringVectorDataPlug( "contextValues" ) );
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new ValuePlug( "in", Plug::In, Plug::Flags::Default & ~Plug::Flags::AcceptsInputs ) );
+	addChild( new ValuePlug( "out", Plug::Out ) );
+	// Will currently always output StringVectorData, but we're using an ObjectPlug
+	// for future compatibility with anticipated modes with non-string context variable
+	// values (following the pattern established by the Wedge node).
+	addChild( new ObjectPlug( "enabledValues", Plug::Out, new StringVectorData ) );
+	addChild( new CompoundObjectPlug( "__collection", Plug::Out, new CompoundObject ) );
+
+	inPlug()->childAddedSignal().connect( boost::bind( &Collect::inputAdded, this, ::_2 ) );
+	inPlug()->childRemovedSignal().connect( boost::bind( &Collect::inputRemoved, this, ::_2 ) );
+}
+
+Collect::~Collect()
+{
+}
+
+StringPlug *Collect::contextVariablePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const StringPlug *Collect::contextVariablePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+StringPlug *Collect::indexContextVariablePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const StringPlug *Collect::indexContextVariablePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+StringVectorDataPlug *Collect::contextValuesPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 2 );
+}
+
+const StringVectorDataPlug *Collect::contextValuesPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 2 );
+}
+
+BoolPlug *Collect::enabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+const BoolPlug *Collect::enabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+ValuePlug *Collect::inPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 4 );
+}
+
+const ValuePlug *Collect::inPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 4 );
+}
+
+ValuePlug *Collect::outPlug()
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 5 );
+}
+
+const ValuePlug *Collect::outPlug() const
+{
+	return getChild<ValuePlug>( g_firstPlugIndex + 5 );
+}
+
+ObjectPlug *Collect::enabledValuesPlug()
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
+}
+
+const ObjectPlug *Collect::enabledValuesPlug() const
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
+}
+
+CompoundObjectPlug *Collect::collectionPlug()
+{
+	return getChild<CompoundObjectPlug>( g_firstPlugIndex + 7 );
+}
+
+const CompoundObjectPlug *Collect::collectionPlug() const
+{
+	return getChild<CompoundObjectPlug>( g_firstPlugIndex + 7 );
+}
+
+bool Collect::canAddInput( const ValuePlug *prototype ) const
+{
+	bool result = false;
+	dispatchPlugFunction( prototype, [&result] ( auto *plug ) { result = true; } );
+	return result;
+}
+
+ValuePlug *Collect::addInput( const ValuePlug *prototype )
+{
+	ValuePlugPtr output;
+	dispatchPlugFunction(
+		prototype, [&output] ( auto *plug ) {
+			using OutputTraits = OutputTraits<remove_const_t<remove_pointer_t<decltype( plug )>>>;
+			output = new typename OutputTraits::PlugType( plug->getName(), Plug::Out );
+		}
+	);
+
+	if( !output )
+	{
+		throw IECore::Exception( fmt::format( "Unsupported plug type {}", prototype->typeName() ) );
+	}
+
+	PlugPtr input = prototype->createCounterpart( prototype->getName(), Plug::In );
+	input->setFlags( Plug::Dynamic, false );
+	inPlug()->addChild( input );
+	outPlug()->addChild( output );
+
+	return static_cast<ValuePlug *>( input.get() );
+}
+
+void Collect::removeInput( ValuePlug *inputPlug )
+{
+	outPlug()->removeChild( outputPlugForInput( inputPlug ) );
+	inPlug()->removeChild( inputPlug );
+}
+
+ValuePlug *Collect::outputPlugForInput( const ValuePlug *inputPlug )
+{
+	return const_cast<ValuePlug *>( const_cast<const Collect *>( this )->outputPlugForInput( inputPlug ) );
+}
+
+const ValuePlug *Collect::outputPlugForInput( const ValuePlug *inputPlug ) const
+{
+	if( inputPlug->parent() != inPlug() )
+	{
+		throw IECore::Exception(
+			fmt::format( "`{}` is not an input of `{}`", inputPlug->fullName(), fullName() )
+		);
+	}
+
+	const ValuePlug *result = outPlug()->getChild<ValuePlug>( inputPlug->getName() );
+	if( !result )
+	{
+		throw IECore::Exception(
+			fmt::format( "Expected output `{}.{}` not found", fullName(), inputPlug->getName().string() )
+		);
+	}
+	return result;
+}
+
+ValuePlug *Collect::inputPlugForOutput( const ValuePlug *outputPlug )
+{
+	return const_cast<ValuePlug *>( const_cast<const Collect *>( this )->inputPlugForOutput( outputPlug ) );
+}
+
+const ValuePlug *Collect::inputPlugForOutput( const ValuePlug *outputPlug ) const
+{
+	if( outputPlug->parent() != outPlug() )
+	{
+		throw IECore::Exception(
+			fmt::format( "`{}` is not an output of `{}`", outputPlug->fullName(), fullName() )
+		);
+	}
+
+	const ValuePlug *result = inPlug()->getChild<ValuePlug>( outputPlug->getName() );
+	if( !result )
+	{
+		throw IECore::Exception(
+			fmt::format( "Expected input `{}.{}` not found", fullName(), outputPlug->getName().string() )
+		);
+	}
+	return result;
+}
+
+void Collect::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if(
+		input == contextValuesPlug() ||
+		input == contextVariablePlug() ||
+		input == indexContextVariablePlug() ||
+		input == enabledPlug() ||
+		inPlug()->isAncestorOf( input )
+	)
+	{
+		outputs.push_back( collectionPlug() );
+	}
+
+	if( input == collectionPlug() )
+	{
+		outputs.push_back( enabledValuesPlug() );
+		for( auto output : Plug::OutputRange( *outPlug() ) )
+		{
+			outputs.push_back( output.get() );
+		}
+	}
+}
+
+void Collect::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	ComputeNode::hash( output, context, h );
+
+	if( output == collectionPlug() )
+	{
+		ConstStringVectorDataPtr contextValuesData = contextValuesPlug()->getValue();
+		const vector<string> &contextValues = contextValuesData->readable();
+		const InternedString contextVariable = contextVariablePlug()->getValue();
+		const InternedString indexContextVariable = indexContextVariablePlug()->getValue();
+
+		for( auto &input : ValuePlug::Range( *inPlug() ) )
+		{
+			h.append( input->typeId() );
+			h.append( input->getName() );
+		}
+
+		const ThreadState &threadState = ThreadState::current();
+		tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+		const IECore::MurmurHash reduction = tbb::parallel_deterministic_reduce(
+
+			IntRange( 0, contextValues.size() ),
+			MurmurHash(),
+
+			[&] ( const IntRange &range, MurmurHash hash )
+			{
+				Context::EditableScope scope( threadState );
+				for( int index = range.begin(); index < range.end(); ++index )
+				{
+					scope.set( contextVariable, &contextValues[index] );
+					scope.set( indexContextVariable, &index );
+					hash.append( contextValues[index] );
+					enabledPlug()->hash( hash );
+					for( auto &input : ValuePlug::Range( *inPlug() ) )
+					{
+						input->hash( hash );
+					}
+				}
+				return hash;
+			},
+
+			[] ( MurmurHash x, const MurmurHash &y ) {
+				x.append( y );
+				return x;
+			},
+
+			simple_partitioner(),
+			taskGroupContext
+		);
+
+		h.append( reduction );
+	}
+	else if( output->parent() == outPlug() || output == enabledValuesPlug() )
+	{
+		collectionPlug()->hash( h );
+	}
+}
+
+void Collect::compute( ValuePlug *output, const Context *context) const
+{
+	ComputeNode::compute( output, context );
+
+	if( output == collectionPlug() )
+	{
+		ConstStringVectorDataPtr contextValuesData = contextValuesPlug()->getValue();
+		const vector<string> &contextValues = contextValuesData->readable();
+		const InternedString contextVariable = contextVariablePlug()->getValue();
+		const InternedString indexContextVariable = indexContextVariablePlug()->getValue();
+
+		// Allocate storage to collect into.
+
+		vector<pair<const ValuePlug *, Object *>> toCollect;
+
+		UCharVectorDataPtr enabledData = new UCharVectorData;
+		enabledData->writable().resize( contextValues.size() );
+		toCollect.push_back( { enabledPlug(), enabledData.get() } );
+
+		CompoundObjectPtr result = new CompoundObject;
+		for( auto &input : ValuePlug::Range( *inPlug() ) )
+		{
+			dispatchPlugFunction(
+				input.get(),
+				[&] ( auto *plug ) {
+					using OutputTraits = OutputTraits<remove_const_t<remove_pointer_t<decltype( plug )>>>;
+					typename OutputTraits::ObjectType::Ptr object = new typename OutputTraits::ObjectType;
+					OutputTraits::container( *object ).resize( contextValues.size() );
+					toCollect.push_back( { input.get(), object.get() } );
+					result->members()[input->getName()] = object;
+				}
+			);
+		}
+
+		// Perform collection in parallel.
+
+		const ThreadState &threadState = ThreadState::current();
+		tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+		tbb::parallel_for(
+			IntRange( 0, contextValues.size() ),
+			[&] ( const IntRange &range )
+			{
+				Context::EditableScope scope( threadState );
+				for( int index = range.begin(); index < range.end(); ++index )
+				{
+					scope.set( contextVariable, &contextValues[index] );
+					scope.set( indexContextVariable, &index );
+
+					for( auto [input, object] : toCollect )
+					{
+						dispatchPlugFunction(
+							input,
+							[&] ( auto *plug ) {
+								using OutputTraits = OutputTraits<remove_const_t<remove_pointer_t<decltype( plug )>>>;
+								auto typedObject = static_cast<typename OutputTraits::ObjectType *>( object );
+								OutputTraits::container( *typedObject )[index] = OutputTraits::collect( plug );
+							}
+						);
+					}
+				}
+			},
+			taskGroupContext
+		);
+
+		// Add context values and filter.
+
+		result->members()[g_enabledOutputs] = contextValuesData->copy();
+		filterVectors( result.get(), enabledData->readable() );
+
+		static_cast<CompoundObjectPlug *>( output )->setValue( result );
+	}
+	else if( output->parent() == outPlug() )
+	{
+		ConstCompoundObjectPtr collection = collectionPlug()->getValue();
+		const ValuePlug *input = inputPlugForOutput( output );
+
+		dispatchPlugFunction(
+			input,
+			[&] ( auto *plug ) {
+
+				using OutputTraits = OutputTraits<remove_const_t<remove_pointer_t<decltype( plug )>>>;
+				auto object = collection->member<typename OutputTraits::PlugType::ValueType>( output->getName(), true );
+				static_cast<typename OutputTraits::PlugType *>( output )->setValue( object );
+			}
+		);
+	}
+	else if( output == enabledValuesPlug() )
+	{
+		ConstCompoundObjectPtr collection = collectionPlug()->getValue();
+		static_cast<ObjectPlug *>( output )->setValue( collection->member<StringVectorData>( g_enabledOutputs, /* throwExceptions = */ true ) );
+	}
+}
+
+ValuePlug::CachePolicy Collect::hashCachePolicy( const ValuePlug *output ) const
+{
+	if( output == collectionPlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return ComputeNode::hashCachePolicy( output );
+}
+
+ValuePlug::CachePolicy Collect::computeCachePolicy( const ValuePlug *output ) const
+{
+	if( output == collectionPlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return ComputeNode::computeCachePolicy( output );
+}
+
+void Collect::inputAdded( GraphComponent *input )
+{
+	m_inputNameChangedConnections[input] = input->nameChangedSignal().connect( boost::bind( &Collect::inputNameChanged, this, ::_1, ::_2 ) );
+}
+
+void Collect::inputRemoved( GraphComponent *input )
+{
+	m_inputNameChangedConnections.erase( input );
+}
+
+void Collect::inputNameChanged( GraphComponent *input, IECore::InternedString oldName )
+{
+	if( input->parent() == inPlug() )
+	{
+		if( auto out = outPlug()->getChild( oldName ) )
+		{
+			out->setName( input->getName() );
+		}
+	}
+}

--- a/src/GafferModule/CollectBinding.cpp
+++ b/src/GafferModule/CollectBinding.cpp
@@ -1,0 +1,98 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "CollectBinding.h"
+
+#include "GafferBindings/ComputeNodeBinding.h"
+
+#include "Gaffer/Collect.h"
+
+using namespace boost::python;
+using namespace GafferBindings;
+using namespace Gaffer;
+
+namespace
+{
+
+Gaffer::ValuePlugPtr addInputWrapper( Collect &c, const Gaffer::ValuePlug &p )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return c.addInput( &p );
+}
+
+void removeInputWrapper( Collect &c, Gaffer::ValuePlug &p )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return c.removeInput( &p );
+}
+
+class CollectSerialiser : public NodeSerialiser
+{
+
+	std::string postConstructor( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, Serialisation &serialisation ) const override
+	{
+		std::string result = NodeSerialiser::postConstructor( graphComponent, identifier, serialisation );
+
+		const Collect *node = static_cast<const Collect *>( graphComponent );
+		for( auto &input : ValuePlug::InputRange( *node->inPlug() ) )
+		{
+			const Serialiser *plugSerialiser = Serialisation::acquireSerialiser( input.get() );
+			result += identifier + ".addInput( " + plugSerialiser->constructor( input.get(), serialisation ) + " )\n";
+		}
+
+		return result;
+	}
+
+};
+
+} // namespace
+
+void GafferModule::bindCollect()
+{
+
+	DependencyNodeClass<Collect>()
+		.def( "canAddInput", &Collect::canAddInput )
+		.def( "addInput", &addInputWrapper )
+		.def( "removeInput", &removeInputWrapper )
+		.def( "outputPlugForInput", (ValuePlug *(Collect::*)( const ValuePlug *))&Collect::outputPlugForInput, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "inputPlugForOutput", (ValuePlug *(Collect::*)( const ValuePlug *))&Collect::inputPlugForOutput, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+	;
+
+	Serialisation::registerSerialiser( Collect::staticTypeId(), new CollectSerialiser );
+
+}

--- a/src/GafferModule/CollectBinding.h
+++ b/src/GafferModule/CollectBinding.h
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace GafferModule
+{
+
+void bindCollect();
+
+} // namespace GafferModule

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -40,6 +40,7 @@
 #include "ApplicationRootBinding.h"
 #include "ArrayPlugBinding.h"
 #include "BoxPlugBinding.h"
+#include "CollectBinding.h"
 #include "CompoundDataPlugBinding.h"
 #include "CompoundNumericPlugBinding.h"
 #include "ContextBinding.h"
@@ -247,6 +248,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindMessages();
 	bindTweakPlugs();
 	bindOptionalValuePlug();
+	bindCollect();
 
 	NodeClass<Backdrop>();
 

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -68,6 +68,18 @@ object findDestinationWrapper( Plug *plug, object predicate )
 	);
 }
 
+object findSourceWrapper( Plug *plug, object predicate )
+{
+	return PlugAlgo::findSource(
+		plug,
+		[&predicate] ( Plug *plug ) {
+			object o = predicate( PlugPtr( plug ) );
+			return o;
+		}
+	);
+}
+
+
 ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direction, unsigned flags, const IECore::Data *value )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -132,6 +144,7 @@ void GafferModule::bindPlugAlgo()
 	def( "replacePlug", &replacePlug, ( arg( "parent" ), arg( "plug" ) ) );
 	def( "dependsOnCompute", &PlugAlgo::dependsOnCompute );
 	def( "findDestination", &findDestinationWrapper );
+	def( "findSource", &findSourceWrapper );
 
 	def( "createPlugFromData", &createPlugFromData );
 	def( "extractDataFromPlug", &extractDataFromPlug );

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -591,6 +591,7 @@ nodeMenu.append( "/Utility/Delete Context Variables", Gaffer.DeleteContextVariab
 nodeMenu.append( "/Utility/Time Warp", Gaffer.TimeWarp, searchText = "TimeWarp" )
 nodeMenu.append( "/Utility/Spreadsheet", Gaffer.Spreadsheet )
 nodeMenu.append( "/Utility/Context Query", Gaffer.ContextQuery, searchText = "ContextQuery" )
+nodeMenu.append( "/Utility/Collect", Gaffer.Collect )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
Like CollectScenes, CollectImages and others, this allows the repeated collection of the same inputs across a range of contexts. Unlike the others, it is designed to collect completely generic values from any plug, outputting the results as arrays of values. This is all parallelised within a `parallel_for` across the range of contexts. We anticipate it being a useful utility node with a variety of uses. In the example below I'm using it to query scene attributes from a range of locations, presenting the results in a handy spreadsheet form - a sort of build-it-yourself scene inspector.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/2eab6c4c-5e24-4876-a8be-4c3921dd1742)

