### PR TITLE
ImageStats : Improve Area Handling 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ Improvements
 - Backdrop : Improved drawing order for nested backdrops :
   - Larger backdrops are automatically drawn behind smaller ones, so that nested backdrops will always appear on top.
   - Added a `depth` plug to assign a manual drawing depth for the rare cases where the automatic depth is unwanted.
+- ImageStats : Added `areaSource` plug, allowing area to be driven by the input display window or data window.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -46,7 +46,9 @@ Fixes
   - Stopped failed jobs jumping to the end of the Local Jobs UI.
   - Fixed message log update.
   - Fixed `Job.statistics()` errors on Windows, ensuring that a `pid` is always returned when available.
-- ImageStats : Fixed output of infinite values, which were previously being clamped.
+- ImageStats :
+  - Fixed output of infinite values, which were previously being clamped.
+  - Results for min/max now correctly reflect zero values outside the data window.
 - NodeMenu, NodeEditor : `userDefault` metadata is now evaluated in the script context, so it can depend on script variables.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -46,6 +46,7 @@ Fixes
   - Fixed message log update.
   - Fixed `Job.statistics()` errors on Windows, ensuring that a `pid` is always returned when available.
 - ImageStats : Fixed output of infinite values, which were previously being clamped.
+- NodeMenu, NodeEditor : `userDefault` metadata is now evaluated in the script context, so it can depend on script variables.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -112,6 +112,7 @@ Breaking Changes
   - Removed ChannelPlug type. Use `Gaffer.ShufflePlug` instead.
   - Renamed `channels` plug to `shuffles` plug, matching nodes such as ShuffleAttributes and ShufflePrimitiveVariables.
 - ShuffleUI : Removed `nodeMenuCreateCommand()`.
+- ImageStatsUI : Removed `postCreate()`.
 
 Build
 -----

--- a/include/GafferImage/ImageStats.h
+++ b/include/GafferImage/ImageStats.h
@@ -59,6 +59,13 @@ class GAFFERIMAGE_API ImageStats : public Gaffer::ComputeNode
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImage::ImageStats, ImageStatsTypeId, Gaffer::ComputeNode );
 
+		enum AreaSource
+		{
+			Area = 0,
+			DataWindow = 1,
+			DisplayWindow = 2,
+		};
+
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
 		GafferImage::ImagePlug *inPlug();
@@ -69,6 +76,9 @@ class GAFFERIMAGE_API ImageStats : public Gaffer::ComputeNode
 
 		Gaffer::StringVectorDataPlug *channelsPlug();
 		const Gaffer::StringVectorDataPlug *channelsPlug() const;
+
+		Gaffer::IntPlug *areaSourcePlug();
+		const Gaffer::IntPlug *areaSourcePlug() const;
 
 		Gaffer::Box2iPlug *areaPlug();
 		const Gaffer::Box2iPlug *areaPlug() const;

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -188,6 +188,40 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		self.__assertColour( s["min"].getValue(), imath.Color4f( 0.25, 0, 0, 0.5 ) )
 		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0, 0.75 ) )
 
+		# Offset the colors in the image so we can see the effects of whether or not we include pixels outside
+		# the data window.
+
+		g = GafferImage.Grade()
+		g["in"].setInput( r["out"] )
+		g['channels'].setValue( "*" )
+		g['blackClamp'].setValue( False )
+		g['whiteClamp'].setValue( False )
+		g['offset'].setValue( imath.Color4f( 1 ) )
+
+		s["in"].setInput( g["out"] )
+
+		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 25, 25 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 1.5, 1, 1, 1.5 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 1.5, 1, 1, 1.5 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 1.5, 1, 1, 1.5 ) )
+
+		s["area"].setValue( imath.Box2i( imath.V2i( 19, 20 ), imath.V2i( 24, 25 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( 1.2, 0.8, 0.8, 1.2 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 1.5, 1, 1, 1.5 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+
+		g['offset'].setValue( imath.Color4f( -2 ) )
+
+		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 25, 25 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( -1.5, -2, -2, -1.5 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( -1.5, -2, -2, -1.5 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( -1.5, -2, -2, -1.5 ) )
+
+		s["area"].setValue( imath.Box2i( imath.V2i( 19, 20 ), imath.V2i( 24, 25 ) ) )
+		self.__assertColour( s["average"].getValue(), imath.Color4f( -1.2, -1.6, -1.6, -1.2 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( -1.5, -2, -2, -1.5 ) )
+
 	# Test only tiles which intersect a changed boundary have modified hashes
 	def testROIHash( self ) :
 

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -116,7 +116,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		r["fileName"].setValue( self.__rgbFilePath )
 
 		s = GafferImage.ImageStats()
-		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.DisplayWindow )
 
 		# Get the hashes of the outputs when there is no input.
 		minHash = s["min"].hash()
@@ -138,7 +138,7 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
-		s["area"].setValue( r["out"]["format"].getValue().getDisplayWindow() )
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.DisplayWindow )
 		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.0544, 0.0744, 0.1250, 0.2537 ) )
 		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
 		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
@@ -152,6 +152,31 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		s = GafferImage.ImageStats()
 		s["in"].setInput( r["out"] )
 		s["channels"].setValue( IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
+
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.DisplayWindow )
+		self.__assertColour( s["average"].getValue(), imath.Color4f(0.054375, 0.074375, 0.125, 0.25375) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
+
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.Area )
+		s["area"].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 100, 100 ) ) )
+
+		self.__assertColour( s["average"].getValue(), imath.Color4f(0.054375, 0.074375, 0.125, 0.25375) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
+
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.DataWindow )
+		self.__assertColour( s["average"].getValue(), imath.Color4f(0.151042, 0.206597, 0.347222, 0.704861) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
+
+		s["areaSource"].setValue( GafferImage.ImageStats.AreaSource.Area )
+		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 80, 80 ) ) )
+
+		self.__assertColour( s["average"].getValue(), imath.Color4f(0.151042, 0.206597, 0.347222, 0.704861) )
+		self.__assertColour( s["min"].getValue(), imath.Color4f( 0, 0, 0, 0 ) )
+		self.__assertColour( s["max"].getValue(), imath.Color4f( 0.5, 0.5, 0.5, 0.875 ) )
+
 
 		s["area"].setValue( imath.Box2i( imath.V2i( 20, 20 ), imath.V2i( 25, 25 ) ) )
 		self.__assertColour( s["average"].getValue(), imath.Color4f( 0.5, 0, 0, 0.5 ) )

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -78,7 +78,7 @@ Gaffer.Metadata.registerNode(
 			Where to source the actual area to use. If this is
 			set to DataWindow, it will use the input's Data Window,
 			if it is set to DisplayWindow, it will use the input's
-			Display Window, and if it is set to Custom, it will use
+			Display Window, and if it is set to Area, it will use
 			the Area plug.
 			""",
 
@@ -97,7 +97,7 @@ Gaffer.Metadata.registerNode(
 			"""
 			The custom area to set the Data/Display Window to.
 			This plug is only used if 'Area Source' is set to
-			Custom.
+			Area.
 			""",
 
 			"layout:activator", "areaSourceIsArea",

--- a/python/GafferImageUI/ImageStatsUI.py
+++ b/python/GafferImageUI/ImageStatsUI.py
@@ -62,6 +62,8 @@ Gaffer.Metadata.registerNode(
 	within the node graph.
 	""",
 
+	"layout:activator:areaSourceIsArea", lambda node : node["areaSource"].getValue() == GafferImage.ImageStats.AreaSource.Area,
+
 	plugs = {
 
 		"in" : [
@@ -98,14 +100,35 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"areaSource" : [
+
+			"description",
+			"""
+			Where to source the area to be analysed. If this is
+			set to DataWindow, it will use the input's Data Window,
+			if it is set to DisplayWindow, it will use the input's
+			Display Window, and if it is set to Area, it will use
+			the Area plug.
+			""",
+
+			"preset:Area", GafferImage.ImageStats.AreaSource.Area,
+			"preset:DataWindow", GafferImage.ImageStats.AreaSource.DataWindow,
+			"preset:DisplayWindow", GafferImage.ImageStats.AreaSource.DisplayWindow,
+
+			"nodule:type", "",
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
 		"area" : [
 
 			"description",
 			"""
 			The area of the image to be analysed.
+			This plug is only used if 'Area Source' is set to Area.
 			""",
 
-			"nodule:type", "",
+			"layout:activator", "areaSourceIsArea",
 
 		],
 

--- a/python/GafferImageUI/ImageStatsUI.py
+++ b/python/GafferImageUI/ImageStatsUI.py
@@ -39,18 +39,6 @@ import GafferUI
 import GafferImage
 import GafferImageUI
 
-## A function suitable as the postCreator in a NodeMenu.append() call. It
-# sets the region of interest for the node to cover the entire format.
-def postCreate( node, menu ) :
-
-	with node.scriptNode().context() :
-		if node["in"].getInput() :
-			format = node["in"]["format"].getValue()
-		else:
-			format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
-
-	node["area"].setValue( format.getDisplayWindow() )
-
 Gaffer.Metadata.registerNode(
 
 	GafferImage.ImageStats,
@@ -117,6 +105,7 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"userDefault", GafferImage.ImageStats.AreaSource.DisplayWindow,
 
 		],
 
@@ -129,6 +118,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"layout:activator", "areaSourceIsArea",
+			"userDefault", lambda plug : GafferImage.FormatPlug.getDefaultFormat( Gaffer.Context.current() ).getDisplayWindow()
 
 		],
 

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -233,7 +233,8 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 		node = self.nodeUI().node()
 		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
 			applyDefaults( node )
-			Gaffer.NodeAlgo.applyUserDefaults( node )
+			with node.ancestor( Gaffer.ScriptNode ).context():
+				Gaffer.NodeAlgo.applyUserDefaults( node )
 
 	def __applyReadOnly( self, readOnly ) :
 

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -116,7 +116,8 @@ class NodeMenu( object ) :
 				if node is None :
 					return
 
-				Gaffer.NodeAlgo.applyUserDefaults( node )
+				with script.context():
+					Gaffer.NodeAlgo.applyUserDefaults( node )
 
 				for plugName, plugValue in plugValues.items() :
 					node.descendant( plugName ).setValue( plugValue )

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -112,6 +112,7 @@ ImageStats::ImageStats( const std::string &name )
 	defaultChannels.push_back( "A" );
 	addChild( new StringVectorDataPlug( "channels", Plug::In, defaultChannelsData ) );
 
+	addChild( new IntPlug( "areaSource", Gaffer::Plug::In, ImageStats::Area, ImageStats::Area, ImageStats::DisplayWindow ) );
 	addChild( new Box2iPlug( "area", Gaffer::Plug::In ) );
 	addChild( new Color4fPlug(
 		"average", Gaffer::Plug::Out, Imath::Color4f( 0, 0, 0, 1 ),
@@ -173,75 +174,85 @@ const Gaffer::StringVectorDataPlug *ImageStats::channelsPlug() const
 	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 2 );
 }
 
+IntPlug *ImageStats::areaSourcePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
+const IntPlug *ImageStats::areaSourcePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 3 );
+}
+
 Box2iPlug *ImageStats::areaPlug()
 {
-	return getChild<Box2iPlug>( g_firstPlugIndex + 3 );
+	return getChild<Box2iPlug>( g_firstPlugIndex + 4 );
 }
 
 const Box2iPlug *ImageStats::areaPlug() const
 {
-	return getChild<Box2iPlug>( g_firstPlugIndex + 3 );
+	return getChild<Box2iPlug>( g_firstPlugIndex + 4 );
 }
 
 Color4fPlug *ImageStats::averagePlug()
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 4 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 5 );
 }
 
 const Color4fPlug *ImageStats::averagePlug() const
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 4 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 5 );
 }
 
 Color4fPlug *ImageStats::minPlug()
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 5 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 6 );
 }
 
 const Color4fPlug *ImageStats::minPlug() const
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 5 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 6 );
 }
 
 Color4fPlug *ImageStats::maxPlug()
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 6 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 7 );
 }
 
 const Color4fPlug *ImageStats::maxPlug() const
 {
-	return getChild<Color4fPlug>( g_firstPlugIndex + 6 );
+	return getChild<Color4fPlug>( g_firstPlugIndex + 7 );
 }
 
 ObjectPlug *ImageStats::tileStatsPlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 8 );
 }
 
 const ObjectPlug *ImageStats::tileStatsPlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 7 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 8 );
 }
 
 ObjectPlug *ImageStats::allStatsPlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 8 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 9 );
 }
 
 const ObjectPlug *ImageStats::allStatsPlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 8 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 9 );
 }
 
 
 ImagePlug *ImageStats::flattenedInPlug()
 {
-	return getChild<ImagePlug>( g_firstPlugIndex + 9 );
+	return getChild<ImagePlug>( g_firstPlugIndex + 10 );
 }
 
 const ImagePlug *ImageStats::flattenedInPlug() const
 {
-	return getChild<ImagePlug>( g_firstPlugIndex + 9 );
+	return getChild<ImagePlug>( g_firstPlugIndex + 10 );
 }
 
 void ImageStats::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
@@ -252,7 +263,9 @@ void ImageStats::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 		input == viewPlug() ||
 		input == flattenedInPlug()->viewNamesPlug() ||
 		input == flattenedInPlug()->dataWindowPlug() ||
+		input == flattenedInPlug()->formatPlug() ||
 		input == flattenedInPlug()->channelDataPlug() ||
+		input == areaSourcePlug() ||
 		areaPlug()->isAncestorOf( input )
 	)
 	{
@@ -264,6 +277,8 @@ void ImageStats::affects( const Gaffer::Plug *input, AffectedPlugsContainer &out
 		input == flattenedInPlug()->viewNamesPlug() ||
 		input == tileStatsPlug() ||
 		input == flattenedInPlug()->dataWindowPlug() ||
+		input == flattenedInPlug()->formatPlug() ||
+		input == areaSourcePlug() ||
 		areaPlug()->isAncestorOf( input )
 	)
 	{
@@ -326,7 +341,26 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 
 	{
 		ImagePlug::GlobalScope s( viewScope.context() );
-		const Imath::Box2i area = areaPlug()->getValue();
+		int areaSource = areaSourcePlug()->getValue();
+		Imath::Box2i area;
+		switch ( areaSource )
+		{
+			case ImageStats::DataWindow:
+			{
+				area = inPlug()->dataWindowPlug()->getValue();
+				break;
+			}
+			case ImageStats::DisplayWindow:
+			{
+				area = inPlug()->formatPlug()->getValue().getDisplayWindow();
+				break;
+			}
+			default:
+			{
+				area = areaPlug()->getValue();
+				break;
+			}
+		}
 		const Imath::Box2i dataWindow = flattenedInPlug()->dataWindowPlug()->getValue();
 		boundsIntersection = BufferAlgo::intersection( area, dataWindow );
 		areaMult = double(area.size().x) * area.size().y;
@@ -412,7 +446,26 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 
 	{
 		ImagePlug::GlobalScope s( viewScope.context() );
-		const Imath::Box2i area = areaPlug()->getValue();
+		int areaSource = areaSourcePlug()->getValue();
+		Imath::Box2i area;
+		switch ( areaSource )
+		{
+			case ImageStats::DataWindow:
+			{
+				area = inPlug()->dataWindowPlug()->getValue();
+				break;
+			}
+			case ImageStats::DisplayWindow:
+			{
+				area = inPlug()->formatPlug()->getValue().getDisplayWindow();
+				break;
+			}
+			default:
+			{
+				area = areaPlug()->getValue();
+				break;
+			}
+		}
 		const Imath::Box2i dataWindow = flattenedInPlug()->dataWindowPlug()->getValue();
 		boundsIntersection = BufferAlgo::intersection( area, dataWindow );
 		areaMult = double(area.size().x) * area.size().y;

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -337,6 +337,7 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 	}
 
 	Imath::Box2i boundsIntersection;
+	bool beyondDataWindow;
 	double areaMult;
 
 	{
@@ -363,6 +364,7 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 		}
 		const Imath::Box2i dataWindow = flattenedInPlug()->dataWindowPlug()->getValue();
 		boundsIntersection = BufferAlgo::intersection( area, dataWindow );
+		beyondDataWindow = boundsIntersection != area;
 		areaMult = double(area.size().x) * area.size().y;
 	}
 
@@ -383,6 +385,8 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 			h.append( 0.0f );
 			return;
 		}
+
+		h.append( beyondDataWindow );
 
 		// We traverse in TopToBottom order because otherwise the hash could change just based on
 		// the order in which hashes are combined
@@ -442,6 +446,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 	}
 
 	Imath::Box2i boundsIntersection;
+	bool beyondDataWindow;
 	double areaMult;
 
 	{
@@ -468,6 +473,7 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 		}
 		const Imath::Box2i dataWindow = flattenedInPlug()->dataWindowPlug()->getValue();
 		boundsIntersection = BufferAlgo::intersection( area, dataWindow );
+		beyondDataWindow = boundsIntersection != area;
 		areaMult = double(area.size().x) * area.size().y;
 	}
 
@@ -509,6 +515,12 @@ void ImageStats::compute( ValuePlug *output, const Context *context ) const
 		float min = std::numeric_limits<float>::infinity();
 		float max = -std::numeric_limits<float>::infinity();
 		double sum = 0.;
+
+		if( beyondDataWindow )
+		{
+			min = 0.;
+			max = 0.;
+		}
 
 		// We traverse in TopToBottom order because floating point precision means that changing
 		// the order to sum in could produce slightly non-deterministic results

--- a/src/GafferImageModule/UtilityNodeBinding.cpp
+++ b/src/GafferImageModule/UtilityNodeBinding.cpp
@@ -48,8 +48,16 @@ using namespace GafferImage;
 
 void GafferImageModule::bindUtilityNodes()
 {
+	{
+		scope s = GafferBindings::DependencyNodeClass<ImageStats>();
 
-	DependencyNodeClass<ImageStats>();
+		enum_<ImageStats::AreaSource>( "AreaSource" )
+			.value( "Area", ImageStats::Area )
+			.value( "DataWindow", ImageStats::DataWindow )
+			.value( "DisplayWindow", ImageStats::DisplayWindow )
+		;
+	}
+
 	DependencyNodeClass<ImageSampler>();
 	DependencyNodeClass<FormatQuery>();
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -388,7 +388,7 @@ nodeMenu.append( "/Image/Channels/Collect", GafferImage.CollectImages, searchTex
 nodeMenu.append( "/Image/Utility/Metadata", GafferImage.ImageMetadata, searchText = "ImageMetadata" )
 nodeMenu.append( "/Image/Utility/Delete Metadata", GafferImage.DeleteImageMetadata, searchText = "DeleteImageMetadata" )
 nodeMenu.append( "/Image/Utility/Copy Metadata", GafferImage.CopyImageMetadata, searchText = "CopyImageMetadata" )
-nodeMenu.append( "/Image/Utility/Stats", GafferImage.ImageStats, searchText = "ImageStats", postCreator = GafferImageUI.ImageStatsUI.postCreate  )
+nodeMenu.append( "/Image/Utility/Stats", GafferImage.ImageStats, searchText = "ImageStats" )
 nodeMenu.append( "/Image/Utility/Sampler", GafferImage.ImageSampler, searchText = "ImageSampler" )
 nodeMenu.append( "/Image/Utility/Catalogue", GafferImage.Catalogue )
 nodeMenu.append( "/Image/Utility/Catalogue Select", GafferImage.CatalogueSelect )


### PR DESCRIPTION
As discussed.

The one thing that might provoke discussion the handling of user default values. We of course want the actual default to stay the same for compatibility reasons. As for the actual choice of what the user default for areaSource should be, I'd be kinda tempted to say DataWindow, but I'm assuming John will want DisplayWindow, so I've gone with that. There's also the question of how it's applied - we'd previously used a postCreate that looks to the connected node to hardcode the area. It's much better to use one of the dynamic values for areaSource, and then it seems like we don't need a postCreate at all, and we can just use userDefaults instead - which to me feels more standard and expected. The one issue I ran into was that a good default for `area` is `FormatPlug.getDefaultFormat` ( which we used before when there wasn't a connection ), but that requires the script context to evaluate properly. It seemed like it should be legitimate for userDefault metadata to depend on the script context, so I made a small change to NodeMenu to make this possible - if that is undesirable for some reason, I can go back to a postCreate, but this feels fairly good to me.