### PR TITLE
Windows wrapper : Fix for modifying quoted paths

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 - Viewer : Fixed context handling bug in the shader view (#5654).
 - PythonCommand : Fixed misleading results for `repr( variables )` and `str( variables )`, which would suggest the dictionary was empty when it was not.
 - CompoundObject : Fixed crashes in Python bindings caused by passing `None` as a key.
+- Windows : Fixed "{path} was unexpected at this time." startup error when environment variables such as `PATH` contain `"` characters.
 
 Build
 -----

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -169,7 +169,7 @@ exit /B 0
 :prependToPath
 	set NewValue=%~1
 	set ExistingValue=!%~2!
-    if "%ExistingValue%" NEQ "" (
+    if "!ExistingValue!" NEQ "" (
         set ReplacedValue=!ExistingValue:%NewValue%=!
         if /I "!ExistingValue!" == "!ReplacedValue!" (
             set "%~2=!NewValue!;!ExistingValue!"
@@ -182,7 +182,7 @@ exit /B 0
 :appendToPath
     set NewValue=%~1
 	set ExistingValue=!%~2!
-    if "%ExistingValue%" NEQ "" (
+    if "!ExistingValue!" NEQ "" (
         set ReplacedValue=!ExistingValue:%NewValue%=!
         if /I "!ExistingValue!" == "!ReplacedValue!" (
             set "%~2=!ExistingValue!;!NewValue!"


### PR DESCRIPTION
If environment variables that we modify contain quoted paths, such as `PATH=C:/foo;"C:/bar;C:/baz";C:/Windows`, gaffer.cmd would error at startup with "C:/baz was unexpected at this time."

Switching this equality test over to using delayed expansion of `ExistingValue` allows startup to continue as expected, though I'm not enough of a batch expert to be able to say why. @ericmehl, I'd appreciate your eyes on this one.

A simple repro is to modify `PATH` like so: `set PATH=%PATH%;"C:/Windows;C:/Windows/foo;"`