### PR TITLE
Catalogue : Fix duplicate save processes when IPR ends

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
   - Improved scene generation for encapsulated instancers significantly, with some production scenes now generating 5-7x faster.
   - Added `omitDuplicateIds` plug, to determine whether points with duplicate IDs are ignored or should trigger an error.
 
+Fixes
+-----
+
+- Catalogue : Fixed performance regressive when saving interactive renders with multiple AOVs (introduced in 1.3.6.1).
+
 API
 ---
 

--- a/python/GafferImageTest/DisplayTest.py
+++ b/python/GafferImageTest/DisplayTest.py
@@ -105,7 +105,11 @@ class DisplayTest( GafferImageTest.ImageTestCase ) :
 				h.assertCalled()
 				h.assertDone()
 
-		def close( self ) :
+		def close( self, withCallHandler = True ) :
+
+			if not withCallHandler :
+				self.__driver.imageClose()
+				return
 
 			with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as h :
 				self.__driver.imageClose()

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -345,6 +345,11 @@ class Catalogue::InternalImage : public ImageNode
 
 		void driverClosed()
 		{
+			if( m_saver )
+			{
+				return;
+			}
+
 			for( const auto &[outputID, display] : m_displays )
 			{
 				if( !display->driverClosed() )


### PR DESCRIPTION
This bug was introduced in d67ace35f72dbc12d98156f6cd2f8c54bf8ccc54. What I'd failed to realise at the time was that `Display::driverClosed()` will return `True` _before_ `Display::imageReceivedSignal()` has been emitted on the UI thread, because it's just an accessor to an atomic flag. This means that its the _first_ call to `InternalImage::driverClosed()` that will initiate the saving process, rather than the last call as before. So in subsequent calls we need to check we haven't yet initialised `m_saver` to avoid repeating the save process unnecessarily.

For people with a lot of AOVs, the slowdown from the multiple saves could be quite drastic. What made it even worse was that the assignment of `m_saver = newRedundantAsynchronousSaver` would block, because the destructor for the old saver waits for the background process to finish.
