### PR TITLE
RendererAlgo : Experiments With How We Handle Capsules and Deformation Blur

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Features
 Fixes
 -----
 
+- InteractiveRender : Fixed unnecessary updates to encapsulated locations when deforming an unrelated object.
 - InteractiveArnoldRender : Fixed creation of new Catalogue image when editing output metadata or pixel filter.
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
 


### PR DESCRIPTION
This all turned out fairly close to what we expected during our conversation this morning. I've described outcomes in the 3 different proposal commits, but the summary is:

Proposal 1) Minimal change, fully correct, small performance improvement ( would be more significant with heavier Capsules )
Proposal 2) Minimal change, fails one weird corner case, 50% time reduction
Proposal 3) More awkward code change, fully correct, 70% time reduction

I think if I spent another day fiddling with it, I could probably come up with a cleaner way to refactor proposal 3, and it seems like it might be worth further exploration, since it is a real improvement in both perf and correctness.