### PR TITLE
Switch : Add `connectedInputs` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Improvements
 - NodeEditor : Improved image channel selectors :
   - Added "Custom" option, to allow strings to be entered manually.
   - Added right-click context menu.
+- Switch : Added `connectedInputs` output plug.
 
 Fixes
 -----

--- a/include/Gaffer/Switch.h
+++ b/include/Gaffer/Switch.h
@@ -39,6 +39,7 @@
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/ComputeNode.h"
 #include "Gaffer/NumericPlug.h"
+#include "Gaffer/TypedObjectPlug.h"
 
 namespace Gaffer
 {
@@ -86,6 +87,9 @@ class GAFFER_API Switch : public ComputeNode
 
 		BoolPlug *enabledPlug() override;
 		const BoolPlug *enabledPlug() const override;
+
+		IntVectorDataPlug *connectedInputsPlug();
+		const IntVectorDataPlug *connectedInputsPlug() const;
 
 		Plug *correspondingInput( const Plug *output ) override;
 		const Plug *correspondingInput( const Plug *output ) const override;

--- a/python/GafferImageTest/ImageSwitchTest.py
+++ b/python/GafferImageTest/ImageSwitchTest.py
@@ -71,8 +71,7 @@ class ImageSwitchTest( GafferImageTest.ImageTestCase ) :
 		for p in [ switch["in"][0], switch["in"][1] ] :
 			for n in [ "format", "dataWindow", "metadata", "deep", "sampleOffsets", "channelNames", "channelData" ] :
 				a = switch.affects( p[n] )
-				self.assertEqual( len( a ), 1 )
-				self.assertTrue( a[0].isSame( switch["out"][n] ) )
+				self.assertEqual( a, [ switch["out"][n], switch["connectedInputs"] ] )
 
 		a = set( [ plug.relativeName( plug.node() ) for plug in switch.affects( switch["enabled"] ) ] )
 		self.assertEqual(

--- a/python/GafferSceneTest/SceneSwitchTest.py
+++ b/python/GafferSceneTest/SceneSwitchTest.py
@@ -73,8 +73,7 @@ class SceneSwitchTest( GafferSceneTest.SceneTestCase ) :
 		for p in [ switch["in"][0], switch["in"][1] ] :
 			for n in p.keys() :
 				a = switch.affects( p[n] )
-				self.assertEqual( len( a ), 1 )
-				self.assertTrue( a[0].isSame( switch["out"][n] ) )
+				self.assertEqual( a, [ switch["out"][n], switch["connectedInputs"] ] )
 
 		a = set( switch.affects( switch["enabled"] ) )
 		self.assertEqual( a, set( switch["out"].children() ) )

--- a/python/GafferTest/NameSwitchTest.py
+++ b/python/GafferTest/NameSwitchTest.py
@@ -195,5 +195,45 @@ class NameSwitchTest( GafferTest.TestCase ) :
 			del c["selector"]
 			self.assertEqual( s["out"]["value"].getValue(), 1 )
 
+	def testConnectedInputs( self ) :
+
+		switch = Gaffer.NameSwitch()
+		self.assertEqual( switch["connectedInputs"].getValue(), IECore.IntVectorData() )
+
+		switch.setup( Gaffer.IntPlug() )
+		self.assertEqual( switch["connectedInputs"].getValue(), IECore.IntVectorData() )
+
+		inputA = Gaffer.IntPlug()
+		switch["in"][0]["value"].setInput( inputA )
+		self.assertEqual( switch["connectedInputs"].getValue(), IECore.IntVectorData( [ 0 ] ) )
+
+		switch["in"][1]["value"].setInput( inputA )
+		self.assertEqual( switch["connectedInputs"].getValue(), IECore.IntVectorData( [ 0, 1 ] ) )
+
+		switch["in"][0]["value"].setInput( None )
+		self.assertEqual( switch["connectedInputs"].getValue(), IECore.IntVectorData( [ 1 ] ) )
+
+	def testConnectedInputsWithPromotedInPlug( self ) :
+
+		box = Gaffer.Box()
+		box["switch"] =  Gaffer.NameSwitch()
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData() )
+
+		box["switch"].setup( Gaffer.IntPlug() )
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData() )
+
+		Gaffer.PlugAlgo.promote( box["switch"]["in"] )
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData() )
+
+		inputA = Gaffer.IntPlug()
+		box["in"][0]["value"].setInput( inputA )
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData( [ 0 ] ) )
+
+		box["in"][1]["value"].setInput( inputA )
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData( [ 0, 1 ] ) )
+
+		box["in"][0]["value"].setInput( None )
+		self.assertEqual( box["switch"]["connectedInputs"].getValue(), IECore.IntVectorData( [ 1 ] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -152,6 +152,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"connectedInputs" : [
+
+			"layout:index", -3,
+
+		],
+
 	}
 
 )

--- a/python/GafferUI/SwitchUI.py
+++ b/python/GafferUI/SwitchUI.py
@@ -35,6 +35,9 @@
 ##########################################################################
 
 import Gaffer
+import GafferUI
+
+from GafferUI.PlugValueWidget import sole
 
 Gaffer.Metadata.registerNode(
 
@@ -98,6 +101,40 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"connectedInputs" : [
+
+			"description",
+			"""
+			The indices of the input array that have incoming connections.
+
+			> Tip : This can be used to drive a Wedge or Collect node so that
+			> they operate over each input in turn.
+			""",
+
+			"nodule:type", "",
+			"layout:section", "Advanced",
+			"plugValueWidget:type", "GafferUI.SwitchUI._ConnectedInputsPlugValueWidget",
+
+		],
+
 	}
 
 )
+
+class _ConnectedInputsPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		self.__textWidget = GafferUI.TextWidget( editable = False )
+		GafferUI.PlugValueWidget.__init__( self, self.__textWidget, plugs, **kw )
+
+	def _updateFromValues( self, values, exception ) :
+
+		value = sole( values )
+		self.__textWidget.setText(
+			", ".join( [ str( x ) for x in value ] )
+			if value is not None
+			else "---"
+		)
+
+		self.__textWidget.setErrored( exception is not None )


### PR DESCRIPTION
This facilitates a pattern whereby another node such as Collect or Wedge can be used to loop across the inputs to the Switch. In the screenshot below I've demonstrated this in a simple little box which builds a table of image statistics, allowing you to compare an arbitrary number of images just by connecting them to the box.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/94c9780a-87cb-4ec3-ae2f-a53a49ad33a5)

My real motivation for this though is in the creation of a new ContactSheet node, which uses `connectedInputs` to allow the contact sheet to work both with multiple input connections and also with multiple input contexts (in a collect style).

Fixes #1797.
