### PR TITLE
Set MSVC_VERSION

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -376,6 +376,8 @@ options.Add( "GAFFER_VERSION_SUFFIX", "Version suffix", str( gafferVersionSuffix
 
 env = Environment(
 
+	MSVC_VERSION = "14.2",
+
 	options = options,
 
 	CPPDEFINES = [


### PR DESCRIPTION
This explicitly sets the `MSVC_VERSION` we're building with. After installing MSVC 2022 to start updating our builds to the VFX Reference platform expectation I found current builds were failing because SCons defaults to the latest compiler it finds. That was attempting to mix compiler versions between newly compiled files and cached builds which it was not happy about.

Hopefully this is benign on Linux and will also formalize which compiler version we're targeting via code rather than only in documentation.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
