### PR TITLE
gui app : Fix copy and paste on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.5.0)
 =======
 
+Fixes
+-----
+
+- Windows : Fixed a bug preventing anything except strings from being copied and pasted.
+
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/apps/gui/gui-1.py
+++ b/apps/gui/gui-1.py
@@ -161,7 +161,7 @@ class gui( Gaffer.Application ) :
 		from Qt import QtWidgets
 
 		text = QtWidgets.QApplication.clipboard().text().encode( "utf-8" )
-		if text :
+		if text and text != str( self.root().getClipboardContents() ).encode( "utf-8" ) :
 			with Gaffer.Signals.BlockedConnection( self.__clipboardContentsChangedConnection ) :
 				self.root().setClipboardContents( IECore.StringData( text ) )
 


### PR DESCRIPTION
It seems that Windows or Qt on Windows emits an extra update signal when copying to the clipboard, thwarting our attempt at not receiving the Qt clipboard update event when syncing the Gaffer clipboard. By checking to make sure there is a real change to make, we don't clobber the Gaffer clipboard's stored `IECore::Object` with a string.

Fixes #5485 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
