### PR TITLE
LightTool color improvement

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - USDLight : Added file browser for `shaping:ies:file` parameter.
 - OpenColorIOContext : Added file browser for `config` plug.
 - Layouts : Added the ability to load layouts containing editors that aren't currently available. This allows layouts containing new editors introduced in Gaffer 1.4 to be loaded in Gaffer 1.3.
+- LightTool : Changed the color of the non-highlighted handles to orange and the highlighted handles to cyan for consistency with other highlight colors.
 
 Fixes
 -----

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -86,7 +86,7 @@ namespace
 {
 
 // Color from `StandardLightVisualiser`
-const Color3f g_lightToolColor = Color3f( 1.0f, 0.835f, 0.07f );
+const Color3f g_lightToolColor = Color3f( 0.850f, 0.345f, 0.129f );
 const Color4f g_lightToolColor4 = Color4f( g_lightToolColor.x, g_lightToolColor.y, g_lightToolColor.z, 1.f );
 
 const Color4f g_lightToolDisabledColor4 = Color4f( 0.4f, 0.4f, 0.4f, 1.f );

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1219,8 +1219,7 @@ class LightToolHandle : public Handle
 			);
 
 			auto standardStyle = runTimeCast<const StandardStyle>( style );
-			assert( standardStyle );
-			const Color3f highlightColor3 = standardStyle->getColor( StandardStyle::Color::HighlightColor );
+			const Color3f highlightColor3 = standardStyle ? standardStyle->getColor( StandardStyle::Color::HighlightColor ) : Color3f( 0.466, 0.612, 0.741 );
 			const Color4f highlightColor4 = Color4f( highlightColor3.x, highlightColor3.y, highlightColor3.z, 1.f );
 
 			const bool enabled = allInspectionsEnabled();

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -106,11 +106,10 @@ namespace
 
 const std::string g_lightAttributePattern = "light *:light";
 
-const Color3f g_lightToolHandleColor = Color3f( 0.825, 0.720f, 0.230f );
+const Color3f g_lightToolArcColor = Color3f( 0.825, 0.720f, 0.230f );
 
-// Color from `StandardLightVisualiser`
-const Color3f g_lightToolHighlightColor = Color3f( 1.0f, 0.835f, 0.07f );
-const Color4f g_lightToolHighlightColor4 = Color4f( g_lightToolHighlightColor.x, g_lightToolHighlightColor.y, g_lightToolHighlightColor.z, 1.f );
+const Color3f g_lightToolColor = Color3f( 0.850f, 0.345f, 0.129f );
+const Color4f g_lightToolColor4 = Color4f( g_lightToolColor.x, g_lightToolColor.y, g_lightToolColor.z, 1.f );
 
 const Color4f g_lightToolDisabledColor4 = Color4f( 0.4f, 0.4f, 0.4f, 1.f );
 
@@ -1226,7 +1225,7 @@ class LightToolHandle : public Handle
 
 			group->getState()->add(
 				new IECoreGL::Color(
-					enabled ? ( highlighted ? g_lightToolHighlightColor4 : highlightColor4 ) : g_lightToolDisabledColor4
+					enabled ? ( highlighted ? highlightColor4 : g_lightToolColor4 ) : g_lightToolDisabledColor4
 				)
 			);
 
@@ -1467,8 +1466,8 @@ class SpotLightHandle : public LightToolHandle
 				IECoreScene::MeshPrimitivePtr previousSolidArc = nullptr;
 				IECoreScene::MeshPrimitivePtr currentSolidArc = nullptr;
 
-				const Color3f previousColor = g_lightToolHandleColor * g_highlightMultiplier;
-				const Color3f currentColor = g_lightToolHandleColor;
+				const Color3f previousColor = g_lightToolArcColor * g_highlightMultiplier;
+				const Color3f currentColor = g_lightToolArcColor;
 
 				const float arcWidth = g_dragArcWidth * ::rasterScaleFactor( this, V3f( 0, 0, -m_arcRadius ) );
 				previousSolidArc = solidArc(


### PR DESCRIPTION
This changes the colors of `LightTool` and `LightPositionTool` handles :
- Non-highlighted gets a new orange color to indicate which light has the handles.
- Highlighted handles are now cyan to match the highlight color used throughout Gaffer.

It may be a bit too colorful in the case of dragging a spot light handle. In that case, there's now a cyan handle you are dragging (it's in hover state), orange handles on the other quadrants of the cone and yellow arcs indicate the previous and current angle. We talked about making sure the orange is only used for things that can be interacted with, and I think the same concept applies to using the highlight color. But opinions are welcome.

I also  improved the naming of the colors which had gotten a little detached from their use.

Lastly, though a mostly conceptual change at the moment, I also added a fallback for the color we get from `StandardStyle` so Gaffer won't crash if another style is used. We're doing this in `LightPositionTool` already and seems like a sensible change to make.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
