### PR TITLE
StringPlugValueWidget : Fix `Esc` keypress

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - GraphEditor : Removed dynamic raster-space sizing of focus icon, as it caused excessive overlap with other nodes at certain zoom levels and on certain high resolution displays (#5435).
+- StringPlugValueWidget : Fixed bug handling <kbd>Esc</kbd>.
 
 1.2.10.3 (relative to 1.2.10.2)
 ========

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -142,7 +142,7 @@ class StringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# escape abandons everything
 		if event.key == "Escape" :
-			self._updateFromPlugs()
+			self._requestUpdateFromValues()
 			return True
 		elif event.key == "Backspace" :
 			# Allow a 'delete' press with the initial keyboard focus and a


### PR DESCRIPTION
We already caught this for the `MultiLineStringPlugValueWidget` in #5210 but missed the `StringPlugValueWidget`.