### PR TITLE
Context : Fix heap read after free

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.2.10.x (relative to 1.2.10.5)
 ========
 
+Fixes
+-----
+
+- Context : Fixed potential crash when setting a variable with ownership.
+
 1.2.10.5 (relative to 1.2.10.4)
 ========
 

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -358,7 +358,9 @@ class GAFFER_API Context : public IECore::RefCounted
 
 		// Sets a variable and emits `changedSignal()` as appropriate. Does not
 		// manage ownership in any way. If ownership is required, the caller must
-		// update `m_allocMap` appropriately _before_ calling `internalSet()`.
+		// update `m_allocMap` appropriately _before_ calling `internalSet()`, _and_
+		// must keep any previous allocation alive until `internalSet()` has
+		// returned.
 		void internalSet( const IECore::InternedString &name, const Value &value );
 		// Throws if variable doesn't exist.
 		const Value &internalGet( const IECore::InternedString &name ) const;

--- a/include/Gaffer/Context.h
+++ b/include/Gaffer/Context.h
@@ -357,11 +357,11 @@ class GAFFER_API Context : public IECore::RefCounted
 		};
 
 		// Sets a variable and emits `changedSignal()` as appropriate. Does not
-		// manage ownership in any way. If ownership is required, the caller must
-		// update `m_allocMap` appropriately _before_ calling `internalSet()`, _and_
-		// must keep any previous allocation alive until `internalSet()` has
-		// returned.
+		// manage ownership in any way. If ownership is required, call
+		// `internalSetWithOwner()` instead.
 		void internalSet( const IECore::InternedString &name, const Value &value );
+		// Sets a variable and maintains ownership of its data via `owner`.
+		void internalSetWithOwner( const IECore::InternedString &name, const Value &value, IECore::ConstDataPtr &&owner );
 		// Throws if variable doesn't exist.
 		const Value &internalGet( const IECore::InternedString &name ) const;
 		// Returns nullptr if variable doesn't exist.


### PR DESCRIPTION
This was introduced in 520c7a35d8818dba0a9f37bd36fbf8ce3dd2678d, and detected by running `ContextTest` and/or `ScriptNodeTest` using an ASAN-instrumented build. The issue was that `internalSet()` compares the new value against the (non-owning) old value stored in `m_map`, but the memory that points to has been deleted already by the assignment to `m_allocMap` (because assignment to `intrusive_ptr` decrements the reference count for the previous pointee). The solution is to temporarily hold on to the old value until after calling `internalSet()`, and to do all the `intrusive_ptr` juggling using `std::move()` so we steal references rather than do unnecessary increment/decrement pairs.

The one other place we call `internalSet()` while using `m_allocMap` is in the Context copy constructor, where we are OK, because `m_allocMap` starts out empty.

I've made the PR to `main` only because I don't currently have a local setup for building 1.3. I'm surprised we never saw this problem in 1.3 already (I _must_ have used ASAN since the bug was introduced, surely?). Maybe the order of operations was different with GCC 9? Is anyone able to reproduce in a GCC 9 build?