### PR TITLE
LightVisualiser/LightTool : Avoid reliance on `Shader::getType()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,11 @@ Fixes
 - PlugAlgo : Updated `canSetValueFromData()`, `setValueFromData()` and `getValueAsData()` with support for missing types.
 - LightPosition Tool : Fixed lingering shadow pivot point after placing a shadow pivot, switching to highlight mode and switching back to shadow mode [^1].
 
+Breaking Changes
+----------------
+
+- StandardLightVisualiser : Added `attributeName` argument to `surfaceTexture()` virtual method.
+
 1.4.0.0b4 (relative to 1.4.0.0b3)
 =========
 

--- a/include/GafferSceneUI/StandardLightVisualiser.h
+++ b/include/GafferSceneUI/StandardLightVisualiser.h
@@ -90,7 +90,7 @@ class GAFFERSCENEUI_API StandardLightVisualiser : public IECoreGLPreview::LightV
 		// The default implementation looks for a string parameter registered
 		// as the "textureNameParameter" for the supplied shader network's
 		// output shader.
-		virtual IECore::DataPtr surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const;
+		virtual IECore::DataPtr surfaceTexture( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const;
 
 	private :
 

--- a/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
+++ b/src/GafferArnoldUI/ArnoldLightVisualiser.cpp
@@ -187,7 +187,7 @@ class ArnoldLightVisualiser : public GafferSceneUI::StandardLightVisualiser
 
 	protected :
 
-		IECore::DataPtr surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const override;
+		IECore::DataPtr surfaceTexture( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const override;
 
 	private :
 
@@ -236,7 +236,7 @@ Visualisations ArnoldLightVisualiser::visualise( const IECore::InternedString &a
 	return v;
 }
 
-IECore::DataPtr ArnoldLightVisualiser::surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const
+IECore::DataPtr ArnoldLightVisualiser::surfaceTexture( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const
 {
 	const ShaderNetwork::Parameter &output = shaderNetwork->getOutput();
 	if( !output )
@@ -245,7 +245,7 @@ IECore::DataPtr ArnoldLightVisualiser::surfaceTexture( const IECoreScene::Shader
 	}
 
 	const IECoreScene::Shader *outputShader = shaderNetwork->outputShader();
-	const IECore::InternedString metadataTarget = outputShader->getType() + ":" + outputShader->getName();
+	const IECore::InternedString metadataTarget = "ai:light:" + outputShader->getName();
 
 	ConstStringDataPtr colorParamData = Gaffer::Metadata::value<StringData>( metadataTarget, "colorParameter" );
 	if( !colorParamData )

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -820,16 +820,16 @@ class LightToolHandle : public Handle
 				)
 				{
 					const auto shader = attributes->member<ShaderNetwork>( attributeName )->outputShader();
-					std::string shaderAttribute = shader->getType() + ":" + shader->getName();
+					const InternedString metadataTarget = attributeName.string() + ":" + shader->getName();
 
-					if( !isLightType( shaderAttribute ) )
+					if( !isLightType( metadataTarget ) )
 					{
 						continue;
 					}
 
 					for( const auto &m : m_metaParameters )
 					{
-						if( auto parameter = Metadata::value<StringData>( shaderAttribute, m ) )
+						if( auto parameter = Metadata::value<StringData>( metadataTarget, m ) )
 						{
 							m_inspectors[m] = new ParameterInspector(
 								scene(),
@@ -972,11 +972,11 @@ class LightToolHandle : public Handle
 			return m_handlePath;
 		}
 
-		// Returns true if `shaderAttribute` refers to the same light type
+		// Returns true if `metadataTarget` refers to the same light type
 		// as this handle was constructed to apply to.
-		bool isLightType( const std::string &shaderAttribute ) const
+		bool isLightType( const InternedString &metadataTarget ) const
 		{
-			auto lightType = Metadata::value<StringData>( shaderAttribute, "type" );
+			auto lightType = Metadata::value<StringData>( metadataTarget, "type" );
 
 			if( !lightType || !StringAlgo::matchMultiple( lightType->readable(), m_lightTypePattern ) )
 			{
@@ -1552,18 +1552,18 @@ class SpotLightHandle : public LightToolHandle
 				)
 				{
 					const auto shader = attributes->member<ShaderNetwork>( attributeName )->outputShader();
-					std::string shaderAttribute = shader->getType() + ":" + shader->getName();
+					const InternedString metadataTarget = attributeName.string() + ":" + shader->getName();
 
-					if( !isLightType( shaderAttribute ) )
+					if( !isLightType( metadataTarget ) )
 					{
 						continue;
 					}
 
-					auto penumbraTypeData = Metadata::value<StringData>( shaderAttribute, "penumbraType" );
+					auto penumbraTypeData = Metadata::value<StringData>( metadataTarget, "penumbraType" );
 					m_penumbraType = penumbraTypeData ? std::optional<InternedString>( InternedString( penumbraTypeData->readable() ) ) : std::nullopt;
 
 					m_lensRadius = 0;
-					if( auto lensRadiusParameterName = Metadata::value<StringData>( shaderAttribute, "lensRadiusParameter" ) )
+					if( auto lensRadiusParameterName = Metadata::value<StringData>( metadataTarget, "lensRadiusParameter" ) )
 					{
 						if( auto lensRadiusData = shader->parametersData()->member<FloatData>( lensRadiusParameterName->readable() ) )
 						{
@@ -1571,7 +1571,7 @@ class SpotLightHandle : public LightToolHandle
 						}
 					}
 
-					auto angleType = Metadata::value<StringData>( shaderAttribute, "coneAngleType" );
+					auto angleType = Metadata::value<StringData>( metadataTarget, "coneAngleType" );
 					if( angleType && angleType->readable() == "half" )
 					{
 						m_angleHandleRatio = 1.f;
@@ -2056,21 +2056,21 @@ class EdgeHandle : public LightToolHandle
 				)
 				{
 					const auto shader = attributes->member<ShaderNetwork>( attributeName )->outputShader();
-					std::string shaderAttribute = shader->getType() + ":" + shader->getName();
+					const InternedString metadataTarget = attributeName.string() + ":" + shader->getName();
 
-					if( !isLightType( shaderAttribute ) )
+					if( !isLightType( metadataTarget ) )
 					{
 						continue;
 					}
 
 					m_orientation = M44f();
-					if( auto orientationData = Metadata::value<M44fData>( shaderAttribute, "visualiserOrientation" ) )
+					if( auto orientationData = Metadata::value<M44fData>( metadataTarget, "visualiserOrientation" ) )
 					{
 						m_orientation = orientationData->readable();
 					}
 
 					m_oppositeAdditionalScale = 1.f;
-					if( auto scaleData = Metadata::value<FloatData>( shaderAttribute, m_oppositeScaleAttributeName ) )
+					if( auto scaleData = Metadata::value<FloatData>( metadataTarget, m_oppositeScaleAttributeName ) )
 					{
 						m_oppositeAdditionalScale = scaleData->readable();
 					}
@@ -2760,15 +2760,15 @@ class LengthHandle : public LightToolHandle
 				)
 				{
 					const auto shader = attributes->member<ShaderNetwork>( attributeName )->outputShader();
-					std::string shaderAttribute = shader->getType() + ":" + shader->getName();
+					const InternedString metadataTarget = attributeName.string() + ":" + shader->getName();
 
-					if( !isLightType( shaderAttribute ) )
+					if( !isLightType( metadataTarget ) )
 					{
 						continue;
 					}
 
 					m_orientation = M44f();
-					if( auto orientationData = Metadata::value<M44fData>( shaderAttribute, "visualiserOrientation" ) )
+					if( auto orientationData = Metadata::value<M44fData>( metadataTarget, "visualiserOrientation" ) )
 					{
 						m_orientation = orientationData->readable();
 					}

--- a/src/GafferSceneUI/StandardLightVisualiser.cpp
+++ b/src/GafferSceneUI/StandardLightVisualiser.cpp
@@ -76,10 +76,10 @@ const Color4f g_mutedLightWireframeColor4 = Color4f( g_mutedLightWireframeColor.
 
 enum Axis { X, Y, Z };
 
-IECore::InternedString metadataTargetForNetwork( const IECoreScene::ShaderNetwork *shaderNetwork )
+IECore::InternedString metadataTargetForNetwork( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork )
 {
 	const IECoreScene::Shader *shader = shaderNetwork->outputShader();
-	return shader->getType() + ":" + shader->getName();
+	return attributeName.string() + ":" + shader->getName();
 }
 
 template<typename T>
@@ -469,7 +469,7 @@ StandardLightVisualiser::~StandardLightVisualiser()
 
 Visualisations StandardLightVisualiser::visualise( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
 {
-	const InternedString metadataTarget = metadataTargetForNetwork( shaderNetwork );
+	const InternedString metadataTarget = metadataTargetForNetwork( attributeName, shaderNetwork );
 	const IECore::CompoundData *shaderParameters = shaderNetwork->outputShader()->parametersData();
 
 	ConstStringDataPtr type = Metadata::value<StringData>( metadataTarget, g_typeString );
@@ -527,7 +527,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	{
 		if( drawShaded )
 		{
-			ConstDataPtr textureData = drawTextured ? surfaceTexture( shaderNetwork, attributes, maxTextureResolution ) : nullptr;
+			ConstDataPtr textureData = drawTextured ? surfaceTexture( attributeName, shaderNetwork, attributes, maxTextureResolution ) : nullptr;
 			result.push_back( Visualisation::createOrnament(
 				environmentSphereSurface( textureData, tint, maxTextureResolution, color ),
 				/* affectsFramingBound = */ true, Visualisation::ColorSpace::Scene
@@ -572,7 +572,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 		{
 			if( drawShaded )
 			{
-				ConstDataPtr textureData = drawTextured ? surfaceTexture( shaderNetwork, attributes, maxTextureResolution ) : nullptr;
+				ConstDataPtr textureData = drawTextured ? surfaceTexture( attributeName, shaderNetwork, attributes, maxTextureResolution ) : nullptr;
 				result.push_back( Visualisation::createGeometry(
 					quadSurface( size, textureData, tint, maxTextureResolution, color, uvOrientation ? uvOrientation->readable() : M33f() ),
 					Visualisation::ColorSpace::Scene
@@ -599,7 +599,7 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 
 		if( drawShaded )
 		{
-			ConstDataPtr textureData = drawTextured ? surfaceTexture( shaderNetwork, attributes, maxTextureResolution ) : nullptr;
+			ConstDataPtr textureData = drawTextured ? surfaceTexture( attributeName, shaderNetwork, attributes, maxTextureResolution ) : nullptr;
 			result.push_back( Visualisation::createGeometry(
 				diskSurface( radius, textureData, tint, maxTextureResolution, color ),
 				Visualisation::ColorSpace::Scene
@@ -698,9 +698,9 @@ Visualisations StandardLightVisualiser::visualise( const IECore::InternedString 
 	return result;
 }
 
-IECore::DataPtr StandardLightVisualiser::surfaceTexture( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const
+IECore::DataPtr StandardLightVisualiser::surfaceTexture( const IECore::InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, int maxTextureResolution ) const
 {
-	const IECore::InternedString metadataTarget = metadataTargetForNetwork( shaderNetwork );
+	const IECore::InternedString metadataTarget = metadataTargetForNetwork( attributeName, shaderNetwork );
 	const IECore::CompoundData *shaderParameters = shaderNetwork->outputShader()->parametersData();
 	const std::string textureName = parameter<std::string>( metadataTarget, shaderParameters, "textureNameParameter", "" );
 	if( !textureName.empty() )
@@ -714,7 +714,7 @@ IECore::DataPtr StandardLightVisualiser::surfaceTexture( const IECoreScene::Shad
 void StandardLightVisualiser::spotlightParameters( const InternedString &attributeName, const IECoreScene::ShaderNetwork *shaderNetwork, float &innerAngle, float &outerAngle, float &radius, float &lensRadius )
 {
 
-	InternedString metadataTarget = metadataTargetForNetwork( shaderNetwork );
+	InternedString metadataTarget = metadataTargetForNetwork( attributeName, shaderNetwork );
 	const IECore::CompoundData *shaderParameters = shaderNetwork->outputShader()->parametersData();
 
 	float coneAngle = parameter<float>( metadataTarget, shaderParameters, "coneAngleParameter", 0.0f );

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -130,7 +130,7 @@ class LocationNameColumn : public StandardPathColumn
 				}
 
 				const IECoreScene::Shader *lightShader = shaderNetwork->outputShader();
-				const string metadataTarget = lightShader->getType() + ":" + lightShader->getName();
+				const string metadataTarget = attribute.first.string() + ":" + lightShader->getName();
 				ConstStringDataPtr lightType = Metadata::value<StringData>( metadataTarget, "type" );
 				if( !lightType )
 				{


### PR DESCRIPTION
This fixes problems visualising and editing Arnold lights after they have been saved to USD and reloaded. We want to move away from reliance on shader types across the board, since OSL has deprecated the concept entirely and they don't map through USD well either.

For Gaffer 1.3 we're working around this via https://github.com/ImageEngine/cortex/pull/1410, but for Gaffer 1.4 we have the luxury of changing the `StandardLightVisualiser::surfaceTexture()` ABI and so can take the more forward-thinking approach seen here.