### PR TITLE
Crop Window Toggle

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.x.x.x (relative to 1.3.x.x)
 =======
 
+Improvements
+------------
+
+- Toolbars : Changed hotkey behavior to toogle any tool on and off. Exclusive tools such as the Translate and Crop Window tools activate the first tool (currently Selection Tool) when they are toggled off.
+
 Breaking Changes
 ----------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Toolbars : Changed hotkey behavior to toogle any tool on and off. Exclusive tools such as the Translate and Crop Window tools activate the first tool (currently Selection Tool) when they are toggled off.
+- CropWindowTool : Added <kbd>`Alt` + <kbd>`C` for toggling both the crop window tool and the relevant crop window `enabled` plug.
 
 Breaking Changes
 ----------------

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -223,6 +223,7 @@ Cycle Transform Tool Orientation     | {kbd}`O`
 Scale Tool                           | {kbd}`R`
 Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`
+Crop Window Tool and crop enabled    | {kbd}`Alt` + {kbd}`C`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
 
 ### 3D scenes ###

--- a/include/GafferSceneUI/CropWindowTool.h
+++ b/include/GafferSceneUI/CropWindowTool.h
@@ -104,6 +104,8 @@ class GAFFERSCENEUI_API CropWindowTool : public GafferUI::Tool
 
 		Imath::Box2f resolutionGate() const;
 
+		bool keyPress( const GafferUI::KeyEvent &event );
+
 		Gaffer::Signals::ScopedConnection m_overlayRectangleChangedConnection;
 
 		std::string m_overlayMessage;

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -189,8 +189,11 @@ class GAFFERUI_API View : public Gaffer::Node
 
 	private :
 
-		void toolsChildAdded( Gaffer::GraphComponent *child ) const;
-		void toolPlugSet( Gaffer::Plug *plug ) const;
+		void toolsChildAdded( Gaffer::GraphComponent *child );
+		void toolPlugSet( Gaffer::Plug *plug );
+
+		using ToolPlugSetMap = std::unordered_map<Tool *, Gaffer::Signals::ScopedConnection>;
+		ToolPlugSetMap m_toolPlugSetConnections;
 
 		ViewportGadgetPtr m_viewportGadget;
 		Gaffer::ContextPtr m_context;

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -225,13 +225,8 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 		for t in self.__toolChooser.tools() :
 			if Gaffer.Metadata.value( t, "viewer:shortCut" ) == event.key :
-				if not t["active"].getValue():
-					t["active"].setValue( True )
-				else:
-					# If it's already active, and it's a non-exclusive tool, then pressing the key
-					# again should deactivate it
-					if Gaffer.Metadata.value( t, "tool:exclusive" ) == False:
-						t["active"].setValue( False )
+				t["active"].setValue( not t["active"].getValue() )
+
 				return True
 
 			# \todo The Viewer should not need to know about `TransformTool` and orientations.

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -536,6 +536,8 @@ CropWindowTool::CropWindowTool( View *view, const std::string &name )
 
 	Metadata::plugValueChangedSignal().connect( boost::bind( &CropWindowTool::metadataChanged, this, ::_3 ) );
 	Metadata::nodeValueChangedSignal().connect( boost::bind( &CropWindowTool::metadataChanged, this, ::_2 ) );
+
+	view->viewportGadget()->keyPressSignal().connect( boost::bind( &CropWindowTool::keyPress, this, ::_2 ) );
 }
 
 CropWindowTool::~CropWindowTool()
@@ -1017,4 +1019,23 @@ Box2f CropWindowTool::resolutionGate() const
 		}
 	}
 	return resolutionGate;
+}
+
+bool CropWindowTool::keyPress( const KeyEvent &event )
+{
+	if( const auto hotkey = Gaffer::Metadata::value<StringData>( this, "viewer:shortCut" ) )
+	{
+		if( event.key == hotkey->readable() && event.modifiers == KeyEvent::Modifiers::Alt )
+		{
+			const bool newState = !activePlug()->getValue();
+
+			activePlug()->setValue( newState );
+			if( m_cropWindowEnabledPlug )
+			{
+				UndoScope undoScope( m_cropWindowPlug->ancestor<ScriptNode>() );
+				m_cropWindowEnabledPlug->setValue( newState );
+			}
+		}
+	}
+	return false;
 }


### PR DESCRIPTION
This changes two related behaviors :
1. Allows all tools, not just non-exclusive tools, to be toggled off with a keyboard shortcut.
2. Adds `Alt+C` shortcut to toggle off the crop window tool as well as the crop window itself, for the plug used for the crop window tool.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
