### PR TITLE
Arnold Renderer : Reuse existing driver nodes where possible

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Features
 Fixes
 -----
 
+- InteractiveArnoldRender : Fixed creation of new Catalogue image when editing output metadata or pixel filter.
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
 
 API


### PR DESCRIPTION
Previously we were deleting and recreating the driver node for _any_ change to the output definition. But when we did that, Arnold closed the old drivers before opening the new ones, no matter what order we deleted and created the nodes in. This meant the Catalogue thought the render was over and saved the image, creaing a new one when the new drivers opened.

By reusing the existing drivers wherever possible, we are able to continue rendering to the original Catalogue image when `header:` metadata parameters and filter parameters change.
