### PR TITLE
ReferenceUI : Fix "Duplicate as Box"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Improvements
 - ArnoldShader : Added a colour space presets menu for the `image` shader.
 - CyclesShader : Added a colour space presets menu for the `image_texture` and `environment_texture` shaders (#5618).
 
+Fixes
+-----
+
+- Reference : Fixed bug where `GAFFER_REFERENCE_PATHS` was not being searched when performing "Duplicate as Box" action.
+
 API
 ---
 

--- a/python/GafferUI/ReferenceUI.py
+++ b/python/GafferUI/ReferenceUI.py
@@ -191,7 +191,8 @@ def __duplicateAsBox( graphEditor, node ) :
 			closeLabel = "Oy vey",
 			parentWindow = graphEditor.ancestor( GafferUI.Window ),
 		) :
-			script.executeFile( node.fileName(), parent = box, continueOnError = True )
+			sp = IECore.SearchPath( os.environ.get( "GAFFER_REFERENCE_PATHS", "" ) )
+			script.executeFile( sp.find( str( node.fileName() ) ), parent = box, continueOnError = True )
 
 def __graphEditorNodeContextMenu( graphEditor, node, menuDefinition ) :
 


### PR DESCRIPTION
Previously, "Duplicate as Box" was not taking into account `GAFFER_REFERENCE_PATHS`, so a Reference path that relied on that for finding the Reference file would fail when trying to duplicate it.

I didn't add a test because GafferTest.ReferenceTest recreates the duplication logic (executing the reference with the box as parent) so I wasn't sure it would be a meaningful test. I can add something if it would be helpful.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
