### PR TITLE
BackgroundMethodTest : Increase `waitForIdle()` count

### DIFF
--- a/python/GafferUITest/BackgroundMethodTest.py
+++ b/python/GafferUITest/BackgroundMethodTest.py
@@ -254,7 +254,7 @@ class BackgroundMethodTest( GafferUITest.TestCase ) :
 			# a zombie widget, we'd get PySide errors in our redirected output,
 			# so make sure that doesn't happen.
 			del window
-			self.waitForIdle( 1000 )
+			self.waitForIdle( 10000 )
 
 		self.assertIsNone( w() )
 		self.assertEqual( out, [] )


### PR DESCRIPTION
We've been seeing regular failures on Windows CI in `assertIsNone( w() )` at L259. `w` can only die when the BackgroundMethod has returned, so my assumption is that when a CI machine is under heavy load, we're not waiting long enough for this to happen. So I'm upping the limit in the hope that it helps matters.
