### PR TITLE
Reference : Make `m_plugEdits` key more unique

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 - Windows :
   - Fixed a bug preventing anything except strings from being copied and pasted.
   - Fixed likely cause of crash when resizing Spreadsheet column width (#5296).
+- Reference : Fixed rare reloading error.
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/src/Gaffer/Reference.cpp
+++ b/src/Gaffer/Reference.cpp
@@ -395,6 +395,11 @@ class Reference::PlugEdits : public Signals::Trackable
 				return;
 			}
 
+			for( Plug::RecursiveIterator it( plug ); !it.done(); ++it )
+			{
+				m_plugEdits.erase( it->get() );
+			}
+
 			m_plugEdits.erase( plug );
 		}
 


### PR DESCRIPTION
This fixes a rare (about 1 in 1,000) test failure on Windows of `GafferTest.ReferenceTest.testAddingChildPlugs`. Though it works, there are a few things I'm not certain of :
1. Is there maybe a better solution? I guess this isn't a terribly performance-critical section and a smart pointer for storage isn't all that much of a burden.
2. Shouldn't this not be an issue because if a node is getting released and it's memory address is up for grabs, shouldn't it also have been removed from the `m_plugEdits` map?
3. Is it worth the performance hit to test `script.load()` and `assertExpectedChildren()` in a loop for something like 1000 iterations? On my workstation this takes about 15 seconds.
4. Does this deserve a mention in `changes.md`? If so, I assume it's a bug fix but what bug is being fixed? If it triggered in real use, it would attempt to set a value on a plug that shouldn't be set?

Thanks to @johnhaddon for pointing me in the direction of the pointer address reuse!

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
