### PR TITLE
Whitespace fixes

### DIFF
--- a/python/GafferOSLTest/scripts/colorToVector-1.3.11.0.gfr
+++ b/python/GafferOSLTest/scripts/colorToVector-1.3.11.0.gfr
@@ -64,4 +64,3 @@ __children["ColorToVector2"]["__uiPosition"].setValue( imath.V2f( -12.8156233, 5
 
 
 del __children
-

--- a/python/GafferOSLTest/scripts/surfaceWithOutputs-1.3.9.0.gfr
+++ b/python/GafferOSLTest/scripts/surfaceWithOutputs-1.3.9.0.gfr
@@ -47,4 +47,3 @@ __children["PathFilter"]["__uiPosition"].setValue( imath.V2f( 22.8434563, 5.4329
 
 
 del __children
-


### PR DESCRIPTION
This fixes a few whitespace errors that cropped up on Windows builds on the `main` branch. I'm not sure why it didn't come up on the Linux builds or even previous Windows builds on `main`, so there may be a better fix.

For the GafferOSLTest scripts, I double checked my workstation settings for converting line endings and all seems right. Checking it out on a Linux machine and doing `cat -A` on them does show and extra newline at the end, so I think this may be justifiable.

The `indent with spaces` error on `DispatcherUI.py` now matches the format used in `StandardOptionsUI` for example, and I verified it matches exactly to the previous tooltip formatting.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
