### PR TITLE
PathFilterUI/CryptomatteUI : Fix drag pointer

### DIFF
--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -343,7 +343,7 @@ def __dragMove( nodeGadget, event ) :
 	if __originalDragPointer is None :
 		return False
 
-	GafferUI.Pointer.setCurrent( str( __dropMode( nodeGadget, event ) ).lower() + "Names" )
+	GafferUI.Pointer.setCurrent( __dropMode( nodeGadget, event ).name.lower() + "Names" )
 
 	return True
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -327,7 +327,7 @@ def __dragMove( nodeGadget, event ) :
 	if __originalDragPointer is None :
 		return False
 
-	GafferUI.Pointer.setCurrent( str( __dropMode( nodeGadget, event ) ).lower() + "Objects" )
+	GafferUI.Pointer.setCurrent( __dropMode( nodeGadget, event ).name.lower() + "Objects" )
 
 	return True
 


### PR DESCRIPTION
This was a victim of the switch to `enum.Enum` in #5559.
