### PR TITLE
GoboVisualiser : Fix display of scaled UV coordinates

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,9 @@ Fixes
 - Application : Fixed the `-threads` argument to clamp the number of threads to the number of available hardware cores (#5403).
 - CompareFloat, CompareColor, CompareVector : Worked around crashes in OSL's batched shading system (#5430).
 - GafferUI : Fixed TableView bug causing the horizontal scrollbar to potentially overlap the last row (#5328).
-- Viewer : Fixed visualisation of Cycles point light size.
+- Viewer :
+  - Fixed visualisation of Cycles point light size.
+  - Fixed visualisation of Arnold light gobo textures with scaled UV coordinates.
 
 1.2.10.1 (relative to 1.2.10.0)
 ========

--- a/src/GafferArnoldUI/GoboVisualiser.cpp
+++ b/src/GafferArnoldUI/GoboVisualiser.cpp
@@ -306,8 +306,8 @@ Visualisations GoboVisualiser::visualise( const IECore::InternedString &attribut
 	const float baseDistance = cos( halfAngle );
 
 	float rotate = parameterOrDefault( filterParameters, "rotate", 0.0f );
-	float scaleS = parameterOrDefault( filterParameters, "scale_s", 1.0f );
-	float scaleT = parameterOrDefault( filterParameters, "scale_t", 1.0f );
+	float scaleS = parameterOrDefault( filterParameters, "sscale", 1.0f );
+	float scaleT = parameterOrDefault( filterParameters, "tscale", 1.0f );
 	V2f offset = parameterOrDefault( filterParameters, "offset", V2f( 0.0f ) );
 
 	Imath::M44f goboTrans;


### PR DESCRIPTION
`scale_s` and `scale_t` were renamed to `sscale` and `tscale` in Arnold 5, so we should have no worries about compatibility.