### PR TITLE
exFAT workaround

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - PythonEditor :
   - Fixed output for `print()` calls with multiple arguments, which was previously spread across multiple lines.
   - Fixed bug that prevented editors being destroyed at the right time.
+- FileSystemPath : Fixed bug on Windows where paths on an exFAT partition were not considered valid.
 
 1.3.4.0 (relative to 1.3.3.0)
 =======


### PR DESCRIPTION
This works around a bug in MSVC's standard library causing `symlink_status()` to fail on exFAT (and maybe FAT) partitions. That bug was fixed in https://github.com/microsoft/STL/issues/233, but this would be a useful fix prior to moving to MSVC 2022.

It doesn't satisfy #5490, but does workaround one of the problems mentioned in that issue.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
