### PR TITLE
Instancer Capsule

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,17 @@
 1.3.x.x (relative to 1.3.6.1)
 =======
 
+Improvements
+------------
 
+- Instancer :
+  - Improved scene generation for encapsulated instancers significantly, with some production scenes now generating 5-7x faster.
+  - Added `omitDuplicateIds` plug, to determine whether points with duplicate IDs are ignored or should trigger an error.
+
+API
+---
+
+- Capsule : Added protected `renderOptions()` and `throwIfNoScene()` methods.
 
 1.3.6.1 (relative to 1.3.6.0)
 =======

--- a/include/GafferScene/Capsule.h
+++ b/include/GafferScene/Capsule.h
@@ -98,6 +98,10 @@ class GAFFERSCENE_API Capsule : public IECoreScenePreview::Procedural
 
 	protected :
 
+		// Returns the current render options - this will be the override if setRenderOptions has been called,
+		// otherwise it will construct render options based on the `scene()`.
+		GafferScene::Private::RendererAlgo::RenderOptions renderOptions() const;
+
 		void throwIfNoScene() const;
 
 	private :

--- a/include/GafferScene/Capsule.h
+++ b/include/GafferScene/Capsule.h
@@ -96,9 +96,11 @@ class GAFFERSCENE_API Capsule : public IECoreScenePreview::Procedural
 		void setRenderOptions( const GafferScene::Private::RendererAlgo::RenderOptions &renderOptions );
 		std::optional<GafferScene::Private::RendererAlgo::RenderOptions> getRenderOptions() const;
 
-	private :
+	protected :
 
 		void throwIfNoScene() const;
+
+	private :
 
 		IECore::MurmurHash m_hash;
 		Imath::Box3f m_bound;

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -117,6 +117,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *idPlug();
 		const Gaffer::StringPlug *idPlug() const;
 
+		Gaffer::BoolPlug *omitDuplicateIdsPlug();
+		const Gaffer::BoolPlug *omitDuplicateIdsPlug() const;
+
 		Gaffer::StringPlug *positionPlug();
 		const Gaffer::StringPlug *positionPlug() const;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -39,6 +39,15 @@
 
 #include "GafferScene/Export.h"
 #include "GafferScene/BranchCreator.h"
+#include "GafferScene/Capsule.h"
+
+namespace GafferSceneModule
+{
+
+// Forward declaration to enable friend declaration.
+void bindHierarchy();
+
+} // namespace GafferSceneModule
 
 namespace GafferScene
 {
@@ -214,6 +223,7 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 	private :
 
 		IE_CORE_FORWARDDECLARE( EngineData );
+		IE_CORE_FORWARDDECLARE( InstancerCapsule );
 
 		Gaffer::ObjectPlug *enginePlug();
 		const Gaffer::ObjectPlug *enginePlug() const;
@@ -243,6 +253,10 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		};
 
 		static size_t g_firstPlugIndex;
+
+		// For bindings
+		friend void GafferSceneModule::bindHierarchy();
+		static const std::type_info &instancerCapsuleTypeInfo();
 
 };
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -215,9 +215,6 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::ObjectPlug *enginePlug();
 		const Gaffer::ObjectPlug *enginePlug() const;
 
-		Gaffer::AtomicCompoundDataPlug *prototypeChildNamesPlug();
-		const Gaffer::AtomicCompoundDataPlug *prototypeChildNamesPlug() const;
-
 		GafferScene::ScenePlug *capsuleScenePlug();
 		const GafferScene::ScenePlug *capsuleScenePlug() const;
 
@@ -229,9 +226,6 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
-
-		IECore::ConstCompoundDataPtr prototypeChildNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
-		void prototypeChildNamesHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -177,6 +177,7 @@ enum TypeId
 	FramingConstraintTypeId = 110633,
 	MeshNormalsTypeId = 110634,
 	ImageScatterTypeId = 110635,
+	InstancerCapsuleTypeId = 110636,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -226,7 +226,9 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 
 			for subName, subObject in procExpanded.items():
 
-				if subName.startswith( "/" ):
+				if subName == "" or subName == "/":
+					newName = objectName
+				elif subName.startswith( "/" ):
 					newName = objectName + subName
 				else:
 					newName = objectName + "/" + subName

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -2417,21 +2417,25 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 				)
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
+	@GafferTest.TestRunner.CategorisedTestMethod( { "expensivePerformance" } )
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContextSetPerfNoVariationsSingleEvaluate( self ):
 		self.runTestContextSetPerf( False, False )
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
+	@GafferTest.TestRunner.CategorisedTestMethod( { "expensivePerformance" } )
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContextSetPerfNoVariationsParallelEvaluate( self ):
 		self.runTestContextSetPerf( False, True )
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
+	@GafferTest.TestRunner.CategorisedTestMethod( { "expensivePerformance" } )
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContextSetPerfWithVariationsSingleEvaluate( self ):
 		self.runTestContextSetPerf( True, False )
 
 	@unittest.skipIf( GafferTest.inCI(), "Performance not relevant on CI platform" )
+	@GafferTest.TestRunner.CategorisedTestMethod( { "expensivePerformance" } )
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testContextSetPerfWithVariationsParallelEvaluate( self ):
 		self.runTestContextSetPerf( True, True )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1963,11 +1963,11 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		instancer["contextVariables"][1]["quantize"].setValue( 10 )
 		self.assertRaisesRegex(
-			Gaffer.ProcessException, 'Instancer.out.attributes : Context variable "0" : cannot quantize variable of type StringVectorData',
+			Gaffer.ProcessException, 'Instancer.out.attributes : Context variable "stringVar" : cannot quantize variable of type StringVectorData',
 			instancer['out'].attributes, "points/instances/withAttrs/0/sphere"
 		)
 		self.assertRaisesRegex(
-			Gaffer.ProcessException, 'Instancer.variations : Context variable "0" : cannot quantize variable of type StringVectorData',
+			Gaffer.ProcessException, 'Instancer.variations : Context variable "stringVar" : cannot quantize variable of type StringVectorData',
 			uniqueCounts
 		)
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -2073,9 +2073,6 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 
 		# Test with multiple point sources
-		pointsMerge = GafferScene.Parent()
-		pointsMerge["parent"].setValue( '/' )
-
 		pointSources = []
 
 		for j in range( 3 ):

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1736,10 +1736,10 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 	def testContexts( self ):
 
 		points = IECoreScene.PointsPrimitive(
-					IECore.V3fVectorData(
-						[ imath.V3f( i, 0, 0 ) for i in range( 100 ) ]
-					)
-				)
+			IECore.V3fVectorData(
+				[ imath.V3f( i, 0, 0 ) for i in range( 100 ) ]
+			)
+		)
 
 		points["floatVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData(
 						[ 2 * math.sin( i ) for i in range( 100 ) ]
@@ -2115,14 +2115,17 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 
 		for j in range( 3 ):
 			points = IECoreScene.PointsPrimitive(
-						IECore.V3fVectorData(
-							[ imath.V3f( i, 0, 0 ) for i in range( 10 ) ]
-						)
-					)
+				IECore.V3fVectorData(
+					[ imath.V3f( i, 0, 0 ) for i in range( 10 ) ]
+				)
+			)
 
-			points["floatVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData(
-							[ i * 0.1 + j for i in range( 10 ) ]
-						) )
+			points["floatVar"] = IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.FloatVectorData(
+					[ i * 0.1 + j for i in range( 10 ) ]
+				)
+			)
 			pointSources.append( GafferScene.ObjectToScene() )
 			pointSources[-1]["name"].setValue( "points" )
 			pointSources[-1]["object"].setValue( points )

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -413,12 +413,12 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 		# which should have the same effect, but is a separate code path.
 
 		rendererA = GafferScene.Private.IECoreScenePreview.CapturingRenderer( GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch )
-		controllerA = GafferScene.RenderController( plugA, Gaffer.Context(), rendererA )
+		controllerA = GafferScene.RenderController( plugA, Gaffer.Context.current(), rendererA )
 		controllerA.setMinimumExpansionDepth( 1024 )
 		controllerA.update()
 
 		rendererB = GafferScene.Private.IECoreScenePreview.CapturingRenderer( GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch )
-		controllerB = GafferScene.RenderController( plugB, Gaffer.Context(), rendererB )
+		controllerB = GafferScene.RenderController( plugB, Gaffer.Context.current(), rendererB )
 		controllerB.setMinimumExpansionDepth( 1024 )
 		controllerB.update()
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -286,50 +286,50 @@ Gaffer.Metadata.registerNode(
 
 	"layout:customWidget:seedColumnHeadings:widgetType", "GafferSceneUI.InstancerUI._SeedColumnHeadings",
 	"layout:customWidget:seedColumnHeadings:section", "Context Variations",
-	"layout:customWidget:seedColumnHeadings:index", 18,
+	"layout:customWidget:seedColumnHeadings:index", 19,
 
 	"layout:customWidget:idContextCountSpacer:widgetType", "GafferSceneUI.InstancerUI._SeedCountSpacer",
 	"layout:customWidget:idContextCountSpacer:section", "Context Variations",
-	"layout:customWidget:idContextCountSpacer:index", 19,
+	"layout:customWidget:idContextCountSpacer:index", 20,
 	"layout:customWidget:idContextCountSpacer:accessory", True,
 
 	"layout:customWidget:idContextCount:widgetType", "GafferSceneUI.InstancerUI._SeedCountWidget",
 	"layout:customWidget:idContextCount:section", "Context Variations",
-	"layout:customWidget:idContextCount:index", 19,
+	"layout:customWidget:idContextCount:index", 20,
 	"layout:customWidget:idContextCount:accessory", True,
 
 	"layout:customWidget:seedVariableSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedVariableSpacer:section", "Context Variations",
-	"layout:customWidget:seedVariableSpacer:index", 20,
+	"layout:customWidget:seedVariableSpacer:index", 21,
 	"layout:customWidget:seedVariableSpacer:accessory", True,
 
 	"layout:customWidget:seedsSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedsSpacer:section", "Context Variations",
-	"layout:customWidget:seedsSpacer:index", 21,
+	"layout:customWidget:seedsSpacer:index", 22,
 	"layout:customWidget:seedsSpacer:accessory", True,
 
 	"layout:customWidget:seedPermutationSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedPermutationSpacer:section", "Context Variations",
-	"layout:customWidget:seedPermutationSpacer:index", 22,
+	"layout:customWidget:seedPermutationSpacer:index", 23,
 	"layout:customWidget:seedPermutationSpacer:accessory", True,
 
 	"layout:customWidget:seedSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:seedSpacer:section", "Context Variations",
-	"layout:customWidget:seedSpacer:index", 23,
+	"layout:customWidget:seedSpacer:index", 24,
 
 	"layout:customWidget:timeOffsetHeadings:widgetType", "GafferSceneUI.InstancerUI._TimeOffsetColumnHeadings",
 	"layout:customWidget:timeOffsetHeadings:section", "Context Variations",
-	"layout:customWidget:timeOffsetHeadings:index", 24,
+	"layout:customWidget:timeOffsetHeadings:index", 25,
 	"layout:customWidget:timeOffsetHeadings:description", "Testing description",
 
 	"layout:customWidget:timeOffsetSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:timeOffsetSpacer:section", "Context Variations",
-	"layout:customWidget:timeOffsetSpacer:index", 25,
+	"layout:customWidget:timeOffsetSpacer:index", 26,
 	"layout:customWidget:timeOffsetSpacer:divider", True,
 
 	"layout:customWidget:totalSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:totalSpacer:section", "Context Variations",
-	"layout:customWidget:totalSpacer:index", 26,
+	"layout:customWidget:totalSpacer:index", 27,
 
 	plugs = {
 
@@ -480,6 +480,21 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:section", "Settings.General",
+
+		],
+
+		"omitDuplicateIds" : [
+
+			"description",
+			"""
+			When off, having the same ids on multiple points is considered
+			an error. Setting on will allow a render to proceed, with all
+			instances that share an id being omitted.
+			""",
+
+			"layout:section", "Settings.General",
+
+			"userDefault", False,
 
 		],
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -604,6 +604,15 @@ def _leafTypes( typeId ) :
 		typeId = IECore.RunTimeTyped.typeIdFromTypeName( typeId )
 
 	derivedTypes = IECore.RunTimeTyped.derivedTypeIds( typeId )
+
+	# By "leaf" we really mean "derived enough to appear in the Selection Mask
+	# menu". So we must pretend that the private InstancerCapsule subclass of
+	# Capsule doesn't exist.
+	## \todo No doubt this could be expressed more naturally somehow, perhaps
+	# just with a set union of `derivedTypes` and `typesWeUseInTheMenu`.
+	instancerCapsuleTypeId = IECore.RunTimeTyped.typeIdFromTypeName( "InstancerCapsule" )
+	derivedTypes = [ t for t in derivedTypes if t != instancerCapsuleTypeId ]
+
 	if derivedTypes :
 		return set().union( *[ _leafTypes( t ) for t in derivedTypes ] )
 	else :

--- a/src/GafferScene/Capsule.cpp
+++ b/src/GafferScene/Capsule.cpp
@@ -172,13 +172,9 @@ void Capsule::render( IECoreScenePreview::Renderer *renderer ) const
 {
 	throwIfNoScene();
 	ScenePlug::GlobalScope scope( m_context.get() );
-	std::optional<GafferScene::Private::RendererAlgo::RenderOptions> renderOptions = getRenderOptions();
-	if( !renderOptions )
-	{
-		renderOptions = GafferScene::Private::RendererAlgo::RenderOptions( m_scene );
-	}
+	const GafferScene::Private::RendererAlgo::RenderOptions renderOpts = renderOptions();
 	GafferScene::Private::RendererAlgo::RenderSets renderSets( m_scene );
-	GafferScene::Private::RendererAlgo::outputObjects( m_scene, *renderOptions, renderSets, /* lightLinks = */ nullptr, renderer, m_root );
+	GafferScene::Private::RendererAlgo::outputObjects( m_scene, renderOpts, renderSets, /* lightLinks = */ nullptr, renderer, m_root );
 }
 
 const ScenePlug *Capsule::scene() const
@@ -217,6 +213,19 @@ std::optional<GafferScene::Private::RendererAlgo::RenderOptions> Capsule::getRen
 		return it->second;
 	}
 	return std::nullopt;
+}
+
+GafferScene::Private::RendererAlgo::RenderOptions Capsule::renderOptions() const
+{
+	std::optional<GafferScene::Private::RendererAlgo::RenderOptions> renderOptions = getRenderOptions();
+	if( renderOptions )
+	{
+		return *renderOptions;
+	}
+	else
+	{
+		return GafferScene::Private::RendererAlgo::RenderOptions( m_scene );
+	}
 }
 
 void Capsule::throwIfNoScene() const

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -585,7 +585,7 @@ class Instancer::EngineData : public Data
 				}
 				catch( QuantizeException & )
 				{
-					throw IECore::Exception( fmt::format( "Context variable \"{}\" : cannot quantize variable of type {}", index, v.primVar->data->typeName() ) );
+					throw IECore::Exception( fmt::format( "Context variable \"{}\" : cannot quantize variable of type {}", v.name.string(), v.primVar->data->typeName() ) );
 				}
 			}
 		}
@@ -613,7 +613,7 @@ class Instancer::EngineData : public Data
 			}
 			catch( QuantizeException & )
 			{
-				throw IECore::Exception( fmt::format( "Context variable \"{}\" : cannot quantize variable of type {}", index, v.primVar->data->typeName() ) );
+				throw IECore::Exception( fmt::format( "Context variable \"{}\" : cannot quantize variable of type {}", v.name.string(), v.primVar->data->typeName() ) );
 			}
 		}
 

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -442,11 +442,15 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 				Context::Scope frameScope( frameContext );
 				std::vector<float> tempTimes = {};
 
+				// \todo - this is quite bad for the case of any Capsules, which use a naive hash
+				// that always varies with the context. This should be investigated soon as a follow
+				// up.
+				//
 				// This is a pretty weird case - we would have taken an earlier branch if the hashes
 				// had all matched, so it looks like this object is actual animated, despite not supporting
 				// animation.
 				// The most correct thing to do here is reset the hash, since we may not have included the
-				// on frame in the samples we hashed, and in theory, the on frame value could vary indepndently
+				// on frame in the samples we hashed, and in theory, the on frame value could vary independently
 				// of shutter open and close.  This means that an animated non-animateable object will never have
 				// a matching hash, and will be updated every pass.  May be a performance hazard, but probably
 				// preferable to incorrect behaviour?  Just means people need to be careful to make sure their

--- a/src/GafferSceneModule/HierarchyBinding.cpp
+++ b/src/GafferSceneModule/HierarchyBinding.cpp
@@ -162,6 +162,18 @@ void GafferSceneModule::bindHierarchy()
 			.attr( "__qualname__" ) = "Instancer.ContextVariablePlug"
 		;
 
+		// Expose InstancerCapsules as if they were plain Capsules. We don't
+		// want to bind them fully because then we'd be exposing a private class, but
+		// we need to register them so that they can be returned to Python
+		// successfully when testing expansion in Python
+		//
+		// See "Boost.Python and slightly more tricky inheritance" at
+		// http://lists.boost.org/Archives/boost/2005/09/93017.php for more details.
+
+		boost::python::objects::copy_class_object(
+			type_id<Capsule>(), Instancer::instancerCapsuleTypeInfo()
+		);
+
 	}
 
 	{


### PR DESCRIPTION
Based on #3998, the concept for this is that when an Instancer is set to "encapsulateInstanceGroups", it should be able to add special cases to communicate more directly with the render, improving performance.

My goal for today was to clear away enough of the construction sawdust for it to not be totally unreasonable for John to do a first pass review before his vacation.

Known issues:
* I haven't yet supported prototype contexts properly. This will be implemented using a local hash map keyed by prototype context in InstancerCapsule::render to create a vector of prototype objects, which will be passed to the command, along with a list of indices for which one to use for each instance.
* Many TODOs
* No tests

Main questions:

Was I right to remove prototypeChildNamesPlug? I think the answer is definitely yes, though this is currently causing some small performance regressions ... I don't think they're actually important, but I will probably investigate further, just because it's deeply bothering that I don't understand why some of the tests have gotten slower ( testEngineDataPerf has gotten obviously slower for obvious reasons, but is not an important case in practice ). If there is going to be any plug that holds something that needs to be global to the Instancer, but doesn't get initialized when EngineData is initialized, then rather than prototypeChildNamesPlug, what would be nice to store separately is the computation of m_prototypeIndexRemap and m_instancesForPrototype which occur here: https://github.com/GafferHQ/gaffer/blob/8003b22e1234070ad55c7892f63f6e760a3c2a25/src/GafferScene/Instancer.cpp#L439
... main time when this work would happen unnecessarily is when there are several transform segments, but the topology does not change within the shutter. Then rather than building separate mappings for each EngineData, you could just build a mapping for the first EngineData, and then compare the topology of each subsequent EngineData, and if they're equal, just use the mapping from the first one. Currently, in order to compare if they're identical, you'd have to get the EngineData for each sample, triggering all the mapping builds. Probably not worth actually doing, but I might try to benchmark the cost we're currently paying at least.

Where should InstancerCapsule live? Currently, EngineData is only forward-declared in Instancer.h ( and I think this is a good thing ), which means that in order to use EngineData, InstancerCapsule must be defined in Instancer.cpp. To achieve this, I've put InstancerCapsule inside Instancer, though I think things might be clearer if it was outside, and just declared as a friend in order to access what it needs. Would it be acceptable to have both GafferScene::Instancer and GafferScene::InstancerCapsule both defined in Instancer.cpp?

I guess those are my specific questions, but also just general feedback on how things are structured ... and how I should go about testing this ... it feels like there are a huge number of special cases.
    