### PR TITLE
Cycles : Light-linking

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,17 @@
 1.4.x.x (relative to 1.4.0.0b4)
 =======
 
+Features
+--------
 
+- Cycles : Added support for light-linking.
+
+Improvements
+------------
+
+- Cycles :
+  - CyclesMeshLight now has emission sampling method strategies on the node itself.
+  - Remove hiding visibility flags on the meshlight created by CyclesMeshLight, this was for Arnold and not correct for Cycles.
 
 1.4.0.0b4 (relative to 1.4.0.0b3)
 =========

--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -108,16 +108,6 @@ class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		pass
 
-	@unittest.skip( "Light linking not supported" )
-	def testLightLinking( self ) :
-
-		pass
-
-	@unittest.skip( "Light linking not supported" )
-	def testHideLinkedLight( self ) :
-
-		pass
-
 	def _createConstantShader( self ) :
 
 		shader = GafferCycles.CyclesShader()

--- a/python/GafferCyclesUI/CyclesMeshLightUI.py
+++ b/python/GafferCyclesUI/CyclesMeshLightUI.py
@@ -50,8 +50,7 @@ Gaffer.Metadata.registerNode(
 	"description",
 	"""
 	Turns mesh primitives into Cycles mesh lights by assigning
-	an emission shader, turning off all visibility except for camera rays,
-	and adding the meshes to the default lights set.
+	an emission shader and adding the meshes to the default lights set.
 	""",
 
 	plugs = {
@@ -64,6 +63,8 @@ Gaffer.Metadata.registerNode(
 			rays.
 			""",
 
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
 		],
 
 		"lightGroup" : [
@@ -72,6 +73,31 @@ Gaffer.Metadata.registerNode(
 			"""
 			The light group that the mesh light will contribute to.
 			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"emissionSamplingMethod" : [
+
+			"description",
+			"""
+			Sampling strategy for emissive surfaces.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"emissionSamplingMethod.value" : [
+
+			"preset:None", "none",
+			"preset:Auto", "auto",
+			"preset:Front", "front",
+			"preset:Back", "back",
+			"preset:Front-Back", "front_back",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/src/GafferCycles/CyclesMeshLight.cpp
+++ b/src/GafferCycles/CyclesMeshLight.cpp
@@ -57,26 +57,12 @@ CyclesMeshLight::CyclesMeshLight( const std::string &name )
 	:	GafferScene::FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
 {
 
-	// CyclesAttributesNode. This hides the objects from the majority
-	// of ray types, since we don't want to add the poor sampling of the
-	// object on top of the nice sampling of the light. The only visibility
-	// option we don't turn off is camera visibility - instead we promote
-	// so the user can decide whether or not the mesh should be visible in
-	// the render.
-
 	CyclesAttributesPtr attributes = new CyclesAttributes( "__attributes" );
 	attributes->inPlug()->setInput( inPlug() );
 	attributes->filterPlug()->setInput( filterPlug() );
-	for( NameValuePlug::Iterator it( attributes->attributesPlug() ); !it.done(); ++it )
-	{
-		if( boost::ends_with( (*it)->getName().string(), "Visibility" ) && (*it)->getName() != "cameraVisibility" )
-		{
-			(*it)->enabledPlug()->setValue( true );
-			(*it)->valuePlug<BoolPlug>()->setValue( false );
-		}
-	}
-
 	addChild( attributes );
+
+	// Camera visibility
 
 	Plug *internalCameraVisibilityPlug = attributes->attributesPlug()->getChild<Plug>( "cameraVisibility" );
 	PlugPtr cameraVisibilityPlug = internalCameraVisibilityPlug->createCounterpart( "cameraVisibility", Plug::In );
@@ -89,6 +75,13 @@ CyclesMeshLight::CyclesMeshLight( const std::string &name )
 	PlugPtr lightGroupPlug = internalLightGroupPlug->createCounterpart( "lightGroup", Plug::In );
 	addChild( lightGroupPlug );
 	internalLightGroupPlug->setInput( lightGroupPlug );
+
+	// Emission sampling method
+
+	Plug *internalEmissionSamplingMethodPlug = attributes->attributesPlug()->getChild<Plug>( "emissionSamplingMethod" );
+	PlugPtr emissionSamplingMethodPlug = internalEmissionSamplingMethodPlug->createCounterpart( "emissionSamplingMethod", Plug::In );
+	addChild( emissionSamplingMethodPlug );
+	internalEmissionSamplingMethodPlug->setInput( emissionSamplingMethodPlug );
 
 	// Shader node. This loads the Cycles emission shader.
 
@@ -115,13 +108,23 @@ CyclesMeshLight::CyclesMeshLight( const std::string &name )
 	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
 	addChild( shaderAssignment );
 
+	// Set node. This adds the objects into the __lights set,
+	// so they will be output correctly to the renderer.
+
+	SetPtr set = new Set( "__set" );
+	set->inPlug()->setInput( shaderAssignment->outPlug() );
+	set->filterPlug()->setInput( filterPlug() );
+	set->namePlug()->setValue( "__lights" );
+	set->modePlug()->setValue( Set::Add );
+	addChild( set );
+
 	// Default lights Set node.
 
 	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
 	addChild( defaultLightPlug );
 
 	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
-	defaultLightsSet->inPlug()->setInput( shaderAssignment->outPlug() );
+	defaultLightsSet->inPlug()->setInput( set->outPlug() );
 	defaultLightsSet->filterPlug()->setInput( filterPlug() );
 	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
 	defaultLightsSet->namePlug()->setValue( "defaultLights" );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- This adds support for Cycles light-linking, as well as shadow groups (however it is using the Arnold `ai:visibility:shadow_group` attribute for now until the renderer interface gets updated)

- Should this PR also add a `StandardAttributes` for shadow groups, now that Cycles supports them and not just Arnold?

- We will also need a shadow-link test but perhaps it should be added as a global test once it is a standard attribute

- I'd love to have new eyes on this as well, as it's a lot of code (however I've been doing some extensive testing and bug-fixing especially for live rendering updates already).

### Related issues ###

- NA

### Dependencies ###

- https://github.com/GafferHQ/gaffer/pull/5578

### Breaking changes ###

- CyclesMeshLight now adds those particular meshes to the `Lights` set so it now gets created like a light, which is needed so that light-linking and shadow groups can work. I've also removed disabling visibility flags as it works differently to Arnold here and they shouldn't be turned off by default (a user can still modify them using a `CyclesAttributes` if they wish).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
