### PR TITLE
installDependencies.py : Clean up temp file

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -125,3 +125,7 @@ if args.outputFormat :
 			archiveDigest = md5.hexdigest()
 		)
 	)
+
+# Clean up
+
+pathlib.Path( archiveFileName ).unlink()


### PR DESCRIPTION
We keep running out of disk space on our GCC11 CI builds, I believe largely because the Docker image is far more bloated than the GCC 9 one (14Gb vs 1.8GB). While the primary fix is going to need to be a cleanup of the image (I'm looking at you CUDA), deleting the download for the dependencies shaves off a few hundred megabytes and might help out a little bit.