### PR TITLE
CI : Add `linux-gcc11` build variants

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,18 +28,19 @@ jobs:
         # and then use `include` to define their settings.
 
         name: [
-          linux,
-          linux-debug,
+          linux-gcc9,
+          linux-debug-gcc9,
+          linux-gcc11,
           windows,
         ]
 
         include:
 
-          - name: linux
+          - name: linux-gcc9
             os: ubuntu-20.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
+            containerImage: ghcr.io/gafferhq/build/build:2.1.1
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -47,16 +48,28 @@ jobs:
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
 
-          - name: linux-debug
+          - name: linux-debug-gcc9
             os: ubuntu-20.04
             buildType: DEBUG
             publish: false
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
+            containerImage: ghcr.io/gafferhq/build/build:2.1.1
             testRunner: su testUser -c
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
             sconsCacheMegabytes: 2500
+
+          - name: linux-gcc11
+            os: ubuntu-20.04
+            buildType: RELEASE
+            publish: true
+            containerImage: ghcr.io/gafferhq/build/build:3.0.0a4
+            # GitHub container builds run as root. This causes failures for tests that
+            # assert that filesystem permissions are respected, because root doesn't
+            # respect permissions. So we run the final test suite as a dedicated
+            # test user rather than as root.
+            testRunner: su testUser -c
+            sconsCacheMegabytes: 400
 
           - name: windows
             os: windows-2019

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
             buildType: RELEASE
             publish: true
             containerImage:
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.0a1/gafferDependencies-8.0.0a1-windows.zip
             testRunner: Invoke-Expression
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 400
@@ -144,7 +145,7 @@ jobs:
       # containing the hash of the archive, for use in the cache key
       # below.
       run: |
-        echo GAFFER_DEPENDENCIES_HASH=`python .github/workflows/main/installDependencies.py --dependenciesDir ${{ env.GAFFER_BUILD_DIR }} --outputFormat "{archiveDigest}"` >> $GITHUB_ENV
+        echo GAFFER_DEPENDENCIES_HASH=`python .github/workflows/main/installDependencies.py ${{ matrix.dependenciesURL != '' && format( '--archiveURL {0}', matrix.dependenciesURL ) || '' }} --dependenciesDir ${{ env.GAFFER_BUILD_DIR }} --outputFormat "{archiveDigest}"` >> $GITHUB_ENV
         ./.github/workflows/main/installDelight.py
         echo DELIGHT=$GITHUB_WORKSPACE/3delight >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import os
 import pathlib
 import sys
 import argparse
@@ -48,10 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/8.0.0a1/gafferDependencies-8.0.0a1-{platform}.{extension}".format(
-	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
-	extension = "tar.gz" if sys.platform != "win32" else "zip"
-)
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/8.0.0a3/gafferDependencies-8.0.0a3-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 
@@ -61,6 +59,13 @@ parser.add_argument(
 	"--archiveURL",
 	help = "The URL to download the dependencies archive from.",
 	default = defaultURL,
+)
+
+parser.add_argument(
+	"--buildEnvironment",
+	help = "The build environment of the dependencies archive to download.",
+	choices = [ "gcc9", "gcc11" ],
+	default = os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "gcc9" ),
 )
 
 parser.add_argument(
@@ -79,10 +84,16 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+archiveURL = args.archiveURL.format(
+	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
+	buildEnvironment = "-{}".format( args.buildEnvironment ) if args.buildEnvironment else "",
+	extension = "tar.gz" if sys.platform != "win32" else "zip"
+)
+
 # Download and unpack the archive.
 
-sys.stderr.write( "Downloading dependencies \"%s\"\n" % args.archiveURL )
-archiveFileName, headers = urlretrieve( args.archiveURL )
+sys.stderr.write( "Downloading dependencies \"{}\"\n".format( archiveURL ) )
+archiveFileName, headers = urlretrieve( archiveURL )
 
 pathlib.Path( args.dependenciesDir ).mkdir( parents = True )
 if sys.platform != "win32" :
@@ -94,7 +105,7 @@ else:
 	)
 	# 7z (and zip extractors generally) don't have an equivalent of --strip-components=1
 	# Copy the files up one directory level to compensate
-	extractedPath = pathlib.Path( args.dependenciesDir ) / pathlib.Path( args.archiveURL ).stem
+	extractedPath = pathlib.Path( args.dependenciesDir ) / pathlib.Path( archiveURL ).stem
 	for p in extractedPath.glob( "*" ) :
 		shutil.move( str( p ), args.dependenciesDir )
 
@@ -110,7 +121,7 @@ if args.outputFormat :
 
 	print(
 		args.outputFormat.format(
-			archiveURL = args.archiveURL,
+			archiveURL = archiveURL,
 			archiveDigest = md5.hexdigest()
 		)
 	)

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.x.x.x (relative to 1.3.x.x)
 =======
 
+> Note : This release introduces `linux-gcc11` builds which are only compatible with Linux distributions using glibc 2.28 or higher.
+> These specific `linux-gcc11` builds are intended for testing purposes while we upgrade our toolchain and dependencies to better align
+> with VFX Platform 2023, and should be considered "beta" in advance of a stable release in Gaffer 1.5.
+
 Features
 --------
 
@@ -129,7 +133,21 @@ Breaking Changes
 Build
 -----
 
+- Imath : Updated to version 3.1.9.
+- MaterialX : Updated to version 1.38.8.
+- LibWebP : Added version 1.3.2.
+- OpenEXR : Updated to version 3.1.9.
+- OpenImageIO : Updated to version 2.4.17.0.
+- OpenSubdiv : Updated to version 3.5.1.
+- OpenSSL : Removed.
+- OpenVDB : Updated to version 10.0.1.
 - PsUtil : Added version 5.9.6.
+- PySide : Updated to version 5.15.12.
+- Qt :
+  - Updated to version 5.15.12.
+  - Removed QtPurchasing library.
+  - Removed QtNetworkAuth library.
+- USD : Updated to version 23.11.
 
 1.3.x.x (relative to 1.3.10.0)
 =======

--- a/src/GafferImage/CollectImages.cpp
+++ b/src/GafferImage/CollectImages.cpp
@@ -728,7 +728,11 @@ void CollectImages::hashChannelData( const GafferImage::ImagePlug *parent, const
 		if( !BufferAlgo::empty( validBound ) )
 		{
 			h.append( inputChannelDataHash );
-			h.append( BufferAlgo::intersection( inputDataWindow, tileBound ) );
+			// Work around strange Box2i hashing behaviour in GCC 11, though it would be
+			// preferable to fix this in MurmurHash.
+			const Box2i boundIntersection = BufferAlgo::intersection( inputDataWindow, tileBound );
+			h.append( boundIntersection.min );
+			h.append( boundIntersection.max );
 		}
 	}
 }

--- a/src/GafferImage/ImageStats.cpp
+++ b/src/GafferImage/ImageStats.cpp
@@ -375,7 +375,10 @@ void ImageStats::hash( const ValuePlug *output, const Context *context, IECore::
 			Imath::Box2i( boundsIntersection.min - tileOrigin, boundsIntersection.max - tileOrigin ),
 			Imath::Box2i( Imath::V2i( 0 ), Imath::V2i( ImagePlug::tileSize() ) )
 		);
-		h.append( tileBound );
+		// Work around strange Box2i hashing behaviour in GCC 11, though it would be
+		// preferable to fix this in MurmurHash.
+		h.append( tileBound.min );
+		h.append( tileBound.max );
 		flattenedInPlug()->channelDataPlug()->hash( h );
 	}
 	else if( output == allStatsPlug() )

--- a/src/GafferImage/Offset.cpp
+++ b/src/GafferImage/Offset.cpp
@@ -168,7 +168,10 @@ void Offset::hashChannelData( const GafferImage::ImagePlug *parent, const Gaffer
 		// Note that two differing output tiles could depend on the same input tile, for
 		// example if the input image is small enough that there is a single valid tile.
 		// Hash in the bound to distinguish the output tiles in this case
-		h.append( inBound );
+		// Work around strange Box2i hashing behaviour in GCC 11, though it would be
+		// preferable to fix this in MurmurHash.
+		h.append( inBound.min );
+		h.append( inBound.max );
 
 		V2i inTileOrigin;
 		for( inTileOrigin.y = ImagePlug::tileOrigin( inBound.min ).y; inTileOrigin.y < inBound.max.y; inTileOrigin.y += ImagePlug::tileSize() )
@@ -325,7 +328,10 @@ void Offset::hashSampleOffsets( const GafferImage::ImagePlug *parent, const Gaff
 		// Note that two differing output tiles could depend on the same input tile, for
 		// example if the input image is small enough that there is a single valid tile.
 		// Hash in the bound to distinguish the output tiles in this case
-		h.append( inBound );
+		// Work around strange Box2i hashing behaviour in GCC 11, though it would be
+		// preferable to fix this in MurmurHash.
+		h.append( inBound.min );
+		h.append( inBound.max );
 
 		V2i inTileOrigin;
 		for( inTileOrigin.y = ImagePlug::tileOrigin( inBound.min ).y; inTileOrigin.y < inBound.max.y; inTileOrigin.y += ImagePlug::tileSize() )


### PR DESCRIPTION
Putting this up a draft to test CI with the new Rocky 8 / GCC 11.2.1 build container and the dependencies produced from that container.