### PR TITLE
Revert "Prefer `contextlib.suppress()` to `IECore.IgnoredExceptions`"

### DIFF
--- a/python/Gaffer/DictPath.py
+++ b/python/Gaffer/DictPath.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -81,7 +79,7 @@ class DictPath( Gaffer.Path ) :
 	def property( self, name, canceller = None ) :
 
 		if name == "dict:value" :
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				e = self.__dictEntry()
 				if not isinstance( e, self.__dictTypes ) :
 					return e

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -37,7 +37,6 @@
 
 import re
 import ast
-import contextlib
 import functools
 import inspect
 import pathlib
@@ -373,7 +372,7 @@ def __compoundObjectPlugValueExtractor( plug, topLevelPlug, value ) :
 
 def __defaultValueExtractor( plug, topLevelPlug, value ) :
 
-	with contextlib.suppress( AttributeError ) :
+	with IECore.IgnoredExceptions( AttributeError ) :
 		value = value.value
 
 	# Deal with the simple atomic plug case.

--- a/python/Gaffer/SequencePath.py
+++ b/python/Gaffer/SequencePath.py
@@ -35,7 +35,6 @@
 ##########################################################################
 
 import collections
-import contextlib
 
 import IECore
 
@@ -155,7 +154,7 @@ class SequencePath( Gaffer.Path ) :
 	def __basePaths( self ) :
 
 		sequence = None
-		with contextlib.suppress( Exception ) :
+		with IECore.IgnoredExceptions( Exception ) :
 			sequence = IECore.FileSequence( str( self ) )
 
 		result = []

--- a/python/GafferCortex/IndexedIOPath.py
+++ b/python/GafferCortex/IndexedIOPath.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -86,7 +84,7 @@ class IndexedIOPath( Gaffer.Path ) :
 		elif name == "indexedIO:dataType" :
 			return e.dataType() if e.entryType() == IECore.IndexedIO.EntryType.File else None
 		elif name == "indexedIO:arrayLength" :
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				return e.arrayLength()
 
 		return None

--- a/python/GafferCortex/ObjectReader.py
+++ b/python/GafferCortex/ObjectReader.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -71,7 +69,7 @@ class ObjectReader( Gaffer.ComputeNode ) :
 		assert( plug.isSame( self["out"] ) )
 
 		reader = None
-		with contextlib.suppress( RuntimeError ) :
+		with IECore.IgnoredExceptions( RuntimeError ) :
 			reader = IECore.Reader.create( self["fileName"].getValue() )
 
 		plug.setValue( reader.read() if reader else plug.defaultValue() )

--- a/python/GafferCortex/ObjectWriter.py
+++ b/python/GafferCortex/ObjectWriter.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -112,7 +111,7 @@ class ObjectWriter( GafferDispatch.TaskNode ) :
 
 				self.__writer = None
 				self.__exposedParameters.clearParameters()
-				with contextlib.suppress( RuntimeError ) :
+				with IECore.IgnoredExceptions( RuntimeError ) :
 					self.__writer = IECore.Writer.create( fileName )
 
 				if self.__writer is not None :

--- a/python/GafferCortex/OpMatcher.py
+++ b/python/GafferCortex/OpMatcher.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import threading
 import traceback
 import weakref
@@ -73,10 +72,10 @@ class OpMatcher( object ) :
 				continue
 
 			ignore = False
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				# backwards compatibility with something proprietary
 				ignore = opInstance.userData()["UI"]["OpMatcher"]["ignore"].value
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				ignore = opInstance.userData()["OpMatcher"]["ignore"].value
 			if ignore :
 				continue
@@ -151,10 +150,10 @@ class OpMatcher( object ) :
 		for child in parameter.values() :
 
 			ignore = False
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				# backwards compatibility with something proprietary
 				ignore = child.userData()["UI"]["OpMatcher"]["ignore"].value
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				# backwards compatibility with something proprietary
 				ignore = child.userData()["OpMatcher"]["ignore"].value
 			if ignore :

--- a/python/GafferCortex/ParameterPath.py
+++ b/python/GafferCortex/ParameterPath.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -75,7 +73,7 @@ class ParameterPath( Gaffer.Path ) :
 	def property( self, name, canceller = None ) :
 
 		if name == "parameter:parameter" :
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				return self.__parameter()
 			return None
 

--- a/python/GafferCortexUI/ClassParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import imath
 
 import IECore
@@ -107,7 +105,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		classInfo = self._parameter().getClass( True )
 
 		classNameFilter = "*"
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			classNameFilter = self._parameter().userData()["UI"]["classNameFilter"].value
 		menuPathStart = max( 0, classNameFilter.find( "*" ) )
 

--- a/python/GafferCortexUI/ClassVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/ClassVectorParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import imath
 
 import IECore
@@ -157,7 +155,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		result = IECore.MenuDefinition()
 
 		classNameFilter = "*"
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			classNameFilter = self._parameter().userData()["UI"]["classNameFilter"].value
 		menuPathStart = max( 0, classNameFilter.find( "*" ) )
 
@@ -252,10 +250,10 @@ class _ChildParameterUI( CompoundPlugValueWidget ) :
 			preHeaderParameters = []
 			headerParameters = []
 			for parameter in self.__parameterHandler.parameter().values() :
-				with contextlib.suppress( KeyError ) :
+				with IECore.IgnoredExceptions( KeyError ) :
 					if parameter.userData()["UI"]["classVectorParameterPreHeader"].value :
 						preHeaderParameters.append( parameter )
-				with contextlib.suppress( KeyError ) :
+				with IECore.IgnoredExceptions( KeyError ) :
 					if parameter.userData()["UI"]["classVectorParameterHeader"].value :
 						headerParameters.append( parameter )
 

--- a/python/GafferCortexUI/CompoundParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import GafferUI
@@ -59,13 +57,13 @@ class CompoundParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 
 		if collapsible is None :
 			collapsible = True
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				collapsible = parameterHandler.parameter().userData()["UI"]["collapsible"].value
 
 		collapsed = None
 		if collapsible :
 			collapsed = True
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				collapsed = parameterHandler.parameter().userData()["UI"]["collapsed"].value
 
 		if _plugValueWidgetClass is None :
@@ -103,7 +101,7 @@ class _PlugValueWidget( CompoundPlugValueWidget ) :
 
 		childParameter = self.__parameterHandler.parameter()[childPlug.getName()]
 
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			if not childParameter.userData()["UI"]["visible"].value :
 				return None
 

--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import imath
 
 import IECore
@@ -83,11 +81,11 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		columnToolTips = [ self._parameterToolTip( self._parameterHandler().childParameterHandler( x ) ) for x in self._parameter().values() ]
 
 		showIndices = True
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			showIndices = self._parameterHandler().parameter().userData()["UI"]["showIndices"].value
 
 		sizeEditable = True
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			sizeEditable = self._parameterHandler().parameter().userData()["UI"]["sizeEditable"].value
 
 		self.__vectorDataWidget = _VectorDataWidget(
@@ -138,12 +136,12 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		for columnIndex, childParameter in enumerate( self._parameter().values() ) :
 
 			columnVisible = True
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				columnVisible = childParameter.userData()["UI"]["visible"].value
 			self.__vectorDataWidget.setColumnVisible( columnIndex, columnVisible )
 
 			columnEditable = True
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				columnEditable = childParameter.userData()["UI"]["editable"].value
 			self.__vectorDataWidget.setColumnEditable( columnIndex, columnEditable )
 
@@ -153,7 +151,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		childParameter = self._parameter().values()[dataIndex]
 
 		presetsOnly = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			presetsOnly = childParameter.userData()["UI"]["elementPresetsOnly"].value
 
 		if not presetsOnly :
@@ -282,12 +280,12 @@ def __parameterPopupMenu( menuDefinition, parameterValueWidget ) :
 	parameter = parameterValueWidget.parameter()
 	columnParameter = parameter.values()[vectorDataWidget.columnToDataIndex( column )[0]]
 
-	with contextlib.suppress( KeyError ) :
+	with IECore.IgnoredExceptions( KeyError ) :
 		if columnParameter.userData()["UI"]["editable"].value == False :
 			return
 
 	presets = None
-	with contextlib.suppress( KeyError ) :
+	with IECore.IgnoredExceptions( KeyError ) :
 		presets = columnParameter.userData()["UI"]["elementPresets"]
 
 	if presets is None :

--- a/python/GafferCortexUI/FileSequenceParameterValueWidget.py
+++ b/python/GafferCortexUI/FileSequenceParameterValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -85,7 +83,7 @@ def __isFileSequence( plug ) :
 		return True
 
 	if isinstance( parameter, IECore.PathParameter ) :
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			return parameter.userData()["UI"]["typeHint"].value == "includeSequences"
 
 	return False
@@ -105,7 +103,7 @@ def __includeFrameRange( plug ) :
 		return None
 
 	includeFrameRange = True
-	with contextlib.suppress( KeyError ) :
+	with IECore.IgnoredExceptions( KeyError ) :
 		includeFrameRange = parameter.userData()["UI"]["includeFrameRange"].value
 
 	return includeFrameRange

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import enum
 import sys
 import threading
@@ -128,7 +127,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 			postExecuteBehaviour = self.PostExecuteBehaviour.DisplayResult
 
 			d = None
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				d = opInstance.userData()["UI"]["postExecuteBehaviour"]
 			if d is not None :
 				for v in self.PostExecuteBehaviour.values() :
@@ -137,7 +136,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 						break
 			else :
 				# backwards compatibility with batata
-				with contextlib.suppress( KeyError ) :
+				with IECore.IgnoredExceptions( KeyError ) :
 					d = opInstance.userData()["UI"]["closeAfterExecution"]
 				if d is not None :
 					postExecuteBehaviour = self.PostExecuteBehaviour.Close if d.value else self.PostExecuteBehaviour.DisplayResult
@@ -266,7 +265,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 		self.__backButtonClickedConnection = self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__close ), scoped = True )
 
 		executeLabel = "OK"
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			executeLabel = self.__node.getParameterised()[0].userData()["UI"]["buttonLabel"].value
 
 		self.__forwardButton.setText( executeLabel )
@@ -456,7 +455,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 		if defaultButton == self.DefaultButton.FromUserData :
 			defaultButton = self.DefaultButton.OK
 			d = None
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				d = self.__node.getParameterised()[0].userData()["UI"]["defaultButton"]
 			if d is not None :
 				for v in self.DefaultButton.values() :
@@ -485,7 +484,7 @@ class OpDialogue( GafferUI.Dialogue ) :
 	def __setUserDefaults( self, graphComponent ) :
 
 		if isinstance( graphComponent, Gaffer.Plug ) and hasattr( graphComponent, "getValue" ) :
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				Gaffer.Metadata.registerValue( graphComponent, "userDefault", graphComponent.getValue() )
 
 		for child in graphComponent.children() :

--- a/python/GafferCortexUI/ParameterPresets.py
+++ b/python/GafferCortexUI/ParameterPresets.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 import re
 import shutil
@@ -108,7 +107,7 @@ class PresetDialogue( GafferUI.Dialogue ) :
 		existingPaths = []
 		for path in paths :
 			if not os.path.isdir( path ) :
-				with contextlib.suppress( Exception ) :
+				with IECore.IgnoredExceptions( Exception ) :
 					os.makedirs( path )
 			if os.path.isdir( path ) :
 				if owned and os.stat( path ).st_uid != os.getuid() :

--- a/python/GafferCortexUI/ParameterValueWidget.py
+++ b/python/GafferCortexUI/ParameterValueWidget.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -89,7 +87,7 @@ class ParameterValueWidget( GafferUI.Widget ) :
 			return GafferCortexUI.PresetsOnlyParameterValueWidget( parameterHandler )
 
 		uiTypeHint = None
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			uiTypeHint = parameter.userData()["UI"]["typeHint"].value
 
 		parameterHierarchy = [ parameter.typeId() ] + IECore.RunTimeTyped.baseTypeIds( parameter.typeId() )

--- a/python/GafferCortexUI/ParameterisedHolderUI.py
+++ b/python/GafferCortexUI/ParameterisedHolderUI.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import re
 import pipes
 import fnmatch
@@ -73,7 +72,7 @@ class _ParameterisedHolderNodeUI( GafferUI.NodeUI ) :
 
 		headerVisible = True
 		parameterised = self.node().getParameterised()[0]
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			headerVisible = parameterised.userData()["UI"]["headerVisible"].value
 
 		with column :

--- a/python/GafferCortexUI/PathParameterValueWidget.py
+++ b/python/GafferCortexUI/PathParameterValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -75,7 +73,7 @@ class PathParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 		result = {}
 
 		bookmarksCategory = None
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			bookmarksCategory = self.parameter().userData()["UI"]["bookmarksCategory"].value
 		result["bookmarks"] = GafferUI.Bookmarks.acquire(
 			# sometimes parameter widgets are used with nodes which are parented to an application,

--- a/python/GafferCortexUI/PathVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/PathVectorParameterValueWidget.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import re
 import os
 
@@ -97,7 +96,7 @@ class PathVectorParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 		result = {}
 
 		bookmarksCategory = None
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			bookmarksCategory = self.parameter().userData()["UI"]["bookmarksCategory"].value
 
 		result["bookmarks"] = GafferUI.Bookmarks.acquire(

--- a/python/GafferCortexUI/StringParameterValueWidget.py
+++ b/python/GafferCortexUI/StringParameterValueWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -61,7 +59,7 @@ class StringParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 	def __init__( self, parameterHandler, **kw ) :
 
 		multiLine = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			multiLine = parameterHandler.parameter().userData()["UI"]["multiLine"].value
 
 		if multiLine :
@@ -69,7 +67,7 @@ class StringParameterValueWidget( GafferCortexUI.ParameterValueWidget ) :
 
 		else :
 			plugValueWidget = GafferUI.StringPlugValueWidget( parameterHandler.plug() )
-			with contextlib.suppress( KeyError ) :
+			with IECore.IgnoredExceptions( KeyError ) :
 				if parameterHandler.parameter().userData()["UI"]["password"].value :
 					plugValueWidget.textWidget().setDisplayMode( GafferUI.TextWidget.DisplayMode.Password )
 
@@ -97,7 +95,7 @@ def __fixedLineHeight( plug ) :
 	# for a brief description, for this reason we check by the user data "multiLineFixedLineHeight" which when set
 	# forces the parameter to show an arbitrary number of lines
 	fixedLineHeight = None
-	with contextlib.suppress( KeyError ) :
+	with IECore.IgnoredExceptions( KeyError ) :
 		fixedLineHeight = parameter.userData()["UI"]["multiLineFixedLineHeight"].value
 
 	return fixedLineHeight

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -35,7 +35,6 @@
 ##########################################################################
 
 import ast
-import contextlib
 
 import IECore
 import imath
@@ -173,7 +172,7 @@ class _VariablesDict( dict ) :
 			value, name = self.__variables.memberDataAndName( plug )
 			if value is None :
 				continue
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				value = value.value
 
 			self[name] = value

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import imath
 
@@ -101,7 +100,7 @@ class Column( GafferUI.PathColumn ) :
 		# Suppress error. The GraphEditor will be displaying the
 		# error anyway, as will the standard type column, and we're
 		# not in a position to do anything more helpful.
-		with contextlib.suppress( Gaffer.ProcessException ) :
+		with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
 
 			# Call `_imageCellData()` in a context which causes the Catalogue
 			# to output the image of interest.

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -309,7 +307,7 @@ class _ColorSpacePlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 
 			automaticSpace = ""
 			if len( colorSpacePlugs ) and preset == "Automatic" :
-				with contextlib.suppress( Gaffer.ProcessException ) :
+				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
 					automaticSpace = colorSpacePlugs[0].getValue() or "Working Space"
 
 			result.append( {

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import enum
 import functools
 import imath
@@ -79,7 +78,7 @@ class _CryptomatteNamesPlugValueWidget( GafferUI.VectorDataPlugValueWidget ) :
 		cryptomatteNode = _findCryptomatteNode( self.getPlug() )
 		if cryptomatteNode :
 			with self.getContext() :
-				with contextlib.suppress( Exception ) :
+				with IECore.IgnoredExceptions( Exception ) :
 					return cryptomatteNode["__manifest"].getValue()
 
 		return None

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import sys
 
 import imath
@@ -86,7 +85,7 @@ class _RightSpacer( GafferUI.Spacer ) :
 
 def _boldFormatter( graphComponents ) :
 
-	with contextlib.suppress( ValueError ) :
+	with IECore.IgnoredExceptions( ValueError ) :
 		## \todo Should the NameLabel ignore ScriptNodes and their ancestors automatically?
 		scriptNodeIndex = [ isinstance( g, Gaffer.ScriptNode ) for g in graphComponents ].index( True )
 		graphComponents = graphComponents[scriptNodeIndex+1:]

--- a/python/GafferTest/ComputeNodeTest.py
+++ b/python/GafferTest/ComputeNodeTest.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import inspect
 import unittest
 import threading
@@ -445,7 +444,7 @@ class ComputeNodeTest( GafferTest.TestCase ) :
 		n = GafferTest.BadNode()
 		c = n.errorSignal().connect( f, scoped = True )
 
-		with contextlib.suppress( Exception ) :
+		with IECore.IgnoredExceptions( Exception ) :
 			n["out1"].getValue()
 
 		self.assertTrue( self.fRan )

--- a/python/GafferTractorTest/__init__.py
+++ b/python/GafferTractorTest/__init__.py
@@ -43,11 +43,11 @@ __mockAPI = None
 def tractorAPI() :
 
 	import types
-	import contextlib
+	import IECore
 
 	# Use the real API if it is available.
 
-	with contextlib.suppress( ImportError ) :
+	with IECore.IgnoredExceptions( ImportError ) :
 		from tractor.api.author import author
 		return author
 

--- a/python/GafferUI/Backups.py
+++ b/python/GafferUI/Backups.py
@@ -41,7 +41,6 @@ import IECore
 from Qt import QtCore
 
 import collections
-import contextlib
 import pathlib
 import re
 import stat
@@ -99,7 +98,7 @@ class Backups( object ) :
 		# temporarily make it writable. If this fails for
 		# any reason we leave it to `serialiseToFile()` to
 		# throw.
-		with contextlib.suppress( OSError ) :
+		with IECore.IgnoredExceptions( OSError ) :
 			path.chmod( stat.S_IWUSR )
 
 		script.serialiseToFile( path )

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -42,7 +42,6 @@ import token
 import keyword
 import tokenize
 import collections
-import contextlib
 import io
 
 import imath
@@ -534,7 +533,7 @@ class PythonCompleter( Completer ) :
 				return []
 			items = []
 			for n in dir( rootObject ) :
-				with contextlib.suppress( AttributeError ) :
+				with IECore.IgnoredExceptions( AttributeError ) :
 					items.append( ( n, getattr( rootObject, n ) ) )
 			return self.__completions(
 				items = items,

--- a/python/GafferUI/DataPathPreview.py
+++ b/python/GafferUI/DataPathPreview.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -61,7 +59,7 @@ class DataPathPreview( GafferUI.DeferredPathPreview ) :
 	def _load( self ) :
 
 		data = None
-		with contextlib.suppress( RuntimeError ) :
+		with IECore.IgnoredExceptions( RuntimeError ) :
 			data = self.getPath().data()
 
 		return data

--- a/python/GafferUI/DotUI.py
+++ b/python/GafferUI/DotUI.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import imath
 
@@ -159,7 +158,7 @@ def __connectionContextMenu( graphEditor, destinationPlug, menuDefinition ) :
 
 	applicationRoot = graphEditor.scriptNode().ancestor( Gaffer.ApplicationRoot )
 	connected = False
-	with contextlib.suppress( AttributeError ) :
+	with IECore.IgnoredExceptions( AttributeError ) :
 		connected = applicationRoot.__dotUIConnected
 
 	if not connected :

--- a/python/GafferUI/FileMenu.py
+++ b/python/GafferUI/FileMenu.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 import functools
 import imath
@@ -169,7 +168,7 @@ def openRecent( menu ) :
 	applicationRoot = currentScript.ancestor( Gaffer.ApplicationRoot )
 
 	recentFiles = []
-	with contextlib.suppress( AttributeError ) :
+	with IECore.IgnoredExceptions( AttributeError ) :
 		recentFiles = applicationRoot.__recentFiles
 
 	result = IECore.MenuDefinition()

--- a/python/GafferUI/HeaderPathPreview.py
+++ b/python/GafferUI/HeaderPathPreview.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -73,14 +72,14 @@ class HeaderPathPreview( GafferUI.DeferredPathPreview ) :
 	def _load( self ) :
 
 		reader = None
-		with contextlib.suppress( RuntimeError ) :
+		with IECore.IgnoredExceptions( RuntimeError ) :
 			reader = IECore.Reader.create( str( self.getPath() ) )
 
 		if reader is None :
 			return None
 
 		header = None
-		with contextlib.suppress( RuntimeError ) :
+		with IECore.IgnoredExceptions( RuntimeError ) :
 			header = reader.readHeader()
 
 		return header

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import weakref
 import functools
 import collections
@@ -126,10 +125,10 @@ class LazyMethod( object ) :
 	def __playback( cls, widget ) :
 
 		context = None
-		with contextlib.suppress( AttributeError ) :
+		with IECore.IgnoredExceptions( AttributeError ) :
 			context = widget.getContext()
 		if context is None :
-			with contextlib.suppress( AttributeError ) :
+			with IECore.IgnoredExceptions( AttributeError ) :
 				context = widget.context()
 
 		return GafferUI.Playback.acquire( context )

--- a/python/GafferUI/MatchPatternPathFilterWidget.py
+++ b/python/GafferUI/MatchPatternPathFilterWidget.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 
 import IECore
@@ -73,7 +72,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 	def _updateFromPathFilter( self ) :
 
 		editable = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			editable = self.pathFilter().userData()["UI"]["editable"].value
 
 		self.__enabledWidget.setVisible( not editable )
@@ -81,7 +80,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 		self.__patternWidget.setVisible( editable )
 
 		label = str( self.pathFilter() )
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			label = self.pathFilter().userData()["UI"]["label"].value
 			if len(label) > 40:
 				self.__enabledWidget.setToolTip( label )
@@ -90,7 +89,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 		self.__enabledWidget.setText( label )
 
 		invertEnabled = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			invertEnabled = self.pathFilter().userData()["UI"]["invertEnabled"].value
 
 		self.__enabledWidget.setState( self.pathFilter().getEnabled() is not invertEnabled )
@@ -101,7 +100,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 		assert( widget is self.__enabledWidget )
 
 		invertEnabled = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			invertEnabled = self.pathFilter().userData()["UI"]["invertEnabled"].value
 
 		with Gaffer.Signals.BlockedConnection( self._pathFilterChangedConnection() ) :
@@ -167,7 +166,7 @@ class MatchPatternPathFilterWidget( GafferUI.PathFilterWidget ) :
 
 		result = { "name": IECore.StringData( "Name" ), "filesystem:owner": IECore.StringData( "Owner" ) }
 
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			result = self.pathFilter().userData()["UI"]["propertyFilters"]
 
 		return result

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import inspect
 import enum
 import functools
@@ -366,7 +365,7 @@ class Menu( GafferUI.Widget ) :
 	def __buildAction( self, item, name, parent ) :
 
 		label = name
-		with contextlib.suppress( AttributeError ) :
+		with IECore.IgnoredExceptions( AttributeError ) :
 			label = item.label
 
 		if item.divider :

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import enum
 
 import imath
@@ -336,7 +335,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 	def __dropText( self, dragData ) :
 
 		signal = None
-		with contextlib.suppress( AttributeError ) :
+		with IECore.IgnoredExceptions( AttributeError ) :
 			signal = self.__dropTextSignal
 
 		text = None

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import inspect
 import imath
 
@@ -104,7 +103,7 @@ class NodeMenu( object ) :
 			script = graphEditor.scriptNode()
 
 			commandArgs = []
-			with contextlib.suppress( TypeError ) :
+			with IECore.IgnoredExceptions( TypeError ) :
 				commandArgs = inspect.getfullargspec( nodeCreator ).args
 
 			with Gaffer.UndoScope( script ) :

--- a/python/GafferUI/PathFilterWidget.py
+++ b/python/GafferUI/PathFilterWidget.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -80,7 +78,7 @@ class PathFilterWidget( GafferUI.Widget ) :
 	def create( cls, pathFilter ) :
 
 		visible = True
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			visible = pathFilter.userData()["UI"]["visible"].value
 
 		if not visible :
@@ -120,19 +118,19 @@ class BasicPathFilterWidget( PathFilterWidget ) :
 	def _updateFromPathFilter( self ) :
 
 		label = str( self.pathFilter() )
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			label = self.pathFilter().userData()["UI"]["label"].value
 		self.__checkBox.setText( label )
 
 		invertEnabled = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			invertEnabled = self.pathFilter().userData()["UI"]["invertEnabled"].value
 		self.__checkBox.setState( self.pathFilter().getEnabled() is not invertEnabled )
 
 	def __stateChanged( self, checkBox ) :
 
 		invertEnabled = False
-		with contextlib.suppress( KeyError ) :
+		with IECore.IgnoredExceptions( KeyError ) :
 			invertEnabled = self.pathFilter().userData()["UI"]["invertEnabled"].value
 		self.pathFilter().setEnabled( checkBox.getState() is not invertEnabled )
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -36,7 +36,6 @@
 ##########################################################################
 
 import collections
-import contextlib
 import functools
 import inspect
 import itertools
@@ -415,7 +414,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			if hasattr( value, "value" ) :
 				dataValue = value.value
 			else :
-				with contextlib.suppress( Exception ) :
+				with IECore.IgnoredExceptions( Exception ) :
 					if len( value ) == 1 :
 						dataValue = value[0]
 
@@ -424,7 +423,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			elif isinstance( dataValue, plugValueType ) :
 				return dataValue
 			else :
-				with contextlib.suppress( Exception ) :
+				with IECore.IgnoredExceptions( Exception ) :
 					return plugValueType( dataValue )
 
 		return None

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import enum
 import functools
 
@@ -1250,7 +1249,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		enabled = True
 		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
-			with contextlib.suppress( Gaffer.ProcessException ) :
+			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
 				enabled = all( [ plug.getValue() for plug in enabledPlugs ] )
 
 		return ( allSettable and not anyReadOnly, enabled )

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import re
 
@@ -219,7 +218,7 @@ def __noduleLabel( plug ) :
 		plug = plug.parent()
 
 	name = None
-	with contextlib.suppress( Exception ) :
+	with IECore.IgnoredExceptions( Exception ) :
 		name = plug["name"].getValue()
 
 	return name or plug.getName()

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import imath
 
@@ -503,7 +502,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 					continue
 				# we have to ignore exceptions, as the items we're setting might
 				# have a different data type than the value we're passing.
-				with contextlib.suppress( Exception ) :
+				with IECore.IgnoredExceptions( Exception ) :
 					self.__model.setData( index, valueToPropagate, QtCore.Qt.EditRole )
 			self.__propagatingDataChangesToSelection = False
 

--- a/python/GafferUITest/GraphGadgetTest.py
+++ b/python/GafferUITest/GraphGadgetTest.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import unittest
 import threading
 import imath
@@ -1049,7 +1048,7 @@ class GraphGadgetTest( GafferUITest.TestCase ) :
 		# a background thread.
 
 		def f() :
-			with contextlib.suppress( Exception ) :
+			with IECore.IgnoredExceptions( Exception ) :
 				script["n"]["out1"].getValue()
 
 		r = threading.Thread( target = f )

--- a/startup/dispatch/gui.py
+++ b/startup/dispatch/gui.py
@@ -34,8 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -58,7 +56,7 @@ if application["gui"].getTypedValue() :
 		"GafferDelightUI",
 		"GafferTractorUI",
 	) :
-		with contextlib.suppress( ImportError ) :
+		with IECore.IgnoredExceptions( ImportError ) :
 			__import__( module )
 
 	menu = GafferDispatchUI.DispatchDialogue.menuDefinition()

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -65,7 +64,7 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "cycles:light" )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	# This import appears unused, but it is intentional; it prevents us from
 	# adding the OSL lights when 3Delight isn't available.
@@ -91,7 +90,7 @@ with contextlib.suppress( ImportError ) :
 	# If 3Delight is available, then assume it will be used in preference to Cycles.
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "osl:light" )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 	# Register Light Editor sections for Arnold before the generic "Visualisation" section

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 import re
 import traceback
@@ -568,7 +567,7 @@ nodeMenu.append( "/Utility/Collect", Gaffer.Collect )
 
 GafferUI.DotUI.connect( application.root() )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	# Raises if Tractor not available, thus avoiding registering the
 	# TractorDispatcher.

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -35,8 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
-
 import IECore
 
 import Gaffer
@@ -72,7 +70,7 @@ for node, plug in [
 
 # Set up Arnold colour manager with metadata that integrates with our OCIO configs.
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -35,7 +35,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -79,7 +78,7 @@ GafferScene.Outputs.registerOutput(
 
 # Add standard AOVs as they are defined in the aiStandard and alSurface shaders
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	# If Arnold isn't available for any reason, this will fail
 	# and we won't add any unnecessary output definitions.
@@ -164,7 +163,7 @@ with contextlib.suppress( ImportError ) :
 
 # Add standard AOVs as they are defined in the 3Delight shaders
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	# If 3Delight isn't available for any reason, this will fail
 	# and we won't add any unnecessary output definitions.
@@ -242,7 +241,7 @@ with contextlib.suppress( ImportError ) :
 
 if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
 
-	with contextlib.suppress( ImportError ) :
+	with IECore.IgnoredExceptions( ImportError ) :
 
 		# If cycles isn't available for any reason, this will fail
 		# and we won't add any unnecessary output definitions.

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import os
 import sys
@@ -109,7 +108,7 @@ if 'GafferUI' in sys.modules :
 ##########################################################################
 
 dispatchers = [ GafferDispatch.LocalDispatcher ]
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 	import tractor.api.author # Raises if Tractor not available
 	import GafferTractor
 	dispatchers.append( GafferTractor.TractorDispatcher )
@@ -124,7 +123,7 @@ for dispatcher in dispatchers :
 # Renderers
 ##########################################################################
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 	import GafferArnold
 	Gaffer.Metadata.registerValue( GafferArnold.ArnoldRender, "fileName", "userDefault", "${project:rootDirectory}/asses/${script:name}/${renderPass}/${script:name}.####.ass" )
 	Gaffer.Metadata.registerValue( GafferArnold.ArnoldTextureBake, "bakeDirectory", "userDefault", "${project:rootDirectory}/bakedTextures/${script:name}/" )

--- a/startup/gui/shaderPresets.py
+++ b/startup/gui/shaderPresets.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -47,7 +46,7 @@ def __registerShaderPresets( presets ) :
 		Gaffer.Metadata.registerValue( GafferScene.ShaderTweaks, "shader", "preset:" + name, value )
 		Gaffer.Metadata.registerValue( GafferScene.ShaderQuery, "shader", "preset:" + name, value )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 
@@ -65,7 +64,7 @@ with contextlib.suppress( ImportError ) :
 
 if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
 
-	with contextlib.suppress( ImportError ) :
+	with IECore.IgnoredExceptions( ImportError ) :
 
 		import GafferCycles
 
@@ -74,7 +73,7 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 			( "Cycles Light", "cycles:light" ),
 		] )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferOSL
 

--- a/startup/gui/shaderView.py
+++ b/startup/gui/shaderView.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import os
 
 import IECore
@@ -43,7 +42,7 @@ import GafferSceneUI
 
 if os.environ.get( "CYCLES_ROOT" ) :
 
-	with contextlib.suppress( ImportError ) :
+	with IECore.IgnoredExceptions( ImportError ) :
 
 		import GafferCycles
 
@@ -68,7 +67,7 @@ if os.environ.get( "CYCLES_ROOT" ) :
 		GafferSceneUI.ShaderView.registerRenderer( "osl", GafferCycles.InteractiveCyclesRender )
 		GafferSceneUI.ShaderView.registerScene( "osl", "Default", __cyclesShaderBall )
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 	GafferSceneUI.ShaderView.registerRenderer( "ai", GafferArnold.InteractiveArnoldRender )

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -34,7 +34,6 @@
 #
 ##########################################################################
 
-import contextlib
 import functools
 import imath
 import inspect
@@ -155,7 +154,7 @@ def __loadRendererSettings( fileName ) :
 
 	return script["Processor"]
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferArnold
 
@@ -180,7 +179,7 @@ with contextlib.suppress( ImportError ) :
 		functools.partial( __loadRendererSettings, os.path.join( os.path.dirname( __file__ ), "arnoldViewerSettings.gfr" ) )
 	)
 
-with contextlib.suppress( ImportError ) :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferDelight
 
@@ -199,7 +198,7 @@ with contextlib.suppress( ImportError ) :
 
 if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
 
-	with contextlib.suppress( ImportError ) :
+	with IECore.IgnoredExceptions( ImportError ) :
 
 		import GafferCycles
 


### PR DESCRIPTION
This reverts commit b1a04bd7ed9fbebda6c47296abb54d5781f57a32, which was now clearly a bad idea because `IgnoredExceptions` clears `__traceback__` and `suppress` doesn't. See  https://github.com/ImageEngine/cortex/commit/0d42ae02b0bd17e366fc59726d95b0978f50f363.
