### PR TITLE
Process : Fix exception handling in `acquireCollaborativeResult()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.x.x (relative to 1.3.6.0)
 =======
 
+Fixes
+-----
 
+- Process : Fixed bug which caused a `No result found` exception to be thrown when a more descriptive exception should have been thrown instead.
 
 1.3.6.0 (relative to 1.3.5.0)
 =======

--- a/src/GafferImage/CollectImages.cpp
+++ b/src/GafferImage/CollectImages.cpp
@@ -48,6 +48,7 @@
 #include "fmt/format.h"
 
 #include <numeric>
+#include <unordered_map>
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferTestModule/ProcessTest.cpp
+++ b/src/GafferTestModule/ProcessTest.cpp
@@ -50,6 +50,8 @@
 
 #include "tbb/parallel_for_each.h"
 
+#include <unordered_map>
+
 using namespace boost::python;
 using namespace IECore;
 using namespace Gaffer;


### PR DESCRIPTION
When an exception was thrown from `ProcessType::run()`, we were catching it and rethrowing it from the code path that initiated the collaboration. But since we were rethrowing after the `run_and_wait()`, collaborating threads could leave their `wait()` before the exception was rethrown. In this case, they would throw their own vague exception about there being no result available, and this exception could be the first thrown, and therefore the first one to surface back to the caller. We now store the original exception in `TypedCollaboration::result` (now a variant) so that both the initiator and the collaborator throw the same exception.

_Technically_ this is an ABI break, because it changes a member in TypedCollaboration. But for it to cause a problem, the following conditions would need to be met :
- Someone would need to be using `acquireCollaborativeResult()` already. I'm not aware of anyone ever creating their own Process subclass, so the chances of someone doing that _and_ using a new feature that was only released yesterday are vanishingly small.
- They would also need to compile some code with the old definition, and some with the new, which again is vanishingly unlikely, as Process subclasses are usually completely hidden.

I think it's pretty clear that the lesser evil in this case is to fix the bug.