### PR TITLE
OSLShader : Always load output parameters in `loadShader()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ Fixes
   - Fixed output of infinite values, which were previously being clamped.
   - Results for min/max now correctly reflect zero values outside the data window.
 - NodeMenu, NodeEditor : `userDefault` metadata is now evaluated in the script context, so it can depend on script variables.
+- 3Delight : Fixed loading of surface shaders such as `dlStandard` so that they can be connected to the inputs of shaders such as `dlLayeredMaterial`.
 
 API
 ---
@@ -119,6 +120,7 @@ Breaking Changes
 - ShuffleUI : Removed `nodeMenuCreateCommand()`.
 - ImageStatsUI : Removed `postCreate()`.
 - 3Delight : Changed NSI scene description export with `.nsi` file extension from ASCII to binary (`.nsia` is used for ASCII now).
+- OSLShader : Output parameters are now loaded onto the `out` plug for all types (`surface`, `displacement` etc), not just `shader`.
 
 Build
 -----

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -1208,14 +1208,17 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		self.assertEqual( shaderAssignment["out"].attributes( "/plane" ).keys(), [ "osl:surface" ] )
 
-	def testConstantOutPlug( self ) :
+	def testSurfaceShaderOutParameters( self ) :
 
-		# For compatibility with Arnold, we hack an output closure
-		# parameter onto our Constant shader, but we don't want that
-		# to affect the way we represent the output plug in Gaffer.
+		# OSL is moving away from strong typing for shaders, and there
+		# are uses for connecting surface shaders as inputs to other shaders
+		# (layered shading etc). So we always load the output parameters
+		# for every shader, even if they are a surface shader.
+
 		shader = GafferOSL.OSLShader()
 		shader.loadShader( "Surface/Constant" )
-		self.assertEqual( len( shader["out"].children() ), 0 )
+		self.assertEqual( shader["out"].keys(), [ "out" ] )
+		self.assertIsInstance( shader["out"]["out"], GafferOSL.ClosurePlug )
 
 	def testShadingEngineDeduplicate( self ) :
 
@@ -1284,6 +1287,27 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		n.loadShader( s )
 
 		self.assertEqual( n["type"].getValue(), "osl:shader" )
+
+	def testLoadSurfaceWithOutputParameters( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "surfaceWithOutputs-1.3.9.0.gfr" )
+		script.load()
+
+		# The script was saved from a version of Gaffer where we didn't load output parameters
+		# for surface shaders. But we expect to load them now.
+
+		self.assertEqual( script["Constant"]["out"].keys(), [ "out" ] )
+		self.assertIsInstance( script["Constant"]["out"]["out"], GafferOSL.ClosurePlug )
+
+		# And we expect the old connection from `Constant.out` to continue to work, even though
+		# we would now expect an equivalent connection to be made from `Constant.out.out`.
+
+		self.assertEqual( script["ShaderAssignment"]["shader"].getInput(), script["Constant"]["out"] )
+		self.assertIn( "osl:surface", script["ShaderAssignment"]["out"].attributes( "/sphere" ) )
+		network = script["ShaderAssignment"]["out"].attributes( "/sphere" )["osl:surface"]
+		self.assertIsInstance( network, IECoreScene.ShaderNetwork )
+		self.assertEqual( network.outputShader().name, "Surface/Constant" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/scripts/surfaceWithOutputs-1.3.9.0.gfr
+++ b/python/GafferOSLTest/scripts/surfaceWithOutputs-1.3.9.0.gfr
@@ -1,0 +1,50 @@
+import Gaffer
+import GafferImage
+import GafferOSL
+import GafferScene
+import IECore
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 3, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 9, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["openColorIO"] = GafferImage.OpenColorIOConfigPlug( "openColorIO", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["openColorIO"] )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["Constant"] = GafferOSL.OSLShader( "Constant" )
+parent.addChild( __children["Constant"] )
+__children["Constant"].loadShader( "Surface/Constant" )
+__children["Constant"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["ShaderAssignment"] = GafferScene.ShaderAssignment( "ShaderAssignment" )
+parent.addChild( __children["ShaderAssignment"] )
+__children["ShaderAssignment"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["Sphere"] = GafferScene.Sphere( "Sphere" )
+parent.addChild( __children["Sphere"] )
+__children["Sphere"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["PathFilter"] = GafferScene.PathFilter( "PathFilter" )
+parent.addChild( __children["PathFilter"] )
+__children["PathFilter"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 64407 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["Constant"]["__uiPosition"].setValue( imath.V2f( -6.19999981, -0.649999917 ) )
+__children["ShaderAssignment"]["in"].setInput( __children["Sphere"]["out"] )
+__children["ShaderAssignment"]["filter"].setInput( __children["PathFilter"]["out"] )
+__children["ShaderAssignment"]["shader"].setInput( __children["Constant"]["out"] )
+__children["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( 8.57124043, -0.649112463 ) )
+__children["Sphere"]["__uiPosition"].setValue( imath.V2f( 8.57124138, 7.51495028 ) )
+__children["PathFilter"]["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+__children["PathFilter"]["__uiPosition"].setValue( imath.V2f( 22.8434563, 5.43291903 ) )
+
+
+del __children
+

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -1271,14 +1271,7 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		setChild( "out", outPlug );
 	}
 
-	if( query->shadertype() == "shader" )
-	{
-		loadShaderParameters( *query, outPlug(), parameterMetadata );
-	}
-	else
-	{
-		outPlug()->clearChildren();
-	}
+	loadShaderParameters( *query, outPlug(), parameterMetadata );
 
 	if( static_cast<bool>( outPlug()->children().size() ) != outPlugHadChildren )
 	{


### PR DESCRIPTION
Prior to this, and dating all the way back to the inception of GafferOSL, we were only loading output parameters when the shader type was `shader`, the generic shader type. This was incompatible with 3Delight's shader library which declares `surface` shaders to have a `closure outColor` output parameter to allow them to be connected as inputs to things like `dlLayeredMaterial`.

Considering the OSL ecosystem more broadly, the OSL project itself has said that [shader types are deprecated](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/pull/899) and all shaders are created equal - "Generic `shader` type is the only one we will talk about as we move forward". Always loading all output parameters for all shader types is also consistent with this direction of travel.

This is a breaking change, so it does come with some compatibility concerns, but the new test case demonstrates that old scripts will still load and that old connections to ShaderAssignment nodes continue to work as before.

This work is in response to a comment on https://github.com/GafferHQ/gaffer/pull/5617 :

> In Gaffer currently OSL shaders with closure input parameters
> (for ex. 3Delight's Layered Material shader) don't accept connections
> from closure output parameters of OSL surface shaders, only from OSL
> generic shaders. Due to this it's not possible to connect any of the
> default surface shaders that come with 3Delight (dlPrincipled, dlGlass,
> dlMetal, dlStandard, etc.) to the closure inputs of dlLayeredMaterial or
> dlRandomMaterial.
