### PR TITLE
SceneAlgo : Add `optionHistory()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,9 @@ API
 ---
 
 - SceneGadget : Added `snapshotToFile()` method.
+- SceneAlgo :
+  - Added `history()` overload for returning computation history independent of a scene location, this is useful when generating history from the globals.
+  - Added `optionHistory()` method which returns a computation history for one specific option.
 
 Build
 -----

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -200,6 +200,7 @@ struct History : public IECore::RefCounted
 };
 
 GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild, const ScenePlug::ScenePath &path );
+GAFFERSCENE_API History::Ptr history( const Gaffer::ValuePlug *scenePlugChild );
 
 /// Extends History to provide information on the history of a specific attribute.
 /// Attributes may be renamed by ShuffleAttributes nodes and this is reflected
@@ -220,6 +221,24 @@ struct AttributeHistory : public History
 /// `history( scene->attributesPlug(), path )`. If the attribute doesn't exist then
 /// null is returned.
 GAFFERSCENE_API AttributeHistory::Ptr attributeHistory( const History *attributesHistory, const IECore::InternedString &attribute );
+
+/// Extends History to provide information on the history of a specific option.
+struct OptionHistory : public History
+{
+	IE_CORE_DECLAREMEMBERPTR( OptionHistory )
+	OptionHistory(
+		const ScenePlugPtr &scene, const Gaffer::ContextPtr &context,
+		const IECore::InternedString &optionName, const IECore::ConstObjectPtr &optionValue
+	) :	History( scene, context ), optionName( optionName ), optionValue( optionValue ) {}
+	IECore::InternedString optionName;
+	IECore::ConstObjectPtr optionValue;
+};
+
+/// Filters `globalsHistory` and returns a history for the specific `option`.
+/// `globalsHistory` should have been obtained from a previous call to
+/// `history( scene->globalsPlug() )`. If the option doesn't exist then
+/// null is returned.
+GAFFERSCENE_API OptionHistory::Ptr optionHistory( const History *globalsHistory, const IECore::InternedString &option );
 
 /// Returns the upstream scene originally responsible for generating the specified location.
 GAFFERSCENE_API ScenePlug *source( const ScenePlug *scene, const ScenePlug::ScenePath &path );

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -203,6 +203,12 @@ SceneAlgo::History::Ptr historyWrapper( const ValuePlug &scenePlugChild, const S
 	return SceneAlgo::history( &scenePlugChild, path );
 }
 
+SceneAlgo::History::Ptr historyWrapper2( const ValuePlug &scenePlugChild )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::history( &scenePlugChild );
+}
+
 std::string attributeHistoryGetAttributeName( const SceneAlgo::AttributeHistory &h )
 {
 	return h.attributeName.string();
@@ -229,6 +235,34 @@ SceneAlgo::AttributeHistory::Ptr attributeHistoryWrapper( const SceneAlgo::Histo
 {
 	IECorePython::ScopedGILRelease r;
 	return SceneAlgo::attributeHistory( &attributesHistory, attributeName );
+}
+
+std::string optionHistoryGetOptionName( const SceneAlgo::OptionHistory &h )
+{
+	return h.optionName.string();
+}
+
+void optionHistorySetOptionName( SceneAlgo::OptionHistory &h, IECore::InternedString n )
+{
+	h.optionName = n;
+}
+
+ObjectPtr optionHistoryGetOptionValue( const SceneAlgo::OptionHistory &h )
+{
+	// Returning a copy because `optionValue` is const, and owned by Gaffer's cache.
+	// Allowing modification in Python would be catastrophic and hard to debug.
+	return h.optionValue ? h.optionValue->copy() : nullptr;
+}
+
+void optionHistorySetOptionValue( SceneAlgo::OptionHistory &h, ConstObjectPtr v )
+{
+	h.optionValue = v;
+}
+
+SceneAlgo::OptionHistory::Ptr optionHistoryWrapper( const SceneAlgo::History &globalsHistory, const InternedString &optionName )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::optionHistory( &globalsHistory, optionName );
 }
 
 ScenePlugPtr sourceWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &path )
@@ -373,6 +407,7 @@ void bindSceneAlgo()
 	}
 
 	def( "history", &historyWrapper );
+	def( "history", &historyWrapper2 );
 
 	IECorePython::RefCountedClass<SceneAlgo::AttributeHistory, SceneAlgo::History>( "AttributeHistory" )
 		.add_property( "attributeName", &attributeHistoryGetAttributeName, &attributeHistorySetAttributeName )
@@ -380,6 +415,13 @@ void bindSceneAlgo()
 	;
 
 	def( "attributeHistory", &attributeHistoryWrapper );
+
+	IECorePython::RefCountedClass<SceneAlgo::OptionHistory, SceneAlgo::History>( "OptionHistory" )
+		.add_property( "optionName", &optionHistoryGetOptionName, &optionHistorySetOptionName )
+		.add_property( "optionValue", &optionHistoryGetOptionValue, &optionHistorySetOptionValue )
+	;
+
+	def( "optionHistory", &optionHistoryWrapper );
 
 	def( "source", &sourceWrapper );
 	def( "objectTweaks", &objectTweaksWrapper );


### PR DESCRIPTION
Another foundational piece of the RenderPasses journey. 

I'm not entirely sold on the overloaded `history()` without a ScenePath and the potential exposure to using the wrong one, maybe `globalsHistory()` is a better name? Or brighter minds have better ideas?