### PR TITLE
OpenGLShaderUI : Fix leading `\` on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.x.x (relative to 1.3.7.0)
 =======
 
+Fixes
+-----
 
+- Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
 
 1.3.7.0 (relative to 1.3.6.1)
 =======

--- a/python/GafferSceneUI/OpenGLShaderUI.py
+++ b/python/GafferSceneUI/OpenGLShaderUI.py
@@ -37,6 +37,7 @@
 import os
 import string
 import functools
+import pathlib
 
 import IECore
 
@@ -99,11 +100,11 @@ def shaderSubMenu() :
 	# a lot of irrelevancies at IE at the moment.
 	paths = [ os.environ["GAFFER_ROOT"] + "/glsl" ]
 	for path in paths :
-		for root, dirs, files in os.walk( path ) :
-			for file in files :
-				if os.path.splitext( file )[1] in ( ".vert", ".frag" ) :
-					shaderPath = os.path.join( root, file ).partition( path )[-1].lstrip( "/" )
-					shaders.add( os.path.splitext( shaderPath )[0] )
+		for extension in [ ".vert", ".frag" ] :
+			shaderPaths = pathlib.Path( path ).glob( "**/*" + extension )
+
+			for shaderPath in shaderPaths :
+				shaders.add( shaderPath.relative_to( path ).as_posix()[:-len( extension )] )
 
 	result = IECore.MenuDefinition()
 	for shader in sorted( list( shaders ) ) :


### PR DESCRIPTION
This fixes a small glitch where a `\` character was being added the start of menu items from `Scene.OpenGL.Shader` on Windows.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
