### PR TITLE
More light handles

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,7 @@ Features
 
 - LightTool :
   - Added manipulator for disk and point light radii.
-  - Added manipulator for cylinder length.
+  - Added manipulators for cylinder length and radius.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Features
 --------
 
-- LightTool : Added manipulator for disk and point light radii.
+- LightTool :
+  - Added manipulator for disk and point light radii.
+  - Added manipulator for cylinder length.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,15 @@
 1.3.x.x (relative to 1.3.5.0)
 =======
 
+Features
+--------
+
+- LightTool : Added manipulator for disk and point light radii.
+
 Fixes
 -----
 
 - Windows : Fixed a bug preventing anything except strings from being copied and pasted.
-
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Features
   - Added manipulator for disk and point light radii.
   - Added manipulators for cylinder length and radius.
 
+Improvements
+------------
+
+- LightTool : Changed spot light tool tip location so that it follows the cone during drag.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,7 @@ Features
 Improvements
 ------------
 
-- LightTool : Changed spot light tool tip location so that it follows the cone during drag.
+- LightTool : Changed spot light and quad light edge tool tip locations so that they follow the cone and edge during drag.
 
 Fixes
 -----

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -284,6 +284,12 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 
 		/// The inspected value that should be displayed by the UI.
 		const IECore::Object *value() const;
+		/// The inspected value cast to its native type. If the inspected
+		/// value is not of the requested type, the given default value
+		/// will be returned.
+		template<typename T>
+		const T typedValue( const T &defaultValue ) const;
+
 		/// The plug that was used to author the current value, or null if
 		/// it cannot be determined.
 		Gaffer::ValuePlug *source() const;
@@ -346,3 +352,5 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 } // namespace Private
 
 } // namespace GafferSceneUI
+
+#include "GafferSceneUI/Private/Inspector.inl"

--- a/include/GafferSceneUI/Private/Inspector.inl
+++ b/include/GafferSceneUI/Private/Inspector.inl
@@ -1,0 +1,61 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECore/RunTimeTyped.h"
+#include "IECore/SimpleTypedData.h"
+
+namespace GafferSceneUI
+{
+
+namespace Private
+{
+
+template<typename T>
+const T Inspector::Result::typedValue( const T &defaultValue ) const
+{
+	if( auto valueData = IECore::runTimeCast<const IECore::TypedData<T>>( value() ) )
+	{
+		return valueData->readable();
+	}
+
+	return defaultValue;
+}
+
+}  // namespace Private
+
+}  // namespace GafferScene

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -465,12 +465,6 @@ IECoreGL::MeshPrimitivePtr cone( float height, float startRadius, float endRadiu
 	return result;
 }
 
-const float g_tipScale = 10.f;
-const float g_tipIconSize = 1.25f;
-const float g_tipIconOffset = -0.25f;
-const float g_tipIndent = 1.75f;
-const float g_tipLineSpacing = -1.375f;
-
 IECoreGL::MeshPrimitivePtr unitCone()
 {
 	static IECoreGL::MeshPrimitivePtr result = cone( 1.5f, 0.5f, 0 );
@@ -502,6 +496,12 @@ GraphComponent *commonAncestor( std::vector<GraphComponent *> &graphComponents )
 
 	return commonAncestor;
 }
+
+const float g_tipScale = 10.f;
+const float g_tipIconSize = 1.25f;
+const float g_tipIconOffset = -0.25f;
+const float g_tipIndent = 1.75f;
+const float g_tipLineSpacing = -1.375f;
 
 void drawSelectionTips(
 	const V3f &gadgetSpacePosition,

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -2044,10 +2044,12 @@ class EdgeHandle : public LightToolHandle
 			m_oppositeScaleAttributeName( oppositeScaleAttributeName ),
 			m_edgeMargin( edgeMargin ),
 			m_tipPlugSuffix( tipPlugSuffix ),
+
 			m_edgeScale( 1.f ),
 			m_oppositeScale( 1.f ),
 			m_orientation(),
-			m_oppositeAdditionalScale( 1.f )
+			m_oppositeAdditionalScale( 1.f ),
+			m_tooltipT( 0 )
 		{
 		}
 
@@ -2234,8 +2236,14 @@ class EdgeHandle : public LightToolHandle
 			edgeSegment.p1 += offset;
 			edgeSegment *= m_orientation;
 
-			V3f eventClosest;
-			setTooltipPosition( edgeSegment.closestPoints( LineSegment3f( eventLine.p0, eventLine.p1 ), eventClosest ) );
+			if( !m_drag )
+			{
+				V3f eventClosest;
+				const V3f closestPoint = edgeSegment.closestPoints( LineSegment3f( eventLine.p0, eventLine.p1 ), eventClosest );
+				m_tooltipT = ( closestPoint - edgeSegment.p0 ).length() / edgeSegment.length();
+			}
+
+			setTooltipPosition( edgeSegment( m_tooltipT ) );
 		}
 
 	private :
@@ -2307,6 +2315,7 @@ class EdgeHandle : public LightToolHandle
 		float m_oppositeScale;
 		M44f m_orientation;
 		float m_oppositeAdditionalScale;
+		float m_tooltipT;  // Parameter `t` along the edge set at the start of the drag
 		std::optional<LinearDrag> m_drag;
 };
 

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1871,6 +1871,12 @@ class SpotLightHandle : public LightToolHandle
 				return;
 			}
 
+			if( m_drag )
+			{
+				setTooltipPosition( V3f( 0, 0, -m_arcRadius ) * r );
+				return;
+			}
+
 			const Line3f rayLine(
 				V3f( 0 ),
 				V3f( 0, 0, m_visualiserScale * m_frustumScale * -10.f ) * r

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1342,7 +1342,7 @@ class SpotLightHandle : public LightToolHandle
 			LightToolHandle( lightType, view, { g_coneAngleParameter, g_penumbraAngleParameter }, name ),
 			m_zRotation( zRotation ),
 			m_handleType( handleType ),
-			m_angleMultiplier( 1.f ),
+			m_angleHandleRatio( 2.f ),
 			m_visualiserScale( 1.f ),
 			m_frustumScale( 1.f ),
 			m_lensRadius( 0 )
@@ -1591,11 +1591,11 @@ class SpotLightHandle : public LightToolHandle
 					auto angleType = Metadata::value<StringData>( shaderAttribute, "coneAngleType" );
 					if( angleType && angleType->readable() == "half" )
 					{
-						m_angleMultiplier = 2.f;
+						m_angleHandleRatio = 1.f;
 					}
 					else
 					{
-						m_angleMultiplier = 1.f;
+						m_angleHandleRatio = 2.f;
 					}
 
 					break;
@@ -1907,7 +1907,7 @@ class SpotLightHandle : public LightToolHandle
 		// Convert from the angle representation used by plugs to that used by handles.
 		float coneHandleAngle( const float angle ) const
 		{
-			return angle * 0.5f;
+			return angle / m_angleHandleRatio;
 		}
 
 		float penumbraHandleAngle( const float angle ) const
@@ -1921,7 +1921,7 @@ class SpotLightHandle : public LightToolHandle
 
 		float conePlugAngle(const float a ) const
 		{
-			return a * 2.f / m_angleMultiplier;
+			return a * m_angleHandleRatio;
 		}
 
 		float penumbraPlugAngle(const float a ) const
@@ -1995,7 +1995,7 @@ class SpotLightHandle : public LightToolHandle
 		HandleType m_handleType;
 		std::optional<InternedString> m_penumbraType;
 
-		float m_angleMultiplier;
+		float m_angleHandleRatio;
 
 		float m_visualiserScale;
 		float m_frustumScale;
@@ -3002,14 +3002,14 @@ LightTool::LightTool( SceneView *view, const std::string &name ) :
 
 	// Spotlight handles
 
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Penumbra, view, 0, "westConeAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Cone, view, 0, "westPenumbraAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Penumbra, view, 90, "southConeAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Cone, view, 90, "southPenumbraAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Penumbra, view, 180, "eastConeAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Cone, view, 180, "eastPenumbraAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Penumbra, view, 270, "northConeAngleParameter" ) );
-	m_handles->addChild( new SpotLightHandle( "spot", SpotLightHandle::HandleType::Cone, view, 270, "northPenumbraAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Penumbra, view, 0, "westConeAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Cone, view, 0, "westPenumbraAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Penumbra, view, 90, "southConeAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Cone, view, 90, "southPenumbraAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Penumbra, view, 180, "eastConeAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Cone, view, 180, "eastPenumbraAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Penumbra, view, 270, "northConeAngleParameter" ) );
+	m_handles->addChild( new SpotLightHandle( "spot quad point disk distant", SpotLightHandle::HandleType::Cone, view, 270, "northPenumbraAngleParameter" ) );
 
 	// Quadlight handles
 

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -83,6 +83,7 @@ Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "exposureParameter", "
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "colorParameter", "color" )
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "radiusParameter", "radius" )
 Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0.5 * math.pi, 0 , 0 ) ) )
+Gaffer.Metadata.registerValue( "ai:light:cylinder_light", "heightToScaleRatio", 2.0 )
 
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "intensityParameter", "intensity" )
 Gaffer.Metadata.registerValue( "ai:light:skydome_light", "exposureParameter", "exposure" )


### PR DESCRIPTION
This is the start of the remaining light tool handles that will cover sphere / point lights, cylinder lights and disk lights.

It's a work in progress currently but could probably benefit from a look at the last commit in particular where I did a major refactoring to make `LightToolHandle` useful for all light types and refined the public interface.

Based in interactive testing, all is working fine so this is meant to be a purely architectural change at this point, with the new lights coming either later in this PR lifetime or separately if that works better.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
