### PR TITLE
TransformTool : Fix corner cases involving connection to individual XYZ components

### DIFF
--- a/include/GafferSceneUI/ScaleTool.h
+++ b/include/GafferSceneUI/ScaleTool.h
@@ -76,7 +76,7 @@ class GAFFERSCENEUI_API ScaleTool : public TransformTool
 			Scale( const Selection &selection );
 
 			bool canApply( const Imath::V3i &axisMask ) const;
-			void apply( const Imath::V3f &scale );
+			void apply( const Imath::V3i &axisMask, const Imath::V3f &scale );
 
 			private :
 

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -1261,5 +1261,29 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			self.assertEqual( script["editScope"]["out"].transform( "/cube1" ).translation(), imath.V3f( 10, 0, 0 ) )
 			self.assertEqual( script["editScope"]["out"].transform( "/cube2" ).translation(), imath.V3f( 10, 0, 0 ) )
 
+	def testIndividualComponentConnections( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["box"] = Gaffer.Box()
+		script["box"]["cube"] = GafferScene.Cube()
+
+		promotedX = Gaffer.PlugAlgo.promote( script["box"]["cube"]["transform"]["translate"]["x"] )
+		promotedY = Gaffer.PlugAlgo.promote( script["box"]["cube"]["transform"]["translate"]["y"] )
+		promotedZ = Gaffer.PlugAlgo.promote( script["box"]["cube"]["transform"]["translate"]["z"] )
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["box"]["cube"]["out"] )
+
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
+
+		tool = GafferSceneUI.TranslateTool( view )
+		tool["active"].setValue( True )
+
+		tool.translate( imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( script["box"]["cube"]["transform"]["translate"].getValue(), imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( promotedX.getValue(), 1 )
+		self.assertEqual( promotedY.getValue(), 2 )
+		self.assertEqual( promotedZ.getValue(), 3 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -1292,12 +1292,36 @@ bool TransformTool::keyPress( const GafferUI::KeyEvent &event )
 
 bool TransformTool::canSetValueOrAddKey( const Gaffer::FloatPlug *plug )
 {
+	// Refuse to edit a plug that is driven by ganging. Our use of
+	// `source()` below would mean that we'd end up editing the driver,
+	// which would cause very unintuitive behaviour.
+	if( auto parent = plug->parent<V3fPlug>() )
+	{
+		if( plug->getInput() && plug->getInput()->parent() == parent )
+		{
+			return false;
+		}
+	}
+
 	if( Animation::isAnimated( plug ) )
 	{
+		// Check editability of the source animation.
 		return !MetadataAlgo::readOnly( plug->source() );
 	}
 
-	return plug->settable() && !MetadataAlgo::readOnly( plug );
+	// We expect `plug` to have been acquired via `spreadsheetAwareSource()`
+	// courtesy of the Selection class. But that _doesn't_ mean that it can't have
+	// an input, because `spreadsheetAwareSource()` operates on the parent V3fPlug,
+	// and won't account for an input to an individual component. So we still
+	// need to call `source()` to find the plug we really want to edit.
+	const FloatPlug *source = plug->source<FloatPlug>();
+	if( !source )
+	{
+		// Input isn't a FloatPlug.
+		return false;
+	}
+
+	return source->settable() && !MetadataAlgo::readOnly( source );
 }
 
 void TransformTool::setValueOrAddKey( Gaffer::FloatPlug *plug, float time, float value )
@@ -1309,6 +1333,8 @@ void TransformTool::setValueOrAddKey( Gaffer::FloatPlug *plug, float time, float
 	}
 	else
 	{
-		plug->setValue( value );
+		FloatPlug *source = plug->source<FloatPlug>();
+		assert( source );
+		source->setValue( value );
 	}
 }


### PR DESCRIPTION
This is motivated by a user request to promote a single float plug to a box, to control the uniform scale of an object within it. The goal being for that to work with the standard ScaleTool. I've attached an example script below showing two methods of doing that which both now work with this PR.

This was a bit fiddlier than I had expected, so any and all testing would be much appreciated.

<details>

```
import Gaffer
import GafferScene
import imath

Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 3, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 8, persistent=False )
Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )

__children = {}

__children["InputForYWithXZGanged"] = Gaffer.Box( "InputForYWithXZGanged" )
parent.addChild( __children["InputForYWithXZGanged"] )
__children["InputForYWithXZGanged"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["InputForYWithXZGanged"].addChild( GafferScene.Sphere( "Sphere" ) )
__children["InputForYWithXZGanged"]["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["InputForYWithXZGanged"].addChild( Gaffer.BoxOut( "BoxOut" ) )
__children["InputForYWithXZGanged"]["BoxOut"].setup( GafferScene.ScenePlug( "in", ) )
__children["InputForYWithXZGanged"]["BoxOut"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["InputForYWithXZGanged"].addChild( GafferScene.ScenePlug( "out", direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["InputForYWithXZGanged"].addChild( Gaffer.FloatPlug( "uniformScale", defaultValue = 1.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SameInputForXYZ"] = Gaffer.Box( "SameInputForXYZ" )
parent.addChild( __children["SameInputForXYZ"] )
__children["SameInputForXYZ"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SameInputForXYZ"].addChild( GafferScene.Sphere( "Sphere" ) )
__children["SameInputForXYZ"]["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SameInputForXYZ"].addChild( Gaffer.BoxOut( "BoxOut" ) )
__children["SameInputForXYZ"]["BoxOut"].setup( GafferScene.ScenePlug( "in", ) )
__children["SameInputForXYZ"]["BoxOut"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SameInputForXYZ"].addChild( GafferScene.ScenePlug( "out", direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["SameInputForXYZ"].addChild( Gaffer.FloatPlug( "uniformScale", defaultValue = 1.0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
__children["InputForYWithXZGanged"]["__uiPosition"].setValue( imath.V2f( -8.80000305, 8.40000057 ) )
__children["InputForYWithXZGanged"]["Sphere"]["transform"]["scale"]["x"].setInput( __children["InputForYWithXZGanged"]["Sphere"]["transform"]["scale"]["y"] )
__children["InputForYWithXZGanged"]["Sphere"]["transform"]["scale"]["y"].setInput( __children["InputForYWithXZGanged"]["uniformScale"] )
__children["InputForYWithXZGanged"]["Sphere"]["transform"]["scale"]["z"].setInput( __children["InputForYWithXZGanged"]["Sphere"]["transform"]["scale"]["y"] )
__children["InputForYWithXZGanged"]["Sphere"]["__uiPosition"].setValue( imath.V2f( 14.5, 2.04999995 ) )
__children["InputForYWithXZGanged"]["BoxOut"]["in"].setInput( __children["InputForYWithXZGanged"]["Sphere"]["out"] )
Gaffer.Metadata.registerValue( __children["InputForYWithXZGanged"]["BoxOut"]["__out"], 'description', 'The output scene.' )
Gaffer.Metadata.registerValue( __children["InputForYWithXZGanged"]["BoxOut"]["__out"], 'nodule:type', 'GafferUI::StandardNodule' )
__children["InputForYWithXZGanged"]["BoxOut"]["__uiPosition"].setValue( imath.V2f( 15.99928, -6.28203106 ) )
__children["InputForYWithXZGanged"]["out"].setInput( __children["InputForYWithXZGanged"]["BoxOut"]["__out"] )
Gaffer.Metadata.registerValue( __children["InputForYWithXZGanged"]["out"], 'description', 'The output scene.' )
Gaffer.Metadata.registerValue( __children["InputForYWithXZGanged"]["out"], 'nodule:type', 'GafferUI::StandardNodule' )
Gaffer.Metadata.registerValue( __children["InputForYWithXZGanged"]["uniformScale"], 'nodule:type', '' )
__children["SameInputForXYZ"]["__uiPosition"].setValue( imath.V2f( 12.3499975, 8.24648571 ) )
__children["SameInputForXYZ"]["Sphere"]["transform"]["scale"]["x"].setInput( __children["SameInputForXYZ"]["uniformScale"] )
__children["SameInputForXYZ"]["Sphere"]["transform"]["scale"]["y"].setInput( __children["SameInputForXYZ"]["uniformScale"] )
__children["SameInputForXYZ"]["Sphere"]["transform"]["scale"]["z"].setInput( __children["SameInputForXYZ"]["uniformScale"] )
__children["SameInputForXYZ"]["Sphere"]["__uiPosition"].setValue( imath.V2f( 14.5, 2.04999995 ) )
__children["SameInputForXYZ"]["BoxOut"]["in"].setInput( __children["SameInputForXYZ"]["Sphere"]["out"] )
Gaffer.Metadata.registerValue( __children["SameInputForXYZ"]["BoxOut"]["__out"], 'description', 'The output scene.' )
Gaffer.Metadata.registerValue( __children["SameInputForXYZ"]["BoxOut"]["__out"], 'nodule:type', 'GafferUI::StandardNodule' )
__children["SameInputForXYZ"]["BoxOut"]["__uiPosition"].setValue( imath.V2f( 15.99928, -6.28203106 ) )
__children["SameInputForXYZ"]["out"].setInput( __children["SameInputForXYZ"]["BoxOut"]["__out"] )
Gaffer.Metadata.registerValue( __children["SameInputForXYZ"]["out"], 'description', 'The output scene.' )
Gaffer.Metadata.registerValue( __children["SameInputForXYZ"]["out"], 'nodule:type', 'GafferUI::StandardNodule' )
Gaffer.Metadata.registerValue( __children["SameInputForXYZ"]["uniformScale"], 'nodule:type', '' )


del __children
```

</details>
