### PR TITLE
Layouts : Improve loading of layouts with unavailable editors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
   - Added bookmarks.
 - USDLight : Added file browser for `shaping:ies:file` parameter.
 - OpenColorIOContext : Added file browser for `config` plug.
+- Layouts : Added the ability to load layouts containing editors that aren't currently available. This allows layouts containing new editors introduced in Gaffer 1.4 to be loaded in Gaffer 1.3.
 
 Fixes
 -----

--- a/python/GafferUITest/LayoutsTest.py
+++ b/python/GafferUITest/LayoutsTest.py
@@ -191,5 +191,47 @@ class LayoutsTest( GafferUITest.TestCase ) :
 		ns = editors[3].getNodeSet()
 		self.assertTrue( isinstance( ns, Gaffer.StandardSet ) )
 
+	def testMissingEditorType( self ) :
+
+		applicationRoot = Gaffer.ApplicationRoot( "testApp" )
+		layouts = GafferUI.Layouts.acquire( applicationRoot )
+
+		# Register a layout containing an editor that doesn't exist.
+		layouts.add( "MissingEditor", "GafferUI.NonexistentEditor( scriptNode )" )
+
+		# Check that we can still create such a layout, and that
+		# it has a proxy with the expected properties.
+		script = Gaffer.ScriptNode()
+		layout = layouts.create( "MissingEditor", script )
+		self.assertIsInstance( layout, GafferUI.Editor )
+		self.assertEqual( layout.getTitle(), "Nonexistent Editor" )
+
+		# Save the layout again and check that the same applies.
+		layouts.add( "MissingEditor2", layout )
+		layout2 = layouts.create( "MissingEditor2", script )
+		self.assertIsInstance( layout2, GafferUI.Editor )
+		self.assertEqual( layout2.getTitle(), "Nonexistent Editor" )
+
+	def testMissingEditorModule( self ) :
+
+		applicationRoot = Gaffer.ApplicationRoot( "testApp" )
+		layouts = GafferUI.Layouts.acquire( applicationRoot )
+
+		# Register a layout containing an editor from a module that doesn't exist.
+		layouts.add( "MissingEditor", "NonexistentGafferModule.NonexistentEditor( scriptNode )" )
+
+		# Check that we can still create such a layout, and that
+		# it has a proxy with the expected properties.
+		script = Gaffer.ScriptNode()
+		layout = layouts.create( "MissingEditor", script )
+		self.assertIsInstance( layout, GafferUI.Editor )
+		self.assertEqual( layout.getTitle(), "Nonexistent Editor" )
+
+		# Save the layout again and check that the same applies.
+		layouts.add( "MissingEditor2", layout )
+		layout2 = layouts.create( "MissingEditor2", script )
+		self.assertIsInstance( layout2, GafferUI.Editor )
+		self.assertEqual( layout2.getTitle(), "Nonexistent Editor" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This uses proxies for missing modules and editors, so we can load the rest of the layout successfully. The proxy editor appears as a tab in the UI as normal but with an "editor not available" label rather than the usual contents. The proxy can also be resaved into a new layout and then be loaded as the _real_ editor later when that becomes available.

This will allow us to load layouts from Gaffer 1.4 in 1.3, even if they include an ImageInspector or LocalJobs panel. Saving the layout in 1.3 and reloading it in 1.4 will even preserve the new editors.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/43dfd48b-0a8a-4e8c-a66a-baba48d82fcd)
