### PR TITLE
SceneViewInspector : Support USD lights and shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- Viewer : Added visualisation of light filters for USD lights.
+- Viewer :
+  - Added visualisation of light filters for USD lights.
+  - Added support for USD lights and shaders in the floating inspector panel.
 - ShaderTweaks/ShaderQuery : Added presets for USD light and surface shaders.
 
 Fixes

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -67,7 +67,8 @@ _rendererAttributePrefixes = {
 	"dl" : "Delight",
 	"gl" : "OpenGL",
 	"osl" : "OSL",
-	"cycles" : "Cycles"
+	"cycles" : "Cycles",
+	"" : "USD",
 };
 
 __registeredShaderParameters = OrderedDict()
@@ -176,7 +177,11 @@ class _SceneViewInspector( GafferUI.Widget ) :
 	@staticmethod
 	def __attributeLabel( attribute ) :
 
-		prefix, name = attribute.split( ":", 1 )
+		prefix, _, name = attribute.partition( ":" )
+		if not name :
+			name = prefix
+			prefix = ""
+
 		prefix = _rendererAttributePrefixes.get( prefix, prefix )
 		name = " ".join( [ IECore.CamelCase.toSpaced( n ) for n in name.split( ":" ) ] )
 		return "{} {}".format( prefix, name )

--- a/startup/GafferSceneUI/sceneViewInspector.py
+++ b/startup/GafferSceneUI/sceneViewInspector.py
@@ -60,3 +60,11 @@ for p in [ "intensity", "exposure", "color", "size", "spot_angle", "samples" ] :
 
 for p in ["base_color", "subsurface_color", "metallic", "subsurface", "subsurface_radius", "specular", "roughness", "specular_tint" ] :
 	GafferSceneUI._SceneViewInspector.registerShaderParameter( "cycles:surface", p )
+
+# USD
+
+for p in [ "intensity", "exposure", "color", "enableColorTemperature", "colorTemperature", "width", "height", "radius", "angle", "shaping:cone:angle", "shaping:cone:softness" ] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "light", p )
+
+for p in [ "diffuseColor", "emissiveColor", "useSpecularWorkflow", "specularColor", "metallic", "roughness", "clearcoat", "clearcoatRoughness" ] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "surface", p )


### PR DESCRIPTION
Registers common parameters for USD lights and shaders and adjusts the label handling to support attribute names without a `renderer:` prefix.