### PR TITLE
SceneReaderTest : Fix import

### DIFF
--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -38,9 +38,8 @@ import pathlib
 import unittest
 import inspect
 import imath
-import pxr
 
-import pxr
+import pxr.Usd
 
 import IECore
 import IECoreScene


### PR DESCRIPTION
This was only working when run with other tests, because those other tests were importing the `Usd` submodule. The SceneReaderTest can now be run in isolation again.
