### PR TITLE
Redundant metadata cleanup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ API
   - Added `RegistrationTypes` enum that allows the different types of registrations to be identified.
   - Added improved `registeredValues()` and `value()` overloads that provide finer-grained queries based on the type of registration.
   - Deprecated `instanceOnly` and `persistentOnly` arguments in favour of new `registrationTypes` arguments.
+  - Prevented `renameable` and `deletable` metadata from being copied during plug promotion.
 - MetadataAlgo : Added `deregisterRedundantValues()` method.
 
 1.3.5.0 (relative to 1.3.4.0)

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Features
 - LightTool :
   - Added manipulator for disk and point light radii.
   - Added manipulators for cylinder length and radius.
+- Tools Menu : Added "Metadata/Clean Up" menu item to optimise file size by removing redundant metadata.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,14 @@ API
 - ValuePlug : Added `Default` CachePolicy and deprecated `Standard`, `TaskIsolation` and `Legacy` policies.
 - Metadata : Fixed redundant copying of metadata when promoting plugs.
 
+API
+---
+
+- Metadata :
+  - Added `RegistrationTypes` enum that allows the different types of registrations to be identified.
+  - Added improved `registeredValues()` and `value()` overloads that provide finer-grained queries based on the type of registration.
+  - Deprecated `instanceOnly` and `persistentOnly` arguments in favour of new `registrationTypes` arguments.
+
 1.3.5.0 (relative to 1.3.4.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ API
 
 - Process : Added `acquireCollaborativeResult()` method, providing an improved mechanism for multiple threads to collaborate on TBB tasks spawned by a single process they all depend on.
 - ValuePlug : Added `Default` CachePolicy and deprecated `Standard`, `TaskIsolation` and `Legacy` policies.
+- Metadata : Fixed redundant copying of metadata when promoting plugs.
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,7 @@ API
   - Added `RegistrationTypes` enum that allows the different types of registrations to be identified.
   - Added improved `registeredValues()` and `value()` overloads that provide finer-grained queries based on the type of registration.
   - Deprecated `instanceOnly` and `persistentOnly` arguments in favour of new `registrationTypes` arguments.
+- MetadataAlgo : Added `deregisterRedundantValues()` method.
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -94,11 +94,22 @@ class GAFFER_API Metadata
 		/// Registration queries
 		/// ====================
 
+		enum RegistrationTypes
+		{
+			None = 0,
+			TypeId = 1,
+			TypeIdDescendant = 2,
+			InstancePersistent = 4,
+			InstanceNonPersistent = 8,
+			Instance = InstancePersistent | InstanceNonPersistent,
+			All = TypeId | TypeIdDescendant | Instance
+		};
+
 		/// Fills the keys vector with keys for all values registered with the methods above.
 		static void registeredValues( IECore::InternedString target, std::vector<IECore::InternedString> &keys );
-		/// Fills the keys vector with keys for all values registered for the specified graphComponent.
-		/// If instanceOnly is true, then only the values registered for that exact instance are returned.
-		/// If persistentOnly is true, then non-persistent instance values are ignored.
+		/// Returns the keys for all values relevant to `target`, taking into account only the specified `registrationTypes`.
+		static std::vector<IECore::InternedString> registeredValues( const GraphComponent *target, unsigned registrationTypes = RegistrationTypes::All );
+		/// \deprecated Pass RegistrationTypes instead.
 		static void registeredValues( const GraphComponent *target, std::vector<IECore::InternedString> &keys, bool instanceOnly = false, bool persistentOnly = false );
 
 		/// Value retrieval
@@ -107,6 +118,11 @@ class GAFFER_API Metadata
 		/// Retrieves a value, returning null if none exists.
 		template<typename T=IECore::Data>
 		static typename T::ConstPtr value( IECore::InternedString target, IECore::InternedString key );
+		/// Ignores any values not included in `registrationTypes`.
+		template<typename T=IECore::Data>
+		static typename T::ConstPtr value( const GraphComponent *target, IECore::InternedString key, unsigned registrationTypes );
+		/// \deprecated Pass RegistrationTypes instead. When we remove this,
+		/// default `registrationTypes` to `All` in overload above.
 		template<typename T=IECore::Data>
 		static typename T::ConstPtr value( const GraphComponent *target, IECore::InternedString key, bool instanceOnly = false );
 
@@ -189,6 +205,8 @@ class GAFFER_API Metadata
 		static void instanceDestroyed( GraphComponent *graphComponent );
 
 		static IECore::ConstDataPtr valueInternal( IECore::InternedString target, IECore::InternedString key );
+		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, unsigned registrationTypes );
+		/// \deprecated
 		static IECore::ConstDataPtr valueInternal( const GraphComponent *target, IECore::InternedString key, bool instanceOnly );
 
 };

--- a/include/Gaffer/Metadata.inl
+++ b/include/Gaffer/Metadata.inl
@@ -46,6 +46,12 @@ typename T::ConstPtr Metadata::value( IECore::InternedString target, IECore::Int
 }
 
 template<typename T>
+typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::InternedString key, unsigned registrationTypes )
+{
+	return IECore::runTimeCast<const T>( valueInternal( target, key, registrationTypes ) );
+}
+
+template<typename T>
 typename T::ConstPtr Metadata::value( const GraphComponent *target, IECore::InternedString key, bool instanceOnly )
 {
 	return IECore::runTimeCast<const T>( valueInternal( target, key, instanceOnly ) );

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -234,6 +234,16 @@ GAFFER_API void copyColors( const Gaffer::Plug *srcPlug, Gaffer::Plug *dstPlug, 
 /// Returns true if metadata can be promoted from one plug to another.
 GAFFER_API bool isPromotable( const GraphComponent *from, const GraphComponent *to, const IECore::InternedString &name );
 
+/// Cleanup
+/// =======
+
+/// Removes any redundant metadata registrations from `graphComponent` and all
+/// its descendants. By redundant we mean instance-level registrations that have
+/// the same value as an exising type-based fallback, so that removing the
+/// instance registration has no effect on the composed result.
+/// \undoable
+GAFFER_API void deregisterRedundantValues( GraphComponent *graphComponent );
+
 } // namespace MetadataAlgo
 
 } // namespace Gaffer

--- a/include/Gaffer/MetadataAlgo.inl
+++ b/include/Gaffer/MetadataAlgo.inl
@@ -48,8 +48,7 @@ namespace MetadataAlgo
 template<typename Predicate>
 void copyIf( const GraphComponent *from, GraphComponent *to, Predicate &&predicate, bool persistent )
 {
-	std::vector<IECore::InternedString> names;
-	Metadata::registeredValues( from, names, /* instanceOnly = */ false, /* persistentOnly = */ false );
+	const std::vector<IECore::InternedString> names = Metadata::registeredValues( from );
 	for( const auto &name : names )
 	{
 		if( predicate( from, const_cast<const GraphComponent *>( to ), name ) )

--- a/python/Gaffer/ExtensionAlgo.py
+++ b/python/Gaffer/ExtensionAlgo.py
@@ -206,7 +206,7 @@ def __uiDefinition( box, extension ) :
 def __metadata( graphComponent ) :
 
 	items = []
-	for k in Gaffer.Metadata.registeredValues( graphComponent, instanceOnly = True, persistentOnly = True ) :
+	for k in Gaffer.Metadata.registeredValues( graphComponent, Gaffer.Metadata.RegistrationTypes.InstancePersistent ) :
 
 		v = Gaffer.Metadata.value( graphComponent, k )
 		items.append(

--- a/python/GafferSceneTest/GroupTest.py
+++ b/python/GafferSceneTest/GroupTest.py
@@ -755,11 +755,8 @@ class GroupTest( GafferSceneTest.SceneTestCase ) :
 
 		g["in"][0].setInput( p["out"] )
 
-		noduleColor = Gaffer.Metadata.value( p, "nodule:color", instanceOnly = True )
-		connectionColor = Gaffer.Metadata.value( p, "connectionGadget:color", instanceOnly = True )
-
-		self.assertEqual( noduleColor, None )
-		self.assertEqual( noduleColor, connectionColor )
+		self.assertIsNone( Gaffer.Metadata.value( p, "nodule:color", Gaffer.Metadata.RegistrationTypes.Instance ) )
+		self.assertIsNone( Gaffer.Metadata.value( p, "connectionGadget:color", Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 	def testProcessInvalidSet( self ) :
 

--- a/python/GafferTest/BoxInTest.py
+++ b/python/GafferTest/BoxInTest.py
@@ -195,7 +195,7 @@ class BoxInTest( GafferTest.TestCase ) :
 		s["b1"]["i"].setup( s["b1"]["n"]["op1"] )
 
 		self.assertEqual( Gaffer.Metadata.value( s["b1"]["i"].promotedPlug(), "test" ), "testValue" )
-		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b1"]["i"].promotedPlug(), instanceOnly = True ) )
+		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b1"]["i"].promotedPlug(), Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 		s["b2"] = Gaffer.Box()
 		s.execute(
@@ -204,7 +204,7 @@ class BoxInTest( GafferTest.TestCase ) :
 		)
 
 		self.assertEqual( Gaffer.Metadata.value( s["b2"]["i"].promotedPlug(), "test" ), "testValue" )
-		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b2"]["i"].promotedPlug(), instanceOnly = True ) )
+		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b2"]["i"].promotedPlug(), Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 	def testNoduleSectionMetadata( self ) :
 

--- a/python/GafferTest/BoxOutTest.py
+++ b/python/GafferTest/BoxOutTest.py
@@ -153,7 +153,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 		s["b1"]["o"].setup( s["b1"]["n"]["sum"] )
 
 		self.assertEqual( Gaffer.Metadata.value( s["b1"]["o"].promotedPlug(), "test" ), "testValue" )
-		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b1"]["o"].promotedPlug(), instanceOnly = True ) )
+		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b1"]["o"].promotedPlug(), Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 		s["b2"] = Gaffer.Box()
 		s.execute(
@@ -162,7 +162,7 @@ class BoxOutTest( GafferTest.TestCase ) :
 		)
 
 		self.assertEqual( Gaffer.Metadata.value( s["b2"]["o"].promotedPlug(), "test" ), "testValue" )
-		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b2"]["o"].promotedPlug(), instanceOnly = True ) )
+		self.assertNotIn( "layout:section", Gaffer.Metadata.registeredValues( s["b2"]["o"].promotedPlug(), Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 	def testNoduleSectionMetadata( self ) :
 

--- a/python/GafferTest/ExtensionAlgoTest.py
+++ b/python/GafferTest/ExtensionAlgoTest.py
@@ -86,9 +86,9 @@ class ExtensionAlgoTest( GafferTest.TestCase ) :
 
 		def assertExpectedMetadata( node ) :
 
-			self.assertEqual( Gaffer.Metadata.registeredValues( node, instanceOnly = True ), [] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( node["in"], instanceOnly = True ), [] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( node["out"], instanceOnly = True ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( node, Gaffer.Metadata.RegistrationTypes.Instance ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( node["in"], Gaffer.Metadata.RegistrationTypes.Instance ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( node["out"], Gaffer.Metadata.RegistrationTypes.Instance ), [] )
 
 			self.assertEqual( Gaffer.Metadata.value( node, "description" ), "Test" )
 			self.assertEqual( Gaffer.Metadata.value( node["in"], "description" ), "The input" )

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -486,13 +486,13 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 		s = Gaffer.ScriptNode()
 		s["n"] = Gaffer.Node()
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 0 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.Instance ) ), 0 )
 
 		Gaffer.MetadataAlgo.setBookmarked( s["n"], True )
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 1 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.Instance ) ), 1 )
 
 		Gaffer.MetadataAlgo.setBookmarked( s["n"], False )
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ) ), 0 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.Instance ) ), 0 )
 
 	def testNumericBookmarks( self ) :
 
@@ -708,21 +708,21 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 
 		n = Gaffer.Node()
 		Gaffer.MetadataAlgo.addAnnotation( n, "test", Gaffer.MetadataAlgo.Annotation( text = "abc" ) )
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, instanceOnly = True ) ), 1 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance ) ), 1 )
 		self.assertEqual(
 			Gaffer.MetadataAlgo.getAnnotation( n, "test" ),
 			Gaffer.MetadataAlgo.Annotation( text = "abc" )
 		)
 
 		Gaffer.MetadataAlgo.addAnnotation( n, "test", Gaffer.MetadataAlgo.Annotation( text = "xyz", color = imath.Color3f( 1 ) ) )
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, instanceOnly = True ) ), 2 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance ) ), 2 )
 		self.assertEqual(
 			Gaffer.MetadataAlgo.getAnnotation( n, "test" ),
 			Gaffer.MetadataAlgo.Annotation( text = "xyz", color = imath.Color3f( 1 ) )
 		)
 
 		Gaffer.MetadataAlgo.addAnnotation( n, "test", Gaffer.MetadataAlgo.Annotation( text = "abc" ) )
-		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, instanceOnly = True ) ), 1 )
+		self.assertEqual( len( Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance ) ), 1 )
 		self.assertEqual(
 			Gaffer.MetadataAlgo.getAnnotation( n, "test" ),
 			Gaffer.MetadataAlgo.Annotation( text = "abc" )

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1282,5 +1282,26 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerValue( node, "test", 2 )
 		self.assertEqual( Gaffer.Metadata.value( node, "test" ), 1 )
 
+	def tearDown( self ) :
+
+		GafferTest.TestCase.tearDown( self )
+
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "aKey" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "iKey" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "k" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "imt" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "maskTest" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "deleteMe" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "nodeData3" )
+
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "description" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "iKey" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "imt" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "k" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "deleteMe" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "plugData3" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op1", "rp" )
+		Gaffer.Metadata.deregisterValue( GafferTest.AddNode, "op*", "aKey" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -352,8 +352,8 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertTrue( "ri" in Gaffer.Metadata.registeredValues( n ) )
 		self.assertTrue( "rpi" in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
-		self.assertTrue( "r" not in Gaffer.Metadata.registeredValues( n, instanceOnly=True ) )
-		self.assertTrue( "rp" not in Gaffer.Metadata.registeredValues( n["op1"], instanceOnly=True ) )
+		self.assertTrue( "r" not in Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance ) )
+		self.assertTrue( "rp" not in Gaffer.Metadata.registeredValues( n["op1"], Gaffer.Metadata.RegistrationTypes.Instance ) )
 		self.assertTrue( "ri" in Gaffer.Metadata.registeredValues( n ) )
 		self.assertTrue( "rpi" in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
@@ -626,19 +626,19 @@ class MetadataTest( GafferTest.TestCase ) :
 
 		def assertPersistent() :
 
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True, persistentOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.Instance ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], Gaffer.Metadata.RegistrationTypes.Instance ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ), [ "b" ] )
 			self.assertEqual( Gaffer.Metadata.value( s["n"], "a" ), 1 )
 			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "b" ), 2 )
 
 		def assertNonPersistent() :
 
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True ), [ "a" ] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True ), [ "b" ] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], instanceOnly = True, persistentOnly = True ), [] )
-			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], instanceOnly = True, persistentOnly = True ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.Instance ), [ "a" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], Gaffer.Metadata.RegistrationTypes.Instance ), [ "b" ] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( s["n"]["op1"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ), [] )
 			self.assertEqual( Gaffer.Metadata.value( s["n"], "a" ), 1 )
 			self.assertEqual( Gaffer.Metadata.value( s["n"]["op1"], "b" ), 2 )
 
@@ -1043,8 +1043,8 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerValue( n, "one", 1 )
 		Gaffer.Metadata.registerValue( n["op1"], "two", 2 )
 
-		self.assertEqual( Gaffer.Metadata.registeredValues( n, instanceOnly = True ), [ "one" ] )
-		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], instanceOnly = True ), [ "two" ] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance), [ "one" ] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], Gaffer.Metadata.RegistrationTypes.Instance ), [ "two" ] )
 
 		self.assertEqual( Gaffer.Metadata.value( n, "one" ), 1 )
 		self.assertEqual( Gaffer.Metadata.value( n["op1"], "two" ), 2 )
@@ -1052,8 +1052,8 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.deregisterValue( n, "one" )
 		Gaffer.Metadata.deregisterValue( n["op1"], "two" )
 
-		self.assertEqual( Gaffer.Metadata.registeredValues( n, instanceOnly = True ), [] )
-		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], instanceOnly = True ), [] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n, Gaffer.Metadata.RegistrationTypes.Instance ), [] )
+		self.assertEqual( Gaffer.Metadata.registeredValues( n["op1"], Gaffer.Metadata.RegistrationTypes.Instance ), [] )
 
 	def testQueryTypeIdRegistrationIgnoringInstanceRegistration( self ) :
 

--- a/python/GafferTest/MonitorAlgoTest.py
+++ b/python/GafferTest/MonitorAlgoTest.py
@@ -94,7 +94,7 @@ class MonitorAlgoTest( GafferTest.TestCase ) :
 		Gaffer.MonitorAlgo.removePerformanceAnnotations( s )
 		for node in Gaffer.Node.RecursiveRange( s ) :
 			self.assertEqual(
-				Gaffer.Metadata.registeredValues( node, instanceOnly = True ),
+				Gaffer.Metadata.registeredValues( node, Gaffer.Metadata.RegistrationTypes.Instance ),
 				[]
 			)
 

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -475,7 +475,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		p = Gaffer.PlugAlgo.promote( n["a"]["op1"] )
 		self.assertEqual( Gaffer.Metadata.value( p, "testPersistence" ), 10 )
 		self.assertTrue( "testPersistence" in Gaffer.Metadata.registeredValues( p ) )
-		self.assertTrue( "testPersistence" not in Gaffer.Metadata.registeredValues( p, persistentOnly = True ) )
+		self.assertTrue( "testPersistence" not in Gaffer.Metadata.registeredValues( p, Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 
 	def testPromoteWithName( self ) :
 
@@ -578,14 +578,14 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Metadata.value( script["box"]["n"]["in"], "plugAlgoTest:a" ), "a" )
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["n"]["in"] ) )
-		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["n"]["in"], persistentOnly = True ) )
+		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["n"]["in"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 
 		# And if we promote up one more level, we want that to work, and we want the
 		# new metadata to be persistent so that it will be serialised and restored.
 
 		Gaffer.PlugAlgo.promote( script["box"]["n"]["in"] )
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["in"] ) )
-		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["in"], persistentOnly = True ) )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script["box"]["in"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 
 		# After serialisation and loading, everything should look the same.
 
@@ -594,9 +594,9 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.Metadata.value( script2["box"]["n"]["in"], "plugAlgoTest:a" ), "a" )
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["n"]["in"] ) )
-		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["n"]["in"], persistentOnly = True ) )
+		self.assertNotIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["n"]["in"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"] ) )
-		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"], persistentOnly = True ) )
+		self.assertIn( "plugAlgoTest:a", Gaffer.Metadata.registeredValues( script2["box"]["in"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 
 	def testPromotableMetadata( self ) :
 
@@ -639,7 +639,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		promoted = Gaffer.PlugAlgo.promote( box["node"]["plug"] )
 		self.assertTrue( promoted.node().isSame( box ) )
 		self.assertEqual( Gaffer.Metadata.value( promoted, "plugAlgoTest:b" ), "testValueB" )
-		self.assertIsNone( Gaffer.Metadata.value( promoted, "plugAlgoTest:b", instanceOnly = True ) )
+		self.assertIsNone( Gaffer.Metadata.value( promoted, "plugAlgoTest:b", Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 		box.removeChild( promoted )
 		Gaffer.Metadata.registerValue( box["node"]["plug"], "plugAlgoTest:b", "testValueC" )
@@ -651,7 +651,7 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 		promoted = Gaffer.PlugAlgo.promote( box["node"]["plug"] )
 		self.assertTrue( promoted.node().isSame( box ) )
 		self.assertEqual( Gaffer.Metadata.value( promoted, "plugAlgoTest:b" ), "testValueC" )
-		self.assertEqual( Gaffer.Metadata.value( promoted, "plugAlgoTest:b", instanceOnly = True ), "testValueC" )
+		self.assertEqual( Gaffer.Metadata.value( promoted, "plugAlgoTest:b", Gaffer.Metadata.RegistrationTypes.Instance ), "testValueC" )
 
 	def testGetValueFromNameValuePlug( self ) :
 

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -799,10 +799,10 @@ class ReferenceTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:minorVersion" ), Gaffer.About.minorVersion() )
 		self.assertEqual( Gaffer.Metadata.value( s["r"], "serialiser:patchVersion" ), Gaffer.About.patchVersion() )
 
-		self.assertTrue( "serialiser:milestoneVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:majorVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:minorVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
-		self.assertTrue( "serialiser:patchVersion" not in Gaffer.Metadata.registeredValues( s["r"], persistentOnly = True ) )
+		self.assertNotIn( "serialiser:milestoneVersion", Gaffer.Metadata.registeredValues( s["r"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
+		self.assertNotIn( "serialiser:majorVersion", Gaffer.Metadata.registeredValues( s["r"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
+		self.assertNotIn( "serialiser:minorVersion", Gaffer.Metadata.registeredValues( s["r"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
+		self.assertNotIn( "serialiser:patchVersion", Gaffer.Metadata.registeredValues( s["r"], Gaffer.Metadata.RegistrationTypes.InstancePersistent ) )
 
 	def testSerialiseWithoutLoading( self ) :
 

--- a/python/GafferUI/BoxUI.py
+++ b/python/GafferUI/BoxUI.py
@@ -164,7 +164,7 @@ def __nonDefaultPlugs( box ) :
 
 	def __nonDefaultWalk( plug ) :
 
-		if Gaffer.Metadata.value( plug, "userDefault", instanceOnly = True ) is not None :
+		if Gaffer.Metadata.value( plug, "userDefault", Gaffer.Metadata.RegistrationTypes.Instance ) is not None :
 			return True
 
 		if len( plug ) == 0 :

--- a/python/GafferUI/NodeUI.py
+++ b/python/GafferUI/NodeUI.py
@@ -95,6 +95,15 @@ Gaffer.Metadata.registerNode(
 
 		),
 
+		"..." : (
+
+			# Just because a plug is renameable and/or deletable on one node
+			# does not mean it should still be when promoted to another.
+			"renameable:promotable", False,
+			"deletable:promotable", False,
+
+		),
+
 	}
 
 )

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -252,6 +252,7 @@ def __defaultCellMetadata( plug, key ) :
 	return Gaffer.Metadata.value( __correspondingDefaultPlug( plug ), key )
 
 for key in [
+	"description",
 	"spreadsheet:columnLabel",
 	"spreadsheet:columnWidth",
 	"plugValueWidget:type",

--- a/python/GafferUI/SpreadsheetUI/_SectionChooser.py
+++ b/python/GafferUI/SpreadsheetUI/_SectionChooser.py
@@ -154,7 +154,7 @@ class _SectionChooser( GafferUI.Widget ) :
 
 		# Remove metadata for sections that no longer exist
 
-		registeredValues = Gaffer.Metadata.registeredValues( rowsPlug, instanceOnly = True )
+		registeredValues = Gaffer.Metadata.registeredValues( rowsPlug, Gaffer.Metadata.RegistrationTypes.Instance )
 		for key in registeredValues :
 			m = re.match( "spreadsheet:section:(.+):index", key )
 			if m and m.group( 1 ) not in sectionNames :

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1153,7 +1153,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		d = self.__pathListing.getPath().dict()
 		d.clear()
 		if self.__plug is not None :
-			for name in Gaffer.Metadata.registeredValues( self.__plug, instanceOnly = True, persistentOnly = True ) :
+			for name in Gaffer.Metadata.registeredValues( self.__plug, Gaffer.Metadata.RegistrationTypes.InstancePersistent ) :
 				if name.startswith( "preset:" ) :
 					d[name[7:]] = Gaffer.Metadata.value( self.__plug, name )
 
@@ -1699,7 +1699,7 @@ class _SectionEditor( GafferUI.Widget ) :
 					emptySections[i] = newSection( emptySections[i] )
 				Gaffer.Metadata.registerValue( self.getPlugParent(), "uiEditor:emptySections", emptySections )
 
-			for name in Gaffer.Metadata.registeredValues( self.getPlugParent(), instanceOnly = True, persistentOnly = True ) :
+			for name in Gaffer.Metadata.registeredValues( self.getPlugParent(), Gaffer.Metadata.RegistrationTypes.InstancePersistent ) :
 				m = re.match( "(layout:section:)(.*)(:.*)", name )
 				if m :
 					if newSection( m.group( 2 ) ) != m.group( 2 ) :

--- a/python/GafferUITest/BoxIOUITest.py
+++ b/python/GafferUITest/BoxIOUITest.py
@@ -1,0 +1,61 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class BoxIOUITest( GafferUITest.TestCase ) :
+
+	def testNoRedundantMetadata( self ) :
+
+		box = Gaffer.Box()
+
+		box["add"] = GafferTest.AddNode()
+
+		box["switch"] = Gaffer.Switch()
+		box["switch"].setup( box["add"]["sum"] )
+		box["switch"]["in"][0].setInput( box["add"]["sum"] )
+
+		Gaffer.PlugAlgo.promote( box["switch"]["in"][1] )
+		Gaffer.BoxIO.insert( box )
+		self.assertEqual( Gaffer.Metadata.registeredValues( box["BoxIn"]["__in"], Gaffer.Metadata.RegistrationTypes.Instance ), [] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -879,5 +879,10 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( promoted[1]["cells"]["column1"]["value"], "plugValueWidget:type" ), "GafferUI.MultiLineStringPlugValueWidget" )
 		self.assertIsNone( Gaffer.Metadata.value( promoted[1]["cells"]["column1"]["value"], "plugValueWidget:type", instanceOnly = True ) )
 
+		# And we don't want any other metadata to be copied for the non-default rows.
+
+		for plug in Gaffer.Plug.RecursiveRange( promoted[1] ) :
+			self.assertEqual( Gaffer.Metadata.registeredValues( plug, instanceOnly = True ), [] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -875,14 +875,14 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 
 		promoted = Gaffer.PlugAlgo.promote( box["spreadsheet"]["rows"] )
 		self.assertEqual( Gaffer.Metadata.value( promoted[0]["cells"]["column1"]["value"], "plugValueWidget:type" ), "GafferUI.MultiLineStringPlugValueWidget" )
-		self.assertEqual( Gaffer.Metadata.value( promoted[0]["cells"]["column1"]["value"], "plugValueWidget:type", instanceOnly = True ), "GafferUI.MultiLineStringPlugValueWidget" )
+		self.assertEqual( Gaffer.Metadata.value( promoted[0]["cells"]["column1"]["value"], "plugValueWidget:type", Gaffer.Metadata.RegistrationTypes.Instance ), "GafferUI.MultiLineStringPlugValueWidget" )
 		self.assertEqual( Gaffer.Metadata.value( promoted[1]["cells"]["column1"]["value"], "plugValueWidget:type" ), "GafferUI.MultiLineStringPlugValueWidget" )
-		self.assertIsNone( Gaffer.Metadata.value( promoted[1]["cells"]["column1"]["value"], "plugValueWidget:type", instanceOnly = True ) )
+		self.assertIsNone( Gaffer.Metadata.value( promoted[1]["cells"]["column1"]["value"], "plugValueWidget:type", Gaffer.Metadata.RegistrationTypes.Instance ) )
 
 		# And we don't want any other metadata to be copied for the non-default rows.
 
 		for plug in Gaffer.Plug.RecursiveRange( promoted[1] ) :
-			self.assertEqual( Gaffer.Metadata.registeredValues( plug, instanceOnly = True ), [] )
+			self.assertEqual( Gaffer.Metadata.registeredValues( plug, Gaffer.Metadata.RegistrationTypes.Instance ), [] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -130,6 +130,7 @@ from .ToolTest import ToolTest
 from .StandardNodeToolbarTest import StandardNodeToolbarTest
 from .LabelPlugValueWidgetTest import LabelPlugValueWidgetTest
 from .PythonEditorTest import PythonEditorTest
+from .BoxIOUITest import BoxIOUITest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -226,7 +226,20 @@ void BoxIO::setup( const Plug *plug )
 				/// individual exclusions.
 				return false;
 			}
-			return MetadataAlgo::isPromotable( from, to, name );
+			if( !MetadataAlgo::isPromotable( from, to, name ) )
+			{
+				return false;
+			}
+			// Only copy if the destination doesn't already have the metadata.
+			// This avoids making unnecessary instance-level metadata when the
+			// same value is registered statically (against the plug type).
+			ConstDataPtr fromValue = Gaffer::Metadata::value( from, name );
+			ConstDataPtr toValue = Gaffer::Metadata::value( to, name );
+			if( fromValue && toValue )
+			{
+				return !toValue->isEqualTo( fromValue.get() );
+			}
+			return (bool)fromValue != (bool)toValue;
 		}
 	);
 

--- a/src/Gaffer/MetadataAlgo.cpp
+++ b/src/Gaffer/MetadataAlgo.cpp
@@ -436,8 +436,7 @@ Annotation getAnnotation( const Node *node, const std::string &name, bool inheri
 void removeAnnotation( Node *node, const std::string &name )
 {
 	const string prefix = g_annotationPrefix + name + ":";
-	vector<InternedString> keys;
-	Metadata::registeredValues( node, keys );
+	const vector<InternedString> keys = Metadata::registeredValues( node );
 
 	for( const auto &key : keys )
 	{
@@ -450,8 +449,7 @@ void removeAnnotation( Node *node, const std::string &name )
 
 void annotations( const Node *node, std::vector<std::string> &names )
 {
-	vector<InternedString> keys;
-	Metadata::registeredValues( node, keys );
+	const vector<InternedString> keys = Metadata::registeredValues( node );
 
 	for( const auto &key : keys )
 	{
@@ -695,8 +693,14 @@ void copy( const GraphComponent *from, GraphComponent *to, bool persistent )
 
 void copy( const GraphComponent *from, GraphComponent *to, const IECore::StringAlgo::MatchPattern &exclude, bool persistentOnly, bool persistent )
 {
-	vector<IECore::InternedString> keys;
-	Metadata::registeredValues( from, keys, /* instanceOnly = */ false, /* persistentOnly = */ persistentOnly );
+	/// \todo Change function signature to take `RegistrationTypes` directly.
+	unsigned registrationTypes = Metadata::RegistrationTypes::TypeId | Metadata::RegistrationTypes::TypeIdDescendant | Metadata::RegistrationTypes::InstancePersistent;
+	if( !persistentOnly )
+	{
+		registrationTypes |= Metadata::RegistrationTypes::InstanceNonPersistent;
+	}
+
+	const vector<IECore::InternedString> keys = Metadata::registeredValues( from, registrationTypes );
 	for( vector<IECore::InternedString>::const_iterator it = keys.begin(), eIt = keys.end(); it != eIt; ++it )
 	{
 		if( StringAlgo::matchMultiple( it->string(), exclude ) )

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -1216,7 +1216,20 @@ Plug *promoteWithName( Plug *plug, const InternedString &name, Plug *parent, con
 				/// individual exclusions.
 				return false;
 			}
-			return MetadataAlgo::isPromotable( from, to, name );
+			if( !MetadataAlgo::isPromotable( from, to, name ) )
+			{
+				return false;
+			}
+			// Only copy if the destination doesn't already have the metadata.
+			// This avoids making unnecessary instance-level metadata when the
+			// same value is registered statically (against the plug type).
+			ConstDataPtr fromValue = Gaffer::Metadata::value( from, name );
+			ConstDataPtr toValue = Gaffer::Metadata::value( to, name );
+			if( fromValue && toValue )
+			{
+				return !toValue->isEqualTo( fromValue.get() );
+			}
+			return (bool)fromValue != (bool)toValue;
 		},
 		// We use `persistent = dynamic` so that `promoteWithName()` can be used in
 		// constructors for custom nodes, to promote a plug from an internal

--- a/src/GafferBindings/MetadataBinding.cpp
+++ b/src/GafferBindings/MetadataBinding.cpp
@@ -66,8 +66,7 @@ namespace GafferBindings
 
 std::string metadataSerialisation( const Gaffer::GraphComponent *graphComponent, const std::string &identifier, Serialisation &serialisation )
 {
-	std::vector<InternedString> keys;
-	Metadata::registeredValues( graphComponent, keys, /* instanceOnly = */ true, /* persistentOnly = */ true );
+	const std::vector<InternedString> keys = Metadata::registeredValues( graphComponent, Metadata::RegistrationTypes::InstancePersistent );
 
 	const Plug *plug = runTimeCast<const Plug>( graphComponent );
 	const Reference *reference = plug ? runTimeCast<const Reference>( plug->node() ) : nullptr;

--- a/src/GafferModule/MetadataAlgoBinding.cpp
+++ b/src/GafferModule/MetadataAlgoBinding.cpp
@@ -205,11 +205,19 @@ void copyColorsWrapper( const Gaffer::Plug &srcPlug, Gaffer::Plug &dstPlug, bool
 // Promotability
 // =============
 
-
 bool isPromotableWrapper( const GraphComponent &from, const GraphComponent &to, const IECore::InternedString &name )
 {
 	IECorePython::ScopedGILRelease gilRelease;
 	return isPromotable( &from, &to, name );
+}
+
+// Cleanup
+// =======
+
+void deregisterRedundantValuesWrapper( GraphComponent &g )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return deregisterRedundantValues( &g );
 }
 
 } // namespace
@@ -338,5 +346,10 @@ void GafferModule::bindMetadataAlgo()
 	// =============
 
 	def( "isPromotable", &isPromotableWrapper, ( arg( "from" ), arg( "to" ), arg( "name" ) ) );
+
+	// Cleanup
+	// =======
+
+	def( "deregisterRedundantValues", &deregisterRedundantValuesWrapper );
 
 }

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -577,8 +577,7 @@ std::vector<NoduleLayout::GadgetKey> NoduleLayout::layoutOrder()
 
 	// Then any custom gadgets specified by the metadata
 
-	vector<InternedString> metadata;
-	Metadata::registeredValues( m_parent.get(), metadata );
+	const vector<InternedString> metadata = Metadata::registeredValues( m_parent.get() );
 	static boost::regex g_customGadgetRegex( "noduleLayout:customGadget:(.+):gadgetType" );
 	for( vector<InternedString>::const_iterator it = metadata.begin(), eIt = metadata.end(); it != eIt; ++it )
 	{

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -567,3 +567,31 @@ GafferUI.DotUI.connect( application.root() )
 with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferTractorUI
+
+
+## Metadata cleanup
+###########################################################################
+
+## \todo This shouldn't be necessary forever, since we've fixed the
+# problems that caused redundant metadata to be produced in the first
+# place. Remove the menu item when it is no longer needed.
+
+def __removeRedundantMetadata( menu ) :
+
+	script = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
+	with Gaffer.UndoScope( script ) :
+		Gaffer.MetadataAlgo.deregisterRedundantValues( script )
+
+def __removeRedundantMetadataActive( menu ) :
+
+	script = menu.ancestor( GafferUI.ScriptWindow ).scriptNode()
+	return not Gaffer.MetadataAlgo.readOnly( script )
+
+scriptWindowMenu.append(
+	"/Tools/Metadata/Clean Up",
+	{
+		"command" : __removeRedundantMetadata,
+		"active" : __removeRedundantMetadataActive,
+		"description" : "Optimises file size by removing redundant node metadata."
+	}
+)


### PR DESCRIPTION
This PR was motivated by the horrible realisation that for at least one large production template, a significant chunk of the file size and a quarter of the load time is taken up by metadata registrations that are completely redundant. They're redundant because they're instance-level overrides with exactly the same value as the static type-based registrations that don't need to be stored in the file at all. So this PR fixes a bunch of problems to prevent such metadata being created again in future, and adds a menu item folks can use to clean up their files.

This required a bit more work than I wanted to do initially, because `MetadataAlgo::deregisterRedundantValues()` needed the ability to query instance-based and type-based registrations separately. This required the new `Metadata::value()` overloads taking a `RegistrationTypes` bitmask to say which types to consider. Although it's a bit wordier than the original, it's more flexible than the two old `instanceOnly, persistentlyOnly` arguments which only exposed half the possibilities. So hopefully this seems like a reasonable improvement. Technically it would have been possible to implement `deregisterRedundantValues()` without this change, but only by speculatively removing each instance value to see if it changed the result, and putting it back if it did. But I couldn't stomach that approach, mostly because of the storm of unnecessary `valueChangedSignals()` we'd be emitting.