### PR TITLE
Update to GafferHQ/dependencies 8.0.0a1

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -48,7 +48,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.5.4.2/cortex-10.5.4.2-{platform}-python3.{extension}".format(
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/8.0.0a1/gafferDependencies-8.0.0a1-{platform}.{extension}".format(
 	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,11 @@ Breaking Changes
 - Windows launch script : Removed the hardcoded `/debugexe` switch used when `GAFFER_DEBUG` is enabled, making it possible to use debuggers other than Visual Studio. Debug switches can be added to the `GAFFER_DEBUGGER` environment variable instead.
 - Enums : Replaced `IECore.Enum` types with standard Python types from the `enum` module.
 
+Build
+-----
+
+- PsUtil : Added version 5.9.6.
+
 1.3.x.x (relative to 1.3.8.0)
 =======
 

--- a/apps/stats/stats-1.py
+++ b/apps/stats/stats-1.py
@@ -45,7 +45,7 @@ import contextlib
 if sys.platform != "win32":
 	import resource
 else:
-	import subprocess
+	import psutil
 
 import IECore
 
@@ -746,8 +746,7 @@ class _Memory( object ) :
 		if sys.platform == "darwin" :
 			return cls( resource.getrusage( resource.RUSAGE_SELF ).ru_maxrss )
 		elif sys.platform == "win32" :
-			result = subprocess.check_output( ["wmic", "process", "where", "processid={}".format(os.getpid()), "get", "PeakWorkingSetSize"] )
-			return cls( int( result.split()[1] ) * 1024 )
+			return cls( psutil.Process().memory_info().peak_wset )
 		else :
 			return cls( resource.getrusage( resource.RUSAGE_SELF ).ru_maxrss * 1024 )
 

--- a/startup/Gaffer/cache.py
+++ b/startup/Gaffer/cache.py
@@ -34,21 +34,13 @@
 #
 ##########################################################################
 
-import os
+import psutil
+
 import Gaffer
 
 # Set cache memory limit to 8 gigs, capped at 3/4 of the total
 # physical memory.
 
-cacheLimit = 1024**3 * 8 # 8 Gigs
-
-if os.name != "nt" :
-	physicalMemory = os.sysconf( "SC_PAGE_SIZE" ) * os.sysconf( "SC_PHYS_PAGES" )
-	cacheLimit = min( cacheLimit, physicalMemory * 3 // 4  )
-else :
-	# No native Python API for querying physical memory on Windows.
-	# And surely nobody is brave enough to use Windows with less
-	# than 8 gigs ;)
-	pass
-
-Gaffer.ValuePlug.setCacheMemoryLimit( cacheLimit )
+Gaffer.ValuePlug.setCacheMemoryLimit(
+	min( 1024**3 * 8, psutil.virtual_memory().total * 3 // 4 )
+)


### PR DESCRIPTION
Currently the only difference in the dependencies is the addition of the `psutil` Python module, which I want for work I'm doing on #5557. But this is also the thin end of the wedge of dependencies changes we're planning for the 1.4 release, which should include an update to Python, the C++ ABI and the build platform.