### PR TITLE
SceneAlgo : `ObjectProcessor` object history fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
 - Reference : Fixed rare reloading error.
 - PlugLayout : Fixed lack of update when `layout:customWidget:*` metadata changes.
 - Dispatch app : Removed unnecessary and misleading "Execute" button.
+- SceneAlgo : Fixed computation of `ScenePlug.object` in networks with nodes derived from `ObjectProcessor`. These include : `CameraTweaks`, `ClosestPointSampler`, `CollectPrimitiveVariables`, `CopyPrimitiveVariables`, `CurveSampler`, `DeleteCurves`, `DeleteFaces`, `DeletePoints`, `MapOffset`, `MapProjection`, `MeshDistortion`, `MeshNormals`, `MeshSegments`, `MeshTangents`, `MeshToPoints`, `MeshType`, `Orientation`, `PointsType`, `PrimitiveSampler`, `PrimitiveVariables`, `ReverseWinding`, `ShufflePrimitiveVariables` and `UVSampler` (#5406).
 
 API
 ---


### PR DESCRIPTION
This fixes #5406  where the scene history was not taking into consideration the internal `processedObjectPlug` used by `ObjectProcessor`.

I'm not sure about the hard-coded handling of `ObjectProcessor`, perhaps some form of registry or new plug method would be better? I looked at the other nodes that are using an internal plug and I _think_ this is the only one that is affected, so maybe a registry isn't warranted just yet?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
