### PR TITLE
ShaderView : Scope correct context when computing shader

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.x.x (relative to 1.3.11.0)
 =======
 
+Fixes
+-----
 
+- Viewer : Fixed context handling bug in the shader view (#5654).
 
 1.3.11.0 (relative to 1.3.10.0)
 ========

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -201,7 +201,11 @@ const GafferImage::Display *ShaderView::display() const
 
 std::string ShaderView::shaderPrefix() const
 {
-	IECore::ConstCompoundObjectPtr attributes = inPlug<ShaderPlug>()->attributes();
+	IECore::ConstCompoundObjectPtr attributes;
+	{
+		Context::Scope scope( getContext() );
+		attributes = inPlug<ShaderPlug>()->attributes();
+	}
 	const char *shaders[] = { "surface", "displacement", "shader", nullptr };
 	for( IECore::CompoundObject::ObjectMap::const_iterator it = attributes->members().begin(), eIt = attributes->members().end(); it != eIt; ++it )
 	{


### PR DESCRIPTION
Fixes #5654.

@ivanimanishi, I believe I have fixed the exact issue corresponding to your repro steps, but that was specific to the ShaderView, and in your issue description you talk more generally about the ImageView. I couldn't reproduce a similar issue in the ImageView, but if you know of one then let me know and I'll fix that too...