### PR TITLE
IECoreArnold : Don't set deprecated "opaque" unless explicitly set

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - GraphEditor : Removed dynamic raster-space sizing of focus icon, as it caused excessive overlap with other nodes at certain zoom levels and on certain high resolution displays (#5435).
 - StringPlugValueWidget : Fixed bug handling <kbd>Esc</kbd>.
+- Don't set deprecated "opaque" attribute in Arnold unless explicitly requested ( avoids deprecation warning from Arnold )
 
 1.2.10.3 (relative to 1.2.10.2)
 ========

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -1352,7 +1352,16 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				AiNodeSetStr( node, g_transformTypeArnoldString, m_transformType );
 				AiNodeSetBool( node, g_receiveShadowsArnoldString, m_shadingFlags & ArnoldAttributes::ReceiveShadows );
 				AiNodeSetBool( node, g_selfShadowsArnoldString, m_shadingFlags & ArnoldAttributes::SelfShadows );
-				AiNodeSetBool( node, g_opaqueArnoldString, m_shadingFlags & ArnoldAttributes::Opaque );
+
+				if( !( m_shadingFlags & ArnoldAttributes::Opaque ) )
+				{
+					AiNodeSetBool( node, g_opaqueArnoldString, false );
+				}
+				else
+				{
+					AiNodeResetParameter( node, g_opaqueArnoldString );
+				}
+
 				AiNodeSetBool( node, g_matteArnoldString, m_shadingFlags & ArnoldAttributes::Matte );
 
 				if( m_surfaceShader && m_surfaceShader->root() )


### PR DESCRIPTION
I think this is a pretty direct implementation of what we discussed this morning.

When I went to test this, I realized that there is no detectable difference in behaviour between this and the previous version - because opaque defaults true, calling `AiNodeResetParameter( node, g_opaqueArnoldString )` has an identical effect to calling `AiNodeSetBool( node, g_opaqueArnoldString, true );`, except it doesn't print the Arnold warning. This means that it's actually unnecessary to add the new HasOpaque flag - we could just keep the single opaque flag, and call `AiNodeSetBool( node, false );` if it's false, and `AiNodeResetParameter` if it's true. That might be slightly weird, and I'm not sure the tradeoff between "slightly weird" and "tracking unnecessary state". Now that I've thought about it, I think I would actually prefer not using HasOpaque, but I figured I'd ask you before I switch it.