### PR TITLE
Viewer : Fix layout jiggle when hiding toolbar

### DIFF
--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -336,10 +336,10 @@ class _Toolbar( GafferUI.Frame ) :
 		if self.__node is not None :
 			toolbar = self.__nodeToolbarCache.get( ( self.__node, self.__edge ) )
 			self.setChild( toolbar )
+			self.setVisible( True )
 		else :
+			self.setVisible( False )
 			self.setChild( None )
-
-		self.setVisible( self.getChild() is not None )
 
 	def getNode( self ) :
 


### PR DESCRIPTION
By setting the child to `None` and _then_ hiding the frame, we were causing Qt to do two lots of layouting, one with an empty frame and one with nothing. This could cause "jiggle" when switching between tools in the Viewer.

In an ideal world Qt would batch up these layout operations and do them once with no redraw in between. In fact I don't really know why it doesn't. As far as I know, it needs to return to the event loop to perform them, and I don't see where or how that's happening. But in lieu of real understanding, this is a simple and logical enough fix that removes a nasty visual annoyance.

@ericmehl, this removes the jiggle caused by the tooltips in #5558.