### PR TITLE
Instancer : Fix ambiguous reference compilation errors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,11 @@ API
 
 - SceneGadget : Added `snapshotToFile()` method.
 
+Build
+-----
+
+- Instancer : Fixed ambiguous reference compilation errors when building with Boost 1.70.
+
 1.3.7.0 (relative to 1.3.6.1)
 =======
 

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -756,13 +756,13 @@ class Instancer::EngineData : public Data
 			template<typename T>
 			AttributeCreator operator()( const TypedData<vector<T>> *data )
 			{
-				return std::bind( &createAttribute<T>, data->readable(), ::_1 );
+				return std::bind( &createAttribute<T>, data->readable(), std::placeholders::_1 );
 			}
 
 			template<typename T>
 			AttributeCreator operator()( const GeometricTypedData<vector<T>> *data )
 			{
-				return std::bind( &createGeometricAttribute<T>, data->readable(), data->getInterpretation(), ::_1 );
+				return std::bind( &createGeometricAttribute<T>, data->readable(), data->getInterpretation(), std::placeholders::_1 );
 			}
 
 			AttributeCreator operator()( const Data *data )


### PR DESCRIPTION
When building for nuke 13's environment, which uses boost 1.70, we started getting compiler errors `reference to '_1' is ambiguous`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
