### PR TITLE
PlugValueWidget : Fix context used for plugs on `Editor.Settings`

### DIFF
--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -746,6 +746,14 @@ class PlugValueWidget( GafferUI.Widget ) :
 		if view is not None :
 			return view.getContext()
 
+		# Special case for plugs that form the settings for an Editor.
+
+		settings = graphComponent if isinstance( graphComponent, GafferUI.Editor.Settings ) else graphComponent.ancestor( GafferUI.Editor.Settings )
+		if settings is not None :
+			scriptNode = settings["__scriptNode"].source().ancestor( Gaffer.ScriptNode )
+			if scriptNode is not None :
+				return scriptNode.context()
+
 		return cls.__fallbackContext
 
 	def __buttonPress( self, widget, event, buttonMask ) :


### PR DESCRIPTION
We have to jump through some hoops to find the right ScriptNode to provide the context in this case. This fixes an error in the ImageInspector `view` widget if the image being inspected didn't exist on frame 1 (or otherwise needed some context variable not present in a default context).
