### PR TITLE
Spreadsheet : Make string popups wider

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Spreadsheet :
   - Popups for string cells and row names are now sized to fit their column.
+  - Added "Triple" and "Quadruple" width options to the spreadsheet row name popup menu.
 
 1.3.4.0 (relative to 1.3.3.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,12 @@
 1.3.x.x (relative to 1.3.4.0)
 =======
 
+Improvements
+------------
+
+- Spreadsheet :
+  - Popups for string cells and row names are now sized to fit their column.
+
 1.3.4.0 (relative to 1.3.3.0)
 =======
 

--- a/python/GafferUI/SpreadsheetUI/_CellPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_CellPlugValueWidget.py
@@ -182,13 +182,16 @@ class _CellPlugValueWidget( GafferUI.PlugValueWidget ) :
 				if childWidget is not None :
 					walk( childWidget )
 
-		if isinstance( plugValueWidget, GafferUI.VectorDataPlugValueWidget ) :
+		if isinstance( plugValueWidget, ( GafferUI.VectorDataPlugValueWidget, GafferUI.StringPlugValueWidget ) ) :
 			# It's pretty common to make wide spreadsheet columns to accommodate
 			# lists of long scene locations. When that is the case, we want
 			# to make sure the editor is equally wide, so that it shows at least
 			# as much content as the spreadsheet itself.
 			columnWidth = Gaffer.Metadata.value( plugValueWidget.getPlug().parent(), "spreadsheet:columnWidth" ) or 0
 			plugValueWidget._qtWidget().setFixedWidth( max( columnWidth, 250 ) )
+			if isinstance( plugValueWidget, GafferUI.StringPlugValueWidget ) :
+				plugValueWidget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
+				plugValueWidget.textWidget().setFixedCharacterWidth( None )
 		else :
 			walk( plugValueWidget )
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -1126,6 +1126,13 @@ class _PlugTableView( GafferUI.Widget ) :
 		self.__editorWidget = GafferUI.PlugPopup( plugs, title = "" )
 		self.__editorWidget.popup( plugBound.center() )
 
+		widget = self.__editorWidget.plugValueWidget()
+		if isinstance( widget, GafferUI.StringPlugValueWidget ) :
+			columnWidth = Gaffer.Metadata.value( self._qtWidget().model().rowsPlug().defaultRow(), "spreadsheet:rowNameWidth" ) or 0
+			widget._qtWidget().setFixedWidth( max( columnWidth, 250 ) )
+			widget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetNoConstraint )
+			widget.textWidget().setFixedCharacterWidth( None )
+
 	# Clears and selects a non-contiguous list of indexes if they're not already selected.
 	def __selectIndexes( self, indexes ) :
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -907,6 +907,8 @@ class _PlugTableView( GafferUI.Widget ) :
 			( "Half", GafferUI.PlugWidget.labelWidth() * 0.5 ),
 			( "Single", GafferUI.PlugWidget.labelWidth() ),
 			( "Double", GafferUI.PlugWidget.labelWidth() * 2 ),
+			( "Triple", GafferUI.PlugWidget.labelWidth() * 3 ),
+			( "Quadruple", GafferUI.PlugWidget.labelWidth() * 4 ),
 		]
 
 		currentWidth = self.__getRowNameWidth()


### PR DESCRIPTION
I think this accomplishes what we wanted to improve for the spreadsheet popup widgets. I'm setting the character width to 60 for the text widgets of both string cells and the row name.

What might be even better is to match the widget width to the column width, but as far as I can tell there's no current way to know what column the plug is being created on behalf of.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
