### PR TITLE
SceneHistoryUI : Fix errors handling `Alt+E` on unexpected editors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - Arnold :
   - Fixed translation of `UsdPreviewSurface` normal maps.
   - Fixed translation of `UsdPreviewSurface` `specularColor` fallback value.
+- Scene History : Fixed error caused by `Alt+E` keypress on panels other than the Viewer, HierarchyView, LightEditor or NodeEditor.
 
 API
 ---

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -67,7 +67,7 @@ def connectToEditor( editor ) :
 		editor.keyPressSignal().connect( __viewerKeyPress, scoped = False )
 	elif isinstance( editor, GafferSceneUI.HierarchyView ) or isinstance( editor, GafferSceneUI.LightEditor ) :
 		editor.keyPressSignal().connect( __hierarchyViewKeyPress, scoped = False )
-	elif isinstance( editor, GafferUI.Editor ) :
+	elif isinstance( editor, GafferUI.NodeEditor ) :
 		editor.keyPressSignal().connect( __nodeEditorKeyPress, scoped = False )
 
 ##########################################################################


### PR DESCRIPTION
It's pretty clear from 6d8060cdb4667123387c462126ad4962ade9ce9d that this keypress handling was only intended to apply to NodeEditors, but it was instead being applied to all Editors, which would lead to errors like this in the GraphEditor :

```
ERROR : EventSignalCombiner : Traceback (most recent call last):
  File "/home/john/dev/build/gaffer-1.3/python/GafferSceneUI/SceneHistoryUI.py", line 237, in __nodeEditorKeyPress
    __editSourceNode( context, scene, selectedPath, nodeEditor )
  File "/home/john/dev/build/gaffer-1.3/python/GafferSceneUI/SceneHistoryUI.py", line 128, in __editSourceNode
    nodeEditor.setNodeSet( Gaffer.StandardSet( [ node ] ) )
AttributeError: 'GraphEditor' object has no attribute 'setNodeSet'
```
