### PR TITLE
ScenePlug, ImagePlug : Allow serialisation of child plugs 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -48,7 +48,7 @@ Improvements
   - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
   - Matched DelightOptions default values for `oversampling` and `shadingSamples` to 3Delight's own default values.
 - GraphEditor : Improved logic used to connect a newly created node to the selected nodes.
-- ScenePlug : Child plugs are now serialisable. Among other things, this enables them to be driven by expressions.
+- ScenePlug, ImagePlug : Child plugs are now serialisable. Among other things, this enables them to be driven by expressions (#3986).
 
 Fixes
 -----
@@ -134,6 +134,7 @@ Breaking Changes
 - OSLShader : Output parameters are now loaded onto the `out` plug for all types (`surface`, `displacement` etc), not just `shader`.
 - DelightOptions : Changed default values for `oversampling` and `shadingSamples` plugs.
 - SceneProcessor : Subclasses no longer serialise internal connections to the `out` plug.
+- ImageProcessor : Internal connections to the `out` plug are no longer serialised.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -48,6 +48,7 @@ Improvements
   - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
   - Matched DelightOptions default values for `oversampling` and `shadingSamples` to 3Delight's own default values.
 - GraphEditor : Improved logic used to connect a newly created node to the selected nodes.
+- ScenePlug : Child plugs are now serialisable. Among other things, this enables them to be driven by expressions.
 
 Fixes
 -----
@@ -132,6 +133,7 @@ Breaking Changes
 - 3Delight : Changed NSI scene description export with `.nsi` file extension from ASCII to binary (`.nsia` is used for ASCII now).
 - OSLShader : Output parameters are now loaded onto the `out` plug for all types (`surface`, `displacement` etc), not just `shader`.
 - DelightOptions : Changed default values for `oversampling` and `shadingSamples` plugs.
+- SceneProcessor : Subclasses no longer serialise internal connections to the `out` plug.
 
 Build
 -----

--- a/src/GafferImage/ImagePlug.cpp
+++ b/src/GafferImage/ImagePlug.cpp
@@ -77,11 +77,7 @@ ImagePlug::ImagePlug( const std::string &name, Direction direction, unsigned fla
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	// we don't want the children to be serialised in any way - we always create
-	// them ourselves in this constructor so they aren't Dynamic, and we don't ever
-	// want to store their values because they are meaningless without an input
-	// connection, so they aren't Serialisable either.
-	unsigned childFlags = flags & ~(Dynamic | Serialisable);
+	const unsigned childFlags = flags & ~Dynamic;
 
 	addChild(
 		new StringVectorDataPlug(

--- a/src/GafferImage/Shape.cpp
+++ b/src/GafferImage/Shape.cpp
@@ -112,7 +112,6 @@ Shape::Shape( const std::string &name )
 	merge->operationPlug()->setValue( Merge::Over );
 
 	outPlug()->setInput( merge->outPlug() );
-	outPlug()->setFlags( Gaffer::Plug::Serialisable, false );
 }
 
 Shape::~Shape()

--- a/src/GafferImageModule/ImageProcessorBinding.cpp
+++ b/src/GafferImageModule/ImageProcessorBinding.cpp
@@ -57,6 +57,29 @@ using namespace Gaffer;
 using namespace GafferBindings;
 using namespace GafferImage;
 
+namespace
+{
+
+class ImageProcessorSerialiser : public GafferBindings::NodeSerialiser
+{
+
+	public :
+
+		bool childNeedsSerialisation( const Gaffer::GraphComponent *child, const Serialisation &serialisation ) const override
+		{
+			auto imageProcessor = static_cast<const ImageProcessor *>( child->parent() );
+			if( child == imageProcessor->outPlug() )
+			{
+				return false;
+			}
+
+			return NodeSerialiser::childNeedsSerialisation( child, serialisation );
+		}
+
+};
+
+} // namespace
+
 void GafferImageModule::bindImageProcessor()
 {
 
@@ -71,6 +94,8 @@ void GafferImageModule::bindImageProcessor()
 			)
 		)
 	;
+
+	Serialisation::registerSerialiser( ImageProcessor::staticTypeId(), new ImageProcessorSerialiser );
 
 	GafferBindings::DependencyNodeClass<FlatImageProcessor>();
 

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -61,11 +61,7 @@ static ContextAlgo::GlobalScope::Registration g_globalScopeRegistration(
 ScenePlug::ScenePlug( const std::string &name, Direction direction, unsigned flags )
 	:	ValuePlug( name, direction, flags )
 {
-	// we don't want the children to be serialised in any way - we always create
-	// them ourselves in this constructor so they aren't Dynamic, and we don't ever
-	// want to store their values because they are meaningless without an input
-	// connection, so they aren't Serialisable either.
-	unsigned childFlags = flags & ~(Dynamic | Serialisable);
+	const unsigned childFlags = flags & ~Dynamic;
 
 	addChild(
 		new AtomicBox3fPlug(


### PR DESCRIPTION
Among other things, this allows individual plugs like `ScenePlug.globals` or `ImagePlug.metadata` to be driven by expressions. Fixes #3986.