### PR TITLE
Dispatch App : Fix setting of dispatch plug from command line

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 - Viewer :
   - Fixed visualisation of Cycles point light size.
   - Fixed visualisation of Arnold light gobo textures with scaled UV coordinates.
+- Dispatch App : Fixed bug that prevented setting specific dispatcher plug values from the command line (#5434).
 
 1.2.10.1 (relative to 1.2.10.0)
 ========

--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -186,7 +186,10 @@ class dispatch( Gaffer.Application ) :
 			return 1
 
 		if args["gui"].value and len(args["alternateDispatchers"]) :
-			dispatchers.extend( GafferDispatch.Dispatcher.createMatching( " ".join( args["alternateDispatchers"] ) ) )
+			pattern = " ".join( args[ "alternateDispatchers" ] )
+			for name in GafferDispatch.Dispatcher.registeredDispatchers() :
+				if name != dispatcherType and IECore.StringAlgo.matchMultiple( name, pattern ) :
+					dispatchers.append( GafferDispatch.Dispatcher.create( name ) )
 
 		dispatcherNames = {}
 		for dispatcher in dispatchers :


### PR DESCRIPTION
The same dispatcher can be added to the `dispatchers` list multiple times, once from the `dispatcher` parameter, and again from the `alternateDispatchers` parameter.

That in turn resulted in the wrong dispatcher object being the one updated by the settings from the command line.

The fix here is to remove duplicate objects from the list, so there is only one dispatcher for a given name.

In our specific scenario, we were making the following sort of command line call:

`gaffer dispatch -gui -tasks GafferJabuka.Nodes.Executable.InputProfileDispatcher -show InputProfileDispatcher -dispatcher Farm -settings -FarmDispatcher.farm.taskType '"InputProfileDispatcher"'`

And the `-FarmDispatcher.farm.taskType` plug wasn't being set.

I considered a way not to add the same dispatcher twice, but couldn't find a nice way of doing that.

So instead I just remove the duplicates before processing the list further.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
