### PR TITLE
3Delight USD Lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.10.0)
 =======
 
+Features
+--------
+
+- 3Delight : Added support for USD `SphereLight`, `RectLight`, `DiskLight`, `DistantLight`, `DomeLight` and `CylinderLight`.
+
 Improvements
 ------------
 

--- a/include/IECoreDelight/ShaderNetworkAlgo.h
+++ b/include/IECoreDelight/ShaderNetworkAlgo.h
@@ -48,6 +48,12 @@ namespace ShaderNetworkAlgo
 
 IECOREDELIGHT_API IECoreScene::ShaderNetworkPtr preprocessedNetwork( const IECoreScene::ShaderNetwork *shaderNetwork );
 
+/// Returns the NSI type of the geometry needed for the light or `nullptr` if none is needed.
+const char *lightGeometryType( const IECoreScene::ShaderNetwork *shaderNetwork );
+/// Edits the light geometry, which will have already been created with the right type.
+/// `state` is used to store the current state and avoid unnecessary edits.
+void updateLightGeometry( const IECoreScene::ShaderNetwork *shaderNetwork, NSIContext_t context, const char *handle, IECore::MurmurHash &state );
+
 }  // namespace ShaderNetworkAlgo
 
 }  // namespace IECoreDelight

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -42,6 +42,7 @@ import shlex
 import pathlib
 import os
 import subprocess
+import math
 
 import imath
 
@@ -1074,6 +1075,260 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( mesh["subdivision.cornervertices"], 3 )
 		self.assertEqual( mesh["subdivision.cornersharpness"], 5 )
 
+	# `lightSettings` is a list of tuples of the form :
+	# ( USD light type, position, rotation (V3f, degrees), 3Delight geometry type,
+	# 3Delight geometry attributes, 3Delight shader, IECore light parameters, 3Delight parameters )
+	# Returns the path to the rendered NSI file.
+	def __renderLights( self, lightSettings ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.nsi" ),
+		)
+
+		for lightType, position, rotation, geometryType, geometryAttributes, shader, lightParameters, dlParameters in lightSettings :
+			lightShader = IECoreScene.ShaderNetwork(
+				{
+					"lightHandle": IECoreScene.Shader( lightType, "light", lightParameters ),
+				},
+				output = "lightHandle"
+			)
+			r.light(
+				"test" + lightType,
+				None,  # IECore.Object
+				r.attributes(IECore.CompoundObject( { "light": lightShader } ) )
+			).transform( imath.M44f().translate( position ) * imath.M44f().rotate( IECore.degreesToRadians( rotation ) ) )
+
+		r.render()
+		del r
+
+		return self.temporaryDirectory() / "test.nsi"
+
+	def __assertLightSettings( self, nsi, lightSettings ) :
+
+		for lightType, translation, rotation, geometryType, geometryAttributes, shader, lightParameters, dlParameters in lightSettings :
+			with self.subTest( lightType = lightType ) :
+				lightName = "test" + lightType
+				self.assertIn( lightName, nsi )
+				transform = nsi[lightName]
+
+				self.assertIn( "geometryattributes", transform )
+				self.assertEqual( len( transform["geometryattributes"] ), 1 )
+				attributes = self.__connectionSource( transform["geometryattributes"][0], nsi )
+
+				self.assertIn( "surfaceshader", attributes )
+				self.assertEqual( len( attributes["surfaceshader"] ), 1 )
+				surface = self.__connectionSource( attributes["surfaceshader"][0], nsi )
+
+				self.assertEqual( pathlib.Path( surface["shaderfilename"] ).name, shader )
+				for k, v in dlParameters.items() :
+					with self.subTest( k = k ) :
+						self.assertIn( k, surface )
+						self.assertEqual( surface[k], v )
+
+				self.assertIn( "objects", transform )
+				self.assertEqual( len( transform["objects"] ), 1 )
+				geometry = self.__connectionSource( transform["objects"][0], nsi )
+
+				self.assertEqual( geometry["nodeType"], geometryType )
+				for k, v in geometryAttributes.items() :
+					with self.subTest( k = k ) :
+						self.assertIn( k, geometry )
+						if isinstance( v, list ) :
+							self.assertEqual( len( geometry[k] ), len( v ) )
+							for i in range( 0, len( v ) ) :
+								if isinstance( v[i], imath.V3f ) :
+									for j in range( 0, 3 ) :
+										self.assertAlmostEqual( geometry[k][i][j], v[i][j], places = 5 )
+								else :
+									self.assertAlmostEqual( geometry[k][i], v[i], places = 5 )
+						else :
+							self.assertAlmostEqual( geometry[k], v, places = 5 )
+
+				self.assertIn( "transformationmatrix", transform )
+				xform = imath.M44f().rotate( IECore.degreesToRadians( rotation ) ).translate( translation )
+				for i in range( 0, 4 ) :
+					with self.subTest( i = i ) :
+						for j in range( 0, 4 ) :
+							with self.subTest( j = j ) :
+								self.assertAlmostEqual( transform["transformationmatrix"][i][j], xform[i][j])
+
+	def testUSDLights( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.nsi" ),
+		)
+
+		# List of tuples of the form :
+		# ( USD light type, position, rotation (V3f, degrees), 3Delight geometry type,
+		# 3Delight geometry attributes, 3Delight shader, IECore light parameters, 3Delight parameters )
+		lightSettings = [
+			(
+				"SphereLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"particles",
+				{ "P": imath.V3f( 0, 0, 0 ), "width": 6.0, },
+				"pointLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "radius": 3.0, },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ) },
+			),
+			(
+				"RectLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"mesh",
+				{
+					"P": [ imath.V3f( 1.0, 1.5, 0.0 ), imath.V3f( 1.0, -1.5, 0.0 ), imath.V3f( -1.0, -1.5, 0.0 ), imath.V3f( -1.0, 1.5, 0.0 ) ],
+					"P.indices": [ 0, 1, 2, 3 ],
+					"N": imath.V3f( 0.0, 0.0, -1.0 ),
+					"N.indices": [ 0, 0, 0, 0 ],
+					"st": [ imath.V2f( 0.0, 1.0 ), imath.V2f( 0.0, 0.0 ), imath.V2f( 1.0, 0.0 ), imath.V2f( 1.0, 1.0 ) ]
+				},
+				"areaLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "width": 2.0, "height": 3.0, },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ) },
+			),
+			(
+				"DiskLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"particles",
+				{ "P": imath.V3f( 0.0, 0.0, 0.0 ), "width": 6.0, "N": imath.V3f( 0.0, 0.0, -1.0 ) },
+				"areaLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "radius": 3.0, },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ) },
+			),
+			(
+				"DistantLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"environment",
+				{ "angle": 10.0 },
+				"distantLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "angle": 10.0 },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ) },
+			),
+			(
+				"DomeLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"environment",
+				{ "angle": 360.0 },
+				"environmentLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "angle": 10.0, "texture:file": "env.exr", "texture:format": "latlong" },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "specular_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ), "image": "env.exr", "mapping": 0 },
+			),
+			(
+				"CylinderLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"mesh",
+				self.__cylinderMesh( 2.0, 3.0 ),
+				"areaLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "length": 2.0, "radius": 3.0 },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ) },
+			),
+		]
+
+		nsi = self.__parseDict( self.__renderLights( lightSettings ) )
+
+		self.__assertLightSettings( nsi, lightSettings )
+
+	def testUSDLightShaping( self ) :
+
+		lightSettings = [
+			(
+				"RectLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"mesh",
+				{
+					"P": [ imath.V3f( 1.0, 1.5, 0.0 ), imath.V3f( 1.0, -1.5, 0.0 ), imath.V3f( -1.0, -1.5, 0.0 ), imath.V3f( -1.0, 1.5, 0.0 ) ],
+					"P.indices": [ 0, 1, 2, 3 ],
+					"N": imath.V3f( 0.0, 0.0, -1.0 ),
+					"N.indices": [ 0, 0, 0, 0 ],
+					"st": [ imath.V2f( 0.0, 1.0 ), imath.V2f( 0.0, 0.0 ), imath.V2f( 1.0, 0.0 ), imath.V2f( 1.0, 1.0 ) ]
+				},
+				"spotLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "width": 2.0, "height": 3.0, "shaping:cone:angle": 45.0, "shaping:cone:softness": 0.1 },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ), "coneAngle": 81.0, "penumbraAngle": 4.5 },
+			),
+			(
+				"DiskLight",
+				imath.V3f( 1.0, 2.0, 3.0 ),
+				imath.V3f( 10.0, 20.0, 30.0 ),
+				"particles",
+				{ "P": imath.V3f( 0.0, 0.0, 0.0 ), "width": 6.0, "N": imath.V3f( 0.0, 0.0, -1.0 ) },
+				"spotLight.oso",
+				{ "intensity": 2.0, "diffuse": 0.1, "specular": 0.5, "exposure": 10.0, "color": imath.Color3f( 4.0, 5.0, 6.0 ), "radius": 3.0, "shaping:cone:angle": 45.0, "shaping:cone:softness": 0.1 },
+				{ "intensity": 2.0, "diffuse_contribution": 0.1, "reflection_contribution": 0.5, "exposure": 10.0, "i_color": imath.Color3f( 4.0, 5.0, 6.0 ), "coneAngle": 81.0, "penumbraAngle": 4.5 },
+			),
+		]
+
+		nsi = self.__parseDict( self.__renderLights( lightSettings ) )
+
+		self.__assertLightSettings( nsi, lightSettings )
+
+	@staticmethod
+	def __cylinderMesh( length, radius ) :
+
+		numSegments = 100
+		halfLength = length * 0.5
+
+		p = []
+		pIndices = []
+		n = []
+		nIndices = []
+
+		for i in range( 0, numSegments + 1 ) :
+			a = ( float(i) / numSegments ) * 2.0 * math.pi
+			z = math.sin( a ) * radius
+			y = math.cos( a ) * radius
+
+			p.append( imath.V3f( halfLength, y, z ) )
+			p.append( imath.V3f( -halfLength, y, z ) )
+			n.append( imath.V3f( 0, y, z ).normalized() )
+
+		for i in range( 0, numSegments ) :
+			pIndices.append( i * 2 )
+			pIndices.append( i * 2 + 1 )
+			pIndices.append( i * 2 + 3 )
+			pIndices.append( i * 2 + 2 )
+
+			nIndices.append( i )
+			nIndices.append( i )
+			nIndices.append( i + 1 )
+			nIndices.append( i + 1 )
+
+		# end caps
+		p.append( imath.V3f( halfLength, 0, 0 ) )
+		p.append( imath.V3f( -halfLength, 0, 0 ) )
+		n.append( imath.V3f( 1, 0, 0 ) )
+		n.append( imath.V3f( -1, 0, 0 ) )
+
+		for i in range( 0, numSegments ) :
+			pIndices.append( numSegments + 1 )
+			pIndices.append( i * 2 )
+			pIndices.append( i * 2 + 2 )
+
+			nIndices.append( numSegments + 1 )
+			nIndices.append( numSegments + 1 )
+			nIndices.append( numSegments + 1 )
+
+			pIndices.append( numSegments + 2 )
+			pIndices.append( i * 2 + 3 )
+			pIndices.append( i * 2 + 1 )
+
+			nIndices.append( numSegments + 2 )
+			nIndices.append( numSegments + 2 )
+			nIndices.append( numSegments + 2 )
+
+		return { "P": p, "P.indices": pIndices, "N": n, "N.indices": nIndices }
+
 	# Helper methods used to check that NSI files we write contain what we
 	# expect. The 3delight API only allows values to be set, not queried,
 	# so we build a simple dictionary-based node graph for now.
@@ -1147,8 +1402,10 @@ class RendererTest( GafferTest.TestCase ) :
 			else :
 				# List of attributes
 				pType = tokens.popleft()
-				if pType == "v normal" or pType == "v point" :
+				if pType == "v normal" or pType == "v point" or pType == "normal" or pType == "point" :
 					pType = "v"
+				elif pType == "v float" :
+					pType = "float"
 				pSize = int( tokens.popleft() )
 				pLength = 1
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -402,7 +402,7 @@ class DelightShader : public IECore::RefCounted
 		{
 			ConstShaderNetworkPtr preprocessedNetwork = IECoreDelight::ShaderNetworkAlgo::preprocessedNetwork( shaderNetwork );
 
-			const string name = "shader:" + preprocessedNetwork->Object::hash().toString();
+			const string name = "shader:" + shaderNetwork->Object::hash().toString();
 			IECoreScene::ShaderNetworkAlgo::depthFirstTraverse(
 				preprocessedNetwork.get(),
 				[this, &name, &context, &ownership] ( const ShaderNetwork *shaderNetwork, const InternedString &handle ) {
@@ -592,6 +592,7 @@ namespace
 std::array<std::string, 4> g_surfaceShaderAttributeNames = { "osl:light", "light", "osl:surface", "surface" };
 std::array<std::string, 2> g_volumeShaderAttributeNames = { "osl:volume", "volume" };
 std::array<std::string, 2> g_displacementShaderAttributeNames = { "osl:displacement", "displacement" };
+const InternedString g_USDLightAttributeName = "light";
 
 IECore::InternedString g_setsAttributeName( "sets" );
 
@@ -630,6 +631,14 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 				}
 			}
 
+			if( auto o = attributes->member<const Object>( g_USDLightAttributeName ) )
+			{
+				if( auto shaderNetwork = reportedCast<const ShaderNetwork>( o, "attribute", g_USDLightAttributeName ) )
+				{
+					m_usdLightShader = shaderNetwork;
+				}
+			}
+
 			ParameterList params;
 			for( const auto &m : attributes->members() )
 			{
@@ -658,9 +667,10 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 				{
 					msg( Msg::Warning, "DelightRenderer", fmt::format( "User attribute \"{}\" not supported", m.first.string() ) );
 				}
-				else if( boost::contains( m.first.string(), ":" ) )
+				else if( boost::contains( m.first.string(), ":" ) || m.first == g_USDLightAttributeName )
 				{
 					// Attribute for another renderer - ignore
+					// Or a USDLight, which we've handled above - ignore
 				}
 				else
 				{
@@ -702,6 +712,11 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 			}
 		}
 
+		const ShaderNetwork *usdLightShader() const
+		{
+			return m_usdLightShader.get();
+		}
+
 		const DelightHandle &handle() const
 		{
 			return m_handle;
@@ -725,6 +740,8 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 		ConstDelightShaderPtr m_surfaceShader;
 		ConstDelightShaderPtr m_volumeShader;
 		ConstDelightShaderPtr m_displacementShader;
+
+		ConstShaderNetworkPtr m_usdLightShader;
 
 };
 
@@ -912,7 +929,7 @@ IE_CORE_DECLAREPTR( InstanceCache )
 namespace
 {
 
-class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
+class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 {
 
 	public :
@@ -920,12 +937,15 @@ class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
 		DelightObject( NSIContext_t context, const std::string &name, DelightHandleSharedPtr instance, DelightHandle::Ownership ownership )
 			:	m_transformHandle( context, name, ownership, "transform", {} ), m_instance( instance ), m_haveTransform( false )
 		{
-			NSIConnect(
-				m_transformHandle.context(),
-				m_instance->name(), "",
-				m_transformHandle.name(), "objects",
-				0, nullptr
-			);
+			if( m_instance )
+			{
+				NSIConnect(
+					m_transformHandle.context(),
+					m_instance->name(), "",
+					m_transformHandle.name(), "objects",
+					0, nullptr
+				);
+			}
 
 			NSIConnect(
 				m_transformHandle.context(),
@@ -1014,17 +1034,105 @@ class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
 			/// \todo Implement
 		}
 
-	private :
+	protected :
 
 		const DelightHandle m_transformHandle;
 		// We keep a reference to the instance and attributes so that they
 		// remain alive for at least as long as the object does.
 		ConstDelightAttributesPtr m_attributes;
+
+	private :
+
 		DelightHandleSharedPtr m_instance;
 
 		bool m_haveTransform;
 
 };
+
+}  // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// DelightLight
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+class DelightLight : public DelightObject
+{
+
+	public :
+
+		DelightLight( NSIContext_t context, const std::string &name, DelightHandleSharedPtr instance, DelightHandle::Ownership ownership )
+			: DelightObject( context, name, instance, ownership ), m_lightGeometryType( nullptr )
+		{
+		}
+
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
+		{
+			DelightObject::attributes( attributes );
+
+			if( const ShaderNetwork *usdLightShader = m_attributes->usdLightShader() )
+			{
+				const char *geometryType = IECoreDelight::ShaderNetworkAlgo::lightGeometryType( usdLightShader );
+
+				if( !geometryType )
+				{
+					msg( Msg::Warning, "IECoreDelight::attributes", "Unknown USD light type." );
+					return true;
+				}
+
+				if( !m_lightGeometryType || strcmp( geometryType, m_lightGeometryType ) )
+				{
+					const std::string lightName = std::string( m_transformHandle.name() ) + ":lightGeometry";
+					if( m_lightGeometry )
+					{
+						NSIDisconnect(
+							m_transformHandle.context(),
+							m_lightGeometry->name(), "",
+							m_transformHandle.name(), "objects"
+						);
+					}
+
+					m_lightGeometry.reset();
+
+					m_lightGeometry = std::make_shared<DelightHandle>(
+						m_transformHandle.context(),
+						lightName,
+						m_transformHandle.ownership(),
+						geometryType
+					);
+
+					NSIConnect(
+						m_transformHandle.context(),
+						m_lightGeometry->name(), "",
+						m_transformHandle.name(), "objects",
+						0, 0
+					);
+
+					m_lightGeometryType = geometryType;
+					m_lightGeometryState = MurmurHash();
+				}
+
+				IECoreDelight::ShaderNetworkAlgo::updateLightGeometry(
+					usdLightShader,
+					m_transformHandle.context(),
+					m_lightGeometry->name(),
+					m_lightGeometryState
+				);
+			}
+
+			return true;
+		}
+
+	private :
+
+		const char *m_lightGeometryType;
+		DelightHandleSharedPtr m_lightGeometry;
+		MurmurHash m_lightGeometryState;
+};
+
+IE_CORE_DECLAREPTR( DelightLight );
 
 } // namespace
 
@@ -1292,7 +1400,18 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
 		{
-			return this->object( name, object, attributes );
+			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
+
+			DelightHandleSharedPtr instance;
+			if( object )
+			{
+				instance = m_instanceCache->get( object );
+			}
+
+			ObjectInterfacePtr result = new DelightLight( m_context, name, instance, ownership() );
+			result->attributes( attributes );
+
+			return result;
 		}
 
 		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override

--- a/src/IECoreDelight/ShaderNetworkAlgo.cpp
+++ b/src/IECoreDelight/ShaderNetworkAlgo.cpp
@@ -36,10 +36,12 @@
 
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
 
+#include "IECoreDelight/ParameterList.h"
 #include "IECoreDelight/ShaderNetworkAlgo.h"
 
 #include "IECoreScene/ShaderNetworkAlgo.h"
 
+#include "IECore/MessageHandler.h"
 #include "IECore/SearchPath.h"
 #include "IECore/SimpleTypedData.h"
 #include "IECore/SplineData.h"
@@ -293,6 +295,341 @@ void addDefaultUVShader( ShaderNetwork *shaderNetwork )
 	}
 }
 
+/// \todo This is almost identical (maybe should be completely identical)
+/// to `IECoreArnold::ShaderNetworkAlgo::parameterValue`. Should that get
+/// pulled out to a common location?
+template<typename T>
+T parameterValue( const Shader *shader, InternedString parameterName, const T &defaultValue )
+{
+	if( auto d = shader->parametersData()->member<TypedData<T>>( parameterName ) )
+	{
+		return d->readable();
+	}
+
+	if constexpr( std::is_same_v<std::remove_cv_t<T>, Color3f> )
+	{
+		// Correction for USD files which author `float3` instead of `color3f`.
+		// See `ShaderNetworkAlgoTest.testConvertUSDFloat3ToColor3f()`.
+		if( auto d = shader->parametersData()->member<V3fData>( parameterName ) )
+		{
+			return d->readable();
+		}
+		/// \todo Do we need the corresponding conversion of Color4 from `IECoreArnold::ShaderNetworkAlgo::parameterValue`?
+	}
+
+	else if constexpr( std::is_same_v<std::remove_cv_t<T>, std::string> )
+	{
+		// Support for USD `token`, which will be loaded as `InternedString`, but which
+		// we want to translate to `string`.
+		if( auto d = shader->parametersData()->member<InternedStringData>( parameterName ) )
+		{
+			return d->readable().string();
+		}
+	}
+
+	return defaultValue;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// USD conversion code
+//////////////////////////////////////////////////////////////////////////
+
+// Traits class to handle the GeometricTypedData fiasco.
+template<typename T>
+struct DataTraits
+{
+
+	using DataType = IECore::TypedData<T>;
+
+};
+
+template<typename T>
+struct DataTraits<Vec2<T> >
+{
+
+	using DataType = IECore::GeometricTypedData<Vec2<T>>;
+
+};
+
+template<typename T>
+struct DataTraits<Vec3<T> >
+{
+
+	using DataType = IECore::GeometricTypedData<Vec3<T>>;
+
+};
+
+Color3f blackbody( float kelvins )
+{
+	// Table borrowed from `UsdLuxBlackbodyTemperatureAsRgb()`, which in
+	// turn is borrowed from Colour Rendering of Spectra by John Walker.
+	static SplinefColor3f g_spline(
+		CubicBasisf::catmullRom(),
+		{
+			{  1000.0f, Color3f( 1.000000f, 0.027490f, 0.000000f ) },
+			{  1000.0f, Color3f( 1.000000f, 0.027490f, 0.000000f ) },
+			{  1500.0f, Color3f( 1.000000f, 0.149664f, 0.000000f ) },
+			{  2000.0f, Color3f( 1.000000f, 0.256644f, 0.008095f ) },
+			{  2500.0f, Color3f( 1.000000f, 0.372033f, 0.067450f ) },
+			{  3000.0f, Color3f( 1.000000f, 0.476725f, 0.153601f ) },
+			{  3500.0f, Color3f( 1.000000f, 0.570376f, 0.259196f ) },
+			{  4000.0f, Color3f( 1.000000f, 0.653480f, 0.377155f ) },
+			{  4500.0f, Color3f( 1.000000f, 0.726878f, 0.501606f ) },
+			{  5000.0f, Color3f( 1.000000f, 0.791543f, 0.628050f ) },
+			{  5500.0f, Color3f( 1.000000f, 0.848462f, 0.753228f ) },
+			{  6000.0f, Color3f( 1.000000f, 0.898581f, 0.874905f ) },
+			{  6500.0f, Color3f( 1.000000f, 0.942771f, 0.991642f ) },
+			{  7000.0f, Color3f( 0.906947f, 0.890456f, 1.000000f ) },
+			{  7500.0f, Color3f( 0.828247f, 0.841838f, 1.000000f ) },
+			{  8000.0f, Color3f( 0.765791f, 0.801896f, 1.000000f ) },
+			{  8500.0f, Color3f( 0.715255f, 0.768579f, 1.000000f ) },
+			{  9000.0f, Color3f( 0.673683f, 0.740423f, 1.000000f ) },
+			{  9500.0f, Color3f( 0.638992f, 0.716359f, 1.000000f ) },
+			{ 10000.0f, Color3f( 0.609681f, 0.695588f, 1.000000f ) },
+			{ 10000.0f, Color3f( 0.609681f, 0.695588f, 1.000000f ) },
+		}
+	);
+
+	Color3f c = g_spline( kelvins );
+	c /= c.dot( V3f( 0.2126f, 0.7152f, 0.0722f ) ); // Normalise luminance
+	return Color3f( std::max( c[0], 0.0f ), std::max( c[1], 0.0f ), std::max( c[2], 0.0f ) );
+}
+
+const InternedString g_angleParameter( "angle" );
+const InternedString g_aParameter( "a" );
+const InternedString g_bParameter( "b" );
+const InternedString g_colorParameter( "color" );
+const InternedString g_colorTemperatureParameter( "colorTemperature" );
+const InternedString g_coneAngleParameter( "coneAngle" );
+const InternedString g_penumbraAngleParameter( "penumbraAngle" );
+const InternedString g_diffuseParameter( "diffuse" );
+const InternedString g_enableColorTemperatureParameter( "enableColorTemperature" );
+const InternedString g_exposureParameter( "exposure" );
+const InternedString g_gParameter( "g" );
+const InternedString g_heightParameter( "height" );
+const InternedString g_intensityParameter( "intensity" );
+const InternedString g_lengthParameter ("length" );
+const InternedString g_radiusParameter( "radius" );
+const InternedString g_multiplyColorParameter( "b" );
+const InternedString g_multiplyInputParameter( "a" );
+const InternedString g_multiplyOutputParameter( "out" );
+const InternedString g_normalizeParameter( "normalize" );
+const InternedString g_rParameter( "r" );
+const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
+const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
+const InternedString g_specularParameter( "specular" );
+const InternedString g_textureFileParameter( "texture:file" );
+const InternedString g_textureFormatParameter( "texture:format" );
+const InternedString g_textureOutputParameter( "outColor" );
+const InternedString g_widthParameter( "width" );
+
+const InternedString g_dlColorParameter( "i_color" );
+const InternedString g_dlDiffuseParameter( "diffuse_contribution" );
+const InternedString g_dlEnvironmentTextureFileParameter( "image" );
+const InternedString g_dlEnvironmentTextureFormatParameter( "mapping" );
+const InternedString g_dlEnvSpecularParameter( "specular_contribution" );
+const InternedString g_dlNormalizeParameter( "normalize_area" );
+const InternedString g_dlSpecularParameter( "reflection_contribution" );
+const InternedString g_dlTextureFileParameter( "textureFile" );
+
+const float g_defaultAngle = 0.53f;
+const float g_defaultLength = 1.f;
+const float g_defaultWidth = 1.f;
+const float g_defaultHeight = 1.f;
+const float g_defaultRadius = 0.5f;
+
+const std::map<std::string, int> g_textureMappingModes{ { "latlong", 0 }, { "angular", 1 } };
+
+template<typename T>
+void transferUSDParameter( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, InternedString usdName, Shader *shader, InternedString name, const T &defaultValue )
+{
+	shader->parameters()[name] = new typename DataTraits<T>::DataType( parameterValue( usdShader, usdName, defaultValue ) );
+
+	if( ShaderNetwork::Parameter input = network->input( { shaderHandle, usdName } ) )
+	{
+		network->addConnection( { input, { shaderHandle, name } } );
+		network->removeConnection( { input, { shaderHandle, usdName } } );
+	}
+}
+
+void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
+{
+	Color3f color = parameterValue( usdShader, g_colorParameter, Color3f( 1 ) );
+	if( parameterValue( usdShader, g_enableColorTemperatureParameter, false ) )
+	{
+		color *= blackbody( parameterValue( usdShader, g_colorTemperatureParameter, 6500.f ) );
+	}
+	shader->parameters()[g_dlColorParameter] = new Color3fData( color );
+
+	transferUSDParameter( network, shaderHandle, usdShader, g_diffuseParameter, shader, g_dlDiffuseParameter, 1.f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_exposureParameter, shader, g_exposureParameter, 0.f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_intensityParameter, shader, g_intensityParameter, 1.f );
+
+	transferUSDParameter(
+		network,
+		shaderHandle,
+		usdShader,
+		g_specularParameter,
+		shader,
+		shader->getName() != "environmentLight" ? g_dlSpecularParameter : g_dlEnvSpecularParameter,
+		1.f
+	);
+}
+
+void transferUSDShapingParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
+{
+	if( auto d = usdShader->parametersData()->member<FloatData>( g_shapingConeAngleParameter) )
+	{
+		shader->setName( "spotLight" );
+		// USD docs don't currently specify any semantics for `shaping:cone:softness`, but we assume
+		// the semantics documented for RenderMan's PxrSphereLight, where it's basically specifying
+		// a penumbra as a 0-1 proportion of the cone. Relevant conversations on usd-interest :
+		//
+		// - https://groups.google.com/u/1/g/usd-interest/c/A6bc4OZjSB0/m/hwUL7Wf1AwAJ, in
+		//   which the opportunity to define semantics is declined.
+		// - https://groups.google.com/u/1/g/usd-interest/c/Ybe4aroAKbc/m/0Ui3DKMyCgAJ, in
+		//   which folks take their best guess.
+		// 3Delight treats the penumbra angle as an outset penumbra, expanding the total cone coverage.
+		// PxrSphereLight appears to treat it as inset, so the cone angle is still the angle at which
+		// light intensity reaches zero.
+		const float halfConeAngle = d->readable();
+		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.f );
+		if( softness > 1.0 )
+		{
+			// Houdini apparently has (or had?) its own interpretation of softness, with the "bar scene"
+			// containing lights with an angle of 20 degrees and a softness of 60! We have no idea how
+			// to interpret that, so punt for now.
+			/// \todo Hopefully things get more standardised and we can remove this, because the RenderMan
+			/// docs do imply that values above one are allowed.
+			IECore::msg( IECore::Msg::Warning, "transferUSDShapingParameters", "Ignoring `shaping:cone:softness` as it is greater than 1" );
+		}
+		else
+		{
+			const float penumbraAngle = softness * halfConeAngle;
+			shader->parameters()[g_coneAngleParameter] = new FloatData( ( halfConeAngle * 2.f ) - ( penumbraAngle * 2.f ) );
+			shader->parameters()[g_penumbraAngleParameter] = new FloatData( penumbraAngle );
+		}
+	}
+}
+
+void replaceUSDShader( ShaderNetwork *network, InternedString handle, ShaderPtr &&newShader )
+{
+	// Replace original shader with the new.
+	network->setShader( handle, std::move( newShader ) );
+
+	// Iterating over a copy because we will modify the range during iteration
+	ShaderNetwork::ConnectionRange range = network->outputConnections( handle );
+	std::vector<ShaderNetwork::Connection> outputConnections( range.begin(), range.end() );
+	for( auto &c : outputConnections )
+	{
+		if( c.source.name != g_rParameter && c.source.name != g_gParameter && c.source.name != g_bParameter && c.source.name != g_aParameter )
+		{
+			network->removeConnection( c );
+			c.source.name = InternedString();
+			network->addConnection( c );
+		}
+	}
+}
+
+void cylinderStatic(
+	std::vector<int> &vertsPerPoly,
+	std::vector<int> &vertIds,
+	std::vector<V3f> &n,
+	std::vector<int> &nIds
+)
+{
+	const int numSegments = 100;
+	vertsPerPoly.reserve( numSegments * 3 );
+	vertIds.reserve( numSegments * 10 );
+	n.reserve( numSegments + 2 );
+	nIds.reserve( numSegments * 10 );
+
+	// sides
+	for( int i = 0; i < numSegments + 1; ++i )
+	{
+		const float a = ( (float)i / (float)numSegments ) * 2.f * M_PI;
+
+		const float z = sin( a ) ;
+		const float y = cos( a );
+
+		n.push_back( V3f( 0, y, z ) );
+	}
+	for( int i = 0; i < numSegments; ++i )
+	{
+		vertIds.push_back( i * 2 );
+		vertIds.push_back( i * 2 + 1 );
+		vertIds.push_back( i * 2 + 3 );
+		vertIds.push_back( i * 2 + 2 );
+
+		nIds.push_back( i );
+		nIds.push_back( i );
+		nIds.push_back( i + 1 );
+		nIds.push_back( i + 1 );
+
+		vertsPerPoly.push_back( 4 );
+	}
+
+	// end caps
+	n.push_back( V3f( 1, 0, 0 ) );
+	n.push_back( V3f( -1, 0, 0 ) );
+
+	for( int i = 0; i < numSegments; ++i )
+	{
+		vertIds.push_back( numSegments + 1 );
+		vertIds.push_back( i * 2 );
+		vertIds.push_back( i * 2 + 2 );
+
+		nIds.push_back( numSegments + 1 );
+		nIds.push_back( numSegments + 1 );
+		nIds.push_back( numSegments + 1 );
+
+		vertsPerPoly.push_back( 3 );
+
+		vertIds.push_back( numSegments + 2 );
+		vertIds.push_back( i * 2 + 3 );
+		vertIds.push_back( i * 2 + 1 );
+
+		nIds.push_back( numSegments + 2 );
+		nIds.push_back( numSegments + 2 );
+		nIds.push_back( numSegments + 2 );
+
+		vertsPerPoly.push_back( 3 );
+	}
+}
+
+void cylinderP( const float radius, const float length, std::vector<V3f> &p )
+{
+	const int numSegments = 100;
+	p.reserve( numSegments * 2 + 2 );
+
+	const float halfLength = length * 0.5;
+
+	// sides
+	for( int i = 0; i < numSegments + 1; ++i )
+	{
+		const float a = ( (float)i / (float)numSegments ) * 2.f * M_PI;
+
+		const float z = sin( a ) * radius;
+		const float y = cos( a ) * radius;
+
+		p.push_back( V3f( halfLength, y, z ) );  // Length along the X-axis
+		p.push_back( V3f( -halfLength, y, z ) );
+	}
+
+	// end caps
+	p.push_back( V3f( halfLength, 0, 0 ) );
+	p.push_back( V3f( -halfLength, 0, 0 ) );
+}
+
+const std::unordered_map<std::string, std::string> g_shaderNameMap{
+	{ "SphereLight", "pointLight" },
+	{ "RectLight", "areaLight" },
+	{ "DiskLight", "areaLight" },
+	{ "DistantLight", "distantLight" },
+	{ "DomeLight", "environmentLight" },
+	{ "CylinderLight", "areaLight" }
+};
+
 }  // namespace
 
 namespace IECoreDelight
@@ -301,18 +638,267 @@ namespace IECoreDelight
 namespace ShaderNetworkAlgo
 {
 
+void convertUSDShaders( ShaderNetwork *shaderNetwork )
+{
+	for( const auto &[handle, shader] : shaderNetwork->shaders() )
+	{
+		ShaderPtr newShader;
+		const auto it = g_shaderNameMap.find( shader->getName() );
+		if( it != g_shaderNameMap.end() )
+		{
+			newShader = new Shader( it->second, "osl:light" );
+		}
+
+		if( newShader )
+		{
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+
+			// `pointLight` and `spotLight` are normalized by nature
+			// and normalization doesn't apply to `environmentLight`
+			if( newShader->getName() == "distantLight" || newShader->getName() == "areaLight" )
+			{
+				transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_dlNormalizeParameter, false );
+			}
+
+			if( shader->getName() == "RectLight" )
+			{
+				const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
+				if( textureFile != "" )
+				{
+					ShaderPtr textureShader = new Shader( "dlTexture" );
+					textureShader->parameters()[g_dlTextureFileParameter] = new StringData( textureFile );
+					// Add a `uvCoord` stub for `addDefaultUVShader()` to work with
+					textureShader->parameters()[g_uvCoordParameterName] = new FloatVectorData( { 0, 0 } );
+					const InternedString textureHandle = shaderNetwork->addShader( handle.string() + "Texture", std::move( textureShader ) );
+
+					const Color3f color = parameterValue( shader.get(), g_colorParameter, Color3f( 1 ) );
+					if( color != Color3f( 1 ) )
+					{
+						// Multiply image with color
+						ShaderPtr multiplyShader = new Shader( "Maths/MultiplyColor" );
+						multiplyShader->parameters()[g_multiplyColorParameter] = new Color3fData( color );
+						const InternedString multiplyHandle = shaderNetwork->addShader( handle.string() + "Multiply", std::move( multiplyShader ) );
+						shaderNetwork->addConnection( ShaderNetwork::Connection( { multiplyHandle, g_multiplyOutputParameter }, { handle, g_dlColorParameter } ) );
+						shaderNetwork->addConnection( ShaderNetwork::Connection( { textureHandle, g_textureOutputParameter }, { multiplyHandle, g_multiplyInputParameter } ) );
+					}
+					else
+					{
+						// Connect image directly
+						shaderNetwork->addConnection( ShaderNetwork::Connection( { textureHandle, g_textureOutputParameter }, { handle, g_dlColorParameter } ) );
+					}
+				}
+			}
+			if( shader->getName() == "DomeLight" )
+			{
+				const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
+				newShader->parameters()[g_dlEnvironmentTextureFileParameter] = new StringData( textureFile );
+
+				if( !textureFile.empty() )
+				{
+					const std::string format = parameterValue( shader.get(), g_textureFormatParameter, std::string() );
+					auto it = g_textureMappingModes.find( format );
+					if( it == g_textureMappingModes.end() )
+					{
+						IECore::msg( IECore::Msg::Warning, "transferUSDTextureFile", fmt::format( "Unsupported mapping mode \"{}\"", format ) );
+					}
+					else
+					{
+						newShader->parameters()[g_dlEnvironmentTextureFormatParameter] = new IntData( it->second );
+					}
+				}
+			}
+
+			replaceUSDShader( shaderNetwork, handle, std::move( newShader ) );
+		}
+	}
+}
+
 ShaderNetworkPtr preprocessedNetwork( const ShaderNetwork *shaderNetwork )
 {
 	ShaderNetworkPtr result = shaderNetwork->copy();
 
 	IECoreScene::ShaderNetworkAlgo::expandSplines( result.get() );
-
 	renameSplineParameters( result.get() );
+	convertUSDShaders( result.get() );
 	addDefaultUVShader( result.get() );
 
 	IECoreScene::ShaderNetworkAlgo::removeUnusedShaders( result.get() );
 
 	return result;
+}
+
+const char *lightGeometryType( const ShaderNetwork *shaderNetwork )
+{
+	if( const Shader *light = shaderNetwork->outputShader() )
+	{
+		if( light->getName() == "SphereLight" || light->getName() == "DiskLight" )
+		{
+			return "particles";
+		}
+		else if( light->getName() == "RectLight" || light->getName() == "CylinderLight" )
+		{
+			return "mesh";
+		}
+		else if( light->getName() == "DistantLight" || light->getName() == "DomeLight" )
+		{
+			return "environment";
+		}
+	}
+
+	return nullptr;
+}
+
+void updateLightGeometry( const ShaderNetwork *shaderNetwork, NSIContext_t context, const char *handle, MurmurHash &state )
+{
+	if( const Shader *light = shaderNetwork->outputShader() )
+	{
+		if( light->getName() == "SphereLight" || light->getName() == "DiskLight" )
+		{
+			if( state == MurmurHash() )
+			{
+				const V3f p( 0 );
+				ParameterList parameters;
+				parameters.add( { "P", &p, NSITypePoint, 1, 1, 0 } );
+
+				if( light->getName() == "DiskLight" )
+				{
+					const V3f n( 0, 0, -1.f );
+					parameters.add( { "N", &n, NSITypeNormal, 1, 1, 0 } );
+				}
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+			}
+
+			const float width = parameterValue( light, g_radiusParameter, g_defaultRadius ) * 2.f;
+
+			MurmurHash newState;
+			newState.append( width );
+
+			if( newState != state )
+			{
+				ParameterList parameters;
+				parameters.add( { "width", &width, NSITypeFloat, 0, 1, 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+
+				state = newState;
+			}
+		}
+		else if( light->getName() == "RectLight" )
+		{
+			if( state == MurmurHash() )
+			{
+				const int nvertices = 4;
+				ParameterList parameters;
+				parameters.add( { "nvertices", &nvertices, NSITypeInteger, 1, 1, 0 } );
+
+				const V2f st[4] = { V2f( 0, 1.f ), V2f( 0, 0 ), V2f( 1.f, 0 ), V2f( 1.f, 1.f ) };
+				parameters.add( { "st", &st, NSITypeFloat, 2, 4, NSIParamIsArray } );
+
+				const V3f n( 0, 0, -1.f );
+				parameters.add( { "N", &n, NSITypeNormal, 1, 1, 0 } );
+				const int nIndices[4] = { 0, 0, 0, 0 };
+				parameters.add( { "N.indices", &nIndices, NSITypeInteger, 1, 4, 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+			}
+
+			const float width = parameterValue( light, g_widthParameter, g_defaultWidth );
+			const float height = parameterValue( light, g_heightParameter, g_defaultHeight );
+
+			MurmurHash newState;
+			newState.append( width );
+			newState.append( height );
+
+			if( newState != state )
+			{
+				const V3f p[4] = {
+					V3f( 0.5f * width, 0.5f * height, 0 ),
+					V3f( 0.5f * width, -0.5f * height, 0 ),
+					V3f( -0.5f * width, -0.5f * height, 0 ),
+					V3f( -0.5f * width, 0.5f * height, 0 )
+				};
+				ParameterList parameters;
+				parameters.add( { "P", &p, NSITypePoint, 1, 4, 0 } );
+
+				const int pIndices[4] = { 0, 1, 2, 3 };
+				parameters.add( { "P.indices", &pIndices, NSITypeInteger, 1, 4, 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+
+				state = newState;
+			}
+		}
+		else if( light->getName() == "DistantLight" )
+		{
+			const double angle = parameterValue( light, g_angleParameter, g_defaultAngle );
+
+			MurmurHash newState;
+			newState.append( angle );
+
+			if( newState != state )
+			{
+				ParameterList parameters;
+				parameters.add( { "angle", &angle, NSITypeDouble, 0, 1, 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+
+				state = newState;
+			}
+		}
+		else if( light->getName() == "DomeLight" )
+		{
+			if( state == MurmurHash() )
+			{
+				const double angle = 360.f;
+				ParameterList parameters;
+				parameters.add( { "angle", &angle, NSITypeDouble, 0, 1, 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+			}
+		}
+		else if( light->getName() == "CylinderLight" )
+		{
+			if( state == MurmurHash() )
+			{
+				std::vector<int> vertsPerPoly;
+				std::vector<int> vertIds;
+				std::vector<V3f> n;
+				std::vector<int> nIds;
+
+				cylinderStatic( vertsPerPoly, vertIds, n, nIds );
+
+				ParameterList parameters;
+				parameters.add( { "nvertices", vertsPerPoly.data(), NSITypeInteger, 1, vertsPerPoly.size(), 0 } );
+				parameters.add( { "P.indices", vertIds.data(), NSITypeInteger, 1, vertIds.size(), 0 } );
+				parameters.add( { "N", n.data(), NSITypeNormal, 1, n.size(), 0 } );
+				parameters.add( { "N.indices", nIds.data(), NSITypeInteger, 1, nIds.size(), 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+			}
+
+			const float radius = parameterValue( light, g_radiusParameter, g_defaultRadius );
+			const float length = parameterValue( light, g_lengthParameter, g_defaultLength );
+
+			MurmurHash newState;
+			newState.append( radius );
+			newState.append( length );
+
+			if( newState != state )
+			{
+				std::vector<V3f> p;
+				cylinderP( radius, length, p );
+
+				ParameterList parameters;
+				parameters.add( { "P", p.data(), NSITypePoint, 1, p.size(), 0 } );
+
+				NSISetAttribute( context, handle, parameters.size(), parameters.data() );
+
+				state = newState;
+			}
+		}
+	}
 }
 
 }  // namespace ShaderNetworkAlgo


### PR DESCRIPTION
This adds support for USD Lights in 3Delight. Because 3Delight uses geometry for lights and Gaffer's lights are only shaders (attributes), the separation between geometry and attributes gets a bit blurry. I think I'm handling it pretty cleanly here, but improvements are welcome.

One oddity in the translation is that the `normalize` parameter does not have an effect on spot lights. So in USD-land that's anything with a cone shaping parameter set, most likely a DiskLight or RectLight from the 3Delight point of view. 3Delight always normalizes its intensity in `spotLight` shaders.

I'm not sure what user expectations / USD behavior should be. Do we un-normalize them by multiplying the intensity by area (when the parameter is `False`).

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
