### PR TITLE
Arnold config : Add default color manager

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
         import sys
         import os
 
-        for arnoldVersion in [ "7.1.1.0", "7.2.1.0" ] :
+        for arnoldVersion in [ "7.2.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
           os.environ["ARNOLD_ROOT"] = arnoldRoot
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Features
 Improvements
 ------------
 
+- Arnold : Gaffer's native OpenColorIO config is now automatically translated to Arnold. Use an ArnoldColorManager node to override this behaviour.
 - Toolbars : Changed hotkey behavior to toogle any tool on and off. Exclusive tools such as the Translate and Crop Window tools activate the first tool (currently Selection Tool) when they are toggled off.
 - CropWindowTool : Added <kbd>`Alt` + <kbd>`C` for toggling both the crop window tool and the relevant crop window `enabled` plug.
 - TaskList, FrameMask : Reimplemented in C++ for improved performance.
@@ -615,6 +616,7 @@ Improvements
 - OpenColorIO :
   - Updated default config to ACES Studio 1.3.
   - Added `openColorIO` plug to ScriptNode, allowing the OpenColorIO config, working space, variables and display transform to be customised on a per-script basis.
+  - Added automatic configuration of Arnold color manager from Gaffer's OpenColorIO configuration. This may be overridden by using an ArnoldColorManager node to define an alternative color manager.
   - Improved colorspace menus :
     - Organised colorspaces into submenus by family.
     - Removed unwanted title-casing, so that names are now displayed verbatim.

--- a/Changes.md
+++ b/Changes.md
@@ -92,6 +92,7 @@ API
 Breaking Changes
 ----------------
 
+- Arnold : Removed support for Arnold 7.1.
 - Render : Changed `render:includedPurposes` default to `"default", "render"`.
 - Backdrop : Changed default drawing order. Use the new `depth` plug to override the order if necessary.
 - ValuePlug : Removed deprecated `getObjectValue()` overload.

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -4058,7 +4058,6 @@ class RendererTest( GafferTest.TestCase ) :
 			{ "diffuse_{}.{}".format( g, c ) for g in lightGroups for c in "RGB" }
 		)
 
-	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 1, 3 ], "Fails due to bug ARNOLD-12282" )
 	def testLightGroupBeautyOutputWithLayerName( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
@@ -4224,7 +4223,6 @@ class RendererTest( GafferTest.TestCase ) :
 			plane = arnold.AiNodeLookUpByName( universe, "testPlane" )
 			self.assertEqual( arnold.AiNodeGetStr( plane, "user:myString" ), "test" )
 
-	@unittest.skipIf( [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 1, 4 ], "Option not available in Arnold" )
 	def testTextureAutoGenerate( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -123,11 +123,6 @@ SurfaceTextureCache g_surfaceTextureCache( surfaceTextureGetter, 1024 * 1024 * 6
 
 IECoreGL::RenderablePtr iesVisualisation( const std::string &filename )
 {
-
-#if AI_VERSION_ARCH_NUM < 6
-	return nullptr;
-#else
-
 	// It's not entirely clear from rendered results exactly how radius
 	// interacts with the profile, so we just draw the normalised distribution
 	// of the profile.
@@ -172,8 +167,6 @@ IECoreGL::RenderablePtr iesVisualisation( const std::string &filename )
 	IECoreGL::PointsPrimitivePtr points = new IECoreGL::PointsPrimitive( IECoreGL::PointsPrimitive::Point );
 	points->addPrimitiveVariable( "P", PrimitiveVariable( PrimitiveVariable::Interpolation::Vertex, pData ) );
 	return points;
-
-#endif
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -40,7 +40,6 @@
 
 #include "ai_array.h"
 #include "ai_msg.h" // Required for __AI_FILE__ macro used by `ai_array.h`
-#include "ai_version.h"
 
 #include "fmt/format.h"
 

--- a/startup/GafferArnold/ocio.py
+++ b/startup/GafferArnold/ocio.py
@@ -1,0 +1,74 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferArnold
+
+# Register a render adaptor that inserts a `color_manager_ocio` driven
+# by the OpenColorIOAlgo context, if no Arnold color manager exists in the
+# scene already.
+
+def __ocioColorManagerAdaptor() :
+
+	result = GafferScene.SceneProcessor()
+
+	result["colorManager"] = GafferArnold.ArnoldColorManager()
+	result["colorManager"].loadColorManager( "color_manager_ocio" )
+	result["colorManager"]["in"].setInput( result["in"] )
+	result["colorManager"]["parameters"]["config"].setValue( "${ocio:config}" )
+	result["colorManager"]["parameters"]["color_space_linear"].setValue( "${ocio:workingSpace}" )
+	# This is the least convincing of the defaults, but the `matte_paint` role is `sRGB` for
+	# both the ACES 1.3 and the Gaffer 1.2 Legacy configs, which seems a decent guess for a
+	# low bit depth file.
+	result["colorManager"]["parameters"]["color_space_narrow"].setValue( "matte_paint" )
+
+	result["optionQuery"] = GafferScene.OptionQuery()
+	result["optionQuery"]["scene"].setInput( result["in"] )
+	result["optionQuery"].addQuery( Gaffer.ObjectPlug( defaultValue = IECore.NullObject().defaultNullObject() ), "ai:color_manager" )
+
+	result["expression"] = Gaffer.Expression()
+	result["expression"].setExpression(
+		"""parent["colorManager"]["enabled"] = not parent["optionQuery"]["out"]["out0"]["exists"]"""
+	)
+
+	result["out"].setInput( result["colorManager"]["out"] )
+
+	return result
+
+GafferScene.SceneAlgo.registerRenderAdaptor( "DefaultArnoldColorManager", __ocioColorManagerAdaptor )


### PR DESCRIPTION
This mirrors Gaffer's OCIO config to Arnold automatically, unless an ArnoldColorManager node has been used to define an alternative. We wanted to do this as part of #5215, but abandoned it after discovering that Arnold 7.1 didn't have built-in ACES configs (see #5380). It seems reasonable to drop Arnold 7.1 support for Gaffer 1.4, which means we can now get the colour management right without user intervention.

The lack of this has caused confusion a couple of times recently, so I thought it was worth getting it done.