### PR TITLE
Menu : Add disabled Attribute

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.10.x (relative to 1.2.10.5)
 ========
 
+Improvements
+-----
+
+- Menu : Added ability to show disabled menu actions 
+
 1.2.10.5 (relative to 1.2.10.4)
 ========
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -391,7 +391,7 @@ class Menu( GafferUI.Widget ) :
 
 			signal.connect( IECore.curry( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )
 
-		active = self.__evaluateItemValue( item.active )
+		active = self.__evaluateItemValue( item.active ) and not getattr( item, "disabled", None )
 		qtAction.setEnabled( active )
 
 		shortCut = getattr( item, "shortCut", None )


### PR DESCRIPTION
This is a feature that has been in discussion at IE for a while where we want to be able to show actions that are disabled in the context menu instead of always removing them/never adding them. This implements that feature in Gaffer's Menu so we can use that with our internal widgets. The disabled attribute here allows showing items in the menu while keeping them disabled.

I targeted 1.2 because I wanted to get this into the version of Gaffer we are using in production quicker but I would be happy to retarget to 1.3 if another 1.2 release is undesirable at this point. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
