### PR TITLE
SceneAlgo : Capture plugs from Expression nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - CompoundObject : Fixed crashes in Python bindings caused by passing `None` as a key.
 - Windows : Fixed "{path} was unexpected at this time." startup error when environment variables such as `PATH` contain `"` characters.
 - PathListingWidget : Fixed bug which caused the pointer to be stuck displaying the "values" icon after dragging cells with no value.
+- SceneAlgo : Fixed computation of history through Expression nodes.
 
 Build
 -----

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -52,6 +52,7 @@
 
 #include "Gaffer/ArrayPlug.h"
 #include "Gaffer/Context.h"
+#include "Gaffer/Expression.h"
 #include "Gaffer/Monitor.h"
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
 #include "Gaffer/Process.h"
@@ -510,7 +511,8 @@ class CapturingMonitor : public Monitor
 		{
 			return
 				( plug->parent<ScenePlug>() && plug->getName() == m_scenePlugChildName ) ||
-				( (Gaffer::TypeId)plug->typeId() == Gaffer::TypeId::ObjectPlugTypeId && plug->getName() == g_processedObjectPlugName )
+				( (Gaffer::TypeId)plug->typeId() == Gaffer::TypeId::ObjectPlugTypeId && plug->getName() == g_processedObjectPlugName ) ||
+				runTimeCast<const Expression>( plug->node() )
 			;
 		}
 


### PR DESCRIPTION
There are use-cases for modifying the globals by connecting an Expression into ScenePlug.globals. Doing so would break the history as we would not traverse through the Expression and find the upstream globals plug. This is currently hard to do outside of a custom node, but we expect to become more prevalent in Gaffer 1.4 with #5624. 

@johnhaddon this is the cheapest and cheerfullest solution we discussed, with a few tests to exercise it. If this causes indigestion, then we can tighten up the conditions of `shouldCapture()`...