### PR TITLE
StandardGraphLayout improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,7 @@ Improvements
   - Added support for reading `dl:` and `user:` attributes from shaders.
   - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
   - Matched DelightOptions default values for `oversampling` and `shadingSamples` to 3Delight's own default values.
+- GraphEditor : Improved logic used to connect a newly created node to the selected nodes.
 
 Fixes
 -----

--- a/include/GafferUI/StandardGraphLayout.h
+++ b/include/GafferUI/StandardGraphLayout.h
@@ -86,10 +86,16 @@ class GAFFERUI_API StandardGraphLayout : public GraphLayout
 
 		bool connectNodeInternal( GraphGadget *graph, Gaffer::Node *node, Gaffer::Set *potentialInputs, bool insertIfPossible ) const;
 
-		size_t outputPlugs( NodeGadget *nodeGadget, std::vector<Gaffer::Plug *> &plugs ) const;
-		size_t outputPlugs( GraphGadget *graph, Gaffer::Set *nodes, std::vector<Gaffer::Plug *> &plugs ) const;
+		struct Endpoint
+		{
+			Gaffer::Plug *plug;
+			Imath::V3f tangent;
+		};
+
+		size_t outputs( NodeGadget *nodeGadget, std::vector<Endpoint> &endpoints ) const;
+		size_t outputs( GraphGadget *graph, Gaffer::Set *nodes, std::vector<Endpoint> &endpoints ) const;
 		Gaffer::Plug *correspondingOutput( const Gaffer::Plug *input ) const;
-		size_t unconnectedInputPlugs( NodeGadget *nodeGadget, std::vector<Gaffer::Plug *> &plugs ) const;
+		size_t unconnectedInputs( NodeGadget *nodeGadget, std::vector<Endpoint> &endpoints ) const;
 
 		float m_connectionScale;
 		float m_nodeSeparationScale;

--- a/include/GafferUI/StandardGraphLayout.h
+++ b/include/GafferUI/StandardGraphLayout.h
@@ -89,6 +89,7 @@ class GAFFERUI_API StandardGraphLayout : public GraphLayout
 		struct Endpoint
 		{
 			Gaffer::Plug *plug;
+			Imath::V3f position;
 			Imath::V3f tangent;
 		};
 

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -153,6 +153,45 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 					else :
 						self.assertIsNone( plug.getInput() )
 
+	def testConnectNodeOrder( self ) :
+
+		for reverseSelection in ( True, False ) :
+
+			with self.subTest( reverseSelection = reverseSelection ) :
+
+				script = Gaffer.ScriptNode()
+
+				script["node1"] = Gaffer.Node()
+				script["node1"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				Gaffer.Metadata.registerValue( script["node1"]["out"], "noduleLayout:section", "bottom" )
+
+				script["node2"] = Gaffer.Node()
+				script["node2"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				Gaffer.Metadata.registerValue( script["node2"]["out"], "noduleLayout:section", "bottom" )
+
+				script["node3"] = self.LayoutNode()
+
+				if reverseSelection :
+					selection = Gaffer.StandardSet( [ script["node2" ], script["node1"] ] )
+				else :
+					selection = Gaffer.StandardSet( [ script["node1" ], script["node2"] ] )
+
+				graph = GafferUI.GraphGadget( script )
+				graph.setNodePosition(
+					script["node1"],
+					graph.getNodePosition( script["node2"] ) - imath.V2f(
+						graph.nodeGadget( script["node1"] ).bound().size().x + graph.nodeGadget( script["node2"] ).bound().size().x,
+						0
+					)
+				)
+
+				self.assertTrue(
+					graph.getLayout().connectNode( graph, script["node3"], selection )
+				)
+
+				self.assertEqual( script["node3"]["top0"].getInput(), script["node1"]["out"] )
+				self.assertEqual( script["node3"]["top1"].getInput(), script["node2"]["out"] )
+
 	def testConnectNodes( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferUITest/StandardGraphLayoutTest.py
+++ b/python/GafferUITest/StandardGraphLayoutTest.py
@@ -115,6 +115,44 @@ class StandardGraphLayoutTest( GafferUITest.TestCase ) :
 		g.getLayout().connectNode( g, s["add3"], Gaffer.StandardSet( [ s["compound"] ] ) )
 		self.assertTrue( s["add3"]["op1"].getInput().isSame( s["compound"]["o"]["f"] ) )
 
+	def testConnectNodeDirectionPriority( self ) :
+
+		for outputDirection in [ "top", "left", "bottom", "right" ] :
+
+			with self.subTest( outputDirection = outputDirection ) :
+
+				script = Gaffer.ScriptNode()
+
+				script["node1"] = Gaffer.Node()
+				script["node1"]["out"] = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				Gaffer.Metadata.registerValue( script["node1"]["out"], "noduleLayout:section", outputDirection )
+
+				script["node2"] = Gaffer.Node()
+				for direction in [ "top", "left", "bottom", "right" ] :
+					for i in range( 0, 3 ) :
+						plug = Gaffer.IntPlug( f"{direction}{i}", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+						Gaffer.Metadata.registerValue( plug, "noduleLayout:section", direction )
+						script["node2"].addChild( plug )
+
+				graph = GafferUI.GraphGadget( script )
+				self.assertTrue(
+					graph.getLayout().connectNode( graph, script["node2"], Gaffer.StandardSet( [ script["node1" ] ] ) )
+				)
+
+				expectedInput = {
+					"top" :  script["node2"]["bottom0"],
+					"bottom" :  script["node2"]["top0"],
+					"left" :  script["node2"]["right0"],
+					"right" :  script["node2"]["left0"],
+				}[outputDirection]
+
+				for plug in Gaffer.Plug.Range( script["node2"] ) :
+
+					if plug.isSame( expectedInput ) :
+						self.assertEqual( plug.getInput(), script["node1"]["out"] )
+					else :
+						self.assertIsNone( plug.getInput() )
+
 	def testConnectNodes( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -1440,17 +1440,17 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	Plug *firstConnectionSrc = nullptr, *firstConnectionDst = nullptr;
 	vector<Plug *> inputPlugs;
 	unconnectedInputPlugs( nodeGadget, inputPlugs );
-	for( vector<Plug *>::const_iterator oIt = outputPlugs.begin(), oEIt = outputPlugs.end(); oIt != oEIt; oIt++ )
+	for( auto outputPlug : outputPlugs )
 	{
-		for( vector<Plug *>::const_iterator iIt = inputPlugs.begin(), iEIt = inputPlugs.end(); iIt != iEIt; iIt++ )
+		for( auto inputPlug : inputPlugs )
 		{
-			if( (*iIt)->acceptsInput( *oIt ) )
+			if( inputPlug->acceptsInput( outputPlug ) )
 			{
-				(*iIt)->setInput( *oIt );
+				inputPlug->setInput( outputPlug );
 				if( numConnectionsMade == 0 )
 				{
-					firstConnectionSrc = *oIt;
-					firstConnectionDst = *iIt;
+					firstConnectionSrc = outputPlug;
+					firstConnectionDst = inputPlug;
 				}
 				numConnectionsMade += 1;
 				// some nodes dynamically add new inputs when we connect
@@ -1473,24 +1473,23 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 			// Find the destination plugs at the end of the existing
 			// connections we want to insert into.
 			vector<Plug *> insertionDsts;
-			const Plug::OutputContainer &outputs = firstConnectionSrc->outputs();
-			for( Plug::OutputContainer::const_iterator it = outputs.begin(); it != outputs.end(); ++it )
+			for( auto output : firstConnectionSrc->outputs() )
 			{
 				// ignore outputs that aren't visible:
-				NodeGadget *nodeGadget = graph->nodeGadget( (*it)->node() );
-				if( !nodeGadget || !nodeGadget->nodule( *it ) )
+				NodeGadget *nodeGadget = graph->nodeGadget( output->node() );
+				if( !nodeGadget || !nodeGadget->nodule( output ) )
 				{
 					continue;
 				}
 				// Ignore the output which we made when connecting the node above
-				if( *it == firstConnectionDst )
+				if( output == firstConnectionDst )
 				{
 					continue;
 				}
-				if( (*it)->acceptsInput( correspondingOutput ) )
+				if( output->acceptsInput( correspondingOutput ) )
 				{
 					// Insertion accepted - store for reconnection
-					insertionDsts.push_back( *it );
+					insertionDsts.push_back( output );
 				}
 				else
 				{
@@ -1501,9 +1500,9 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 				}
 			}
 			// Reconnect the destination plugs such that we've inserted our node
-			for( vector<Plug *>::const_iterator it = insertionDsts.begin(), eIt = insertionDsts.end(); it != eIt; ++it )
+			for( auto insertDst : insertionDsts )
 			{
-				(*it)->setInput( correspondingOutput );
+				insertDst->setInput( correspondingOutput );
 			}
 		}
 	}

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -1356,8 +1356,8 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	}
 
 	// get all visible output plugs we could potentially connect in to our node
-	vector<Plug *> outputPlugs;
-	if( !this->outputPlugs( graph, potentialInputs, outputPlugs ) )
+	vector<Endpoint> outputs;
+	if( !this->outputs( graph, potentialInputs, outputs ) )
 	{
 		return false;
 	}
@@ -1382,35 +1382,35 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	{
 		if( !dot->inPlug() )
 		{
-			dot->setup( outputPlugs.front() );
+			dot->setup( outputs.front().plug );
 		}
 	}
 	else if( NameSwitch *switchNode = runTimeCast<NameSwitch>( node ) )
 	{
 		if( !switchNode->inPlugs() )
 		{
-			switchNode->setup( outputPlugs.front() );
+			switchNode->setup( outputs.front().plug );
 		}
 	}
 	else if( Switch *switchNode = runTimeCast<Switch>( node ) )
 	{
 		if( !switchNode->inPlugs() )
 		{
-			switchNode->setup( outputPlugs.front() );
+			switchNode->setup( outputs.front().plug );
 		}
 	}
 	else if( BoxOut *boxOut = runTimeCast<BoxOut>( node ) )
 	{
 		if( !boxOut->plug() )
 		{
-			boxOut->setup( outputPlugs.front() );
+			boxOut->setup( outputs.front().plug );
 		}
 	}
 	else if( ContextProcessor *contextProcessor = runTimeCast<ContextProcessor>( node ) )
 	{
 		if( !contextProcessor->inPlug() )
 		{
-			if( ValuePlug *valuePlug = runTimeCast<ValuePlug>( outputPlugs.front() ) )
+			if( ValuePlug *valuePlug = runTimeCast<ValuePlug>( outputs.front().plug ) )
 			{
 				contextProcessor->setup( valuePlug );
 			}
@@ -1420,7 +1420,7 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	{
 		if( !loop->inPlug() )
 		{
-			if( ValuePlug *valuePlug = runTimeCast<ValuePlug>( outputPlugs.front() ) )
+			if( ValuePlug *valuePlug = runTimeCast<ValuePlug>( outputs.front().plug ) )
 			{
 				loop->setup( valuePlug );
 			}
@@ -1430,7 +1430,7 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	{
 		if( !editScope->inPlug() )
 		{
-			editScope->setup( outputPlugs.front() );
+			editScope->setup( outputs.front().plug );
 		}
 	}
 
@@ -1438,27 +1438,40 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 
 	size_t numConnectionsMade = 0;
 	Plug *firstConnectionSrc = nullptr, *firstConnectionDst = nullptr;
-	vector<Plug *> inputPlugs;
-	unconnectedInputPlugs( nodeGadget, inputPlugs );
-	for( auto outputPlug : outputPlugs )
+	vector<Endpoint> inputs;
+	unconnectedInputs( nodeGadget, inputs );
+	for( const auto &output : outputs )
 	{
-		for( auto inputPlug : inputPlugs )
+		// Find the best destination for the source, based on
+		// how well the nodule tangents match.
+		Plug *bestDst = nullptr;
+		float bestScore = std::numeric_limits<float>::lowest();
+		for( const auto &input : inputs )
 		{
-			if( inputPlug->acceptsInput( outputPlug ) )
+			if( !input.plug->acceptsInput( output.plug ) )
 			{
-				inputPlug->setInput( outputPlug );
-				if( numConnectionsMade == 0 )
-				{
-					firstConnectionSrc = outputPlug;
-					firstConnectionDst = inputPlug;
-				}
-				numConnectionsMade += 1;
-				// some nodes dynamically add new inputs when we connect
-				// existing inputs, so we recalculate the input plugs
-				// to take account
-				unconnectedInputPlugs( nodeGadget, inputPlugs );
-				break;
+				continue;
 			}
+
+			const float score = input.tangent.dot( -output.tangent );
+			if( score > bestScore )
+			{
+				bestDst = input.plug;
+				bestScore = score;
+			}
+		}
+		if( bestDst )
+		{
+			bestDst->setInput( output.plug );
+			if( numConnectionsMade == 0 )
+			{
+				firstConnectionSrc = output.plug;
+				firstConnectionDst = bestDst;
+			}
+			numConnectionsMade += 1;
+			// Some nodes dynamically add new inputs when we connect existing
+			// inputs, so we recalculate the inputs to take account.
+			unconnectedInputs( nodeGadget, inputs );
 		}
 	}
 
@@ -1510,7 +1523,7 @@ bool StandardGraphLayout::connectNodeInternal( GraphGadget *graph, Gaffer::Node 
 	return numConnectionsMade;
 }
 
-size_t StandardGraphLayout::outputPlugs( NodeGadget *nodeGadget, std::vector<Gaffer::Plug *> &plugs ) const
+size_t StandardGraphLayout::outputs( NodeGadget *nodeGadget, std::vector<Endpoint> &endpoints ) const
 {
 	for( Plug::RecursiveOutputIterator it( nodeGadget->node() ); !it.done(); it++ )
 	{
@@ -1518,15 +1531,15 @@ size_t StandardGraphLayout::outputPlugs( NodeGadget *nodeGadget, std::vector<Gaf
 		{
 			if( !runTimeCast<CompoundNodule>( nodule ) )
 			{
-				plugs.push_back( it->get() );
+				endpoints.push_back( { it->get(), nodeGadget->connectionTangent( nodule ) } );
 			}
 		}
 	}
 
-	return plugs.size();
+	return endpoints.size();
 }
 
-size_t StandardGraphLayout::outputPlugs( GraphGadget *graph, Gaffer::Set *nodes, std::vector<Gaffer::Plug *> &plugs ) const
+size_t StandardGraphLayout::outputs( GraphGadget *graph, Gaffer::Set *nodes, std::vector<Endpoint> &endpoints ) const
 {
 	for( size_t i = 0; i < nodes->size(); i++ )
 	{
@@ -1536,24 +1549,28 @@ size_t StandardGraphLayout::outputPlugs( GraphGadget *graph, Gaffer::Set *nodes,
 			NodeGadget *nodeGadget = graph->nodeGadget( node );
 			if( nodeGadget )
 			{
-				outputPlugs( nodeGadget, plugs );
+				outputs( nodeGadget, endpoints );
 			}
 		}
 	}
-	return plugs.size();
+	return endpoints.size();
 }
 
-size_t StandardGraphLayout::unconnectedInputPlugs( NodeGadget *nodeGadget, std::vector<Plug *> &plugs ) const
+size_t StandardGraphLayout::unconnectedInputs( NodeGadget *nodeGadget, std::vector<Endpoint> &endpoints ) const
 {
-	plugs.clear();
+	endpoints.clear();
 	for( Plug::RecursiveInputIterator it( nodeGadget->node() ); !it.done(); it++ )
 	{
-		if( (*it)->getInput() == nullptr && nodeGadget->nodule( it->get() ) )
+		if( (*it)->getInput() )
 		{
-			plugs.push_back( it->get() );
+			continue;
+		}
+		if( auto *nodule = nodeGadget->nodule( it->get() ) )
+		{
+			endpoints.push_back( { it->get(), nodeGadget->connectionTangent( nodule ) } );
 		}
 	}
-	return plugs.size();
+	return endpoints.size();
 }
 
 Gaffer::Plug *StandardGraphLayout::correspondingOutput( const Gaffer::Plug *input ) const


### PR DESCRIPTION
This improves the logic used to connect newly-created nodes to the currently selected nodes in the GraphEditor. It avoids the creation of intersecting connections, and prefers to connect plugs that have opposing tangents. The first makes the creation of Group nodes much less tedious, and the second is necessary for an upcoming Dispatcher feature.

<img width="532" alt="image" src="https://github.com/GafferHQ/gaffer/assets/1133871/56694050-9e9c-41b0-b481-7f1a71350246">