### PR TITLE
LightToCamera : Support USD spot lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,11 +13,13 @@ Improvements
 - Viewer :
   - Added visualisation of light filters for USD lights.
   - Added support for USD lights and shaders in the floating inspector panel.
+  - Improved support for looking through USD spot lights.
 - ShaderTweaks/ShaderQuery : Added presets for USD light and surface shaders.
 - Test app :
   - The `-category` argument now accepts a space-separated list of categories, optionally containing wildcards.
   - Added `-excludedCategories` and `-showCategories` arguments.
   - Added information about performance test timings to the output stream.
+- LightToCamera : Added support for USD spot lights.
 
 Fixes
 -----

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -134,6 +134,12 @@ const char *lightType( const IECore::CompoundData *shaderParameters, const std::
 		return "";
 	}
 
+	if( boost::starts_with( metadataTarget, "light:" ) && shaderParameters->member<FloatData>( "shaping:cone:angle" ) )
+	{
+		// USD lights with a cone angle defined are treated as spot lights
+		return "spot";
+	}
+
 	return type->readable().c_str();
 }
 
@@ -148,6 +154,14 @@ float lightOuterAngle( const IECore::CompoundData *shaderParameters, const std::
 		{
 			coneAngle *= 180.0 / M_PI;
 			penumbraAngle *= 180 / M_PI;
+		}
+	}
+
+	if( ConstStringDataPtr coneAngleType = Metadata::value<StringData>( metadataTarget, "coneAngleType" ) )
+	{
+		if( coneAngleType->readable() == "half" )
+		{
+			coneAngle *= 2.0f;
 		}
 	}
 


### PR DESCRIPTION
This adds support for USD spot lights to LightToCamera, identifying them based on the presence of a `shaping:cone:angle` parameter and adding support for `coneAngleType` metadata.