### PR TITLE
3Delight NSI importance sample filter and evaluate file options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ Improvements
   - Added camera overscan support.
   - NSI scene description export format is now based on file extension - `.nsi` for binary and `.nsia` for ASCII.
   - Added support for reading `dl:` and `user:` attributes from shaders.
+  - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -41,6 +41,7 @@ Improvements
   - NSI scene description export format is now based on file extension - `.nsi` for binary and `.nsia` for ASCII.
   - Added support for reading `dl:` and `user:` attributes from shaders.
   - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
+  - Matched DelightOptions default values for `oversampling` and `shadingSamples` to 3Delight's own default values.
 
 Fixes
 -----
@@ -123,6 +124,7 @@ Breaking Changes
 - ImageStatsUI : Removed `postCreate()`.
 - 3Delight : Changed NSI scene description export with `.nsi` file extension from ASCII to binary (`.nsia` is used for ASCII now).
 - OSLShader : Output parameters are now loaded onto the `out` plug for all types (`surface`, `displacement` etc), not just `shader`.
+- DelightOptions : Changed default values for `oversampling` and `shadingSamples` plugs.
 
 Build
 -----

--- a/python/GafferDelightUI/DelightOptionsUI.py
+++ b/python/GafferDelightUI/DelightOptionsUI.py
@@ -71,6 +71,9 @@ def __qualitySummary( plug ) :
 	if plug["clampIndirect"]["enabled"].getValue() :
 		info.append( "Clamp Indirect {}".format( plug["clampIndirect"]["value"].getValue() ) )
 
+	if plug["importanceSampleFilter"]["enabled"].getValue() :
+		info.append( "Importance Sample Filter {}".format( "On" if plug["importanceSampleFilter"]["value"].getValue() else "Off" ) )
+
 	return ", ".join( info )
 
 def __featuresSummary( plug ) :
@@ -282,6 +285,18 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The maximum value to clamp indirect light rays to.
+			""",
+
+			"layout:section", "Quality",
+
+		],
+
+		"options.importanceSampleFilter" : [
+
+			"description",
+			"""
+			Use filter importance sampling (on) or splatting (off)
+			for sample filtering.
 			""",
 
 			"layout:section", "Quality",

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -483,7 +483,6 @@ class RendererTest( GafferTest.TestCase ) :
 		self.__assertInNSI( '"pixelaspectratio" "float" 1 1', nsi )
 		self.__assertInNSI( '"clippingrange" "double" 2 [ 0.25 10 ]', nsi )
 		self.__assertInNSI( '"shutterrange" "double" 2 [ 0 1 ]', nsi )
-		self.__assertInNSI( '"overscan" "int[2]" 2 [ 200 100 400 200 ]', nsi )
 
 	def testObjectInstancing( self ) :
 
@@ -650,6 +649,39 @@ class RendererTest( GafferTest.TestCase ) :
 		for name, value, type in options :
 			self.__assertInNSI(
 				'SetAttribute ".global" "{}" "{}" 1 {}{}{}'.format(
+				name[3:],
+				type,
+				"\"" if type == "string" else "",
+				value.value if not isinstance( value, IECore.BoolData ) else int( value.value ),
+				"\"" if type == "string" else ""
+			),
+			nsi
+		)
+
+	def testScreenOptions( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.nsia" )
+		)
+
+		options = [
+			( "dl:oversampling", IECore.IntData( 16 ), "int" ),
+			( "dl:importancesamplefilter", IECore.BoolData( True ), "int" ),
+		]
+
+		for name, value, type in options :
+			r.option( name, value )
+
+		r.render()
+		del r
+
+		nsi = self.__parse( self.temporaryDirectory() / "test.nsia" )
+
+		for name, value, type in options :
+			self.__assertInNSI(
+				'SetAttribute "ieCoreDelight:defaultScreen" "{}" "{}" 1 {}{}{}'.format(
 				name[3:],
 				type,
 				"\"" if type == "string" else "",

--- a/src/GafferDelight/DelightOptions.cpp
+++ b/src/GafferDelight/DelightOptions.cpp
@@ -54,8 +54,8 @@ DelightOptions::DelightOptions( const std::string &name )
 
 	// Quality
 
-	options->addChild( new Gaffer::NameValuePlug( "dl:oversampling", new IECore::IntData( 9 ), false, "oversampling" ) );
-	options->addChild( new Gaffer::NameValuePlug( "dl:quality.shadingsamples", new IECore::IntData( 64 ), false, "shadingSamples" ) );
+	options->addChild( new Gaffer::NameValuePlug( "dl:oversampling", new IECore::IntData( 4 ), false, "oversampling" ) );
+	options->addChild( new Gaffer::NameValuePlug( "dl:quality.shadingsamples", new IECore::IntData( 1 ), false, "shadingSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "dl:quality.volumesamples", new IECore::IntData( 1 ), false, "volumeSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "dl:clampindirect", new IECore::FloatData( 2 ), false, "clampIndirect" ) );
 	options->addChild( new Gaffer::NameValuePlug( "dl:importancesamplefilter", new IECore::BoolData( false ), false, "importanceSampleFilter" ) );

--- a/src/GafferDelight/DelightOptions.cpp
+++ b/src/GafferDelight/DelightOptions.cpp
@@ -58,6 +58,7 @@ DelightOptions::DelightOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "dl:quality.shadingsamples", new IECore::IntData( 64 ), false, "shadingSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "dl:quality.volumesamples", new IECore::IntData( 1 ), false, "volumeSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "dl:clampindirect", new IECore::FloatData( 2 ), false, "clampIndirect" ) );
+	options->addChild( new Gaffer::NameValuePlug( "dl:importancesamplefilter", new IECore::BoolData( false ), false, "importanceSampleFilter" ) );
 
 	// Features
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Support for importance sample filter and evaluate file options in the NSI scene passed from Gaffer to 3Delight for rendering (or exported to an NSI file). The importance sample filter enables compatibility of the rendered image with ML based denoisers. The evaluate file reads an external NSI apistream or lua script file and adds the evaluated result at the end of the Gaffer generated NSI scene. Both options are exposed to the user in the DelightOptions node. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
