### PR TITLE
Arnold Minor Aov Fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,9 @@ Features
 Improvements
 ------------
 
-- ArnoldShader : Added a colour space presets menu for the `image` shader.
+- Arnold :
+  - ArnoldShader : Added a colour space presets menu for the `image` shader.
+  - Added specific warning for outputs with space in name.
 - CyclesShader : Added a colour space presets menu for the `image_texture` and `environment_texture` shaders (#5618).
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - Arnold :
   - ArnoldShader : Added a colour space presets menu for the `image` shader.
   - Added specific warning for outputs with space in name.
+  - Added normal and depth AOVs.
 - CyclesShader : Added a colour space presets menu for the `image_texture` and `environment_texture` shaders (#5618).
 
 Fixes

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -473,6 +473,10 @@ class ArnoldOutput : public IECore::RefCounted
 		ArnoldOutput( AtUniverse *universe, const IECore::InternedString &name, const IECoreScene::Output *output, NodeDeleter nodeDeleter )
 			:	m_universe( universe ), m_name( name ), m_nodeDeleter( nodeDeleter )
 		{
+			if( m_name.string().find( " " ) != std::string::npos )
+			{
+				throw IECore::Exception( fmt::format( "Unable to create output driver with name \"{}\", Arnold does not allow spaces in output names.", m_name.string() ) );
+			}
 			update( output );
 		}
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -116,10 +116,19 @@ with IECore.IgnoredExceptions( ImportError ) :
 		"volume_indirect",
 		"volume_albedo",
 		"motionvector",
+		"normal",
+		"depth",
 	] :
 
 		label = aov.replace( "_", " " ).title().replace( " ", "_" )
-		data = "color " + aov if aov != "beauty" else "rgba"
+		if aov == "beauty":
+			data = "rgba"
+		elif aov == "depth":
+			data = "float Z"
+		elif aov == "normal":
+			data = "color N"
+		else:
+			data = "color " + aov
 
 		if aov == "motionvector" :
 			parameters = {
@@ -127,6 +136,9 @@ with IECore.IgnoredExceptions( ImportError ) :
 			}
 		else :
 			parameters = {}
+
+		if aov == "depth":
+			parameters["layerName"] = "Z"
 
 		if aov not in { "motionvector", "emission", "background" } :
 			parameters["layerPerLightGroup"] = False


### PR DESCRIPTION
Couple of little things from discussion on the discord.

Added normal and depth AOVs to the presets list ... do these names seem right, or should they be N and Z?
In the output images, the depth channel is named Z, which is what everyone should expect. The normal channels are named RGB, which I think is also what people expect - I'm not aware of any custom convention for the axis names.

I've also added in an exception if the output name contains a space - this prevents getting a much more confusing error from Arnold. This is turned into a warning upstream ... I wasn't sure whether this is worth halting the render for, but this behaviour just matches how we handle outputs with invalid driver types.

