### PR TITLE
Filter : Sanitise context used to evaluate `Filter.enabled`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
 Fixes
 -----
 
+- Filter : Fixed bug which allowed the `scene:path` context variable to "leak" upstream via the `Filter.enabled` plug. This caused unnecessary evaluations of the input, and also provided a loophole via which the filter result could be made inconsistent with respect to descendant and ancestor matches.
 - Windows :
   - Fixed a bug preventing anything except strings from being copied and pasted.
   - Fixed likely cause of crash when resizing Spreadsheet column width (#5296).

--- a/include/GafferScene/Filter.h
+++ b/include/GafferScene/Filter.h
@@ -113,6 +113,8 @@ class GAFFERSCENE_API Filter : public Gaffer::ComputeNode
 
 	private :
 
+		bool enabled( const Gaffer::Context *context ) const;
+
 		friend class FilterPlug;
 
 		static size_t g_firstPlugIndex;


### PR DESCRIPTION
Without this, any input connections were evaluated once per location rather than just once, leading to much unnecessary pressure on the hash cache. It also provided a loophole via which you could modify the filter per location in a way that meant that ancestor and descendant matches would be inaccurate.
