### PR TITLE
SetEditor : Add VisibleSet Inclusions and Exclusions columns

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
   - Shaders (including light shaders) are only loaded from the `osl` subdirectory of the 3Delight installation.
   - Primitive variables named `uv` are now automatically renamed `st` for compatibility with the `uvCoord` shader's expectation.
   - Added a default `uvCoord` shader during internal shader network preprocessing to shader parameters that do not have an input connection.
+- SetEditor : Added columns for controlling the Visible Set membership of set members. These allow the current members of a set to be included or excluded from the Visible Set by clicking within the Set Editor's Inclusions and Exclusions columns.
 
 Fixes
 -----


### PR DESCRIPTION
This adds two new columns to the Set Editor, allowing Visible Set inclusions and exclusions to be modified based on the current members of one or more sets.

I've tried to keep the interaction and visual language consistent with that used in the Hierarchy View's inclusion and exclusion columns. The same icons are reused here, as well as the concept of the icon representing an inclusion being drawn dimmed when that inclusion is overridden by an exclusion.

Compared to the Hierarchy View's columns, there's some additional complexity in the various states represented here as some or all of a set's members may be currently included, and some or all of those included members could be overridden by exclusions. Icons and tooltips represent the various states, and the count of each set's members currently added to inclusions and exclusions is displayed. I've tried to strike the balance of communicating the state of play while not overloading the user with too much information, but let me know what you think!

![setEditorInclusion](https://github.com/GafferHQ/gaffer/assets/50844517/cfa232d2-1a19-4822-b873-6a9e14823242)