### PR TITLE
Revert "ValuePlug : Don't evaluate cache policy for plugs just changing type"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -202,7 +202,6 @@ Fixes
   - Fixed the Difference operation to return correct values for exceptional floating point values. Now there is 0 difference between `inf` and `inf`, or `NaN` and `NaN`. Additionally, there is infinite difference between `NaN` and any other number, so assertImagesEqual will correctly report `NaN`s that don't belong.
   - Fixed the Divide operation to return 0 for 0/0. This is consistent with how we previously handled fully black tiles, and avoids introducing `NaN` values which create problems in compositing.
 - Median/Erode/Dilate : Fixed possible crash bug if there were `NaN`s in the input image.
-- ValuePlug : Fixed bug which caused `ComputeNode::computeCachePolicy()` to be called unnecessarily for input plugs in some circumstances. This could affect performance, particularly when the plug belonged to a node implemented in Python.
 
 API
 ---

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -980,38 +980,6 @@ class ValuePlugTest( GafferTest.TestCase ) :
 			backgroundTask2.cancelAndWait()
 			backgroundTask1.cancelAndWait()
 
-	# A node that inherits from ComputeNode, but doesn't implement a compute.
-	# We would expect the cache policies to never be evaluated
-	class NoComputeNode( Gaffer.ComputeNode ) :
-
-		def __init__( self, name="NoComputeNode" ) :
-
-			Gaffer.ComputeNode.__init__( self, name )
-
-			self["in"] = Gaffer.BoolPlug()
-
-		def computeCachePolicy( self, plug ) :
-
-			raise IECore.Exception( "Cache policy should not be called" )
-
-		def hashCachePolicy( self, plug ) :
-
-			raise IECore.Exception( "Hash cache policy should not be called" )
-
-	IECore.registerRunTimeTyped( NoComputeNode )
-
-	def testNoCachePolicyForConversions( self ) :
-
-		m = GafferTest.MultiplyNode()
-		n = self.NoComputeNode()
-
-		# Make sure that the conversion triggered by connecting a float plug to a bool plug
-		# does not use the nodes cache policies
-		n["in"].setInput( m["product"] )
-
-		n["in"].hash()
-		self.assertEqual( n["in"].getValue(), False )
-
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -606,11 +606,9 @@ class ValuePlug::ComputeProcess : public Process
 		{
 			const ValuePlug *p = sourcePlug( plug );
 
-			const ComputeNode *computeNode = IECore::runTimeCast<const ComputeNode>( p->node() );
-
 			if( !p->getInput() )
 			{
-				if( p->direction()==In || !computeNode )
+				if( p->direction()==In || !IECore::runTimeCast<const ComputeNode>( p->node() ) )
 				{
 					// No input connection, and no means of computing
 					// a value. There can only ever be a single value,
@@ -626,19 +624,8 @@ class ValuePlug::ComputeProcess : public Process
 			const ThreadState &threadState = ThreadState::current();
 			const Context *currentContext = threadState.context();
 
-			CachePolicy cachePolicy = CachePolicy::Uncached;
-			if( p->getInput() )
-			{
-				// Type conversion will be implemented by `setFrom()`.
-				// \todo Determine if caching is actually worthwhile for this.
-				cachePolicy = CachePolicy::Legacy;
-			}
-			else if( computeNode )
-			{
-				cachePolicy = computeNode->computeCachePolicy( p );
-			}
-
-			const ComputeProcessKey processKey( p, plug, computeNode, cachePolicy, precomputedHash );
+			const ComputeNode *computeNode = IECore::runTimeCast<const ComputeNode>( p->node() );
+			const ComputeProcessKey processKey( p, plug, computeNode, computeNode ? computeNode->computeCachePolicy( p ) : CachePolicy::Uncached, precomputedHash );
 
 			if( processKey.cachePolicy == CachePolicy::Uncached )
 			{


### PR DESCRIPTION
This is the latest suspect in my hunt for the regression. No review needed - I just want to get my hands on the builds. Apologies for the noise - we really should sort out a way of getting build artifacts out of CI without an unnecessary PR.