### PR TITLE
LightPositionTool : Add tool for placing shadows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,11 @@ API
   - `fileSystemPath:extensions`
   - `fileSystemPath:extensionsLabel`
 
+Improvements
+------------
+
+- Translate and Rotate tools : Added viewer tip to the upper left corner of the viewer explaining how to use the target modes.
+
 1.3.9.0 (relative to 1.3.8.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.9.0)
 =======
 
+Features
+--------
+
+- LightPositionTool : Added tool to the scene viewer to place shadows. With a light selected, holding <kbd>Shift</kbd> + <kbd>V</kbd> and clicking on geometry will set the pivot point used for casting a shadow. Holding <kbd>V</kdb> and clicking sets the point to receive the shadow. The light is repositioned to be the same distance from the pivot, along the pivot-shadow point line, and oriented to face the shadow point.
+
 Improvements
 ------------
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -223,6 +223,7 @@ Cycle Transform Tool Orientation     | {kbd}`O`
 Scale Tool                           | {kbd}`R`
 Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`
+Light Position Tool                  | {kbd}`D`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
 
 ### 3D scenes ###
@@ -272,6 +273,16 @@ Action                                        | Control or shortcut
 ----------------------------------------------|--------------------
 Adjust, fine precision                        | Hold {kbd}`Shift` during action
 Constrain to aspect ratio (Quad lights only)  | Hold {kbd}`Ctrl` during action
+
+### Light Position Tool ###
+
+> Note :
+> For the following controls and shortcuts, the Light Position Tool must be active.
+
+Action                                        | Control or shortcut
+----------------------------------------------|--------------------
+Set shadow target position                    | {kbd}`V` + {{leftClick}}
+Set shadow pivot position                     | {kbd}`Shift` + {kbd}`V` + {{leftClick}}
 
 
 ### 2D images ###

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -98,6 +98,11 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool handleDragEnd();
 
+		IECore::RunTimeTypedPtr sceneGadgetDragBegin( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool sceneGadgetDragEnter( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool sceneGadgetDragMove( const GafferUI::DragDropEvent &event );
+		bool sceneGadgetDragEnd();
+
 		bool keyPress( const GafferUI::KeyEvent &event );
 		bool keyRelease( const GafferUI::KeyEvent &event );
 		void viewportGadgetLeave( const GafferUI::ButtonEvent &event );
@@ -107,6 +112,8 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		bool buttonPress( const GafferUI::ButtonEvent &event );
 		bool buttonRelease( const GafferUI::ButtonEvent &event );
+
+		bool placeTarget( const IECore::LineSegment3f &eventLine );
 
 		enum class TargetMode
 		{
@@ -138,6 +145,8 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowPivotMap;  // world-space
 		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowTargetMap;  // world-space
 		std::unordered_map<std::string, std::optional<float>> m_shadowPivotDistanceMap;
+
+		bool m_draggingTarget;
 
 		static ToolDescription<LightPositionTool, SceneView> g_toolDescription;
 		static size_t g_firstPlugIndex;

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -64,7 +64,7 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		// Positions the current selection to cast a shadow from `shadowPivot` to `shadowTarget`,
 		// with the light `targetDistance` from the pivot. All coordinates are in world space.
-		void position( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
+		void positionShadow( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
 
 	protected :
 
@@ -120,26 +120,26 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		enum class TargetMode
 		{
 			None,
-			ShadowPivot,
-			ShadowTarget
+			Pivot,
+			Target
 		};
 
 		void setTargetMode( TargetMode mode );
 		TargetMode getTargetMode() const { return m_targetMode; }
 
-		void setShadowPivot( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
-		std::optional<Imath::V3f> getShadowPivot() const;
-		void setShadowTarget( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
-		std::optional<Imath::V3f> getShadowTarget() const;
-		void setShadowPivotDistance( const float d );
-		std::optional<float> getShadowPivotDistance() const;
+		void setPivot( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
+		std::optional<Imath::V3f> getPivot() const;
+		void setTarget( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
+		std::optional<Imath::V3f> getTarget() const;
+		void setPivotDistance( const float d );
+		std::optional<float> getPivotDistance() const;
 
 		TargetMode m_targetMode;
 
 		std::optional<TranslationRotation> m_drag;
-		float m_startShadowPivotDistance;
+		float m_startPivotDistance;
 
-		GafferUI::HandlePtr m_shadowHandle;
+		GafferUI::HandlePtr m_distanceHandle;
 		GafferUI::RotateHandlePtr m_rotateHandle;
 
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
@@ -147,10 +147,10 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		// Pivots and targets are stored in transform space - the world space transform
 		// of the scene in which the transform will be applied.
 		// See `TransformTool::transformSpace()` for details.
-		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowPivotMap;
-		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowTargetMap;
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_pivotMap;
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_targetMap;
 
-		std::unordered_map<std::string, std::optional<float>> m_shadowPivotDistanceMap;
+		std::unordered_map<std::string, std::optional<float>> m_pivotDistanceMap;
 
 		bool m_draggingTarget;
 

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -62,6 +62,8 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::LightPositionTool, LightPositionToolTypeId, TransformTool );
 
+		// Positions the current selection to cast a shadow from `shadowPivot` to `shadowTarget`,
+		// with the light `targetDistance` from the pivot. All coordinates are in world space.
 		void position( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
 
 	protected :
@@ -142,8 +144,12 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 
-		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowPivotMap;  // world-space
-		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowTargetMap;  // world-space
+		// Pivots and targets are stored in transform space - the world space transform
+		// of the scene in which the transform will be applied.
+		// See `TransformTool::transformSpace()` for details.
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowPivotMap;
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowTargetMap;
+
 		std::unordered_map<std::string, std::optional<float>> m_shadowPivotDistanceMap;
 
 		bool m_draggingTarget;

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -1,0 +1,138 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferSceneUI/Export.h"
+#include "GafferSceneUI/TransformTool.h"
+#include "GafferSceneUI/TypeIds.h"
+
+#include "GafferUI/Handle.h"
+
+#include "Gaffer/ScriptNode.h"
+
+#include <unordered_map>
+
+namespace GafferSceneUI
+{
+
+IE_CORE_FORWARDDECLARE( SceneView );
+
+class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
+{
+
+	public :
+
+		LightPositionTool( SceneView *view, const std::string &name = defaultName<LightPositionTool>() );
+		~LightPositionTool() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::LightPositionTool, LightPositionToolTypeId, TransformTool );
+
+		void position( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
+
+	protected :
+
+		bool affectsHandles( const Gaffer::Plug *input ) const override;
+		void updateHandles( float rasterScale ) override;
+
+	private :
+
+		struct TranslationRotation
+		{
+
+			TranslationRotation( const Selection &selection );
+
+			bool canApply() const;
+			void apply( const Imath::V3f &tranlation, const Imath::Eulerf &rotation );
+
+			private :
+
+				Imath::V3f updatedRotateValue( const Gaffer::V3fPlug *rotatePlug, const Imath::Eulerf &rotation, Imath::V3f *currentValue = nullptr ) const;
+
+				const Selection &m_selection;
+				Imath::M44f m_gadgetToTranslationXform;
+				Imath::M44f m_gadgetToRotationXform;
+
+				mutable std::optional<Imath::V3f> m_originalTranslation;
+				mutable std::optional<Imath::Eulerf> m_originalRotation;  // Radians
+
+		};
+
+		bool keyPress( const GafferUI::KeyEvent &event );
+		bool keyRelease( const GafferUI::KeyEvent &event );
+		void viewportGadgetLeave( const GafferUI::ButtonEvent &event );
+		void visibilityChanged( GafferUI::Gadget *gadget );
+
+		void plugSet( Gaffer::Plug *plug );
+
+		bool buttonPress( const GafferUI::ButtonEvent &event );
+		bool buttonRelease( const GafferUI::ButtonEvent &event );
+
+		enum class TargetMode
+		{
+			None,
+			ShadowPivot,
+			ShadowTarget
+		};
+
+		void setTargetMode( TargetMode mode );
+		TargetMode getTargetMode() const { return m_targetMode; }
+
+		void setShadowPivot( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
+		std::optional<Imath::V3f> getShadowPivot() const;
+		void setShadowTarget( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
+		std::optional<Imath::V3f> getShadowTarget() const;
+		void setShadowPivotDistance( const float d );
+		std::optional<float> getShadowPivotDistance() const;
+
+		TargetMode m_targetMode;
+
+		GafferUI::HandlePtr m_shadowHandle;
+
+		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
+
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowPivotMap;  // world-space
+		std::unordered_map<std::string, std::optional<Imath::V3f>> m_shadowTargetMap;  // world-space
+		std::unordered_map<std::string, std::optional<float>> m_shadowPivotDistanceMap;
+
+		static ToolDescription<LightPositionTool, SceneView> g_toolDescription;
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( LightPositionTool )
+
+}  // namespace GafferSceneUI

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -41,6 +41,7 @@
 #include "GafferSceneUI/TypeIds.h"
 
 #include "GafferUI/Handle.h"
+#include "GafferUI/RotateHandle.h"
 
 #include "Gaffer/ScriptNode.h"
 
@@ -93,7 +94,7 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		};
 
-		IECore::RunTimeTypedPtr handleDragBegin();
+		IECore::RunTimeTypedPtr handleDragBegin( GafferUI::Gadget *gadget );
 		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool handleDragEnd();
 
@@ -130,6 +131,7 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		float m_startShadowPivotDistance;
 
 		GafferUI::HandlePtr m_shadowHandle;
+		GafferUI::RotateHandlePtr m_rotateHandle;
 
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -73,10 +73,12 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		struct TranslationRotation
 		{
 
-			TranslationRotation( const Selection &selection );
+			TranslationRotation( const Selection &selection, Orientation orientation );
 
-			bool canApply() const;
-			void apply( const Imath::V3f &tranlation, const Imath::Eulerf &rotation );
+			bool canApplyTranslation() const;
+			bool canApplyRotation( const Imath::V3i &axisMask ) const;
+			void applyTranslation( const Imath::V3f &translation );
+			void applyRotation( const Imath::Eulerf &rotation );
 
 			private :
 
@@ -90,6 +92,10 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 				mutable std::optional<Imath::Eulerf> m_originalRotation;  // Radians
 
 		};
+
+		IECore::RunTimeTypedPtr handleDragBegin();
+		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
+		bool handleDragEnd();
 
 		bool keyPress( const GafferUI::KeyEvent &event );
 		bool keyRelease( const GafferUI::KeyEvent &event );
@@ -119,6 +125,9 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		std::optional<float> getShadowPivotDistance() const;
 
 		TargetMode m_targetMode;
+
+		std::optional<TranslationRotation> m_drag;
+		float m_startShadowPivotDistance;
 
 		GafferUI::HandlePtr m_shadowHandle;
 

--- a/include/GafferSceneUI/TypeIds.h
+++ b/include/GafferSceneUI/TypeIds.h
@@ -57,6 +57,7 @@ enum TypeId
 	HistoryPathTypeId = 110664,
 	SetPathTypeId = 110665,
 	LightToolTypeId = 110666,
+	LightPositionToolTypeId = 110667,
 
 	LastTypeId = 110700
 };

--- a/python/GafferSceneUI/LightPositionToolUI.py
+++ b/python/GafferSceneUI/LightPositionToolUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,33 +34,21 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
-from .ParameterInspectorTest import ParameterInspectorTest
-from .AttributeInspectorTest import AttributeInspectorTest
-from .HistoryPathTest import HistoryPathTest
-from .LightEditorTest import LightEditorTest
-from .SetMembershipInspectorTest import SetMembershipInspectorTest
-from .SetEditorTest import SetEditorTest
-from .LightToolTest import LightToolTest
-from .OptionInspectorTest import OptionInspectorTest
-from .LightPositionToolTest import LightPositionToolTest
+import Gaffer
+import GafferUI
+import GafferSceneUI
 
-if __name__ == "__main__":
-	unittest.main()
+Gaffer.Metadata.registerNode(
+
+	GafferSceneUI.LightPositionTool,
+
+	"description",
+	"""
+	Tool for placing lights.
+	""",
+
+	"viewer:shortCut", "D",
+	"order", 7,
+	"tool:exclusive", True,
+
+)

--- a/python/GafferSceneUI/LightPositionToolUI.py
+++ b/python/GafferSceneUI/LightPositionToolUI.py
@@ -34,6 +34,10 @@
 #
 ##########################################################################
 
+import imath
+
+import IECore
+
 import Gaffer
 import GafferUI
 import GafferSceneUI
@@ -50,5 +54,7 @@ Gaffer.Metadata.registerNode(
 	"viewer:shortCut", "D",
 	"order", 7,
 	"tool:exclusive", True,
+
+	"ui:transformTool:toolTip", "Hold 'Shift' + 'V' to place shadow pivot\nHold 'V' to place shadow target",
 
 )

--- a/python/GafferSceneUI/RotateToolUI.py
+++ b/python/GafferSceneUI/RotateToolUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferSceneUI
 
@@ -50,6 +52,8 @@ Gaffer.Metadata.registerNode(
 
 	"viewer:shortCut", "E",
 	"order", 2,
+
+	"ui:transformTool:toolTip", "Hold 'V' and click to aim at target",
 
 	plugs = {
 

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -69,6 +69,14 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:RightSpacer:section", "Bottom",
 	"toolbarLayout:customWidget:RightSpacer:index", -1,
 
+	"nodeToolbar:top:type", "GafferUI.StandardNodeToolbar.top",
+	"toolbarLayout:customWidget:TargetTipWidget:widgetType", "GafferSceneUI.TransformToolUI._TargetTipWidget",
+	"toolbarLayout:customWidget:TargetTipWidget:section", "Top",
+
+	"toolbarLayout:customWidget:TopRightSpacer:widgetType", "GafferSceneUI.TransformToolUI._RightSpacer",
+	"toolbarLayout:customWidget:TopRightSpacer:section", "Top",
+	"toolbarLayout:customWidget:TopRightSpacer:index", -1,
+
 )
 
 class _LeftSpacer( GafferUI.Spacer ) :
@@ -100,6 +108,21 @@ def _distance( ancestor, descendant ) :
 		descendant = descendant.parent()
 
 	return result
+
+class _TargetTipWidget( GafferUI.Frame ) :
+
+	def __init__( self, tool, **kw ) :
+
+		GafferUI.Frame.__init__( self, borderWidth = 4, **kw )
+
+		label = Gaffer.Metadata.value( tool, "ui:transformTool:toolTip" ) or ""
+
+		with self :
+			with GafferUI.Frame( borderWidth = 0 ) as self.__innerFrame :
+				GafferUI.Label( label )
+
+		if not label :
+			self.__innerFrame.setVisible( False )
 
 class _SelectionWidget( GafferUI.Frame ) :
 

--- a/python/GafferSceneUI/TranslateToolUI.py
+++ b/python/GafferSceneUI/TranslateToolUI.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import IECore
+
 import Gaffer
 import GafferSceneUI
 
@@ -50,6 +52,8 @@ Gaffer.Metadata.registerNode(
 
 	"viewer:shortCut", "W",
 	"order", 1,
+
+	"ui:transformTool:toolTip", "Hold 'V' and click to snap to geometry",
 
 	plugs = {
 

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -190,6 +190,7 @@ from . import ImageScatterUI
 from . import RenderPassesUI
 from . import DeleteRenderPassesUI
 from . import RenderPassWedgeUI
+from . import LightPositionToolUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/python/GafferSceneUITest/LightPositionToolTest.py
+++ b/python/GafferSceneUITest/LightPositionToolTest.py
@@ -106,7 +106,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 			upDir = script["light"]["transform"].matrix().multDirMatrix( imath.V3f( 0, 1, 0 ) )
 
 			with Gaffer.Context() :
-				tool.position( shadowPivot, shadowPoint, d0 )
+				tool.positionShadow( shadowPivot, shadowPoint, d0 )
 
 			p = script["light"]["transform"]["translate"].getValue()
 
@@ -166,7 +166,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 				d = ( worldP - shadowPivot ).length()
 
 				with Gaffer.Context() :
-					tool.position( shadowPivot, shadowPoint, d )
+					tool.positionShadow( shadowPivot, shadowPoint, d )
 
 				parentInverseTransform = script["group"]["out"].fullTransform( "/group" ).inverse()
 

--- a/python/GafferSceneUITest/LightPositionToolTest.py
+++ b/python/GafferSceneUITest/LightPositionToolTest.py
@@ -1,0 +1,220 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import random
+import math
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferUITest
+import GafferSceneUI
+import GafferSceneTest
+
+class LightPositionToolTest( GafferUITest.TestCase ) :
+
+	@staticmethod
+	def assertAnglesAlmostEqual( a, b, places = 7 ) :
+		# Check for equivalent euler orientations. `a` and `b` in degrees.
+		a[0] = a[0] % 360
+		a[1] = a[1] % 360
+		a[2] = a[2] % 360
+		b[0] = b[0] % 360
+		b[1] = b[1] % 360
+		b[2] = b[2] % 360
+
+		if (
+			round( abs( a[0] - b[0] ), places ) == 0 and
+			round( abs( a[1] - b[1] ), places ) == 0 and
+			round( abs( a[2] - b[2] ), places ) == 0
+		) :
+			return
+		if (
+			round( abs( ( 180.0 + a[0] ) % 360 - b[0] ), places ) == 0 and
+			round( abs( ( 180.0 - a[1] ) % 360 - b[1] ), places ) == 0 and
+			round( abs( ( 180.0 + a[2] ) % 360 - b[2] ), places ) == 0
+		) :
+			return
+		diff = a - b
+		diff[0] = abs( diff[0] )
+		diff[1] = abs( diff[1] )
+		diff[2] = abs( diff[2] )
+		raise AssertionError( f"{a} != {b} within {places} places ({diff} difference)" )
+
+	def __shadowSource( self, lightP, shadowPivot, shadowPoint ) :
+		return ( shadowPivot - shadowPoint ).normalize() * ( lightP - shadowPivot ).length() + shadowPivot
+
+	def testPosition( self ) :
+
+		random.seed( 42 )
+
+		script = Gaffer.ScriptNode()
+		script["light"] = GafferSceneTest.TestLight()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["light"]["out"] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light" ] ) )
+
+		tool = GafferSceneUI.LightPositionTool( view )
+		tool["active"].setValue( True )
+
+		for i in range( 0, 5 ) :
+			lightP = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+			shadowPivot = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+			shadowPoint = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+
+			script["light"]["transform"]["translate"].setValue( lightP )
+
+			d0 = ( lightP - shadowPivot ).length()
+			upDir = script["light"]["transform"].matrix().multDirMatrix( imath.V3f( 0, 1, 0 ) )
+
+			with Gaffer.Context() :
+				tool.position( shadowPivot, shadowPoint, d0 )
+
+			p = script["light"]["transform"]["translate"].getValue()
+
+			d1 = ( p - shadowPivot ).length()
+			self.assertAlmostEqual( d0, d1, places = 4 )
+
+			desiredP = self.__shadowSource( lightP, shadowPivot, shadowPoint )
+
+			for j in range( 0, 3 ) :
+				self.assertAlmostEqual( p[j], desiredP[j], places = 4 )
+
+			desiredO = imath.M44f()
+			imath.M44f.rotationMatrixWithUpDir( desiredO, imath.V3f( 0, 0, -1 ), shadowPoint - shadowPivot, upDir )
+			rotationO = imath.V3f()
+			desiredO.extractEulerXYZ( rotationO )
+
+			o = script["light"]["transform"]["rotate"].getValue()
+
+			self.assertAnglesAlmostEqual(
+					o,
+					IECore.radiansToDegrees( imath.V3f( rotationO ) ),
+					places = 4
+				)
+
+	def testPositionWithParentTransform( self ) :
+
+		random.seed( 44 )
+
+		script = Gaffer.ScriptNode()
+
+		script["light"] = GafferSceneTest.TestLight()
+
+		script["group"] = GafferScene.Group()
+		script["group"]["in"][0].setInput( script["light"]["out"] )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["group"]["out"] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/light"] ) )
+
+		tool = GafferSceneUI.LightPositionTool( view )
+		tool["active"].setValue( True )
+
+		for i in range( 0, 10 ) :
+			with self.subTest( i = i ) :
+				script["light"]["transform"]["translate"].setValue( imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 ) )
+				script["light"]["transform"]["rotate"].setValue( imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 ) )
+
+				script["group"]["transform"]["translate"].setValue( imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 ) )
+				script["group"]["transform"]["rotate"].setValue( imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 ) )
+
+				shadowPivot = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+				shadowPoint = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+
+				worldTransform = script["group"]["out"].fullTransform( "/group/light" )
+				worldP = imath.V3f( 0 ) * worldTransform
+
+				d = ( worldP - shadowPivot ).length()
+
+				with Gaffer.Context() :
+					tool.position( shadowPivot, shadowPoint, d )
+
+				parentInverseTransform = script["group"]["out"].fullTransform( "/group" ).inverse()
+
+				desiredWorldP = self.__shadowSource( worldP, shadowPivot, shadowPoint )
+				desiredLocalP = desiredWorldP * parentInverseTransform
+				t = script["light"]["transform"]["translate"].getValue()
+				for j in range( 0, 3 ) :
+					with self.subTest( j = j ) :
+						self.assertAlmostEqual( t[j], desiredLocalP[j], places = 4 )
+
+				upDir = worldTransform.multDirMatrix( imath.V3f( 0, 1, 0 ) )
+
+				desiredWorldO = imath.M44f()
+				imath.M44f.rotationMatrixWithUpDir( desiredWorldO, imath.V3f( 0, 0, -1 ), shadowPoint - shadowPivot, upDir )
+
+				worldTransform = script["group"]["out"].fullTransform( "/group/light" )
+				worldO = worldTransform
+				worldO[3][0] = worldO[3][1] = worldO[3][2] = 0.0
+				for j in range( 0, 4 ) :
+					with self.subTest( j = j ) :
+						for k in range( 0, 4 ) :
+							with self.subTest( k = k ) :
+								self.assertAlmostEqual( desiredWorldO[j][k], worldO[j][k], places = 3 )
+
+				parentInverseO = parentInverseTransform
+				parentInverseO[3][0] = parentInverseO[3][1] = parentInverseO[3][2] = 0.0
+				desiredLocalO = desiredWorldO * parentInverseO
+				localTransform = script["group"]["out"].transform( "/group/light" )
+				localO = localTransform
+				localO[3][0] = localO[3][1] = localO[3][2] = 0.0
+
+				for j in range( 0, 4 ) :
+					with self.subTest( j = j ) :
+						for k in range( 0, 4 ) :
+							with self.subTest( k = k ) :
+								self.assertAlmostEqual( desiredLocalO[j][k], localO[j][k], places = 3 )
+
+
+				r = script["light"]["transform"]["rotate"].getValue()
+
+				desiredLocalR = imath.Eulerf()
+				desiredLocalO.extractEulerXYZ( desiredLocalR )
+
+				self.assertAnglesAlmostEqual(
+					r,
+					IECore.radiansToDegrees( imath.V3f( desiredLocalR ) ),
+					places = 4
+				)
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1489,9 +1489,17 @@ _styleSheet = string.Template(
 		background-color: $brightColor;
 	}
 
+	*[gafferClass="GafferSceneUI.TransformToolUI._TargetTipWidget"]
+	{
+		border: 0px;
+		margin: 0px;
+		padding: 0px;
+	}
+
 	#gafferColorInspector,
 	*[gafferClass="GafferSceneUI.TransformToolUI._SelectionWidget"],
 	*[gafferClass="GafferSceneUI.CropWindowToolUI._StatusWidget"],
+	*[gafferClass="GafferSceneUI.TransformToolUI._TargetTipWidget"] > QFrame,
 	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] > QFrame,
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] > QFrame,
 	*[gafferClass="GafferSceneUI._SceneViewInspector"] > QFrame

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -33,6 +33,7 @@
 				"pointerAdd",
 				"pointerRemove",
 				"pointerRotate",
+				"pointerPivot",
 			]
 		},
 
@@ -195,6 +196,7 @@
 				'gafferSceneUIScaleTool',
 				'gafferSceneUITranslateTool',
 				'gafferSceneUILightTool',
+				'gafferSceneUILightPositionTool',
 			]
 
 		},

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -159,7 +159,7 @@
     </linearGradient>
     <linearGradient
        id="foreground"
-       gradientTransform="matrix(2.4748712,0,0,2.4748712,306.23756,9040.4548)"
+       gradientTransform="matrix(3.299828,0,0,3.2998284,319.81673,11436.486)"
        inkscape:swatch="solid">
       <stop
          style="stop-color:#e0e0e0;stop-opacity:1;"
@@ -278,13 +278,13 @@
      inkscape:showpageshadow="2"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#4c4c4c"
-     showgrid="false"
-     inkscape:zoom="5.357041"
-     inkscape:cx="260.68496"
-     inkscape:cy="2570.2622"
-     inkscape:window-width="3747"
+     showgrid="true"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="705.16224"
+     inkscape:cy="1362.7715"
+     inkscape:window-width="3745"
      inkscape:window-height="2126"
-     inkscape:window-x="82"
+     inkscape:window-x="84"
      inkscape:window-y="-11"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1">
@@ -595,6 +595,43 @@
        position="22.112383,-1784"
        orientation="0,1"
        id="guide2303"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="253,-779.90051"
+       orientation="1,0"
+       id="guide5282"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="258.65492,-774"
+       orientation="0,-1"
+       id="guide5284"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="278,-782.21056"
+       orientation="1,0"
+       id="guide5286"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="271.13849,-799"
+       orientation="0,-1"
+       id="guide5288"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="265.5,-789.5"
+       orientation="-0.70710678,-0.70710678"
+       id="guide4982"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="265.5,-798"
+       orientation="-1,0"
+       id="guide4986"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="276.5,-778.5"
+       orientation="0,-1"
+       id="guide5064"
        inkscape:locked="false" />
   </sodipodi:namedview>
   <metadata
@@ -1599,7 +1636,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect8084-2" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
-         id="flowPara8088-1">SetEditor</flowPara></flowRoot>  </g>
+         id="flowPara8088-1">SetEditor</flowPara></flowRoot>
+  </g>
   <g
      id="layer4"
      inkscape:label="ExportAreas"
@@ -1745,13 +1783,21 @@
          id="pointerRemove"
          style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.93652129;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerRotate"
          width="32"
          height="32"
          x="670"
          y="1290"
          inkscape:label="pointerRotate" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerPivot"
+         width="32"
+         height="32"
+         x="710"
+         y="1290"
+         inkscape:label="pointerPivot" />
     </g>
     <g
        id="g2889"
@@ -2358,6 +2404,14 @@
          x="220"
          y="1774"
          inkscape:label="gafferSceneUILightTool" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="gafferSceneUILightPositionTool"
+         width="25"
+         height="25"
+         x="253"
+         y="1774"
+         inkscape:label="gafferSceneUILightPositionTool" />
     </g>
     <g
        id="g3414"
@@ -4962,6 +5016,31 @@
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="csc" />
         </g>
+      </g>
+      <g
+         id="g12364"
+         style="display:inline"
+         inkscape:label="lightPositionTool"
+         transform="translate(0,-1.7e-5)">
+        <path
+           style="display:inline;fill:#818181;fill-opacity:1;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 254,1848.8622 h 23 l -5,-12 h -13 z"
+           id="path14061"
+           sodipodi:nodetypes="ccccc"
+           inkscape:label="plane" />
+        <ellipse
+           style="display:inline;fill:url(#foreground);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.33333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path6796"
+           cy="1842.3622"
+           cx="265.5"
+           rx="3.3333333"
+           ry="3.3333335"
+           inkscape:label="highlight" />
+        <path
+           style="color:#000000;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+           d="m 270.5,1830.3613 v 1 h 4.79297 l -9.79297,9.793 -10.64648,-10.6465 -0.70704,0.707 11.35352,11.3536 10.5,-10.5 v 4.7929 h 1 v -6.5 z"
+           id="path4996"
+           inkscape:label="ray" />
       </g>
     </g>
     <g
@@ -9406,7 +9485,7 @@
     <path
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 224,2665.8622 c 0,0 -3.5,0 -3.5,0 0,0 0,3.5 0,3.5"
-       id="path2265"
+       id="path2976"
        inkscape:connector-curvature="0"
        inkscape:path-effect="#path-effect2267"
        inkscape:original-d="m 224,2665.8622 h -3.5 v 3.5"
@@ -9417,7 +9496,7 @@
        inkscape:original-d="m 224,2665.8622 h -3.5 v 3.5"
        inkscape:path-effect="#path-effect2297"
        inkscape:connector-curvature="0"
-       id="path2295"
+       id="path2978"
        d="m 224,2665.8622 c 0,0 -3.5,0 -3.5,0 0,0 0,3.5 0,3.5"
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        transform="rotate(-180,226,2671.3622)" />
@@ -9489,5 +9568,14 @@
            style="display:inline;opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
     </g>
+    <g
+       id="layer6"
+       inkscape:label="Pointers"
+       transform="translate(0,52.362183)" />
+    <path
+       style="color:#000000;fill:#000000;stroke:#ffffff;stroke-width:2;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       d="m 722.5,1343.8622 -10.75195,12.8593 1.5039,1.3184 9.24805,-11.1406 9.24805,11.1406 1.50391,-1.3184 z"
+       id="path10506"
+       sodipodi:nodetypes="ccccccc" />
   </g>
 </svg>

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -1,0 +1,975 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/LightPositionTool.h"
+#include "GafferSceneUI/SceneView.h"
+
+#include "GafferSceneUI/ContextAlgo.h"
+
+#include "GafferUI/Handle.h"
+#include "GafferUI/Pointer.h"
+#include "GafferUI/StandardStyle.h"
+
+#include "Gaffer/MetadataAlgo.h"
+
+#include "IECoreGL/Group.h"
+#include "IECoreGL/MeshPrimitive.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/TextureLoader.h"
+#include "IECoreGL/ToGLMeshConverter.h"
+
+#include "IECoreScene/MeshPrimitive.h"
+
+#include "IECore/AngleConversion.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
+#include "OpenEXR/ImathEuler.h"
+#include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathEuler.h"
+#include "Imath/ImathMatrixAlgo.h"
+#endif
+IECORE_POP_DEFAULT_VISIBILITY
+
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/bind/bind.hpp"
+
+#include "fmt/format.h"
+
+using namespace boost::placeholders;
+using namespace Imath;
+using namespace IECoreScene;
+using namespace IECoreGL;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferScene;
+using namespace GafferSceneUI;
+
+namespace
+{
+
+// Color from `StandardLightVisualiser`
+const Color3f g_lightToolColor = Color3f( 1.0f, 0.835f, 0.07f );
+const Color4f g_lightToolColor4 = Color4f( g_lightToolColor.x, g_lightToolColor.y, g_lightToolColor.z, 1.f );
+
+const Color4f g_lightToolDisabledColor4 = Color4f( 0.4f, 0.4f, 0.4f, 1.f );
+
+const float g_circleHandleWidth = 4.375f;
+const float g_circleHandleWidthLarge = 5.25f;
+const float g_circleHandleSelectionWidth = 8.875f;
+
+const float g_lineHandleWidth = 0.875f;
+const float g_lineHandleWidthLarge = 1.75f;
+const float g_lineSelectionWidth = 5.25f;
+
+const float g_arrowHandleSize = g_circleHandleWidth * 2.f;
+const float g_arrowHandleSizeLarge = g_circleHandleWidthLarge * 2.f;
+const float g_arrowHandleSelectionSize = g_circleHandleSelectionWidth * 2.f;
+
+const float g_unitConeHeight = 1.5f;
+
+const char *constantFragSource()
+{
+	return
+		"#version 120\n"
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
+		""
+		"in vec3 fragmentCs;"
+		""
+		"void main()"
+		"{"
+			"gl_FragColor = vec4( fragmentCs, 1 );"
+		"}"
+	;
+}
+
+const char *faceCameraVertexSource()
+{
+	return
+
+		"#version 120\n"
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in attribute\n"
+		"#define out varying\n"
+		"#endif\n"
+		""
+		"uniform vec3 Cs = vec3( 1, 1, 1 );"
+		"uniform bool vertexCsActive = false;"
+		""
+		"in vec3 vertexP;"
+		"in vec3 vertexN;"
+		"in vec2 vertexuv;"
+		"in vec3 vertexCs;"
+		""
+		"out vec3 geometryI;"
+		"out vec3 geometryP;"
+		"out vec3 geometryN;"
+		"out vec2 geometryuv;"
+		"out vec3 geometryCs;"
+		""
+		"out vec3 fragmentI;"
+		"out vec3 fragmentP;"
+		"out vec3 fragmentN;"
+		"out vec2 fragmentuv;"
+		"out vec3 fragmentCs;"
+		""
+		"void main()"
+		"{"
+		""
+		""
+		"	vec3 aimedXAxis, aimedYAxis, aimedZAxis;"
+
+		"	aimedXAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 0, -1, 0 ) ).xyz;"
+		"	aimedYAxis = normalize( gl_ModelViewMatrixInverse * vec4( 0, 1, 0, 0 ) ).xyz;"
+		"	aimedZAxis = normalize( gl_ModelViewMatrixInverse * vec4( 1, 0, 0, 0 ) ).xyz;"
+		""
+		"	vec3 pAimed = vertexP.x * aimedXAxis + vertexP.y * aimedYAxis + vertexP.z * aimedZAxis;"
+		""
+		"	vec4 pCam = gl_ModelViewMatrix * vec4( pAimed, 1 );"
+		"	gl_Position = gl_ProjectionMatrix * pCam;"
+		"	geometryP = pCam.xyz;"
+		"	geometryN = normalize( gl_NormalMatrix * vertexN );"
+		"	if( gl_ProjectionMatrix[2][3] != 0.0 )"
+		"	{"
+		"		geometryI = normalize( -pCam.xyz );"
+		"	}"
+		"	else"
+		"	{"
+		"		geometryI = vec3( 0, 0, -1 );"
+		"	}"
+		""
+		"	geometryuv = vertexuv;"
+		"	geometryCs = mix( Cs, vertexCs, float( vertexCsActive ) );"
+		""
+		"	fragmentI = geometryI;"
+		"	fragmentP = geometryP;"
+		"	fragmentN = geometryN;"
+		"	fragmentuv = geometryuv;"
+		"	fragmentCs = geometryCs;"
+		"}"
+
+	;
+}
+
+// Adapted from `Handle::rasterScaleFactor()` to get the raster scale factor for
+// an arbitrary point in gadget space.
+float rasterScaleFactor( const Handle *handle, const V3f &p )
+{
+	auto viewport = handle->ancestor<ViewportGadget>();
+	const M44f fullTransform = handle->fullTransform();
+
+	const M44f cameraToGadget = viewport->getCameraTransform() * fullTransform.inverse();
+	V3f cameraUpInGadgetSpace = V3f( 0, 1, 0 );
+	cameraToGadget.multDirMatrix( cameraUpInGadgetSpace, cameraUpInGadgetSpace );
+
+	const V2f p1 = viewport->gadgetToRasterSpace( p, handle );
+	const V2f p2 = viewport->gadgetToRasterSpace( p + cameraUpInGadgetSpace, handle );
+
+	return 1.f / ( p1 - p2 ).length();
+}
+
+// Returns a solid circle with normal along the +X-axis
+IECoreGL::MeshPrimitivePtr circle()
+{
+	static IECoreGL::MeshPrimitivePtr result;
+	if( result )
+	{
+		return result;
+	}
+
+	IntVectorDataPtr vertsPerPolyData = new IntVectorData;
+	IntVectorDataPtr vertIdsData = new IntVectorData;
+	V3fVectorDataPtr pData = new V3fVectorData;
+
+	std::vector<int> &vertsPerPoly = vertsPerPolyData->writable();
+	std::vector<int> &vertIds = vertIdsData->writable();
+	std::vector<V3f> &p = pData->writable();
+
+	p.push_back( V3f( 0 ) );
+
+	const int numSegments = 20;
+	for( int i = 0; i < numSegments + 1; ++i )
+	{
+		const float a = ( (float)i / (float)numSegments ) * 2.f * M_PI;
+		const V3f v = V3f( 0, cos( a ), -sin( a ) );
+		p.push_back( v );
+	}
+	for( int i = 0; i < numSegments; ++i )
+	{
+		vertIds.push_back( i + 1 );
+		vertIds.push_back( i + 2 );
+		vertIds.push_back( 0 );
+		vertsPerPoly.push_back( 3 );
+	}
+
+	IECoreScene::MeshPrimitivePtr circle = new IECoreScene::MeshPrimitive( vertsPerPolyData, vertIdsData, "linear", pData );
+	ToGLMeshConverterPtr converter = new ToGLMeshConverter( circle );
+	result = runTimeCast<IECoreGL::MeshPrimitive>( converter->convert() );
+
+	return result;
+}
+
+// Returns a (potentially truncated) cone facing the -Z axis.
+IECoreGL::MeshPrimitivePtr cone( float height, float startRadius, float endRadius )
+{
+	IECoreGL::MeshPrimitivePtr result;
+
+	IntVectorDataPtr vertsPerPolyData = new IntVectorData;
+	IntVectorDataPtr vertIdsData = new IntVectorData;
+	V3fVectorDataPtr pData = new V3fVectorData;
+
+	std::vector<int> &vertsPerPoly = vertsPerPolyData->writable();
+	std::vector<int> &vertIds = vertIdsData->writable();
+	std::vector<V3f> &p = pData->writable();
+
+	const int numSegments = 20;
+	for( int i = 0; i < numSegments + 1; ++i )
+	{
+		const float a = ( (float)i / (float)numSegments ) * 2.f * M_PI;
+
+		p.push_back( V3f( -sin( a ) * startRadius, cos( a ) * startRadius, 0 ) );
+		p.push_back( V3f( -sin( a ) * endRadius, cos( a ) * endRadius, -height ) );
+	}
+	for( int i = 0; i < numSegments; ++i )
+	{
+		vertIds.push_back( i * 2 );
+		vertIds.push_back( i * 2 + 1 );
+		vertIds.push_back( i * 2 + 3 );
+		vertIds.push_back( i * 2 + 2 );
+		vertsPerPoly.push_back( 4 );
+	}
+
+	IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPolyData, vertIdsData, "linear", pData );
+	IECoreGL::ToGLMeshConverterPtr converter = new ToGLMeshConverter( mesh );
+	result = runTimeCast<IECoreGL::MeshPrimitive>( converter->convert() );
+
+	return result;
+}
+
+// Returns a cone faceing the -Z axis.
+IECoreGL::MeshPrimitivePtr unitCone()
+{
+	static IECoreGL::MeshPrimitivePtr result = cone( g_unitConeHeight, 0.5f, 0 );
+	return result;
+}
+
+V3f shadowSourcePosition( const V3f &shadowPivot, const V3f &shadowTarget, const float pivotDistance )
+{
+	return (shadowPivot - shadowTarget ).normalized() * pivotDistance + shadowPivot;
+}
+
+// Must be called with the current context scoped.
+M44f shadowSourceOrientation( const TransformTool::Selection &s, const V3f &shadowPivot, const V3f &shadowTarget )
+{
+	ScenePlug::ScenePath parentPath( s.path() );
+	parentPath.pop_back();
+
+	const M44f worldParentTransform = s.scene()->fullTransform( parentPath );
+	const M44f worldParentTransformInverse = worldParentTransform.inverse();
+	const M44f localTransform = s.scene()->transform( s.path() );
+
+	V3f currentYAxis;
+	localTransform.multDirMatrix( V3f( 0.f, 1.f, 0.f ), currentYAxis );
+
+	// Point in the pivot-shadowTarget direction, in local space
+	V3f targetZAxis;
+	worldParentTransformInverse.multDirMatrix( ( shadowTarget - shadowPivot ), targetZAxis );
+
+	return rotationMatrixWithUpDir( V3f( 0.f, 0.f, -1.f ), targetZAxis, currentYAxis );
+
+}
+
+std::string selectedUpstreamPathToString( const std::vector<TransformTool::Selection> &s )
+{
+	if( !s.empty() )
+	{
+		return ScenePlug::pathToString( s.back().upstreamPath() );
+	}
+	return "";
+}
+
+class ShadowHandle : public Handle
+{
+
+	public :
+
+		ShadowHandle()
+		{
+
+		}
+
+		~ShadowHandle() override
+		{
+
+		}
+
+		// Set the position of the shadow pivot from the given world-space coordinate.
+		void setShadowPivot( const std::optional<V3f> &p )
+		{
+			m_shadowPivot = p;
+			dirty( DirtyType::Render );
+		}
+
+		const std::optional<V3f> &getShadowPivot() const
+		{
+			return m_shadowPivot;
+		}
+
+		// Set the position of the shadow target from the given world-space coordinate.
+		void setShadowTarget( const std::optional<V3f> &p )
+		{
+			m_shadowTarget = p;
+			dirty( DirtyType::Render );
+		}
+
+		const std::optional<V3f> &getShadowTarget() const
+		{
+			return m_shadowTarget;
+		}
+
+		void setPivotDistance( const std::optional<float> d )
+		{
+			m_pivotDistance = d;
+		}
+
+		const std::optional<float> &getPivotDistance() const
+		{
+			return m_pivotDistance;
+		}
+
+	protected :
+
+		void renderHandle( const Style *style, Style::State state ) const override
+		{
+			if( !m_shadowPivot && !m_shadowTarget )
+			{
+				return;
+			}
+
+			float lineRadius = 0;
+			float circleSize = 0;
+			float coneSize = 0;
+
+			const bool highlighted = state == Style::State::HighlightedState;
+			const bool selectionPass = (bool)IECoreGL::Selector::currentSelector();
+
+			if( selectionPass )
+			{
+				lineRadius = g_lineSelectionWidth;
+				circleSize = g_circleHandleSelectionWidth;
+				coneSize = g_arrowHandleSelectionSize;
+			}
+			else
+			{
+				lineRadius = highlighted ? g_lineHandleWidthLarge : g_lineHandleWidth;
+				circleSize = highlighted ? g_circleHandleWidthLarge : g_circleHandleWidth;
+				coneSize = highlighted ? g_arrowHandleSizeLarge : g_arrowHandleSize;
+			}
+
+			State::bindBaseState();
+			auto glState = const_cast<State *>( State::defaultState() );
+
+			IECoreGL::GroupPtr group = new IECoreGL::Group;
+
+			group->getState()->add(
+				new IECoreGL::ShaderStateComponent(
+					ShaderLoader::defaultShaderLoader(),
+					TextureLoader::defaultTextureLoader(),
+					"",
+					"",
+					constantFragSource(),
+					new CompoundObject
+				)
+			);
+
+			auto standardStyle = runTimeCast<const StandardStyle>( style );
+			const Color3f highlightColor3 = standardStyle ? standardStyle->getColor( StandardStyle::Color::HighlightColor ) : Color3f( 0.466, 0.612, 0.741 );
+			const Color4f highlightColor4 = Color4f( highlightColor3.x, highlightColor3.y, highlightColor3.z, 1.f );
+
+			group->getState()->add(
+				new IECoreGL::Color(
+					enabled() ? ( highlighted ? highlightColor4 : g_lightToolColor4 ) : g_lightToolDisabledColor4
+				)
+			);
+
+			const M44f fullTransformInverse = fullTransform().inverse();
+
+			if( m_shadowPivot )
+			{
+				IECoreGL::GroupPtr pivotGroup = new IECoreGL::Group;
+				pivotGroup->getState()->add(
+					new IECoreGL::ShaderStateComponent(
+						ShaderLoader::defaultShaderLoader(),
+						TextureLoader::defaultTextureLoader(),
+						faceCameraVertexSource(),
+						"",
+						constantFragSource(),
+						new CompoundObject
+					)
+				);
+				pivotGroup->addChild( circle() );
+
+				const V3f localPivot = m_shadowPivot.value() * fullTransformInverse;
+
+				pivotGroup->setTransform(
+					M44f().scale( V3f( circleSize ) * ::rasterScaleFactor( this, localPivot ) ) *
+					M44f().translate( localPivot )
+				);
+
+				group->addChild( pivotGroup );
+			}
+
+			V3f localTarget;
+			V3f coneHeightOffset;
+
+			if( m_shadowTarget )
+			{
+				IECoreGL::GroupPtr coneGroup = new IECoreGL::Group;
+				coneGroup->addChild( unitCone() );
+
+				localTarget = m_shadowTarget.value() * fullTransformInverse;
+				const V3f coneScale = V3f( coneSize ) * ::rasterScaleFactor( this, localTarget );
+				coneHeightOffset = V3f( 0, 0, g_unitConeHeight * coneScale.z );
+
+				coneGroup->setTransform(
+					M44f().scale( coneScale ) *
+					M44f().translate( localTarget + coneHeightOffset )
+				);
+
+				group->addChild( coneGroup );
+			}
+
+			if( m_shadowTarget && m_shadowPivot )
+			{
+				IECoreGL::GroupPtr lineGroup = new IECoreGL::Group;
+				lineGroup->addChild(
+					cone(
+						localTarget.length() - coneHeightOffset.z,
+						lineRadius * ::rasterScaleFactor( this, V3f( 0 ) ),
+						lineRadius * ::rasterScaleFactor( this, localTarget )
+					)
+				);
+
+				group->addChild( lineGroup );
+			}
+
+			group->render( glState );
+		}
+
+		void dragBegin( const DragDropEvent &event ) override
+		{
+		}
+
+	private :
+
+		std::optional<V3f> m_shadowPivot;
+		std::optional<V3f> m_shadowTarget;
+		std::optional<float> m_pivotDistance;
+
+};
+
+}  // namespace
+
+GAFFER_NODE_DEFINE_TYPE( LightPositionTool );
+
+LightPositionTool::ToolDescription<LightPositionTool, SceneView> LightPositionTool::g_toolDescription;
+size_t LightPositionTool::g_firstPlugIndex = 0;
+
+LightPositionTool::LightPositionTool( SceneView *view, const std::string &name ) :
+	TransformTool( view, name ),
+	m_targetMode( TargetMode::None )
+{
+	m_shadowHandle = new ShadowHandle();
+	m_shadowHandle->setRasterScale( 0 );
+	handles()->setChild( "shadowHandle", m_shadowHandle );
+
+	SceneGadget *sg = runTimeCast<SceneGadget>( this->view()->viewportGadget()->getPrimaryChild() );
+	sg->keyPressSignal().connect( boost::bind( &LightPositionTool::keyPress, this, ::_2 ) );
+	sg->keyReleaseSignal().connect( boost::bind( &LightPositionTool::keyRelease, this, ::_2 ) );
+	// We have to insert this before the underlying SelectionTool connections or it starts an object drag.
+	sg->buttonPressSignal().connectFront( boost::bind( &LightPositionTool::buttonPress, this, ::_2 ) );
+	sg->buttonReleaseSignal().connectFront( boost::bind( &LightPositionTool::buttonRelease, this, ::_2 ) );
+
+	// We need to track the tool state/view visibility so we don't leave a lingering target cursor
+	sg->visibilityChangedSignal().connect( boost::bind( &LightPositionTool::visibilityChanged, this, ::_1 ) );
+
+	this->view()->viewportGadget()->leaveSignal().connect( boost::bind( &LightPositionTool::viewportGadgetLeave, this, ::_2 ) );
+
+	plugSetSignal().connect( boost::bind( &LightPositionTool::plugSet, this, ::_1 ) );
+
+	storeIndexOfNextChild( g_firstPlugIndex );
+}
+
+LightPositionTool::~LightPositionTool()
+{
+}
+
+void LightPositionTool::position( const V3f &shadowPivot, const V3f &shadowTarget, const float pivotDistance )
+{
+	if( !m_shadowHandle->enabled() || selection().empty() )
+	{
+		return;
+	}
+	const Selection &s = selection().back();
+
+	const V3f newP = shadowSourcePosition( shadowPivot, shadowTarget, pivotDistance );
+
+	// See `RotateTool::buttonPress()` for a description of why we use this relatively
+	// elaborate orientation calculation.
+
+	Context::Scope scopedContext( s.context() );
+
+	const M44f localTransform = s.scene()->transform( s.path() );
+
+	const M44f orientationMatrix = shadowSourceOrientation( s, shadowPivot, shadowTarget );
+
+	V3f originalRotation;
+	extractEulerXYZ( localTransform, originalRotation );
+	const M44f originalRotationMatrix = M44f().rotate( originalRotation );
+
+	const M44f relativeMatrix = originalRotationMatrix.inverse() * orientationMatrix;
+
+	V3f relativeRotation;
+	extractEulerXYZ( relativeMatrix, relativeRotation );
+
+	const V3f p = V3f( 0 ) * s.orientedTransform( Orientation::World );
+	const V3f offset = newP - p;
+
+	TranslationRotation( s ).apply( offset, relativeRotation );
+}
+
+bool LightPositionTool::affectsHandles( const Gaffer::Plug *input ) const
+{
+	if( TransformTool::affectsHandles( input ) )
+	{
+		return true;
+	}
+
+	return input == scenePlug()->transformPlug();
+}
+
+void LightPositionTool::updateHandles( float rasterScale )
+{
+	Selection s = selection().back();
+
+	handles()->setTransform( s.orientedTransform( Orientation::Local ) );
+
+	m_shadowHandle->setEnabled( selection().size() == 1 && TranslationRotation( s ).canApply() );
+
+	m_shadowHandle->setRasterScale( 0 );
+
+	auto shadowHandle = static_cast<ShadowHandle *>( m_shadowHandle.get() );
+
+	std::optional<V3f> shadowPivot = getShadowPivot();
+	std::optional<V3f> shadowTarget = getShadowTarget();
+
+	shadowHandle->setShadowPivot( shadowPivot );
+	shadowHandle->setShadowTarget( shadowTarget );
+
+	if( !shadowPivot || !shadowTarget )
+	{
+		return;
+	}
+
+	// The user can control the distance along the line from shadow target
+	// to pivot, and the rotation around the Z-axis. Any variance from those
+	// contraints invalidates the stored shadow parameters.
+
+	Context::Scope scopedContext( s.context() );
+
+	const M44f worldTransform = s.scene()->fullTransform( s.path() );
+	const V3f p = worldTransform.translation();
+	const Line3f handleLine( shadowTarget.value(), shadowPivot.value() );
+
+	V3f direction;
+	worldTransform.multDirMatrix( V3f( 0, 0, -1.f ), direction );
+
+	if(
+		!direction.equalWithAbsError( ( shadowTarget.value() - shadowPivot.value() ).normalized(), 1e-4 ) ||
+		handleLine.distanceTo( p ) > shadowHandle->getPivotDistance().value() * 1e-4
+	)
+	{
+		shadowHandle->setShadowPivot( std::nullopt );
+		shadowHandle->setShadowTarget( std::nullopt );
+		shadowHandle->setPivotDistance( std::nullopt );
+
+		const std::string p = ScenePlug::pathToString( s.path() );
+		m_shadowTargetMap.erase( p );
+		m_shadowPivotMap.erase( p );
+		m_shadowPivotDistanceMap.erase( p );
+	}
+
+	shadowHandle->setPivotDistance( ( p - shadowPivot.value() ).length() );
+}
+
+bool LightPositionTool::keyPress( const KeyEvent &event )
+{
+	if( activePlug()->getValue() )
+	{
+		if(
+			( event.key == "V" && event.modifiers == KeyEvent::Modifiers::Shift ) ||
+			( event.key == "Shift" && getTargetMode() == TargetMode::ShadowTarget )
+		)
+		{
+			setTargetMode( TargetMode::ShadowPivot );
+			return true;
+		}
+		if( event.key == "V" && event.modifiers == KeyEvent::Modifiers::None )
+		{
+			setTargetMode( TargetMode::ShadowTarget );
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool LightPositionTool::keyRelease( const KeyEvent &event )
+{
+	if( activePlug()->getValue() )
+	{
+		if( event.key == "V" )
+		{
+			setTargetMode( TargetMode::None );
+			return true;
+		}
+		if( event.key == "Shift" && getTargetMode() == TargetMode::ShadowPivot )
+		{
+			setTargetMode( TargetMode::ShadowTarget );
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void LightPositionTool::viewportGadgetLeave( const ButtonEvent &event )
+{
+	if( getTargetMode() != TargetMode::None )
+	{
+		// We loose keyRelease events in a variety of scenarios so turn targeted
+		// off whenever the mouse leaves the viewport. Key-repeat events will
+		// cause it to be re-enabled when the mouse re-enters if the key is still
+		// held down at that time.
+		setTargetMode( TargetMode::None );
+	}
+}
+
+void LightPositionTool::visibilityChanged( GafferUI::Gadget *gadget )
+{
+	if( !gadget->visible() && getTargetMode() != TargetMode::None )
+	{
+		setTargetMode( TargetMode::None );
+	}
+}
+
+void LightPositionTool::plugSet( Plug *plug )
+{
+	if( plug == activePlug() && !activePlug()->getValue() && getTargetMode() != TargetMode::None )
+	{
+		setTargetMode( TargetMode::None );
+	}
+}
+
+bool LightPositionTool::buttonPress( const ButtonEvent &event )
+{
+	if( event.button != ButtonEvent::Left || !activePlug()->getValue() || getTargetMode() == TargetMode::None )
+	{
+		return false;
+	}
+
+	// We always return true to prevent the SelectTool defaults.
+
+	if( !selectionEditable() || !m_shadowHandle->enabled() )
+	{
+		return true;
+	}
+
+	ScenePlug::ScenePath scenePath;
+	V3f targetPos;
+
+	const SceneGadget *sceneGadget = runTimeCast<SceneGadget>( view()->viewportGadget()->getPrimaryChild() );
+	if( !sceneGadget->objectAt( event.line, scenePath, targetPos ) )
+	{
+		return true;
+	}
+
+	const auto shadowHandle = static_cast<ShadowHandle *>( m_shadowHandle.get() );
+	Selection s = selection().back();
+	ScriptNodePtr scriptNode = s.editTarget()->ancestor<ScriptNode>();
+
+	UndoScope undoScope( scriptNode );
+
+	if( getTargetMode() == TargetMode::ShadowPivot )
+	{
+		const V3f newPivot = targetPos * sceneGadget->fullTransform();
+		if( !shadowHandle->getShadowPivot() )
+		{
+			setShadowPivotDistance(
+				( newPivot - ( V3f( 0 ) * s.orientedTransform( Orientation::World ) ) ).length()
+			);
+		}
+		setShadowPivot( newPivot, scriptNode );
+	}
+	else if( getTargetMode() == TargetMode::ShadowTarget )
+	{
+		setShadowTarget( targetPos * sceneGadget->fullTransform(), scriptNode );
+	}
+
+	if( !shadowHandle->getShadowPivot() || !shadowHandle->getShadowTarget() )
+	{
+		return true;
+	}
+
+	position( shadowHandle->getShadowPivot().value(), shadowHandle->getShadowTarget().value(), shadowHandle->getPivotDistance().value() );
+
+	return true;
+}
+
+void LightPositionTool::setTargetMode( TargetMode targeted )
+{
+	if( targeted == m_targetMode )
+	{
+		return;
+	}
+
+	m_targetMode = targeted;
+
+	switch( m_targetMode )
+	{
+		case TargetMode::None : GafferUI::Pointer::setCurrent( "" ); break;
+		case TargetMode::ShadowPivot : GafferUI::Pointer::setCurrent( "pivot" ); break;
+		case TargetMode::ShadowTarget : GafferUI::Pointer::setCurrent( "target" ); break;
+	}
+}
+
+void LightPositionTool::setShadowPivot( const V3f &p, ScriptNodePtr scriptNode )
+{
+	std::optional<V3f> currentValue = getShadowPivot();
+	auto shadowHandle = static_cast<ShadowHandle *>( m_shadowHandle.get() );
+	const auto pathString = selectedUpstreamPathToString( selection() );
+	Action::enact(
+		scriptNode,
+		[t = LightPositionToolPtr( this ), k = pathString, p, shadowHandle]() {
+			t->m_shadowPivotMap[k] = p;
+			shadowHandle->setShadowPivot( p );
+		},
+		[t = LightPositionToolPtr( this ), k = pathString, currentValue, shadowHandle]() {
+			t->m_shadowPivotMap[k] = currentValue;
+			const std::string upstreamPath = selectedUpstreamPathToString( t->selection() );
+			if( !upstreamPath.empty() && upstreamPath == k )
+			{
+				shadowHandle->setShadowPivot( currentValue );
+			}
+		}
+	);
+}
+
+std::optional<V3f> LightPositionTool::getShadowPivot() const
+{
+	auto it = m_shadowPivotMap.find( selectedUpstreamPathToString( selection() ) );
+	if( it == m_shadowPivotMap.end() )
+	{
+		return std::nullopt;
+	}
+	return it->second;
+}
+
+void LightPositionTool::setShadowTarget( const V3f &p, ScriptNodePtr scriptNode )
+{
+	std::optional<V3f> currentValue = getShadowTarget();
+	auto shadowHandle = static_cast<ShadowHandle *>( m_shadowHandle.get() );
+	const auto pathString = selectedUpstreamPathToString( selection() );
+	Action::enact(
+		scriptNode,
+		[t = LightPositionToolPtr( this ), k = pathString, p, shadowHandle]() {
+			t->m_shadowTargetMap[k] = p;
+			shadowHandle->setShadowTarget( p );
+		},
+		[t = LightPositionToolPtr( this ), k = pathString, currentValue, shadowHandle]() {
+			t->m_shadowTargetMap[k] = currentValue;
+			const std::string upstreamPath = selectedUpstreamPathToString( t->selection() );
+			if( !upstreamPath.empty() && upstreamPath == k )
+			{
+				shadowHandle->setShadowTarget( currentValue );
+			}
+		}
+	);
+}
+
+std::optional<V3f> LightPositionTool::getShadowTarget() const
+{
+	auto it = m_shadowTargetMap.find( selectedUpstreamPathToString( selection() ) );
+	if( it == m_shadowTargetMap.end() )
+	{
+		return std::nullopt;
+	}
+	return it->second;
+}
+
+void LightPositionTool::setShadowPivotDistance( const float d )
+{
+	m_shadowPivotDistanceMap[selectedUpstreamPathToString( selection() )] = d;
+	static_cast<ShadowHandle *>( m_shadowHandle.get() )->setPivotDistance( d );
+}
+
+std::optional<float> LightPositionTool::getShadowPivotDistance() const
+{
+	auto it = m_shadowPivotDistanceMap.find( selectedUpstreamPathToString( selection() ) );
+	if( it == m_shadowPivotDistanceMap.end() )
+	{
+		return std::nullopt;
+	}
+	return it->second;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// LightPositionTool::TranslationRotation
+//////////////////////////////////////////////////////////////////////////
+
+/// \todo These methods are either exactly the same as those in
+/// `TranslateTool` and `RotateTool` or very close. Do they belong
+/// in a `TransformToolAlgo` or something similar?
+
+LightPositionTool::TranslationRotation::TranslationRotation( const Selection &selection )
+	: m_selection( selection )
+{
+	const M44f handleRotationXform = selection.orientedTransform( Orientation::World );
+	m_gadgetToRotationXform = handleRotationXform * selection.sceneToTransformSpace();
+
+	const M44f handleTranslateXform = selection.orientedTransform( Orientation::Parent );
+	m_gadgetToTranslationXform = handleTranslateXform * selection.sceneToTransformSpace();
+}
+
+bool LightPositionTool::TranslationRotation::canApply() const
+{
+	auto edit = m_selection.acquireTransformEdit( /* createIfNecessary = */ false );
+	if( !edit )
+	{
+		// Edit will be created on demand in `apply()`.
+		return !MetadataAlgo::readOnly( m_selection.editTarget() );
+	}
+
+	for( int i = 0; i < 3; ++i )
+	{
+		if(
+			!canSetValueOrAddKey( edit->translate->getChild( i ) ) ||
+			!canSetValueOrAddKey( edit->rotate->getChild( i ) )
+		)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void LightPositionTool::TranslationRotation::apply( const V3f &translation, const Eulerf &rotation )
+{
+	V3fPlug *translatePlug = m_selection.acquireTransformEdit()->translate.get();
+	if( !m_originalTranslation )
+	{
+		Context::Scope scopedContext( m_selection.context() );
+		m_originalTranslation = translatePlug->getValue();
+	}
+
+	V3f offsetInTransformSpace;
+	m_gadgetToTranslationXform.multDirMatrix( translation, offsetInTransformSpace );
+
+	V3fPlug *rotatePlug = m_selection.acquireTransformEdit()->rotate.get();
+
+	const Imath::V3f e = updatedRotateValue( rotatePlug, rotation );
+	for( int i = 0; i < 3; ++i )
+	{
+		FloatPlug *pTranslate = translatePlug->getChild( i );
+		if( canSetValueOrAddKey( pTranslate ) )
+		{
+			setValueOrAddKey( pTranslate, m_selection.context()->getTime(), (*m_originalTranslation)[i] + offsetInTransformSpace[i] );
+		}
+
+		FloatPlug *pRotate = rotatePlug->getChild( i );
+		if( canSetValueOrAddKey( pRotate ) )
+		{
+			setValueOrAddKey( pRotate, m_selection.context()->getTime(), e[i] );
+		}
+	}
+}
+
+V3f LightPositionTool::TranslationRotation::updatedRotateValue( const V3fPlug *rotatePlug, const Eulerf &rotation, V3f *currentValue ) const
+{
+	// Duplicated verbatim from `RotateTool::Rotation::updatedRotateValue()`
+
+	if( !m_originalRotation )
+	{
+		Context::Scope scopedContext( m_selection.context() );
+		m_originalRotation = degreesToRadians( rotatePlug->getValue() );
+	}
+
+	// Convert the rotation into the space of the
+	// upstream transform.
+	Quatf q = rotation.toQuat();
+	V3f transformSpaceAxis;
+	m_gadgetToRotationXform.multDirMatrix( q.axis(), transformSpaceAxis );
+	float d = Imath::sign( m_gadgetToRotationXform.determinant() );
+	q.setAxisAngle( transformSpaceAxis, q.angle() * d );
+
+	// Compose it with the original.
+
+	M44f m = q.toMatrix44();
+	m.rotate( *m_originalRotation );
+
+	// Convert to the euler angles closest to
+	// those we currently have.
+
+	const V3f current = rotatePlug->getValue();
+	if( currentValue )
+	{
+		*currentValue = current;
+	}
+
+	Eulerf e; e.extract( m );
+	e.makeNear( degreesToRadians( current ) );
+
+	return radiansToDegrees( V3f( e ) );
+}

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -38,11 +38,12 @@
 
 #include "GafferSceneUI/CameraTool.h"
 #include "GafferSceneUI/CropWindowTool.h"
+#include "GafferSceneUI/LightPositionTool.h"
+#include "GafferSceneUI/LightTool.h"
 #include "GafferSceneUI/RotateTool.h"
 #include "GafferSceneUI/ScaleTool.h"
 #include "GafferSceneUI/SceneView.h"
 #include "GafferSceneUI/SelectionTool.h"
-#include "GafferSceneUI/LightTool.h"
 #include "GafferSceneUI/TransformTool.h"
 #include "GafferSceneUI/TranslateTool.h"
 
@@ -267,5 +268,10 @@ void GafferSceneUIModule::bindTools()
 
 		GafferBindings::SignalClass<LightTool::SelectionChangedSignal, GafferBindings::DefaultSignalCaller<LightTool::SelectionChangedSignal>, SelectionChangedSlotCaller<LightTool>>( "SelectionChangedSignal" );
 	}
+
+	GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )
+		.def( init<SceneView *>() )
+		.def( "position", &LightPositionTool::position )
+	;
 
 }

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -271,7 +271,7 @@ void GafferSceneUIModule::bindTools()
 
 	GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )
 		.def( init<SceneView *>() )
-		.def( "position", &LightPositionTool::position )
+		.def( "positionShadow", &LightPositionTool::positionShadow )
 	;
 
 }

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -70,6 +70,7 @@ static Registry &registry()
 		r["add"] = new Pointer( "pointerAdd.png", Imath::V2i( 18, 11 ) );
 		r["remove"] = new Pointer( "pointerRemove.png", Imath::V2i( 18, 11 ) );
 		r["rotate"] = new Pointer( "pointerRotate.png", Imath::V2i( 10 ) );
+		r["pivot"] = new Pointer( "pointerPivot.png", Imath::V2i( 13, 0 ) );
 	}
 	return r;
 }


### PR DESCRIPTION
This adds a new tool to the scene viewer for placing shadows. Two points are set using `Control` + Click to set the pivot point and `Shift` + Click to set the shadow point. The selected light (or any selection, like a group) is repositioned so it lies along the line from the shadow point to the pivot, the same distance back from the pivot as its original distance from the pivot. It's also reoriented to face the shadow point.

This currently uses the last selected object as the source of the original position. I'll add a follow up commit to use the centroid of the full selection.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
