### PR TITLE
GraphEditor : Create SceneReader, ImageReader or Reference nodes from file drag & drop

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Fixes
 
 - InteractiveRender : Fixed unnecessary updates to encapsulated locations when deforming an unrelated object.
 - InteractiveArnoldRender : Fixed creation of new Catalogue image when editing output metadata or pixel filter.
+- GraphEditor : Fixed error caused by additional connections to `dragEnterSignal()`.
 - Windows `Scene/OpenGL/Shader` Menu : Removed `\` at the beginning of menu items.
 - Arnold :
   - Fixed translation of `UsdPreviewSurface` normal maps.

--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - SceneAlgo :
   - Added `history()` overload for returning computation history independent of a scene location, this is useful when generating history from the globals.
   - Added `optionHistory()` method which returns a computation history for one specific option.
+- Widget : Added handling for drag & drop from an external application via the existing `dragEnterSignal()`, `dragMoveSignal()`, `dragLeaveSignal()` and `dropSignal()` signals.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Features
 Improvements
 ------------
 
+- GraphEditor : Added drag & drop of files into the graph editor, automatically creating a SceneReader, ImageReader or Reference node as appropriate.
 - ImageTransform, Resample : Improved performance for non-separable filters without scaling, with 2-6x speedups in some benchmark cases.
 - Outputs : Included `renderPass` in the filename for newly created Arnold, Cycles and 3Delight outputs. Allowing rendered images to be written to a specific directory based on the name of the current render pass.
 - GUI Config : Included `renderPass` in the default filename when writing ass files from an ArnoldRender node.

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -47,6 +47,7 @@
 #include "boost/regex.hpp"
 
 #include <functional>
+#include <unordered_map>
 
 namespace Gaffer
 {

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -70,6 +70,7 @@ class GraphEditor( GafferUI.Editor ) :
 		self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
 		self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ), scoped = False )
 		self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ), scoped = False )
+		self.__dragEnterPointer = None
 		self.__gadgetWidget.getViewportGadget().preRenderSignal().connect( Gaffer.WeakMethod( self.__preRender ), scoped = False )
 
 		with GafferUI.ListContainer( borderWidth = 8, spacing = 0 ) as overlay :
@@ -511,8 +512,12 @@ class GraphEditor( GafferUI.Editor ) :
 
 	def __dragLeave( self, widget, event ) :
 
-		GafferUI.Pointer.setCurrent( self.__dragEnterPointer )
-		return True
+		if self.__dragEnterPointer is not None :
+			GafferUI.Pointer.setCurrent( self.__dragEnterPointer )
+			self.__dragEnterPointer = None
+			return True
+
+		return False
 
 	def __drop( self, widget, event ) :
 
@@ -523,6 +528,7 @@ class GraphEditor( GafferUI.Editor ) :
 		if dropNodes :
 			self.graphGadget().setRoot( dropNodes[0].parent() )
 			self.__frame( dropNodes, at = imath.V2f( event.line.p0.x, event.line.p0.y ) )
+			self.__dragEnterPointer = None
 			return True
 
 		return False

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -370,6 +370,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 	def __drop( self, widget, event ) :
 
 		self.insertText( self.__dropText( event.data ) )
+		return True
 
 class _PlainTextEdit( QtWidgets.QPlainTextEdit ) :
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -884,8 +884,10 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		if isinstance( event.sourceWidget, GafferUI.PlugValueWidget ) :
 			sourcePlugValueWidget = event.sourceWidget
-		else :
+		elif event.sourceWidget is not None :
 			sourcePlugValueWidget = event.sourceWidget.ancestor( GafferUI.PlugValueWidget )
+		else :
+			sourcePlugValueWidget = None
 
 		if sourcePlugValueWidget is not None and sourcePlugValueWidget.getPlugs() & self.getPlugs() :
 			return False


### PR DESCRIPTION
This allows you to drag and drop files from the OS file browser to the GraphEditor, automatically creating an appropriate node for reading each particular file. I've only tested it on Mac OS so far.