### PR TITLE
NameSwitchUI : Fix editability when a child has an input

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.10.x (relative to 1.2.10.4)
 ========
 
+Fixes
+-----
+
+- NameSwitch : Fixed bug which prevented drag and drop reordering of rows with an input connection.
+
 1.2.10.4 (relative to 1.2.10.3)
 ========
 

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -401,7 +401,9 @@ class _RowPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def _updateFromEditable( self ) :
 
-		self.__dragHandle.setEnabled( self._editable() )
+		# Not using `_editable()` as it considers the whole plug to be non-editable if
+		# any child has an input connection, but that shouldn't prevent us reordering rows.
+		self.__dragHandle.setEnabled( not Gaffer.MetadataAlgo.readOnly( self.getPlug() ) )
 
 	def __updateWidgetVisibility( self ) :
 


### PR DESCRIPTION
Another variant of #5282 and #5231, this one preventing drag-and-drop reordering of rows with inputs.