### PR TITLE
3Delight NSI shaderattributes support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ Improvements
 - 3Delight :
   - Added camera overscan support.
   - NSI scene description export format is now based on file extension - `.nsi` for binary and `.nsia` for ASCII.
+  - Added support for reading `dl:` and `user:` attributes from shaders.
 
 Fixes
 -----

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -731,13 +731,19 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( len( allAttributes ), 1 )
 		attributes = allAttributes[next( iter( allAttributes ) )]
 
+		allTransforms = { k: v for k, v in nsi.items() if nsi[k]["nodeType"] == "transform" }
+		self.assertEqual( len( allTransforms ), 1 )
+		transforms = allTransforms[next( iter( allTransforms ) )]
+
 		self.assertIn( "surfaceshader", attributes )
 		self.assertIn( "volumeshader", attributes )
 		self.assertIn( "displacementshader", attributes )
+		self.assertIn( "shaderattributes", transforms )
 
 		self.assertGreater( len( attributes["surfaceshader"] ), 0 )
 		self.assertGreater( len( attributes["volumeshader"] ), 0 )
 		self.assertGreater( len( attributes["displacementshader"] ), 0 )
+		self.assertGreater( len( transforms["shaderattributes"] ), 0 )
 
 		surfaceShader = self.__connectionSource( attributes["surfaceshader"][0], nsi )
 		volumeShader = self.__connectionSource( attributes["volumeshader"][0], nsi )

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -656,7 +656,10 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 				}
 				else if( boost::starts_with( m.first.string(), "user:" ) )
 				{
-					msg( Msg::Warning, "DelightRenderer", fmt::format( "User attribute \"{}\" not supported", m.first.string() ) );
+					if( const Data *d = reportedCast<const IECore::Data>( m.second.get(), "attribute", m.first ) )
+					{
+						params.add( m.first.c_str(), d, true );
+					}
 				}
 				else if( boost::contains( m.first.string(), ":" ) )
 				{
@@ -992,6 +995,11 @@ class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
 					m_attributes->handle().name(), "",
 					m_transformHandle.name(), "geometryattributes"
 				);
+				NSIDisconnect(
+					m_transformHandle.context(),
+					m_attributes->handle().name(), "",
+					m_transformHandle.name(), "shaderattributes"
+				);
 			}
 
 			m_attributes = static_cast<const DelightAttributes *>( attributes );
@@ -1002,6 +1010,14 @@ class DelightObject : public IECoreScenePreview::Renderer::ObjectInterface
 				0, nullptr
 
 			);
+			NSIConnect(
+				m_transformHandle.context(),
+				m_attributes->handle().name(), "",
+				m_transformHandle.name(), "shaderattributes",
+				0, nullptr
+
+			);
+
 			return true;
 		}
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Support for translating Gaffer dl: attributes into NSI shaderattributes. Previously dl: attributes were only exported as geometryattributes making them inaccessible by shaders.  

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
