### PR TITLE
CI : Update to podman build container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
             os: ubuntu-20.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:3.0.0a4
+            containerImage: ghcr.io/gafferhq/build/build:3.0.0a6
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated


### PR DESCRIPTION
Update to `build:3.0.0a6`, which is a container built with `podman build --squash-all` and various unnecessary software removed in order to reduce the amount of disk space required for a CI run.