### PR TITLE
DispatchDialogue : Use Close instead of Ok

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.10.x (relative to 1.2.10.2)
 ========
 
+Fixes
+-----
+- DispatchDialogue : Changed the button label for the results display from Ok to Close
+
 1.2.10.2 (relative to 1.2.10.1)
 ========
 

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -309,7 +309,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		self.__backButton.setEnabled( True )
 		self.__backButton.setVisible( True )
 
-		self.__primaryButton.setText( "Ok" )
+		self.__primaryButton.setText( "Close" )
 		self.__primaryButton.setEnabled( True )
 		self.__primaryButton.setVisible( True )
 		self.__primaryButtonConnection = self.__primaryButton.clickedSignal().connect( Gaffer.WeakMethod( self.__close ), scoped = True )


### PR DESCRIPTION
Users sometimes click the Ok button, thinking it will take them back to be able to run the dispatch again. Using Close instead of Ok here removes the ambiguity.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
