### PR TITLE
StandardPathColumn, IconPathColumn : Support full CellData in header

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,15 @@ Fixes
 API
 ---
 
-- PathColumn : Added `CellData::sortValue` member, to provide additional control over sorting in the PathListingWidget.
+- PathColumn :
+  - Added `CellData::sortValue` member, to provide additional control over sorting in the PathListingWidget.
+  - Added missing Python binding for `headerData()` method.
+- StandardPathColumn :
+  - Added constructor which allows the full header CellData to be specified.
+  - Added missing Python binding for `property()` method.
+- IconPathColumn :
+  - Added constructor which allows the full header CellData to be specified.
+  - Added `prefix()` and `property()` accessors.
 - LocalDispatcher :
   - Added `Job.status()` and `Job.statusChangedSignal()` methods.
   - Added `Job.messages()` and `Job.messagesChangedSignal()` methods.

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -179,6 +179,7 @@ class GAFFERUI_API StandardPathColumn : public PathColumn
 		IE_CORE_DECLAREMEMBERPTR( StandardPathColumn )
 
 		StandardPathColumn( const std::string &label, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
+		StandardPathColumn( const CellData &headerData, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
 
 		IECore::InternedString property() const;
 
@@ -187,7 +188,7 @@ class GAFFERUI_API StandardPathColumn : public PathColumn
 
 	private :
 
-		IECore::ConstStringDataPtr m_label;
+		const CellData m_headerData;
 		IECore::InternedString m_property;
 
 };
@@ -209,13 +210,17 @@ class GAFFERUI_API IconPathColumn : public PathColumn
 		/// - IntData, UInt44Data
 		/// - BoolData
 		IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
+		IconPathColumn( const CellData &headerData, const std::string &prefix, IECore::InternedString property, PathColumn::SizeMode sizeMode = Default );
+
+		const std::string &prefix() const;
+		IECore::InternedString property() const;
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
 		CellData headerData( const IECore::Canceller *canceller ) const override;
 
 	private :
 
-		IECore::ConstStringDataPtr m_label;
+		const CellData m_headerData;
 		std::string m_prefix;
 		IECore::InternedString m_property;
 

--- a/python/GafferUITest/PathColumnTest.py
+++ b/python/GafferUITest/PathColumnTest.py
@@ -96,5 +96,39 @@ class PathColumnTest( GafferUITest.TestCase ) :
 		p.setSizeMode( GafferUI.PathColumn.SizeMode.Interactive )
 		self.assertEqual( p.getSizeMode(), GafferUI.PathColumn.SizeMode.Interactive )
 
+	def testStandardPathColumnConstructors( self ) :
+
+		c = GafferUI.StandardPathColumn( "label", "property" )
+		self.assertEqual( c.property(), "property" )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
+		self.assertEqual( c.headerData().value, "label" )
+
+		c = GafferUI.StandardPathColumn(
+			GafferUI.PathColumn.CellData( value = "label", toolTip = "help!" ),
+			"property", GafferUI.PathColumn.SizeMode.Stretch
+		)
+		self.assertEqual( c.property(), "property" )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
+		self.assertEqual( c.headerData().value, "label" )
+		self.assertEqual( c.headerData().toolTip, "help!" )
+
+	def testIconPathColumnConstructors( self ) :
+
+		c = GafferUI.IconPathColumn( "label", "prefix", "property" )
+		self.assertEqual( c.prefix(), "prefix" )
+		self.assertEqual( c.property(), "property" )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
+		self.assertEqual( c.headerData().value, "label" )
+
+		c = GafferUI.IconPathColumn(
+			GafferUI.PathColumn.CellData( value = "label", toolTip = "help!" ),
+			"prefix", "property", GafferUI.PathColumn.SizeMode.Stretch
+		)
+		self.assertEqual( c.prefix(), "prefix" )
+		self.assertEqual( c.property(), "property" )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
+		self.assertEqual( c.headerData().value, "label" )
+		self.assertEqual( c.headerData().toolTip, "help!" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -115,7 +115,12 @@ PathColumn::ButtonSignal &PathColumn::buttonDoubleClickSignal()
 //////////////////////////////////////////////////////////////////////////
 
 StandardPathColumn::StandardPathColumn( const std::string &label, IECore::InternedString property, SizeMode sizeMode )
-	:	PathColumn( sizeMode ), m_label( new IECore::StringData( label ) ), m_property( property )
+	:	StandardPathColumn( CellData( new StringData( label ) ), property, sizeMode )
+{
+}
+
+StandardPathColumn::StandardPathColumn( const CellData &headerData, IECore::InternedString property, PathColumn::SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_headerData( headerData ), m_property( property )
 {
 }
 
@@ -159,7 +164,7 @@ PathColumn::CellData StandardPathColumn::cellData( const Gaffer::Path &path, con
 
 PathColumn::CellData StandardPathColumn::headerData( const IECore::Canceller *canceller ) const
 {
-	return CellData( m_label );
+	return m_headerData;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -167,8 +172,23 @@ PathColumn::CellData StandardPathColumn::headerData( const IECore::Canceller *ca
 //////////////////////////////////////////////////////////////////////////
 
 IconPathColumn::IconPathColumn( const std::string &label, const std::string &prefix, IECore::InternedString property, SizeMode sizeMode )
-	:	PathColumn( sizeMode ), m_label( new StringData( label ) ), m_prefix( prefix ), m_property( property )
+	:	IconPathColumn( CellData( new StringData( label ) ), prefix, property, sizeMode )
 {
+}
+
+IconPathColumn::IconPathColumn( const CellData &headerData, const std::string &prefix, IECore::InternedString property, PathColumn::SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_headerData( headerData ), m_prefix( prefix ), m_property( property )
+{
+}
+
+const std::string &IconPathColumn::prefix() const
+{
+	return m_prefix;
+}
+
+IECore::InternedString IconPathColumn::property() const
+{
+	return m_property;
 }
 
 PathColumn::CellData IconPathColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
@@ -207,7 +227,7 @@ PathColumn::CellData IconPathColumn::cellData( const Gaffer::Path &path, const I
 
 PathColumn::CellData IconPathColumn::headerData( const IECore::Canceller *canceller ) const
 {
-	return CellData( m_label );
+	return m_headerData;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -270,6 +270,12 @@ PathColumn::CellData cellDataWrapper( PathColumn &pathColumn, const Path &path, 
 	return pathColumn.cellData( path, canceller );
 }
 
+PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Canceller *canceller )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return pathColumn.headerData( canceller );
+}
+
 struct ChangedSignalSlotCaller
 {
 	void operator()( boost::python::object slot, PathColumnPtr c )
@@ -313,6 +319,12 @@ struct ButtonSignalSlotCaller
 		}
 	}
 };
+
+template<typename T>
+const char *pathColumnProperty( const T &column )
+{
+	return column.property().c_str();
+}
 
 } // namespace
 
@@ -363,6 +375,7 @@ void GafferUIModule::bindPathColumn()
 	pathColumnClass.def( init<PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::SizeMode::Default ) )
 		.def( "changedSignal", &PathColumn::changedSignal, return_internal_reference<1>() )
 		.def( "cellData", &cellDataWrapper, ( arg( "path" ), arg( "canceller" ) = object() ) )
+		.def( "headerData", &headerDataWrapper, ( arg( "canceller" ) = object() ) )
 		.def( "buttonPressSignal", &PathColumn::buttonPressSignal, return_internal_reference<1>() )
 		.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
 		.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )
@@ -372,10 +385,15 @@ void GafferUIModule::bindPathColumn()
 
 	IECorePython::RefCountedClass<StandardPathColumn, PathColumn>( "StandardPathColumn" )
 		.def( init<const std::string &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
+		.def( init<const PathColumn::CellData &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
+		.def( "property", &pathColumnProperty<StandardPathColumn> )
 	;
 
 	IECorePython::RefCountedClass<IconPathColumn, PathColumn>( "IconPathColumn" )
 		.def( init<const std::string &, const std::string &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
+		.def( init<const PathColumn::CellData &, const std::string &, IECore::InternedString, PathColumn::SizeMode>( arg( "sizeMode" ) = PathColumn::Default ) )
+		.def( "prefix", &IconPathColumn::prefix, return_value_policy<copy_const_reference>() )
+		.def( "property", &pathColumnProperty<IconPathColumn> )
 	;
 
 	IECorePython::RefCountedClass<FileIconPathColumn, PathColumn>( "FileIconPathColumn" )


### PR DESCRIPTION
We didn't need this for #5580 in the end, but we do reckon it'll be handy for other stuff in future.