### PR TITLE
3Delight external procedural support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -53,6 +53,7 @@ Improvements
   - Added support for reading `dl:` and `user:` attributes from shaders.
   - Added `importanceSampleFilter` plug to DelightOptions, providing denoiser-compatible output.
   - Matched DelightOptions default values for `oversampling` and `shadingSamples` to 3Delight's own default values.
+  - Added support for external procedurals. 
 - GraphEditor : Improved logic used to connect a newly created node to the selected nodes.
 - ScenePlug, ImagePlug : Child plugs are now serialisable. Among other things, this enables them to be driven by expressions (#3986).
 - Premultiply : Added `useDeepVisibility` plug, which weights samples according to their visibility based on the opacity of samples in front.

--- a/include/IECoreDelight/ParameterList.h
+++ b/include/IECoreDelight/ParameterList.h
@@ -65,6 +65,9 @@ class IECOREDELIGHT_API ParameterList
 
 		void add( const NSIParam_t &parameter );
 		void add( const char *name, const std::string &value );
+		// Prevent calls to `add()` with a temporary string, since that
+		// would cause a dangling pointer to be passed to 3Delight.
+		void add( const char *name, const std::string &&value ) = delete;
 		/// \deprecated Use the version below.
 		void add( const char *name, const IECore::Data *value );
 		void add( const char *name, const IECore::Data *value, bool isSingleArray );

--- a/src/IECoreDelight/ProceduralAlgo.cpp
+++ b/src/IECoreDelight/ProceduralAlgo.cpp
@@ -1,0 +1,108 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreDelight/NodeAlgo.h"
+#include "IECoreDelight/ParameterList.h"
+
+#include "IECoreScene/ExternalProcedural.h"
+
+#include "IECore/SimpleTypedData.h"
+
+#include "boost/algorithm/string.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "fmt/format.h"
+
+#include <nsi.h>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreDelight;
+
+namespace
+{
+
+bool convert( const IECoreScene::ExternalProcedural *object, NSIContext_t context, const char *handle )
+{
+	NSICreate( context, handle, "procedural", 0, nullptr );
+
+	ParameterList procParameters;
+
+	const std::string &filename = object->getFileName();
+	std::string type;
+
+	if( boost::ends_with( filename, "lua" ) )
+	{
+		type = "lua";
+	}
+	else if ( boost::ends_with( filename, "nsi" ) or boost::ends_with( filename, "nsia" ) )
+	{
+		type = "apistream";
+	}
+	else
+	{
+		type = "dynamiclibrary";
+	}
+
+	// 3Delight seems to behave weirdly when passed the boundingbox parameter:
+	// doesn't render the procedural content when streaming the NSI scene initially,
+	// yet always renders the procedural content when reading a NSI scene from disk.
+	// Due to this commenting out the corresponding code for now.
+	//
+	// const Box3f &bbox = object->getBound();
+	//
+	// if ( bbox != Box3f( V3f( -0.5, -0.5, -0.5 ), V3f( 0.5, 0.5, 0.5 ) ) )
+	// {
+	//	procParameters.add( { "boundingbox", bbox.min.getValue(), NSITypePoint, 2, 1, NSIParamIsArray } );
+	// }
+
+	procParameters.add( "type", type );
+	procParameters.add( "filename", filename );
+
+	for( const auto &parameter : object->parameters()->readable() )
+	{
+		procParameters.add( parameter.first.c_str(), parameter.second.get(), true );
+	}
+
+	NSISetAttribute( context, handle, procParameters.size(), procParameters.data() );
+	return true;
+}
+
+NodeAlgo::ConverterDescription<ExternalProcedural> g_description( convert );
+
+} // namespace


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Added ExternalProcedural node support for 3Delight matching the NSI scene procedural node. 
- The procedural type is determined based on the file extension: lua for Lua scripts, nsi and nsia for NSI scene apistream and anything else for compiled executables / dynamic libraries. 
- The boundingbox parameter is currently ignored due to a weird behavior from 3Delight when using the NSI parameter - any bounding box values resulted with not rendering the procedural content when the NSI scene is streamed to the renderer initially, yet also any bounding box values resulted in rendering the procedural content when rendering a NSI scene file. 
- I kept the boundingbox code commented out with an added description / reason, but it would be no problem to remove it from `
src/IECoreDelight/ProceduralAlgo.cpp` completely if that would be preferred. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
