### PR TITLE
OptionTweaks : Allow multiple tweaks to the same option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 
 - DispatchDialogue : Changed the button label for the results display from "Ok" to "Close".
 - Viewer : Fixed display of infinite values in the pixel inspectors. These were being incorrectly displayed as `nan` instead of `inf`.
+- OptionTweaks : Fixed bug that prevented multiple tweaks being made to the same option in one node.
 
 API
 ---

--- a/python/GafferSceneTest/OptionTweaksTest.py
+++ b/python/GafferSceneTest/OptionTweaksTest.py
@@ -139,6 +139,15 @@ class OptionTweaksTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( tweaks["out"]["globals"].getValue()["option:test"], IECore.IntData( 10 ) )
 
+	def testChainedTweaks( self ) :
+
+		tweaks = GafferScene.OptionTweaks()
+
+		tweaks["tweaks"].addChild( Gaffer.TweakPlug( "test", 1, Gaffer.TweakPlug.Mode.Create ) )
+		tweaks["tweaks"].addChild( Gaffer.TweakPlug( "test", 10, Gaffer.TweakPlug.Mode.Multiply ) )
+		tweaks["tweaks"].addChild( Gaffer.TweakPlug( "test", 2, Gaffer.TweakPlug.Mode.Add ) )
+
+		self.assertEqual( tweaks["out"].globals()["option:test"].value, 12 )
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/GafferScene/OptionTweaks.cpp
+++ b/src/GafferScene/OptionTweaks.cpp
@@ -120,12 +120,10 @@ IECore::ConstCompoundObjectPtr OptionTweaks::computeProcessedGlobals(
 	CompoundObjectPtr result = new CompoundObject();
 	result->members() = inputGlobals->members();
 
-	const CompoundObject *source = inputGlobals.get();
-
 	tweaksPlug->applyTweaks(
-		[&source]( const std::string &valueName )
+		[&result]( const std::string &valueName )
 		{
-			return source->member<Data>( g_namePrefix + valueName );
+			return result->member<Data>( g_namePrefix + valueName );
 		},
 		[&result]( const std::string &valueName, DataPtr newData )
 		{


### PR DESCRIPTION
This is particularly useful for the list editing modes, where you might want to add some items and remove others. This also brings the behaviour of OptionTweaks into line with ShaderTweaks, which has always been able to apply multiple tweaks to the same parameter. AttributeTweaks is now the outlier, and will need fixing as well at some point,