### PR TITLE
ImageView : Change default comparison mode to "replace"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- Viewer : Changed the default image comparison (wipe) mode from `Over` to `Replace`.
 - Spreadsheet :
   - Popups for string cells and row names are now sized to fit their column.
   - Added "Triple" and "Quadruple" width options to the spreadsheet row name popup menu.

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1152,7 +1152,7 @@ class _CompareModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			v = self.getPlug().getValue()
 
 		if v == "":
-			return Gaffer.Metadata.value( self.getPlug(), "imageViewer:lastCompareMode" ) or "over"
+			return Gaffer.Metadata.value( self.getPlug(), "imageViewer:lastCompareMode" ) or "replace"
 		else:
 			return ""
 


### PR DESCRIPTION
Following a render debugging session where I and some senior colleagues took an embarassingly amount of time to realise that two partially transparent alphas were actually identical, and one only looked brighter because it was being composited over the other. :flushed: :flushed: :flushed:

We had originally defaulted the comparison mode to "over" because we anticipated it being used most commonly to view an image over a plate, but a quick survey of users suggests that it is far more common to be just doing a straight up image comparison. And several users hadn't even realised that this wasn't actually what was happening by default...