### PR TITLE
GUI startup : Add USD presets for ShaderTweaks and ShaderQuery

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Viewer : Added visualisation of light filters for USD lights.
+- ShaderTweaks/ShaderQuery : Added presets for USD light and surface shaders.
 
 Fixes
 -----

--- a/startup/gui/shaderPresets.py
+++ b/startup/gui/shaderPresets.py
@@ -84,4 +84,10 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	] )
 
-__registerShaderPresets( [ ( "OpenGL Surface", "gl:surface" ) ] )
+__registerShaderPresets( [
+
+		( "OpenGL Surface", "gl:surface" ),
+		( "USD Surface", "surface" ),
+		( "USD Light", "light" ),
+
+	] )


### PR DESCRIPTION
Now that we can create USD lights and shaders, we'll want to more easily tweak and query them. Whether these stay "USD" prefixed in the long run is debatable, but for now this is consistent with the Light Editor and Tab menu.