### PR TITLE
OSL indexed context queries

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Fixes
 - SceneAlgo : Fixed computation of `ScenePlug.object` in networks with nodes derived from `ObjectProcessor`. These include : `CameraTweaks`, `ClosestPointSampler`, `CollectPrimitiveVariables`, `CopyPrimitiveVariables`, `CurveSampler`, `DeleteCurves`, `DeleteFaces`, `DeletePoints`, `MapOffset`, `MapProjection`, `MeshDistortion`, `MeshNormals`, `MeshSegments`, `MeshTangents`, `MeshToPoints`, `MeshType`, `Orientation`, `PointsType`, `PrimitiveSampler`, `PrimitiveVariables`, `ReverseWinding`, `ShufflePrimitiveVariables` and `UVSampler` (#5406).
 - Metadata : Fixed redundant copying of metadata when promoting plugs.
 - OpenColorIO : Fixed hang when opening a script which didn't yet have the `openColorIO.config` plug.
+- Context : Fixed bug preventing the retrieval of `V2iVectorData`, `V2fVectorData`, `V3iVectorData` and `V3fVectorData` from a context.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
 - LightTool : Changed spot light and quad light edge tool tip locations so that they follow the cone and edge during drag.
 - Arnold : Improved speed of translation of encapsulated scenes when using many threads.
 - CollectImages : Added `addLayerPrefix` plug, to allow the layer prefix to be omitted in the case that the input images are already prefixed.
+- OSL Expression : Added support for getting an element of an array context variable using `contextElement( variableName, index )` or `contextElement( variableName, index, defaultValue )`. Negative indices can be used to get elements relative to the end of the array.
 
 Fixes
 -----

--- a/doc/source/Reference/ScriptingReference/Expressions/index.md
+++ b/doc/source/Reference/ScriptingReference/Expressions/index.md
@@ -23,7 +23,11 @@ Set value          | `parent["NodeName"]["plugName"] = value` | `parent.NodeName
 Context Variables
 -----------------
 
-Operation             | Python                                    | OSL
-----------------------|-------------------------------------------|----
-Get variable          | `context["variableName"]`                 | `context( "variableName" )`
-Get with default      | `context.get( "variableName", default )`  | `context( "variableName", default )`
+Operation                       | Python                                                                                   | OSL
+--------------------------------|------------------------------------------------------------------------------------------|----
+Get variable                    | `context["variableName"]`                                                                | `context( "variableName" )`
+Get with default                | `context.get( "variableName", default )`                                                 | `context( "variableName", default )`
+Get array element               | `context["variableName"][index]`                                                         | `contextElement( "variableName", index )`
+Get array element with default  | `a = context.get( "variableName", [] )`<br/>`a[index] if len( a ) > index else default`  | `contextElement( "variableName", index, default )`
+Get array element from end      | `context["variableName"][-index]`                                                        | `contextElement( "variableName", -index )`
+

--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -82,6 +82,22 @@ struct DataTraits<Imath::Vec3<T> >
 
 };
 
+template<typename T>
+struct DataTraits<std::vector<Imath::Vec2<T> > >
+{
+
+	using DataType = IECore::GeometricTypedData<std::vector<Imath::Vec2<T>>>;
+
+};
+
+template<typename T>
+struct DataTraits<std::vector<Imath::Vec3<T> > >
+{
+
+	using DataType = IECore::GeometricTypedData<std::vector<Imath::Vec3<T>>>;
+
+};
+
 } // namespace Detail
 
 inline Context::Value::Value()

--- a/python/GafferTest/ContextTest.py
+++ b/python/GafferTest/ContextTest.py
@@ -137,6 +137,15 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertIsInstance( c["v2i"], imath.V2i )
 		self.assertNotEqual( compare, c.hash() )
 
+		c["v2iv"] = IECore.V2iVectorData( [ imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ] )
+		self.assertEqual( c["v2iv"], IECore.V2iVectorData( [ imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ] ) )
+		self.assertEqual( c.get( "v2iv" ), IECore.V2iVectorData( [ imath.V2i( 1, 2 ), imath.V2i( 3, 4 ) ] ) )
+		compare = c.hash()
+		c.set( "v2iv", IECore.V2iVectorData( [ imath.V2i( 5, 6 ), imath.V2i( 7, 8 ) ] ) )
+		self.assertEqual( c["v2iv"], IECore.V2iVectorData( [ imath.V2i( 5, 6 ), imath.V2i( 7, 8 ) ] ) )
+		self.assertIsInstance( c["v2iv"], IECore.V2iVectorData )
+		self.assertNotEqual( compare, c.hash() )
+
 		c["v3i"] = imath.V3i( 1, 2, 3 )
 		self.assertEqual( c["v3i"], imath.V3i( 1, 2, 3 ) )
 		self.assertEqual( c.get( "v3i" ), imath.V3i( 1, 2, 3 ) )
@@ -144,6 +153,15 @@ class ContextTest( GafferTest.TestCase ) :
 		c.set( "v3i", imath.V3i( 4, 5, 6 ) )
 		self.assertEqual( c["v3i"], imath.V3i( 4, 5, 6 ) )
 		self.assertIsInstance( c["v3i"], imath.V3i )
+		self.assertNotEqual( compare, c.hash() )
+
+		c["v3iv"] = IECore.V3iVectorData( [ imath.V3i( 1, 2, 3 ), imath.V3i( 4, 5, 6 ) ] )
+		self.assertEqual( c["v3iv"], IECore.V3iVectorData( [ imath.V3i( 1, 2, 3 ), imath.V3i( 4, 5, 6 ) ] ) )
+		self.assertEqual( c.get( "v3iv" ), IECore.V3iVectorData( [ imath.V3i( 1, 2, 3 ), imath.V3i( 4, 5, 6 ) ] ) )
+		compare = c.hash()
+		c.set( "v3iv", IECore.V3iVectorData( [ imath.V3i( 7, 8, 9 ), imath.V3i( 10, 11, 12 ) ] ) )
+		self.assertEqual( c["v3iv"], IECore.V3iVectorData( [ imath.V3i( 7, 8, 9 ), imath.V3i( 10, 11, 12 ) ] ) )
+		self.assertIsInstance( c["v3iv"], IECore.V3iVectorData )
 		self.assertNotEqual( compare, c.hash() )
 
 		c["v2f"] = imath.V2f( 1, 2 )
@@ -155,6 +173,15 @@ class ContextTest( GafferTest.TestCase ) :
 		self.assertIsInstance( c["v2f"], imath.V2f )
 		self.assertNotEqual( compare, c.hash() )
 
+		c["v2fv"] = IECore.V2fVectorData( [ imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) ] )
+		self.assertEqual( c["v2fv"], IECore.V2fVectorData( [ imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) ] ) )
+		self.assertEqual( c.get( "v2fv" ), IECore.V2fVectorData( [ imath.V2f( 1, 2 ), imath.V2f( 3, 4 ) ] ) )
+		compare = c.hash()
+		c.set( "v2fv", IECore.V2fVectorData( [ imath.V2f( 5, 6 ), imath.V2f( 7, 8 ) ] ) )
+		self.assertEqual( c["v2fv"], IECore.V2fVectorData( [ imath.V2f( 5, 6 ), imath.V2f( 7, 8 ) ] ) )
+		self.assertIsInstance( c["v2fv"], IECore.V2fVectorData )
+		self.assertNotEqual( compare, c.hash() )
+
 		c["v3f"] = imath.V3f( 1, 2, 3 )
 		self.assertEqual( c["v3f"], imath.V3f( 1, 2, 3 ) )
 		self.assertEqual( c.get( "v3f" ), imath.V3f( 1, 2, 3 ) )
@@ -162,6 +189,15 @@ class ContextTest( GafferTest.TestCase ) :
 		c.set( "v3f", imath.V3f( 4, 5, 6 ) )
 		self.assertEqual( c["v3f"], imath.V3f( 4, 5, 6 ) )
 		self.assertIsInstance( c["v3f"], imath.V3f )
+		self.assertNotEqual( compare, c.hash() )
+
+		c["v3fv"] = IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] )
+		self.assertEqual( c["v3fv"], IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
+		self.assertEqual( c.get( "v3fv" ), IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ) ] ) )
+		compare = c.hash()
+		c.set( "v3fv", IECore.V3fVectorData( [ imath.V3f( 7, 8, 9 ), imath.V3f( 10, 11, 12 ) ] ) )
+		self.assertEqual( c["v3fv"], IECore.V3fVectorData( [ imath.V3f( 7, 8, 9 ), imath.V3f( 10, 11, 12 ) ] ) )
+		self.assertIsInstance( c["v3fv"], IECore.V3fVectorData )
 		self.assertNotEqual( compare, c.hash() )
 
 	def testSwitchTypes( self ) :

--- a/shaders/GafferOSL/Expression.h
+++ b/shaders/GafferOSL/Expression.h
@@ -97,4 +97,66 @@ string context( string name )
 	return context( name, "" );
 }
 
+// Vector context variable queries with index
+
+int contextElement( string name, int index, int defaultValue )
+{
+	int result = defaultValue;
+	getattribute( "gaffer:context", name, index, result );
+	return result;
+}
+
+int contextElement( string name, int index )
+{
+	return contextElement( name, index, 0 );
+}
+
+float contextElement( string name, int index, float defaultValue )
+{
+	float result = defaultValue;
+	getattribute( "gaffer:context", name, index, result );
+	return result;
+}
+
+float contextElement( string name, int index )
+{
+	return contextElement( name, index, 0.0 );
+}
+
+color contextElement( string name, int index, color defaultValue )
+{
+	color result = defaultValue;
+	getattribute( "gaffer:context", name, index, result );
+	return result;
+}
+
+color contextElement( string name, int index )
+{
+	return contextElement( name, index, color( 0.0 ) );
+}
+
+vector contextElement( string name, int index, vector defaultValue )
+{
+	vector result = defaultValue;
+	getattribute( "gaffer:context", name, index, result );
+	return result;
+}
+
+vector contextElement( string name, int index )
+{
+	return contextElement( name, index, vector( 0.0 ) );
+}
+
+string contextElement( string name, int index, string defaultValue )
+{
+	string result = defaultValue;
+	getattribute( "gaffer:context", name, index, result );
+	return result;
+}
+
+string contextElement( string name, int index )
+{
+	return contextElement( name, index, "" );
+}
+
 #endif // GAFFEROSL_EXPRESSION_H


### PR DESCRIPTION
This adds the ability to query specific indices of a vector-typed context variable in OSL. The original motivation was querying the `scene:path` context variable as described in #5292. The method was simple to generalize for all supported vector types, so those can be queried by index too.

I'm opening this now as a work-in-progress so I can mention this PR in a related Cortex PR. There are still a couple things left to do before it's ready for review.

### Related issues ###

Fixes #5292

### Dependencies ###

https://github.com/ImageEngine/cortex/pull/1391

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
