### PR TITLE
Replace `IECore.Enum` with standard types from `enum` module

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Breaking Changes
 - StringPlug : Removed deprecated `precomputedHash` argument from `getValue()` method.
 - OpenColorIOContext : Removed `configEnabledPlug()`, `configValuePlug()`, `workingSpaceEnabledPlug()` and `workingSpaceValuePlug()` methods. Use the OptionalValuePlug child accessors instead.
 - Windows launch script : Removed the hardcoded `/debugexe` switch used when `GAFFER_DEBUG` is enabled, making it possible to use debuggers other than Visual Studio. Debug switches can be added to the `GAFFER_DEBUGGER` environment variable instead.
+- Enums : Replaced `IECore.Enum` types with standard Python types from the `enum` module.
 
 1.3.x.x (relative to 1.3.7.0)
 =======

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import contextlib
+import enum
 import sys
 import threading
 import traceback
@@ -67,7 +68,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 	#
 	# NoneByDefault : deprecated - the same as DisplayResult
 	# CloseByDefault : deprecated - the same as DisplayResult
-	PostExecuteBehaviour = IECore.Enum.create( "FromUserData", "None_", "Close", "DisplayResult", "DisplayResultAndClose", "NoneByDefault", "CloseByDefault" )
+	PostExecuteBehaviour = enum.Enum( "PostExecuteBehaviour", [ "FromUserData", "None_", "Close", "DisplayResult", "DisplayResultAndClose", "NoneByDefault", "CloseByDefault" ] )
 
 	## Defines which button has the focus when the op is displayed for editing.
 	#
@@ -80,7 +81,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 	# OK : The OK button has the focus.
 	#
 	# Cancel : The cancel button has the focus.
-	DefaultButton = IECore.Enum.create( "FromUserData", "None_", "OK", "Cancel" )
+	DefaultButton = enum.Enum( "DefaultButton", [ "FromUserData", "None_", "OK", "Cancel" ] )
 
 	# If executeInBackground is True, then the Op will be executed on another
 	# thread, allowing the UI to remain responsive during execution. This is
@@ -255,7 +256,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 		# the op is running in the background.
 		return self.__state != self.__State.Execution
 
-	__State = IECore.Enum.create( "ParameterEditing", "Execution", "ErrorDisplay", "ResultDisplay" )
+	__State = enum.Enum( "__State", [ "ParameterEditing", "Execution", "ErrorDisplay", "ResultDisplay" ] )
 
 	def __initiateParameterEditing( self, *unused ) :
 

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import enum
 import os
 import errno
 import signal
@@ -62,7 +63,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 	class Job( object ) :
 
-		Status = IECore.Enum.create( "Waiting", "Running", "Complete", "Failed", "Killed" )
+		Status = enum.IntEnum( "Status", [ "Waiting", "Running", "Complete", "Failed", "Killed" ] )
 
 		def __init__( self, batch, dispatcher ) :
 

--- a/python/GafferDispatch/Wedge.py
+++ b/python/GafferDispatch/Wedge.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import math
+import enum
 import imath
 
 import IECore
@@ -44,7 +44,7 @@ import GafferDispatch
 
 class Wedge( GafferDispatch.TaskContextProcessor ) :
 
-	Mode = IECore.Enum.create( "FloatRange", "IntRange", "ColorRange", "FloatList", "IntList", "StringList" )
+	Mode = enum.IntEnum( "Mode", [ "FloatRange", "IntRange", "ColorRange", "FloatList", "IntList", "StringList" ], start = 0 )
 
 	def __init__( self, name = "Wedge" ) :
 

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import enum
 import functools
 import sys
 import threading
@@ -54,7 +55,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 	# Close : The dialogue is closed immediately.
 	#
 	# Confirm : The dialogue remains open confirming success, with a button for returning to the editing state.
-	PostDispatchBehaviour = IECore.Enum.create( "Close", "Confirm" )
+	PostDispatchBehaviour = enum.Enum( "PostDispatchBehaviour", [ "Close", "Confirm" ] )
 
 	__dispatchDialogueMenuDefinition = None
 

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import inspect
 import unittest
 import time
@@ -218,7 +219,7 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 
 		class SphereOrCube( GafferScene.SceneNode ) :
 
-			Type = IECore.Enum.create( "Sphere", "Cube" )
+			Type = enum.IntEnum( "Type", [ "Sphere", "Cube" ], start = 0 )
 
 			def __init__( self, name = "SphereOrCube" ) :
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import contextlib
+import enum
 import functools
 import imath
 import re
@@ -294,7 +295,7 @@ GafferUI.Pointer.registerPointer( "addNames", GafferUI.Pointer( "addObjects.png"
 GafferUI.Pointer.registerPointer( "removeNames", GafferUI.Pointer( "removeObjects.png", imath.V2i( 36, 18 ) ) )
 GafferUI.Pointer.registerPointer( "replaceNames", GafferUI.Pointer( "replaceObjects.png", imath.V2i( 36, 18 ) ) )
 
-__DropMode = IECore.Enum.create( "None_", "Add", "Remove", "Replace" )
+__DropMode = enum.Enum( "__DropMode", [ "None_", "Add", "Remove", "Replace" ] )
 
 __originalDragPointer = None
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import types
+import enum
 import imath
 import functools
 from collections import deque
@@ -236,7 +236,7 @@ GafferUI.Pointer.registerPointer( "addObjects", GafferUI.Pointer( "addObjects.pn
 GafferUI.Pointer.registerPointer( "removeObjects", GafferUI.Pointer( "removeObjects.png", imath.V2i( 53, 14 ) ) )
 GafferUI.Pointer.registerPointer( "replaceObjects", GafferUI.Pointer( "replaceObjects.png", imath.V2i( 53, 14 ) ) )
 
-__DropMode = IECore.Enum.create( "None_", "Add", "Remove", "Replace" )
+__DropMode = enum.Enum( "__DropMode", [ "None_", "Add", "Remove", "Replace" ] )
 
 __originalDragPointer = None
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import math
 import difflib
 import html
@@ -332,7 +333,7 @@ class Diff( GafferUI.Widget ) :
 # with background colours appropriate to the relationship between the two.
 class SideBySideDiff( Diff ) :
 
-	Background = IECore.Enum.create( "A", "B", "AB", "Other" )
+	Background = enum.Enum( "Background", [ "A", "B", "AB", "Other" ] )
 
 	def __init__( self, **kw ) :
 
@@ -412,8 +413,8 @@ class SideBySideDiff( Diff ) :
 				continue
 
 			repolish = False
-			if str(backgrounds[i]) != frame._qtWidget().property( "gafferDiff" ) :
-				frame._qtWidget().setProperty( "gafferDiff", str(backgrounds[i]) )
+			if backgrounds[i].name != frame._qtWidget().property( "gafferDiff" ) :
+				frame._qtWidget().setProperty( "gafferDiff", backgrounds[i].name )
 				repolish = True
 
 			if i == 0 :
@@ -1238,7 +1239,7 @@ from Qt import QtWidgets
 
 class _Rail( GafferUI.ListContainer ) :
 
-	Type = IECore.Enum.create( "Top", "Middle", "Gap", "Bottom", "Single" )
+	Type = enum.Enum( "Type", [ "Top", "Middle", "Gap", "Bottom", "Single" ] )
 
 	def __init__( self, type, **kw ) :
 

--- a/python/GafferUI/BoolWidget.py
+++ b/python/GafferUI/BoolWidget.py
@@ -34,9 +34,7 @@
 #
 ##########################################################################
 
-import types
-
-import IECore
+import enum
 
 import Gaffer
 import GafferUI
@@ -47,10 +45,10 @@ from Qt import QtWidgets
 
 class BoolWidget( GafferUI.Widget ) :
 
-	DisplayMode = IECore.Enum.create( "CheckBox", "Switch", "Tool" )
+	DisplayMode = enum.Enum( "DisplayMode", [ "CheckBox", "Switch", "Tool" ] )
 	# True/False states are deliberately omitted from this enum;
 	# For backwards compatibility we use `bool` values instead.
-	State = IECore.Enum.create( "Indeterminate" )
+	State = enum.Enum( "State", [ "Indeterminate" ] )
 
 	def __init__( self, text="", checked=False, displayMode=DisplayMode.CheckBox, image = None, **kw ) :
 
@@ -118,7 +116,7 @@ class BoolWidget( GafferUI.Widget ) :
 
 	def setDisplayMode( self, displayMode ) :
 
-		self._qtWidget().setProperty( "gafferDisplayMode", str( displayMode ) )
+		self._qtWidget().setProperty( "gafferDisplayMode", displayMode.name )
 		self._qtWidget().setHitMode(
 			_CheckBox.HitMode.Button if displayMode == self.DisplayMode.Tool else _CheckBox.HitMode.CheckBox
 		)
@@ -159,7 +157,7 @@ class BoolWidget( GafferUI.Widget ) :
 
 class _CheckBox( QtWidgets.QCheckBox ) :
 
-	HitMode = IECore.Enum.create( "Button", "CheckBox" )
+	HitMode = enum.Enum( "HitMode", [ "Button", "CheckBox" ] )
 
 	def __init__( self, text, parent = None ) :
 

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -36,6 +36,7 @@
 
 import os
 import re
+import enum
 import functools
 import token
 import keyword
@@ -285,10 +286,13 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 
 class Highlighter( object ) :
 
-	Type = IECore.Enum.create(
-		"SingleQuotedString", "DoubleQuotedString", "Number",
-		"Keyword", "ControlFlow", "Braces", "Operator", "Call",
-		"Comment", "ReservedWord", "Preprocessor"
+	Type = enum.Enum(
+		"Type",
+		[
+			"SingleQuotedString", "DoubleQuotedString", "Number",
+			"Keyword", "ControlFlow", "Braces", "Operator", "Call",
+			"Comment", "ReservedWord", "Preprocessor"
+		]
 	)
 
 	# Specifies a highlight type to be used for the characters

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -35,10 +35,9 @@
 #
 ##########################################################################
 
+import enum
 import sys
 import imath
-
-import IECore
 
 import Gaffer
 import GafferUI
@@ -110,7 +109,7 @@ class _ComponentSlider( GafferUI.Slider ) :
 
 class ColorChooser( GafferUI.Widget ) :
 
-	ColorChangedReason = IECore.Enum.create( "Invalid", "SetColor", "Reset" )
+	ColorChangedReason = enum.Enum( "ColorChangedReason", [ "Invalid", "SetColor", "Reset" ] )
 
 	def __init__( self, color=imath.Color3f( 1 ), **kw ) :
 

--- a/python/GafferUI/Divider.py
+++ b/python/GafferUI/Divider.py
@@ -34,7 +34,7 @@
 #
 ##########################################################################
 
-import IECore
+import enum
 
 import GafferUI
 
@@ -42,7 +42,7 @@ from Qt import QtWidgets
 
 class Divider( GafferUI.Widget ) :
 
-	Orientation = IECore.Enum.create( "Vertical", "Horizontal" )
+	Orientation = enum.Enum( "Divider", [ "Vertical", "Horizontal" ] )
 
 	def __init__( self, orientation = Orientation.Horizontal, **kw ) :
 

--- a/python/GafferUI/Enums.py
+++ b/python/GafferUI/Enums.py
@@ -34,7 +34,8 @@
 #
 ##########################################################################
 
-import IECore
+import enum
+
 import GafferUI
 
 from Qt import QtCore
@@ -44,7 +45,7 @@ __all__ = [ "HorizontalAlignment", "VerticalAlignment", "Edge", "ScrollMode" ]
 
 # HorizontalAlignment
 
-HorizontalAlignment = IECore.Enum.create( "None_", "Left", "Right", "Center", "Justify" )
+HorizontalAlignment = enum.Enum( "HorizontalAlignment", [ "None_", "Left", "Right", "Center", "Justify" ] )
 
 @staticmethod
 def __horizontalFromQt( a ) :
@@ -80,7 +81,7 @@ HorizontalAlignment._toQt = __horizontalToQt
 
 # VerticalAlignment
 
-VerticalAlignment = IECore.Enum.create( "None_", "Top", "Bottom", "Center" )
+VerticalAlignment = enum.Enum( "VerticalAlignment", [ "None_", "Top", "Bottom", "Center" ] )
 
 @staticmethod
 def __verticalFromQt( a ) :
@@ -112,11 +113,11 @@ VerticalAlignment._toQt = __verticalToQt
 
 # Edge
 
-Edge = IECore.Enum.create( "Top", "Bottom", "Left", "Right" )
+Edge = enum.Enum( "Edge", [ "Top", "Bottom", "Left", "Right" ] )
 
 # Scroll Mode
 
-ScrollMode = IECore.Enum.create( "Never", "Always", "Automatic" )
+ScrollMode = enum.Enum( "ScrollMode", [ "Never", "Always", "Automatic" ] )
 
 __modesToPolicies = {
 	ScrollMode.Never : QtCore.Qt.ScrollBarAlwaysOff,

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import time
 import weakref
 import threading
@@ -53,7 +54,7 @@ from Qt import QtWidgets
 ## This class provides the event loops used to run GafferUI based applications.
 class EventLoop( object ) :
 
-	__RunStyle = IECore.Enum.create( "Normal", "PumpThread", "AlreadyRunning", "Houdini" )
+	__RunStyle = enum.Enum( "__RunStyle", [ "Normal", "PumpThread", "AlreadyRunning", "Houdini" ] )
 
 	## Creates a new EventLoop. Note that if you are creating the primary
 	# EventLoop for an application then you should use mainEventLoop() instead.

--- a/python/GafferUI/Frame.py
+++ b/python/GafferUI/Frame.py
@@ -35,7 +35,7 @@
 #
 ##########################################################################
 
-import IECore
+import enum
 
 import GafferUI
 
@@ -44,7 +44,7 @@ from Qt import QtWidgets
 class Frame( GafferUI.ContainerWidget ) :
 
 	## \todo Raised and Inset?
-	BorderStyle = IECore.Enum.create( "None_", "Flat" )
+	BorderStyle = enum.Enum( "BorderStyle", [ "None_", "Flat" ] )
 
 	def __init__( self, child=None, borderWidth=8, borderStyle=BorderStyle.Flat, **kw ) :
 
@@ -61,7 +61,7 @@ class Frame( GafferUI.ContainerWidget ) :
 
 	def setBorderStyle( self, borderStyle ) :
 
-		self._qtWidget().setProperty( "gafferBorderStyle", str( borderStyle ) )
+		self._qtWidget().setProperty( "gafferBorderStyle", borderStyle.name )
 
 	def getBorderStyle( self ) :
 

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import sys
 import logging
 import collections
@@ -74,11 +75,7 @@ class GLWidget( GafferUI.Widget ) :
 
 	## This enum defines the optional elements of the GL buffer used
 	# for display.
-	BufferOptions = IECore.Enum.create(
-		"Alpha",
-		"Depth",
-		"AntiAlias",
-	)
+	BufferOptions = enum.Enum( "BufferOptions", [ "Alpha", "Depth", "AntiAlias" ] )
 
 	## Note that you won't always get the buffer options you ask for - a best fit is found
 	# among the available formats. In particular it appears that a depth buffer is often present

--- a/python/GafferUI/ListContainer.py
+++ b/python/GafferUI/ListContainer.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import enum
+
 import imath
 
 import IECore
@@ -47,7 +49,7 @@ from Qt import QtCore
 # It attempts to provide a list like interface for manipulation of the widgets.
 class ListContainer( GafferUI.ContainerWidget ) :
 
-	Orientation = IECore.Enum.create( "Vertical", "Horizontal" )
+	Orientation = enum.Enum( "Orientation", [ "Vertical", "Horizontal" ] )
 	HorizontalAlignment = GafferUI.Enums.HorizontalAlignment
 	VerticalAlignment = GafferUI.Enums.VerticalAlignment
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -37,6 +37,7 @@
 
 import contextlib
 import inspect
+import enum
 import functools
 import weakref
 import types
@@ -707,7 +708,7 @@ class _SpacerAction( QtWidgets.QWidgetAction ) :
 
 class _Menu( QtWidgets.QMenu ) :
 
-	KeyboardMode = IECore.Enum.create( "Grab", "Close", "Forward" )
+	KeyboardMode = enum.Enum( "KeyboardMode", [ "Grab", "Close", "Forward" ] )
 
 	def __init__( self, parent, title=None ) :
 

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import bisect
+import enum
 import functools
 import imath
 import weakref
@@ -58,7 +59,7 @@ class MessageWidget( GafferUI.Widget ) :
 
 	# Messages : For presenting longer messages in detail. They are shown as line-wrapped paragraphs.
 	# Log : For presenting a large number of messages in tabular form with un-wrapped lines.
-	Role = IECore.Enum.create( "Messages", "Log" )
+	Role = enum.Enum( "Role", [ "Messages", "Log" ] )
 
 	# messageLevel : The minimum importance of message that will be displayed.
 	# role : The style of message presentation.
@@ -1353,7 +1354,7 @@ class _MessageTableFilterModel( QtCore.QSortFilterProxyModel ) :
 class _MessageTableModel( QtCore.QAbstractTableModel ) :
 
 	ColumnCount = 3
-	Column = IECore.Enum.create( "Level", "Context", "Message" )
+	Column = enum.IntEnum( "Column", [ "Level", "Context", "Message" ], start = 0 )
 
 	# A role to allow access the underlying Message data, without any display coercion.
 	ValueRole = 100

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import contextlib
+import enum
 
 import imath
 
@@ -50,8 +51,8 @@ from Qt import QtCore
 
 class MultiLineTextWidget( GafferUI.Widget ) :
 
-	WrapMode = IECore.Enum.create( "None_", "Word", "Character", "WordOrCharacter" )
-	Role = IECore.Enum.create( "Text", "Code" )
+	WrapMode = enum.Enum( "WrapNode", [ "None_", "Word", "Character", "WordOrCharacter" ] )
+	Role = enum.Enum( "Role", [ "Text", "Code" ] )
 
 	def __init__( self, text="", editable=True, wrapMode=WrapMode.WordOrCharacter, fixedLineHeight=None, role=Role.Text, **kw ) :
 
@@ -240,7 +241,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 		if role == self.getRole() :
 			return
 
-		self._qtWidget().setProperty( "gafferRole", GafferUI._Variant.toVariant( str( role ) ) )
+		self._qtWidget().setProperty( "gafferRole", GafferUI._Variant.toVariant( role.name ) )
 		self._repolish()
 
 	def getRole( self ) :

--- a/python/GafferUI/NodeToolbar.py
+++ b/python/GafferUI/NodeToolbar.py
@@ -73,7 +73,7 @@ class NodeToolbar( GafferUI.Widget ) :
 	def create( cls, node, edge = GafferUI.Edge.Top ) :
 
 		# Try to create a toolbar using metadata.
-		toolbarType = Gaffer.Metadata.value( node, "nodeToolbar:%s:type" % str( edge ).lower() )
+		toolbarType = Gaffer.Metadata.value( node, "nodeToolbar:{}:type".format( edge.name.lower() ) )
 		if toolbarType is not None :
 			if toolbarType == "" :
 				return None

--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import math
 import re
 import operator
@@ -49,7 +50,7 @@ from Qt import QtGui
 ## \todo Fix bug when pressing up arrow with cursor to left of minus sign
 class NumericWidget( GafferUI.TextWidget ) :
 
-	ValueChangedReason = IECore.Enum.create( "Invalid", "SetValue", "DragBegin", "DragMove", "DragEnd", "Increment", "Edit", "InvalidEdit" )
+	ValueChangedReason = enum.Enum( "ValueChangedReason", [ "Invalid", "SetValue", "DragBegin", "DragMove", "DragEnd", "Increment", "Edit", "InvalidEdit" ] )
 
 	def __init__( self, value, **kw ) :
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -36,6 +36,7 @@
 ##########################################################################
 
 import collections
+import enum
 import math
 import warnings
 
@@ -88,8 +89,8 @@ class PathListingWidget( GafferUI.Widget ) :
 		defaultIndexedIOArrayLengthColumn,
 	)
 
-	DisplayMode = IECore.Enum.create( "List", "Tree" )
-	SelectionMode = IECore.Enum.create( "Row", "Rows", "Cell", "Cells" )
+	DisplayMode = enum.Enum( "DisplayMode", [ "List", "Tree" ] )
+	SelectionMode = enum.Enum( "SelectionMode", [ "Row", "Rows", "Cell", "Cells" ] )
 
 	def __init__(
 		self,

--- a/python/GafferUI/Playback.py
+++ b/python/GafferUI/Playback.py
@@ -34,9 +34,8 @@
 #
 ##########################################################################
 
+import enum
 import math
-
-import IECore
 
 import Gaffer
 import GafferUI
@@ -50,7 +49,7 @@ from Qt import QtCore
 # a Playback object to ensure synchronisation between elements.
 class Playback( object ) :
 
-	State = IECore.Enum.create( "PlayingForwards", "PlayingBackwards", "Scrubbing", "Stopped" )
+	State = enum.Enum( "State", [ "PlayingForwards", "PlayingBackwards", "Scrubbing", "Stopped" ] )
 
 	## Use acquire rather than this method.
 	def __init__( self, __context ) :

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import math
 
 import IECore
@@ -48,7 +49,7 @@ from Qt import QtWidgets
 
 class Slider( GafferUI.Widget ) :
 
-	ValueChangedReason = IECore.Enum.create( "Invalid", "SetValues", "Click", "IndexAdded", "IndexRemoved", "DragBegin", "DragMove", "DragEnd", "Increment" )
+	ValueChangedReason = enum.Enum( "ValueChangedReason", [ "Invalid", "SetValues", "Click", "IndexAdded", "IndexRemoved", "DragBegin", "DragMove", "DragEnd", "Increment" ] )
 
 	# The min and max arguments define the numeric values at the ends of the slider.
 	# By default, values outside this range will be clamped, but hardMin and hardMax

--- a/python/GafferUI/SplineWidget.py
+++ b/python/GafferUI/SplineWidget.py
@@ -35,6 +35,8 @@
 #
 ##########################################################################
 
+import enum
+
 import imath
 
 import IECore
@@ -49,7 +51,7 @@ from Qt import QtWidgets
 ## This Widget simply displays an IECore.Spline object.
 class SplineWidget( GafferUI.Widget ) :
 
-	DrawMode = IECore.Enum.create( "Invalid", "Ramp", "Splines" )
+	DrawMode = enum.Enum( "DrawMode", [ "Invalid", "Ramp", "Splines" ] )
 
 	def __init__( self, spline=None, drawMode=DrawMode.Splines, **kw ) :
 

--- a/python/GafferUI/SplitContainer.py
+++ b/python/GafferUI/SplitContainer.py
@@ -35,7 +35,7 @@
 #
 ##########################################################################
 
-import IECore
+import enum
 
 import GafferUI
 
@@ -45,7 +45,7 @@ from Qt import QtWidgets
 ## \todo Support other list operations for child access
 class SplitContainer( GafferUI.ContainerWidget ) :
 
-	Orientation = IECore.Enum.create( "Vertical", "Horizontal" )
+	Orientation = enum.Enum( "Orientation", [ "Vertical", "Horizontal" ] )
 
 	def __init__( self, orientation=Orientation.Vertical, borderWidth=0, **kw ) :
 

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import contextlib
+import enum
 import functools
 
 import imath
@@ -63,7 +64,7 @@ from .._TableView import _TableView
 
 class _PlugTableView( GafferUI.Widget ) :
 
-	Mode = IECore.Enum.create( "RowNames", "Defaults", "Cells" )
+	Mode = enum.Enum( "Mode", [ "RowNames", "Defaults", "Cells" ] )
 
 	def __init__( self, selectionModel, mode, **kw ) :
 		tableView = _NavigableTable()
@@ -512,7 +513,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 				self.__applyColumnVisibility()
 
-	__DropMode = IECore.Enum.create( "Set", "Add", "Remove" )
+	__DropMode = enum.Enum( "__DropMode", [ "Set", "Add", "Remove" ] )
 	def __dropMode( self, destinationPlug, event ) :
 
 		if (

--- a/python/GafferUI/StandardNodeToolbar.py
+++ b/python/GafferUI/StandardNodeToolbar.py
@@ -44,7 +44,7 @@ class StandardNodeToolbar( GafferUI.NodeToolbar ) :
 			node,
 			orientation = GafferUI.ListContainer.Orientation.Horizontal if edge in ( GafferUI.Edge.Top, GafferUI.Edge.Bottom ) else GafferUI.ListContainer.Orientation.Vertical,
 			layoutName = "toolbarLayout",
-			rootSection = str( edge )
+			rootSection = edge.name
 		)
 
 		GafferUI.NodeToolbar.__init__( self, node, self.__layout, **kw )

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import enum
 import functools
 
 import IECore
@@ -48,7 +49,7 @@ from Qt import QtWidgets
 
 class TabbedContainer( GafferUI.ContainerWidget ) :
 
-	__DragState = IECore.Enum.create( "None_", "Waiting", "Active" )
+	__DragState = enum.Enum( "__DragState", [ "None_", "Waiting", "Active" ] )
 	__palette = None
 
 	def __init__( self, cornerWidget=None, **kw ) :

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -35,9 +35,8 @@
 #
 ##########################################################################
 
+import enum
 import warnings
-
-import IECore
 
 import Gaffer
 import GafferUI
@@ -48,7 +47,7 @@ from Qt import QtWidgets
 
 class TextWidget( GafferUI.Widget ) :
 
-	DisplayMode = IECore.Enum.create( "Normal", "Password" )
+	DisplayMode = enum.Enum( "DisplayMode", [ "Normal", "Password" ] )
 
 	def __init__( self, text="", editable=True, displayMode=DisplayMode.Normal, characterWidth=None, **kw ) :
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -35,11 +35,10 @@
 #
 ##########################################################################
 
+import enum
 import sys
 import warnings
 import imath
-
-import IECore
 
 import GafferUI
 import Gaffer
@@ -51,7 +50,7 @@ import Qt
 
 class Window( GafferUI.ContainerWidget ) :
 
-	SizeMode = IECore.Enum.create( "Fixed", "Manual", "Automatic" )
+	SizeMode = enum.Enum( "SizeMode", [ "Fixed", "Manual", "Automatic" ] )
 
 	## \todo Remove the deprecated resizable argument
 	def __init__( self, title="GafferUI.Window", borderWidth=0, resizeable=None, child=None, sizeMode=SizeMode.Manual, icon="GafferLogoMini.png", **kw ) :

--- a/python/GafferUITest/MultiLineTextWidgetTest.py
+++ b/python/GafferUITest/MultiLineTextWidgetTest.py
@@ -82,7 +82,7 @@ class MultiLineTextWidgetTest( GafferUITest.TestCase ) :
 		w = GafferUI.MultiLineTextWidget()
 		self.assertEqual( w.getWrapMode(), w.WrapMode.WordOrCharacter )
 
-		for wm in w.WrapMode.values() :
+		for wm in w.WrapMode :
 			w.setWrapMode( wm )
 			self.assertEqual( w.getWrapMode(), wm )
 


### PR DESCRIPTION
Now we're Python 3 only we can use the standard `enum` module, which provides a more comprehensive framework than `IECore.Enum`. For the most part its a drop-in replacement, but there are a few gotchas to be aware of, which I have hopefully dealt with everywhere necessary :

- `str( e )` returns only `<name>` for `IECore.Enum` but returns `<className>.<name>` for `enum.Enum`.
- `int( e )` is provided by default for `IECore.Enum`, but not by `enum.Enum`, so we must use `enum.IntEnum` when that is needed.
- `IECore.Enum` values start at 0, but `enum.Enum` values start at 1 by default. Where this is important (see Wedge), we must specify `start = 0`.
