### PR TITLE
Docs : Add missing build targets

### DIFF
--- a/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/screengrab.py
+++ b/doc/source/GettingStarted/TutorialAssemblingTheGafferBot/screengrab.py
@@ -1,5 +1,6 @@
 # BuildTarget: images/mainDefaultLayout.png
 # BuildTarget: images/mainSceneReaderNode.png
+# BuildTarget: images/mainSceneReaderNodeFocussed.png
 # BuildTarget: images/sceneReaderBound.png
 # BuildTarget: images/viewerSceneReaderBounding.png
 # BuildTarget: images/hierarchyViewExpandedTwoLevels.png

--- a/doc/source/WorkingWithScenes/LightLinking/screengrab.py
+++ b/doc/source/WorkingWithScenes/LightLinking/screengrab.py
@@ -2,6 +2,7 @@
 # BuildTarget: images/interfaceLightLinkSetupGraphEditor.png
 # BuildTarget: images/interfaceLightSetGraphEditor.png
 # BuildTarget: images/interfaceLightSetNodeEditor.png
+# BuildTarget: images/interfaceLinkedLightsAttribute.png
 # BuildTarget: images/interfaceLinkedLightsPlug.png
 # BuildTarget: images/taskLightLinkingSetExpressionLocation.png
 # BuildTarget: images/taskLightLinkingSetExpressionSet.png

--- a/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/screengrab.py
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialSettingUpASpreadsheet/screengrab.py
@@ -1,6 +1,7 @@
 # BuildTarget: images/tutorialSettingUpASpreadsheetCleanColumn.png
 # BuildTarget: images/tutorialSettingUpASpreadsheetCyclesOptionsNode.png
 # BuildTarget: images/tutorialSettingUpASpreadsheetDefaultCell.png
+# BuildTarget: images/tutorialSettingUpASpreadsheetExtraColumns.png
 # BuildTarget: images/tutorialSettingUpASpreadsheetFullName.png
 # BuildTarget: images/tutorialSettingUpASpreadsheetGlobalContextVariables.png
 # BuildTarget: images/tutorialSettingUpASpreadsheetNewSpreadsheet.png


### PR DESCRIPTION
Clean up of a few missing docs image build targets. These are a minor annoyance when running docs builds independently of a regular build.