### PR TITLE
Normalize Unnormalized Quaternions in Both Orientation and Instancer

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,7 @@ Fixes
 -----
 
 - Arnold : Fixed translation of USD `uchar` attributes and shader parameters.
-- Orientation : Now normalizes unnormalized quaternion inputs - this allows correctly processing files with primvars that contain unnormalized quaternions ( which it is possible to write from Houdini ).
+- Orientation/Instancer : Now normalizes unnormalized quaternion inputs - this allows correctly processing files with primvars that contain unnormalized quaternions ( which it is possible to write from Houdini ).
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 -----
 
 - Arnold : Fixed translation of USD `uchar` attributes and shader parameters.
+- Orientation : Now normalizes unnormalized quaternion inputs - this allows correctly processing files with primvars that contain unnormalized quaternions ( which it is possible to write from Houdini ).
 
 API
 ---

--- a/include/GafferScene/Orientation.h
+++ b/include/GafferScene/Orientation.h
@@ -193,6 +193,11 @@ class GAFFERSCENE_API Orientation : public ObjectProcessor
 		Gaffer::StringPlug *outMatrixPlug();
 		const Gaffer::StringPlug *outMatrixPlug() const;
 
+		// Normalize a quaternion if it is not already normalized. Values within tolerance of being
+		// normalized are passed through unmodified. The tolerance is calibrated so that any quaternion
+		// produced by Imath::Quatf::normalized() should be unmodified.
+		static inline Imath::Quatf normalizedIfNeeded( const Imath::Quatf &q );
+
 	protected :
 
 		bool affectsProcessedObject( const Gaffer::Plug *input ) const override;
@@ -208,3 +213,5 @@ class GAFFERSCENE_API Orientation : public ObjectProcessor
 IE_CORE_DECLAREPTR( Orientation )
 
 } // namespace GafferScene
+
+#include "GafferScene/Orientation.inl"

--- a/include/GafferScene/Orientation.inl
+++ b/include/GafferScene/Orientation.inl
@@ -1,0 +1,58 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace GafferScene
+{
+
+inline Imath::Quatf Orientation::normalizedIfNeeded( const Imath::Quatf &q )
+{
+	// Testing with four hundred million random quaternions, normalized using Imath, the lengths
+	// are always > 1 - 5e-7 and < 1 + 5e-7. We make this threshold slightly more tolerant
+	// to be safe.
+	float lengthSquared = q.r * q.r + ( q.v ^ q.v );
+	if( lengthSquared >= ( 1 - 6e-7 ) && lengthSquared <= ( 1 + 6e-7 ) )
+	{
+		return q;
+	}
+	else
+	{
+		return q.normalized();
+	}
+}
+
+} // namespace GafferScene

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -38,6 +38,7 @@
 #include "GafferScene/Instancer.h"
 
 #include "GafferScene/Capsule.h"
+#include "GafferScene/Orientation.h"
 #include "GafferScene/SceneAlgo.h"
 
 #include "GafferScene/Private/ChildNamesMap.h"
@@ -580,7 +581,11 @@ class Instancer::EngineData : public Data
 			}
 			if( m_orientations )
 			{
-				result = (*m_orientations)[pointIndex].toMatrix44() * result;
+				// Using Orientation::normalizedIfNeeded avoids modifying quaternions that are already
+				// normalized. It's better for consistency to not be pointlessly changing the values
+				// slightly at the limits of floating point precision, when they're already as close to
+				// normalized as they can get, and this saves 4% runtime on InstancerTest.testBoundPerformance.
+				result = Orientation::normalizedIfNeeded((*m_orientations)[pointIndex]).toMatrix44() * result;
 			}
 			if( m_scales )
 			{

--- a/src/GafferScene/Orientation.cpp
+++ b/src/GafferScene/Orientation.cpp
@@ -188,11 +188,11 @@ PrimitiveVariable inQuaternion( const Primitive *inputPrimitive, Primitive *outp
 	{
 		if( xyzw )
 		{
-			quaternions.push_back( Quatf( q.v.z, V3f( q.r, q.v.x, q.v.y ) ) );
+			quaternions.push_back( Orientation::normalizedIfNeeded( Quatf( q.v.z, V3f( q.r, q.v.x, q.v.y ) ) ) );
 		}
 		else
 		{
-			quaternions.push_back( q );
+			quaternions.push_back( Orientation::normalizedIfNeeded( q ) );
 		}
 	}
 

--- a/src/GafferSceneModule/ObjectProcessorBinding.cpp
+++ b/src/GafferSceneModule/ObjectProcessorBinding.cpp
@@ -100,7 +100,10 @@ void GafferSceneModule::bindObjectProcessor()
 	}
 
 	{
-		scope s = GafferBindings::DependencyNodeClass<Orientation>();
+		scope s = GafferBindings::DependencyNodeClass<Orientation>()
+			.def( "normalizedIfNeeded", &Orientation::normalizedIfNeeded )
+			.staticmethod( "normalizedIfNeeded" )
+		;
 
 		enum_<GafferScene::Orientation::Mode>( "Mode" )
 			.value( "Euler", GafferScene::Orientation::Mode::Euler )


### PR DESCRIPTION
I was asked to take a look at how normalizing orientations in the Instancer would affect performance.

I'm seeing a 7% overhead when evaluating the bounding box for a prototype ... this is a fairly minor difference on a fairly niche test - we would usually be doing more than just evaluating the bounding box, and I think there's a good case to be made that this evaluation should not actually be using orientations. But it is measurable ...

If I was confident in the correctness of always normalizing, I don't think that this performance difference is enough by itself to be worth dealing with. But I think there is a correctness argument in favour of not normalizing already normalized quaternions. If I set up a primvar with normalized quaternions in it, I think I have a reasonable expectations that myQuat.toMatrix44() will be used to transform the data. Having floating point tolerance result in my quaternion getting a length slightly different than 1, and then having all my results modified a tiny little bit ... feels undesirable and possibly confusing?

So, combined with the small but observable performance difference, I've tried out a convention of "normalize if it isn't already normalized" for both Instancer and Orientation. This completely removed all measurable slowdown from the performance test, and I think it's a pretty reasonable convention for correctness as well?