### PR TITLE
Instancer : Fix handling of unindexed primvars in RootPerVertex mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - InteractiveRender : Fixed context used to evaluate scene globals when renderer is set to "Default".
+- Instancer : Fixed handling of unindexed primvars in RootPerVertex mode.
 
 1.3.14.0 (relative to 1.3.13.1)
 ========

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1325,6 +1325,11 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		self.assertRootsMatchPrototypeSceneChildren( script )
 		self.assertEncapsulatedRendersSame( script["instancer"] )
 
+		# We should be able to get the same result with an un-indexed primvar
+		updateRoots( IECore.StringVectorData( [ "/foo", "/bar", "/bar", "/foo" ] ), None )
+		self.assertRootsMatchPrototypeSceneChildren( script )
+		self.assertEncapsulatedRendersSame( script["instancer"] )
+
 		updateRoots( IECore.StringVectorData( [ "/foo/bar", "/bar" ] ), IECore.IntVectorData( [ 0, 1, 1, 0 ] ) )
 		self.assertConflictingRootNames( script )
 		self.assertEncapsulatedRendersSame( script["instancer"] )
@@ -2200,18 +2205,10 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		self.assertEncapsulatedRendersSame( instancer )
 
 		instancer["prototypeRoots"].setValue( "unindexedRoots" )
-		"""
-		# How things should work
 		self.assertEqual( uniqueCounts(), { "" : 3 } )
 		self.assertEqual( childNameStrings( "points/instances/cube" ), [ str(i) for i in range( 0, 34 ) ] )
 		self.assertEqual( childNameStrings( "points/instances/plane" ), [ str(i) for i in range( 34, 68 ) ] )
 		self.assertEqual( childNameStrings( "points/instances/sphere" ), [ str(i) for i in range( 68, 100 ) ] )
-		"""
-		# How things currently work
-		self.assertEqual( uniqueCounts(), { "" : 1 } )
-		self.assertEqual( childNameStrings( "points/instances/cube" ), [ str(i) for i in range( 100 ) ] )
-		self.assertEqual( childNameStrings( "points/instances/plane" ), [] )
-		self.assertEqual( childNameStrings( "points/instances/sphere" ), [] )
 
 		self.assertEncapsulatedRendersSame( instancer )
 


### PR DESCRIPTION
As discussed, we actually had a test noting this incorrect behaviour, but it wasn't enabled.

I actually don't have a good feeling about this code ... trying to put a finger on it, I think there are a few factors:
* we need to handle duplicate prototype names in this mode ... but do we not need to handle duplicate prototypes correctly in any other mode? I guess it's fairly reasonable to assume that an indexed primvar doesn't have too indices with the same value ( though I don't think anything would really prevent this ). There's nothing to prevent a user from entering duplicates if they manually enter a prototypeRootsList ... I guess it's OK to consider that user error, and give inconsistent results?
* in order to handle duplicates, we need to build a map. We then convert the rootStrings to paths, and put them in a ChildNamesMap which then builds its own map. This is useful if two roots have the same leaf name ... but it's pointless if all prototypes come from the same parent location ( in which case they must already have unique names ) ... and that's probably by far the most common case?

Anyway, after contemplating whether there was any better solution that could address more of these issues, I figured I should forget about it for now, and just do the basic fix that makes this case at least work, even if it isn't optimal.