### PR TITLE
SceneAlgo : Add `findAll()` method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 API
 ---
 
+- SceneAlgo : Added `findAll()` method, for finding all scene locations matching a predicate.
 - ThreadState : Added `process()` method.
 - Process : Added const overload for `handleException()` method. The non-const version will be removed in future.
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 API
 ---
 
-- SceneAlgo : Added `findAll()` method, for finding all scene locations matching a predicate.
+- SceneAlgo :
+  - Added `findAll()` method, for finding all scene locations matching a predicate.
+  - Added `findAllWithAttribute()` method, for finding all scene locations with a particular attribute.
 - ThreadState : Added `process()` method.
 - Process : Added const overload for `handleException()` method. The non-const version will be removed in future.
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -154,6 +154,10 @@ void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher
 template<typename Predicate>
 IECore::PathMatcher findAll( const ScenePlug *scene, Predicate &&predicate, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
+/// Returns all the locations which have a local attribute called `name`. If `value` is specified, then only
+/// returns locations where the attribute has that value.
+GAFFERSCENE_API IECore::PathMatcher findAllWithAttribute( const ScenePlug *scene, IECore::InternedString name, const IECore::Object *value = nullptr, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
+
 /// Globals
 /// =======
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -144,6 +144,16 @@ void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterP
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
+/// Searching
+/// =========
+
+/// Returns all the locations for which `predicate( scene, path )` returns `true`.
+///
+/// > Caution : The search is performed in parallel, so `predicate` must be safe to call
+///   concurrently from multiple threads.
+template<typename Predicate>
+IECore::PathMatcher findAll( const ScenePlug *scene, Predicate &&predicate, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
+
 /// Globals
 /// =======
 

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -1829,6 +1829,40 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 				with self.assertRaises( RuntimeError ) :
 					GafferScene.SceneAlgo.validateName( badName )
 
+	def testFindAll( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		sphere = GafferScene.Sphere()
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( plane["out"] )
+		instancer["prototypes"].setInput( sphere["out"] )
+		instancer["filter"].setInput( planeFilter["out"] )
+
+		self.assertEqual(
+			GafferScene.SceneAlgo.findAll(
+				instancer["out"],
+				lambda scene, path : scene["transform"].getValue().translation().x > 0
+			),
+			IECore.PathMatcher( [
+				"/plane/instances/sphere/1",
+				"/plane/instances/sphere/3",
+			] )
+		)
+
+		self.assertEqual(
+			GafferScene.SceneAlgo.findAll(
+				instancer["out"],
+				lambda scene, path : scene["transform"].getValue().translation().x > 0,
+				root = "/not/a/location"
+			),
+			IECore.PathMatcher()
+		)
+
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/src/GafferScene/DeleteObject.cpp
+++ b/src/GafferScene/DeleteObject.cpp
@@ -45,7 +45,7 @@ using namespace IECore;
 using namespace Gaffer;
 using namespace GafferScene;
 
-GAFFER_NODE_DEFINE_TYPE( DeleteObject );
+GAFFER_NODE_DEFINE_TYPE( GafferScene::DeleteObject );
 
 size_t DeleteObject::g_firstPlugIndex = 0;
 

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -239,6 +239,26 @@ IECore::MurmurHash GafferScene::SceneAlgo::matchingPathsHash( const PathMatcher 
 }
 
 //////////////////////////////////////////////////////////////////////////
+// Searching
+//////////////////////////////////////////////////////////////////////////
+
+IECore::PathMatcher GafferScene::SceneAlgo::findAllWithAttribute( const ScenePlug *scene, IECore::InternedString name, const IECore::Object *value, const ScenePlug::ScenePath &root )
+{
+	return findAll(
+		scene,
+		[&] ( const ScenePlug *scene, const ScenePlug::ScenePath &path ) {
+			ConstCompoundObjectPtr attributes = scene->attributesPlug()->getValue();
+			if( const Object *attribute = attributes->member<Object>( name ) )
+			{
+				return !value || attribute->isEqualTo( value );
+			}
+			return false;
+		},
+		root
+	);
+}
+
+//////////////////////////////////////////////////////////////////////////
 // Globals
 //////////////////////////////////////////////////////////////////////////
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -142,6 +142,12 @@ IECore::PathMatcher findAllWrapper( const ScenePlug &scene, object predicate, co
 	);
 }
 
+IECore::PathMatcher findAllWithAttributeWrapper( const ScenePlug &scene, InternedString name, const Object *value, const ScenePlug::ScenePath &root )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return SceneAlgo::findAllWithAttribute( &scene, name, value, root );
+}
+
 Imath::V2f shutterWrapper( const IECore::CompoundObject &globals, const ScenePlug &scene )
 {
 	IECorePython::ScopedGILRelease r;
@@ -335,6 +341,7 @@ void bindSceneAlgo()
 	def( "matchingPathsHash", &matchingPathsHashWrapper2, ( arg( "filter" ), arg( "scene" ) ) );
 
 	def( "findAll", &findAllWrapper, ( arg( "scene" ), arg( "predicate" ), arg( "root" ) = "/" ) );
+	def( "findAllWithAttribute", &findAllWithAttributeWrapper, ( arg( "scene" ), arg( "name" ), arg( "value" ) = object(), arg( "root" ) = "/" ) );
 
 	def( "shutter", &shutterWrapper );
 	def( "setExists", &setExistsWrapper );

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -128,6 +128,20 @@ IECore::MurmurHash matchingPathsHashWrapper2( const IECore::PathMatcher &filter,
 	return SceneAlgo::matchingPathsHash( filter, &scene );
 }
 
+IECore::PathMatcher findAllWrapper( const ScenePlug &scene, object predicate, const ScenePlug::ScenePath &root )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return SceneAlgo::findAll(
+		&scene,
+		[&] ( ConstScenePlugPtr scene, const ScenePlug::ScenePath &path ) {
+			const std::string pathString = ScenePlug::pathToString( path );
+			IECorePython::ScopedGILLock gilLock;
+			return predicate( boost::const_pointer_cast<ScenePlug>( scene ), pathString );
+		},
+		root
+	);
+}
+
 Imath::V2f shutterWrapper( const IECore::CompoundObject &globals, const ScenePlug &scene )
 {
 	IECorePython::ScopedGILRelease r;
@@ -319,6 +333,9 @@ void bindSceneAlgo()
 	def( "matchingPaths", &matchingPathsWrapper4 );
 	def( "matchingPathsHash", &matchingPathsHashWrapper1, ( arg( "filter" ), arg( "scene" ), arg( "root" ) = "/" ) );
 	def( "matchingPathsHash", &matchingPathsHashWrapper2, ( arg( "filter" ), arg( "scene" ) ) );
+
+	def( "findAll", &findAllWrapper, ( arg( "scene" ), arg( "predicate" ), arg( "root" ) = "/" ) );
+
 	def( "shutter", &shutterWrapper );
 	def( "setExists", &setExistsWrapper );
 	def(


### PR DESCRIPTION
This does a parallel traversal of the scene, returning a PathMatcher containing all paths for which a predicate returns `true`.