### PR TITLE
Fix compilation with Apple Clang 13

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ API
 - ThreadState : Added `process()` method.
 - Process : Added const overload for `handleException()` method. The non-const version will be removed in future.
 
+Build
+-----
+
+- MacOS : Fixed compilation with Clang 13.
+
 1.3.2.0 (relative to 1.3.1.0)
 =======
 

--- a/include/Gaffer/Collect.h
+++ b/include/Gaffer/Collect.h
@@ -42,6 +42,8 @@
 #include "Gaffer/TypedObjectPlug.h"
 #include "Gaffer/TypeIds.h"
 
+#include <unordered_map>
+
 namespace Gaffer
 {
 

--- a/src/Gaffer/Collect.cpp
+++ b/src/Gaffer/Collect.cpp
@@ -566,7 +566,7 @@ void Collect::compute( ValuePlug *output, const Context *context) const
 					{
 						dispatchPlugFunction(
 							input,
-							[&] ( auto *plug ) {
+							[&, object=object] ( auto *plug ) {
 								using OutputTraits = OutputTraits<remove_const_t<remove_pointer_t<decltype( plug )>>>;
 								auto typedObject = static_cast<typename OutputTraits::ObjectType *>( object );
 								OutputTraits::container( *typedObject )[index] = OutputTraits::collect( plug );

--- a/src/GafferImage/FilterAlgo.cpp
+++ b/src/GafferImage/FilterAlgo.cpp
@@ -416,7 +416,7 @@ float GafferImage::FilterAlgo::sampleBox( Sampler &sampler, const V2f &p, float 
 			float yFilterWeight = filter->yfilt( ( y + 0.5f - p.y ) * yscale );
 			sampler.visitPixels(
 				visitBounds,
-				[ &totalW, &v, &p, &pixelBounds, &scratchMemory, &yFilterWeight ] ( float value, int x, int y )
+				[ &totalW, &v, &pixelBounds, &scratchMemory, &yFilterWeight ] ( float value, int x, int y )
 				{
 					float w = scratchMemory[ x - pixelBounds.min.x ] * yFilterWeight;
 


### PR DESCRIPTION
- Add missing include
- Remove unused lambda capture in FilterAlgo
- Capture `object` explicitly by value in Collect, because we're not allowed to capture structured bindings directly.

