### PR TITLE
GafferCycles : Don't nest `__ParametersPlugProxy`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1346,7 +1346,10 @@ libraries = {
 		"requiredOptions" : [ "CYCLES_ROOT" ],
 	},
 
-	"GafferCyclesTest" : { "requiredOptions" : [ "CYCLES_ROOT" ], },
+	"GafferCyclesTest" : {
+		"requiredOptions" : [ "CYCLES_ROOT" ],
+		"additionalFiles" : glob.glob( "python/GafferCyclesTest/*/*" )
+	},
 
 	"GafferCyclesUI" : { "requiredOptions" : [ "CYCLES_ROOT" ], },
 

--- a/python/GafferCyclesTest/CyclesShaderTest.py
+++ b/python/GafferCyclesTest/CyclesShaderTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import unittest
+import pathlib
 
 import Gaffer
 import GafferOSL
@@ -84,6 +85,15 @@ class CyclesShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader = GafferCycles.CyclesShader()
 		shader.loadShader( "emission" )
 		self.assertEqual( shader["type"].getValue(), "cycles:surface" )
+
+	def testShaderCompatibility( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["fileName"].setValue( pathlib.Path( __file__ ).parent / "scripts" / "principledBSDF-3.x.gfr" )
+		script.load()
+
+		self.assertIn( "emission_color", script["principled_bsdf"]["parameters"] )
+		self.assertNotIn( "emission", script["principled_bsdf"]["parameters"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/scripts/principledBSDF-3.x.gfr
+++ b/python/GafferCyclesTest/scripts/principledBSDF-3.x.gfr
@@ -1,0 +1,33 @@
+import Gaffer
+import GafferCycles
+import GafferImage
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 3, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 7, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["openColorIO"] = GafferImage.OpenColorIOConfigPlug( "openColorIO", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["openColorIO"] )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["principled_bsdf"] = GafferCycles.CyclesShader( "principled_bsdf" )
+parent.addChild( __children["principled_bsdf"] )
+__children["principled_bsdf"].loadShader( "principled_bsdf" )
+__children["principled_bsdf"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 2528 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["principled_bsdf"]["parameters"]["emission"].setValue( imath.Color3f( 0.5, 0.600000024, 0.699999988 ) )
+__children["principled_bsdf"]["__uiPosition"].setValue( imath.V2f( -11.7127047, 3.72868872 ) )
+
+
+del __children
+

--- a/python/GafferCyclesTest/scripts/principledBSDF-3.x.gfr
+++ b/python/GafferCyclesTest/scripts/principledBSDF-3.x.gfr
@@ -30,4 +30,3 @@ __children["principled_bsdf"]["__uiPosition"].setValue( imath.V2f( -11.7127047, 
 
 
 del __children
-

--- a/startup/GafferCycles/principledBSDFCompatibility.py
+++ b/startup/GafferCycles/principledBSDFCompatibility.py
@@ -67,7 +67,7 @@ def __cyclesShaderGetItem( originalGetItem ) :
 	def getItem( self, key ) :
 
 		result = originalGetItem( self, key )
-		if key == "parameters" :
+		if key == "parameters" and isinstance( result, Gaffer.Plug ) :
 			scriptNode = self.ancestor( Gaffer.ScriptNode )
 			if scriptNode is not None and scriptNode.isExecuting() :
 				return __ParametersPlugProxy( result )


### PR DESCRIPTION
This fixes what I think is a bug in `principledBSDFCompatibility`, at least on Windows. It was triggered when loading scripts with `GafferCycles.CyclesShader` nodes. The error was
`IECore.Exception: Line 276 of startup\gui\cyclesViewerSettings.gfr :
 AttributeError: '__ParametersPlugProxy' object has no attribute
 'parent'`

I believe it's because every time we were calling `GafferCycles.CyclesShader.__getItem__` on a plug named `parameters`, we were putting that plug into a `__ParametersPlugProxy` and returning that object. This meant on the second `__getItem__` we'd be putting a `__ParametersPlugProxy` inside a `__ParametersPlugProxy` and it would error because `__ParameterPlugProxy` doesn't have a `parent()` method (called on L60)

I initially wanted to do `not isinstance( result, __ParametersPlugProxy )` instead of `isinstance( result, Gaffer.Plug )` since it's more specific. But that comparison was always coming out `False`, which I can't explain. Maybe `__ParametersPlugProxy` is getting redefined somehow, causing comparison to be `False`? Maybe this is something that should be looked at instead of bailing and checking to make sure `result` is a `Gaffer.Plug`?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
