### PR TITLE
Compare(Float|Color|Vector) : Work around OSL shading system crash

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - Arnold : Fixed screen window export for Lentil cameras.
 - Application : Fixed the `-threads` argument to clamp the number of threads to the number of available hardware cores (#5403).
+- CompareFloat, CompareColor, CompareVector : Worked around crashes in OSL's batched shading system (#5430).
 
 1.2.10.1 (relative to 1.2.10.0)
 ========

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -971,5 +971,26 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 				imath.Color3f( 1, 2, 3 )
 			)
 
+	def testCompareFloat( self ) :
+
+		e = GafferOSL.ShadingEngine( IECoreScene.ShaderNetwork(
+			shaders = {
+				"globals" : IECoreScene.Shader( "Utility/Globals", "osl:shader" ),
+				"compareFloat" : IECoreScene.Shader( "Utility/CompareFloat", "osl:shader" ),
+				"output" : IECoreScene.Shader( "Surface/Constant", "osl:surface" )
+			},
+			connections = [
+				( ( "globals", "globalU" ), ( "compareFloat", "a" ) ),
+				( ( "globals", "globalV" ), ( "compareFloat", "b" ) ),
+				( ( "compareFloat", "success" ), ( "output", "Cs.r" ) ),
+			],
+			output = "output"
+		) )
+
+		r = e.shade( self.rectanglePoints() )
+		for x in range( 0, 10 ) :
+			for y in range( 0, 10 ) :
+				self.assertEqual( r["Ci"][y*10+x].r, 1 if x == y else 0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/shaders/Utility/CompareColor.osl
+++ b/shaders/Utility/CompareColor.osl
@@ -58,10 +58,10 @@ shader CompareColor
 {
 	if( condition == CONDITION_EQUAL )
 	{
-		success = a == b;
+		success = a == b ? 1 : 0;
 	}
 	else
 	{
-		success = a != b;
+		success = a != b ? 1 : 0;
 	}
 }

--- a/shaders/Utility/CompareFloat.osl
+++ b/shaders/Utility/CompareFloat.osl
@@ -62,26 +62,26 @@ shader CompareFloat
 {
 	if( condition == CONDITION_EQUAL )
 	{
-		success = a == b;
+		success = a == b ? 1 : 0;
 	}
 	else if( condition == CONDITION_NOT_EQUAL )
 	{
-		success = a != b;
+		success = a != b ? 1 : 0;
 	}
 	else if( condition == CONDITION_GREATER )
 	{
-		success = a > b;
+		success = a > b ? 1 : 0;
 	}
 	else if( condition == CONDITION_GREATER_OR_EQUAL )
 	{
-		success = a >= b;
+		success = a >= b ? 1 : 0;
 	}
 	else if( condition == CONDITION_LESS )
 	{
-		success = a < b;
+		success = a < b ? 1 : 0;
 	}
 	else
 	{
-		success = a <= b;
+		success = a <= b ? 1 : 0;
 	}
 }

--- a/shaders/Utility/CompareVector.osl
+++ b/shaders/Utility/CompareVector.osl
@@ -58,10 +58,10 @@ shader CompareVector
 {
 	if( condition == CONDITION_EQUAL )
 	{
-		success = a == b;
+		success = a == b ? 1 : 0;
 	}
 	else
 	{
-		success = a != b;
+		success = a != b ? 1 : 0;
 	}
 }


### PR DESCRIPTION
When in batched mode, assigning an implicit boolean result to an integer causes the following assertion failures :

```
new_val type=<16 x i1> dest_ptr type=<16 x i32>*
/home/john/dev/gafferDependencies/OpenShadingLanguage/working/OpenShadingLanguage-1.12.9.0/src/liboslexec/batched_backendllvm.cpp:1234: llvm_store_value: Assertion 'll.type_ptr(ll.llvm_typeof(new_val)) == ll.llvm_typeof(dst_ptr)' failed.
/home/john/dev/gafferDependencies/OpenShadingLanguage/working/OpenShadingLanguage-1.12.9.0/src/liboslexec/llvm_util.cpp:2958: native_to_llvm_mask: Assertion 'native_mask->getType() == type_native_mask()' failed.
Invalid operands for select instruction!
 %31 = select <16 x i1> %10, <16 x i1> %26, <16 x i32> %30, !dbg !12
Stored value type does not match pointer operand type!
 store <16 x i1> %31, <16 x i32>* %29, align 16, !dbg !12
<16 x i32>LLVM ERROR: Broken module found, compilation aborted!
```

We can work around this by assigning an integer instead.

Fixes #5430.
