### PR TITLE
Dispatcher : Remove `createMatching()` static method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.x.x.x (relative to 1.3.x.x)
 =======
 
+Breaking Changes
+----------------
+
+- Dispatcher : Removed `createMatching()` method.
 
 1.3.x.x (relative to 1.3.1.0)
 =======

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -194,8 +194,6 @@ class GAFFERDISPATCH_API Dispatcher : public Gaffer::Node
 		//@{
 		/// Create a registered Dispatcher of the specified type.
 		static DispatcherPtr create( const std::string &dispatcherType );
-		/// Create any dispatchers if the type matches the pattern.
-		static std::vector<DispatcherPtr> createMatching( const IECore::StringAlgo::MatchPattern &pattern );
 		static const std::string &getDefaultDispatcherType();
 		static void setDefaultDispatcherType( const std::string &dispatcherType );
 		/// Register a Dispatcher creation function.

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -1562,39 +1562,6 @@ class DispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( [ l.context.getFrame() for l in log ], [ 1, 2, 3, 1 ] * 2 )
 		self.assertEqual( [ l.context["wedge:value"] for l in log ], [ "X", "X", "X", "X", "Y", "Y", "Y", "Y" ] )
 
-	def testCreateMatching( self ) :
-
-		self.assertEqual( GafferDispatch.Dispatcher.registeredDispatchers(), tuple([ "Debug", "Local", "testDispatcher" ]) )
-
-		# match all
-		dispatchers = GafferDispatch.Dispatcher.createMatching( "*" )
-		self.assertEqual( len(dispatchers), 3 )
-		self.assertTrue( isinstance( dispatchers[0], GafferDispatchTest.DebugDispatcher ) )
-		self.assertTrue( isinstance( dispatchers[1], GafferDispatch.LocalDispatcher ) )
-		self.assertTrue( isinstance( dispatchers[2], DispatcherTest.TestDispatcher ) )
-
-		# match specific
-		dispatchers = GafferDispatch.Dispatcher.createMatching( "Local" )
-		self.assertEqual( len(dispatchers), 1 )
-		self.assertTrue( isinstance( dispatchers[0], GafferDispatch.LocalDispatcher ) )
-
-		# match specific with wildcards
-		dispatchers = GafferDispatch.Dispatcher.createMatching( "test*" )
-		self.assertEqual( len(dispatchers), 1 )
-		self.assertTrue( isinstance( dispatchers[0], DispatcherTest.TestDispatcher ) )
-
-		# match several by wildcard
-		dispatchers = GafferDispatch.Dispatcher.createMatching( "*e*" )
-		self.assertEqual( len(dispatchers), 2 )
-		self.assertTrue( isinstance( dispatchers[0], GafferDispatchTest.DebugDispatcher ) )
-		self.assertTrue( isinstance( dispatchers[1], DispatcherTest.TestDispatcher ) )
-
-		# match seveal exactly
-		dispatchers = GafferDispatch.Dispatcher.createMatching( "Debug Local" )
-		self.assertEqual( len(dispatchers), 2 )
-		self.assertTrue( isinstance( dispatchers[0], GafferDispatchTest.DebugDispatcher ) )
-		self.assertTrue( isinstance( dispatchers[1], GafferDispatch.LocalDispatcher ) )
-
 	def testBatchContextsAreIdentical( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -902,22 +902,6 @@ DispatcherPtr Dispatcher::create( const std::string &dispatcherType )
 	return it->second.first();
 }
 
-std::vector<DispatcherPtr> Dispatcher::createMatching( const IECore::StringAlgo::MatchPattern &pattern )
-{
-	std::vector<DispatcherPtr> dispatchers;
-
-	const CreatorMap &m = creators();
-	for( const auto &it : m )
-	{
-		if( IECore::StringAlgo::matchMultiple( it.first, pattern ) )
-		{
-			dispatchers.push_back( it.second.first() );
-		}
-	}
-
-	return dispatchers;
-}
-
 const std::string &Dispatcher::getDefaultDispatcherType()
 {
 	return g_defaultDispatcherType;

--- a/src/GafferDispatchModule/DispatcherBinding.cpp
+++ b/src/GafferDispatchModule/DispatcherBinding.cpp
@@ -270,17 +270,6 @@ tuple registeredDispatchersWrapper()
 	return boost::python::tuple( result );
 }
 
-list createMatching( std::string pattern )
-{
-	std::vector<DispatcherPtr> dispatchers = Dispatcher::createMatching( pattern );
-	list result;
-	for( auto &d : dispatchers )
-	{
-		result.append( d );
-	}
-	return result;
-}
-
 struct PreDispatchSlotCaller
 {
 	bool operator()( boost::python::object slot, const Dispatcher *d, const std::vector<TaskNodePtr> &nodes )
@@ -354,7 +343,6 @@ void GafferDispatchModule::bindDispatcher()
 		.def( "jobDirectory", &Dispatcher::jobDirectory )
 		.def( "frameRange", &frameRange )
 		.def( "create", &Dispatcher::create ).staticmethod( "create" )
-		.def( "createMatching", &createMatching, ( arg( "matchPattern" ) ) ).staticmethod( "createMatching" )
 		.def( "getDefaultDispatcherType", &Dispatcher::getDefaultDispatcherType, return_value_policy<copy_const_reference>() ).staticmethod( "getDefaultDispatcherType" )
 		.def( "setDefaultDispatcherType", &Dispatcher::setDefaultDispatcherType ).staticmethod( "setDefaultDispatcherType" )
 		.def( "registerDispatcher", &registerDispatcher, ( arg( "dispatcherType" ), arg( "creator" ), arg( "setupPlugsFn" ) = 0 ) ).staticmethod( "registerDispatcher" )


### PR DESCRIPTION
This was a premature addition to the API - to our knowledge it only ever had one use case, and this eventually turned out to be poorly served by it anyway - see #5434. It's better to conform to the more minimal registry API used by other classes, and then let people compose their own logic on top.
