### PR TITLE
Highlight Placement Tool

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - GraphEditor : Added <kbd>X</kbd> shortcut for removing connections between nodules. Hold <kbd>X</kbd> then left click to remove all connections under the cursor. Hold <kbd>X</kbd> then left drag to draw a line, all connections that intersect with the line will be removed once the drag is ended (#788).
+- LightPosition Tool : Added a variation on the shadow placement tool to place highlights. Lights are positioned such that they will create a specular highlight at the target point.
 
 Improvements
 ------------

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -62,9 +62,21 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::LightPositionTool, LightPositionToolTypeId, TransformTool );
 
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
 		// Positions the current selection to cast a shadow from `shadowPivot` to `shadowTarget`,
 		// with the light `targetDistance` from the pivot. All coordinates are in world space.
 		void positionShadow( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
+
+		enum class Mode
+		{
+			Shadow,
+			Highlight,
+
+			First = Shadow,
+			Last = Highlight
+		};
 
 	protected :
 

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -69,6 +69,16 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		// with the light `targetDistance` from the pivot. All coordinates are in world space.
 		void positionShadow( const Imath::V3f &shadowPivot, const Imath::V3f &shadowTarget, const float targetDistance );
 
+		// Positions the current selection to be along the ray that is the reflection of the line
+		// from `viewpoint` to `highlightTarget` about `normal`, `targetDistance` from `highlightTarget`.
+		// All coordinates are in world space.
+		void positionHighlight(
+			const Imath::V3f &highlightTarget,
+			const Imath::V3f &viewpoint,
+			const Imath::V3f &normal,
+			const float targetDistance
+		);
+
 		enum class Mode
 		{
 			Shadow,
@@ -129,11 +139,18 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		bool placeTarget( const IECore::LineSegment3f &eventLine );
 
+		void translateAndOrient(
+			const Selection &s,
+			const Imath::M44f &localTransform,
+			const Imath::V3f &newPosition,
+			const Imath::M44f &newOrientation
+		) const;
+
 		enum class TargetMode
 		{
 			None,
 			Pivot,
-			Target
+			Target,
 		};
 
 		void setTargetMode( TargetMode mode );

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -182,6 +182,11 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 			IECore::PathMatcher &paths
 		) const;
 
+		/// Returns the approximate gadget space normal of the frontmost object intersecting
+		/// the specified line through gadget space, if an intersection exists. Returns `std::nullopt`
+		/// if there is no such object intersection.
+		std::optional<Imath::V3f> normalAt( const IECore::LineSegment3f &lineInGadgetSpace ) const;
+
 		/// Returns the bounding box of all the selected objects.
 		/// Deprecated, prefer using `bound( true )` below
 		Imath::Box3f selectionBound() const;

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -1076,7 +1076,7 @@ class ImageListing( GafferUI.PlugValueWidget ) :
 			imageToReplace = targetPath.property( "catalogue:image" )
 		else :
 			# Drag has gone above or below all listed items. Use closest image.
-			imageToReplace = images[0] if event.line.p0.y < 1 else images[-1]
+			imageToReplace = images[0] if event.line.p0.y < 1.5 else images[-1]
 
 		if not imageToReplace or imageToReplace in imagesToMove :
 			return

--- a/python/GafferSceneUI/LightPositionToolUI.py
+++ b/python/GafferSceneUI/LightPositionToolUI.py
@@ -90,6 +90,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Shadow", GafferSceneUI.LightPositionTool.Mode.Shadow,
 			"preset:Highlight", GafferSceneUI.LightPositionTool.Mode.Highlight,
 
+			"viewer:cyclePresetShortcut", "O",
+
 		]
 
 	}

--- a/python/GafferSceneUI/LightPositionToolUI.py
+++ b/python/GafferSceneUI/LightPositionToolUI.py
@@ -42,6 +42,17 @@ import Gaffer
 import GafferUI
 import GafferSceneUI
 
+def __toolTip( tool ) :
+
+	mode = tool["mode"].getValue()
+	result = None
+	if mode == GafferSceneUI.LightPositionTool.Mode.Shadow :
+		result = "Hold 'Shift' + 'V' to place shadow pivot\nHold 'V' to place shadow target"
+	else :
+		result = "Hold 'V' to place highlight target"
+
+	return result
+
 Gaffer.Metadata.registerNode(
 
 	GafferSceneUI.LightPositionTool,
@@ -55,6 +66,32 @@ Gaffer.Metadata.registerNode(
 	"order", 7,
 	"tool:exclusive", True,
 
-	"ui:transformTool:toolTip", "Hold 'Shift' + 'V' to place shadow pivot\nHold 'V' to place shadow target",
+	"ui:transformTool:toolTip", __toolTip,
+
+	plugs = {
+
+		"mode": [
+
+			"description",
+			"""
+			The method to use for placing the light.
+
+			- Shadow : Places the light so that it casts a shadow from the pivot point
+			onto the target point.
+			- Highlight : Places the light so that it creates a specular highlight at
+			the target point.
+			""",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 100,
+
+			"preset:Shadow", GafferSceneUI.LightPositionTool.Mode.Shadow,
+			"preset:Highlight", GafferSceneUI.LightPositionTool.Mode.Highlight,
+
+		]
+
+	}
 
 )

--- a/python/GafferSceneUI/RotateToolUI.py
+++ b/python/GafferSceneUI/RotateToolUI.py
@@ -76,6 +76,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Parent", GafferSceneUI.TransformTool.Orientation.Parent,
 			"preset:World", GafferSceneUI.TransformTool.Orientation.World,
 
+			"viewer:cyclePresetShortcut", "O",
+
 		],
 
 	}

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -115,11 +115,20 @@ class _TargetTipWidget( GafferUI.Frame ) :
 
 		GafferUI.Frame.__init__( self, borderWidth = 4, **kw )
 
-		label = Gaffer.Metadata.value( tool, "ui:transformTool:toolTip" ) or ""
+		self.__tool = tool
+
+		tool.plugSetSignal().connect( Gaffer.WeakMethod( self.__plugSet ), scoped = False )
 
 		with self :
 			with GafferUI.Frame( borderWidth = 0 ) as self.__innerFrame :
-				GafferUI.Label( label )
+				self.__tipLabel = GafferUI.Label( "" )
+
+		self.__plugSet()
+
+	def __plugSet( self, *unused ) :
+
+		label = Gaffer.Metadata.value( self.__tool, "ui:transformTool:toolTip" ) or ""
+		self.__tipLabel.setText( label )
 
 		if not label :
 			self.__innerFrame.setVisible( False )

--- a/python/GafferSceneUI/TranslateToolUI.py
+++ b/python/GafferSceneUI/TranslateToolUI.py
@@ -76,6 +76,8 @@ Gaffer.Metadata.registerNode(
 			"preset:Parent", GafferSceneUI.TransformTool.Orientation.Parent,
 			"preset:World", GafferSceneUI.TransformTool.Orientation.World,
 
+			"viewer:cyclePresetShortcut", "O",
+
 		],
 
 	}

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -497,8 +497,8 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		self.assertIsNotNone( pathA )
 		self.assertEqual( pathA, IECore.InternedStringVectorData( [ "group", "left" ] ) )
 		self.assertEqual( pathA,  pathB )
-		self.assertAlmostEqual( hitPoint.x, -2, delta = 0.01 )
-		self.assertAlmostEqual( hitPoint.y, 0, delta = 0.01 )
+		self.assertAlmostEqual( hitPoint.x, -2.0 + ( 1.0 / vp.getViewport().x ), delta = 0.01 )
+		self.assertAlmostEqual( hitPoint.y, -1.0 / vp.getViewport().y, delta = 0.01 )
 		self.assertAlmostEqual( hitPoint.z, -2, delta = 0.01 )
 
 		centerCubeDir = IECore.LineSegment3f( imath.V3f( 0, 0, 1 ), imath.V3f( 0, 0, -1 ) )
@@ -507,8 +507,8 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		self.assertIsNotNone( pathA )
 		self.assertEqual( pathA, IECore.InternedStringVectorData( [ "group", "center" ] ) )
 		self.assertEqual( pathA,  pathB )
-		self.assertAlmostEqual( hitPoint.x, 0, delta = 0.01 )
-		self.assertAlmostEqual( hitPoint.y, 0, delta = 0.01  )
+		self.assertAlmostEqual( hitPoint.x, 1.0 / vp.getViewport().x, delta = 0.01 )
+		self.assertAlmostEqual( hitPoint.y, -1.0 / vp.getViewport().y, delta = 0.01  )
 		self.assertAlmostEqual( hitPoint.z, -2, delta = 0.01 )
 
 		rightCubeDir = IECore.LineSegment3f( imath.V3f( 0, 0, 2 ), imath.V3f( 2, 0, -2 ) )
@@ -517,8 +517,8 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 		self.assertIsNotNone( pathA )
 		self.assertEqual( pathA, IECore.InternedStringVectorData( [ "group", "right" ] ) )
 		self.assertEqual( pathA,  pathB )
-		self.assertAlmostEqual( hitPoint.x, 2, delta = 0.01 )
-		self.assertAlmostEqual( hitPoint.y, 0, delta = 0.01 )
+		self.assertAlmostEqual( hitPoint.x, 2 + ( 1.0 / vp.getViewport().x ), delta = 0.01 )
+		self.assertAlmostEqual( hitPoint.y, -1.0 / vp.getViewport().y, delta = 0.01 )
 		self.assertAlmostEqual( hitPoint.z, -2, delta = 0.01 )
 
 		missDir = IECore.LineSegment3f( imath.V3f( 0, 0, 2 ), imath.V3f( 0, 10, -2 ) )

--- a/python/GafferSceneUITest/SceneGadgetTest.py
+++ b/python/GafferSceneUITest/SceneGadgetTest.py
@@ -448,6 +448,10 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 			[]
 		)
 
+	@unittest.skipIf(
+		os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "" ) == "gcc9",
+		"The gcc9 container does not support floating point depth buffers."
+	)
 	def testObjectAtLine( self ) :
 
 		script = Gaffer.ScriptNode()
@@ -701,6 +705,10 @@ class SceneGadgetTest( GafferUITest.TestCase ) :
 
 		return origin + direction * t
 
+	@unittest.skipIf(
+		os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "" ) == "gcc9",
+		"The gcc9 container does not support floating point depth buffers."
+	)
 	def testNormalAt( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -531,7 +531,7 @@ class Slider( GafferUI.Widget ) :
 
 	def __eventValue( self, event ) :
 
-		f = event.line.p0.x / float( self.size().x )
+		f = ( event.line.p0.x - 0.5 ) / float( self.size().x )
 		value = self.__min + ( self.__max - self.__min ) * f
 		if not (event.modifiers & event.modifiers.Shift) :
 			# Clamp

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -854,7 +854,7 @@ class _PlugListing( GafferUI.Widget ) :
 		else :
 			# drag has gone above or below all listed items
 			newParent = self.__pathListing.getPath().rootItem()
-			newIndex = 0 if event.line.p0.y < 1 else len( newParent )
+			newIndex = 0 if event.line.p0.y < 1.5 else len( newParent )
 
 		# skip any attempted circular reparenting
 
@@ -1198,7 +1198,7 @@ class _PresetsEditor( GafferUI.Widget ) :
 		if targetPath is not None :
 			targetIndex = list( d.keys() ).index( targetPath[0] )
 		else :
-			targetIndex = 0 if event.line.p0.y < 1 else len( d )
+			targetIndex = 0 if event.line.p0.y < 1.5 else len( d )
 
 		if srcIndex == targetIndex :
 			return True

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -229,17 +229,17 @@ class Viewer( GafferUI.NodeSetEditor ) :
 
 				return True
 
-			# \todo The Viewer should not need to know about `TransformTool` and orientations.
-			# This can be made more general by adding metadata to plugs such as
-			# `viewer:cyclePresetShortcut` and acting on that instead of this one special case.
-			if event.key == "O" and t["active"].getValue() and "orientation" in t :
-				orientation = Gaffer.NodeAlgo.currentPreset( t["orientation"] )
-				presets = Gaffer.NodeAlgo.presets( t["orientation"] )
+			if t["active"].getValue() :
+				for plug in Gaffer.ValuePlug.Range( t ) :
+					cycleKey = Gaffer.Metadata.value( plug, "viewer:cyclePresetShortcut" )
+					if event.key == cycleKey :
+						currentValue = Gaffer.NodeAlgo.currentPreset( plug )
+						presets = Gaffer.NodeAlgo.presets( plug )
 
-				Gaffer.NodeAlgo.applyPreset(
-					t["orientation"],
-					presets[ ( presets.index( orientation ) + 1 ) % len( presets ) ]
-				)
+						Gaffer.NodeAlgo.applyPreset(
+							plug,
+							presets[ ( presets.index( currentValue ) + 1 ) % len( presets ) ]
+						)
 
 		return False
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1650,6 +1650,13 @@ class _EventFilter( QtCore.QObject ) :
 	# space of the target Gaffer widget. This is required as certain widget
 	# configurations (eg: QTableView with a visible header) result in qEvent
 	# coordinate origins differing from the Gaffer Widget's origin.
+
+	# \todo There should be a 0.5 pixel offset added to the Qt pixel position
+	# so the resulting `LineSegment3f` goes through the center of the
+	# pixel, not the corner. This can be especially important when the returned
+	# line segment is used to calculate positions in a 3d perspective view, where
+	# small differences in direction can introduce significant error at
+	# long distances.
 	def __widgetSpaceLine( self, qEvent, targetWidget ) :
 
 		cursorPos = imath.V2i( qEvent.globalPos().x(), qEvent.globalPos().y() )

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -578,6 +578,18 @@ LightPositionTool::LightPositionTool( SceneView *view, const std::string &name )
 	plugSetSignal().connect( boost::bind( &LightPositionTool::plugSet, this, ::_1 ) );
 
 	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::Shadow, (int)Mode::First, (int)Mode::Last ) );
+}
+
+IntPlug *LightPositionTool::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
+}
+
+const IntPlug *LightPositionTool::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex );
 }
 
 LightPositionTool::~LightPositionTool()
@@ -956,7 +968,11 @@ void LightPositionTool::setTargetMode( TargetMode targeted )
 	switch( m_targetMode )
 	{
 		case TargetMode::None : GafferUI::Pointer::setCurrent( "" ); break;
-		case TargetMode::Pivot : GafferUI::Pointer::setCurrent( "pivot" ); break;
+		case TargetMode::Pivot :
+			GafferUI::Pointer::setCurrent(
+				modePlug()->getValue() == (int)Mode::Shadow ? "pivot" : ""
+			);
+			break;
 		case TargetMode::Target : GafferUI::Pointer::setCurrent( "target" ); break;
 	}
 }

--- a/src/GafferSceneUI/OutputBuffer.cpp
+++ b/src/GafferSceneUI/OutputBuffer.cpp
@@ -201,7 +201,7 @@ OutputBuffer::OutputBuffer( IECoreScenePreview::Renderer *renderer )
 	for(
 		auto &[name, data, filter] : {
 			OutputDefinition( "beauty", "rgba", "box" ),
-			OutputDefinition( "depth", "float Z", "closest" ),
+			OutputDefinition( "depth", "float Z", "box" ),
 			OutputDefinition( "id", "uint id", "closest" ),
 		}
 	)

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -48,6 +48,8 @@
 
 #include "tbb/enumerable_thread_specific.h"
 
+#include <math.h>
+
 using namespace std;
 using namespace boost::placeholders;
 using namespace Imath;
@@ -654,6 +656,75 @@ size_t SceneGadget::objectsAt(
 	}
 
 	return paths.size();
+}
+
+std::optional<V3f> SceneGadget::normalAt( const IECore::LineSegment3f &lineInGadgetSpace ) const
+{
+	V3f centerP;
+	ScenePlug::ScenePath centerPath;
+
+	auto viewportGadget = ancestor<ViewportGadget>();
+
+	// Transforming from raster to gadget space (done by `Widget`) and back to raster space
+	// can introduce enough floating point error to make positions, and therefore normals,
+	// incorrect. We expect that `lineInGadgetSpace` corresponds to the center of a pixel,
+	// so we snap to the nearest center as a corrective.
+	V2f centerRasterP = viewportGadget->gadgetToRasterSpace( lineInGadgetSpace.p0, this );
+	centerRasterP.x = (int)centerRasterP.x + 0.5f;
+	centerRasterP.y = (int)centerRasterP.y + 0.5f;
+
+	if( objectAt( viewportGadget->rasterToGadgetSpace( centerRasterP, this ), centerPath, centerP ) )
+	{
+		// Find the average normal of the triangles formed by `pixelPosition` and
+		// left + top, right + top, left + bottom and right + bottom depth samples
+		// where each pair has the same object ID as the center pixel.
+
+		const float spread = 1.f;
+
+		int sampleCount = 0;
+		V3f gadgetNormal( 0 );
+
+		ScenePlug::ScenePath prevPath;
+		V3f prevP;
+		bool prevHit = objectAt(
+			viewportGadget->rasterToGadgetSpace( centerRasterP + V2f( -spread, 0 ), this ),
+			prevPath,
+			prevP
+		);
+
+		std::array<V2f, 4> offsetList{
+			V2f( 0, -spread ),
+			V2f( spread, 0 ),
+			V2f( 0, spread ),
+			V2f( -spread, 0 )  // wrap back to left for final comparison
+		};
+
+		for( const auto &offset : offsetList )
+		{
+			V2f rasterP = centerRasterP + offset;
+			ScenePlug::ScenePath hitPath;
+			V3f hitP;
+			bool hit = objectAt( viewportGadget->rasterToGadgetSpace( rasterP, this ), hitPath, hitP );
+
+			if( hit && prevHit && prevPath == centerPath && hitPath == centerPath )
+			{
+				gadgetNormal += ( hitP - centerP ).cross( prevP - centerP ).normalized();
+				sampleCount++;
+			}
+
+			prevPath = hitPath;
+			prevP = hitP;
+			prevHit = hit;
+		}
+
+		if( sampleCount > 0 )
+		{
+			gadgetNormal /= sampleCount;
+			return gadgetNormal;
+		}
+	}
+
+	return std::nullopt;
 }
 
 IECore::PathMatcher SceneGadget::convertSelection( IECore::UIntVectorDataPtr ids ) const

--- a/src/GafferSceneUIModule/SceneGadgetBinding.cpp
+++ b/src/GafferSceneUIModule/SceneGadgetBinding.cpp
@@ -167,6 +167,17 @@ size_t objectsAt( SceneGadget &g, const Imath::V3f &corner0InGadgetSpace, const 
 	return g.objectsAt( corner0InGadgetSpace, corner1InGadgetSpace, paths );
 }
 
+object normalAt( SceneGadget &g, const IECore::LineSegment3f &l )
+{
+	std::optional<Imath::V3f> result;
+	{
+		ScopedGILRelease gilRelease;
+		result = g.normalAt( l );
+	}
+
+	return result ? object( result.value() ) : object();
+}
+
 Imath::Box3f selectionBound( SceneGadget &g )
 {
 	ScopedGILRelease gilRelease;
@@ -216,6 +227,7 @@ void GafferSceneUIModule::bindSceneGadget()
 		.def( "objectAt", &objectAt )
 		.def( "objectAndIntersectionAt", &objectAndIntersectionAt )
 		.def( "objectsAt", &objectsAt )
+		.def( "normalAt", &normalAt )
 		.def( "setSelection", &SceneGadget::setSelection )
 		.def( "getSelection", &SceneGadget::getSelection, return_value_policy<copy_const_reference>() )
 		.def( "selectionBound", &selectionBound )

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -272,9 +272,16 @@ void GafferSceneUIModule::bindTools()
 		GafferBindings::SignalClass<LightTool::SelectionChangedSignal, GafferBindings::DefaultSignalCaller<LightTool::SelectionChangedSignal>, SelectionChangedSlotCaller<LightTool>>( "SelectionChangedSignal" );
 	}
 
-	GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )
-		.def( init<SceneView *>() )
-		.def( "positionShadow", &LightPositionTool::positionShadow )
-	;
+	{
+		scope s = GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )
+			.def( init<SceneView *>() )
+			.def( "positionShadow", &LightPositionTool::positionShadow )
+		;
+
+		enum_<LightPositionTool::Mode>( "Mode" )
+			.value( "Shadow", LightPositionTool::Mode::Shadow )
+			.value( "Highlight", LightPositionTool::Mode::Highlight )
+		;
+	}
 
 }

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -276,6 +276,7 @@ void GafferSceneUIModule::bindTools()
 		scope s = GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )
 			.def( init<SceneView *>() )
 			.def( "positionShadow", &LightPositionTool::positionShadow )
+			.def( "positionHighlight", &LightPositionTool::positionHighlight )
 		;
 
 		enum_<LightPositionTool::Mode>( "Mode" )

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -1381,7 +1381,12 @@ static const std::string &vertexSource()
 	// When isCurve is set, this renders a curve defined by start and end points, and start and end tangents.
 	// See contrib/dd/notes/noodleShapes.svg for explanation.
 	static const std::string g_vertexSource =
-
+		""
+		"#if __VERSION__ <= 120\n"
+		"#define in attribute\n"
+		"#define out varying\n"
+		"#endif\n"
+		""
 		"uniform bool isCurve;"
 		"uniform vec3 v0;"
 		"uniform vec3 v1;"
@@ -1389,6 +1394,8 @@ static const std::string &vertexSource()
 		"uniform vec3 t1;"
 		"uniform float endPointSize;"
 		"uniform float lineWidth;"
+
+		"out vec3 geometryP;"
 
 		"void main()"
 		"{"
@@ -1438,6 +1445,7 @@ static const std::string &vertexSource()
 		"	gl_FrontColor = gl_Color;"
 		"	gl_BackColor = gl_Color;"
 		"	gl_TexCoord[0] = gl_MultiTexCoord0;"
+		"	geometryP = gl_Position.xyz;"
 		"}";
 
 	return g_vertexSource;
@@ -1467,8 +1475,10 @@ static const std::string &fragmentSource()
 		"#if __VERSION__ >= 330\n"
 
 		"uniform uint ieCoreGLNameIn;\n"
+		"in vec3 geometryP;\n"
 		"layout( location=0 ) out vec4 outColor;\n"
 		"layout( location=1 ) out uint ieCoreGLNameOut;\n"
+		"layout( location=2 ) out vec4 ieCoreGLCameraDepth;\n"
 		"#define OUTCOLOR outColor\n"
 
 		"#else\n"
@@ -1526,6 +1536,7 @@ static const std::string &fragmentSource()
 
 		"#if __VERSION__ >= 330\n"
 		"	ieCoreGLNameOut = ieCoreGLNameIn;\n"
+		"	ieCoreGLCameraDepth = vec4( -geometryP.z, -geometryP.z, -geometryP.z, 1 );\n"
 		"#endif\n"
 		"}";
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1385,7 +1385,7 @@ GLuint ViewportGadget::acquireFramebuffer() const
 
 	// Resize depth buffer and attach to framebuffer
 	glBindRenderbuffer( GL_RENDERBUFFER, m_depthBuffer );
-	glRenderbufferStorageMultisample( GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT24, size.x, size.y );
+	glRenderbufferStorageMultisample( GL_RENDERBUFFER, samples, GL_DEPTH_COMPONENT32F, size.x, size.y );
 	glFramebufferRenderbuffer( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthBuffer );
 
 	// Validate framebuffer

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -2230,7 +2230,7 @@ void ViewportGadget::SelectionScope::begin( const ViewportGadget *viewportGadget
 	m_depthSort = false;
 	camera->render( nullptr );
 
-	m_selector = SelectorPtr( new IECoreGL::Selector( ndcRegion, mode, m_selection ) );
+	m_selector = SelectorPtr( new IECoreGL::Selector( ndcRegion, mode, m_selection, true ) );
 
 	glPushMatrix();
 	glMultMatrixf( transform.getValue() );


### PR DESCRIPTION
This adds a variation to the Light Position Tool that moves the selected light such that it creates a specular highlight at the target point.

The test for the placement calculation is failing currently, but I think that may be a matter of a bad test rather than an actual failure. It's failing in the orientation calculation and if anything, this seems to be better at maintaining the orientation than the shadow tool, so I think it could be a matter of pesky equivalent Euler rotations.

It's a bit noisy when dragging but clicking individually seems to be mostly pretty good though not 100% perfect in my testing.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
