### PR TITLE
PythonEditor fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,9 @@ Improvements
 Fixes
 -----
 
-- PythonEditor : Fixed bug that prevented editors being destroyed at the right time.
+- PythonEditor :
+  - Fixed output for `print()` calls with multiple arguments, which was previously spread across multiple lines.
+  - Fixed bug that prevented editors being destroyed at the right time.
 
 1.3.4.0 (relative to 1.3.3.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
   - Popups for string cells and row names are now sized to fit their column.
   - Added "Triple" and "Quadruple" width options to the spreadsheet row name popup menu.
 
+Fixes
+-----
+
+- PythonEditor : Fixed bug that prevented editors being destroyed at the right time.
+
 1.3.4.0 (relative to 1.3.3.0)
 =======
 

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import ast
+import contextlib
 import functools
 import sys
 import traceback
@@ -125,7 +126,7 @@ class PythonEditor( GafferUI.Editor ) :
 
 		self.__outputWidget.appendHTML( self.__codeToHTML( toExecute ) )
 
-		with Gaffer.OutputRedirection( stdOut = Gaffer.WeakMethod( self.__redirectOutput ), stdErr = Gaffer.WeakMethod( self.__redirectOutput ) ) :
+		with self.__outputRedirection() :
 			with _MessageHandler( self.__outputWidget ) :
 				with Gaffer.UndoScope( self.scriptNode() ) :
 					with self.getContext() :
@@ -200,13 +201,40 @@ class PythonEditor( GafferUI.Editor ) :
 
 		return result
 
-	def __redirectOutput( self, output ) :
+	# Context manager used to redirect `sys.stdout` and `sys.stderr` into our
+	# output widget during execution. This is a little bit of a faff for several
+	# reasons :
+	#
+	# 1. `__outputWidget.appendText()` automatically appends the text on a new
+	#    line.
+	# 2. A simple call to `print( 1, 2 )` makes four separate calls to
+	#    `stdout.write()`, with values of "1" "2", " " and "\n".
+	# 3. We don't want to simply buffer up all the writes and print them after
+	#    execution. Instead we want to update the UI for each new `print()` so
+	#    that users can get feedback on the progress of their script.
+	#
+	# So we maintain a buffer that we flush to `appendText()` every time we
+	# encounter a newline.
+	@contextlib.contextmanager
+	def __outputRedirection( self ) :
 
-		if output != "\n" :
-			self.__outputWidget.appendText( output )
-			# update the gui so messages are output as they occur, rather than all getting queued
-			# up till the end.
-			QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+		buffer = ""
+		def __redirect( output ) :
+
+			nonlocal buffer
+			buffer += output
+			if buffer.endswith( "\n" ) :
+				self.__outputWidget.appendText( buffer[:-1] )
+				buffer = ""
+				# Update the GUI so messages are output as they occur, rather
+				# than all getting queued up till the end.
+				QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )
+
+		with Gaffer.OutputRedirection( stdOut = __redirect, stdErr = __redirect ) :
+			yield
+
+		if buffer :
+			self.__outputWidget.appendText( buffer )
 
 	def __contextMenu( self, widget ) :
 

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -39,6 +39,7 @@ import ast
 import functools
 import sys
 import traceback
+import weakref
 import imath
 
 import IECore
@@ -279,9 +280,13 @@ class _MessageHandler( IECore.MessageHandler ) :
 
 		IECore.MessageHandler.__init__( self )
 
-		self.__textWidget = textWidget
+		self.__textWidget = weakref.ref( textWidget )
 
 	def handle( self, level, context, message ) :
+
+		widget = self.__textWidget()
+		if widget is None :
+			return
 
 		html = formatted = "<h1 class='%s'>%s : %s </h1><pre class='message'>%s</pre><br>" % (
 			IECore.Msg.levelAsString( level ),
@@ -289,7 +294,7 @@ class _MessageHandler( IECore.MessageHandler ) :
 			context,
 			message
 		)
-		self.__textWidget.appendHTML( html )
+		widget.appendHTML( html )
 		# update the gui so messages are output as they occur, rather than all getting queued
 		# up till the end.
 		QtWidgets.QApplication.instance().processEvents( QtCore.QEventLoop.ExcludeUserInputEvents )

--- a/python/GafferUITest/PythonEditorTest.py
+++ b/python/GafferUITest/PythonEditorTest.py
@@ -55,6 +55,35 @@ class PythonEditorTest( GafferUITest.TestCase ) :
 		del editor
 		self.assertIsNone( weakEditor() )
 
+	def testPrint( self ) :
+
+		script = Gaffer.ScriptNode()
+		editor = GafferUI.PythonEditor( script )
+		weakEditor = weakref.ref( editor )
+
+		editor.inputWidget().setText( "print( 1, 2 )" )
+		editor.execute()
+		self.assertEqual(
+			editor.outputWidget().getText(),
+			"print( 1, 2 )\n1 2"
+		)
+
+		del editor
+		self.assertIsNone( weakEditor() )
+
+	def testLifetimeAfterExecuteException( self ) :
+
+		script = Gaffer.ScriptNode()
+		editor = GafferUI.PythonEditor( script )
+		weakEditor = weakref.ref( editor )
+
+		editor.inputWidget().setText( "ohDearThisVariableDoesntExist" )
+		editor.execute()
+		self.assertIn( "name 'ohDearThisVariableDoesntExist' is not defined", editor.outputWidget().getText() )
+
+		del editor
+		self.assertIsNone( weakEditor() )
+
 	def testMessageHandler( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/python/GafferUITest/PythonEditorTest.py
+++ b/python/GafferUITest/PythonEditorTest.py
@@ -1,0 +1,76 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import weakref
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class PythonEditorTest( GafferUITest.TestCase ) :
+
+	def testLifetimeAfterExecute( self ) :
+
+		script = Gaffer.ScriptNode()
+		editor = GafferUI.PythonEditor( script )
+		weakEditor = weakref.ref( editor )
+
+		editor.inputWidget().setText( "a = 10" )
+		editor.execute()
+
+		del editor
+		self.assertIsNone( weakEditor() )
+
+	def testMessageHandler( self ) :
+
+		script = Gaffer.ScriptNode()
+		editor = GafferUI.PythonEditor( script )
+		weakEditor = weakref.ref( editor )
+
+		editor.inputWidget().setText( 'import IECore; IECore.msg( IECore.Msg.Level.Warning, "PythonEditorTest", "Alert!" )' )
+		editor.execute()
+
+		output = editor.outputWidget().getText()
+		self.assertIn( "import IECore", output )
+		self.assertIn( "WARNING : PythonEditorTest", output )
+		self.assertIn( "Alert!", output )
+
+		del editor
+		self.assertIsNone( weakEditor() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -129,6 +129,7 @@ from .PathColumnTest import PathColumnTest
 from .ToolTest import ToolTest
 from .StandardNodeToolbarTest import StandardNodeToolbarTest
 from .LabelPlugValueWidgetTest import LabelPlugValueWidgetTest
+from .PythonEditorTest import PythonEditorTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes the annoying bug whereby the output from `print( 1, 2 )` was spread across multiple lines, and a separate bug I found while checking that my new code didn't affect the editor lifetime.