### PR TITLE
ShaderUI : Fix missing identical shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - GraphEditor : Removed dynamic raster-space sizing of focus icon, as it caused excessive overlap with other nodes at certain zoom levels and on certain high resolution displays (#5435).
 - StringPlugValueWidget : Fixed bug handling <kbd>Esc</kbd>.
 - Arnold : Fixed unnecessary `opaque` attribute deprecation warnings. These are now only emitted in the case that `opaque` has been explicitly turned off.
+- ShaderUI : Fixed bug causing identical but independent shaders in a shader network from being included in the shader browser.
 
 1.2.10.3 (relative to 1.2.10.2)
 ========

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -549,7 +549,7 @@ class _ShaderPath( Gaffer.Path ) :
 				shaderNetwork, shaderHandle = stack.popleft()
 				shader = shaderNetwork.shaders()[shaderHandle]
 
-				h = shaderNetwork.hash().append( shader.hash() )
+				h = shaderNetwork.hash().append( shaderHandle )
 
 				if h not in visited :
 					visited.add( h )


### PR DESCRIPTION
This fixes a bug causing shaders to be left out of the shader browser when their hash is the same but are separate shaders and should be displayed as such.

One addition to the line called out in #5472 is needed to make sure the duplicate shader icon is applied appropriately, for example in a network like

<details><summary>Details</summary>
<p>

import Gaffer
import GafferArnold
import GafferDispatch
import GafferOSL
import GafferScene
import IECore
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 2, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 10, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 3, persistent=False )

__children = {}

__children["Plane"] = GafferScene.Plane( "Plane" )
parent.addChild( __children["Plane"] )
__children["Plane"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
parent.addChild( __children["ShaderAssignment"] )
__children["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["PathFilter"] = GafferScene.PathFilter( "PathFilter" )
parent.addChild( __children["PathFilter"] )
__children["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ShaderTweaks"] = GafferScene.ShaderTweaks( "ShaderTweaks" )
parent.addChild( __children["ShaderTweaks"] )
__children["ShaderTweaks"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SceneWriter"] = GafferScene.SceneWriter( "SceneWriter" )
parent.addChild( __children["SceneWriter"] )
__children["SceneWriter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SceneReader"] = GafferScene.SceneReader( "SceneReader" )
parent.addChild( __children["SceneReader"] )
__children["SceneReader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Switch"] = Gaffer.Switch( "Switch" )
parent.addChild( __children["Switch"] )
__children["Switch"].setup( GafferScene.ScenePlug( "in", ) )
__children["Switch"]["in"].addChild( GafferScene.ScenePlug( "in1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Switch"]["in"].addChild( GafferScene.ScenePlug( "in2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Switch"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"] = GafferScene.Parent( "Parent" )
parent.addChild( __children["Parent"] )
__children["Parent"]["children"].addChild( GafferScene.ScenePlug( "child1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"]["children"].addChild( GafferScene.ScenePlug( "child2", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Parent"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Plane1"] = GafferScene.Plane( "Plane1" )
parent.addChild( __children["Plane1"] )
__children["Plane1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["PathFilter1"] = GafferScene.PathFilter( "PathFilter1" )
parent.addChild( __children["PathFilter1"] )
__children["PathFilter1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["PathFilter2"] = GafferScene.PathFilter( "PathFilter2" )
parent.addChild( __children["PathFilter2"] )
__children["PathFilter2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["LayerShader"] = GafferArnold.ArnoldShader( "LayerShader" )
parent.addChild( __children["LayerShader"] )
__children["LayerShader"].loadShader( "layer_shader" )
__children["LayerShader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["StandardSurface"] = GafferArnold.ArnoldShader( "StandardSurface" )
parent.addChild( __children["StandardSurface"] )
__children["StandardSurface"].loadShader( "standard_surface" )
__children["StandardSurface"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["StandardSurface1"] = GafferArnold.ArnoldShader( "StandardSurface1" )
parent.addChild( __children["StandardSurface1"] )
__children["StandardSurface1"].loadShader( "standard_surface" )
__children["StandardSurface1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Noise"] = GafferArnold.ArnoldShader( "Noise" )
parent.addChild( __children["Noise"] )
__children["Noise"].loadShader( "noise" )
__children["Noise"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["ShaderAssignment1"] = GafferScene.ShaderAssignment( "ShaderAssignment1" )
parent.addChild( __children["ShaderAssignment1"] )
__children["ShaderAssignment1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"] = Gaffer.Box( "Box" )
parent.addChild( __children["Box"] )
__children["Box"].addChild( GafferArnold.ArnoldShader( "LayerShader" ) )
__children["Box"]["LayerShader"].loadShader( "layer_shader" )
__children["Box"]["LayerShader"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( GafferOSL.ClosurePlug( "out", direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( GafferArnold.ArnoldShader( "StandardSurface" ) )
__children["Box"]["StandardSurface"].loadShader( "standard_surface" )
__children["Box"]["StandardSurface"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( Gaffer.Color3fPlug( "parameters_subsurface_color", defaultValue = imath.Color3f( 1, 1, 1 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( GafferArnold.ArnoldShader( "StandardSurface1" ) )
__children["Box"]["StandardSurface1"].loadShader( "standard_surface" )
__children["Box"]["StandardSurface1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( GafferArnold.ArnoldShader( "Noise" ) )
__children["Box"]["Noise"].loadShader( "noise" )
__children["Box"]["Noise"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( Gaffer.BoxOut( "BoxOut" ) )
__children["Box"]["BoxOut"].setup( GafferOSL.ClosurePlug( "in", ) )
__children["Box"]["BoxOut"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( Gaffer.BoxIn( "BoxIn" ) )
__children["Box"]["BoxIn"].setup( Gaffer.Color3fPlug( "out", defaultValue = imath.Color3f( 1, 1, 1 ), ) )
__children["Box"]["BoxIn"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Box"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["Plane"]["__uiPosition"].setValue( imath.V2f( 14.0682869, 75.4107208 ) )
__children["ShaderAssignment"]["in"].setInput( __children["ShaderAssignment1"]["out"] )
__children["ShaderAssignment"]["filter"].setInput( __children["PathFilter"]["out"] )
__children["ShaderAssignment"]["shader"].setInput( __children["LayerShader"]["out"] )
__children["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( 14.0682869, 27.3549538 ) )
__children["PathFilter"]["paths"].setValue( IECore.StringVectorData( [ '/plane1' ] ) )
__children["PathFilter"]["__uiPosition"].setValue( imath.V2f( 28.3405018, 33.436985 ) )
__children["ShaderTweaks"]["in"].setInput( __children["Switch"]["out"] )
__children["ShaderTweaks"]["filter"].setInput( __children["PathFilter2"]["out"] )
__children["ShaderTweaks"]["shader"].setValue( 'ai:surface' )
__children["ShaderTweaks"]["__uiPosition"].setValue( imath.V2f( 17.1682854, -13.664875 ) )
__children["SceneWriter"]["in"].setInput( __children["ShaderAssignment"]["out"] )
__children["SceneWriter"]["fileName"].setValue( 'C:/Users/eric.HYPOTHETICAL/Desktop/test.usd' )
__children["SceneWriter"]["__uiPosition"].setValue( imath.V2f( 41.4551353, 19.1908913 ) )
__children["SceneReader"]["fileName"].setValue( 'C:/Users/eric.HYPOTHETICAL/Desktop/test.usd' )
__children["SceneReader"]["__uiPosition"].setValue( imath.V2f( 38.3050652, 8.8632412 ) )
__children["Switch"]["index"].setValue( 1 )
__children["Switch"]["enabled"].setValue( False )
Gaffer.Metadata.registerValue( __children["Switch"]["in"], 'noduleLayout:section', 'top' )
__children["Switch"]["in"][0].setInput( __children["ShaderAssignment"]["out"] )
__children["Switch"]["in"][1].setInput( __children["SceneReader"]["out"] )
Gaffer.Metadata.registerValue( __children["Switch"]["out"], 'noduleLayout:section', 'bottom' )
__children["Switch"]["__uiPosition"].setValue( imath.V2f( 17.0682869, 0.699178696 ) )
__children["Parent"]["parent"].setValue( '/' )
__children["Parent"]["children"][0].setInput( __children["Plane"]["out"] )
__children["Parent"]["children"][1].setInput( __children["Plane1"]["out"] )
__children["Parent"]["__uiPosition"].setValue( imath.V2f( 14.0682869, 67.2466583 ) )
__children["Plane1"]["transform"]["translate"].setValue( imath.V3f( 2, 0, 0 ) )
__children["Plane1"]["__uiPosition"].setValue( imath.V2f( 39.8718796, 75.4107208 ) )
__children["PathFilter1"]["paths"].setValue( IECore.StringVectorData( [ '/plane' ] ) )
__children["PathFilter1"]["__uiPosition"].setValue( imath.V2f( 32.9577866, 63.3370399 ) )
__children["PathFilter2"]["paths"].setValue( IECore.StringVectorData( [ '/plane', '/plane1' ] ) )
__children["PathFilter2"]["__uiPosition"].setValue( imath.V2f( 30.1682835, -7.58223248 ) )
__children["LayerShader"]["parameters"]["input1"].setInput( __children["StandardSurface"]["out"] )
__children["LayerShader"]["parameters"]["input2"].setInput( __children["StandardSurface1"]["out"] )
__children["LayerShader"]["__uiPosition"].setValue( imath.V2f( -8.32155228, 30.7839127 ) )
__children["StandardSurface"]["parameters"]["base_color"].setInput( __children["Noise"]["out"] )
__children["StandardSurface"]["__uiPosition"].setValue( imath.V2f( -25.6215534, 39.7839165 ) )
__children["StandardSurface1"]["__uiPosition"].setValue( imath.V2f( -25.821558, 24.4839134 ) )
__children["Noise"]["__uiPosition"].setValue( imath.V2f( -48.2471619, 51.6840286 ) )
__children["ShaderAssignment1"]["in"].setInput( __children["Parent"]["out"] )
__children["ShaderAssignment1"]["filter"].setInput( __children["PathFilter1"]["out"] )
__children["ShaderAssignment1"]["shader"].setInput( __children["Box"]["out"] )
__children["ShaderAssignment1"]["__uiPosition"].setValue( imath.V2f( 14.0682869, 59.0825958 ) )
__children["Box"]["LayerShader"]["parameters"]["input1"].setInput( __children["Box"]["StandardSurface"]["out"] )
__children["Box"]["LayerShader"]["parameters"]["input2"].setInput( __children["Box"]["StandardSurface1"]["out"] )
__children["Box"]["LayerShader"]["__uiPosition"].setValue( imath.V2f( -5.77666473, 70.7531738 ) )
__children["Box"]["out"].setInput( __children["Box"]["BoxOut"]["__out"] )
Gaffer.Metadata.registerValue( __children["Box"]["out"], 'description', 'The output from the shader.' )
Gaffer.Metadata.registerValue( __children["Box"]["out"], 'noduleLayout:section', 'right' )
Gaffer.Metadata.registerValue( __children["Box"]["out"], 'plugValueWidget:type', '' )
Gaffer.Metadata.registerValue( __children["Box"]["out"], 'noduleLayout:customGadget:addButton:gadgetType', 'GafferSceneUI.ShaderUI.PlugAdder' )
__children["Box"]["StandardSurface"]["parameters"]["base_color"].setInput( __children["Box"]["BoxIn"]["out"] )
__children["Box"]["StandardSurface"]["parameters"]["subsurface_color"].setInput( __children["Box"]["Noise"]["out"] )
__children["Box"]["StandardSurface"]["__uiPosition"].setValue( imath.V2f( -23.0766659, 79.7531738 ) )
__children["Box"]["parameters_subsurface_color"].setInput( __children["Noise"]["out"] )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'nodule:color', imath.Color3f( 0.689999998, 0.537800014, 0.228300005 ) )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'presetValues', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'presetNames', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'noduleLayout:label', 'Subsurface Color' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'description', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'plugValueWidget:type', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'nodule:type', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'label', 'Subsurface Color' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"], 'noduleLayout:visible', True )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["r"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["r"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["r"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["r"], 'noduleLayout:label', 'Subsurface Color.r' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["g"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["g"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["g"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["g"], 'noduleLayout:label', 'Subsurface Color.g' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["b"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["b"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["b"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["parameters_subsurface_color"]["b"], 'noduleLayout:label', 'Subsurface Color.b' )
__children["Box"]["StandardSurface1"]["__uiPosition"].setValue( imath.V2f( -23.2766685, 64.4531708 ) )
__children["Box"]["Noise"]["__uiPosition"].setValue( imath.V2f( -44.9548874, 84.5531769 ) )
__children["Box"]["BoxOut"]["in"].setInput( __children["Box"]["LayerShader"]["out"] )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["in"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'deletable', True )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'renameable', True )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'description', 'The output from the shader.' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'noduleLayout:section', 'right' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'plugValueWidget:type', '' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxOut"]["__out"], 'noduleLayout:customGadget:addButton:gadgetType', 'GafferSceneUI.ShaderUI.PlugAdder' )
__children["Box"]["BoxOut"]["__uiPosition"].setValue( imath.V2f( 6.86756659, 70.7535858 ) )
__children["Box"]["BoxIn"]["name"].setValue( 'parameters_subsurface_color' )
__children["Box"]["BoxIn"]["__in"].setInput( __children["Box"]["parameters_subsurface_color"] )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'nodule:color', imath.Color3f( 0.689999998, 0.537800014, 0.228300005 ) )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'deletable', True )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'renameable', True )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'presetValues', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'presetNames', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'noduleLayout:label', 'Subsurface Color' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'description', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'plugValueWidget:type', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'nodule:type', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'label', 'Subsurface Color' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"], 'noduleLayout:visible', True )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["r"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["r"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["r"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["r"], 'noduleLayout:label', 'Subsurface Color.r' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["g"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["g"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["g"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["g"], 'noduleLayout:label', 'Subsurface Color.g' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["b"], 'nodule:color', imath.Color3f( 0.246700004, 0.376199991, 0.469999999 ) )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["b"], 'noduleLayout:section', 'left' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["b"], 'userDefault', None )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["__in"]["b"], 'noduleLayout:label', 'Subsurface Color.b' )
Gaffer.Metadata.registerValue( __children["Box"]["BoxIn"]["out"], 'noduleLayout:section', 'right' )
__children["Box"]["BoxIn"]["__uiPosition"].setValue( imath.V2f( -44.2514496, 74.3031769 ) )
__children["Box"]["__uiPosition"].setValue( imath.V2f( -25.3547668, 58.4825974 ) )


del __children



</p>
</details> 

Fixes #5472

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
