### PR TITLE
Better Image Read Performance Using OpenExrCore

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -62,6 +62,7 @@ Improvements
 - Premultiply : Added `useDeepVisibility` plug, which weights samples according to their visibility based on the opacity of samples in front.
 - CyclesOptions : Improved device selection UI.
 - ImageReader : Improved multithreading of EXR reads. This can result in a performance improvement of around 4X for large images.
+- Added OIIO config that disables OIIO threading by default. This simplifies our threading model, and has no impact on performance for our main use cases. If read performance of Gaffer compositing using non-EXR formats, such as Tiff, is important to you, you may want to add your own config to turn OIIO threading back on.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -61,6 +61,7 @@ Improvements
 - ScenePlug, ImagePlug : Child plugs are now serialisable. Among other things, this enables them to be driven by expressions (#3986).
 - Premultiply : Added `useDeepVisibility` plug, which weights samples according to their visibility based on the opacity of samples in front.
 - CyclesOptions : Improved device selection UI.
+- ImageReader : Improved multithreading of EXR reads. This can result in a performance improvement of around 4X for large images.
 
 Fixes
 -----

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -46,6 +46,8 @@ import subprocess
 import imath
 import inspect
 
+import OpenImageIO
+
 import IECore
 import IECoreImage
 
@@ -73,6 +75,9 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		GafferImageTest.ImageTestCase.tearDown( self )
 		GafferImage.ImageWriter.setDefaultColorSpaceFunction( self.__defaultColorSpaceFunction )
+
+		# Restore ExrCore back to default
+		OpenImageIO.attribute( "openexr:core", 1 )
 
 	# Test that we can select which channels to write.
 	def testChannelMask( self ) :
@@ -329,6 +334,9 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( self.__representativeDeepPath )
 
+		flatten = GafferImage.DeepToFlat()
+		flatten["in"].setInput( r["out"] )
+
 		c = GafferImage.Crop()
 		c["in"].setInput( r["out"] )
 		c["area"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 64 ) ) )
@@ -340,6 +348,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 
 		w = GafferImage.ImageWriter()
 		w['fileName'].setValue( testFile )
+		w["openexr"]["dataType"].setValue( 'float' )
+
 		w['in'].setInput( o['out'] )
 
 		reRead = GafferImage.ImageReader()
@@ -357,48 +367,64 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		trimToDataWindowStage2["in"].setInput( trimToDataWindowStage1["out"] )
 		trimToDataWindowStage2["offset"].setValue( imath.V2i( -1, 0 ) )
 
-		for mode in [ GafferImage.ImageWriter.Mode.Scanline, GafferImage.ImageWriter.Mode.Tile]:
+		for exrCore in [ 1, 0 ]:
 
-			w["openexr"]["mode"].setValue( mode )
+			Gaffer.ValuePlug.clearCache()
+			Gaffer.ValuePlug.clearHashCache()
+			r["refreshCount"].setValue( r["refreshCount"].getValue() + 1 )
+			OpenImageIO.attribute( "openexr:core", exrCore )
 
-			for area, affectDisplayWindow in [
-					( imath.Box2i( imath.V2i( 0 ), imath.V2i( 64 ) ), True ),
-					( imath.Box2i( imath.V2i( 0 ), imath.V2i( 63 ) ), True ),
-					( imath.Box2i( imath.V2i( 0 ), imath.V2i( 65 ) ), True ),
-					( imath.Box2i( imath.V2i( 0 ), imath.V2i( 150, 100 ) ), True ),
-					( imath.Box2i( imath.V2i( 37, 21 ), imath.V2i( 96, 43 ) ), False ),
-					( imath.Box2i( imath.V2i( 0 ), imath.V2i( 0 ) ), False )
-				]:
-				c["area"].setValue( area )
-				c["affectDisplayWindow"].setValue( affectDisplayWindow )
+			for deep in [ True, False ]:
+				c["in"].setInput( r["out"] if deep else flatten["out"] )
 
-				for offset in [
-						imath.V2i( 0, 0 ),
-						imath.V2i( 13, 17 ),
-						imath.V2i( -13, -17 ),
-						imath.V2i( -233, 431 ),
-						imath.V2i( -GafferImage.ImagePlug.tileSize(), 2 * GafferImage.ImagePlug.tileSize() ),
-						imath.V2i( 106, 28 )
-					]:
+				for mode in [ GafferImage.ImageWriter.Mode.Scanline, GafferImage.ImageWriter.Mode.Tile]:
 
-					o["offset"].setValue( offset )
+					with self.subTest( exrCore = exrCore, deep = deep, mode = mode ):
+						w["openexr"]["mode"].setValue( mode )
 
-					w["task"].execute()
+						for area, affectDisplayWindow in [
+								( imath.Box2i( imath.V2i( 0 ), imath.V2i( 64 ) ), True ),
+								( imath.Box2i( imath.V2i( 0 ), imath.V2i( 63 ) ), True ),
+								( imath.Box2i( imath.V2i( 0 ), imath.V2i( 65 ) ), True ),
+								( imath.Box2i( imath.V2i( 0 ), imath.V2i( 150, 100 ) ), True ),
+								( imath.Box2i( imath.V2i( 37, 21 ), imath.V2i( 96, 43 ) ), False ),
+								( imath.Box2i( imath.V2i( 0 ), imath.V2i( 0 ) ), False )
+							]:
+							c["area"].setValue( area )
+							c["affectDisplayWindow"].setValue( affectDisplayWindow )
 
-					reRead["refreshCount"].setValue( reRead["refreshCount"].getValue() + 1 )
-					if area.size() != imath.V2i( 0 ):
-						self.assertImagesEqual( reRead["out"], trimToDataWindowStage2["out"], ignoreMetadata = True )
-					else:
-						# We have to write one pixel to file, since OpenEXR doesn't permit empty dataWindow
-						onePixelDataWindow = imath.Box2i( imath.V2i( 0, 99 ), imath.V2i( 1, 100 ) )
-						self.assertEqual( reRead["out"].dataWindow(), onePixelDataWindow )
+							for offset in [
+									imath.V2i( 0, 0 ),
+									imath.V2i( 13, 17 ),
+									imath.V2i( -13, -17 ),
+									imath.V2i( -233, 431 ),
+									imath.V2i( -GafferImage.ImagePlug.tileSize(), 2 * GafferImage.ImagePlug.tileSize() ),
+									imath.V2i( 106, 28 )
+								]:
 
-						emptyPixelData = IECore.CompoundObject()
-						emptyPixelData["tileOrigins"] = IECore.V2iVectorData( [ GafferImage.ImagePlug.tileOrigin( imath.V2i( 0, 99 ) ) ] )
-						emptyPixelData["sampleOffsets"] = IECore.ObjectVector( [ GafferImage.ImagePlug.emptyTileSampleOffsets() ] )
-						for channel in [ "R", "G","B", "A", "Z", "ZBack" ]:
-							emptyPixelData[channel] = IECore.ObjectVector( [ IECore.FloatVectorData() ] )
-						self.assertEqual( GafferImage.ImageAlgo.tiles( reRead["out"] ), emptyPixelData )
+								o["offset"].setValue( offset )
+
+								w["task"].execute()
+
+								reRead["refreshCount"].setValue( reRead["refreshCount"].getValue() + 1 )
+								if area.size() != imath.V2i( 0 ):
+									self.assertImagesEqual( reRead["out"], trimToDataWindowStage2["out"], ignoreMetadata = True )
+								else:
+									# We have to write one pixel to file, since OpenEXR doesn't permit empty dataWindow
+									onePixelDataWindow = imath.Box2i( imath.V2i( 0, 99 ), imath.V2i( 1, 100 ) )
+									self.assertEqual( reRead["out"].dataWindow(), onePixelDataWindow )
+
+									emptyPixelData = IECore.CompoundObject()
+									emptyPixelData["tileOrigins"] = IECore.V2iVectorData( [ GafferImage.ImagePlug.tileOrigin( imath.V2i( 0, 99 ) ) ] )
+
+									refData = IECore.FloatVectorData() if deep else GafferImage.ImagePlug.blackTile()
+									if deep:
+										emptyPixelData["sampleOffsets"] = IECore.ObjectVector( [ GafferImage.ImagePlug.emptyTileSampleOffsets() ] )
+									for channel in [ "R", "G","B", "A", "Z", "ZBack" ]:
+										if channel == "ZBack" and not deep:
+											continue
+										emptyPixelData[channel] = IECore.ObjectVector( [ refData ] )
+									self.assertEqual( GafferImage.ImageAlgo.tiles( reRead["out"] ), emptyPixelData )
 
 	# Write an RGBA image that has a data window to various supported formats and in both scanline and tile modes.
 	def __testExtension( self, ext, formatName, options = {}, metadataToIgnore = [] ) :

--- a/startup/GafferImage/oiioConfig.py
+++ b/startup/GafferImage/oiioConfig.py
@@ -1,0 +1,52 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import OpenImageIO
+
+# This cleans up the process by getting rid of OIIO threads that we don't use much.
+# Our main use case is reading EXRs using ExrCore, where we can efficiently use
+# Gaffer threads instead of OIIO's internal threading, so turning off OIIO threads
+# has no negative impact ( it actually may have a tiny positive effect ).
+# This results in a moderate slowdown of reading Tiffs, and a more severe slowdown
+# of reading EXRs if you disable "openexr:core" so we can't do the threading ourselves.
+
+# If you disable "openexr:core" then you also need to set "exr_threads" to 0
+# to enable the default behaviour, and if Tiff performance is really important to you,
+# you may want to override this completely back to the default behaviour by setting both
+# to zero.
+
+OpenImageIO.attribute( "threads", 1 )
+OpenImageIO.attribute( "exr_threads", -1 )


### PR DESCRIPTION
I think this is in a pretty decent place for an initial review.

The main remaining thing I might want to do is some better test coverage. The one existing perf test does show a 40% improvement, but the performance improvement is far more drastic on larger images. In theory it could be worth having some performance tests specifically for "zip" compressed exrs with weird offsets in their data windows, to make sure that we're not misaligning chunks and doing 2 decompresses to fill each batch, but maybe that's getting pretty deep in the weeds.