### PR TITLE
__gaffer.py : Remove unused import

### DIFF
--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -43,7 +43,6 @@ import os
 import sys
 import signal
 import warnings
-import pathlib
 
 # Get rid of the annoying signal handler which turns Ctrl-C into a KeyboardInterrupt exception
 signal.signal( signal.SIGINT, signal.SIG_DFL )


### PR DESCRIPTION
That got added in 2e3384d179fd4dd4e6d855fb341cb7b8a2e41278 and was no longer needed after 64adf406d2568360e1f9891e92ab7d7b21c200fe. I had flip-flopped on where the `add_dll_directory()` stuff belonged and botched the rebase where I intended to do it right in one single commit. This is a remnant of that.
