### PR TITLE
Improve cache limit configuration

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Breaking Changes
 
 - Render : Changed `render:includedPurposes` default to `"default", "render"`.
 - ValuePlug : Removed deprecated `getObjectValue()` overload.
+- Preferences : Removed `cache` plug.
 - Dispatcher : Removed `createMatching()` method.
 - Process : Removed non-const variant of the `handleException()` method.
 - StringPlug : Removed deprecated `precomputedHash` argument from `getValue()` method.

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - Toolbars : Changed hotkey behavior to toogle any tool on and off. Exclusive tools such as the Translate and Crop Window tools activate the first tool (currently Selection Tool) when they are toggled off.
 - CropWindowTool : Added <kbd>`Alt` + <kbd>`C` for toggling both the crop window tool and the relevant crop window `enabled` plug.
 - TaskList, FrameMask : Reimplemented in C++ for improved performance.
+- Cache : Increased default computation cache size to 8Gb. Call `Gaffer.ValuePlug.setCacheMemoryLimit()` from a startup file to override this.
 
 Breaking Changes
 ----------------

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -695,6 +695,7 @@ class ValuePlug::ComputeProcess : public Process
 
 const IECore::InternedString ValuePlug::ComputeProcess::staticType( ValuePlug::computeProcessType() );
 // Using a null `GetterFunction` because it will never get called, because we only ever call `getIfCached()`.
+// Note : The default size here is overridden by `startup/Gaffer/cache.py`.
 ValuePlug::ComputeProcess::CacheType ValuePlug::ComputeProcess::g_cache( CacheType::GetterFunction(), 1024 * 1024 * 1024 * 1, CacheType::RemovalCallback(), /* cacheErrors = */ false ); // 1 gig
 
 //////////////////////////////////////////////////////////////////////////

--- a/startup/Gaffer/cache.py
+++ b/startup/Gaffer/cache.py
@@ -1,0 +1,54 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import Gaffer
+
+# Set cache memory limit to 8 gigs, capped at 3/4 of the total
+# physical memory.
+
+cacheLimit = 1024**3 * 8 # 8 Gigs
+
+if os.name != "nt" :
+	physicalMemory = os.sysconf( "SC_PAGE_SIZE" ) * os.sysconf( "SC_PHYS_PAGES" )
+	cacheLimit = min( cacheLimit, physicalMemory * 3 // 4  )
+else :
+	# No native Python API for querying physical memory on Windows.
+	# And surely nobody is brave enough to use Windows with less
+	# than 8 gigs ;)
+	pass
+
+Gaffer.ValuePlug.setCacheMemoryLimit( cacheLimit )

--- a/startup/gui/cacheCompatibility.py
+++ b/startup/gui/cacheCompatibility.py
@@ -1,7 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -36,38 +35,25 @@
 ##########################################################################
 
 import Gaffer
-import GafferImage
 
-# add plugs to the preferences node
+# Backwards compatibility for old `preferences.py` files that reference the
+# `cache` plug we had at one point.
 
-preferences = application.root()["preferences"]
-preferences["cache"] = Gaffer.Plug()
-preferences["cache"]["enabled"] = Gaffer.BoolPlug( defaultValue = True )
-preferences["cache"]["memoryLimit"] = Gaffer.IntPlug( defaultValue = Gaffer.ValuePlug.getCacheMemoryLimit() // ( 1024 * 1024 ) )
+def __preferencesGetItemWrapper( originalGetItem ) :
 
-Gaffer.Metadata.registerValue( preferences["cache"], "plugValueWidget:type", "GafferUI.LayoutPlugValueWidget", persistent = False )
-Gaffer.Metadata.registerValue( preferences["cache"], "layout:section", "Cache", persistent = False )
+	def getItem( self, key ) :
 
-Gaffer.Metadata.registerValue(
-	preferences["cache"]["memoryLimit"],
-	"description",
-	"""
-	Controls the memory limit for Gaffer's ValuePlug cache.
-	""",
-	persistent = False
-)
+		if key == "cache" and key not in self :
+			# Just return a dangling plug that does nothing, but is
+			# enough to keep the `setValue()` calls in the preferences
+			# happy.
+			result = Gaffer.Plug( "cache" )
+			result["enabled"] = Gaffer.BoolPlug()
+			result["memoryLimit"] = Gaffer.IntPlug()
+			return result
 
-# update cache settings when they change
+		return originalGetItem( self, key )
 
-def __plugSet( plug ) :
+	return getItem
 
-	if plug.relativeName( plug.node() ) != "cache" :
-		return
-
-	memoryLimit = plug["memoryLimit"].getValue() * 1024 * 1024
-	if not plug["enabled"].getValue() :
-		memoryLimit = 0
-
-	Gaffer.ValuePlug.setCacheMemoryLimit( memoryLimit )
-
-preferences.plugSetSignal().connect( __plugSet, scoped = False )
+Gaffer.Preferences.__getitem__ = __preferencesGetItemWrapper( Gaffer.Preferences.__getitem__ )


### PR DESCRIPTION
This removes the questionable cache limit plugs from the GUI preferences, and ups the default limit to 8Gb via a config file.