### PR TITLE
SceneViewInspector : Support Arnold light filters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - Viewer :
   - Added visualisation of light filters for USD lights.
   - Added support for USD lights and shaders in the floating inspector panel.
+  - Added support for Arnold barndoor, gobo, and light_decay light filters in the floating inspector panel.
 - ShaderTweaks/ShaderQuery : Added presets for USD light and surface shaders.
 
 Fixes

--- a/startup/GafferSceneUI/sceneViewInspector.py
+++ b/startup/GafferSceneUI/sceneViewInspector.py
@@ -45,6 +45,18 @@ for p in [ "exposure", "color", "width", "height", "radius", "roundness", "sprea
 for p in ["geometry_type", "density", "filtered_lights", "shader" ] :
 	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ai:lightFilter:filter", p )
 
+for p in [
+	"barndoor_top_left", "barndoor_top_right", "barndoor_top_edge", "barndoor_right_top", "barndoor_right_bottom", "barndoor_right_edge",
+	"barndoor_bottom_left", "barndoor_bottom_right", "barndoor_bottom_edge", "barndoor_left_top", "barndoor_left_bottom", "barndoor_left_edge"
+] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ai:lightFilter:barndoor", p )
+
+for p in [ "filter_mode", "density", "rotate", "offset" ] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ai:lightFilter:gobo", p )
+
+for p in [ "use_near_atten", "near_start", "near_end", "use_far_atten", "far_start", "far_end" ] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ai:lightFilter:light_decay", p )
+
 for p in ["base", "base_color", "diffuse_roughness", "metallness", "specular", "specular_color", "specular_roughness" ] :
 	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ai:surface", p )
 


### PR DESCRIPTION
We currently support inspecting and editing Arnold lights and the standalone light filter in the Scene View Inspector, but were missing registration of the other light filters. 

The wall of parameters presented for the barndoor is a bit unfortunate, but they're all necessary for shaping. Short of having dedicated manipulators for the various filters, this may go some small way to improve the interactive editing of lights with filters...