### PR TITLE
Viewer Snapshot to Catalogue

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Fixes
 
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
 
+API
+---
+
+- SceneGadget : Added `snapshotToFile()` method.
+
 1.3.7.0 (relative to 1.3.6.1)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.7.0)
 =======
 
+Features
+--------
+
+- Viewer : Added "Snapshot To Catalogue" command to the right-click menu of the 3D view.
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -1105,7 +1105,7 @@ libraries = {
 
 	"GafferSceneUI" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX" ],
+			"LIBS" : [ "Gaffer", "GafferUI", "GafferImage", "GafferImageUI", "GafferScene", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX", "IECoreScene$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "IECoreGL$CORTEX_LIB_SUFFIX", "GafferBindings", "GafferScene", "GafferImage", "GafferUI", "GafferImageUI", "GafferSceneUI", "IECoreScene$CORTEX_LIB_SUFFIX" ],

--- a/include/GafferSceneUI/Private/OutputBuffer.h
+++ b/include/GafferSceneUI/Private/OutputBuffer.h
@@ -44,6 +44,7 @@
 
 #include "IECore/PathMatcher.h"
 
+#include <filesystem>
 #include <mutex>
 
 namespace GafferSceneUI
@@ -80,6 +81,13 @@ class OutputBuffer
 		/// should be called.
 		using BufferChangedSignal = Gaffer::Signals::Signal<void()>;
 		BufferChangedSignal &bufferChangedSignal();
+
+		/// See `SceneGadget::snapshotToFile()` for documentation.
+		void snapshotToFile(
+			const std::filesystem::path &fileName,
+			const Imath::Box2f &resolutionGate = Imath::Box2f(),
+			const IECore::CompoundData *metadata = nullptr
+		);
 
 	private :
 

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -53,6 +53,8 @@
 
 #include "IECoreGL/State.h"
 
+#include <filesystem>
+
 namespace GafferSceneUI
 {
 
@@ -190,6 +192,17 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 
 		/// Implemented to return the name of the object under the mouse.
 		std::string getToolTip( const IECore::LineSegment3f &line ) const override;
+
+		/// Saves a snapshot of the current rendered scene. All renderers are supported _except_
+		/// the OpenGL renderer. All formats supported by OpenImageIO can be used. The output
+		/// display window will be set to `resolutionGate` if it is not an empty `Box2f`.
+		/// All of the supplied metadata will be written, regardless of conflicts with
+		/// OpenImageIO built-in metadata.
+		void snapshotToFile(
+			const std::filesystem::path &fileName,
+			const Imath::Box2f &resolutionGate =  Imath::Box2f(),
+			const IECore::CompoundData *metadata = nullptr
+		) const;
 
 	protected :
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -780,6 +780,20 @@ Imath::Box3f SceneGadget::bound() const
 	return bound( /* selection = */ false );
 }
 
+void SceneGadget::snapshotToFile(
+	const std::filesystem::path &fileName,
+	const Box2f &resolutionGate,
+	const CompoundData *metadata
+) const
+{
+	if( !m_outputBuffer )
+	{
+		return;
+	}
+
+	m_outputBuffer->snapshotToFile( fileName, resolutionGate, metadata );
+}
+
 void SceneGadget::renderLayer( Layer layer, const GafferUI::Style *style, RenderReason reason ) const
 {
 	assert( layer == m_layer || layer == Layer::MidFront );

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -179,6 +179,12 @@ Imath::Box3f bound( SceneGadget &g, bool selected, const IECore::PathMatcher *om
 	return g.bound( selected, omitted );
 }
 
+void snapshotToFile( SceneGadget &g, const std::filesystem::path &fileName, const Imath::Box2f &resolutionGate, const IECore::CompoundData *metadata )
+{
+	ScopedGILRelease gilRelease;
+	g.snapshotToFile( fileName, resolutionGate, metadata );
+}
+
 } // namespace
 
 void GafferSceneUIModule::bindSceneGadget()
@@ -214,6 +220,11 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "getSelection", &SceneGadget::getSelection, return_value_policy<copy_const_reference>() )
 		.def( "selectionBound", &selectionBound )
 		.def( "bound", &bound, ( arg( "selected" ), arg( "omitted" ) = object() ) )
+		.def(
+			"snapshotToFile",
+			&snapshotToFile,
+			( arg( "fileName" ), arg( "resolutionGate" ) = Imath::Box2f(), arg( "metadata" ) = object() )
+		)
 	;
 
 	enum_<SceneGadget::State>( "State" )


### PR DESCRIPTION
This does pretty much what the title suggests. In addition to sending the pixel data, a display window indicating the camera's resolution gate will be added if the snapshot is taken when viewing through a camera. I'm currently including the frame and the scene plug from which the snapshot was taken in metadata.

Identifying the catalogues in a script is one area that might deserve some more attention. I'm using `GafferImage.Catalogue.RecursiveRange()` to find all `Catalogue` nodes from the script root. Some recent production scripts have around 600k - 1m nodes. Remote machines didn't seem to have any noticeable lag in getting all of the catalogues using  `list( catalogues )` in the Python terminal.

I do notice a pretty good lag on my workstation with an artificially generated network of a similar number of nodes - 3-4 seconds on a release build.

Not sure if that's a matter of the topology of the node graphs or simply CPU speed / cores (I have 48, not sure what the remote machines have).

I put the `Catalogue` search into the "Send to Catalogue" submenu so it can be deferred until the user expands that menu, so that provides a bit of a guard against unwanted lags.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
