### PR TITLE
Arnold Renderer : Fix translation of `uchar` data from USD

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,11 @@ Improvements
 - USDLight : Added file browser for `shaping:ies:file` parameter.
 - OpenColorIOContext : Added file browser for `config` plug.
 
+Fixes
+-----
+
+- Arnold : Fixed translation of USD `uchar` attributes and shader parameters.
+
 API
 ---
 

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -184,6 +184,32 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 				ctypes.addressof( nodes[0].contents )
 			)
 
+	def testUCharParameters( self ) :
+
+		for dataType in ( IECore.IntData, IECore.UCharData ) :
+
+			with self.subTest( dataType = dataType ) :
+
+				network = IECoreScene.ShaderNetwork(
+					shaders = {
+						"imageHandle" : IECoreScene.Shader(
+							"image", "surface",
+							{
+								"start_channel" : dataType( 10 ),
+							}
+						),
+					},
+					output = "imageHandle"
+				)
+
+				with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+					nodes = IECoreArnold.ShaderNetworkAlgo.convert( network, universe, "test" )
+
+					self.assertEqual( len( nodes ), 1 )
+					self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( nodes[0] ) ), "image" )
+					self.assertEqual( arnold.AiNodeGetByte( nodes[0], "start_channel" ), 10 )
+
 	def testBlindData( self ) :
 
 		flat = IECoreScene.Shader( "flat" )

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -107,7 +107,11 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 				}
 				break;
 			case AI_TYPE_BYTE :
-				if( const IntData *data = dataCast<IntData>( name, value ) )
+				if( const IntData *data = runTimeCast<const IntData>( value ) )
+				{
+					AiNodeSetByte( node, name, data->readable() );
+				}
+				else if( const UCharData *data = dataCast<UCharData>( name, value ) )
 				{
 					AiNodeSetByte( node, name, data->readable() );
 				}


### PR DESCRIPTION
Gaffer represents all integral data as IntData generated from IntPlugs, ignoring the fact that the underlying type in Arnold might be `AI_TYPE_BYTE`, `AI_TYPE_INT` or `AI_TYPE_UINT`. So the renderer backend was only looking for IntData in several cases, which was OK for data generated in Gaffer but not for data loaded directly from USD. We now check for the exact type in addition to checking for IntData.

Longer term it seems clear that we should change Gaffer to generate the exact datatypes as well. This probably means introducing new plug types, and changing the type of common plugs on ArnoldAttributes and ArnoldShader should probably be considered a breaking change, as should changing the data types being output. So that remains as future work targeted to a major version change.
