### PR TITLE
Cycles : Update to version 4.0.2

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - CropWindowTool : Added <kbd>`Alt` + <kbd>`C` for toggling both the crop window tool and the relevant crop window `enabled` plug.
 - TaskList, FrameMask : Reimplemented in C++ for improved performance.
 - Cache : Increased default computation cache size to 8Gb. Call `Gaffer.ValuePlug.setCacheMemoryLimit()` from a startup file to override this.
+- Cycles : Updated to version 4.0.2.
 
 API
 ---

--- a/SConstruct
+++ b/SConstruct
@@ -1311,7 +1311,7 @@ libraries = {
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
-				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex", "openpgl",
+				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : [
@@ -1329,7 +1329,7 @@ libraries = {
 				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
 				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky",
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
-				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree3", "Iex", "openpgl",
+				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : [

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -80,11 +80,11 @@ class RendererTest( GafferTest.TestCase ) :
 				"render:displayColor" : IECore.Color3fData( imath.Color3f( 1, 0.5, 0.25 ) ),
 				"cycles:surface" : IECoreScene.ShaderNetwork(
 					shaders = {
-						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface" ),
+						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "emission_strength" : 1 } ),
 						"info" : IECoreScene.Shader( "object_info", "cycles:shader" )
 					},
 					connections = [
-						( ( "info", "color" ), ( "output", "emission" ) )
+						( ( "info", "color" ), ( "output", "emission_color" ) )
 					],
 					output = "output",
 				)
@@ -551,11 +551,11 @@ class RendererTest( GafferTest.TestCase ) :
 			renderer.attributes( IECore.CompoundObject ( {
 				"cycles:surface" : IECoreScene.ShaderNetwork(
 					shaders = {
-						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface" ),
+						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "emission_strength" : 1 } ),
 						"attribute" : IECoreScene.Shader( "attribute", "cycles:shader", { "attribute" : "N" } ),
 					},
 					connections = [
-						( ( "attribute", "color" ), ( "output", "emission" ) ),
+						( ( "attribute", "color" ), ( "output", "emission_color" ) ),
 					],
 					output = "output",
 				)
@@ -733,11 +733,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 		shader = IECoreScene.ShaderNetwork(
 			shaders = {
-				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
 				"attribute" : IECoreScene.Shader( "attribute", "cycles:shader", { "attribute" : attributeName } ),
 			},
 			connections = [
-				( ( "attribute", "color" ), ( "output", "emission" ) ),
+				( ( "attribute", "color" ), ( "output", "emission_color" ) ),
 			],
 			output = "output",
 		)
@@ -1187,11 +1187,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 		shader = IECoreScene.ShaderNetwork(
 			shaders = {
-				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface" ),
+				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "emission_strength" : 1 } ),
 				"texture" : IECoreScene.Shader( "image_texture", "cycles:shader", { "filename" : "<attr:textureFileName>" } )
 			},
 			connections = [
-				( ( "texture", "color" ), ( "output", "emission" ) )
+				( ( "texture", "color" ), ( "output", "emission_color" ) )
 			],
 			output = "output",
 		)
@@ -1283,11 +1283,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 		shader = IECoreScene.ShaderNetwork(
 			shaders = {
-				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+				"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
 				"attribute" : IECoreScene.Shader( "attribute", "cycles:shader", { "attribute" : attribute } ),
 			},
 			connections = [
-				( ( "attribute", outputPlug ), ( "output", "emission" ) ),
+				( ( "attribute", outputPlug ), ( "output", "emission_color" ) ),
 				( ( "attribute", "alpha" ), ( "output", "alpha" ) )
 			],
 			output = "output",
@@ -1359,11 +1359,11 @@ class RendererTest( GafferTest.TestCase ) :
 				"render:user:testColor" : IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ),
 				"cycles:surface" : IECoreScene.ShaderNetwork(
 					shaders = {
-						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
 						"attribute" : IECoreScene.Shader( "attribute", "cycles:shader", { "attribute" : "user:testColor" } ),
 					},
 					connections = [
-						( ( "attribute", "color" ), ( "output", "emission" ) )
+						( ( "attribute", "color" ), ( "output", "emission_color" ) )
 					],
 					output = "output",
 				)
@@ -1476,13 +1476,13 @@ class RendererTest( GafferTest.TestCase ) :
 			renderer.attributes( IECore.CompoundObject ( {
 				"cycles:surface" : IECoreScene.ShaderNetwork(
 					shaders = {
-						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+						"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
 						"multiplyColor" : IECoreScene.Shader( "Maths/MultiplyColor", "osl:shader", { "b" : imath.Color3f( 0, 0, 0 ) } ),
 						"multiplyFloat" : IECoreScene.Shader( "Maths/MultiplyFloat", "osl:shader" ),
 					},
 					connections = [
 						( ( "multiplyFloat", "out" ), ( "multiplyColor", "b.b" ) ),
-						( ( "multiplyColor", "out" ), ( "output", "emission" ) ),
+						( ( "multiplyColor", "out" ), ( "output", "emission_color" ) ),
 					],
 					output = "output",
 				)
@@ -1530,7 +1530,7 @@ class RendererTest( GafferTest.TestCase ) :
 					shaders = {
 						"output" : IECoreScene.Shader(
 							"principled_bsdf", "cycles:shader",
-							{ "emission" : imath.Color3f( 1, 0, 1 ) }
+							{ "emission_color" : imath.Color3f( 1, 0, 1 ), "emission_strength" : 1 }
 						),
 					},
 					output = "output",
@@ -1729,13 +1729,13 @@ class RendererTest( GafferTest.TestCase ) :
 
 			shader = IECoreScene.ShaderNetwork(
 				shaders = {
-					"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) } ),
+					"output" : IECoreScene.Shader( "principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 } ),
 					"value" : IECoreScene.Shader( "value", "cycles:shader", { "value" : value } ),
 					"converter" : IECoreScene.Shader( "convert_float_to_color", "cycles:shader" ),
 				},
 				connections = [
 					( ( "value", "value" ), ( "converter", "value_float" ) ),
-					( ( "converter", "value_color" ), ( "output", "emission" ) ),
+					( ( "converter", "value_color" ), ( "output", "emission_color" ) ),
 				],
 				output = "output",
 			)
@@ -1755,7 +1755,7 @@ class RendererTest( GafferTest.TestCase ) :
 				shaders = {
 					"output" : IECoreScene.Shader(
 						"principled_bsdf", "cycles:surface",
-						{ "base_color" : imath.Color3f( 0 ), "emission" : value }
+						{ "base_color" : imath.Color3f( 0 ), "emission_color" : value, "emission_strength" : 1 }
 					),
 				},
 				output = "output",
@@ -1778,11 +1778,11 @@ class RendererTest( GafferTest.TestCase ) :
 						"convert_vector_to_color", "cycles:shader", { "value_vector" : value }
 					),
 					"output" : IECoreScene.Shader(
-						"principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) }
+						"principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 }
 					),
 				},
 				connections = [
-					( ( "converter", "value_color" ), ( "output", "emission" ) )
+					( ( "converter", "value_color" ), ( "output", "emission_color" ) )
 				],
 				output = "output",
 			)
@@ -1807,12 +1807,12 @@ class RendererTest( GafferTest.TestCase ) :
 					}
 				),
 				"output" : IECoreScene.Shader(
-					"principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ) }
+					"principled_bsdf", "cycles:surface", { "base_color" : imath.Color3f( 0 ), "emission_strength" : 1 }
 				),
 			},
 			connections = [
 				( ( "coordinates", "UV.x" ), ( "ramp", "fac" ) ),
-				( ( "ramp", "color" ), ( "output", "emission" ) ),
+				( ( "ramp", "color" ), ( "output", "emission_color" ) ),
 			],
 			output = "output",
 		)
@@ -1834,7 +1834,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		for name, value in {
-			"sheen" : IECore.StringData( "iShouldBeAFloat" ),
+			"sheen_weight" : IECore.StringData( "iShouldBeAFloat" ),
 			"base_color" : IECore.StringData( "iShouldBeAColor" ),
 			"normal" : IECore.StringData( "iShouldBeAV3f" ),
 			"subsurface_method" : IECore.Color3fData( imath.Color3f( 10 ) ),

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2208,11 +2208,6 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 				return;
 			ccl::Transform tfm = SocketAlgo::setTransform( transform );
 			light->set_tfm( tfm );
-			// To feed into area lights
-			light->set_axisu( ccl::transform_get_column(&tfm, 0) );
-			light->set_axisv( ccl::transform_get_column(&tfm, 1) );
-			light->set_co( ccl::transform_get_column(&tfm, 3) );
-			light->set_dir( -ccl::transform_get_column(&tfm, 2) );
 
 			light->tag_update( m_session->scene );
 		}

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -387,8 +387,6 @@ py::dict getLights()
 			}
 			else if( type == "area_light" )
 			{
-				in["axisu"] = _in["axisu"];
-				in["axisv"] = _in["axisv"];
 				in["sizeu"] = _in["sizeu"];
 				in["sizev"] = _in["sizev"];
 				in["spread"] = _in["spread"];


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Updates Cycles to 4.0.2 absolute minimum changes. Embree 4 commit separated if we go with embree 3.

### Related issues ###

- NA

### Dependencies ###

- https://github.com/GafferHQ/dependencies/pull/246

### Breaking changes ###

- Cycles API changed, no more axisu/axisv in the python bindings for quad lights
- The default PrincipledBSDF shader has changed and will need a compatibility script (maybe other shaders?)

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
