### PR TITLE
LightFilterVisualiser : Fix Arnold light blockers

### DIFF
--- a/src/GafferArnoldUI/BarndoorVisualiser.cpp
+++ b/src/GafferArnoldUI/BarndoorVisualiser.cpp
@@ -180,6 +180,11 @@ BarndoorVisualiser::~BarndoorVisualiser()
 
 Visualisations BarndoorVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
+	if( !lightShaderNetwork )
+	{
+		return {};
+	}
+
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
 	const IECore::CompoundData *filterShaderParameters = shaderNetwork->outputShader()->parametersData();

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -215,6 +215,11 @@ GoboVisualiser::~GoboVisualiser()
 
 Visualisations GoboVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECoreScene::ShaderNetwork *lightShaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
+	if( !lightShaderNetwork )
+	{
+		return {};
+	}
+
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
 	const StringData *visualiserDrawingModeData = attributes->member<StringData>( "gl:light:drawingMode" );

--- a/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
+++ b/src/GafferScene/IECoreGLPreview/LightFilterVisualiser.cpp
@@ -138,11 +138,6 @@ Visualisations LightFilterVisualiser::allVisualisations( const IECore::CompoundO
 			lightShaderNetwork = attributes->member<IECoreScene::ShaderNetwork>( "light" );
 		}
 
-		if( !lightShaderNetwork )
-		{
-			continue;
-		}
-
 		// It's possible that we found a light filter defined in world space
 		// that isn't assigned to a light just yet. If we found a filter in
 		// light space it must have a valid light shader, though.


### PR DESCRIPTION
This fixes a regression in #5421 that prevented Arnold Light blockers from being visualized. I had originally tested to see if the `lightShaderNetwork` was present and skipped the visualizer if it wasn't. Arnold light blockers don't need a `lightShaderNetwork`, and I don't suppose would make sense for them to have one (?) so my skip criteria was too aggressive.

I think I'm happy with this solution as-is, but is it worth not returning an empty visualiser set from `visualise()` and throwing an exception or something else instead?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
