### PR TITLE
SetEditor : Display and filter by selected set members

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,9 @@ Improvements
 ------------
 
 - 3Delight : Added support for subdivision corners and creases.
+- SetEditor :
+  - Added "Selection" column displaying the number of currently selected members for each set.
+  - Added "Hide Empty Selection" checkbox. When on, the SetEditor will only display sets with currently selected members.
 
 Fixes
 -----

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -75,8 +75,8 @@ class SetEditor( GafferUI.NodeSetEditor ) :
 				GafferUI.BasicPathFilterWidget( emptySetFilter )
 				GafferUI.BasicPathFilterWidget( emptySelectionFilter )
 
-			self.__setMembersColumn = GafferUI.StandardPathColumn( "Members", "setPath:memberCount" )
-			self.__selectedSetMembersColumn = GafferUI.StandardPathColumn( "Selection", "setPath:selectedMemberCount" )
+			self.__setMembersColumn = _GafferSceneUI._SetEditor.SetMembersColumn()
+			self.__selectedSetMembersColumn = _GafferSceneUI._SetEditor.SetSelectionColumn()
 			self.__includedSetMembersColumn = _GafferSceneUI._SetEditor.VisibleSetInclusionsColumn( scriptNode.context() )
 			self.__excludedSetMembersColumn = _GafferSceneUI._SetEditor.VisibleSetExclusionsColumn( scriptNode.context() )
 			self.__pathListing = GafferUI.PathListingWidget(

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -58,11 +58,11 @@ class SetEditor( GafferUI.NodeSetEditor ) :
 
 		searchFilter = _GafferSceneUI._SetEditor.SearchFilter()
 		emptySetFilter = _GafferSceneUI._SetEditor.EmptySetFilter()
-		emptySetFilter.userData()["UI"] = { "label" : "Hide Empty" }
+		emptySetFilter.userData()["UI"] = { "label" : "Hide Empty Members", "toolTip" : "Hide sets with no members" }
 		emptySetFilter.setEnabled( False )
 
 		emptySelectionFilter = _GafferSceneUI._SetEditor.EmptySetFilter( propertyName = "setPath:selectedMemberCount" )
-		emptySelectionFilter.userData()["UI"] = { "label" : "Hide Empty Selection" }
+		emptySelectionFilter.userData()["UI"] = { "label" : "Hide Empty Selection", "toolTip" : "Hide sets with no selected members or descendants" }
 		emptySelectionFilter.setEnabled( False )
 
 		self.__filter = Gaffer.CompoundPathFilter( [ searchFilter, emptySetFilter, emptySelectionFilter ] )

--- a/python/GafferUI/PathFilterWidget.py
+++ b/python/GafferUI/PathFilterWidget.py
@@ -127,6 +127,11 @@ class BasicPathFilterWidget( PathFilterWidget ) :
 			invertEnabled = self.pathFilter().userData()["UI"]["invertEnabled"].value
 		self.__checkBox.setState( self.pathFilter().getEnabled() is not invertEnabled )
 
+		toolTip = ""
+		with IECore.IgnoredExceptions( KeyError ) :
+			toolTip = self.pathFilter().userData()["UI"]["toolTip"].value
+		self.__checkBox.setToolTip( toolTip )
+
 	def __stateChanged( self, checkBox ) :
 
 		invertEnabled = False


### PR DESCRIPTION
This adds a new "Selection" column and "Hide Empty Selection" checkbox to the Set Editor. These display the number of currently selected scene locations that are a member of each set, and allow the list of sets to be filtered to only display those with currently selected members. These aim to aid in introspection of scenes containing large numbers of sets, where a user may only be currently interested in the sets a selection of scene locations are a member of.

https://github.com/GafferHQ/gaffer/assets/50844517/703a3f34-b717-4351-87e6-e916a47208d8

