### PR TITLE
_LinkedScrollBar : Guard against recursive updates

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,7 +16,9 @@ Improvements
 Fixes
 -----
 
-- Windows : Fixed a bug preventing anything except strings from being copied and pasted.
+- Windows :
+  - Fixed a bug preventing anything except strings from being copied and pasted.
+  - Fixed likely cause of crash when resizing Spreadsheet column width (#5296).
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/python/GafferUI/SpreadsheetUI/_LinkedScrollBar.py
+++ b/python/GafferUI/SpreadsheetUI/_LinkedScrollBar.py
@@ -91,23 +91,45 @@ class _LinkedScrollBar( GafferUI.Widget ) :
 			scrollBar.rangeChanged.connect( Gaffer.WeakMethod( self.__rangeChanged ) )
 			scrollBar.stepsChanged.connect( Gaffer.WeakMethod( self.__stepsChanged ) )
 
+		self.__isUpdating = False
+
 	def __valueChanged( self, value ) :
 
-		for scrollBar in self.__scrollBars :
-			scrollBar.setValue( value )
+		if self.__isUpdating :
+			return
+
+		try :
+			self.__isUpdating = True
+			for scrollBar in self.__scrollBars :
+				scrollBar.setValue( value )
+		finally :
+			self.__isUpdating = False
 
 	def __rangeChanged( self, min, max ) :
 
-		for scrollBar in self.__scrollBars :
-			scrollBar.setRange( min, max )
+		if self.__isUpdating :
+			return
 
-		self.setVisible( min != max )
+		try :
+			self.__isUpdating = True
+			for scrollBar in self.__scrollBars :
+				scrollBar.setRange( min, max )
+			self.setVisible( min != max )
+		finally :
+			self.__isUpdating = False
 
 	def __stepsChanged( self, page, single ) :
 
-		for scrollBar in self.__scrollBars :
-			scrollBar.setPageStep( page )
-			scrollBar.setSingleStep( single )
+		if self.__isUpdating :
+			return
+
+		try :
+			self.__isUpdating = True
+			for scrollBar in self.__scrollBars :
+				scrollBar.setPageStep( page )
+				scrollBar.setSingleStep( single )
+		finally :
+			self.__isUpdating = False
 
 # QScrollBar provides signals for when the value and range are changed,
 # but not for when the page step is changed. This subclass adds the missing


### PR DESCRIPTION
This is a potential fix for #5296. As noted in the commit message, I haven't been able to reproduce the crash. This should prevent problematic recursion by blocking updates from happening if an update is already in progress.

### Related issues ###

#5296 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
