### PR TITLE
Build : Update Cortex to `10.5.6.0`

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -48,7 +48,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.5.4.2/cortex-10.5.4.2-{platform}-python3.{extension}".format(
+defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.5.6.0/cortex-10.5.6.0-{platform}-python3.{extension}".format(
 	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )

--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,23 @@
 1.3.x.x (relative to 1.3.11.0)
 =======
 
+Improvements
+------------
+
+- SceneReader : Added basic loding of UsdGeomNurbsCurves, converting them to CurvesPrimitives (basis curves).
+- Console output : Every line is now prefixed with the message level.
+
 Fixes
 -----
 
 - Viewer : Fixed context handling bug in the shader view (#5654).
 - PythonCommand : Fixed misleading results for `repr( variables )` and `str( variables )`, which would suggest the dictionary was empty when it was not.
+- CompoundObject : Fixed crashes in Python bindings caused by passing `None` as a key.
+
+Build
+-----
+
+- Cortex : Updated to version 10.5.6.0.
 
 1.3.11.0 (relative to 1.3.10.0)
 ========


### PR DESCRIPTION
This just upgrades Cortex to the latest version, `10.5.6.0`. This is needed for https://github.com/GafferHQ/gaffer/pull/5630 to be able to use the more accurate OpenGL depth sampling.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
