### PR TITLE
Revert "CompoundNumericPlugBinding : Add implicit V3f -> Color3f binding"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -111,7 +111,7 @@ API
 - ImageTestCase : in `assertImageEqual` function, maxDifference may now be a tuple, to specify an asymmetric range.
 - Editor : Added `Settings` class, which should be used to store settings for subclasses. See LightEditor and ImageInspector for examples.
 - DeepPixelAccessor : Added utility class for accessing deep samples while abstracting away the underlying tile storage.
-- V3f : Added implicit conversion to Color3f, among other things enabling calls to `Color3fPlug.setValue( V3f() )`.
+- Color3fPlug : Added `setValue( V3f() )` overload.
 
 Breaking Changes
 ----------------

--- a/python/GafferTest/CompoundDataPlugTest.py
+++ b/python/GafferTest/CompoundDataPlugTest.py
@@ -347,6 +347,15 @@ class CompoundDataPlugTest( GafferTest.TestCase ) :
 
 		self.assertEqual( d1, d2 )
 
+	def testAddV3fMember( self ) :
+
+		p = Gaffer.CompoundDataPlug()
+
+		p.addMembers( IECore.CompoundData( { "v" : imath.V3f( 1, 2, 3 ) } ) )
+		self.assertEqual( len( p ), 1 )
+		self.assertIsInstance( p[0]["value"], Gaffer.V3fPlug )
+		self.assertEqual( p[0]["value"].defaultValue(), imath.V3f( 1, 2, 3 ) )
+
 	def testBoxTypes( self ) :
 
 		p = Gaffer.CompoundDataPlug()


### PR DESCRIPTION
This reverts commit df9b2113750cb457e76f717a83daf2cc61f927ec, minus the test for `Color3fPlug.setValue( V3f() )`, and ensures that the test still passes by other means.

The problem with the implicit conversion was that it caused Cortex's `dict -> CompoundData` binding to prefer to convert `V3f` to `Color3fData`, which caused the following test failures :

<details>
<summary>Test failures</summary>

```
======================================================================
FAIL: testConvertUSDLights (IECoreArnoldTest.ShaderNetworkAlgoTest.ShaderNetworkAlgoTest) (testName='cylinderLight')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/arnold/7.2/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py", line 1137, in testConvertUSDLights
    self.__assertShadersEqual( network.getShader( "light" ), shaders[1], "Testing {}".format( testName ) )
  File "/__w/gaffer/gaffer/build/arnold/7.2/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py", line 840, in __assertShadersEqual
    "{}(Parameter = {})".format( message or "", k )
AssertionError: IECore.V3fData( imath.V3f( -1, 0, 0 ) ) != IECore.Color3fData( imath.Color3f( -1, 0, 0 ) ) : Testing cylinderLight(Parameter = bottom)

======================================================================
FAIL: testConvertUSDPrimvarReader (IECoreArnoldTest.ShaderNetworkAlgoTest.ShaderNetworkAlgoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/arnold/7.2/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py", line 795, in testConvertUSDPrimvarReader
    self.assertEqual( reader.parameters["default"].value, arnoldDefault )
AssertionError: Color3f(0, 0, 0) != Color3f(1, 2, 3)

======================================================================
FAIL: testPrimitiveVariables (IECoreArnoldTest.SphereAlgoTest.SphereAlgoTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/gaffer/gaffer/build/arnold/7.2/python/IECoreArnoldTest/SphereAlgoTest.py", line 85, in testPrimitiveVariables
    self.assertEqual( arnold.AiNodeGetVec( n, "v" ), arnold.AtVector( 1, 2, 3 ) )
AssertionError: <arnold.ai_vector.AtVector object at 0x7fb0960e3b00> != <arnold.ai_vector.AtVector object at 0x7fb0960e39e0>
```

</details>

These had gone unnoticed because we can no longer run the Arnold unit tests in CI for pull requests.

Added a new test exposing the problem in CompoundDataPlugTest, and fixed it by removing the implicit conversion and instead adding a more targeted overload to `Color3fPlug.setValue()`.
