### PR TITLE
ImageScatter : Add new node for scattering points on images

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
   - Popups for string cells and row names are now sized to fit their column.
   - Added "Triple" and "Quadruple" width options to the spreadsheet row name popup menu.
 
+API
+---
+
+- Sampler : Added `populate()` method, which populates the internal tile cache in parallel, and subsequently allows `sample()` to be called concurrently.
+
 1.3.4.0 (relative to 1.3.3.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.4.0)
 =======
 
+Features
+--------
+
+- ImageScatter : Added a new node for scattering points across an image, with density controlled by an image channel.
+
 Improvements
 ------------
 

--- a/include/GafferScene/ImageScatter.h
+++ b/include/GafferScene/ImageScatter.h
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/ObjectSource.h"
+
+#include "GafferImage/ImagePlug.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API ImageScatter : public ObjectSource
+{
+
+	public :
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::ImageScatter, ImageScatterTypeId, ObjectSource );
+
+		explicit ImageScatter( const std::string &name=defaultName<ImageScatter>() );
+		~ImageScatter() override;
+
+		GafferImage::ImagePlug *imagePlug();
+		const GafferImage::ImagePlug *imagePlug() const;
+
+		Gaffer::StringPlug *viewPlug();
+		const Gaffer::StringPlug *viewPlug() const;
+
+		Gaffer::FloatPlug *densityPlug();
+		const Gaffer::FloatPlug *densityPlug() const;
+
+		Gaffer::StringPlug *densityChannelPlug();
+		const Gaffer::StringPlug *densityChannelPlug() const;
+
+		Gaffer::StringPlug *primitiveVariablesPlug();
+		const Gaffer::StringPlug *primitiveVariablesPlug() const;
+
+		Gaffer::FloatPlug *widthPlug();
+		const Gaffer::FloatPlug *widthPlug() const;
+
+		Gaffer::StringPlug *widthChannelPlug();
+		const Gaffer::StringPlug *widthChannelPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
+
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( ImageScatter )
+
+} // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -176,6 +176,7 @@ enum TypeId
 	MeshSplitTypeId = 110632,
 	FramingConstraintTypeId = 110633,
 	MeshNormalsTypeId = 110634,
+	ImageScatterTypeId = 110635,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/python/GafferSceneTest/ImageScatterTest.py
+++ b/python/GafferSceneTest/ImageScatterTest.py
@@ -1,0 +1,177 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferImage
+import GafferScene
+import GafferSceneTest
+
+class ImageScatterTest( GafferSceneTest.SceneTestCase ) :
+
+	def testDensity( self ) :
+
+		constant = GafferImage.Constant()
+
+		scatter = GafferScene.ImageScatter()
+		scatter["image"].setInput( constant["out"] )
+
+		for width in ( 100, 200, 400 ) :
+			for height in ( 100, 200, 400 ) :
+				for pixelAspect in ( 0.5, 1.0, 2.0 ) :
+					for value in ( 0, 0.1, 0.5, 1.0 ) :
+						for density in ( 0, 0.1, 0.5, 1.0, 2.0 ) :
+							with self.subTest( width = width, height = height, value = value, density = density, pixelAspect = pixelAspect ) :
+								constant["format"].setValue( GafferImage.Format( width, height, pixelAspect ) )
+								constant["color"]["r"].setValue( value )
+								scatter["density"].setValue( density )
+								points = scatter["out"].object( "/points" )
+								expected = width * pixelAspect * height * density * value
+								self.assertAlmostEqual(
+									points.numPoints, expected,
+									delta = expected * 0.07
+								)
+
+	def testMissingChannels( self ) :
+
+		constant = GafferImage.Constant()
+		scatter = GafferScene.ImageScatter()
+		scatter["image"].setInput( constant["out"] )
+
+		scatter["densityChannel"].setValue( "doesNotExist" )
+
+		with self.assertRaisesRegex( Gaffer.ProcessException, 'Density channel "doesNotExist" does not exist' ) :
+			scatter["out"].object( "/points" )
+
+		scatter["densityChannel"].setValue( "R" )
+		scatter["widthChannel"].setValue( "doesNotExist" )
+
+		with self.assertRaisesRegex( Gaffer.ProcessException, 'Width channel "doesNotExist" does not exist' ) :
+			scatter["out"].object( "/points" )
+
+	def testPrimitiveVariables( self ) :
+
+		ramp = GafferImage.Ramp()
+		ramp["format"].setValue( GafferImage.Format( 2, 3 ) )
+		ramp["startPosition"].setValue( imath.V2f( 0, 0.5 ) )
+		ramp["endPosition"].setValue( imath.V2f( 0, 2.5 ) )
+		ramp["ramp"]["p0"]["y"]["a"].setValue( 1 ) # Solid alpha
+		ramp["ramp"]["interpolation"].setValue( Gaffer.SplineDefinitionInterpolation.Linear )
+
+		scatter = GafferScene.ImageScatter()
+		scatter["image"].setInput( ramp["out"] )
+		scatter["density"].setValue( 10 )
+		scatter["densityChannel"].setValue( "A" )
+		scatter["width"].setValue( 2.0 )
+		scatter["widthChannel"].setValue( "R" )
+
+		points = scatter["out"].object( "/points" )
+		self.assertEqual( set( points.keys() ), { "P", "width" } )
+
+		scatter["primitiveVariables"].setValue( "[RGBA]" )
+		points = scatter["out"].object( "/points" )
+		self.assertEqual( set( points.keys() ), { "P", "width", "Cs", "A" } )
+		self.assertIsInstance( points["Cs"].data, IECore.Color3fVectorData )
+		self.assertEqual( len( points["Cs"].data ), len( points["P"].data ) )
+		self.assertIsInstance( points["width"].data, IECore.FloatVectorData )
+		self.assertEqual( len( points["width"].data ), len( points["P"].data ) )
+
+		for i, c in enumerate( points["Cs"].data ) :
+			# Expected spline value
+			y = points["P"].data[i].y
+			y = (y - 0.5) / 2.0
+			y = max( 0, min( y, 1 ) )
+			# Should match what we sampled for `Cs`
+			self.assertAlmostEqual( c[0], y, delta = 0.000001 )
+			self.assertAlmostEqual( c[1], y, delta = 0.000001 )
+			self.assertAlmostEqual( c[2], y, delta = 0.000001 )
+			# And width should be double that
+			self.assertAlmostEqual( points["width"].data[i], y * 2, delta = 0.000001 )
+
+		self.assertEqual(
+			points["A"].data,
+			IECore.FloatVectorData( [ 1.0 ] * len( points["P"].data ) )
+		)
+
+	def testWidth( self ) :
+
+		constant = GafferImage.Constant()
+		constant["format"].setValue( GafferImage.Format( 1, 1 ) )
+		constant["color"].setValue( imath.Color4f( 1, 0.5, 0, 1 ) )
+
+		scatter = GafferScene.ImageScatter()
+		scatter["image"].setInput( constant["out"] )
+
+		# If no width channel is specified, we get a constant width
+		# from the width plug.
+
+		self.assertEqual(
+			scatter["out"].object( "/points" )["width"],
+			IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.FloatData( 1 )
+			)
+		)
+
+		scatter["width"].setValue( 0.5 )
+		self.assertEqual(
+			scatter["out"].object( "/points" )["width"],
+			IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Constant,
+				IECore.FloatData( 0.5 )
+			)
+		)
+
+		# If a width channel is specified, then that should be multiplied
+		# with the width from the plug.
+
+		scatter["widthChannel"].setValue( "G" )
+		points = scatter["out"].object( "/points" )
+		self.assertEqual(
+			points["width"],
+			IECoreScene.PrimitiveVariable(
+				IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+				IECore.FloatVectorData( [ 0.5 * 0.5 ] * points.numPoints )
+			)
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -172,6 +172,7 @@ from .ImageToPointsTest import ImageToPointsTest
 from .MeshSplitTest import MeshSplitTest
 from .FramingConstraintTest import FramingConstraintTest
 from .MeshNormalsTest import MeshNormalsTest
+from .ImageScatterTest import ImageScatterTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/ImageScatterUI.py
+++ b/python/GafferSceneUI/ImageScatterUI.py
@@ -1,0 +1,158 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferScene
+
+##########################################################################
+# Metadata
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ImageScatter,
+
+	"description",
+	"""
+	Scatters points across an image, using pixel values to control the density
+	of the points. Arbitrary image channels may be converted to additional
+	primitive variables on the points, and point width may also be driven by an
+	image channel.
+
+	> Note : Only the area of the `displayWindow` is considered. To
+	> include overscan pixels, use a Crop node to extend the display
+	> window.
+	""",
+
+	plugs = {
+
+		"sets" : [
+
+			"layout:divider", True,
+
+		],
+
+		"image" : [
+
+			"description",
+			"""
+			The image used to drive the point scattering process.
+			""",
+
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+		"view" : [
+
+			"description",
+			"""
+			The view within the image to be used by the scattering process.
+			""",
+
+			"plugValueWidget:type", "GafferImageUI.ViewPlugValueWidget",
+			"layout:divider", True,
+
+		],
+
+		"density" : [
+
+			"description",
+			"""
+			The overall density of the scattered points, defined in points
+			per pixel.
+			"""
+
+		],
+
+		"densityChannel" : [
+
+			"description",
+			"""
+			The image channel used to modulate the density of the scattered points.
+			Black pixels will receive no points and white pixels will receive the
+			full amount as defined by the `density` plug.
+			"""
+
+		],
+
+		"primitiveVariables" : [
+
+			"description",
+			"""
+			The image channels to be converted to primitive variables on
+			the points. The chosen channels are converted using the
+			following rules :
+
+			- The main `RGB` channels are converted to a colour primitive variable called `Cs`.
+			- `<layerName>.RGB` channels are converted to a colour primitive variable called `<layerName>`.
+			- Other channels are converted to individual float primitive variables.
+			""",
+
+			"plugValueWidget:type", "GafferImageUI.ChannelMaskPlugValueWidget",
+
+		],
+
+		"width" : [
+
+			"description",
+			"""
+			The width of the points. If `widthChannel` is used as well, then this acts as
+			a multiplier on the channel values.
+			"""
+
+		],
+
+		"widthChannel" : [
+
+			"description",
+			"""
+			The channel used to provide per-point width values for the points.
+			""",
+
+			"plugValueWidget:type", "GafferImageUI.ChannelPlugValueWidget",
+			"channelPlugValueWidget:imagePlugName", "image",
+			"channelPlugValueWidget:extraChannels", IECore.StringVectorData( [ "" ] ),
+			"channelPlugValueWidget:extraChannelLabels", IECore.StringVectorData( [ "None" ] ),
+			"layout:divider", True,
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -186,6 +186,7 @@ from . import MeshSplitUI
 from . import FramingConstraintUI
 from . import MeshNormalsUI
 from . import LightToolUI
+from . import ImageScatterUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -36,6 +36,8 @@
 
 #include "GafferImage/Sampler.h"
 
+#include "GafferImage/ImageAlgo.h"
+
 using namespace IECore;
 using namespace Imath;
 using namespace Gaffer;
@@ -111,6 +113,20 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 	m_dataCacheRaw.resize( m_cacheWidth * cacheHeight, nullptr );
 
 	m_cacheOriginIndex = ( m_cacheWindow.min.x >> ImagePlug::tileSizeLog2() ) + m_cacheWidth * ( m_cacheWindow.min.y >> ImagePlug::tileSizeLog2() );
+}
+
+void Sampler::populate()
+{
+	ImageAlgo::parallelProcessTiles(
+		m_plug,
+		[&] ( const ImagePlug *imagePlug, const V2i &tileOrigin ) {
+			const float *tileData;
+			int tilePixelIndex;
+			cachedData( tileOrigin, tileData, tilePixelIndex );
+			assert( tilePixelIndex == 0 );
+		},
+		m_cacheWindow
+	);
 }
 
 void Sampler::hash( IECore::MurmurHash &h ) const

--- a/src/GafferScene/ImageScatter.cpp
+++ b/src/GafferScene/ImageScatter.cpp
@@ -1,0 +1,371 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/ImageScatter.h"
+
+#include "GafferImage/ImageAlgo.h"
+#include "GafferImage/Sampler.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/PointsPrimitive.h"
+
+#include "IECore/PointDistribution.h"
+
+#include "tbb/parallel_for.h"
+
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferImage;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Imath;
+using namespace std;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+void sampleChannel( const ImagePlug *image, const Box2i &displayWindow, const string &channelName, const vector<V3f> &positions, const IECore::Canceller *canceller, float *outData, int stride, float multiplier = 1.0f )
+{
+	Sampler sampler( image, channelName, displayWindow, Sampler::Clamp );
+	sampler.populate(); // Multithread the population of image tiles
+
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+	tbb::parallel_for( tbb::blocked_range<size_t>( 0, positions.size() ),
+		[&] ( const tbb::blocked_range<size_t> &range ) {
+			IECore::Canceller::check( canceller );
+			for( size_t i = range.begin(); i < range.end(); ++i )
+			{
+				outData[i*stride] = sampler.sample( positions[i].x, positions[i].y ) * multiplier;
+			}
+		},
+		taskGroupContext
+	);
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// ImageScatter
+//////////////////////////////////////////////////////////////////////////
+
+GAFFER_NODE_DEFINE_TYPE( ImageScatter );
+
+size_t ImageScatter::g_firstPlugIndex = 0;
+
+ImageScatter::ImageScatter( const std::string &name )
+	:	ObjectSource( name, "points" )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ImagePlug( "image" ) );
+	addChild( new StringPlug( "view", Plug::In, "default" ) );
+	addChild( new FloatPlug( "density", Plug::In, 0.5f, 0.0f ) );
+	addChild( new StringPlug( "densityChannel", Plug::In, "R" ) );
+	addChild( new StringPlug( "primitiveVariables" ) );
+	addChild( new FloatPlug( "width", Plug::In, 1.0f ) );
+	addChild( new StringPlug( "widthChannel" ) );
+}
+
+ImageScatter::~ImageScatter()
+{
+}
+
+GafferImage::ImagePlug *ImageScatter::imagePlug()
+{
+	return getChild<ImagePlug>( g_firstPlugIndex );
+}
+
+const GafferImage::ImagePlug *ImageScatter::imagePlug() const
+{
+	return getChild<ImagePlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *ImageScatter::viewPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *ImageScatter::viewPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::FloatPlug *ImageScatter::densityPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::FloatPlug *ImageScatter::densityPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 2 );
+}
+
+Gaffer::StringPlug *ImageScatter::densityChannelPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+const Gaffer::StringPlug *ImageScatter::densityChannelPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 3 );
+}
+
+Gaffer::StringPlug *ImageScatter::primitiveVariablesPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringPlug *ImageScatter::primitiveVariablesPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 4 );
+}
+
+Gaffer::FloatPlug *ImageScatter::widthPlug()
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::FloatPlug *ImageScatter::widthPlug() const
+{
+	return getChild<FloatPlug>( g_firstPlugIndex + 5 );
+}
+
+Gaffer::StringPlug *ImageScatter::widthChannelPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+const Gaffer::StringPlug *ImageScatter::widthChannelPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+}
+
+void ImageScatter::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ObjectSource::affects( input, outputs );
+
+	if(
+		input == viewPlug() ||
+		input == imagePlug()->viewNamesPlug() ||
+		input == imagePlug()->channelNamesPlug() ||
+		input == densityChannelPlug() ||
+		input == widthChannelPlug() ||
+		input == imagePlug()->formatPlug() ||
+		input == imagePlug()->dataWindowPlug() ||
+		input == imagePlug()->channelDataPlug() ||
+		input == densityPlug() ||
+		input == widthPlug() ||
+		input == primitiveVariablesPlug()
+	)
+	{
+		outputs.push_back( sourcePlug() );
+	}
+}
+
+void ImageScatter::hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	ImagePlug::ViewScope viewScope( context );
+	const std::string view = viewPlug()->getValue();
+	viewScope.setViewNameChecked( &view, imagePlug()->viewNames().get() );
+
+	ConstStringVectorDataPtr channelNamesData = imagePlug()->channelNamesPlug()->getValue();
+	const string densityChannel = densityChannelPlug()->getValue();
+	if( !ImageAlgo::channelExists( channelNamesData->readable(), densityChannel ) )
+	{
+		throw IECore::Exception( fmt::format( "Density channel \"{}\" does not exist", densityChannel ) );
+	}
+
+	const string widthChannel = widthChannelPlug()->getValue();
+	if( widthChannel.size() && !ImageAlgo::channelExists( channelNamesData->readable(), widthChannel ) )
+	{
+		throw IECore::Exception( fmt::format( "Width channel \"{}\" does not exist", widthChannel ) );
+	}
+
+	const Format format = imagePlug()->formatPlug()->getValue();
+	const Box2i &displayWindow = format.getDisplayWindow();
+	Sampler densitySampler( imagePlug(), densityChannel, displayWindow, Sampler::Clamp );
+
+	h.append( displayWindow );
+	h.append( format.getPixelAspect() );
+	densitySampler.hash( h );
+	densityPlug()->hash( h );
+
+	widthPlug()->hash( h );
+	h.append( widthChannel );
+
+	const std::string primitiveVariablesMatchPattern = primitiveVariablesPlug()->getValue();
+	for( const auto &channelName : channelNamesData->readable() )
+	{
+		if( channelName == widthChannel || StringAlgo::matchMultiple( channelName, primitiveVariablesMatchPattern ) )
+		{
+			h.append( channelName );
+			Sampler sampler( imagePlug(), channelName, displayWindow, Sampler::Clamp );
+			sampler.hash( h );
+		}
+	}
+}
+
+IECore::ConstObjectPtr ImageScatter::computeSource( const Context *context ) const
+{
+	// Validate input image.
+
+	ImagePlug::ViewScope viewScope( context );
+	const std::string view = viewPlug()->getValue();
+	viewScope.setViewNameChecked( &view, imagePlug()->viewNames().get() );
+
+	ConstStringVectorDataPtr channelNamesData = imagePlug()->channelNamesPlug()->getValue();
+	const string densityChannel = densityChannelPlug()->getValue();
+	if( !ImageAlgo::channelExists( channelNamesData->readable(), densityChannel ) )
+	{
+		throw IECore::Exception( fmt::format( "Density channel \"{}\" does not exist", densityChannel ) );
+	}
+
+	const string widthChannel = widthChannelPlug()->getValue();
+	if( widthChannel.size() && !ImageAlgo::channelExists( channelNamesData->readable(), widthChannel ) )
+	{
+		throw IECore::Exception( fmt::format( "Density channel \"{}\" does not exist", widthChannel ) );
+	}
+
+	const Format format = imagePlug()->formatPlug()->getValue();
+	const Box2i &displayWindow = format.getDisplayWindow();
+	const float pixelAspect = format.getPixelAspect();
+	const Box2f outputArea = Box2f(
+		V2f( displayWindow.min.x * pixelAspect, displayWindow.min.y ),
+		V2f( displayWindow.max.x * pixelAspect, displayWindow.max.y )
+	);
+
+	// Generate positions using a PointDistribution reading from a Sampler for
+	// the density channel.
+
+	Sampler densitySampler( imagePlug(), densityChannel, displayWindow, Sampler::Clamp );
+	densitySampler.populate(); // Multithread the population of image tiles
+
+	// Point distribution is designed for samping within a unit square, so we
+	// offset and scale to fit that to our input image.
+	const float scale = std::max( outputArea.size().x, outputArea.size().y );
+	const V2i offset = displayWindow.min;
+
+	auto densityFunction = [&] ( const V2f &p ) {
+		IECore::Canceller::check( context->canceller() );
+		return densitySampler.sample( offset.x + p.x * scale / pixelAspect, offset.y + p.y * scale );
+	};
+
+	V3fVectorDataPtr positionsData = new V3fVectorData;
+	positionsData->setInterpretation( IECore::GeometricData::Point );
+	vector<V3f> &positions = positionsData->writable();
+	auto emitter = [&] ( const V2f &p ) {
+		positions.push_back( V3f( offset.x + p.x * scale, offset.y + p.y * scale, 0.0f ) );
+	};
+
+	/// \todo It would be nice to multithread this, but it could also be pretty
+	/// handy that the order of the points we're outputting matches the
+	/// progressive order in which they are generated.
+	PointDistribution::defaultInstance()(
+		Box2f( V2f( 0 ), V2f( outputArea.size() ) / scale ),
+		// Scale density to be in points per pixel
+		densityPlug()->getValue() * scale * scale,
+		densityFunction,
+		emitter
+	);
+
+	// Make a PointsPrimitive from the positions
+
+	PointsPrimitivePtr result = new PointsPrimitive( positionsData );
+
+	// Add on primitive variables.
+
+	const float width = widthPlug()->getValue();
+	if( widthChannel.empty() )
+	{
+		result->variables["width"] = PrimitiveVariable( PrimitiveVariable::Interpolation::Constant, new FloatData( width ) );
+	}
+
+	const std::string primitiveVariablesMatchPattern = primitiveVariablesPlug()->getValue();
+	for( const auto &channelName : channelNamesData->readable() )
+	{
+		if( StringAlgo::matchMultiple( channelName, primitiveVariablesMatchPattern ) )
+		{
+			const int colorIndex = ImageAlgo::colorIndex( channelName );
+			if( colorIndex >= 0 && colorIndex <= 2 )
+			{
+				// Map R, G and B to the components of colour primitive variables.
+				// This is the same behaviour as ImageToPoints.
+				string name = ImageAlgo::layerName( channelName );
+				name = name == "" ? "Cs" : name;
+				Color3fVectorDataPtr colorData = result->variableData<Color3fVectorData>( name );
+				if( !colorData )
+				{
+					colorData = new Color3fVectorData;
+					colorData->writable().resize( positions.size() );
+					result->variables[name] = PrimitiveVariable( PrimitiveVariable::Vertex, colorData );
+				}
+				sampleChannel( imagePlug(), displayWindow, channelName, positions, context->canceller(), colorData->baseWritable() + colorIndex, 3 );
+			}
+			else
+			{
+				// Map everything else to individual float primitive variables.
+				const string name = channelName == widthChannel ? "width" : channelName;
+				FloatVectorDataPtr floatData = new FloatVectorData;
+				floatData->writable().resize( positions.size() );
+				result->variables[name] = PrimitiveVariable( PrimitiveVariable::Vertex, floatData );
+				sampleChannel( imagePlug(), displayWindow, channelName, positions, context->canceller(), floatData->writable().data(), 1 );
+			}
+		}
+
+		if( channelName == widthChannel )
+		{
+			FloatVectorDataPtr widthData = new FloatVectorData;
+			widthData->writable().resize( positions.size() );
+			result->variables["width"] = PrimitiveVariable( PrimitiveVariable::Vertex, widthData );
+			sampleChannel( imagePlug(), displayWindow, channelName, positions, context->canceller(), widthData->writable().data(), 1, width );
+		}
+	}
+
+	return result;
+}
+
+Gaffer::ValuePlug::CachePolicy ImageScatter::computeCachePolicy( const Gaffer::ValuePlug *output ) const
+{
+	if( output == sourcePlug() )
+	{
+		return ValuePlug::CachePolicy::TaskCollaboration;
+	}
+	return ObjectSource::computeCachePolicy( output );
+}

--- a/src/GafferSceneModule/PrimitivesBinding.cpp
+++ b/src/GafferSceneModule/PrimitivesBinding.cpp
@@ -46,6 +46,7 @@
 #include "GafferScene/Cube.h"
 #include "GafferScene/ExternalProcedural.h"
 #include "GafferScene/Grid.h"
+#include "GafferScene/ImageScatter.h"
 #include "GafferScene/ImageToPoints.h"
 #include "GafferScene/Light.h"
 #include "GafferScene/ObjectToScene.h"
@@ -150,6 +151,7 @@ void GafferSceneModule::bindPrimitives()
 	GafferBindings::DependencyNodeClass<Cube>();
 	GafferBindings::DependencyNodeClass<Text>();
 	GafferBindings::DependencyNodeClass<ObjectToScene>();
+	GafferBindings::DependencyNodeClass<ImageScatter>();
 	GafferBindings::DependencyNodeClass<ImageToPoints>();
 
 	{

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -247,6 +247,7 @@ nodeMenu.append( "/Scene/File/Reader", GafferScene.SceneReader, searchText = "Sc
 nodeMenu.append( "/Scene/File/Writer", GafferScene.SceneWriter, searchText = "SceneWriter" )
 nodeMenu.append( "/Scene/Source/Object To Scene", GafferScene.ObjectToScene, searchText = "ObjectToScene" )
 nodeMenu.append( "/Scene/Source/Image To Points", GafferScene.ImageToPoints, searchText = "ImageToPoints" )
+nodeMenu.append( "/Scene/Source/Image Scatter", GafferScene.ImageScatter, searchText = "ImageScatter" )
 nodeMenu.append( "/Scene/Source/Camera", GafferScene.Camera )
 nodeMenu.append( "/Scene/Source/Coordinate System", GafferScene.CoordinateSystem, searchText = "CoordinateSystem" )
 nodeMenu.append( "/Scene/Source/Clipping Plane", GafferScene.ClippingPlane, searchText = "ClippingPlane" )


### PR DESCRIPTION
This uses the same high quality blue-noise point distribution that we use in the main Scatter node, but this time scattering across an image, with an image channel providing the density values. You can also sample additional image channels and store them as primitive variables, using the same mapping rules established already in the ImageToPoints node.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/77282c7a-3a5d-4f24-a5df-42c762fd41ec)