### PR TITLE
LightTool : Remove unused variables

### DIFF
--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -2869,9 +2869,6 @@ class LengthHandle : public LightToolHandle
 
 		void setupDrag( const DragDropEvent &event ) override
 		{
-			Inspector::ResultPtr inspection = handleInspection( m_parameter );
-			V3f offset = this->offset( inspection.get() );
-
 			m_drag = Handle::LinearDrag(
 				this,
 				LineSegment3f( V3f( 0 ), ( m_axis * m_orientation ) ),


### PR DESCRIPTION
I don't know why this was not caught during the builds for #5483, but @danieldresser found that `offset` is causing a warning about `offset` not being used in `LengthHandle::setupDrag()`. `inspection` in that same function is also not being used, so I removed it as well.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
