### PR TITLE
Orientation : Normalize quaternion inputs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,11 @@ API
   - `fileSystemPath:extensions`
   - `fileSystemPath:extensionsLabel`
 
+Fixes
+-----
+
+- Orientation : Now normalizes quaternion inputs - this allows correctly processing files with primvars that contain unnormalized quaternions ( which it is possible to write from Houdini ).
+
 1.3.9.0 (relative to 1.3.8.0)
 =======
 

--- a/python/GafferSceneTest/OrientationTest.py
+++ b/python/GafferSceneTest/OrientationTest.py
@@ -68,6 +68,16 @@ class OrientationTest( GafferSceneTest.SceneTestCase ) :
 			IECore.QuatfVectorData()
 		)
 
+		points["unnormalizedQuaternion"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.QuatfVectorData()
+		)
+
+		points["unnormalizedHoudiniAlembicOrderQuaternion"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.QuatfVectorData()
+		)
+
 		points["axis"] = IECoreScene.PrimitiveVariable(
 			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
 			IECore.V3fVectorData()
@@ -93,6 +103,10 @@ class OrientationTest( GafferSceneTest.SceneTestCase ) :
 
 			points["euler"].data.append( degrees )
 			points["quaternion"].data.append( q )
+			points["unnormalizedQuaternion"].data.append( 0.2 * q )
+			points["unnormalizedHoudiniAlembicOrderQuaternion"].data.append(
+				0.2 * imath.Quatf( q.v()[0], q.v()[1], q.v()[2], q.r() )
+			)
 			points["axis"].data.append( q.axis() )
 			points["angle"].data.append( q.angle() )
 
@@ -163,6 +177,34 @@ class OrientationTest( GafferSceneTest.SceneTestCase ) :
 			orientation["out"].object( "/object" )["outAngle"].data,
 		)
 
+		# Test quaternion -> quaternion
+
+		orientation["inMode"].setValue( orientation.Mode.Quaternion )
+		orientation["outMode"].setValue( orientation.Mode.Quaternion )
+		orientation["outQuaternion"].setValue( "outQuaternion" )
+
+		orientation["inQuaternion"].setValue( "quaternion" )
+
+		self.__assertVectorDataAlmostEqual(
+			orientation["in"].object( "/object" )["quaternion"].data,
+			orientation["out"].object( "/object" )["outQuaternion"].data,
+		)
+
+		orientation["inQuaternion"].setValue( "unnormalizedQuaternion" )
+
+		self.__assertVectorDataAlmostEqual(
+			orientation["in"].object( "/object" )["quaternion"].data,
+			orientation["out"].object( "/object" )["outQuaternion"].data,
+		)
+
+		orientation["inQuaternion"].setValue( "unnormalizedHoudiniAlembicOrderQuaternion" )
+		orientation["inMode"].setValue( orientation.Mode.QuaternionXYZW )
+
+		self.__assertVectorDataAlmostEqual(
+			orientation["in"].object( "/object" )["quaternion"].data,
+			orientation["out"].object( "/object" )["outQuaternion"].data,
+		)
+
 	def testMismatchedInputSizes( self ) :
 
 		points = IECoreScene.PointsPrimitive(
@@ -223,7 +265,7 @@ class OrientationTest( GafferSceneTest.SceneTestCase ) :
 
 		if isinstance( a, IECore.QuatfVectorData ) :
 			equal = [
-				aa.axis().equalWithAbsError( bb.axis(), delta ) and math.fabs( aa.angle() - bb.angle() ) < delta
+				aa.v().equalWithAbsError( bb.v(), delta ) and math.fabs( aa.r() - bb.r() ) < delta
 				for aa, bb in zip( a, b )
 			]
 		elif isinstance( a, IECore.V3fVectorData ) :

--- a/src/GafferScene/Orientation.cpp
+++ b/src/GafferScene/Orientation.cpp
@@ -188,11 +188,11 @@ PrimitiveVariable inQuaternion( const Primitive *inputPrimitive, Primitive *outp
 	{
 		if( xyzw )
 		{
-			quaternions.push_back( Quatf( q.v.z, V3f( q.r, q.v.x, q.v.y ) ) );
+			quaternions.push_back( Quatf( q.v.z, V3f( q.r, q.v.x, q.v.y ) ).normalized() );
 		}
 		else
 		{
-			quaternions.push_back( q );
+			quaternions.push_back( q.normalized() );
 		}
 	}
 


### PR DESCRIPTION
As discussed ... there are some more complicated questions about whether other nodes should deal with unnormalized quaternions, but it seems pretty clear that Orientation should be able to deal with them.