### PR TITLE
ColorToVector.osl - fix parameter types

### DIFF
--- a/shaders/Conversion/ColorToVector.osl
+++ b/shaders/Conversion/ColorToVector.osl
@@ -36,8 +36,8 @@
 
 shader ColorToVector
 (
-	vector col = 0,
-	output color vec = 0
+	color col = 0,
+	output vector vec = 0
 )
 {
 	vec = vector( col );


### PR DESCRIPTION
The input and output types were opposite of what this conversion shader does, i flipped them around so the input is a color and the output is a vector