### PR TITLE
Fix `ValuePlug::getValue()` performance regression

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 Fixes
 -----
 
+- ValuePlug : Fixed performance regression (introduced in 1.3.1.0) getting values from plugs without an input connection. This could severely affect scene generation times in some cases.
 - NameSwitch : Fixed bug which prevented drag and drop reordering of rows with an input connection.
 - PythonEditor :
   - Fixed output for `print()` calls with multiple arguments, which was previously spread across multiple lines.

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - Spreadsheet :
   - Popups for string cells and row names are now sized to fit their column.
   - Added "Triple" and "Quadruple" width options to the spreadsheet row name popup menu.
+- Node : Improved performance when casting Python-derived types to ComputeNode.
 
 Fixes
 -----

--- a/include/GafferBindings/NodeBinding.h
+++ b/include/GafferBindings/NodeBinding.h
@@ -101,9 +101,10 @@ class NodeWrapper : public GraphComponentWrapper<T>
 				// the `Dispatcher::dispatch()` process.
 				typeId == (IECore::TypeId)Gaffer::ContextProcessorTypeId ||
 				typeId == (IECore::TypeId)Gaffer::SwitchTypeId ||
-				// ScriptNode, DependencyNode and EditScope also appear on
-				// performance critical code paths.
+				// ScriptNode, DependencyNode, ComputeNode and EditScope also
+				// appear on performance critical code paths.
 				typeId == (IECore::TypeId)Gaffer::ScriptNodeTypeId ||
+				typeId == (IECore::TypeId)Gaffer::ComputeNodeTypeId ||
 				typeId == (IECore::TypeId)Gaffer::DependencyNodeTypeId ||
 				typeId == (IECore::TypeId)Gaffer::EditScopeTypeId
 			)

--- a/python/GafferTest/BoxTest.py
+++ b/python/GafferTest/BoxTest.py
@@ -1119,5 +1119,24 @@ class BoxTest( GafferTest.TestCase ) :
 
 		assertPassThrough( s2 )
 
+	def testComputeNodeCastDoesntRequirePython( self ) :
+
+		class CastChecker( Gaffer.Box ) :
+
+			def __init__( self, name = "CastChecker" ) :
+
+				Gaffer.Box.__init__( self, name )
+				self["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out )
+
+			def isInstanceOf( self, typeId ) :
+
+				raise Exception( "Cast to ComputeNode should not require Python" )
+
+		# The call to `dependsOnCompute()` will internally cast to `ComputeNode`
+		# in C++. We don't want that to require entry into Python because it is
+		# far too costly and the answer can be determined on the C++ side anyway.
+		node = CastChecker()
+		self.assertFalse( Gaffer.PlugAlgo.dependsOnCompute( node["out"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ValuePlugTest.py
+++ b/python/GafferTest/ValuePlugTest.py
@@ -691,6 +691,15 @@ class ValuePlugTest( GafferTest.TestCase ) :
 		with GafferTest.TestRunner.PerformanceScope() :
 			GafferTest.parallelGetValue( m["product"], 10000000 )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testStaticNumericValuePerformance( self ) :
+
+		node = Gaffer.Node()
+		node["plug"] = Gaffer.IntPlug()
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferTest.parallelGetValue( node["plug"], 10000000 )
+
 	def testIsSetToDefault( self ) :
 
 		n1 = GafferTest.AddNode()
@@ -1011,6 +1020,21 @@ class ValuePlugTest( GafferTest.TestCase ) :
 
 		n["in"].hash()
 		self.assertEqual( n["in"].getValue(), False )
+
+	def testOutputPlugWithConvertingInput( self ) :
+
+		for nodeType in ( Gaffer.Node, Gaffer.ComputeNode ) :
+			with self.subTest( nodeType = nodeType ) :
+
+				node = nodeType()
+				node["in"] = Gaffer.IntPlug()
+				node["out"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out )
+				node["out"].setInput( node["in"] )
+
+				for i in range( 0, 10 ) :
+
+					node["in"].setValue( i )
+					self.assertEqual( node["out"].getValue(), i )
 
 	def setUp( self ) :
 


### PR DESCRIPTION
This fixes a performance regression introduced in 1.3.1.0 by https://github.com/GafferHQ/gaffer/commit/055f07d9b8726437e5fabc0335cee6fdaf36e19f. That commit removed unnecessary overhead for any type-converting-inputs on plugs held by Python-derived nodes, but added equivalent overhead for the far more common case of unconnected inputs on Python-derived nodes. This had a noticeable impact on scene generation times (around 3x in the case I've been debugging).