### PR TITLE
DuplicateTest : Test that uses Duplicate to expose exception issue

### DIFF
--- a/python/GafferSceneTest/DuplicateTest.py
+++ b/python/GafferSceneTest/DuplicateTest.py
@@ -314,5 +314,30 @@ class DuplicateTest( GafferSceneTest.SceneTestCase ) :
 			imath.M44f().translate( imath.V3f( 5, 0, 0 ) )
 		)
 
+	def testUpstreamError( self ):
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+
+		sphere = GafferScene.Sphere()
+
+		purposeAttr = GafferScene.CustomAttributes()
+		purposeAttr["in"].setInput( sphere["out"] )
+		purposeAttr["filter"].setInput( sphereFilter["out"] )
+		purposeAttr["attributes"].addChild( Gaffer.NameValuePlug( "testAttribute", 0 ) )
+		purposeAttr["expression"] = Gaffer.Expression()
+		purposeAttr["expression"].setExpression( 'parent["attributes"]["NameValuePlug"]["value"] = 1 / 0', "python" )
+
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( purposeAttr["out"] )
+		duplicate["filter"].setInput( sphereFilter["out"] )
+		duplicate["copies"].setValue( 100 )
+
+		for i in range( 20 ):
+			with self.subTest( i = i ):
+				with self.assertRaisesRegex( RuntimeError, "division by zero" ):
+					GafferSceneTest.traverseScene( duplicate["out"] )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This feels exceptionally weird - this is a pretty simple graph, with an obvious error in a Python expression that should lead to an exception, but in my testing, about half the time, non-deterministically, this exception gets lost.

I was originally worried this could be related to the recent work on acquireCollaborativeResult, because when the exception got lost, the exception I got instead was:

```line 340, in testUpstreamError
    GafferSceneTest.traverseScene( duplicate["out"] )
AssertionError: "division by zero" does not match "CustomAttributes.expression.__out.p0 : Process::acquireCollaborativeResult : No result found"
```

However, testing on Gaffer 1.3.5.0, I see the same issue with the exception non-deterministically getting lost, except with this message instead:

```
line 340, in testUpstreamError
    GafferSceneTest.traverseScene( duplicate["out"] )
AssertionError: "division by zero" does not match "CustomAttributes.expression.__out.p0 : CustomAttributes.expression.__execute : getValueInternal() didn't return expected type (wanted ObjectVector but got nullptr). Is the hash being computed correctly?"
```

This message is a bit more descriptive - but it still doesn't make a huge amount of sense. If there is a hash bug, I'm not sure where it is - maybe in CustomAttributes? ( I was able to rule out Instancer ). Even if there is a bug in CustomAttributes, it's a bit alarming that it would manifest as a non-deterministic failure like this.

I don't have any solution yet, but putting up a PR with the test seemed like the quickest way to share the code ( and get a result on CI, which will hopefully reproduce what I'm seeing on my local machine ).