### PR TITLE
PathColumn : Restore reserved CellData member

### DIFF
--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -135,6 +135,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 			private :
 
 				IECore::ConstDataPtr m_reserved1;
+				IECore::ConstDataPtr m_reserved2;
 
 		};
 


### PR DESCRIPTION
We took one to add `foreground` in 1.3_maintenance, so add it back to main for future generations...