### PR TITLE
StandardNodeGadget : Remove raster-space sizing for focus border

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.2.10.x (relative to 1.2.10.3)
 ========
 
+Fixes
+-----
+
+- GraphEditor : Removed dynamic raster-space sizing of focus icon, as it caused excessive overlap with other nodes at certain zoom levels and on certain high resolution displays (#5435).
 
 1.2.10.3 (relative to 1.2.10.2)
 ========

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -778,12 +778,7 @@ void StandardNodeGadget::renderLayer( Layer layer, const Style *style, RenderRea
 
 float StandardNodeGadget::focusBorderWidth() const
 {
-	// Compute a fixed size in raster space, clamped to a maximum
-	const ViewportGadget *viewport = ancestor<ViewportGadget>();
-	const V3f p0 = viewport->rasterToGadgetSpace( V2f( 0 ), this ).p0;
-	const V3f p1 = viewport->rasterToGadgetSpace( V2f( 0, 1.0f ), this ).p0;
-	float pixelSize = ( p0 - p1 ).length();
-	return min( g_maxFocusWidth, max( 0.75f, 8.0f * pixelSize ) );
+	return 0.8;
 }
 
 void StandardNodeGadget::setHighlighted( bool highlighted )


### PR DESCRIPTION
We were scaling the size up to make the focus icon more prominent when the graph editor was zoomed out. But this had the unwanted side effect of obscuring more parts of the underlying UI when zoomed out. So while managing focus was easier, some other operations - such as making a connection - became _impossible_ at some zoom levels. This appears to have been further exacerbated by a bug whereby the default scaling was not consistent between 2K and 4K displays, as reported in #5435, making some operations impossible at common zoom levels.

Removing this dynamic sizing does make focus management a little harder, but the fixed sizing maintains the relative importance of UI elements across all zoom levels. Let's see how folks get on with it.

Fixes #5435.
