### PR TITLE
PlugLayout : Update layout when custom widget metadata changes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,8 @@ Fixes
   - Fixed a bug preventing anything except strings from being copied and pasted.
   - Fixed likely cause of crash when resizing Spreadsheet column width (#5296).
 - Reference : Fixed rare reloading error.
+- PlugLayout : Fixed lack of update when `layout:customWidget:*` metadata changes.
+- Dispatch app : Removed unnecessary and misleading "Execute" button.
 
 1.3.5.0 (relative to 1.3.4.0)
 =======

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -530,6 +530,9 @@ class PlugLayout( GafferUI.Widget ) :
 		if re.match( self.__layoutName + ":section:.*:summary", key ) :
 			self.__summariesDirty = True
 			self.__updateLazily()
+		elif re.match( self.__layoutName + ":customWidget:.*", key ) :
+			self.__layoutDirty = True
+			self.__updateLazily()
 
 	def __plugDirtied( self, plug ) :
 

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -100,6 +100,9 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		self.assertTrue( isinstance( p.customWidget( "test" ), self.CustomWidget ) )
 		self.assertTrue( p.customWidget( "test" ).node.isSame( n ) )
 
+		Gaffer.Metadata.registerValue( n, "layout:customWidget:test:widgetType", "" )
+		self.assertIsNone( p.customWidget( "test") )
+
 	def testSectionQueries( self ) :
 
 		n = Gaffer.Node()


### PR DESCRIPTION
This fixes the hiding of the unwanted "Execute" buttons in the DispatchDialogue, because it overwrites the `layout:customWidget:dispatchButton:widgetType` metadata _after_ creating the UI for the nodes.
