### PR TITLE
ColorToVector : Fix parameter types

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -79,6 +79,7 @@ Fixes
 - DeepState : Fixed handling of `NaN` values and samples where `ZBack` is less than `Z`.
 - Premultiply : Fixed handling of non-existent alpha channel.
 - PlugAlgo : Fixed promotion of CompoundDataPlugs with non-dynamic children, such as the `Camera.renderSettingOverrides` plug.
+- ColorToVector : Fixed parameter types.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -110,6 +110,7 @@ API
 - ImageTestCase : in `assertImageEqual` function, maxDifference may now be a tuple, to specify an asymmetric range.
 - Editor : Added `Settings` class, which should be used to store settings for subclasses. See LightEditor and ImageInspector for examples.
 - DeepPixelAccessor : Added utility class for accessing deep samples while abstracting away the underlying tile storage.
+- V3f : Added implicit conversion to Color3f, among other things enabling calls to `Color3fPlug.setValue( V3f() )`.
 
 Breaking Changes
 ----------------

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -1309,5 +1309,17 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		self.assertIsInstance( network, IECoreScene.ShaderNetwork )
 		self.assertEqual( network.outputShader().name, "Surface/Constant" )
 
+	def testLoadColorToVectorFromVersion1_3( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "colorToVector-1.3.11.0.gfr" )
+		script.load()
+
+		self.assertEqual( script["ColorToVector"]["parameters"]["col"].getInput(), script["VectorToColor"]["out"]["c"] )
+		self.assertEqual( script["ColorToVector1"]["parameters"]["col"].getValue(), imath.Color3f( 1, 2, 3 ) )
+		self.assertEqual( script["ColorToVector2"]["parameters"]["col"].getInput(), script["FloatToColor"]["out"]["c"] )
+		self.assertEqual( script["VectorToColor1"]["parameters"]["vec"].getInput(), script["ColorToVector"]["out"]["vec"] )
+		self.assertEqual( script["ColorToFloat"]["parameters"]["c"].getInput(), script["ColorToVector"]["out"]["vec"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLTest/scripts/colorToVector-1.3.11.0.gfr
+++ b/python/GafferOSLTest/scripts/colorToVector-1.3.11.0.gfr
@@ -1,0 +1,67 @@
+import Gaffer
+import GafferImage
+import GafferOSL
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 3, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 11, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["openColorIO"] = GafferImage.OpenColorIOConfigPlug( "openColorIO", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["openColorIO"] )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["ColorToVector"] = GafferOSL.OSLShader( "ColorToVector" )
+parent.addChild( __children["ColorToVector"] )
+__children["ColorToVector"].loadShader( "Conversion/ColorToVector" )
+__children["ColorToVector"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["VectorToColor"] = GafferOSL.OSLShader( "VectorToColor" )
+parent.addChild( __children["VectorToColor"] )
+__children["VectorToColor"].loadShader( "Conversion/VectorToColor" )
+__children["VectorToColor"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["VectorToColor1"] = GafferOSL.OSLShader( "VectorToColor1" )
+parent.addChild( __children["VectorToColor1"] )
+__children["VectorToColor1"].loadShader( "Conversion/VectorToColor" )
+__children["VectorToColor1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["ColorToVector1"] = GafferOSL.OSLShader( "ColorToVector1" )
+parent.addChild( __children["ColorToVector1"] )
+__children["ColorToVector1"].loadShader( "Conversion/ColorToVector" )
+__children["ColorToVector1"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["ColorToFloat"] = GafferOSL.OSLShader( "ColorToFloat" )
+parent.addChild( __children["ColorToFloat"] )
+__children["ColorToFloat"].loadShader( "Conversion/ColorToFloat" )
+__children["ColorToFloat"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["FloatToColor"] = GafferOSL.OSLShader( "FloatToColor" )
+parent.addChild( __children["FloatToColor"] )
+__children["FloatToColor"].loadShader( "Conversion/FloatToColor" )
+__children["FloatToColor"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["ColorToVector2"] = GafferOSL.OSLShader( "ColorToVector2" )
+parent.addChild( __children["ColorToVector2"] )
+__children["ColorToVector2"].loadShader( "Conversion/ColorToVector" )
+__children["ColorToVector2"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 41613 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["ColorToVector"]["parameters"]["col"].setInput( __children["VectorToColor"]["out"]["c"] )
+__children["ColorToVector"]["__uiPosition"].setValue( imath.V2f( -12.3499985, 15.6999998 ) )
+__children["VectorToColor"]["__uiPosition"].setValue( imath.V2f( -27.1483383, 15.6999998 ) )
+__children["VectorToColor1"]["parameters"]["vec"].setInput( __children["ColorToVector"]["out"]["vec"] )
+__children["VectorToColor1"]["__uiPosition"].setValue( imath.V2f( 2.76328278, 15.6999998 ) )
+__children["ColorToVector1"]["parameters"]["col"].setValue( imath.V3f( 1, 2, 3 ) )
+__children["ColorToVector1"]["__uiPosition"].setValue( imath.V2f( -12.3999968, 25.2999973 ) )
+__children["ColorToFloat"]["parameters"]["c"].setInput( __children["ColorToVector"]["out"]["vec"] )
+__children["ColorToFloat"]["__uiPosition"].setValue( imath.V2f( 2.02451324, 6.95000029 ) )
+__children["FloatToColor"]["__uiPosition"].setValue( imath.V2f( -27.4850559, 5.31601667 ) )
+__children["ColorToVector2"]["parameters"]["col"].setInput( __children["FloatToColor"]["out"]["c"] )
+__children["ColorToVector2"]["__uiPosition"].setValue( imath.V2f( -12.8156233, 5.31601667 ) )
+
+
+del __children
+

--- a/python/GafferTest/CompoundNumericPlugTest.py
+++ b/python/GafferTest/CompoundNumericPlugTest.py
@@ -246,6 +246,12 @@ class CompoundNumericPlugTest( GafferTest.TestCase ) :
 		self.assertTrue( p3[2].getInput().isSame( p4[2] ) )
 		self.assertEqual( p4[3].outputs(), () )
 
+	def testColor3fAcceptsV3fValue( self ) :
+
+		p = Gaffer.Color3fPlug()
+		p.setValue( imath.V3f( 1, 2, 3 ) )
+		self.assertEqual( p.getValue(), imath.Color3f( 1, 2, 3 ) )
+
 	def testColor4fDoesntAcceptColor3fInput( self ) :
 
 		p4 = Gaffer.Color4fPlug()

--- a/shaders/Conversion/ColorToVector.osl
+++ b/shaders/Conversion/ColorToVector.osl
@@ -36,8 +36,8 @@
 
 shader ColorToVector
 (
-	vector col = 0,
-	output color vec = 0
+	color col = 0,
+	output vector vec = 0
 )
 {
 	vec = vector( col );

--- a/src/GafferModule/CompoundNumericPlugBinding.cpp
+++ b/src/GafferModule/CompoundNumericPlugBinding.cpp
@@ -171,6 +171,9 @@ void bind()
 	const PyTypeObject *valueType = boost::python::to_python_value<const V &>().get_pytype();
 	s.attr( "ValueType" ) = boost::python::object( boost::python::handle<>( boost::python::borrowed( const_cast<PyTypeObject *>( valueType ) ) ) );
 
+	// Alow V3f to be passed to Color3f arguments, as it can be in C++.
+	implicitly_convertible<Imath::V3f, Imath::Color3f>();
+
 	Serialisation::registerSerialiser( T::staticTypeId(), new CompoundNumericPlugSerialiser<T>() );
 
 }


### PR DESCRIPTION
This takes Geoff's fix from #5650 and fixes the knock-on backwards compatibility problems it causes, adding a unit test to be sure all is well.