### PR TITLE
Resample : Optimize inseparable case with no scaling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - Viewer : Added "Snapshot To Catalogue" command to the right-click menu of the 3D view.
 
+Improvements
+------------
+
+- ImageTransform, Resample : Improved performance for non-separable filters without scaling, with 2-6x speedups in some benchmark cases.
+
 Fixes
 -----
 


### PR DESCRIPTION
The goal was to make as self-contained a change a possible that gets some big wins for one of the more embarassing cases for Reasmple: using a large, inseparable filter without any scaling.

It's reasonably successful on the performance side:
```
- testPerfInseparableAwkwardSize (GafferImageTest.ResampleTest.ResampleTest) : was 0.48s now 0.30s (38% reduction)
- testPerfInseparableDisk (GafferImageTest.ResampleTest.ResampleTest) : was 3.67s now 1.78s (52% reduction)
- testPerfInseparableLanczos (GafferImageTest.ResampleTest.ResampleTest) : was 12.20s now 2.05s (83% reduction)
```

I thought about putting together a Changelog entry in case you're happy with this approach and it's ready to merge - but then I realized I'm not sure how the Changelog for this should look, since it's technically not user facing - we don't expose the filter type on the Blur, and you can't create a Resample from the menu. I still think that doing a blur with a non-separable filter shouldn't be an overly large performance hazard, and this change is worth making.