### PR TITLE
ValuePlug : Remove deprecated `getObjectValue()` method

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Breaking Changes
 ----------------
 
+- ValuePlug : Removed deprecated `getObjectValue()` overload.
 - Dispatcher : Removed `createMatching()` method.
 - Process : Removed non-const variant of the `handleException()` method.
 - StringPlug : Removed deprecated `precomputedHash` argument from `getValue()` method.

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -251,9 +251,6 @@ class GAFFER_API ValuePlug : public Plug
 		/// so this feature is not suitable for use in classes that override that method.
 		template<typename T = IECore::Object>
 		const T *getObjectValue( IECore::ConstObjectPtr &owner, const IECore::MurmurHash *precomputedHash = nullptr ) const;
-		/// \deprecated
-		template<typename T = IECore::Object>
-		boost::intrusive_ptr<const T> getObjectValue( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		/// Should be called by derived classes when they wish to set the plug
 		/// value - the value is referenced directly (not copied) and so must
 		/// not be changed following the call.
@@ -271,8 +268,6 @@ class GAFFER_API ValuePlug : public Plug
 		class SetValueAction;
 
 		const IECore::Object *getValueInternal( IECore::ConstObjectPtr &owner, const IECore::MurmurHash *precomputedHash = nullptr ) const;
-		/// \deprecated
-		IECore::ConstObjectPtr getValueInternal( const IECore::MurmurHash *precomputedHash = nullptr ) const;
 		void setValueInternal( IECore::ConstObjectPtr value, bool propagateDirtiness );
 		void childAddedOrRemoved();
 		// Emits the appropriate Node::plugSetSignal() for this plug and all its

--- a/include/Gaffer/ValuePlug.inl
+++ b/include/Gaffer/ValuePlug.inl
@@ -54,21 +54,4 @@ const T *ValuePlug::getObjectValue( IECore::ConstObjectPtr &owner, const IECore:
 	) );
 }
 
-template<typename T>
-boost::intrusive_ptr<const T> ValuePlug::getObjectValue( const IECore::MurmurHash *precomputedHash ) const
-{
-	IECore::ConstObjectPtr owner;
-	const T *value = getObjectValue<T>( owner, precomputedHash );
-	if( owner )
-	{
-		// Avoid unnecessary reference count manipulations.
-		return boost::static_pointer_cast<const T>( std::move( owner ) );
-	}
-	else
-	{
-		return value;
-	}
-
-}
-
 } // namespace Gaffer

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -967,7 +967,8 @@ void ValuePlug::resetDefault()
 {
 	if( m_defaultValue != nullptr )
 	{
-		IECore::ConstObjectPtr newDefault = getObjectValue();
+		IECore::ConstObjectPtr newDefaultOwner;
+		IECore::ConstObjectPtr newDefault = getObjectValue( newDefaultOwner );
 		IECore::ConstObjectPtr oldDefault = m_defaultValue;
 		Action::enact(
 			this,
@@ -1038,13 +1039,6 @@ const IECore::Object *ValuePlug::defaultObjectValue() const
 const IECore::Object *ValuePlug::getValueInternal( IECore::ConstObjectPtr &owner, const IECore::MurmurHash *precomputedHash ) const
 {
 	return ComputeProcess::value( this, owner, precomputedHash );
-}
-
-IECore::ConstObjectPtr ValuePlug::getValueInternal( const IECore::MurmurHash *precomputedHash ) const
-{
-	IECore::ConstObjectPtr owner;
-	const IECore::Object *result = getValueInternal( owner, precomputedHash );
-	return owner ? owner : result;
 }
 
 void ValuePlug::setObjectValue( IECore::ConstObjectPtr value )


### PR DESCRIPTION
This removes the methods deprecated in #5520. It also includes the fix from #5522 so that the CI can pass.