### PR TITLE
GafferTractorTest : Test using mock API if Tractor unavailable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
             publish: true
             containerImage:
             testRunner: Invoke-Expression
-            testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
+            testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 400
 
     runs-on: ${{ matrix.os }}

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,12 @@ Improvements
 - TaskList, FrameMask : Reimplemented in C++ for improved performance.
 - Cache : Increased default computation cache size to 8Gb. Call `Gaffer.ValuePlug.setCacheMemoryLimit()` from a startup file to override this.
 
+API
+---
+
+- GafferTractor : Added `tractorAPI()` method used for accessing the `tractor.api.author` module.
+- GafferTractorTest : Added `tractorAPI()` method which returns a mock API if Tractor is not available. This allows the GafferTractor module to be tested without Tractor being installed.
+
 Breaking Changes
 ----------------
 

--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -36,18 +36,19 @@
 
 import os
 
-import tractor.api.author as author
-
 import IECore
 
 import Gaffer
 import GafferDispatch
+import GafferTractor
 
 class TractorDispatcher( GafferDispatch.Dispatcher ) :
 
 	def __init__( self, name = "TractorDispatcher" ) :
 
 		GafferDispatch.Dispatcher.__init__( self, name )
+
+		self.__tractorAPI = GafferTractor.tractorAPI()
 
 		self["service"] = Gaffer.StringPlug( defaultValue = '"*"' )
 		self["envKey"] = Gaffer.StringPlug()
@@ -82,7 +83,7 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 
 		context = Gaffer.Context.current()
 
-		job = author.Job(
+		job = self.__tractorAPI.Job(
 			## \todo Remove these manual substitutions once #887 is resolved.
 			title = context.substitute( self["jobName"].getValue() ) or "untitled",
 			service = context.substitute( self["service"].getValue() ),
@@ -143,7 +144,7 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 		# Make a task.
 
 		nodeName = batch.node().relativeName( dispatchData["scriptNode"] )
-		task = author.Task( title = nodeName )
+		task = self.__tractorAPI.Task( title = nodeName )
 
 		if batch.frames() :
 
@@ -172,7 +173,7 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 			# Create a Tractor command to execute that command line, and add
 			# it to the task.
 
-			command = author.Command( argv = args )
+			command = self.__tractorAPI.Command( argv = args )
 			task.addCommand( command )
 
 			# Apply any custom dispatch settings to the command.

--- a/python/GafferTractor/__init__.py
+++ b/python/GafferTractor/__init__.py
@@ -36,4 +36,12 @@
 
 from .TractorDispatcher import TractorDispatcher
 
+## Returns the `tractor.api.author` module, and must be the _only_
+# method used to access that module in GafferTractor. This allows us
+# to insert a mock API for testing in GafferTractorTest.
+def tractorAPI() :
+
+	from tractor.api.author import author
+	return author
+
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferTractor" )

--- a/python/GafferTractorTest/ModuleTest.py
+++ b/python/GafferTractorTest/ModuleTest.py
@@ -41,7 +41,6 @@ import IECore
 
 import GafferTest
 
-@unittest.skipIf( not IECore.SearchPath( sys.path ).find( "tractor" ), "Tractor not available" )
 class ModuleTest( GafferTest.TestCase ) :
 
 	def testDoesNotImportUI( self ) :

--- a/python/GafferTractorTest/TractorDispatcherTest.py
+++ b/python/GafferTractorTest/TractorDispatcherTest.py
@@ -35,8 +35,10 @@
 ##########################################################################
 
 import unittest
+import unittest.mock
 import inspect
 import sys
+
 import imath
 
 import IECore
@@ -45,13 +47,13 @@ import Gaffer
 import GafferTest
 import GafferDispatch
 import GafferDispatchTest
+import GafferTractor
+import GafferTractorTest
 
-@unittest.skipIf( not IECore.SearchPath( sys.path ).find( "tractor" ), "Tractor not available" )
+@unittest.mock.patch( "GafferTractor.tractorAPI", new = GafferTractorTest.tractorAPI )
 class TractorDispatcherTest( GafferTest.TestCase ) :
 
 	def __dispatcher( self ) :
-
-		import GafferTractor
 
 		dispatcher = GafferTractor.TractorDispatcher()
 		dispatcher["jobsDirectory"].setValue( self.temporaryDirectory() / "testJobDirectory" )
@@ -59,8 +61,6 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 		return dispatcher
 
 	def __job( self, nodes, dispatcher = None ) :
-
-		import GafferTractor
 
 		jobs = []
 		def f( dispatcher, job ) :
@@ -77,8 +77,6 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 		return jobs[0]
 
 	def testPreSpoolSignal( self ) :
-
-		import GafferTractor
 
 		s = Gaffer.ScriptNode()
 		s["n"] = GafferDispatchTest.LoggingTaskNode()
@@ -187,8 +185,6 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 
 	def testSharedPreTasks( self ) :
 
-		import tractor.api.author as author
-
 		#   n1
 		#  / \
 		# i1 i2
@@ -221,7 +217,10 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 		self.assertEqual( job.subtasks[0].subtasks[0].subtasks[0].title, "n1 1" )
 		self.assertEqual( job.subtasks[0].subtasks[1].subtasks[0].title, "n1 1" )
 
-		self.assertTrue( isinstance( job.subtasks[0].subtasks[1].subtasks[0], author.Instance ) )
+		self.assertIsInstance(
+			job.subtasks[0].subtasks[1].subtasks[0],
+			GafferTractor.tractorAPI().Instance
+		)
 
 	def testTaskPlugs( self ) :
 
@@ -241,13 +240,9 @@ class TractorDispatcherTest( GafferTest.TestCase ) :
 
 	def testTypeNamePrefixes( self ) :
 
-		import GafferTractor
-
 		self.assertTypeNamesArePrefixed( GafferTractor )
 
 	def testDefaultNames( self ) :
-
-		import GafferTractor
 
 		self.assertDefaultNamesAreCorrect( GafferTractor )
 

--- a/python/GafferTractorUITest/DocumentationTest.py
+++ b/python/GafferTractorUITest/DocumentationTest.py
@@ -41,14 +41,13 @@ import IECore
 
 import GafferUITest
 import GafferDispatch
+import GafferDispatchUI
+import GafferTractor
+import GafferTractorUI
 
-@unittest.skipIf( not IECore.SearchPath( sys.path ).find( "tractor" ), "Tractor not available" )
 class DocumentationTest( GafferUITest.TestCase ) :
 
 	def test( self ) :
-
-		import GafferTractor
-		import GafferTractorUI
 
 		self.maxDiff = None
 		self.assertNodesAreDocumented( GafferTractor )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -570,8 +570,11 @@ GafferUI.DotUI.connect( application.root() )
 
 with contextlib.suppress( ImportError ) :
 
-	import GafferTractorUI
+	# Raises if Tractor not available, thus avoiding registering the
+	# TractorDispatcher.
+	import tractor.api.author
 
+	import GafferTractorUI
 
 ## Metadata cleanup
 ###########################################################################

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -110,6 +110,7 @@ if 'GafferUI' in sys.modules :
 
 dispatchers = [ GafferDispatch.LocalDispatcher ]
 with contextlib.suppress( ImportError ) :
+	import tractor.api.author # Raises if Tractor not available
 	import GafferTractor
 	dispatchers.append( GafferTractor.TractorDispatcher )
 


### PR DESCRIPTION
This allows us to run GafferTractorTest and GafferTractorUITest in CI even though we don't have Tractor installed.
