### PR TITLE
Windows : Disable Arnold ADP by default

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Improved scene generation for encapsulated instancers significantly, with some production scenes now generating 5-7x faster.
   - Added `omitDuplicateIds` plug, to determine whether points with duplicate IDs are ignored or should trigger an error.
 - ScenePathPlugValueWidget : Added fallback to browsing the focussed scene when no other scene can be found. This makes the widget suitable for use on ShaderNodes.
+- Windows : Disabled Arnold's ADP usage and crash reporting module by default. Users can enable it by setting `ARNOLD_ADP_DISABLE=0` for Arnold versions after 7.1.4.0 or `ARNOLD_ADP_OPTIN=1` for earlier versions.
 
 API
 ---


### PR DESCRIPTION
This disables Arnold's ADP crash reporter on Windows by default. This had already been done on Linux in #5106, and is now being applied to Windows after users have reported crashes traced back to ADP.

I verified the code paths in `gaffer.cmd` are hit appropriately using debug `echo` commands. But I can't verify for sure this is disabling ADP since I can't reproduce the crashes. The debugger reports loading `AdpSDKCore.dll` for what it's worth.

Maybe you could try it out @murraystevenson since you've been able to reproduce the crash in some Arnold versions?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
