### PR TITLE
RenderPassEditor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - 3Delight : Added support for USD `SphereLight`, `RectLight`, `DiskLight`, `DistantLight`, `DomeLight` and `CylinderLight`.
+- RenderPassEditor : Added a new editor UI for inspecting and editing render passes.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ API
 ---
 
 - ArnoldShaderUI : Added support for `colorSpace` widget type metadata, allowing an OpenColorIO colour space to be chosen.
+- PathColumn : Added `CellData::foreground` member, to provide additional control over foreground colours in the PathListingWidget.
 
 1.3.10.0 (relative to 1.3.9.0)
 ========

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -177,6 +177,10 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		/// > that edits the processor itself.
 		virtual EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const;
 
+		/// Can be implemented by derived classes to provide a fallback value for the inspection,
+		/// used when no value is returned from `value()`.
+		virtual IECore::ConstObjectPtr fallbackValue() const;
+
 	protected :
 
 		Gaffer::EditScope *targetEditScope() const;
@@ -308,7 +312,9 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 			Downstream,
 			/// No EditScope was specified, or the EditScope was not found in
 			/// the value's history.
-			Other
+			Other,
+			/// The value was provided from a fallback value from the Inspector.
+			Fallback
 		};
 
 		/// The relationship between `source()` and `editScope()`.

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -65,6 +65,7 @@ class GAFFERSCENEUI_API OptionInspector : public Inspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+		IECore::ConstObjectPtr fallbackValue() const override;
 
 	private :
 

--- a/include/GafferSceneUI/TypeIds.h
+++ b/include/GafferSceneUI/TypeIds.h
@@ -58,6 +58,7 @@ enum TypeId
 	SetPathTypeId = 110665,
 	LightToolTypeId = 110666,
 	LightPositionToolTypeId = 110667,
+	RenderPassPathTypeId = 110668,
 
 	LastTypeId = 110700
 };

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -89,8 +89,11 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 				const IECore::ConstDataPtr &value = nullptr,
 				const IECore::ConstDataPtr &icon = nullptr,
 				const IECore::ConstDataPtr &background = nullptr,
-				const IECore::ConstDataPtr &toolTip = nullptr
-			)	:	value( value ), icon( icon ), background( background ), toolTip( toolTip ) {}
+				const IECore::ConstDataPtr &toolTip = nullptr,
+				const IECore::ConstDataPtr &foreground = nullptr
+			)	:	value( value ), icon( icon ), background( background ), toolTip( toolTip ),
+					foreground( foreground ) {}
+
 			CellData( const CellData &other ) = default;
 
 			/// The primary value to be displayed in a cell or header.
@@ -119,11 +122,15 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 			///
 			/// - StringData
 			IECore::ConstDataPtr toolTip;
+			/// The foreground colour for the cell value. Supported types :
+			///
+			/// - Color3fData
+			/// - Color4fData
+			IECore::ConstDataPtr foreground;
 
 			private :
 
 				IECore::ConstDataPtr m_reserved1;
-				IECore::ConstDataPtr m_reserved2;
 
 		};
 

--- a/python/GafferSceneTest/EditScopeAlgoTest.py
+++ b/python/GafferSceneTest/EditScopeAlgoTest.py
@@ -1636,5 +1636,22 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( edit["enabled"].getValue(), True )
 		self.assertEqual( edit["value"].getValue(), 20 )
 
+	def testOptionEditFromDefaultValueMetadata( self ) :
+
+		options = GafferScene.Options()
+		editScope = Gaffer.EditScope()
+		editScope.setup( options["out"] )
+		editScope["in"].setInput( options["out"] )
+		emptyKeys = editScope.keys()
+
+		with self.assertRaisesRegex( RuntimeError, 'Option "test:bogus" does not exist' ) :
+			GafferScene.EditScopeAlgo.acquireOptionEdit( editScope, "test:bogus" )
+		self.assertEqual( editScope.keys(), emptyKeys )
+
+		Gaffer.Metadata.registerValue( "option:test:bogus", "defaultValue", 123 )
+
+		self.assertIsNotNone( GafferScene.EditScopeAlgo.acquireOptionEdit( editScope, "test:bogus" ) )
+		self.assertNotEqual( editScope.keys(), emptyKeys )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -137,15 +137,22 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 	@classmethod
 	def registerOption( cls, groupKey, optionName, section = "Main", columnName = None ) :
 
+		optionLabel = Gaffer.Metadata.value( "option:" + optionName, "label" )
 		if not columnName :
-			columnName = optionName.split( ":" )[-1]
+			columnName = optionLabel or optionName.split( ":" )[-1]
+
+		toolTip = "<h3>{}</h3>".format( optionLabel or columnName )
+		optionDescription = Gaffer.Metadata.value( "option:" + optionName, "description" )
+		if optionDescription :
+			toolTip += "\n\n" + optionDescription
 
 		GafferSceneUI.RenderPassEditor.registerColumn(
 			groupKey,
 			optionName,
 			lambda scene, editScope : _GafferSceneUI._RenderPassEditor.OptionInspectorColumn(
 				GafferSceneUI.Private.OptionInspector( scene, editScope, optionName ),
-				columnName
+				columnName,
+				toolTip
 			),
 			section
 		)

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1,0 +1,743 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import collections
+
+import functools
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferScene
+import GafferSceneUI
+
+from . import _GafferSceneUI
+
+from GafferUI.PlugValueWidget import sole
+from GafferSceneUI._HistoryWindow import _HistoryWindow
+
+from Qt import QtWidgets
+
+## \todo Make a SceneEditor base class to encapsulate the logic about what
+# scene to view, and to track the reparenting of the plug.
+class RenderPassEditor( GafferUI.NodeSetEditor ) :
+
+	# We store our settings as plugs on a node for a few reasons :
+	#
+	# - We want to use an EditScopePlugValueWidget, and that requires it.
+	# - We get a bunch of useful widgets and signals for free.
+	# - Longer term we want to refactor all Editors to derive from Node,
+	#   in the same way that View does already. This will let us serialise
+	#   _all_ layout state in the same format we serialise node graphs in.
+	# - The `userDefault` metadata provides a convenient way of configuring
+	#   defaults.
+	# - The PlugLayout we use to display the settings allows users to add
+	#   their own widgets to the UI.
+	class Settings( Gaffer.Node ) :
+
+		def __init__( self ) :
+
+			Gaffer.Node.__init__( self, "Settings" )
+
+			self["in"] = GafferScene.ScenePlug()
+			self["tabGroup"] = Gaffer.StringPlug( defaultValue = "Cycles" )
+			self["section"] = Gaffer.StringPlug( defaultValue = "Main" )
+			self["editScope"] = Gaffer.Plug()
+
+	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::RenderPassEditor::Settings" )
+
+	def __init__( self, scriptNode, **kw ) :
+
+		mainColumn = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 4, spacing = 4 )
+
+		GafferUI.NodeSetEditor.__init__( self, mainColumn, scriptNode, nodeSet = scriptNode.focusSet(), **kw )
+
+		self.__settingsNode = self.Settings()
+		Gaffer.NodeAlgo.applyUserDefaults( self.__settingsNode )
+
+		searchFilter = _GafferSceneUI._RenderPassEditor.SearchFilter()
+		self.__filter = searchFilter
+
+		with mainColumn :
+
+			GafferUI.PlugLayout(
+				self.__settingsNode,
+				orientation = GafferUI.ListContainer.Orientation.Horizontal,
+				rootSection = "Settings"
+			)
+
+			_SearchFilterWidget( searchFilter )
+
+			self.__renderPassNameColumn = _GafferSceneUI._RenderPassEditor.RenderPassNameColumn()
+			self.__renderPassActiveColumn = _GafferSceneUI._RenderPassEditor.RenderPassActiveColumn()
+			self.__pathListing = GafferUI.PathListingWidget(
+				Gaffer.DictPath( {}, "/" ), # temp till we make an RenderPassPath
+				columns = [
+					self.__renderPassNameColumn,
+					self.__renderPassActiveColumn,
+				],
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
+				horizontalScrollMode = GafferUI.ScrollMode.Automatic
+			)
+
+			self.__pathListing.buttonDoubleClickSignal().connectFront( Gaffer.WeakMethod( self.__buttonDoubleClick ), scoped = False )
+			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+			self.__pathListing.buttonPressSignal().connectFront( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+
+			self.__settingsNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__settingsPlugSet ), scoped = False )
+
+		self._updateFromSet()
+		self.__updateColumns()
+
+	__columnRegistry = collections.OrderedDict()
+
+	@classmethod
+	def registerOption( cls, groupKey, optionName, section = "Main", columnName = None ) :
+
+		if not columnName :
+			columnName = optionName.split( ":" )[-1]
+
+		GafferSceneUI.RenderPassEditor.registerColumn(
+			groupKey,
+			optionName,
+			lambda scene, editScope : _GafferSceneUI._RenderPassEditor.OptionInspectorColumn(
+				GafferSceneUI.Private.OptionInspector( scene, editScope, optionName ),
+				columnName
+			),
+			section
+		)
+
+	# Registers a column in the Render Pass Editor.
+	# `inspectorFunction` is a callable object of the form
+	# `inspectorFunction( scene, editScope )` returning a
+	# `GafferSceneUI._RenderPassEditor.OptionInspectorColumn` object.
+	@classmethod
+	def registerColumn( cls, groupKey, columnKey, inspectorFunction, section = "Main" ) :
+
+		sections = cls.__columnRegistry.setdefault( groupKey, collections.OrderedDict() )
+		section = sections.setdefault( section, collections.OrderedDict() )
+
+		section[columnKey] = inspectorFunction
+
+	def __repr__( self ) :
+
+		return "GafferSceneUI.RenderPassEditor( scriptNode )"
+
+	def __firstValidScenePlug( self, node ):
+
+		for plug in GafferScene.ScenePlug.RecursiveOutputRange( node ) :
+			if not plug.getName().startswith( "__" ):
+				return plug
+		return None
+
+	def _updateFromSet( self ) :
+
+		# Decide what plug we're viewing.
+		plug = None
+		self.__plugParentChangedConnection = None
+		node = self._lastAddedNode()
+		if node is not None :
+			plug = self.__firstValidScenePlug( node )
+			if plug is not None :
+				self.__plugParentChangedConnection = plug.parentChangedSignal().connect(
+					Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True
+				)
+
+		self.__settingsNode["in"].setInput( plug )
+
+		# call base class update - this will trigger a call to _titleFormat(),
+		# hence the need for already figuring out the plug.
+		GafferUI.NodeSetEditor._updateFromSet( self )
+
+		## \todo Remove in Gaffer 1.4 when we can drive `RenderPassEditor.Settings` from
+		# `GafferUI.Editor.Settings` to follow the changes introduced with ImageInspector.
+		self.__setPathListingPath()
+
+	def _updateFromContext( self, modifiedItems ) :
+
+		if any( not i.startswith( "ui:" ) for i in modifiedItems ) :
+			self.__setPathListingPath()
+
+	def _titleFormat( self ) :
+
+		return GafferUI.NodeSetEditor._titleFormat(
+			self,
+			_maxNodes = 1 if self.__settingsNode["in"].getInput() is not None else 0,
+			_reverseNodes = True,
+			_ellipsis = False
+		)
+
+	@GafferUI.LazyMethod()
+	def __updateColumns( self ) :
+
+		tabGroup = self.__settingsNode["tabGroup"].getValue()
+		currentSection = self.__settingsNode["section"].getValue()
+
+		sectionColumns = []
+
+		for groupKey, sections in self.__columnRegistry.items() :
+			if IECore.StringAlgo.match( tabGroup, groupKey ) :
+				section = sections.get( currentSection or None, {} )
+				sectionColumns += [ c( self.__settingsNode["in"], self.__settingsNode["editScope"] ) for c in section.values() ]
+
+		self.__pathListing.setColumns( [ self.__renderPassNameColumn, self.__renderPassActiveColumn ] + sectionColumns )
+
+	def __settingsPlugSet( self, plug ) :
+
+		if plug in ( self.__settingsNode["section"], self.__settingsNode["tabGroup"] ) :
+			self.__updateColumns()
+
+	def __plugParentChanged( self, plug, oldParent ) :
+
+		# if a plug has been removed or moved to another node, then
+		# we need to stop viewing it - _updateFromSet() will find the
+		# next suitable plug from the current node set.
+		self._updateFromSet()
+
+	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	def __setPathListingPath( self ) :
+
+		## \todo Simplify in Gaffer 1.4, we shouldn't require the fallback to DictPath when we have no input.
+		if self.__settingsNode["in"].getInput() is not None :
+			# We take a static copy of our current context for use in the RenderPassPath - this prevents the
+			# PathListing from updating automatically when the original context changes, and allows us to take
+			# control of updates ourselves in _updateFromContext(), using LazyMethod to defer the calls to this
+			# function until we are visible and playback has stopped.
+			contextCopy = Gaffer.Context( self.getContext() )
+			self.__pathListing.setPath( _GafferSceneUI._RenderPassEditor.RenderPassPath( self.__settingsNode["in"], contextCopy, "/", filter = self.__filter ) )
+		else :
+			self.__pathListing.setPath( Gaffer.DictPath( {}, "/" ) )
+
+	def __buttonDoubleClick( self, pathListing, event ) :
+
+		# A small corner area below the vertical scroll bar may pass through
+		# to us, causing odd selection behavior. Check that we're within the
+		# scroll area.
+		if pathListing.pathAt( event.line.p0 ) is None :
+			return False
+
+		if event.button == event.Buttons.Left :
+			column = pathListing.columnAt( event.line.p0 )
+			if column == self.__renderPassActiveColumn :
+				self.__setActiveRenderPass( pathListing )
+			else :
+				self.__editSelectedCells( pathListing )
+
+			return True
+
+		return False
+
+	def __keyPress( self, pathListing, event ) :
+
+		if event.modifiers == event.Modifiers.None_ :
+
+			if event.key == "Return" or event.key == "Enter" :
+				selection = pathListing.getSelection()
+				if len( selection[1].paths() ) :
+					self.__setActiveRenderPass( pathListing )
+				else :
+					self.__editSelectedCells( pathListing )
+				return True
+
+			if event.key == "D" and len( self.__disablableInspectionTweaks( pathListing ) ) > 0 :
+				self.__disableEdits( pathListing )
+				return True
+
+	def __selectedRenderPasses( self, columns = [ 0 ] ) :
+
+		# There may be multiple columns with a selection, but we only operate on the specified column indices.
+		selection = self.__pathListing.getSelection()
+		renderPassPath = self.__pathListing.getPath().copy()
+		result = set()
+		for c in columns :
+			for path in selection[c].paths() :
+				renderPassPath.setFromString( path )
+				name = renderPassPath.property( "renderPassPath:name" )
+				if name is not None :
+					result.add( name )
+
+		return list( result )
+
+	def __setActiveRenderPass( self, pathListing ) :
+
+		selectedPassNames = self.__selectedRenderPasses( columns = [ 1 ] )
+
+		if len( selectedPassNames ) != 1 :
+			return
+
+		script = self.scriptNode()
+		if Gaffer.MetadataAlgo.readOnly( script ) :
+			with GafferUI.PopupWindow() as self.__popup :
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+					GafferUI.Image( "warningSmall.png" )
+					GafferUI.Label( "<h4>The script is read-only.</h4>" )
+
+			self.__popup.popup()
+			return
+
+		if "renderPass" not in script["variables"] :
+			renderPassPlug = Gaffer.NameValuePlug( "renderPass", "", "renderPass", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+			script["variables"].addChild( renderPassPlug )
+			Gaffer.MetadataAlgo.setReadOnly( renderPassPlug["name"], True )
+		else :
+			renderPassPlug = script["variables"]["renderPass"]
+
+		renderPassPlug["value"].setValue( selectedPassNames[0] )
+
+	## \todo Consider consolidating this with `LightEditor.__editSelectedCells()`.
+	# The main difference being the name of the context variable that is set before inspection,
+	# (`renderPass` vs `scene:path`) and the source of data for that variable.
+	def __editSelectedCells( self, pathListing, quickBoolean = True ) :
+
+		# A dictionary of the form :
+		# { inspector : { renderPass1 : inspection, renderPass2 : inspection, ... }, ... }
+		inspectors = {}
+		inspections = []
+
+		with Gaffer.Context( self.getContext() ) as context :
+			renderPassPath = self.__pathListing.getPath().copy()
+			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
+				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+					continue
+				for path in selection.paths() :
+					renderPassPath.setFromString( path )
+					renderPassName = renderPassPath.property( "renderPassPath:name" )
+					if not renderPassName :
+						continue
+
+					context["renderPass"] = renderPassName
+					inspection = column.inspector().inspect()
+
+					if inspection is not None :
+						inspectors.setdefault( column.inspector(), {} )[renderPassName] = inspection
+						inspections.append( inspection )
+
+		if len( inspectors ) == 0 :
+			with GafferUI.PopupWindow() as self.__popup :
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+					GafferUI.Image( "warningSmall.png" )
+					GafferUI.Label( "<h4>The selected cells cannot be edited in the current Edit Scope</h4>" )
+
+			self.__popup.popup()
+
+			return
+
+		nonEditable = [ i for i in inspections if not i.editable() ]
+
+		if len( nonEditable ) == 0 :
+			with Gaffer.Context( self.getContext() ) as context :
+				if not quickBoolean or not self.__toggleBoolean( inspectors, inspections ) :
+					edits = [ i.acquireEdit() for i in inspections ]
+					warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
+					# The plugs are either not boolean, boolean with mixed values,
+					# or attributes that don't exist and are not boolean. Show the popup.
+					self.__popup = GafferUI.PlugPopup( edits, warning = warnings )
+
+					if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
+						self.__popup.plugValueWidget().setNameVisible( False )
+
+					## \todo : Adjust popup width based on the inspector column width(s) to improve
+					# editing of long paths, similar to how we handle this in the Spreadsheet.
+					self.__popup.popup()
+
+		else :
+
+			with GafferUI.PopupWindow() as self.__popup :
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+					GafferUI.Image( "warningSmall.png" )
+					GafferUI.Label( "<h4>{}</h4>".format( nonEditable[0].nonEditableReason() ) )
+
+			self.__popup.popup()
+
+	def __toggleBoolean( self, inspectors, inspections ) :
+
+		plugs = [ i.acquireEdit() for i in inspections ]
+		# Make sure all the plugs either contain, or are themselves a BoolPlug
+		if not all (
+			(
+				isinstance( plug, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) and
+				isinstance( plug["value"], Gaffer.BoolPlug )
+			) or (
+				isinstance( plug, ( Gaffer.BoolPlug ) )
+			)
+			for plug, inspector in zip( plugs, inspectors )
+		) :
+			return False
+
+		currentValues = []
+
+		# Use a single new value for all plugs.
+		# First we need to find out what the new value would be for each plug in isolation.
+		for inspector, pathInspections in inspectors.items() :
+			for path, inspection in pathInspections.items() :
+				currentValue = inspection.value().value if inspection.value() is not None else None
+				currentValues.append( currentValue )
+
+		# Now set the value for all plugs, defaulting to `True` if they are not
+		# currently all the same.
+		newValue = not sole( currentValues )
+
+		with Gaffer.UndoScope( self.scriptNode() ) :
+			for inspector, pathInspections in inspectors.items() :
+				for path, inspection in pathInspections.items() :
+					plug = inspection.acquireEdit()
+					if isinstance( plug, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) :
+						plug["value"].setValue( newValue )
+						plug["enabled"].setValue( True )
+						if isinstance( plug, Gaffer.TweakPlug ) :
+							plug["mode"].setValue( Gaffer.TweakPlug.Mode.Create )
+					else :
+						plug.setValue( newValue )
+
+		return True
+
+	def __disablableInspectionTweaks( self, pathListing ) :
+
+		tweaks = []
+
+		with Gaffer.Context( self.getContext() ) as context :
+			renderPassPath = self.__pathListing.getPath().copy()
+			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
+				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+					continue
+				for path in columnSelection.paths() :
+					renderPassPath.setFromString( path )
+					renderPassName = renderPassPath.property( "renderPassPath:name" )
+					if not renderPassName :
+						continue
+
+					context["renderPass"] = renderPassName
+					inspection = column.inspector().inspect()
+					if inspection is not None and inspection.editable() :
+						source = inspection.source()
+						editScope = self.__settingsNode["editScope"].getInput()
+						if (
+							(
+								isinstance( source, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) and
+								source["enabled"].getValue()
+							) and
+							( editScope is None or editScope.node().isAncestorOf( source ) )
+						) :
+							tweaks.append( ( path, column.inspector() ) )
+						else :
+							return []
+					else :
+						return []
+
+		return tweaks
+
+	def __disableEdits( self, pathListing ) :
+
+		edits = self.__disablableInspectionTweaks( pathListing )
+
+		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.getContext() ) as context :
+			renderPassPath = self.__pathListing.getPath().copy()
+			for path, inspector in edits :
+				renderPassPath.setFromString( path )
+				context["renderPass"] = renderPassPath.property( "renderPassPath:name" )
+				inspection = inspector.inspect()
+				if inspection is not None and inspection.editable() :
+					source = inspection.source()
+
+					if isinstance( source, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) :
+						source["enabled"].setValue( False )
+
+	def __buttonPress( self, pathListing, event ) :
+
+		if event.button != event.Buttons.Right or event.modifiers != event.Modifiers.None_ :
+			return False
+
+		selection = pathListing.getSelection()
+
+		columns = pathListing.getColumns()
+		cellColumn = pathListing.columnAt( event.line.p0 )
+		columnIndex = -1
+		for i in range( 0, len( columns ) ) :
+			if cellColumn == columns[i] :
+				columnIndex = i
+
+		cellPath = pathListing.pathAt( event.line.p0 )
+		if cellPath is None :
+			return False
+
+		if not selection[columnIndex].match( str( cellPath ) ) & IECore.PathMatcher.Result.ExactMatch :
+			for p in selection :
+				p.clear()
+			selection[columnIndex].addPath( str( cellPath ) )
+			pathListing.setSelection( selection, scrollToFirst = False )
+
+		menuDefinition = IECore.MenuDefinition()
+
+		if columnIndex > 1 :
+			# Option cells
+
+			menuDefinition.append(
+				"Show History...",
+				{
+					"command" : Gaffer.WeakMethod( self.__showEditHistory )
+				}
+			)
+			menuDefinition.append(
+				"Edit...",
+				{
+					"command" : functools.partial( self.__editSelectedCells, pathListing, False ),
+					"active" : pathListing.getSelection()[0].isEmpty(),
+				}
+			)
+			menuDefinition.append(
+				"Disable Edit",
+				{
+					"command" : functools.partial( self.__disableEdits, pathListing ),
+					"active" : len( self.__disablableInspectionTweaks( pathListing ) ) > 0,
+					"shortCut" : "D",
+				}
+			)
+
+		self.__contextMenu = GafferUI.Menu( menuDefinition )
+		self.__contextMenu.popup( pathListing )
+
+		return True
+
+	def __showEditHistory( self, *unused ) :
+
+		selection = self.__pathListing.getSelection()
+		columns = self.__pathListing.getColumns()
+		renderPassPath = self.__pathListing.getPath().copy()
+
+		for i in range( 0, len( columns ) ) :
+			column = columns[ i ]
+			if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+				continue
+
+			for path in selection[i].paths() :
+				renderPassPath.setFromString( path )
+				renderPassName = renderPassPath.property( "renderPassPath:name" )
+				if renderPassName is None :
+					continue
+
+				historyContext = Gaffer.Context( self.getContext() )
+				historyContext["renderPass"] = renderPassName
+				window = _HistoryWindow(
+					column.inspector(),
+					"/",
+					historyContext,
+					self.ancestor( GafferUI.ScriptWindow ).scriptNode(),
+					"History : {} : {}".format( renderPassName, column.headerData().value )
+				)
+				self.ancestor( GafferUI.Window ).addChildWindow( window, removeOnClose = True )
+				window.setVisible( True )
+
+GafferUI.Editor.registerType( "RenderPassEditor", RenderPassEditor )
+
+##########################################################################
+# Metadata controlling the settings UI
+##########################################################################
+
+Gaffer.Metadata.registerNode(
+
+	RenderPassEditor.Settings,
+
+	## \todo Doing spacers with custom widgets is tedious, and we're doing it
+	# in all the View UIs. Maybe we could just attach metadata to the plugs we
+	# want to add space around, in the same way we use `divider` to add a divider?
+	"layout:customWidget:spacer:widgetType", "GafferSceneUI.RenderPassEditor._Spacer",
+	"layout:customWidget:spacer:section", "Settings",
+	"layout:customWidget:spacer:index", 3,
+
+	plugs = {
+
+		"*" : [
+
+			"label", "",
+
+		],
+
+		"tabGroup" : [
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"layout:width", 100,
+
+		],
+
+		"section" : [
+
+			"plugValueWidget:type", "GafferSceneUI.RenderPassEditor._SectionPlugValueWidget",
+
+		],
+
+		"editScope" : [
+
+			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
+
+		],
+
+	}
+
+)
+
+class _SectionPlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plug, **kw ) :
+
+		GafferUI.PlugValueWidget.__init__( self, QtWidgets.QTabBar(), plug, **kw )
+
+		self._qtWidget().setDrawBase( False )
+
+		self._qtWidget().currentChanged.connect( Gaffer.WeakMethod( self.__currentChanged ) )
+		self.__ignoreCurrentChanged = False
+
+		plug.node().plugSetSignal().connect( Gaffer.WeakMethod( self.__plugSet ), scoped = False )
+
+		# Borrow the styling from the Spreadsheet's section chooser.
+		## \todo Should we be introducing a `GafferUI.TabBar` class which can be used in
+		# both?
+		self._qtWidget().setProperty( "gafferClass", "GafferUI.SpreadsheetUI._SectionChooser" )
+
+		self.__updateTabs()
+
+	def _updateFromValues( self, values, exception ) :
+
+		for i in range( 0, self._qtWidget().count() ) :
+			if self._qtWidget().tabText( i ) == values[0] :
+				try :
+					self.__ignoreCurrentChanged = True
+					self._qtWidget().setCurrentIndex( i )
+				finally :
+					self.__ignoreCurrentChanged = False
+				break
+
+	def __currentChanged( self, index ) :
+
+		if self.__ignoreCurrentChanged :
+			return
+
+		index = self._qtWidget().currentIndex()
+		text = self._qtWidget().tabText( index )
+		with self._blockedUpdateFromValues() :
+			self.getPlug().setValue( text )
+
+	def __updateTabs( self ) :
+
+		try :
+			self.__ignoreCurrentChanged = True
+			while self._qtWidget().count() :
+				self._qtWidget().removeTab( 0 )
+
+			tabGroup = self.getPlug().node()["tabGroup"].getValue()
+
+			for groupKey, sections in RenderPassEditor._RenderPassEditor__columnRegistry.items() :
+				if IECore.StringAlgo.match( tabGroup, groupKey ) :
+					for section in sections.keys() :
+						self._qtWidget().addTab( section )
+		finally :
+			self.__ignoreCurrentChanged = False
+
+	def __plugSet( self, plug ) :
+
+		if plug == self.getPlug().node()["tabGroup"] :
+			self.__updateTabs()
+			# Preserve the current section if there is an equivalently
+			# named section registered for the new renderer
+			self._updateFromValues( [ self.getPlug().getValue() ], None )
+			self.__currentChanged( self._qtWidget().currentIndex() )
+
+RenderPassEditor._SectionPlugValueWidget = _SectionPlugValueWidget
+
+class _Spacer( GafferUI.Spacer ) :
+
+	def __init__( self, settingsNode, **kw ) :
+
+		GafferUI.Spacer.__init__( self, imath.V2i( 0 ) )
+
+RenderPassEditor._Spacer = _Spacer
+
+##########################################################################
+# _SearchFilterWidget
+##########################################################################
+
+class _SearchFilterWidget( GafferUI.PathFilterWidget ) :
+
+	def __init__( self, pathFilter ) :
+
+		self.__patternWidget = GafferUI.TextWidget()
+		GafferUI.PathFilterWidget.__init__( self, self.__patternWidget, pathFilter )
+
+		self.__patternWidget._qtWidget().setPlaceholderText( "Filter..." )
+
+		self.__patternWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__patternEditingFinished ), scoped = False )
+		self.__patternWidget.dragEnterSignal().connectFront( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
+		self.__patternWidget.dragLeaveSignal().connectFront( Gaffer.WeakMethod( self.__dragLeave ), scoped = False )
+		self.__patternWidget.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ), scoped = False )
+
+		self._updateFromPathFilter()
+
+	def _updateFromPathFilter( self ) :
+
+		self.__patternWidget.setText( self.pathFilter().getMatchPattern() )
+
+	def __patternEditingFinished( self, widget ) :
+
+		self.pathFilter().setMatchPattern( self.__patternWidget.getText() )
+
+	def __dragEnter( self, widget, event ) :
+
+		if not isinstance( event.data, IECore.StringVectorData ) :
+			return False
+
+		if not len( event.data ) :
+			return False
+
+		self.__patternWidget.setHighlighted( True )
+
+		return True
+
+	def __dragLeave( self, widget, event ) :
+
+		self.__patternWidget.setHighlighted( False )
+
+		return True
+
+	def __drop( self, widget, event ) :
+
+		if isinstance( event.data, IECore.StringVectorData ) and len( event.data ) > 0 :
+			self.pathFilter().setMatchPattern( " ".join( sorted( event.data ) ) )
+
+		self.__patternWidget.setHighlighted( False )
+
+		return True

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -91,7 +91,11 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 		Gaffer.NodeAlgo.applyUserDefaults( self.__settingsNode )
 
 		searchFilter = _GafferSceneUI._RenderPassEditor.SearchFilter()
-		self.__filter = searchFilter
+		disabledRenderPassFilter = _GafferSceneUI._RenderPassEditor.DisabledRenderPassFilter()
+		disabledRenderPassFilter.userData()["UI"] = { "label" : "Hide Disabled", "toolTip" : "Hide render passes that are disabled for rendering" }
+		disabledRenderPassFilter.setEnabled( False )
+
+		self.__filter = Gaffer.CompoundPathFilter( [ searchFilter, disabledRenderPassFilter ] )
 
 		with mainColumn :
 
@@ -101,7 +105,10 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 				rootSection = "Settings"
 			)
 
-			_SearchFilterWidget( searchFilter )
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+
+				_SearchFilterWidget( searchFilter )
+				GafferUI.BasicPathFilterWidget( disabledRenderPassFilter )
 
 			self.__renderPassNameColumn = _GafferSceneUI._RenderPassEditor.RenderPassNameColumn()
 			self.__renderPassActiveColumn = _GafferSceneUI._RenderPassEditor.RenderPassActiveColumn()

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -49,6 +49,7 @@ from .FilterPlugValueWidget import FilterPlugValueWidget
 from .ScenePathPlugValueWidget import ScenePathPlugValueWidget
 from .LightEditor import LightEditor
 from .SetEditor import SetEditor
+from .RenderPassEditor import RenderPassEditor
 from . import SceneHistoryUI
 from . import EditScopeUI
 

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -862,5 +862,29 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		Gaffer.Metadata.registerValue( "option:test:enabled", "defaultValue", False )
 		self.assertEqual( self.__inspect( editScope["out"], "test:enabled", editScope ).value(), IECore.BoolData( 0 ) )
 
+		# The default value now allows the option edit to take place.
+
+		inspection = self.__inspect( editScope["out"], "test:enabled", editScope )
+		edit = inspection.acquireEdit()
+		self.assertEqual(
+			edit,
+			GafferScene.EditScopeAlgo.acquireOptionEdit(
+				editScope, "test:enabled", createIfNecessary = False
+			)
+		)
+
+		edit["enabled"].setValue( True )
+
+		# With the tweak in place in `editScope`, force the history to be checked again
+		# to make sure we get the right source back.
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "test:enabled", editScope ),
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -433,10 +433,13 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		editScope.setup( standardOptions["out"] )
 		editScope["in"].setInput( standardOptions["out"] )
 
-		# Inspecting the "renderPass:enabled" option without an active EditScope
-		# returns `None` as we have no upstream nodes capable of editing it.
+		self.assertIsNotNone( Gaffer.Metadata.value( "option:renderPass:enabled" , "defaultValue" ) )
 
-		self.assertIsNone( self.__inspect( editScope["out"], "renderPass:enabled" ) )
+		# Inspecting the source of the "renderPass:enabled" option without an active EditScope
+		# returns `None` as we have no upstream nodes capable of editing it. We still get a result
+		# from this inspection as "defaultValue" metadata has been registered for this option.
+
+		self.assertIsNone( self.__inspect( editScope["out"], "renderPass:enabled" ).source() )
 
 		# Providing an EditScope allows the option edit to take place.
 

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -1,0 +1,154 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferUITest
+
+from GafferSceneUI import _GafferSceneUI
+
+class RenderPassEditorTest( GafferUITest.TestCase ) :
+
+	def testRenderPassPathSimpleChildren( self ) :
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "B", "C", "D"] ) )
+
+		context = Gaffer.Context()
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], context, "/" )
+		self.assertTrue( path.isValid() )
+		self.assertFalse( path.isLeaf() )
+
+		children = path.children()
+		self.assertEqual( [ str( c ) for c in children ], [ "/A", "/B", "/C", "/D" ] )
+		for child in children :
+			self.assertIsInstance( child, _GafferSceneUI._RenderPassEditor.RenderPassPath )
+			self.assertTrue( child.getContext().isSame( context ) )
+			self.assertTrue( child.getScene().isSame( renderPasses["out"] ) )
+			self.assertTrue( child.isLeaf() )
+			self.assertTrue( child.isValid() )
+			self.assertEqual( child.children(), [] )
+
+	def testRenderPassPathIsValid( self ) :
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "B", "C", "D"] ) )
+
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], Gaffer.Context(), "/" )
+		self.assertTrue( path.isValid() )
+		self.assertFalse( path.isLeaf() )
+
+		for parent, valid in [
+			( "/", True ),
+			( "/A", True ),
+			( "/A/B", False ),
+			( "/B", True ),
+			( "/C", True ),
+			( "/D", True ),
+			( "/E", False ),
+			( "/E/F", False ),
+		] :
+
+			path.setFromString( parent )
+			self.assertEqual( path.isValid(), valid )
+
+	def testRenderPassPathIsLeaf( self ) :
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "B", "C", "D"] ) )
+
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], Gaffer.Context(), "/" )
+		self.assertTrue( path.isValid() )
+		self.assertFalse( path.isLeaf() )
+
+		for parent, leaf in [
+			( "/", False ),
+			( "/A", True ),
+			( "/A/B", False ),
+			( "/B", True ),
+			( "/C", True ),
+			( "/D", True ),
+			( "/E", False ),
+			( "/E/F", False ),
+		] :
+
+			path.setFromString( parent )
+			self.assertEqual( path.isLeaf(), leaf )
+
+	def testRenderPassPathCancellation( self ) :
+
+		plane = GafferScene.Plane()
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( plane["out"], Gaffer.Context(), "/" )
+
+		canceller = IECore.Canceller()
+		canceller.cancel()
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.children( canceller )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.isValid( canceller )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.isLeaf( canceller )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			path.property( "renderPassPath:enabled", canceller )
+
+	def testSearchFilter( self ) :
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "B", "C", "D"] ) )
+
+		context = Gaffer.Context()
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], context, "/" )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
+
+		searchFilter = _GafferSceneUI._RenderPassEditor.SearchFilter()
+		searchFilter.setMatchPattern( "A" )
+		path.setFilter( searchFilter )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A" ] )
+
+		searchFilter.setMatchPattern( "A D" )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/D" ] )

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -61,6 +61,7 @@ from .SetEditorTest import SetEditorTest
 from .LightToolTest import LightToolTest
 from .OptionInspectorTest import OptionInspectorTest
 from .LightPositionToolTest import LightPositionToolTest
+from .RenderPassEditorTest import RenderPassEditorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -1071,6 +1071,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 		]
 
 		descendantMatch = any( m & IECore.PathMatcher.Result.DescendantMatch for m in cellMatches )
+		rowMatch = any( m & IECore.PathMatcher.Result.ExactMatch for m in cellMatches )
 
 		for i in range( 0, header.count() ) :
 			cellMatch = cellMatches[i]
@@ -1080,10 +1081,12 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 			cellRect = QtCore.QRectF(left, rect.top(), width, rect.height() )
 
-			if descendantMatch and not( cellMatch & IECore.PathMatcher.Result.ExactMatch ) :
-				self.__drawHighlight( painter, cellRect, 50 )
-			elif cellMatch & IECore.PathMatcher.Result.ExactMatch :
+			if cellMatch & IECore.PathMatcher.Result.ExactMatch :
 				self.__drawHighlight( painter, cellRect, 200 )
+			elif descendantMatch :
+				self.__drawHighlight( painter, cellRect, 50 )
+			elif rowMatch :
+				self.__drawHighlight( painter, cellRect, 25 )
 
 	def __drawHighlight( self, painter, rect, alpha ) :
 

--- a/python/GafferUITest/PathColumnTest.py
+++ b/python/GafferUITest/PathColumnTest.py
@@ -52,6 +52,7 @@ class PathColumnTest( GafferUITest.TestCase ) :
 		self.assertIsNone( d.icon )
 		self.assertIsNone( d.background )
 		self.assertIsNone( d.toolTip )
+		self.assertIsNone( d.foreground )
 
 	def testCellDataKeywordConstructor( self ) :
 
@@ -59,12 +60,14 @@ class PathColumnTest( GafferUITest.TestCase ) :
 			value = 10,
 			icon = "test.png",
 			background = imath.Color3f( 1 ),
-			toolTip = "help!"
+			toolTip = "help!",
+			foreground = imath.Color3f( 1 )
 		)
 		self.assertEqual( d.value, 10 )
 		self.assertEqual( d.icon, "test.png" )
 		self.assertEqual( d.background, imath.Color3f( 1 ) )
 		self.assertEqual( d.toolTip, "help!" )
+		self.assertEqual( d.foreground, imath.Color3f( 1 ) )
 
 	def testCellDataSetters( self ) :
 
@@ -81,6 +84,9 @@ class PathColumnTest( GafferUITest.TestCase ) :
 
 		d.toolTip = "help!"
 		self.assertEqual( d.toolTip, "help!" )
+
+		d.foreground = imath.Color4f( 1 )
+		self.assertEqual( d.foreground, imath.Color4f( 1 ) )
 
 	def testSizeMode( self ) :
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -441,6 +441,23 @@
 				"emptySet",
 				"setFolder",
 			]
+		},
+
+		"renderPassEditor" : {
+
+			"options" : {
+				"requiredWidth" : 16,
+				"requiredHeight" : 16,
+				"validatePixelAlignment" : True
+			},
+
+			"ids" : [
+				"renderPass",
+				"disabledRenderPass",
+				"renderPassFolder",
+				"activeRenderPass",
+				"activeRenderPassFadedHighlighted",
+			]
 		}
 
 	},

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -1637,6 +1637,29 @@
            id="rect8084-2" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
          id="flowPara8088-1">SetEditor</flowPara></flowRoot>
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M -5.8202246,2879.2996 H 744.17977"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc"
+       inkscape:label="hr1"
+       id="path7" />
+    <flowRoot
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:1"
+       transform="matrix(1,0,0,1.0000138,288.28134,1866.3792)"
+       inkscape:label="docTitle"
+       id="flowRoot7"><flowRegion
+         style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
+         id="flowRegion7"><rect
+           width="343.75"
+           height="54.25"
+           x="-295"
+           y="983"
+           style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
+           id="rect7" /></flowRegion><flowPara
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
+         id="flowPara7">RenderPassEditor</flowPara></flowRoot>
   </g>
   <g
      id="layer4"
@@ -3176,6 +3199,51 @@
        id="path2293"
        d="m 224,2624.5 h -3.5 v -3.5"
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       id="g17"
+       inkscape:label="RenderPassEditor"
+       transform="translate(0,107)">
+      <rect
+         inkscape:label="renderPassIcon"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="30"
+         y="2776"
+         id="renderPass" />
+      <rect
+         id="disabledRenderPass"
+         y="2776"
+         x="50"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="disabledRenderPassIcon" />
+      <rect
+         id="renderPassFolder"
+         y="2776"
+         x="70"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="renderPassFolderIcon" />
+      <rect
+         id="activeRenderPass"
+         y="2776"
+         x="90"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="activeRenderPassIcon" />
+      <rect
+         id="activeRenderPassFadedHighlighted"
+         y="2776"
+         x="110"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="activeRenderPassFadedHighlightedIcon" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
@@ -9566,6 +9634,102 @@
            cx="53.141415"
            id="circle7867"
            style="display:inline;opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       id="g13"
+       inkscape:label="RenderPassEditor"
+       transform="translate(0,159.23177)">
+      <rect
+         id="rect8"
+         y="2776.1304"
+         x="9.9351273"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="sizeGuide" />
+      <g
+         style="fill:url(#backgroundLight);fill-opacity:1"
+         inkscape:label="disabledRenderPass"
+         id="g8"
+         transform="translate(-0.036244,0.12970317)">
+        <rect
+           style="display:inline;fill:url(#backgroundLight);stroke:#3d3d3d;stroke-width:1;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect13-7"
+           width="11"
+           height="7"
+           x="52.537006"
+           y="2782.4839" />
+        <rect
+           style="display:inline;fill:url(#backgroundLight);stroke:#3d3d3d;stroke-width:1;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect14-0"
+           width="11"
+           height="2.5"
+           x="52.536243"
+           y="2779.0571" />
+      </g>
+      <g
+         id="g9"
+         inkscape:label="renderPassFolder"
+         style="fill:url(#backgroundLight);fill-opacity:1"
+         transform="matrix(0.99889295,0,0,1.0166942,0.0863502,-46.342392)">
+        <rect
+           style="opacity:1;fill:url(#backgroundLight);fill-opacity:1;stroke:#3d3d3d;stroke-width:1.08437;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect9"
+           width="2.4712856"
+           height="12.867659"
+           x="1830.3557"
+           y="3283.8118"
+           transform="matrix(1,0,-0.53296674,0.84613619,0,0)"
+           ry="0" />
+      </g>
+      <g
+         inkscape:label="renderPass"
+         id="g12"
+         style="fill:#cccccc;fill-opacity:1"
+         transform="translate(-15.135344,-0.81469727)">
+        <rect
+           style="display:inline;fill:#cccccc;fill-opacity:0.992157;stroke:#3d3d3d;stroke-width:1;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect13"
+           width="11"
+           height="7"
+           x="47.635345"
+           y="2783.4512"
+           rx="0" />
+        <rect
+           style="display:inline;fill:#cccccc;fill-opacity:0.992157;stroke:#3d3d3d;stroke-width:1.00692315;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect14"
+           width="11.162248"
+           height="2.3981025"
+           x="-59.454838"
+           y="2788.3389"
+           transform="matrix(-0.98629618,0.1649844,0,1,0,0)"
+           inkscape:label="rect14"
+           rx="0" />
+      </g>
+      <g
+         transform="translate(43.820791,-0.81469727)"
+         inkscape:label="activeRenderPass"
+         id="g18"
+         style="fill:#cccccc;fill-opacity:1">
+        <circle
+           r="5.5"
+           cy="2784.9451"
+           cx="54.179211"
+           id="circle6245-3"
+           style="display:inline;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+      </g>
+      <g
+         transform="translate(61.820791,-0.81469727)"
+         inkscape:label="activeRenderPassFadedHighlighted"
+         id="g20"
+         style="fill:#cccccc;fill-opacity:1">
+        <circle
+           r="5.5"
+           cy="2784.9451"
+           cx="56.179211"
+           id="circle6253-6"
+           style="display:inline;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
       </g>
     </g>
     <g

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -1145,6 +1145,10 @@ ConstObjectPtr optionValue( const ScenePlug *scene, const std::string &option )
 	{
 		result = it->second;
 	}
+	else if( const auto defaultValue = Gaffer::Metadata::value( g_optionPrefix + option, "defaultValue" ) )
+	{
+		return defaultValue;
+	}
 
 	if( !result )
 	{

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -190,6 +190,12 @@ Inspector::ResultPtr Inspector::inspect() const
 	}
 
 	ConstObjectPtr value = this->value( history.get() );
+	bool fallbackValue = false;
+	if( !value )
+	{
+		value = this->fallbackValue();
+		fallbackValue = (bool)value;
+	}
 
 	ResultPtr result = new Result( value, targetEditScope() );
 	inspectHistoryWalk( history.get(), result.get() );
@@ -215,6 +221,11 @@ Inspector::ResultPtr Inspector::inspect() const
 		// There's no source plug and no way of making
 		// the property.
 		result->m_editFunction = "No editable source found in history.";
+	}
+
+	if( fallbackValue )
+	{
+		result->m_sourceType = Result::SourceType::Fallback;
 	}
 
 	return result;
@@ -352,6 +363,11 @@ Gaffer::ValuePlugPtr Inspector::source( const GafferScene::SceneAlgo::History *h
 Inspector::EditFunctionOrFailure Inspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	return "Editing not supported";
+}
+
+IECore::ConstObjectPtr Inspector::fallbackValue() const
+{
+	return nullptr;
 }
 
 Gaffer::EditScope *Inspector::targetEditScope() const

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -61,7 +61,9 @@ namespace
 {
 
 const std::string g_emptyString( "" );
+const std::string g_optionPrefix( "option:" );
 const InternedString g_renderPassContextName( "renderPass" );
+const InternedString g_defaultValue( "defaultValue" );
 
 // This uses the same strategy that ValuePlug uses for the hash cache,
 // using `plug->dirtyCount()` to invalidate previous cache entries when
@@ -210,6 +212,16 @@ IECore::ConstObjectPtr OptionInspector::value( const GafferScene::SceneAlgo::His
 		return optionHistory->optionValue;
 	}
 	// Option doesn't exist.
+	return nullptr;
+}
+
+IECore::ConstObjectPtr OptionInspector::fallbackValue() const
+{
+	if( const auto defaultValue = Gaffer::Metadata::value( g_optionPrefix + m_option.string(), g_defaultValue ) )
+	{
+		return defaultValue;
+	}
+
 	return nullptr;
 }
 

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -141,6 +141,7 @@ void GafferSceneUIModule::bindInspector()
 			.value( "EditScope", Inspector::Result::SourceType::EditScope )
 			.value( "Downstream", Inspector::Result::SourceType::Downstream )
 			.value( "Other", Inspector::Result::SourceType::Other )
+			.value( "Fallback", Inspector::Result::SourceType::Fallback )
 		;
 	}
 

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -154,6 +154,7 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 	{ (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
 	{ (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },
 	{ (int)Inspector::Result::SourceType::Other, nullptr },
+	{ (int)Inspector::Result::SourceType::Fallback, nullptr },
 };
 
 class InspectorColumn : public PathColumn

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -484,6 +484,7 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 	{ (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
 	{ (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },
 	{ (int)Inspector::Result::SourceType::Other, nullptr },
+	{ (int)Inspector::Result::SourceType::Fallback, nullptr },
 };
 
 class OptionInspectorColumn : public PathColumn

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -1,0 +1,759 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "RenderPassEditorBinding.h"
+
+#include "GafferSceneUI/Private/Inspector.h"
+#include "GafferSceneUI/Private/OptionInspector.h"
+
+#include "GafferSceneUI/ContextAlgo.h"
+#include "GafferSceneUI/TypeIds.h"
+
+#include "GafferScene/ScenePlug.h"
+
+#include "GafferUI/PathColumn.h"
+
+#include "GafferBindings/PathBinding.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/Node.h"
+#include "Gaffer/Path.h"
+#include "Gaffer/PathFilter.h"
+#include "Gaffer/ScriptNode.h"
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+
+#include "IECorePython/RefCountedBinding.h"
+
+#include "IECore/CamelCase.h"
+#include "IECore/StringAlgo.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/bind/bind.hpp"
+
+using namespace std;
+using namespace boost::placeholders;
+using namespace boost::python;
+using namespace IECore;
+using namespace IECorePython;
+using namespace Gaffer;
+using namespace GafferBindings;
+using namespace GafferUI;
+using namespace GafferScene;
+using namespace GafferSceneUI;
+using namespace GafferSceneUI::Private;
+
+namespace
+{
+
+//////////////////////////////////////////////////////////////////////////
+// LRU cache of PathMatchers built from render passes
+//////////////////////////////////////////////////////////////////////////
+
+struct PathMatcherCacheGetterKey
+{
+
+	PathMatcherCacheGetterKey()
+		:	renderPassNames( nullptr )
+	{
+	}
+
+	PathMatcherCacheGetterKey( ConstStringVectorDataPtr renderPassNames )
+		:	renderPassNames( renderPassNames )
+	{
+		renderPassNames->hash( hash );
+	}
+
+	operator const IECore::MurmurHash & () const
+	{
+		return hash;
+	}
+
+	MurmurHash hash;
+	const ConstStringVectorDataPtr renderPassNames;
+
+};
+
+PathMatcher pathMatcherCacheGetter( const PathMatcherCacheGetterKey &key, size_t &cost, const IECore::Canceller *canceller )
+{
+	cost = 1;
+
+	PathMatcher result;
+
+	for( const auto &renderPass : key.renderPassNames->readable() )
+	{
+		result.addPath( renderPass );
+	}
+
+	return result;
+}
+
+using PathMatcherCache = IECorePreview::LRUCache<IECore::MurmurHash, IECore::PathMatcher, IECorePreview::LRUCachePolicy::Parallel, PathMatcherCacheGetterKey>;
+PathMatcherCache g_pathMatcherCache( pathMatcherCacheGetter, 25 );
+
+const InternedString g_renderPassContextName( "renderPass" );
+const InternedString g_renderPassNamePropertyName( "renderPassPath:name" );
+const InternedString g_renderPassEnabledPropertyName( "renderPassPath:enabled" );
+const InternedString g_renderPassNamesOption( "option:renderPass:names" );
+const InternedString g_renderPassEnabledOption( "option:renderPass:enabled" );
+
+//////////////////////////////////////////////////////////////////////////
+// RenderPassPath
+//////////////////////////////////////////////////////////////////////////
+
+class RenderPassPath : public Gaffer::Path
+{
+
+	public :
+
+		RenderPassPath( ScenePlugPtr scene, Gaffer::ContextPtr context, Gaffer::PathFilterPtr filter = nullptr )
+			:	Path( filter )
+		{
+			setScene( scene );
+			setContext( context );
+		}
+
+		RenderPassPath( ScenePlugPtr scene, Gaffer::ContextPtr context, const Names &names, const IECore::InternedString &root = "/", Gaffer::PathFilterPtr filter = nullptr )
+			:	Path( names, root, filter )
+		{
+			setScene( scene );
+			setContext( context );
+		}
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( RenderPassPath, GafferSceneUI::RenderPassPathTypeId, Gaffer::Path );
+
+		~RenderPassPath() override
+		{
+		}
+
+		void setScene( ScenePlugPtr scene )
+		{
+			if( m_scene == scene )
+			{
+				return;
+			}
+
+			m_scene = scene;
+			m_plugDirtiedConnection = scene->node()->plugDirtiedSignal().connect( boost::bind( &RenderPassPath::plugDirtied, this, ::_1 ) );
+
+			emitPathChanged();
+		}
+
+		ScenePlug *getScene()
+		{
+			return m_scene.get();
+		}
+
+		const ScenePlug *getScene() const
+		{
+			return m_scene.get();
+		}
+
+		void setContext( Gaffer::ContextPtr context )
+		{
+			if( m_context == context )
+			{
+				return;
+			}
+
+			m_context = context;
+			m_contextChangedConnection = context->changedSignal().connect( boost::bind( &RenderPassPath::contextChanged, this, ::_2 ) );
+
+			emitPathChanged();
+		}
+
+		Gaffer::Context *getContext()
+		{
+			return m_context.get();
+		}
+
+		const Gaffer::Context *getContext() const
+		{
+			return m_context.get();
+		}
+
+		bool isValid( const IECore::Canceller *canceller = nullptr ) const override
+		{
+			if( !Path::isValid() )
+			{
+				return false;
+			}
+
+			const PathMatcher p = pathMatcher( canceller );
+			return p.match( names() ) & ( PathMatcher::ExactMatch | PathMatcher::DescendantMatch );
+		}
+
+		bool isLeaf( const IECore::Canceller *canceller ) const override
+		{
+			const PathMatcher p = pathMatcher( canceller );
+			const unsigned match = p.match( names() );
+			return match & PathMatcher::ExactMatch && !( match & PathMatcher::DescendantMatch );
+		}
+
+		PathPtr copy() const override
+		{
+			return new RenderPassPath( m_scene, m_context, names(), root(), const_cast<PathFilter *>( getFilter() ) );
+		}
+
+		void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr ) const override
+		{
+			Path::propertyNames( names, canceller );
+			names.push_back( g_renderPassNamePropertyName );
+			names.push_back( g_renderPassEnabledPropertyName );
+		}
+
+		IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override
+		{
+			if( name == g_renderPassNamePropertyName )
+			{
+				const PathMatcher p = pathMatcher( canceller );
+				if( p.match( names() ) & PathMatcher::ExactMatch )
+				{
+					return new StringData( names().back().string() );
+				}
+			}
+			else if( name == g_renderPassEnabledPropertyName )
+			{
+				const PathMatcher p = pathMatcher( canceller );
+				if( p.match( names() ) & PathMatcher::ExactMatch )
+				{
+					Context::EditableScope scopedContext( getContext() );
+					if( canceller )
+					{
+						scopedContext.setCanceller( canceller );
+					}
+					scopedContext.set( g_renderPassContextName, &( names().back().string() ) );
+					ConstBoolDataPtr enabledData = getScene()->globals()->member<BoolData>( g_renderPassEnabledOption );
+					return new BoolData( enabledData ? enabledData->readable() : true );
+				}
+			}
+
+			return Path::property( name, canceller );
+		}
+
+		const Gaffer::Plug *cancellationSubject() const override
+		{
+			return m_scene.get();
+		}
+
+	protected :
+
+		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const override
+		{
+			const PathMatcher p = pathMatcher( canceller );
+
+			auto it = p.find( names() );
+			if( it == p.end() )
+			{
+				return;
+			}
+
+			++it;
+			while( it != p.end() && it->size() == names().size() + 1 )
+			{
+				children.push_back( new RenderPassPath( m_scene, m_context, *it, root(), const_cast<PathFilter *>( getFilter() ) ) );
+				it.prune();
+				++it;
+			}
+
+			std::sort(
+				children.begin(), children.end(),
+				[]( const PathPtr &a, const PathPtr &b ) {
+					return a->names().back().string() < b->names().back().string();
+				}
+			);
+		}
+
+
+	private :
+
+		// We construct our path from a pathMatcher as we anticipate users requiring render passes to be organised
+		// hierarchically, with the last part of the path representing the render pass name. While it's technically
+		// possible to create a render pass name containing one or more '/' characters, we don't expect this to be
+		// practical as render pass names are used in output file paths where the included '/' characters would be
+		// interpreted as subdirectories. Validation in the UI will prevent users from inserting invalid characters
+		// such as '/' into render pass names.
+		const IECore::PathMatcher pathMatcher( const IECore::Canceller *canceller ) const
+		{
+			Context::EditableScope scopedContext( m_context.get() );
+			if( canceller )
+			{
+				scopedContext.setCanceller( canceller );
+			}
+
+			if( ConstStringVectorDataPtr renderPassData = m_scene.get()->globals()->member<StringVectorData>( g_renderPassNamesOption ) )
+			{
+				const PathMatcherCacheGetterKey key( renderPassData );
+				return g_pathMatcherCache.get( key );
+			}
+
+			return IECore::PathMatcher();
+		}
+
+		void contextChanged( const IECore::InternedString &key )
+		{
+			if( !boost::starts_with( key.c_str(), "ui:" ) )
+			{
+				emitPathChanged();
+			}
+		}
+
+		void plugDirtied( Gaffer::Plug *plug )
+		{
+			if( plug == m_scene->globalsPlug() )
+			{
+				emitPathChanged();
+			}
+		}
+
+		Gaffer::NodePtr m_node;
+		ScenePlugPtr m_scene;
+		Gaffer::ContextPtr m_context;
+		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;
+		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
+
+};
+
+IE_CORE_DEFINERUNTIMETYPED( RenderPassPath );
+
+RenderPassPath::Ptr constructor1( ScenePlug &scene, Context &context, PathFilterPtr filter )
+{
+	return new RenderPassPath( &scene, &context, filter );
+}
+
+RenderPassPath::Ptr constructor2( ScenePlug &scene, Context &context, const std::vector<IECore::InternedString> &names, const IECore::InternedString &root, PathFilterPtr filter )
+{
+	return new RenderPassPath( &scene, &context, names, root, filter );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// RenderPassNameColumn
+//////////////////////////////////////////////////////////////////////////
+
+ConstStringDataPtr g_disabledRenderPassIcon = new StringData( "disabledRenderPass.png" );
+ConstStringDataPtr g_renderPassIcon = new StringData( "renderPass.png" );
+ConstStringDataPtr g_renderPassFolderIcon = new StringData( "renderPassFolder.png" );
+
+class RenderPassNameColumn : public StandardPathColumn
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( RenderPassNameColumn )
+
+		RenderPassNameColumn()
+			:	StandardPathColumn( "Name", "name" )
+		{
+		}
+
+		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
+		{
+			CellData result = StandardPathColumn::cellData( path, canceller );
+
+			const auto renderPassName = runTimeCast<const IECore::StringData>( path.property( g_renderPassNamePropertyName, canceller ) );
+			if( !renderPassName )
+			{
+				result.icon = g_renderPassFolderIcon;
+			}
+			else
+			{
+				if( const auto renderPassEnabled = runTimeCast<const IECore::BoolData>( path.property( g_renderPassEnabledPropertyName, canceller ) ) )
+				{
+					result.icon = renderPassEnabled->readable() ? g_renderPassIcon : g_disabledRenderPassIcon;
+				}
+				else
+				{
+					result.icon = g_renderPassIcon;
+				}
+			}
+
+			return result;
+		}
+
+};
+
+//////////////////////////////////////////////////////////////////////////
+// RenderPassActiveColumn
+//////////////////////////////////////////////////////////////////////////
+
+class RenderPassActiveColumn : public PathColumn
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( RenderPassActiveColumn )
+
+		RenderPassActiveColumn()
+			:	PathColumn()
+		{
+		}
+
+		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
+		{
+			CellData result;
+
+			auto renderPassPath = runTimeCast<const RenderPassPath>( &path );
+			if( !renderPassPath )
+			{
+				return result;
+			}
+
+			const auto renderPassName = runTimeCast<const IECore::StringData>( path.property( g_renderPassNamePropertyName, canceller ) );
+			if( !renderPassName )
+			{
+				return result;
+			}
+
+			auto iconData = new CompoundData;
+			result.icon = iconData;
+
+			if( const std::string *currentPassName = renderPassPath->getContext()->getIfExists< std::string >( g_renderPassContextName ) )
+			{
+				if( *currentPassName == renderPassName->readable() )
+				{
+					iconData->writable()["state:normal"] = g_activeRenderPassIcon;
+					/// \todo This is only to allow sorting, replace with `CellData::sortValue` in Gaffer 1.4
+					result.value = new StringData( " " );
+					result.toolTip = new StringData( fmt::format( "{} is the currently active render pass.", renderPassName->readable() ) );
+
+					return result;
+				}
+			}
+
+			iconData->writable()["state:highlighted"] = g_activeRenderPassFadedHighlightedIcon;
+			result.toolTip = new StringData( fmt::format( "Double-click to set {} as the active render pass.", renderPassName->readable() ) );
+
+			return result;
+		}
+
+		CellData headerData( const IECore::Canceller *canceller ) const override
+		{
+			return CellData( nullptr, /* icon = */ g_activeRenderPassIcon, /* background = */ nullptr, new IECore::StringData( "The currently active render pass." ) );
+		}
+
+		static IECore::StringDataPtr g_activeRenderPassIcon;
+		static IECore::StringDataPtr g_activeRenderPassFadedHighlightedIcon;
+
+};
+
+StringDataPtr RenderPassActiveColumn::g_activeRenderPassIcon = new StringData( "activeRenderPass.png" );
+StringDataPtr RenderPassActiveColumn::g_activeRenderPassFadedHighlightedIcon = new StringData( "activeRenderPassFadedHighlighted.png" );
+
+//////////////////////////////////////////////////////////////////////////
+// OptionInspectorColumn
+//////////////////////////////////////////////////////////////////////////
+
+/// \todo This map of SourceType colours is a duplicate of the one in LightEditorBinding.cpp.
+/// We should consolidate these in the future.
+const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = {
+	{ (int)Inspector::Result::SourceType::Upstream, nullptr },
+	{ (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
+	{ (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },
+	{ (int)Inspector::Result::SourceType::Other, nullptr },
+};
+
+class OptionInspectorColumn : public PathColumn
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( OptionInspectorColumn )
+
+		OptionInspectorColumn( GafferSceneUI::Private::OptionInspectorPtr inspector, const std::string &columnName, const std::string &columnToolTip )
+			:	m_inspector( inspector ), m_headerValue( headerValue( columnName != "" ? columnName : inspector->name() ) ), m_headerToolTip( new IECore::StringData( columnToolTip ) )
+		{
+			m_inspector->dirtiedSignal().connect( boost::bind( &OptionInspectorColumn::inspectorDirtied, this ) );
+		}
+
+		GafferSceneUI::Private::Inspector *inspector()
+		{
+			return m_inspector.get();
+		}
+
+		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
+		{
+			CellData result;
+
+			auto renderPassPath = runTimeCast<const RenderPassPath>( &path );
+			if( !renderPassPath )
+			{
+				return result;
+			}
+
+			const auto renderPassName = runTimeCast<const IECore::StringData>( path.property( g_renderPassNamePropertyName, canceller ) );
+			if( !renderPassName )
+			{
+				return result;
+			}
+
+			Context::EditableScope scope( renderPassPath->getContext() );
+			scope.setCanceller( canceller );
+			scope.set( g_renderPassContextName, &( renderPassName->readable() ) );
+
+			Inspector::ConstResultPtr inspectorResult = m_inspector->inspect();
+			if( !inspectorResult )
+			{
+				return result;
+			}
+
+			result.value = runTimeCast<const IECore::Data>( inspectorResult->value() );
+			/// \todo Should PathModel create a decoration automatically when we
+			/// return a colour for `Role::Value`?
+			result.icon = runTimeCast<const Color3fData>( inspectorResult->value() );
+			result.background = g_sourceTypeColors.at( (int)inspectorResult->sourceType() );
+			std::string toolTip;
+			if( const auto source = inspectorResult->source() )
+			{
+				toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
+			}
+
+			if( inspectorResult->editable() )
+			{
+				toolTip += !toolTip.empty() ? "\n\n" : "";
+				if( runTimeCast<const IECore::BoolData>( result.value ) )
+				{
+					toolTip += "Double-click to toggle";
+				}
+				else
+				{
+					toolTip += "Double-click to edit";
+				}
+			}
+
+			if( !toolTip.empty() )
+			{
+				result.toolTip = new StringData( toolTip );
+			}
+
+			return result;
+		}
+
+		CellData headerData( const IECore::Canceller *canceller ) const override
+		{
+			return CellData( m_headerValue, /* icon = */ nullptr, /* background = */ nullptr, m_headerToolTip );
+		}
+
+	private :
+
+		void inspectorDirtied()
+		{
+			changedSignal()( this );
+		}
+
+		static IECore::ConstStringDataPtr headerValue( const std::string &inspectorName )
+		{
+			std::string name = inspectorName;
+			// Convert from snake case and/or camel case to UI case.
+			if( name.find( '_' ) != std::string::npos )
+			{
+				std::replace( name.begin(), name.end(), '_', ' ' );
+			}
+			if( name.find( ' ' ) != std::string::npos )
+			{
+				name = CamelCase::fromSpaced( name );
+			}
+			return new StringData( CamelCase::toSpaced( name ) );
+		}
+
+		const OptionInspectorPtr m_inspector;
+		const ConstStringDataPtr m_headerValue;
+		const ConstStringDataPtr m_headerToolTip;
+
+};
+
+PathColumn::CellData headerDataWrapper( PathColumn &pathColumn, const Canceller *canceller )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return pathColumn.headerData( canceller );
+}
+
+//////////////////////////////////////////////////////////////////////////
+// RenderPassEditorSearchFilter - filters based on a match pattern. This
+// removes non-leaf paths if all their children have also been
+// removed by the filter.
+//////////////////////////////////////////////////////////////////////////
+
+/// \todo This is the same as the SetEditorSearchFilter, we'll need the non-leaf
+/// path removal functionality when we start grouping render passes by category.
+/// Could be worth turning into common functionality?
+class RenderPassEditorSearchFilter : public Gaffer::PathFilter
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( RenderPassEditorSearchFilter )
+
+		RenderPassEditorSearchFilter( IECore::CompoundDataPtr userData = nullptr )
+			:	PathFilter( userData )
+		{
+		}
+
+		void setMatchPattern( const string &matchPattern )
+		{
+			if( m_matchPattern == matchPattern )
+			{
+				return;
+			}
+			m_matchPattern = matchPattern;
+			m_wildcardPattern = IECore::StringAlgo::hasWildcards( matchPattern ) ? matchPattern : "*" + matchPattern + "*";
+
+			changedSignal()( this );
+		}
+
+		const string &getMatchPattern() const
+		{
+			return m_matchPattern;
+		}
+
+		void doFilter( std::vector<PathPtr> &paths, const IECore::Canceller *canceller ) const override
+		{
+			if( m_matchPattern.empty() || paths.empty() )
+			{
+				return;
+			}
+
+			paths.erase(
+				std::remove_if(
+					paths.begin(),
+					paths.end(),
+					[this] ( const auto &p ) { return remove( p ); }
+				),
+				paths.end()
+			);
+		}
+
+		bool remove( PathPtr path ) const
+		{
+			if( !path->names().size() )
+			{
+				return true;
+			}
+
+			bool leaf = path->isLeaf();
+			if( !leaf )
+			{
+				std::vector<PathPtr> c;
+				path->children( c );
+
+				leaf = std::all_of( c.begin(), c.end(), [this] ( const auto &p ) { return remove( p ); } );
+			}
+
+			const bool match = IECore::StringAlgo::matchMultiple( path->names().back().string(), m_wildcardPattern );
+
+			return leaf && !match;
+		}
+
+	private:
+
+		std::string m_matchPattern;
+		std::string m_wildcardPattern;
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Bindings
+//////////////////////////////////////////////////////////////////////////
+
+void GafferSceneUIModule::bindRenderPassEditor()
+{
+
+	object module( borrowed( PyImport_AddModule( "GafferSceneUI._RenderPassEditor" ) ) );
+	scope().attr( "_RenderPassEditor" ) = module;
+	scope moduleScope( module );
+
+	PathClass<RenderPassPath>()
+		.def(
+			"__init__",
+			make_constructor(
+				constructor1,
+				default_call_policies(),
+				(
+					boost::python::arg( "scene" ),
+					boost::python::arg( "context" ),
+					boost::python::arg( "filter" ) = object()
+				)
+			)
+		)
+		.def(
+			"__init__",
+			make_constructor(
+				constructor2,
+				default_call_policies(),
+				(
+					boost::python::arg( "scene" ),
+					boost::python::arg( "context" ),
+					boost::python::arg( "names" ),
+					boost::python::arg( "root" ) = "/",
+					boost::python::arg( "filter" ) = object()
+				)
+			)
+		)
+		.def( "setScene", &RenderPassPath::setScene )
+		.def( "getScene", (ScenePlug *(RenderPassPath::*)())&RenderPassPath::getScene, return_value_policy<CastToIntrusivePtr>() )
+		.def( "setContext", &RenderPassPath::setContext )
+		.def( "getContext", (Context *(RenderPassPath::*)())&RenderPassPath::getContext, return_value_policy<CastToIntrusivePtr>() )
+	;
+
+	RefCountedClass<RenderPassNameColumn, GafferUI::PathColumn>( "RenderPassNameColumn" )
+		.def( init<>() )
+	;
+
+	RefCountedClass<RenderPassActiveColumn, GafferUI::PathColumn>( "RenderPassActiveColumn" )
+		.def( init<>() )
+	;
+
+	RefCountedClass<OptionInspectorColumn, GafferUI::PathColumn>( "OptionInspectorColumn" )
+		.def( init<GafferSceneUI::Private::OptionInspectorPtr, const std::string &, const std::string &>(
+			(
+				arg_( "inspector" ),
+				arg_( "columName" ) = "",
+				arg_( "columnToolTip" ) = ""
+			)
+		) )
+		.def( "inspector", &OptionInspectorColumn::inspector, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "headerData", &headerDataWrapper, ( arg_( "canceller" ) = object() ) )
+	;
+
+	RefCountedClass<RenderPassEditorSearchFilter, PathFilter>( "SearchFilter" )
+		.def( init<IECore::CompoundDataPtr>( ( boost::python::arg( "userData" ) = object() ) ) )
+		.def( "setMatchPattern", &RenderPassEditorSearchFilter::setMatchPattern )
+		.def( "getMatchPattern", &RenderPassEditorSearchFilter::getMatchPattern, return_value_policy<copy_const_reference>() )
+	;
+
+}

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -486,6 +486,7 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 	{ (int)Inspector::Result::SourceType::Other, nullptr },
 	{ (int)Inspector::Result::SourceType::Fallback, nullptr },
 };
+const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
 
 class OptionInspectorColumn : public PathColumn
 {
@@ -537,7 +538,12 @@ class OptionInspectorColumn : public PathColumn
 			result.icon = runTimeCast<const Color3fData>( inspectorResult->value() );
 			result.background = g_sourceTypeColors.at( (int)inspectorResult->sourceType() );
 			std::string toolTip;
-			if( const auto source = inspectorResult->source() )
+			if( inspectorResult->sourceType() == Inspector::Result::SourceType::Fallback )
+			{
+				toolTip = "Source : Default value";
+				result.foreground = g_fallbackValueForegroundColor;
+			}
+			else if( const auto source = inspectorResult->source() )
 			{
 				toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
 			}

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.h
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,35 +34,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "InspectorBinding.h"
-#include "SceneGadgetBinding.h"
-#include "LightEditorBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
-#include "QueryBinding.h"
-#include "SetEditorBinding.h"
-#include "RenderPassEditorBinding.h"
-
-using namespace GafferSceneUIModule;
-
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+namespace GafferSceneUIModule
 {
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindQueries();
-	bindInspector();
-	bindLightEditor();
-	bindSetEditor();
-	bindRenderPassEditor();
+void bindRenderPassEditor();
 
-}
+} // namespace GafferSceneUIModule

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -254,6 +254,16 @@ void cellDataSetToolTip( PathColumn::CellData &cellData, const ConstDataPtr &dat
 	cellData.toolTip = data;
 }
 
+object cellDataGetForeground( PathColumn::CellData &cellData )
+{
+	return dataToPython( cellData.foreground.get(), /* copy = */ false );
+}
+
+void cellDataSetForeground( PathColumn::CellData &cellData, const ConstDataPtr &data )
+{
+	cellData.foreground = data;
+}
+
 PathColumn::CellData cellDataWrapper( PathColumn &pathColumn, const Path &path, const Canceller *canceller )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -319,12 +329,13 @@ void GafferUIModule::bindPathColumn()
 
 		class_<PathColumn::CellData>( "CellData" )
 			.def(
-				init<const IECore::ConstDataPtr &, const IECore::ConstDataPtr &, const IECore::ConstDataPtr &,const IECore::ConstDataPtr &>(
+				init<const IECore::ConstDataPtr &, const IECore::ConstDataPtr &, const IECore::ConstDataPtr &, const IECore::ConstDataPtr &, const IECore::ConstDataPtr &>(
 					(
 						arg( "value" ) = object(),
 						arg( "icon" ) = object(),
 						arg( "background" ) = object(),
-						arg( "toolTip" ) = object()
+						arg( "toolTip" ) = object(),
+						arg( "foreground" ) = object()
 					)
 				)
 			)
@@ -339,6 +350,9 @@ void GafferUIModule::bindPathColumn()
 			)
 			.add_property(
 				"toolTip", &cellDataGetToolTip, &cellDataSetToolTip
+			)
+			.add_property(
+				"foreground", &cellDataGetForeground, &cellDataSetForeground
 			)
 		;
 

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -277,7 +277,7 @@ QVariant dataToVariant( const IECore::Data *value, int role )
 		}
 	}
 
-	if( role == Qt::BackgroundRole )
+	if( role == Qt::BackgroundRole || role == Qt::ForegroundRole )
 	{
 		switch( value->typeId() )
 		{
@@ -343,7 +343,8 @@ struct CellVariants
 		:	m_display( dataToVariant( cellData.value.get(), Qt::DisplayRole ) ),
 			m_decoration( dataToVariant( cellData.icon.get(), Qt::DecorationRole ) ),
 			m_background( dataToVariant( cellData.background.get(), Qt::BackgroundRole ) ),
-			m_toolTip( dataToVariant( cellData.toolTip.get(), Qt::ToolTipRole ) )
+			m_toolTip( dataToVariant( cellData.toolTip.get(), Qt::ToolTipRole ) ),
+			m_foreground( dataToVariant( cellData.foreground.get(), Qt::ForegroundRole ) )
 	{
 	}
 
@@ -363,6 +364,8 @@ struct CellVariants
 				return m_background;
 			case Qt::ToolTipRole :
 				return m_toolTip;
+			case Qt::ForegroundRole :
+				return m_foreground;
 			default :
 				return QVariant();
 		}
@@ -374,7 +377,8 @@ struct CellVariants
 			m_display == rhs.m_display &&
 			m_decoration == rhs.m_decoration &&
 			m_background == rhs.m_background &&
-			m_toolTip == rhs.m_toolTip
+			m_toolTip == rhs.m_toolTip &&
+			m_foreground == rhs.m_foreground
 		;
 	}
 
@@ -384,6 +388,7 @@ struct CellVariants
 		QVariant m_decoration;
 		QVariant m_background;
 		QVariant m_toolTip;
+		QVariant m_foreground;
 
 };
 

--- a/startup/GafferScene/arnoldOptions.py
+++ b/startup/GafferScene/arnoldOptions.py
@@ -1,0 +1,237 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+
+## \todo Migrate ArnoldOptions to use this metadata so we have one source of truth.
+Gaffer.Metadata.registerValue( "option:ai:AA_samples", "label", "AA Samples" )
+Gaffer.Metadata.registerValue( "option:ai:AA_samples", "defaultValue", IECore.IntData( 3 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:AA_samples",
+	"description",
+	"""
+	Controls the number of rays per pixel
+	traced from the camera. The more samples,
+	the better the quality of antialiasing,
+	motion blur and depth of field. The actual
+	number of rays per pixel is the square of
+	the AA Samples value - so a value of 3
+	means 9 rays are traced, 4 means 16 rays are
+	traced and so on.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:enable_adaptive_sampling", "label", "Enable Adaptive Sampling" )
+Gaffer.Metadata.registerValue( "option:ai:enable_adaptive_sampling", "defaultValue", IECore.BoolData( False ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:enable_adaptive_sampling",
+	"description",
+	"""
+	If adaptive sampling is enabled, Arnold will
+	take a minimum of ( AA Samples * AA Samples )
+	samples per pixel, and will then take up to
+	( AA Samples Max * AA Samples Max ) samples per
+	pixel, or until the remaining estimated noise
+	gets lower than aaAdaptiveThreshold.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:AA_samples_max", "label", "AA Samples Max" )
+Gaffer.Metadata.registerValue( "option:ai:AA_samples_max", "defaultValue", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:AA_samples_max",
+	"description",
+	"""
+	The maximum sampling rate during adaptive
+	sampling. Like AA Samples, this value is
+	squared. So AA Samples Max == 6 means up to
+	36 samples per pixel.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:AA_adaptive_threshold", "label", "AA Adaptive Threshold" )
+Gaffer.Metadata.registerValue( "option:ai:AA_adaptive_threshold", "defaultValue", IECore.FloatData( 0.05 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:AA_adaptive_threshold",
+	"description",
+	"""
+	How much leftover noise is acceptable when
+	terminating adaptive sampling. Higher values
+	accept more noise, lower values keep rendering
+	longer to achieve smaller amounts of noise.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_samples", "label", "Diffuse Samples" )
+Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_samples", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_diffuse_samples",
+	"description",
+	"""
+	Controls the number of rays traced when
+	computing indirect illumination.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_specular_samples", "label", "Specular Samples" )
+Gaffer.Metadata.registerValue( "option:ai:GI_specular_samples", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_specular_samples",
+	"description",
+	"""
+	Controls the number of rays traced when
+	computing specular reflections.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_transmission_samples", "label", "Transmission Samples" )
+Gaffer.Metadata.registerValue( "option:ai:GI_transmission_samples", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_transmission_samples",
+	"description",
+	"""
+	Controls the number of rays traced when
+	computing specular refractions.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_sss_samples", "label", "SSS Samples" )
+Gaffer.Metadata.registerValue( "option:ai:GI_sss_samples", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_sss_samples",
+	"description",
+	"""
+	Controls the number of rays traced when
+	computing subsurface scattering.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_volume_samples", "label", "Volume Samples" )
+Gaffer.Metadata.registerValue( "option:ai:GI_volume_samples", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_volume_samples",
+	"description",
+	"""
+	Controls the number of rays traced when
+	computing indirect lighting for volumes.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:light_samples", "label", "Light Samples" )
+Gaffer.Metadata.registerValue( "option:ai:light_samples", "defaultValue", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:light_samples",
+	"description",
+	"""
+	Specifies a fixed number of light samples to be taken at each
+	shading point. This enables "Global Light Sampling", which provides
+	significantly improved performance for scenes containing large numbers
+	of lights. In this mode, the `samples` setting on each light is ignored,
+	and instead the fixed number of samples is distributed among all the
+	lights according to their contribution at the shading point.
+
+	A value of `0` disables Global Light Sampling, reverting to the original
+	per-light sampling algorithm.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_total_depth", "label", "Total Depth" )
+Gaffer.Metadata.registerValue( "option:ai:GI_total_depth", "defaultValue", IECore.IntData( 10 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_total_depth",
+	"description",
+	"""
+	The maximum depth of any ray (Diffuse + Specular +
+	Transmission + Volume).
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_depth", "label", "Diffuse Depth" )
+Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_depth", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_diffuse_depth",
+	"description",
+	"""
+	Controls the number of ray bounces when
+	computing indirect illumination ("bounce light").
+	"""
+)
+
+
+Gaffer.Metadata.registerValue( "option:ai:GI_specular_depth", "label", "Specular Depth" )
+Gaffer.Metadata.registerValue( "option:ai:GI_specular_depth", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_specular_depth",
+	"description",
+	"""
+	Controls the number of ray bounces when
+	computing specular reflections.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_transmission_depth", "label", "Transmission Depth" )
+Gaffer.Metadata.registerValue( "option:ai:GI_transmission_depth", "defaultValue", IECore.IntData( 2 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_transmission_depth",
+	"description",
+	"""
+	Controls the number of ray bounces when
+	computing specular refractions.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:GI_volume_depth", "label", "Volume Depth" )
+Gaffer.Metadata.registerValue( "option:ai:GI_volume_depth", "defaultValue", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:GI_volume_depth",
+	"description",
+	"""
+	Controls the number of ray bounces when
+	computing indirect lighting on volumes.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:ai:auto_transparency_depth", "label", "Transparency Depth" )
+Gaffer.Metadata.registerValue( "option:ai:auto_transparency_depth", "defaultValue", IECore.IntData( 10 ) )
+Gaffer.Metadata.registerValue(
+	"option:ai:auto_transparency_depth",
+	"description",
+	"""
+	The number of allowable transparent layers - after
+	this the last object will be treated as opaque.
+	"""
+)

--- a/startup/GafferScene/cyclesOptions.py
+++ b/startup/GafferScene/cyclesOptions.py
@@ -1,0 +1,153 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+
+Gaffer.Metadata.registerValue( "option:cycles:session:samples", "label", "Samples" )
+Gaffer.Metadata.registerValue( "option:cycles:session:samples", "defaultValue", IECore.IntData( 1024 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:session:samples",
+	"description",
+	"""
+	Number of samples to render for each pixel.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:use_adaptive_sampling", "label", "Adaptive Sampling" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:use_adaptive_sampling", "defaultValue", IECore.BoolData( False ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:use_adaptive_sampling",
+	"description",
+	"""
+	Automatically determine the number of samples
+	per pixel based on a variance estimation.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:adaptive_threshold", "label", "Adaptive Threshold" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:adaptive_threshold", "defaultValue", IECore.FloatData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:adaptive_threshold",
+	"description",
+	"""
+	Noise level step to stop sampling at, lower values reduce noise the cost of render time.
+	`0` for automatic setting based on number of AA samples.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:use_guiding", "label", "Path Guiding" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:use_guiding", "defaultValue", IECore.BoolData( False ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:use_guiding",
+	"description",
+	"""
+	Use path guiding for sampling paths. Path guiding incrementally
+	learns the light distribution of the scene and guides paths into directions
+	with high direct and indirect light contributions.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:min_bounce", "label", "Min Bounces" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:min_bounce", "defaultValue", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:min_bounce",
+	"description",
+	"""
+	Minimum number of light bounces. Setting this higher reduces noise in the first bounces,
+	but can also be less efficient for more complex geometry like hair and volumes.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_bounce", "label", "Max Bounces" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:max_bounce",
+	"description",
+	"""
+	Total maximum number of bounces.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_diffuse_bounce", "label", "Diffuse" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_diffuse_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:max_diffuse_bounce",
+	"description",
+	"""
+	Maximum number of diffuse reflection bounces, bounded by total maximum.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_glossy_bounce", "label", "Glossy" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_glossy_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:max_glossy_bounce",
+	"description",
+	"""
+	Maximum number of glossy reflection bounces, bounded by total maximum.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_transmission_bounce", "label", "Transmission" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_transmission_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:max_transmission_bounce",
+	"description",
+	"""
+	Maximum number of transmission reflection bounces, bounded by total maximum.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_volume_bounce", "label", "Volume" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:max_volume_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:max_volume_bounce",
+	"description",
+	"""
+	Maximum number of volumetric scattering events.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:cycles:integrator:transparent_max_bounce", "label", "Transparency" )
+Gaffer.Metadata.registerValue( "option:cycles:integrator:transparent_max_bounce", "defaultValue", IECore.IntData( 7 ) )
+Gaffer.Metadata.registerValue(
+	"option:cycles:integrator:transparent_max_bounce",
+	"description",
+	"""
+	Maximum number of transparent bounces.
+	"""
+)

--- a/startup/GafferScene/delightOptions.py
+++ b/startup/GafferScene/delightOptions.py
@@ -1,0 +1,131 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+
+Gaffer.Metadata.registerValue( "option:dl:oversampling", "label", "Oversampling" )
+Gaffer.Metadata.registerValue( "option:dl:oversampling", "defaultValue", IECore.IntData( 9 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:oversampling",
+	"description",
+	"""
+	The number of camera rays to fire for each pixel of
+	the image. Higher values may be needed to resolve fine
+	geometric detail such as hair, or to reduce noise in
+	heavily motion blurred renders.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:quality.shadingsamples", "label", "Shading Samples" )
+Gaffer.Metadata.registerValue( "option:dl:quality.shadingsamples", "defaultValue", IECore.IntData( 64 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:quality.shadingsamples",
+	"description",
+	"""
+	The number of samples to take when evaluating shading.
+	This is the primary means of improving image quality and
+	reducing shading noise.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:quality.volumesamples", "label", "Volume Samples" )
+Gaffer.Metadata.registerValue( "option:dl:quality.volumesamples", "defaultValue", IECore.IntData( 1 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:quality.volumesamples",
+	"description",
+	"""
+	The number of samples to take when evaluating volumes.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.diffuse", "label", "Diffuse" )
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.diffuse", "defaultValue", IECore.IntData( 1 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:maximumraydepth.diffuse",
+	"description",
+	"""
+	The maximum bounce depth a diffuse ray can reach. A depth
+	of 1 specifies one additional bounce compared to purely
+	local illumination.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.hair", "label", "Hair" )
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.hair", "defaultValue", IECore.IntData( 4 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:maximumraydepth.hair",
+	"description",
+	"""
+	The maximum bounce depth a hair ray can reach. Note that hair
+	is akin to volumetric primitives and might need elevated ray
+	depth to properly capture the illumination.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.reflection", "label", "Reflection" )
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.reflection", "defaultValue", IECore.IntData( 1 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:maximumraydepth.reflection",
+	"description",
+	"""
+	The maximum bounce depth a reflection ray can reach. Setting
+	the reflection depth to 0 will only compute local illumination
+	meaning that only emissive surfaces will appear in the reflections.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.refraction", "label", "Refraction" )
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.refraction", "defaultValue", IECore.IntData( 4 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:maximumraydepth.refraction",
+	"description",
+	"""
+	The maximum bounce depth a refraction ray can reach. A value of 4
+	allows light to shine through a properly modeled object such as a
+	glass.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.volume", "label", "Volume" )
+Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.volume", "defaultValue", IECore.IntData( 0 ) )
+Gaffer.Metadata.registerValue(
+	"option:dl:maximumraydepth.volume",
+	"description",
+	"""
+	The maximum bounce depth a volume ray can reach.
+	"""
+)

--- a/startup/GafferScene/renderPassOptions.py
+++ b/startup/GafferScene/renderPassOptions.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import Gaffer
+
+Gaffer.Metadata.registerValue( "option:renderPass:enabled", "label", "Enabled" )
+Gaffer.Metadata.registerValue( "option:renderPass:enabled", "description", "Whether the render pass is enabled for rendering." )
+Gaffer.Metadata.registerValue( "option:renderPass:enabled", "defaultValue", IECore.BoolData( True ) )

--- a/startup/GafferScene/standardOptions.py
+++ b/startup/GafferScene/standardOptions.py
@@ -1,0 +1,111 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+import Gaffer
+
+Gaffer.Metadata.registerValue( "option:render:camera", "label", "Camera" )
+Gaffer.Metadata.registerValue( "option:render:camera", "defaultValue", IECore.StringData( "" ) )
+Gaffer.Metadata.registerValue(
+	"option:render:camera",
+	"description",
+	"""
+	The primary camera to be used for rendering. If this
+	is not specified, then a default orthographic camera
+	positioned at the origin is used.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:render:resolution", "label", "Resolution" )
+Gaffer.Metadata.registerValue( "option:render:resolution", "defaultValue", IECore.V2iData( imath.V2i( 1024, 778 ) ) )
+Gaffer.Metadata.registerValue(
+	"option:render:resolution",
+	"description",
+	"""
+	The resolution of the image to be rendered.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:render:resolutionMultiplier", "label", "Resolution Multiplier" )
+Gaffer.Metadata.registerValue( "option:render:resolutionMultiplier", "defaultValue", IECore.FloatData( 1.0 ) )
+Gaffer.Metadata.registerValue(
+	"option:render:resolutionMultiplier",
+	"description",
+	"""
+	Multiplies the resolution of the render by this amount.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:render:deformationBlur", "label", "Deformation Blur" )
+Gaffer.Metadata.registerValue( "option:render:deformationBlur", "defaultValue", IECore.BoolData( False ) )
+Gaffer.Metadata.registerValue(
+	"option:render:deformationBlur",
+	"description",
+	"""
+	Whether or not deformation motion is taken into
+	account in the rendered image. To specify the
+	number of deformation segments to use for each
+	object in the scene, use a StandardAttributes
+	node with appropriate filters.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:render:transformBlur", "label", "Transform Blur" )
+Gaffer.Metadata.registerValue( "option:render:transformBlur", "defaultValue", IECore.BoolData( False ) )
+Gaffer.Metadata.registerValue(
+	"option:render:transformBlur",
+	"description",
+	"""
+	Whether or not transform motion is taken into
+	account in the rendered image. To specify the
+	number of transform segments to use for each
+	object in the scene, use a StandardAttributes
+	node with appropriate filters.
+	"""
+)
+
+Gaffer.Metadata.registerValue( "option:render:shutter", "label", "Shutter" )
+Gaffer.Metadata.registerValue( "option:render:shutter", "defaultValue", IECore.V2fData( imath.V2f( -0.25, 0.25 ) ) )
+Gaffer.Metadata.registerValue(
+	"option:render:shutter",
+	"description",
+	"""
+	The interval over which the camera shutter is open. Measured
+	in frames, and specified relative to the frame being rendered.
+	"""
+)

--- a/startup/gui/layouts.py
+++ b/startup/gui/layouts.py
@@ -54,6 +54,7 @@ layouts.registerEditor( "UIEditor" )
 layouts.registerEditor( "AnimationEditor" )
 layouts.registerEditor( "PrimitiveInspector")
 layouts.registerEditor( "UVInspector")
+layouts.registerEditor( "RenderPassEditor" )
 
 # Register some predefined layouts
 #

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -1,0 +1,115 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+
+import IECore
+import Gaffer
+import GafferSceneUI
+
+GafferSceneUI.RenderPassEditor.registerOption( "*", "renderPass:enabled" )
+
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:camera", "Render" )
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:resolution", "Render" )
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:resolutionMultiplier", "Render" )
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:deformationBlur", "Render" )
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:transformBlur", "Render" )
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:shutter", "Render" )
+
+if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
+
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "preset:Cycles", "Cycles" )
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "userDefault", "Cycles" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:session:samples", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:use_adaptive_sampling", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:adaptive_threshold", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:use_guiding", "Sampling" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:min_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:max_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:max_diffuse_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:max_glossy_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:max_transmission_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:max_volume_bounce", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Cycles", "cycles:integrator:transparent_max_bounce", "Ray Depth" )
+
+with IECore.IgnoredExceptions( ImportError ) :
+
+	# This import appears unused, but it is intentional; it prevents us from
+	# registering when 3Delight isn't available.
+	import GafferDelight
+
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "preset:3Delight", "3Delight" )
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "userDefault", "3Delight" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:oversampling", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:quality.shadingsamples", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:quality.volumesamples", "Sampling" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:maximumraydepth.diffuse", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:maximumraydepth.hair", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:maximumraydepth.reflection", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:maximumraydepth.refraction", "Ray Depth" )
+	GafferSceneUI.RenderPassEditor.registerOption( "3Delight", "dl:maximumraydepth.volume", "Ray Depth" )
+
+with IECore.IgnoredExceptions( ImportError ) :
+
+	# This import appears unused, but it is intentional; it prevents us from
+	# registering when Arnold isn't available.
+	import GafferArnold
+
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "preset:Arnold", "Arnold" )
+	Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "userDefault", "Arnold" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:AA_samples", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:enable_adaptive_sampling", "Sampling", "Adaptive Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:AA_samples_max", "Sampling" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:AA_adaptive_threshold", "Sampling", "Adaptive Threshold" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_diffuse_samples", "Sampling", "Diffuse" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_specular_samples", "Sampling", "Specular" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_transmission_samples", "Sampling", "Transmission" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_sss_samples", "Sampling", "SSS" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_volume_samples", "Sampling", "Volume" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:light_samples", "Sampling", "Light" )
+
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_total_depth", "Ray Depth", "Total" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_diffuse_depth", "Ray Depth", "Diffuse" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_specular_depth", "Ray Depth", "Specular" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_transmission_depth", "Ray Depth", "Transmission" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_volume_depth", "Ray Depth", "Volume" )
+	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:auto_transparency_depth", "Ray Depth", "Transparency" )


### PR DESCRIPTION
This introduces the first version of a Gaffer native Render Pass Editor - An EditScope-aware panel for inspecting and editing Render Passes in a similar form to Gaffer's LightEditor.

![RenderPassEditorOptionEdit](https://github.com/GafferHQ/gaffer/assets/50844517/9b6837d7-d3a1-47b0-a50c-feca6beeb869)

This initial version provides the following functionality :

- Registration of options as columns within the editor, with columns assignable to tabs, and groups of tabs selectable from the drop-down menu.
- Inspection and editing of options per render pass via EditScopes or upstream `*Options` nodes, with fallback values displayed for options that do not exist in the scene globals.
- Inspection of option histories per Render Pass via Right-Click->Show History...
- Enabling and disabling of Render Passes for batch rendering with a RenderPassWedge by editing the "Enabled" column within an active EditScope.
- Filtering the display of render passes by name, and hiding disabled render passes via the "Hide Disabled" checkbox.
- Setting a render pass as "active" for interactive preview by double-clicking within the "Active" column (represented by a :green_circle:).

![renderPassEditor_activeRenderPass2](https://github.com/GafferHQ/gaffer/assets/50844517/bc36efb4-9484-43f7-9315-176e5e5c11d5)

I've attached a script useful for testing the above based on an example scene originally adapted from @xanderKendogg, plus an example with 500 randomly named RenderPasses as a bit of a stress test...

[renderPassEditorExample.zip](https://github.com/GafferHQ/gaffer/files/14019324/renderPassEditorExample.zip)

Upcoming functionality is expected to include :

- Creating and deleting render passes directly from the editor.
- Registration of additional columns for editing render pass membership & render visibility. These columns would be used to configure which scene locations are considered renderable for a specific render pass, and define subsets of those locations as camera invisible, matte, etc.
- Registration of "Types" of render passes, such as shadow, reflection, etc.
- Grouping of render passes via a "Category" column.
- Further UI improvements such as support for copy/paste and drag & drop.

I've kept the editor out of the default layouts until we have some of this additional functionality, but have included it in the Layout menu for advanced user testing.
