### PR TITLE
HierarchyView, SetEditor : Improve comments surrounding context copies

### DIFF
--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -160,10 +160,15 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 			f.setScene( self.__plug )
 
 		if self.__plug is not None :
-			# We take a static copy of our current context for use in the ScenePath - this prevents the
-			# PathListing from updating automatically when the original context changes, and allows us to take
-			# control of updates ourselves in _updateFromContext(), using LazyMethod to defer the calls to this
-			# function until we are visible and playback has stopped.
+			# We take a static copy of our current context for use in the ScenePath for two reasons :
+			#
+			# 1. To prevent the PathListing from updating automatically when the original context
+			#    changes, which allows us to take control of updates ourselves in `_updateFromContext()`,
+			#    using LazyMethod to defer the calls to this function until we are visible and
+			#    playback has stopped.
+			# 2. Because the PathListingWidget uses a BackgroundTask to evaluate the Path, and it
+			#    would not be thread-safe to directly reference a context that could be modified by
+			#    the UI thread at any time.
 			contextCopy = Gaffer.Context( self.getContext() )
 			for f in self.__filter.getFilters() :
 				f.setContext( contextCopy )

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -128,12 +128,13 @@ class SetEditor( GafferUI.NodeSetEditor ) :
 	def __updatePathListingPath( self ) :
 
 		if self.__plug is not None :
-			# We take a static copy of our current context for use in the SetPath - this prevents the
-			# PathListing from updating automatically when the original context changes, and allows us to take
-			# control of updates ourselves in _updateFromContext(), using LazyMethod to defer the calls to this
-			# function until we are visible and playback has stopped.
-			## \todo This may no longer be necessary now that the PathListingWidget updates asynchronously and
-			# doesn't update when hidden.
+			# We take a static copy of our current context for use in the SetPath for two reasons :
+			#
+			# 1. To prevent the PathListing from updating automatically when the original context
+			#    changes, allowing us to use LazyMethod to defer updates until playback stops.
+			# 2. Because the PathListingWidget uses a BackgroundTask to evaluate the Path, and it
+			#    would not be thread-safe to directly reference a context that could be modified by
+			#    the UI thread at any time.
 			contextCopy = Gaffer.Context( self.getContext() )
 			self.__searchFilterWidget.setScene( self.__plug )
 			self.__searchFilterWidget.setContext( contextCopy )


### PR DESCRIPTION
The SetEditor one in particular was misleading, and both benefit from spelling out the important thread-safety reason for taking a static copy of the context.

This was prompted by reviewing #5580, worrying about the thread-safety of the context accesses, and realising it was fine but perilously close to being lost if the todo in SetEditor was done.