### PR TITLE
LightTool crash fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
 - Windows : Fixed "{path} was unexpected at this time." startup error when environment variables such as `PATH` contain `"` characters.
 - PathListingWidget : Fixed bug which caused the pointer to be stuck displaying the "values" icon after dragging cells with no value.
 - SceneAlgo : Fixed computation of history through Expression nodes.
+- LightTool : Fixed crash when deleting the node being viewed.
 - USD : Fixed loading of Arnold lights previously exported from Gaffer to USD.
 - Catalogue : Fixed connection delays on Windows.
 

--- a/python/GafferSceneUITest/LightToolTest.py
+++ b/python/GafferSceneUITest/LightToolTest.py
@@ -171,7 +171,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 
 		preRenderSlot = GafferTest.CapturingSlot( view.viewportGadget().preRenderSignal() )
 		while not len( preRenderSlot ) :
-			self.waitForIdle()
+			self.waitForIdle( 1000 )
 
 		# Delete the node being viewed.
 
@@ -183,7 +183,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 		del preRenderSlot[:]
 		with IECore.CapturingMessageHandler() as mh :
 			while not len( preRenderSlot ) :
-				self.waitForIdle()
+				self.waitForIdle( 1000 )
 
 		# Ignore unrelated message from BackgroundTask. This needs a separate fix.
 		self.assertEqual( len( mh.messages ), 1 )

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -1266,18 +1266,13 @@ class LightToolHandle : public Handle
 		// Returns `nullptr` if no inspector or no inspection exists.
 		Inspector::ResultPtr inspection( const InternedString &metaParameter ) const
 		{
-			auto it = m_inspectors.find( metaParameter );
+			const auto it = m_inspectors.find( metaParameter );
 			if( it == m_inspectors.end() )
 			{
 				return nullptr;
 			}
 
-			if( Inspector::ResultPtr inspection = it->second->inspect() )
-			{
-				return inspection;
-			}
-
-			return nullptr;
+			return it->second->inspect();
 		}
 
 		bool allInspectionsEnabled() const


### PR DESCRIPTION
This fixes a crash in the LightTool when deleting the node being viewed - see the second commit message for full repro steps and a stacktrace. @ericmehl, I'm not particularly familiar with this part of the codebase but I hope the approach I've taken makes sense and simplifies things slightly - please do let me know if I'm missing anything.