### PR TITLE
GUI Config : Add LocalDispatcher shutdown checks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - IconPathColumn :
   - Added constructor which allows the full header CellData to be specified.
   - Added `prefix()` and `property()` accessors.
+- Window : Added `preCloseSignal()`, which allows connected slots to prevent a window from being closed.
 - LocalDispatcher :
   - Added `Job.status()` and `Job.statusChangedSignal()` methods.
   - Added `Job.messages()` and `Job.messagesChangedSignal()` methods.

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
   - Added a new dockable LocalJobs editor, to replace the floating window previously accessible via the "Execute/Local Jobs" menu item.
   - Task output is now shown in the UI.
   - Jobs are no longer removed from the UI as soon as they complete.
+  - Incomplete jobs are now killed automatically when the application is closed, after prompting to confirm that shutdown should go ahead.
 - Cache : Increased default computation cache size to 8Gb. Call `Gaffer.ValuePlug.setCacheMemoryLimit()` from a startup file to override this.
 - Dispatcher : Reduced internal overhead of `dispatch()` call, with one benchmark showing around a 3x speedup.
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
   - Incomplete jobs are now killed automatically when the application is closed, after prompting to confirm that shutdown should go ahead.
 - Cache : Increased default computation cache size to 8Gb. Call `Gaffer.ValuePlug.setCacheMemoryLimit()` from a startup file to override this.
 - Dispatcher : Reduced internal overhead of `dispatch()` call, with one benchmark showing around a 3x speedup.
+- ScriptWindow : Added "Save" option to dialogue shown when closing a window containing unsaved changes.
 
 Fixes
 -----

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -94,6 +94,7 @@ class Window( GafferUI.ContainerWidget ) :
 		else :
 			self.setSizeMode( sizeMode )
 
+		self.__preCloseSignal = GafferUI.WidgetSignal()
 		self.__closedSignal = GafferUI.WidgetSignal()
 
 		self.setChild( child )
@@ -359,12 +360,18 @@ class Window( GafferUI.ContainerWidget ) :
 		if not self.getVisible() :
 			return False
 
-		if self._acceptsClose() :
+		if self._acceptsClose() and not self.__preCloseSignal( self ) :
 			self.setVisible( False )
 			self.closedSignal()( self )
 			return True
 		else :
 			return False
+
+	## Emitted when `close()` is called. Slots may return `True` to prevent
+	# the window from being closed.
+	def preCloseSignal( self ) :
+
+		return self.__preCloseSignal
 
 	## Subclasses may override this to deny the closing of a window triggered
 	# either by user action or by a call to close(). Simply return False to

--- a/python/GafferUITest/WindowTest.py
+++ b/python/GafferUITest/WindowTest.py
@@ -46,6 +46,7 @@ import imath
 import IECore
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -458,6 +459,31 @@ class WindowTest( GafferUITest.TestCase ) :
 
 			# If the bug is fixed, nothing should have been printed.
 			self.assertEqual( tmpStdErr.getvalue(), "" )
+
+	def testPreCloseSignal( self ) :
+
+		window = GafferUI.Window()
+		window.setVisible( True )
+
+		preCloseSlotResult = True
+		def preCloseSlot( w ) :
+
+			nonlocal preCloseSlotResult
+			return preCloseSlotResult
+
+		window.preCloseSignal().connect( preCloseSlot, scoped = False )
+		preCloseCapturingSlot = GafferTest.CapturingSlot( window.preCloseSignal() )
+		closedSlot = GafferTest.CapturingSlot( window.closedSignal() )
+
+		self.assertFalse( window.close() )
+		self.assertEqual( len( preCloseCapturingSlot ), 0 )
+		self.assertEqual( len( closedSlot ), 0 )
+
+		preCloseSlotResult = False
+
+		self.assertTrue( window.close() )
+		self.assertEqual( len( preCloseCapturingSlot ), 1 )
+		self.assertEqual( len( closedSlot ), 1 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/gui/localDispatcher.py
+++ b/startup/gui/localDispatcher.py
@@ -36,6 +36,52 @@
 
 import Gaffer
 import GafferDispatch
+import GafferUI
+import GafferDispatchUI
 
 Gaffer.Metadata.registerValue( GafferDispatch.LocalDispatcher, "executeInBackground", "userDefault", True )
 GafferDispatch.Dispatcher.setDefaultDispatcherType( "Local" )
+
+def __scriptWindowPreClose( scriptWindow ) :
+
+	numScripts = len( scriptWindow.scriptNode().parent() )
+	if numScripts > 1 :
+		return False
+
+	# The last window is about to be closed, which will quit the
+	# application. Check for LocalJobs that are still running,
+	# and prompt the user.
+
+	incompleteJobs = [
+		job for job in
+		GafferDispatch.LocalDispatcher.defaultJobPool().jobs()
+		if job.status() in (
+			GafferDispatch.LocalDispatcher.Job.Status.Waiting,
+			GafferDispatch.LocalDispatcher.Job.Status.Running,
+		)
+	]
+
+	if len( incompleteJobs ) == 0 :
+		return False
+
+	dialogue = GafferUI.ConfirmationDialogue(
+		"Kill Incomplete Jobs?",
+		"{} LocalDispatcher job{} still running and will be killed".format(
+			len( incompleteJobs ),
+			"s are" if len( incompleteJobs ) > 1 else " is"
+		),
+		confirmLabel = "Kill"
+	)
+
+	# If `Cancel` was pressed, prevent the window from being closed.
+	return dialogue.waitForConfirmation( parentWindow = scriptWindow ) == False
+
+def __scriptAdded( container, script ) :
+
+	window = GafferUI.ScriptWindow.acquire( script, createIfNecessary = False )
+	if window is None :
+		return
+
+	window.preCloseSignal().connect( __scriptWindowPreClose, scoped = False )
+
+application.root()["scripts"].childAddedSignal().connect( __scriptAdded, scoped = False )


### PR DESCRIPTION
This is a follow up to #5557, adding a prompt at shutdown if there are any LocalDispatcher jobs still running. It required rejigging the Quit action so that it prompts once per window with unsaved changes rather than once for all such windows. But hopefully the potential inconvenience of that is more than offset by the addition of a "Save" button into those prompts, so you can save during quit rather than cancelling, saving and quitting again.

I wasn't sure where a bunch of this code belonged so I've taken the most non-commital approach, leaving old stuff where it was and not adding new stuff (other than `preCloseSignal()` to the public API. 