### PR TITLE
3Delight camera overscan support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ Improvements
   - Larger backdrops are automatically drawn behind smaller ones, so that nested backdrops will always appear on top.
   - Added a `depth` plug to assign a manual drawing depth for the rare cases where the automatic depth is unwanted.
 - ImageStats : Added `areaSource` plug, allowing area to be driven by the input display window or data window.
+- 3Delight : Added camera overscan support.
 
 Fixes
 -----

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -460,6 +460,11 @@ class RendererTest( GafferTest.TestCase ) :
 					"focalLength" : 2.0,
 					"clippingPlanes" : imath.V2f( 0.25, 10 ),
 					"shutter" : imath.V2f( 0, 1 ),
+					"overscan" : True,
+					"overscanTop" : 0.1,
+					"overscanBottom" : 0.2,
+					"overscanLeft" : 0.1,
+					"overscanRight" : 0.2,
 				}
 			),
 			r.attributes( IECore.CompoundObject() )
@@ -478,6 +483,7 @@ class RendererTest( GafferTest.TestCase ) :
 		self.__assertInNSI( '"pixelaspectratio" "float" 1 1', nsi )
 		self.__assertInNSI( '"clippingrange" "double" 2 [ 0.25 10 ]', nsi )
 		self.__assertInNSI( '"shutterrange" "double" 2 [ 0 1 ]', nsi )
+		self.__assertInNSI( '"overscan" "int[2]" 2 [ 200 100 400 200 ]', nsi )
 
 	def testObjectInstancing( self ) :
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1505,10 +1505,36 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			const V2i &resolution = camera->getResolution();
 			screeenParameters.add( { "resolution", resolution.getValue(), NSITypeInteger, 2, 1, NSIParamIsArray } );
 
+			const bool &overscanOn = camera->getOverscan();
+
+			const int overscanLeft = static_cast<int>(camera->getOverscanLeft() * resolution.x);
+			const int overscanTop = static_cast<int>(camera->getOverscanTop() * resolution.y);
+			const int overscanRight = static_cast<int>(camera->getOverscanRight() * resolution.x);
+			const int overscanBottom = static_cast<int>(camera->getOverscanBottom() * resolution.y);
+
+			const Box2i overscan(
+				V2i(
+					overscanLeft,
+					overscanTop
+				),
+				V2i(
+					overscanRight,
+					overscanBottom
+				)
+			);
+
+			if( overscanOn == true )
+			{
+				screeenParameters.add( { "overscan", overscan.min.getValue(), NSITypeInteger, 2, 2, NSIParamIsArray } );
+			}
+
 			Box2i renderRegion = camera->renderRegion();
 
-			// I can't find any support in 3delight for overscan - and if crop goes outside 0 - 1,
-			// it ignores crop.  So we clamp it.
+			// If crop goes outside 0 - 1, 3Delight ignores it, so we clamp.
+			/// \todo 3Delight interprets crop as 0-1 across the overscanned data window, but
+			/// Gaffer defines it as 0-1 across the original (non-overscanned) display window.
+			/// Adjust for that. This will only work nicely with the CropWindowTool if we also
+			/// update the display driver to output an accurate display window for overscanned renders.
 			renderRegion.min.x = std::max( 0, renderRegion.min.x );
 			renderRegion.max.x = std::min( resolution.x, renderRegion.max.x );
 			renderRegion.min.y = std::max( 0, renderRegion.min.y );


### PR DESCRIPTION

Generally describe what this PR will do, and why it is needed

- Camera overscan support (StandardOptions / Overscan ... ) for 3Delight 

This is my first Gaffer pull request, so I hope I have followed the expected conventions and processes correctly. If all is well with this pull request, I have several additional improvements for 3Delight's support in Gaffer that I have already implemented and I'll create individual pull requests for each of these additional features. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
