### PR TITLE
_TableView : Account for horizontalScrollBar in sizeHint

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - Arnold : Fixed screen window export for Lentil cameras.
 - Application : Fixed the `-threads` argument to clamp the number of threads to the number of available hardware cores (#5403).
 - CompareFloat, CompareColor, CompareVector : Worked around crashes in OSL's batched shading system (#5430).
+- GafferUI : Fixed TableView bug causing the horizontal scrollbar to potentially overlap the last row (#5328).
 
 1.2.10.1 (relative to 1.2.10.0)
 ========

--- a/python/GafferUI/_TableView.py
+++ b/python/GafferUI/_TableView.py
@@ -92,6 +92,10 @@ class _TableView( QtWidgets.QTableView ) :
 
 		if not self.horizontalHeader().isHidden() :
 			minimumHeight += self.horizontalHeader().sizeHint().height()
+		# allow room for a visible horizontal scrollbar to prevent it overlapping
+		# the last row.
+		if self.horizontalScrollBarPolicy() != QtCore.Qt.ScrollBarAlwaysOff and not self.horizontalScrollBar().isHidden() :
+			minimumHeight += self.horizontalScrollBar().sizeHint().height()
 
 		numRows = self.verticalHeader().count()
 		if numRows :
@@ -124,6 +128,10 @@ class _TableView( QtWidgets.QTableView ) :
 		h = self.verticalHeader().length() + margins.top() + margins.bottom()
 		if not self.horizontalHeader().isHidden() :
 			h += self.horizontalHeader().sizeHint().height()
+		# allow room for a visible horizontal scrollbar to prevent it overlapping
+		# the last row.
+		if self.horizontalScrollBarPolicy() != QtCore.Qt.ScrollBarAlwaysOff and not self.horizontalScrollBar().isHidden() :
+			h += self.horizontalScrollBar().sizeHint().height()
 
 		return QtCore.QSize( w, h )
 


### PR DESCRIPTION
Quick one for end of day. This appears to address the issue mentioned in #5328 by including the horizontal scroll bar height in the _TableView sizeHints when visible. Otherwise the scroll bar can be drawn on top of the last row as there is no other available space for it to occupy. 

Fixes #5328