### PR TITLE
GafferSceneUI : Add OptionInspector

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.x.x (relative to 1.3.9.0)
 =======
 
+API
+---
 
+- EditScopeAlgo : Added support for editing options for a specific render pass.
 
 1.3.9.0 (relative to 1.3.8.0)
 =======

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -149,6 +149,17 @@ GAFFERSCENE_API Gaffer::TweakPlug *acquireOptionEdit( Gaffer::EditScope *scope, 
 GAFFERSCENE_API void removeOptionEdit( Gaffer::EditScope *scope, const std::string &option );
 GAFFERSCENE_API const Gaffer::GraphComponent *optionEditReadOnlyReason( const Gaffer::EditScope *scope, const std::string &option );
 
+
+// Render Pass Options
+// ===================
+//
+// These methods edit scene options for a particular render pass.
+
+GAFFERSCENE_API bool hasRenderPassOptionEdit( const Gaffer::EditScope *scope, const std::string &renderPass, const std::string &option );
+GAFFERSCENE_API Gaffer::TweakPlug *acquireRenderPassOptionEdit( Gaffer::EditScope *scope, const std::string &renderPass, const std::string &option, bool createIfNecessary = true );
+GAFFERSCENE_API void removeRenderPassOptionEdit( Gaffer::EditScope *scope, const std::string &renderPass, const std::string &option );
+GAFFERSCENE_API const Gaffer::GraphComponent *renderPassOptionEditReadOnlyReason( const Gaffer::EditScope *scope, const std::string &renderPass, const std::string &option );
+
 } // namespace EditScopeAlgo
 
 } // namespace GafferScene

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -1,0 +1,84 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferSceneUI/Export.h"
+
+#include "GafferSceneUI/Private/Inspector.h"
+
+namespace GafferSceneUI
+{
+
+namespace Private
+{
+
+class GAFFERSCENEUI_API OptionInspector : public Inspector
+{
+
+	public :
+
+		OptionInspector(
+			const GafferScene::ScenePlugPtr &scene,
+			const Gaffer::PlugPtr &editScope,
+			IECore::InternedString option
+		);
+
+		IE_CORE_DECLAREMEMBERPTR( OptionInspector );
+
+	protected :
+
+		GafferScene::SceneAlgo::History::ConstPtr history() const override;
+		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
+		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
+		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+
+	private :
+
+		void plugDirtied( Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
+
+		const GafferScene::ScenePlugPtr m_scene;
+		const IECore::InternedString m_option;
+
+};
+
+IE_CORE_DECLAREPTR( OptionInspector )
+
+}  // namespace Private
+
+}  // namespace GafferSceneUI

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -54,12 +54,12 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		self.assertEqual( inspector.name(), "option:foo" )
 
 	@staticmethod
-	def __inspect( scene, optionName, editScope = None ) :
+	def __inspect( scene, optionName, editScope = None, context = Gaffer.Context() ) :
 
 		editScopePlug = Gaffer.Plug()
 		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
 		inspector = GafferSceneUI.Private.OptionInspector( scene, editScopePlug, optionName )
-		with Gaffer.Context() as context :
+		with context :
 			return inspector.inspect()
 
 	def __assertExpectedResult(
@@ -424,6 +424,356 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 1 )
 		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
 		self.assertEqual( len( cs ), 2 )  # Change affects the result of `inspect().editable()`
+
+	def testRenderPassValues( self ) :
+
+		options = GafferScene.StandardOptions()
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["selector"].setValue( "${renderPass}" )
+		spreadsheet["rows"].addColumn( options["options"]["renderCamera"]["value"] )
+		options["options"]["renderCamera"]["value"].setInput( spreadsheet["out"][0] )
+
+		rowA = spreadsheet["rows"].addRow()
+		rowA["name"].setValue( "renderPassA" )
+		rowA["cells"][0]["value"].setValue( "/cameraA" )
+
+		rowB = spreadsheet["rows"].addRow()
+		rowB["name"].setValue( "renderPassB" )
+		rowB["cells"][0]["value"].setValue( "/cameraB" )
+
+		with Gaffer.Context() as context :
+
+			self.assertEqual(
+				self.__inspect( options["out"], "render:camera", context = context ).value().value,
+				"/defaultCamera"
+			)
+
+			context["renderPass"] = "renderPassA"
+			self.assertEqual(
+				self.__inspect( options["out"], "render:camera", context = context ).value().value,
+				"/cameraA"
+			)
+
+			context["renderPass"] = "renderPassB"
+			self.assertEqual(
+				self.__inspect( options["out"], "render:camera", context = context ).value().value,
+				"/cameraB"
+			)
+
+			context["renderPass"] = "renderPassC"
+			self.assertEqual(
+				self.__inspect( options["out"], "render:camera", context = context ).value().value,
+				"/defaultCamera"
+			)
+
+	def testRenderPassSourceAndEdits( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		s["group"] = GafferScene.Group()
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope2"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["standardOptions"]["out"] )
+
+		s["editScope1"].setup( s["group"]["out"] )
+		s["editScope1"]["in"].setInput( s["group"]["out"] )
+
+		s["editScope2"].setup( s["editScope1"]["out"] )
+		s["editScope2"]["in"].setInput( s["editScope1"]["out"] )
+
+		with Gaffer.Context() as context :
+
+			context["renderPass"] = "renderPassA"
+
+			# Should be able to edit standardOptions directly.
+
+			SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+			self.__assertExpectedResult(
+				self.__inspect( s["group"]["out"], "render:camera", context = context ),
+				source = s["standardOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Other,
+				editable = True,
+				edit = s["standardOptions"]["options"]["renderCamera"]
+			)
+
+			# Even if there is an edit scope in the way
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope1"]["out"], "render:camera", context = context ),
+				source = s["standardOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Other,
+				editable = True,
+				edit = s["standardOptions"]["options"]["renderCamera"]
+			)
+
+			# We shouldn't be able to edit it if we've been told to use an EditScope and it isn't in the history
+			self.__assertExpectedResult(
+				self.__inspect( s["group"]["out"], "render:camera", s["editScope1"], context ),
+				source = s["standardOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Other,
+				editable = False,
+				nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+			)
+
+			# If it is in the history though, and we're told to use it, then we will.
+
+			inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"], context )
+			self.assertIsNone(
+				GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+					s["editScope2"], "renderPassA", "render:camera", createIfNecessary = False
+				)
+			)
+
+			self.__assertExpectedResult(
+				inspection,
+				source = s["standardOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Upstream,
+				editable = True
+			)
+
+			optionEditScope2Edit = inspection.acquireEdit()
+			self.assertIsNotNone( optionEditScope2Edit )
+			self.assertEqual(
+				optionEditScope2Edit,
+				GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+					s["editScope2"], "renderPassA", "render:camera", createIfNecessary = False
+				)
+			)
+
+			# If there's an edit downstream of the EditScope we're asked to use,
+			# then we're allowed to be editable still
+
+			inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"], context )
+			self.assertTrue( inspection.editable() )
+			self.assertEqual( inspection.nonEditableReason(), "" )
+			self.assertEqual(
+				inspection.acquireEdit(),
+				GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+					s["editScope1"], "renderPassA", "render:camera", createIfNecessary = False
+				)
+			)
+			self.assertEqual( inspection.editWarning(), "" )
+
+			# If there is a source node inside an edit scope, make sure we use that
+
+			s["editScope1"]["standardOptions2"] = GafferScene.StandardOptions()
+			s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]["enabled"].setValue( True )
+			s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]["value"].setValue( 4.0 )
+			s["editScope1"]["standardOptions2"]["in"].setInput( s["editScope1"]["BoxIn"]["out"] )
+			s["editScope1"]["RenderPassOptionEdits"]["in"].setInput( s["editScope1"]["standardOptions2"]["out"] )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:resolutionMultiplier", s["editScope1"], context ),
+				source = s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"],
+				sourceType = SourceType.EditScope,
+				editable = True,
+				edit = s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]
+			)
+
+			# If there is a OptionTweaks node in the scope's processor, make sure we use that
+
+			cameraEdit = GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+				s["editScope1"], "renderPassA", "render:camera", createIfNecessary = True
+			)
+			cameraEdit["enabled"].setValue( True )
+			cameraEdit["value"].setValue( "/bar" )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"], context ),
+				source = cameraEdit,
+				sourceType = SourceType.EditScope,
+				editable = True,
+				edit = cameraEdit
+			)
+
+			# If there is a StandardOptions node downstream of the scope's scene processor, make sure we use that
+
+			s["editScope1"]["standardOptions3"] = GafferScene.StandardOptions()
+			s["editScope1"]["standardOptions3"]["options"]["renderCamera"]["enabled"].setValue( True )
+			s["editScope1"]["standardOptions3"]["options"]["renderCamera"]["value"].setValue( "/baz" )
+			s["editScope1"]["standardOptions3"]["in"].setInput( s["editScope1"]["RenderPassOptionEdits"]["out"] )
+			s["editScope1"]["BoxOut"]["in"].setInput( s["editScope1"]["standardOptions3"]["out"] )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"], context ),
+				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+				sourceType = SourceType.EditScope,
+				editable = True,
+				edit = s["editScope1"]["standardOptions3"]["options"]["renderCamera"]
+			)
+
+			# If there is a StandardOptions node outside of an edit scope, make sure we use that with no scope
+
+			s["independentOptions"] = GafferScene.StandardOptions()
+			s["independentOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+			s["independentOptions"]["options"]["renderCamera"]["value"].setValue( "/camera" )
+			s["independentOptions"]["in"].setInput( s["editScope2"]["out"] )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["independentOptions"]["out"], "render:camera", None, context ),
+				source = s["independentOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Other,
+				editable = True,
+				edit = s["independentOptions"]["options"]["renderCamera"]
+			)
+
+			# Check editWarnings and nonEditableReasons
+
+			self.__assertExpectedResult(
+				self.__inspect( s["independentOptions"]["out"], "render:camera", s["editScope2"], context ),
+				source = s["independentOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Downstream,
+				editable = True,
+				edit = optionEditScope2Edit,
+				editWarning = "Option has edits downstream in independentOptions."
+			)
+
+			s["editScope2"]["enabled"].setValue( False )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["independentOptions"]["out"], "render:camera", s["editScope2"], context ),
+				source = s["independentOptions"]["options"]["renderCamera"],
+				sourceType = SourceType.Downstream,
+				editable = False,
+				nonEditableReason = "The target EditScope (editScope2) is disabled."
+			)
+
+			s["editScope2"]["enabled"].setValue( True )
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], True )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"], context ),
+				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+				sourceType = SourceType.Upstream,
+				editable = False,
+				nonEditableReason = "editScope2 is locked."
+			)
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], False )
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["RenderPassOptionEdits"]["edits"], True )
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"], context ),
+				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+				sourceType = SourceType.Upstream,
+				editable = False,
+				nonEditableReason = "editScope2.RenderPassOptionEdits.edits is locked."
+			)
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["RenderPassOptionEdits"], True )
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"], context ),
+				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+				sourceType = SourceType.Upstream,
+				editable = False,
+				nonEditableReason = "editScope2.RenderPassOptionEdits is locked."
+			)
+
+	def testMultipleRenderPassOptionEdits( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		s["customOptions"] = GafferScene.CustomOptions()
+		s["customOptions"]["in"].setInput( s["standardOptions"]["out"] )
+		s["customOptions"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:type", "default" ) )
+
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope2"] = Gaffer.EditScope()
+
+		s["editScope1"].setup( s["customOptions"]["out"] )
+		s["editScope1"]["in"].setInput( s["customOptions"]["out"] )
+
+		s["editScope2"].setup( s["editScope1"]["out"] )
+		s["editScope2"]["in"].setInput( s["editScope1"]["out"] )
+
+		renderPasses = [ "renderPassA", "renderPassB", "gafferBot_beauty" ]
+
+		def assertRenderPassEdits( renderPass, option, defaultValue ) :
+
+			with Gaffer.Context() as context :
+				context["renderPass"] = renderPass
+
+				inspection = self.__inspect( s["editScope1"]["out"], option, s["editScope1"], context )
+				self.assertTrue( inspection.editable() )
+				self.assertEqual( inspection.nonEditableReason(), "" )
+				editScope1Edit = inspection.acquireEdit()
+				self.assertEqual(
+					editScope1Edit,
+					GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+						s["editScope1"], renderPass, option, createIfNecessary = False
+					)
+				)
+				self.assertEqual( inspection.editWarning(), "" )
+
+				self.assertEqual(
+					self.__inspect( s["editScope1"]["out"], option, context = context ).value().value,
+					defaultValue
+				)
+
+				editScope1Value = "/editScope1/{}".format( renderPass )
+				editScope1Edit["enabled"].setValue( True )
+				editScope1Edit["value"].setValue( editScope1Value )
+
+				inspection = self.__inspect( s["editScope2"]["out"], option, s["editScope2"], context )
+				self.assertTrue( inspection.editable() )
+				self.assertEqual( inspection.nonEditableReason(), "" )
+				editScope2Edit = inspection.acquireEdit()
+				self.assertEqual(
+					editScope2Edit,
+					GafferScene.EditScopeAlgo.acquireRenderPassOptionEdit(
+						s["editScope2"], renderPass, option, createIfNecessary = False
+					)
+				)
+				self.assertEqual( inspection.editWarning(), "" )
+
+				self.assertEqual(
+					self.__inspect( s["editScope2"]["out"], option, context = context ).value().value,
+					editScope1Value
+				)
+
+				editScope2Edit["enabled"].setValue( True )
+				editScope2Edit["value"].setValue( "/editScope2/{}".format( renderPass ) )
+
+		def assertRenderPassEditResults( renderPass, option ) :
+
+			with Gaffer.Context() as context :
+				context["renderPass"] = renderPass
+
+				self.assertEqual(
+					self.__inspect( s["editScope1"]["out"], option, context = context ).value().value,
+					"/editScope1/{}".format( renderPass )
+				)
+
+				self.assertEqual(
+					self.__inspect( s["editScope2"]["out"], option, context = context ).value().value,
+					"/editScope2/{}".format( renderPass )
+				)
+
+		for option, defaultValue in [
+			( "render:camera", "/defaultCamera" ),
+			( "renderPass:type", "default" ),
+		] :
+			for renderPass in renderPasses :
+				with self.subTest( renderPass = renderPass, option = option, defaultValue = defaultValue ) :
+					assertRenderPassEdits( renderPass, option, defaultValue )
+
+		for option in [ "render:camera", "renderPass:type" ] :
+			for renderPass in renderPasses :
+				with self.subTest( renderPass = renderPass, option = option ) :
+					assertRenderPassEditResults( renderPass, option )
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -1,0 +1,429 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class OptionInspectorTest( GafferUITest.TestCase ) :
+
+	def testName( self ) :
+
+		plane = GafferScene.Plane()
+
+		inspector = GafferSceneUI.Private.OptionInspector( plane["out"], None, "option:foo" )
+		self.assertEqual( inspector.name(), "option:foo" )
+
+	@staticmethod
+	def __inspect( scene, optionName, editScope = None ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.OptionInspector( scene, editScopePlug, optionName )
+		with Gaffer.Context() as context :
+			return inspector.inspect()
+
+	def __assertExpectedResult(
+		self,
+		result,
+		source,
+		sourceType,
+		editable,
+		nonEditableReason = "",
+		edit = None,
+		editWarning = ""
+	) :
+
+		self.assertEqual( result.source(), source )
+		self.assertEqual( result.sourceType(), sourceType )
+		self.assertEqual( result.editable(), editable )
+
+		if editable :
+			self.assertEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), "" )
+
+			acquiredEdit = result.acquireEdit()
+			self.assertIsNotNone( acquiredEdit )
+			if result.editScope() :
+				self.assertTrue( result.editScope().isAncestorOf( acquiredEdit ) )
+
+			if edit is not None :
+				self.assertEqual(
+					acquiredEdit.fullName() if acquiredEdit is not None else "",
+					edit.fullName() if edit is not None else ""
+				)
+
+			self.assertEqual( result.editWarning(), editWarning )
+
+		else :
+			self.assertIsNone( edit )
+			self.assertEqual( editWarning, "" )
+			self.assertEqual( result.editWarning(), "" )
+			self.assertNotEqual( nonEditableReason, "" )
+			self.assertEqual( result.nonEditableReason(), nonEditableReason )
+			self.assertRaises( RuntimeError, result.acquireEdit )
+
+	def testValue( self ) :
+
+		options = GafferScene.StandardOptions()
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/customCamera" )
+
+		self.assertEqual(
+			self.__inspect( options["out"], "render:camera" ).value().value,
+			"/customCamera"
+		)
+
+	def testSourceAndEdits( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		s["group"] = GafferScene.Group()
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope2"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["standardOptions"]["out"] )
+
+		s["editScope1"].setup( s["group"]["out"] )
+		s["editScope1"]["in"].setInput( s["group"]["out"] )
+
+		s["editScope2"].setup( s["editScope1"]["out"] )
+		s["editScope2"]["in"].setInput( s["editScope1"]["out"] )
+
+		# Should be able to edit standardOptions directly.
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "render:camera" ),
+			source = s["standardOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["standardOptions"]["options"]["renderCamera"]
+		)
+
+		# Even if there is an edit scope in the way
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope1"]["out"], "render:camera" ),
+			source = s["standardOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["standardOptions"]["options"]["renderCamera"]
+		)
+
+		# We shouldn't be able to edit it if we've been told to use an EditScope and it isn't in the history
+
+		self.__assertExpectedResult(
+			self.__inspect( s["group"]["out"], "render:camera", s["editScope1"] ),
+			source = s["standardOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Other,
+			editable = False,
+			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+		)
+
+		# If it is in the history though, and we're told to use it, then we will.
+
+		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] )
+		self.assertIsNone(
+			GafferScene.EditScopeAlgo.acquireOptionEdit(
+				s["editScope2"], "render:camera", createIfNecessary = False
+			)
+		)
+
+		self.__assertExpectedResult(
+			inspection,
+			source = s["standardOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Upstream,
+			editable = True
+		)
+
+		optionEditScope2Edit = inspection.acquireEdit()
+		self.assertIsNotNone( optionEditScope2Edit )
+		self.assertEqual(
+			optionEditScope2Edit,
+			GafferScene.EditScopeAlgo.acquireOptionEdit(
+				s["editScope2"], "render:camera", createIfNecessary = False
+			)
+		)
+
+		# If there's an edit downstream of the EditScope we're asked to use,
+		# then we're allowed to be editable still
+
+		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"] )
+		self.assertTrue( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "" )
+		self.assertEqual(
+			inspection.acquireEdit(),
+			GafferScene.EditScopeAlgo.acquireOptionEdit(
+				s["editScope1"], "render:camera", createIfNecessary = False
+			)
+		)
+		self.assertEqual( inspection.editWarning(), "" )
+
+		# If there is a source node inside an edit scope, make sure we use that
+
+		s["editScope1"]["standardOptions2"] = GafferScene.StandardOptions()
+		s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]["enabled"].setValue( True )
+		s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]["value"].setValue( 4.0 )
+		s["editScope1"]["standardOptions2"]["in"].setInput( s["editScope1"]["BoxIn"]["out"] )
+		s["editScope1"]["OptionEdits"]["in"].setInput( s["editScope1"]["standardOptions2"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:resolutionMultiplier", s["editScope1"] ),
+			source = s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"],
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = s["editScope1"]["standardOptions2"]["options"]["resolutionMultiplier"]
+		)
+
+		# If there is a OptionTweaks node in the scope's processor, make sure we use that
+
+		cameraEdit = GafferScene.EditScopeAlgo.acquireOptionEdit(
+			s["editScope1"], "render:camera", createIfNecessary = True
+		)
+		cameraEdit["enabled"].setValue( True )
+		cameraEdit["value"].setValue( "/bar" )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"] ),
+			source = cameraEdit,
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = cameraEdit
+		)
+
+		# If there is a StandardOptions node downstream of the scope's scene processor, make sure we use that
+
+		s["editScope1"]["standardOptions3"] = GafferScene.StandardOptions()
+		s["editScope1"]["standardOptions3"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["editScope1"]["standardOptions3"]["options"]["renderCamera"]["value"].setValue( "/baz" )
+		s["editScope1"]["standardOptions3"]["in"].setInput( s["editScope1"]["OptionEdits"]["out"] )
+		s["editScope1"]["BoxOut"]["in"].setInput( s["editScope1"]["standardOptions3"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope1"] ),
+			source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+			sourceType = SourceType.EditScope,
+			editable = True,
+			edit = s["editScope1"]["standardOptions3"]["options"]["renderCamera"]
+		)
+
+		# If there is a StandardOptions node outside of an edit scope, make sure we use that with no scope
+
+		s["independentOptions"] = GafferScene.StandardOptions()
+		s["independentOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["independentOptions"]["options"]["renderCamera"]["value"].setValue( "/camera" )
+		s["independentOptions"]["in"].setInput( s["editScope2"]["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentOptions"]["out"], "render:camera", None ),
+			source = s["independentOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = s["independentOptions"]["options"]["renderCamera"]
+		)
+
+		# Check editWarnings and nonEditableReasons
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentOptions"]["out"], "render:camera", s["editScope2"] ),
+			source = s["independentOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Downstream,
+			editable = True,
+			edit = optionEditScope2Edit,
+			editWarning = "Option has edits downstream in independentOptions."
+		)
+
+		s["editScope2"]["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["independentOptions"]["out"], "render:camera", s["editScope2"] ),
+			source = s["independentOptions"]["options"]["renderCamera"],
+			sourceType = SourceType.Downstream,
+			editable = False,
+			nonEditableReason = "The target EditScope (editScope2) is disabled."
+		)
+
+		s["editScope2"]["enabled"].setValue( True )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] ),
+			source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2 is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"], False )
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["OptionEdits"]["edits"], True )
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] ),
+			source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.OptionEdits.edits is locked."
+		)
+
+		Gaffer.MetadataAlgo.setReadOnly( s["editScope2"]["OptionEdits"], True )
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] ),
+			source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+			sourceType = SourceType.Upstream,
+			editable = False,
+			nonEditableReason = "editScope2.OptionEdits is locked."
+		)
+
+	def testDisabledTweaks( self ) :
+
+		options = GafferScene.StandardOptions()
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		optionTweaks = GafferScene.OptionTweaks()
+		optionTweaks["in"].setInput( options["out"] )
+		cameraTweak = Gaffer.TweakPlug( "render:camera", "/bar" )
+		optionTweaks["tweaks"].addChild( cameraTweak )
+
+		SourceType = GafferSceneUI.Private.Inspector.Result.SourceType
+
+		self.__assertExpectedResult(
+			self.__inspect( optionTweaks["out"], "render:camera" ),
+			source = cameraTweak,
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = cameraTweak
+		)
+
+		cameraTweak["enabled"].setValue( False )
+
+		self.__assertExpectedResult(
+			self.__inspect( optionTweaks["out"], "render:camera" ),
+			source = options["options"]["renderCamera"],
+			sourceType = SourceType.Other,
+			editable = True,
+			edit = options["options"]["renderCamera"]
+		)
+
+	def testNonExistentOption( self ) :
+
+		plane = GafferScene.Plane()
+		self.assertIsNone( self.__inspect( plane["out"], "not:an:option" ) )
+
+	def testDirtiedSignal( self ) :
+
+		camera = GafferScene.Camera()
+
+		options = GafferScene.StandardOptions()
+		options["in"].setInput( camera["out"] )
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		editScope1 = Gaffer.EditScope()
+		editScope1.setup( options["out"] )
+		editScope1["in"].setInput( options["out"] )
+
+		editScope2 = Gaffer.EditScope()
+		editScope2.setup( editScope1["out"] )
+		editScope2["in"].setInput( editScope1["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.OptionInspector(
+			editScope2["out"], settings["editScope"], "render:camera"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		# Changing the option should dirty the inspector
+		options["options"]["renderCamera"]["value"].setValue( "/newCamera" )
+		self.assertEqual( len( cs ), 1 )
+
+		# Changing sets should not
+		camera["sets"].setValue( "foo" )
+		self.assertEqual( len( cs ), 1 )
+
+		# Changing the EditScope should dirty the inspector
+		settings["editScope"].setInput( editScope1["enabled"] )
+		self.assertEqual( len( cs ), 2 )
+		settings["editScope"].setInput( editScope2["enabled"] )
+		self.assertEqual( len( cs ), 3 )
+		settings["editScope"].setInput( None )
+		self.assertEqual( len( cs ), 4 )
+
+	def testReadOnlyMetadataSignalling( self ) :
+
+		options = GafferScene.StandardOptions()
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( options["out"] )
+		editScope["in"].setInput( options["out"] )
+
+		settings = Gaffer.Node()
+		settings["editScope"] = Gaffer.Plug()
+
+		inspector = GafferSceneUI.Private.OptionInspector(
+			editScope["out"], settings["editScope"], "render:camera"
+		)
+
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, False )
+		self.assertEqual( len( cs ), 0 )  # Changes not relevant because we're not using the EditScope
+
+		settings["editScope"].setInput( editScope["enabled"] )
+		self.assertEqual( len( cs ), 1 )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		self.assertEqual( len( cs ), 2 )  # Change affects the result of `inspect().editable()`
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -59,6 +59,7 @@ from .LightEditorTest import LightEditorTest
 from .SetMembershipInspectorTest import SetMembershipInspectorTest
 from .SetEditorTest import SetEditorTest
 from .LightToolTest import LightToolTest
+from .OptionInspectorTest import OptionInspectorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -97,7 +97,9 @@ CreatableRegistry g_attributeRegistry {
 };
 
 /// Entry keys for `g_optionRegistry` should not include the "option:" prefix.
-CreatableRegistry g_optionRegistry;
+CreatableRegistry g_optionRegistry {
+	{ "renderPass:enabled", new BoolData( true ) },
+};
 
 // Pruning
 // =======
@@ -1146,7 +1148,7 @@ ConstObjectPtr optionValue( const ScenePlug *scene, const std::string &option )
 
 	if( !result )
 	{
-		CreatableRegistry::const_iterator registeredOption = g_optionRegistry.find( g_optionPrefix + option );
+		CreatableRegistry::const_iterator registeredOption = g_optionRegistry.find( option );
 		if( registeredOption != g_optionRegistry.end() )
 		{
 			return registeredOption->second;

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -227,6 +227,32 @@ GraphComponentPtr optionEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, con
 	return const_cast<GraphComponent *>( EditScopeAlgo::optionEditReadOnlyReason( &scope, option ) );
 }
 
+// Render Pass Option Edits
+// ========================
+
+bool hasRenderPassOptionEditWrapper( const Gaffer::EditScope &scope, const std::string &renderPass, const std::string &option )
+{
+	return EditScopeAlgo::hasRenderPassOptionEdit( &scope, renderPass, option );
+}
+
+TweakPlugPtr acquireRenderPassOptionEditWrapper( Gaffer::EditScope &scope, const std::string &renderPass, const std::string &option, bool createIfNecessary )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::acquireRenderPassOptionEdit( &scope, renderPass, option, createIfNecessary );
+}
+
+void removeRenderPassOptionEditWrapper( Gaffer::EditScope &scope, const std::string &renderPass, const std::string &option )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::removeRenderPassOptionEdit( &scope, renderPass, option );
+}
+
+GraphComponentPtr renderPassOptionEditReadOnlyReasonWrapper( Gaffer::EditScope &scope, const std::string &renderPass, const std::string &option )
+{
+	return const_cast<GraphComponent *>( EditScopeAlgo::renderPassOptionEditReadOnlyReason( &scope, renderPass, option ) );
+}
+
+
 } // namespace
 
 namespace GafferSceneModule
@@ -283,6 +309,11 @@ void bindEditScopeAlgo()
 	def( "hasOptionEdit", &hasOptionEditWrapper, ( arg( "scope" ), arg( "option" ) ) );
 	def( "removeOptionEdit", &removeOptionEditWrapper, ( arg( "scope" ), arg( "option" ) ) );
 	def( "optionEditReadOnlyReason", &optionEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "option" ) ) );
+
+	def( "acquireRenderPassOptionEdit", &acquireRenderPassOptionEditWrapper, ( arg( "scope" ), arg( "renderPass" ), arg( "option" ), arg( "createIfNecessary" ) = true ) );
+	def( "hasRenderPassOptionEdit", &hasRenderPassOptionEditWrapper, ( arg( "scope" ), arg( "renderPass" ), arg( "option" ) ) );
+	def( "removeRenderPassOptionEdit", &removeRenderPassOptionEditWrapper, ( arg( "scope" ), arg( "renderPass" ), arg( "option" ) ) );
+	def( "renderPassOptionEditReadOnlyReason", &renderPassOptionEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "renderPass" ), arg( "option" ) ) );
 
 }
 

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -276,7 +276,7 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 		{
 			if(
 				plug->namePlug()->getValue() == m_attribute.string() &&
-				plug->enabledPlug()->getValue()
+				( !plug->enabledPlug() || plug->enabledPlug()->getValue() )
 			)
 			{
 				/// \todo This is overly conservative. We should test to see if there is more than

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -1,0 +1,326 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/OptionInspector.h"
+
+#include "GafferScene/Options.h"
+#include "GafferScene/OptionTweaks.h"
+#include "GafferScene/EditScopeAlgo.h"
+
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+#include "Gaffer/Metadata.h"
+#include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/ParallelAlgo.h"
+
+#include "boost/bind/bind.hpp"
+
+#include "fmt/format.h"
+
+using namespace boost::placeholders;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+namespace
+{
+
+// This uses the same strategy that ValuePlug uses for the hash cache,
+// using `plug->dirtyCount()` to invalidate previous cache entries when
+// a plug is dirtied.
+struct HistoryCacheKey
+{
+	HistoryCacheKey() {};
+	HistoryCacheKey( const ValuePlug *plug )
+		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
+	{
+	}
+
+	bool operator==( const HistoryCacheKey &rhs ) const
+	{
+		return
+			plug == rhs.plug &&
+			contextHash == rhs.contextHash &&
+			dirtyCount == rhs.dirtyCount
+		;
+	}
+
+	const ValuePlug *plug;
+	IECore::MurmurHash contextHash;
+	uint64_t dirtyCount;
+};
+
+size_t hash_value( const HistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, key.plug );
+	boost::hash_combine( result, key.contextHash );
+	boost::hash_combine( result, key.dirtyCount );
+	return result;
+}
+
+using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+HistoryCache g_historyCache(
+	// Getter
+	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		return SceneAlgo::history(
+			key.plug
+		);
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// Histories contain PlugPtrs, which could potentially be the sole
+		// owners. Destroying plugs can trigger dirty propagation, so as a
+		// precaution we destroy the history on the UI thread, where this would
+		// be OK.
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+struct OptionHistoryCacheKey : public HistoryCacheKey
+{
+	OptionHistoryCacheKey() {};
+	OptionHistoryCacheKey( const ScenePlug *plug, IECore::InternedString option )
+		:	HistoryCacheKey( plug->globalsPlug() ), option( option )
+	{
+	}
+
+	bool operator==( const OptionHistoryCacheKey &rhs ) const
+	{
+		return HistoryCacheKey::operator==( rhs ) && option == rhs.option;
+	}
+
+	IECore::InternedString option;
+};
+
+size_t hash_value( const OptionHistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, static_cast<const HistoryCacheKey &>( key ) );
+	boost::hash_combine( result, key.option.c_str() );
+	return result;
+}
+
+using OptionHistoryCache = IECorePreview::LRUCache<OptionHistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+OptionHistoryCache g_optionHistoryCache(
+	// Getter
+	[] ( const OptionHistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) -> SceneAlgo::History::ConstPtr {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		SceneAlgo::History::ConstPtr globalsHistory = g_historyCache.get( key, canceller );
+		if( auto h = SceneAlgo::optionHistory( globalsHistory.get(), key.option ) )
+		{
+			return h;
+		}
+		else
+		{
+			// The specific option doesn't exist. But we return the history for the
+			// whole CompoundObject so we get a chance to discover nodes that could
+			// _create_ the option.
+			return globalsHistory;
+		}
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const OptionHistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// See comment in g_historyCache
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+}  // namespace
+
+OptionInspector::OptionInspector(
+	const GafferScene::ScenePlugPtr &scene,
+	const Gaffer::PlugPtr &editScope,
+	IECore::InternedString option
+) :
+Inspector( "option", option.string(), editScope ),
+m_scene( scene ),
+m_option( option )
+{
+	m_scene->node()->plugDirtiedSignal().connect(
+		boost::bind( &OptionInspector::plugDirtied, this, ::_1 )
+	);
+
+	Metadata::plugValueChangedSignal().connect( boost::bind( &OptionInspector::plugMetadataChanged, this, ::_3, ::_4 ) );
+	Metadata::nodeValueChangedSignal().connect( boost::bind( &OptionInspector::nodeMetadataChanged, this, ::_2, ::_3 ) );
+}
+
+GafferScene::SceneAlgo::History::ConstPtr OptionInspector::history() const
+{
+	return g_optionHistoryCache.get( OptionHistoryCacheKey( m_scene.get(), m_option ), Context::current()->canceller() );
+}
+
+IECore::ConstObjectPtr OptionInspector::value( const GafferScene::SceneAlgo::History *history ) const
+{
+	if( auto optionHistory = dynamic_cast<const SceneAlgo::OptionHistory *>( history ) )
+	{
+		return optionHistory->optionValue;
+	}
+	// Option doesn't exist.
+	return nullptr;
+}
+
+Gaffer::ValuePlugPtr OptionInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
+{
+	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );
+	if( !sceneNode || history->scene != sceneNode->outPlug() )
+	{
+		return nullptr;
+	}
+
+	if( auto options = runTimeCast<GafferScene::Options>( sceneNode ) )
+	{
+		for( const auto &plug : NameValuePlug::Range( *options->optionsPlug() ) )
+		{
+			if(
+				plug->namePlug()->getValue() == m_option.string() &&
+				( !plug->enabledPlug() || plug->enabledPlug()->getValue() )
+			)
+			{
+				return plug;
+			}
+		}
+	}
+	else if( auto optionTweaks = runTimeCast<OptionTweaks>( sceneNode ) )
+	{
+		for( const auto &tweak : TweakPlug::Range( *optionTweaks->tweaksPlug() ) )
+		{
+			if( tweak->namePlug()->getValue() == m_option.string() && tweak->enabledPlug()->getValue() )
+			{
+				return tweak;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+Inspector::EditFunctionOrFailure OptionInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+{
+	const GraphComponent *readOnlyReason = EditScopeAlgo::optionEditReadOnlyReason(
+		editScope,
+		m_option
+	);
+
+	if( readOnlyReason )
+	{
+		// If we don't have an edit and the scope is locked, we error,
+		// as we can't add an edit. Other cases where we already _have_
+		// an edit will have been found by `source()`.
+		return fmt::format(
+			"{} is locked.",
+			readOnlyReason->relativeName( readOnlyReason->ancestor<ScriptNode>() )
+		);
+	}
+	else
+	{
+		return [
+			editScope = EditScopePtr( editScope ),
+			option = m_option,
+			context = history->context
+		] () {
+			Context::Scope scope( context.get() );
+			return EditScopeAlgo::acquireOptionEdit(
+				editScope.get(),
+				option
+			);
+		};
+	}
+}
+
+void OptionInspector::plugDirtied( Gaffer::Plug *plug )
+{
+	if( plug == m_scene->globalsPlug() )
+	{
+		dirtiedSignal()( this );
+	}
+}
+
+void OptionInspector::plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug )
+{
+	if( !plug )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+	nodeMetadataChanged( key, plug->node() );
+}
+
+void OptionInspector::nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node )
+{
+	if( !node )
+	{
+		// Assume readOnly metadata is only registered on instances.
+		return;
+	}
+
+	EditScope *scope = targetEditScope();
+	if( !scope )
+	{
+		return;
+	}
+
+	if(
+		MetadataAlgo::readOnlyAffectedByChange( scope, node, key ) ||
+		( MetadataAlgo::readOnlyAffectedByChange( key ) && scope->isAncestorOf( node ) )
+	)
+	{
+		// Might affect `EditScopeAlgo::optionEditReadOnlyReason()`
+		// which we call in `editFunction()`.
+		/// \todo Can we ditch the signal processing and call `optionEditReadOnlyReason()`
+		/// just-in-time from `editable()`? In the past that wasn't possible
+		/// because editability changed the appearance of the UI, but it isn't
+		/// doing that currently.
+		dirtiedSignal()( this );
+	}
+}

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -42,6 +42,7 @@
 #include "GafferSceneUI/Private/AttributeInspector.h"
 #include "GafferSceneUI/Private/ParameterInspector.h"
 #include "GafferSceneUI/Private/SetMembershipInspector.h"
+#include "GafferSceneUI/Private/OptionInspector.h"
 
 #include "GafferBindings/PathBinding.h"
 #include "GafferBindings/SignalBinding.h"
@@ -166,5 +167,13 @@ void GafferSceneUIModule::bindInspector()
 			)
 		)
 		.def( "editSetMembership", &editSetMembershipWrapper)
+	;
+
+	RefCountedClass<OptionInspector, Inspector>( "OptionInspector" )
+		.def(
+			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString>(
+				( arg( "scene" ), arg( "editScope" ), arg( "option" ) )
+			)
+		)
 	;
 }


### PR DESCRIPTION
This PR extends our growing family of Inspectors, adding support for inspection and editing of options, making use of the prior EditScopeAlgo work in #4907. It then goes on to extend EditScopeAlgo to support new RenderPass specific option edits, where edits are applied via a Spreadsheet selecting based on `${renderPass}`, with  `OptionInspector::editFunction` acquiring a RenderPass specific option edit when called from contexts containing `${renderPass}`. 

This provides the base functionality for inspecting and editing options in the upcoming Render Pass Editor. The Render Pass Editor will still require a couple of additions to this, namely support for the `RenderPasses` and `DeleteRenderPasses` nodes, and the ability to return default values registered as metadata in place of non-existent options, but it'd be good to get this core reviewed and merged before moving on to the specifics...