### PR TITLE
Arnold : Fix UsdPreviewSurface translation bugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,7 +24,9 @@ Fixes
 - InteractiveRender : Fixed unnecessary updates to encapsulated locations when deforming an unrelated object.
 - InteractiveArnoldRender : Fixed creation of new Catalogue image when editing output metadata or pixel filter.
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
-- Arnold : Fixed translation of `UsdPreviewSurface` normal maps.
+- Arnold :
+  - Fixed translation of `UsdPreviewSurface` normal maps.
+  - Fixed translation of `UsdPreviewSurface` `specularColor` fallback value.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Fixes
 - InteractiveRender : Fixed unnecessary updates to encapsulated locations when deforming an unrelated object.
 - InteractiveArnoldRender : Fixed creation of new Catalogue image when editing output metadata or pixel filter.
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
+- Arnold : Fixed translation of `UsdPreviewSurface` normal maps.
 
 API
 ---

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -487,56 +487,63 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 	def testConvertUSDSpecular( self ) :
 
 		for useSpecularWorkflow in ( True, False ) :
+			for specularColor in ( imath.Color3f( 0, 0.25, 0.5 ), None ) :
+				with self.subTest( useSpecularWorkflow = useSpecularWorkflow, specularColor = specularColor ) :
 
-			network = IECoreScene.ShaderNetwork(
-				shaders = {
-					"previewSurface" : IECoreScene.Shader(
-						"UsdPreviewSurface", "surface",
-						{
-							"specularColor" : imath.V3f( 0, 0.25, 0.5 ),
-							"metallic" : 0.5,
-							"useSpecularWorkflow" : int( useSpecularWorkflow ),
-						}
+					parameters = {
+						"metallic" : 0.5,
+						"useSpecularWorkflow" : int( useSpecularWorkflow ),
+					}
+					if specularColor is not None :
+						parameters["specularColor"] = specularColor
+
+					network = IECoreScene.ShaderNetwork(
+						shaders = {
+							"previewSurface" : IECoreScene.Shader(
+								"UsdPreviewSurface", "surface", parameters
+							)
+						},
+						output = "previewSurface",
 					)
-				},
-				output = "previewSurface",
-			)
 
-			convertedNetwork = network.copy()
-			IECoreArnold.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
-			convertedShader = convertedNetwork.getShader( "previewSurface" )
+					convertedNetwork = network.copy()
+					IECoreArnold.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+					convertedShader = convertedNetwork.getShader( "previewSurface" )
 
-			if useSpecularWorkflow :
-				self.assertEqual( convertedShader.parameters["specular_color"].value, imath.V3f( 0, 0.25, 0.5 ) )
-				self.assertNotIn( "metalness", convertedShader.parameters )
-			else :
-				self.assertEqual( convertedShader.parameters["metalness"].value, 0.5 )
-				self.assertNotIn( "specularColor", convertedShader.parameters )
+					if useSpecularWorkflow :
+						self.assertEqual(
+							convertedShader.parameters["specular_color"].value,
+							specularColor if specularColor is not None else imath.Color3f( 1 )
+						)
+						self.assertNotIn( "metalness", convertedShader.parameters )
+					else :
+						self.assertEqual( convertedShader.parameters["metalness"].value, 0.5 )
+						self.assertNotIn( "specularColor", convertedShader.parameters )
 
-			# Repeat with input connections
+					# Repeat with input connections
 
-			network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
-			network.addConnection( ( ( "texture", "rgb" ), ( "previewSurface", "specularColor" ) ) )
-			network.addConnection( ( ( "texture", "r" ), ( "previewSurface", "metallic" ) ) )
+					network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
+					network.addConnection( ( ( "texture", "rgb" ), ( "previewSurface", "specularColor" ) ) )
+					network.addConnection( ( ( "texture", "r" ), ( "previewSurface", "metallic" ) ) )
 
-			convertedNetwork = network.copy()
-			IECoreArnold.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+					convertedNetwork = network.copy()
+					IECoreArnold.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
 
-			if useSpecularWorkflow :
-				self.assertEqual(
-					convertedNetwork.input( ( "previewSurface", "specular_color" ) ),
-					( "texture", "" ),
-				)
-				self.assertFalse( convertedNetwork.input( ( "previewSurface", "metalness" ) ) )
-			else :
-				self.assertEqual(
-					convertedNetwork.input( ( "previewSurface", "metalness" ) ),
-					( "texture", "r" ),
-				)
-				self.assertFalse( convertedNetwork.input( ( "previewSurface", "specular_color" ) ) )
+					if useSpecularWorkflow :
+						self.assertEqual(
+							convertedNetwork.input( ( "previewSurface", "specular_color" ) ),
+							( "texture", "" ),
+						)
+						self.assertFalse( convertedNetwork.input( ( "previewSurface", "metalness" ) ) )
+					else :
+						self.assertEqual(
+							convertedNetwork.input( ( "previewSurface", "metalness" ) ),
+							( "texture", "r" ),
+						)
+						self.assertFalse( convertedNetwork.input( ( "previewSurface", "specular_color" ) ) )
 
-			self.assertFalse( convertedNetwork.input( ( "previewSurface", "specularColor" ) ) )
-			self.assertFalse( convertedNetwork.input( ( "previewSurface", "metallic" ) ) )
+					self.assertFalse( convertedNetwork.input( ( "previewSurface", "specularColor" ) ) )
+					self.assertFalse( convertedNetwork.input( ( "previewSurface", "metallic" ) ) )
 
 	def testConvertUSDClearcoat( self ) :
 

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -347,6 +347,35 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			)
 			self.assertEqual( convertedShader.parameters["emission"], IECore.FloatData( 1 ) )
 
+	def testConvertUSDPreviewSurfaceNormalMap( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"previewSurface" : IECoreScene.Shader(
+					"UsdPreviewSurface", "surface"
+				),
+				"normalMap" : IECoreScene.Shader(
+					"UsdUVTexture", "shader"
+				),
+			},
+			connections = [
+				( ( "normalMap", "rgb" ), ( "previewSurface", "normal" ) )
+			],
+			output = "previewSurface",
+		)
+
+		convertedNetwork = network.copy()
+		IECoreArnold.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+		normalConnection = convertedNetwork.input( ( "previewSurface", "normal" ) )
+		normalShader = convertedNetwork.getShader( normalConnection.shader )
+		self.assertEqual( normalShader.name, "normal_map" )
+		self.assertFalse( normalShader.parameters["color_to_signed"].value )
+
+		inputConnection = convertedNetwork.input( ( normalConnection.shader, "input" ) )
+		inputShader = convertedNetwork.getShader( inputConnection.shader )
+		self.assertEqual( inputShader.name, "image" )
+
 	def testConvertUSDFloat3ToColor3f( self ) :
 
 		# Although UsdPreviewSurface parameters are defined to be `color3f` in the spec,

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -939,10 +939,12 @@ void IECoreArnold::ShaderNetworkAlgo::convertUSDShaders( ShaderNetwork *shaderNe
 
 			if( parameterValue<int>( shader.get(), g_useSpecularWorkflowParameter, 0 ) )
 			{
-				// > Note : Not completely equivalent to USD's specification. USD's colour
-				// is for the facing angle, and the edge colour is always white. In Arnold,
-				// this is a tint applied uniformly.
-				transferUSDParameter( shaderNetwork, handle, shader.get(), g_specularColorParameter, newShader.get(), g_specularColorArnoldParameter, Color3f( 0.0f ) );
+				// > Note : Not completely equivalent to USD's specification.
+				// USD's colour is for the facing angle, and the edge colour is
+				// always white. But Arnold's is a tint applied uniformly
+				// everywhere, so we use a fallback value of `1.0` rather than
+				// the `0.0` from the USD spec.
+				transferUSDParameter( shaderNetwork, handle, shader.get(), g_specularColorParameter, newShader.get(), g_specularColorArnoldParameter, Color3f( 1.0f ) );
 			}
 			else
 			{

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -644,6 +644,7 @@ const InternedString g_colorParameter( "color" );
 const InternedString g_colorModeParameter( "color_mode" );
 const InternedString g_colorSpaceParameter( "color_space" );
 const InternedString g_colorTemperatureParameter( "colorTemperature" );
+const InternedString g_colorToSignedParameter( "color_to_signed" );
 const InternedString g_coneAngleParameter( "cone_angle" );
 const InternedString g_cosinePowerParameter( "cosine_power" );
 const InternedString g_defaultParameter( "default" );
@@ -677,6 +678,7 @@ const InternedString g_metalnessParameter( "metalness" );
 const InternedString g_missingTextureColorParameter( "missing_texture_color" );
 const InternedString g_multiplyParameter( "multiply" );
 const InternedString g_normalizeParameter( "normalize" );
+const InternedString g_normalParameter( "normal" );
 const InternedString g_offsetParameter( "offset" );
 const InternedString g_opacityParameter( "opacity" );
 const InternedString g_opacityThresholdParameter( "opacityThreshold" );
@@ -981,6 +983,18 @@ void IECoreArnold::ShaderNetworkAlgo::convertUSDShaders( ShaderNetwork *shaderNe
 			}
 
 			newShader->parameters()[g_opacityParameter] = new Color3fData( Color3f( opacity ) );
+
+			// Normal
+
+			if( const ShaderNetwork::Parameter normalInput = shaderNetwork->input( { handle, g_normalParameter } ) )
+			{
+				ShaderPtr normalShader = new Shader( "normal_map" );
+				normalShader->parameters()[g_colorToSignedParameter] = new BoolData( false );
+				const InternedString normalHandle = shaderNetwork->addShader( handle.string() + "Normal", std::move( normalShader ) );
+				shaderNetwork->addConnection( ShaderNetwork::Connection( normalInput, { normalHandle, g_inputParameter } ) );
+				shaderNetwork->removeConnection( ShaderNetwork::Connection( normalInput, { handle, g_normalParameter } ) );
+				shaderNetwork->addConnection( ShaderNetwork::Connection( normalHandle, { handle, g_normalParameter } ) );
+			}
 		}
 		else if( shader->getName() == "UsdTransform2d" )
 		{


### PR DESCRIPTION
This fixes the translation of normal maps and `specularColor` fallback values. For testing, I found the following assets helpful :

- https://github.com/usd-wg/assets/tree/main/test_assets/NormalsTextureBiasAndScale (very very simple normal map example)
- https://github.com/usd-wg/assets/tree/main/full_assets/McUsd (normal map on grass)
