### PR TITLE
Switch : Fix context used when managing internal connection

### DIFF
--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -109,7 +109,7 @@ class GAFFER_API Switch : public ComputeNode
 		void childAdded( GraphComponent *child );
 		void plugSet( Plug *plug );
 		void plugInputChanged( Plug *plug );
-		size_t inputIndex( const Context *context = nullptr ) const;
+		size_t inputIndex( const Context *context ) const;
 
 		// Returns the input corresponding to the output and vice versa. Returns null
 		// if plug is not meaningful to the switching process.

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -55,6 +55,8 @@ namespace
 const IECore::InternedString g_inPlugsName( "in" );
 const IECore::InternedString g_outPlugName( "out" );
 
+ConstContextPtr g_defaultContext = new Context;
+
 } // namespace
 
 GAFFER_NODE_DEFINE_TYPE( Switch );
@@ -423,6 +425,12 @@ void Switch::updateInternalConnection()
 		return;
 	}
 
-	Plug *in = const_cast<Plug *>( oppositePlug( out, Context::current() ) );
+	// The context is irrelevant since we've already checked that `indexPlug()`
+	// and `enabledPlug()` aren't computed. But we need to pass _something_ non-null
+	// because that is how we tell `oppositePlug()` we want it to take the index
+	// into account. And we need to scope this default context too - see
+	// `SwitchTest.testInternalConnectionWithTypeConversionAndCanceller()`.
+	Context::Scope scope( g_defaultContext.get() );
+	Plug *in = const_cast<Plug *>( oppositePlug( out, g_defaultContext.get() ) );
 	out->setInput( in );
 }

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -49,8 +49,13 @@
 using namespace boost::placeholders;
 using namespace Gaffer;
 
-static IECore::InternedString g_inPlugsName( "in" );
-static IECore::InternedString g_outPlugName( "out" );
+namespace
+{
+
+const IECore::InternedString g_inPlugsName( "in" );
+const IECore::InternedString g_outPlugName( "out" );
+
+} // namespace
 
 GAFFER_NODE_DEFINE_TYPE( Switch );
 


### PR DESCRIPTION
This concludes my lengthy investigation into the strange `Unexpected message : ERROR : Emitting signal : Unknown error` CI failures we've been seeing on `main` lately. See the final commit message for all the gory details.