### PR TITLE
PathListingWidget : Do not change pointer when dragging a value of `None`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 - PythonCommand : Fixed misleading results for `repr( variables )` and `str( variables )`, which would suggest the dictionary was empty when it was not.
 - CompoundObject : Fixed crashes in Python bindings caused by passing `None` as a key.
 - Windows : Fixed "{path} was unexpected at this time." startup error when environment variables such as `PATH` contain `"` characters.
+- PathListingWidget : Fixed bug which caused the pointer to be stuck displaying the "values" icon after dragging cells with no value.
 
 Build
 -----

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -734,9 +734,11 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		index = self.__indexAt( event.line.p0 )
 		if index is not None :
-			GafferUI.Pointer.setCurrent( "values" )
+			value = self.getColumns()[index.column()].cellData( path ).value
+			if value is not None :
+				GafferUI.Pointer.setCurrent( "values" )
 
-			return self.getColumns()[index.column()].cellData( path ).value
+				return value
 
 		return None
 


### PR DESCRIPTION
Dragging a cell with no value from a PathListingWidget would cause the mouse pointer to be stuck on the "values" icon until the next interaction that sets the pointer icon. Instead, only change the pointer icon when there is a value to drag.