### PR TITLE
Arnold Renderer : Avoid mutex lock in ProceduralRenderer

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 ------------
 
 - LightTool : Changed spot light and quad light edge tool tip locations so that they follow the cone and edge during drag.
+- Arnold : Improved speed of translation of encapsulated scenes when using many threads.
 
 Fixes
 -----


### PR DESCRIPTION
As suggested by @danieldresser-ie in a discussion yesterday. This knocks around 30% off the runtime of `ArnoldRenderTest.testInstancerEncapsulatePerf` in PR #5453, testing with 64 threads.