### PR TITLE
Backdrop : Improve ordering of nested backdrops

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,9 @@ Improvements
   - Added "Custom" option, to allow strings to be entered manually.
   - Added right-click context menu.
 - Switch : Added `connectedInputs` output plug.
+- Backdrop : Improved drawing order for nested backdrops :
+  - Larger backdrops are automatically drawn behind smaller ones, so that nested backdrops will always appear on top.
+  - Added a `depth` plug to assign a manual drawing depth for the rare cases where the automatic depth is unwanted.
 
 Fixes
 -----
@@ -75,6 +78,7 @@ Breaking Changes
 ----------------
 
 - Render : Changed `render:includedPurposes` default to `"default", "render"`.
+- Backdrop : Changed default drawing order. Use the new `depth` plug to override the order if necessary.
 - ValuePlug : Removed deprecated `getObjectValue()` overload.
 - Preferences : Removed `cache` plug.
 - TaskNode :

--- a/include/Gaffer/Backdrop.h
+++ b/include/Gaffer/Backdrop.h
@@ -65,6 +65,9 @@ class GAFFER_API Backdrop : public Node
 		StringPlug *descriptionPlug();
 		const StringPlug *descriptionPlug() const;
 
+		IntPlug *depthPlug();
+		const IntPlug *depthPlug() const;
+
 	private :
 
 		static size_t g_firstPlugIndex;

--- a/python/GafferUI/BackdropUI.py
+++ b/python/GafferUI/BackdropUI.py
@@ -126,6 +126,25 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"depth" : [
+
+			"description",
+			"""
+			Determines the drawing order of overlapping backdrops.
+
+			> Note : Larger backdrops are _automatically_ drawn behind smaller ones,
+			> so it is only necessary to manually assign a depth in rare cases where
+			> this is not desirable.
+			""",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"preset:Back", -1,
+			"preset:Middle", 0,
+			"preset:Front", 1,
+
+
+		],
+
 	}
 
 )

--- a/src/Gaffer/Backdrop.cpp
+++ b/src/Gaffer/Backdrop.cpp
@@ -51,6 +51,7 @@ Backdrop::Backdrop( const std::string &name )
 	addChild( new StringPlug( "title", Plug::In, "Title" ) );
 	addChild( new FloatPlug( "scale", Plug::In, 1.0f, 1.0f ) );
 	addChild( new StringPlug( "description" ) );
+	addChild( new IntPlug( "depth", Plug::In, 0, -1, 1 ) );
 }
 
 Backdrop::~Backdrop()
@@ -85,4 +86,14 @@ Gaffer::StringPlug *Backdrop::descriptionPlug()
 const Gaffer::StringPlug *Backdrop::descriptionPlug() const
 {
 	return getChild<StringPlug>( g_firstPlugIndex + 2 );
+}
+
+IntPlug *Backdrop::depthPlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+const IntPlug *Backdrop::depthPlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
 }

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1499,11 +1499,6 @@ static const std::string &fragmentSource()
 		"		OUTCOLOR.a *= ieFilteredPulse( 0.2, 0.8, gl_TexCoord[0].x );"
 		"	}"
 
-		"	if( OUTCOLOR.a == 0.0 )"
-		"	{"
-		"		discard;"
-		"	}"
-
 		/// \todo Deal with all colourspace nonsense outside of the shader. Ideally the shader would accept only linear"
 		/// textures and output only linear data."
 
@@ -1522,6 +1517,11 @@ static const std::string &fragmentSource()
 		"	else if( textureType==2 )"
 		"	{"
 		"		OUTCOLOR = vec4( OUTCOLOR.rgb, OUTCOLOR.a * texture2D( texture, gl_TexCoord[0].xy ).a );"
+		"	}\n"
+
+		"	if( OUTCOLOR.a == 0.0 )"
+		"	{"
+		"		discard;"
 		"	}\n"
 
 		"#if __VERSION__ >= 330\n"


### PR DESCRIPTION
We now automatically draw larger backdrops behind smaller ones, so that nested backdrops "just work". An additional `depth` plug allows the user to override this in rare cases where they want a smaller backdrop to appear beneath a larger one.

![Peek 2023-12-19 14-37](https://github.com/GafferHQ/gaffer/assets/1133871/afafdaf9-00fe-4d12-ace8-92dc3cc4d42d)
