### PR TITLE
CyclesRenderer : Prep for refactoring the session reset code 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.0.0b1)
 =======
 
+Breaking Changes
+----------------
 
+- CyclesOptions : - Removed all texture cache options. These had never been exposed in the UI because this never became an offical Cycles feature.
 
 1.4.0.0b1 (relative to 1.3.x.x)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Breaking Changes
 - CyclesOptions :
   - Removed `useFrameAsSeed` plug. The frame is now automatically used as the seed if `seed` is not set.
   - Removed all texture cache options. These had never been exposed in the UI because this never became an offical Cycles feature.
+  - Removed `cryptomatteAccurate`. This feature is no longer present in Cycles.
 
 1.4.0.0b1 (relative to 1.3.x.x)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Breaking Changes
 ----------------
 
-- CyclesOptions : - Removed all texture cache options. These had never been exposed in the UI because this never became an offical Cycles feature.
+- CyclesOptions :
+  - Removed `useFrameAsSeed` plug. The frame is now automatically used as the seed if `seed` is not set.
+  - Removed all texture cache options. These had never been exposed in the UI because this never became an offical Cycles feature.
 
 1.4.0.0b1 (relative to 1.3.x.x)
 =========

--- a/SConstruct
+++ b/SConstruct
@@ -1003,6 +1003,39 @@ if env["ARNOLD_ROOT"] :
 # Definitions for the libraries we wish to build
 ###############################################################################################
 
+# When Cycles is built, it uses several preprocessor variables that enable and
+# disable various features, and sometimes those defines are used to omit or
+# include members in public classes : *they affect ABI*. Traditionally a library
+# would provide a header which reproduced such definitions for client code, but
+# not Cycles : we must do that ourselves, to the point where we're even telling
+# it what namespace it was built in.
+#
+# When encountering mysterious GafferCycles memory corruptions, your first port of
+# call should be to ensure that these defines line up with Cycles' build-time
+# settings, lest the ABIs be misaligned.
+cyclesDefines = [
+	( "CCL_NAMESPACE_BEGIN", "namespace ccl {" ),
+	( "CCL_NAMESPACE_END", "}" ),
+	( "EMBREE_MAJOR_VERSION", "4" ),
+	( "PATH_GUIDING_LEVEL", "5" ),
+	( "WITH_ALEMBIC" ),
+	( "WITH_EMBREE" ),
+	( "WITH_OCIO" ),
+	( "WITH_OPENSUBDIV" ),
+	( "WITH_OPENVDB" ),
+	( "WITH_NANOVDB" ),
+	( "WITH_OSL" ),
+	( "WITH_PATH_GUIDING" ),
+	( "WITH_SYSTEM_PUGIXML" ),
+	# Technically these are not actually right for all builds - we
+	# currently only build GPU support for GCC 11 builds. But they
+	# don't currently affect ABI, and it won't be long till they
+	# apply everywhere.
+	( "WITH_CUDA" ),
+	( "WITH_CUDA_DYNLOAD" ),
+	( "WITH_OPTIX" ),
+]
+
 libraries = {
 
 	"Gaffer" : {
@@ -1319,12 +1352,7 @@ libraries = {
 				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
-			"CPPDEFINES" : [
-				( "CCL_NAMESPACE_BEGIN", "namespace ccl {" ),
-				( "CCL_NAMESPACE_END", "}" ),
-				( "WITH_OSL", "1" ),
-				( "WITH_CYCLES_PATH_GUIDING", "1" ),
-			],
+			"CPPDEFINES" : cyclesDefines,
 			"FRAMEWORKS" : [ "Foundation", "Metal", "IOKit" ],
 		},
 		"pythonEnvAppends" : {
@@ -1337,11 +1365,7 @@ libraries = {
 				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
-			"CPPDEFINES" : [
-				( "CCL_NAMESPACE_BEGIN", "namespace ccl {" ),
-				( "CCL_NAMESPACE_END", "}" ),
-				( "WITH_CYCLES_PATH_GUIDING", "1" ),
-			],
+			"CPPDEFINES" : cyclesDefines,
 		},
 		"requiredOptions" : [ "CYCLES_ROOT" ],
 	},

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -315,48 +315,6 @@ def __backgroundSummary( plug ) :
 
 	return ", ".join( info )
 
-def __textureCacheSummary( plug ) :
-
-	info = []
-
-	if plug["useTextureCache"]["enabled"].getValue() :
-		info.append( "Use Texture Cache {}".format( plug["useTextureCache"]["value"].getValue() ) )
-
-	if plug["textureCacheSize"]["enabled"].getValue() :
-		info.append( "Texture Cache Size {}".format( plug["textureCacheSize"]["value"].getValue() ) )
-
-	if plug["textureAutoConvert"]["enabled"].getValue() :
-		info.append( "Texture Auto-Convert {}".format( plug["textureAutoConvert"]["value"].getValue() ) )
-
-	if plug["textureAcceptUnmipped"]["enabled"].getValue() :
-		info.append( "Texture Accept Unmipped {}".format( plug["textureAcceptUnmipped"]["value"].getValue() ) )
-
-	if plug["textureAcceptUntiled"]["enabled"].getValue() :
-		info.append( "Texture Accept Untiled {}".format( plug["textureAcceptUntiled"]["value"].getValue() ) )
-
-	if plug["textureAutoTile"]["enabled"].getValue() :
-		info.append( "Texture Auto-Tile {}".format( plug["textureAutoTile"]["value"].getValue() ) )
-
-	if plug["textureAutoMip"]["enabled"].getValue() :
-		info.append( "Texture Auto-Mip {}".format( plug["textureAutoMip"]["value"].getValue() ) )
-
-	if plug["textureTileSize"]["enabled"].getValue() :
-		info.append( "Texture Tile Size {}".format( plug["textureTileSize"]["value"].getValue() ) )
-
-	if plug["textureBlurDiffuse"]["enabled"].getValue() :
-		info.append( "Texture Blur Diffuse {}".format( plug["textureBlurDiffuse"]["value"].getValue() ) )
-
-	if plug["textureBlurGlossy"]["enabled"].getValue() :
-		info.append( "Texture Blur Glossy {}".format( plug["textureBlurGlossy"]["value"].getValue() ) )
-
-	if plug["useCustomCachePath"]["enabled"].getValue() :
-		info.append( "Use Custom Cache Path {}".format( plug["useCustomCachePath"]["value"].getValue() ) )
-
-	if plug["customCachePath"]["enabled"].getValue() :
-		info.append( "Custom Cache Path {}".format( plug["customCachePath"]["value"].getValue() ) )
-
-	return ", ".join( info )
-
 def __logSummary( plug ) :
 
 	info = []
@@ -440,7 +398,6 @@ Gaffer.Metadata.registerNode(
 			"layout:section:Film:summary", __filmSummary,
 			"layout:section:Denoising:summary", __denoisingSummary,
 			"layout:section:Background:summary", __backgroundSummary,
-			"layout:section:Texture Cache:summary", __textureCacheSummary,
 			"layout:section:Log:summary", __logSummary,
 
 		],
@@ -1539,135 +1496,6 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		# Texture Cache
-
-		"options.useTextureCache" : [
-
-			"description",
-			"""
-			Enables out-of-core texturing to conserve RAM.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureCacheSize" : [
-
-			"description",
-			"""
-			The size of the OpenImageIO texture cache in MB.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureAutoConvert" : [
-
-			"description",
-			"""
-			Automatically convert textures to .tx files for optimal texture
-			cache performance.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureAcceptUnmipped" : [
-
-			"description",
-			"""
-			Texture cached rendering without mip mapping is very expensive.
-			Uncheck to prevent Cycles from using textures that are not mip
-			mapped.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureAcceptUntiled" : [
-
-			"description",
-			"""
-			Texture cached rendering without tiled textures is very expensive.
-			Uncheck to prevent Cycles from using textures that are not tiled.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureAutoTile" : [
-
-			"description",
-			"""
-			On the fly creation of tiled versions of textures that are not
-			tiled. This can increase render time but helps reduce memory usage.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureAutoMip" : [
-
-			"description",
-			"""
-			On the fly creation of mip maps of textures that are not mip
-			mapped. This can increase render time but helps reduce memory
-			usage.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureTileSize" : [
-
-			"description",
-			"""
-			The size of tiles that Cycles uses for auto tiling.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureBlurDiffuse" : [
-
-			"description",
-			"""
-			The amount of texture blur applied to diffuse bounces.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.textureBlurGlossy" : [
-
-			"description",
-			"""
-			The amount of texture blur applied to glossy bounces.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.useCustomCachePath" : [
-
-			"description",
-			"""
-			Use Custom Cache Path.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
-		"options.customCachePath" : [
-
-			"description",
-			"""
-			Custom path for the texture cache.
-			""",
-
-			"layout:section", "Texture Cache",
-		],
-
 		# Log
 
 		"options.logLevel" : [
@@ -1694,21 +1522,6 @@ Gaffer.Metadata.registerNode(
 )
 
 __registerDevicePresets()
-
-if not GafferCycles.withTextureCache :
-
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.useTextureCache", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureCacheSize", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureAutoConvert", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureAcceptUnmipped", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureAcceptUntiled", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureAutoTile", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureAutoMip", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureTileSize", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureBlurDiffuse", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.textureBlurGlossy", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.useCustomCachePath", "plugValueWidget:type", "" )
-	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.customCachePath", "plugValueWidget:type", "" )
 
 if GafferCycles.hasOptixDenoise :
 

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -255,9 +255,6 @@ def __filmSummary( plug ) :
 	if plug["mistFalloff"]["enabled"].getValue() :
 		info.append( "Mist Falloff {}".format( plug["mistFalloff"]["value"].getValue() ) )
 
-	if plug["cryptomatteAccurate"]["enabled"].getValue() :
-		info.append( "Cryptomatte Accurate {}".format( plug["cryptomatteAccurate"]["value"].getValue() ) )
-
 	if plug["cryptomatteDepth"]["enabled"].getValue() :
 		info.append( "Cryptomatte Depth {}".format( plug["cryptomatteDepth"]["value"].getValue() ) )
 
@@ -1344,17 +1341,6 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Falloff of the mist/fog.
-			""",
-
-			"layout:section", "Film",
-
-		],
-
-		"options.cryptomatteAccurate" : [
-
-			"description",
-			"""
-			Generate a more accurate Cryptomatte pass. CPU only, may render slower and use more memory.
 			""",
 
 			"layout:section", "Film",

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -129,9 +129,6 @@ def __samplingSummary( plug ) :
 	if plug["filterGlossy"]["enabled"].getValue() :
 		info.append( "Filter Glossy {}".format( plug["filterGlossy"]["value"].getValue() ) )
 
-	if plug["useFrameAsSeed"]["enabled"].getValue() :
-		info.append( "Use Frame As Seed {}".format( plug["useFrameAsSeed"]["value"].getValue() ) )
-
 	if plug["seed"]["enabled"].getValue() :
 		info.append( "Seed Value {}".format( plug["seed"]["value"].getValue() ) )
 
@@ -757,22 +754,11 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"options.useFrameAsSeed" : [
-
-			"description",
-			"""
-			Use current frame as the seed value for the sampling pattern.
-			""",
-
-			"layout:section", "Sampling",
-
-		],
-
 		"options.seed" : [
 
 			"description",
 			"""
-			Seed value for the sampling pattern. Disabled if \"Use Frame As Seed\" is on.
+			Seed value for the sampling pattern. If not specified, the frame number is used instead.
 			""",
 
 			"layout:section", "Sampling",

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -157,7 +157,6 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "cycles:film:mist_depth", new IECore::FloatData( 100.0f ), false, "mistDepth" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:film:mist_falloff", new IECore::FloatData( 1.0f ), false, "mistFalloff" ) );
 
-	options->addChild( new Gaffer::NameValuePlug( "cycles:film:cryptomatte_accurate", new IECore::BoolData( false ), false, "cryptomatteAccurate" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:film:cryptomatte_depth", new IECore::IntData( 6 ), false, "cryptomatteDepth" ) );
 
 	// Dicing camera

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -163,20 +163,6 @@ CyclesOptions::CyclesOptions( const std::string &name )
 
 	// Dicing camera
 	options->addChild( new Gaffer::NameValuePlug( "cycles:dicing_camera", new IECore::StringData(), false, "dicingCamera" ) );
-
-	// Texture cache
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:use_texture_cache", new IECore::BoolData( false ), false, "useTextureCache" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:cache_size", new IECore::IntData( 1024 ), false, "textureCacheSize" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:auto_convert", new IECore::BoolData( true ), false, "textureAutoConvert" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:accept_unmipped", new IECore::BoolData( true ), false, "textureAcceptUnmipped" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:accept_untiled", new IECore::BoolData( true ), false, "textureAcceptUntiled" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:auto_tile", new IECore::BoolData( true ), false, "textureAutoTile" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:auto_mip", new IECore::BoolData( true ), false, "textureAutoMip" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:tile_size", new IECore::IntData( 64 ), false, "textureTileSize" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:blur_diffuse", new IECore::FloatData( 0.0156f ), false, "textureBlurDiffuse" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:blur_glossy", new IECore::FloatData( 0.0f ), false, "textureBlurGlossy" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:use_custom_cache_path", new IECore::BoolData( false ), false, "useCustomCachePath" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:texture:custom_cache_path", new IECore::StringData(), false, "customCachePath" ) );
 }
 
 CyclesOptions::~CyclesOptions()

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -101,7 +101,6 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:caustics_reflective", new IECore::BoolData( true ), false, "causticsReflective" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:caustics_refractive", new IECore::BoolData( true ), false, "causticsRefractive" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:filter_glossy", new IECore::FloatData( 0.0f ), false, "filterGlossy" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_frame_as_seed", new IECore::BoolData( true ), false, "useFrameAsSeed" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:seed", new IECore::IntData( 0 ), false, "seed" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:sample_clamp_direct", new IECore::FloatData( 0.0f ), false, "sampleClampDirect" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:sample_clamp_indirect", new IECore::FloatData( 0.0f ), false, "sampleClampIndirect" ) );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2478,7 +2478,6 @@ ccl::PathRayFlag nameToRayType( const std::string &name )
 IECore::InternedString g_dicingCameraOptionName( "cycles:dicing_camera" );
 
 // Cryptomatte
-IECore::InternedString g_cryptomatteAccurateOptionName( "cycles:film:cryptomatte_accurate" );
 IECore::InternedString g_cryptomatteDepthOptionName( "cycles:film:cryptomatte_depth");
 
 IE_CORE_FORWARDDECLARE( CyclesRenderer )
@@ -2506,7 +2505,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				m_frame( 1 ),
 				m_renderState( RENDERSTATE_READY ),
 				m_outputsChanged( true ),
-				m_cryptomatteAccurate( true ),
 				m_cryptomatteDepth( 0 ),
 				m_messageHandler( messageHandler )
 		{
@@ -2839,21 +2837,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 			else if( boost::starts_with( name.string(), "cycles:film:" ) )
 			{
-				if( name == g_cryptomatteAccurateOptionName )
-				{
-					m_outputsChanged = true;
-					if( value == nullptr )
-					{
-						m_cryptomatteAccurate = false;
-						return;
-					}
-					if( const BoolData *data = reportedCast<const BoolData>( value, "option", name ) )
-					{
-						m_cryptomatteAccurate = data->readable();
-						return;
-					}
-				}
-
 				if( name == g_cryptomatteDepthOptionName )
 				{
 					m_outputsChanged = true;
@@ -3303,10 +3286,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			paramData->writable()["default"] = new StringData( "rgba" );
 
 			ccl::CryptomatteType crypto = ccl::CRYPT_NONE;
-			if( m_cryptomatteAccurate )
-			{
-				crypto = static_cast<ccl::CryptomatteType>( crypto | ccl::CRYPT_ACCURATE );
-			}
 
 			CompoundDataPtr layersData = new CompoundData();
 			InternedString cryptoAsset;
@@ -3367,7 +3346,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 
 			// Adding cryptomattes in-order matters
 			ccl::Film *film = m_scene->film;
-			if( crypto == ccl::CRYPT_NONE || crypto == ( ccl::CRYPT_NONE | ccl::CRYPT_ACCURATE ) )
+			if( crypto == ccl::CRYPT_NONE )
 			{
 				// If there's no crypto, we must set depth to 0 otherwise bugs appear
 				film->set_cryptomatte_depth( 0 );
@@ -3659,7 +3638,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		string m_camera;
 		RenderState m_renderState;
 		bool m_outputsChanged;
-		bool m_cryptomatteAccurate;
 		int m_cryptomatteDepth;
 		std::optional<int> m_seed;
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -298,7 +298,7 @@ class CyclesOutput : public IECore::RefCounted
 
 	public :
 
-		CyclesOutput( const ccl::Session *session, const IECore::InternedString &name, const IECoreScene::Output *output )
+		CyclesOutput( const IECore::InternedString &name, const IECoreScene::Output *output )
 			: m_passType( ccl::PASS_NONE ), m_denoise( false ), m_interactive( false ), m_lightgroup( false )
 		{
 			m_parameters = output->parametersData()->copy();
@@ -2992,7 +2992,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				const auto coutput = m_outputs.find( name );
 				if( coutput == m_outputs.end() )
 				{
-					m_outputs[name] = new CyclesOutput( m_session, name, output );
+					m_outputs[name] = new CyclesOutput( name, output );
 					m_outputsChanged = true;
 				}
 			}

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -726,16 +726,6 @@ class ShaderCache : public IECore::RefCounted
 			m_shaderAssignPairs.push_back( shaderAssign );
 		}
 
-		bool hasOSLShader()
-		{
-			for( ccl::Shader *shader : m_scene->shaders )
-			{
-				if( IECoreCycles::ShaderNetworkAlgo::hasOSL( shader ) )
-					return true;
-			}
-			return false;
-		}
-
 		uint32_t numDefaultShaders()
 		{
 			return m_numDefaultShaders;
@@ -765,19 +755,6 @@ class ShaderCache : public IECore::RefCounted
 					//}
 				}
 			}
-		}
-
-		void removeOSLShaders()
-		{
-			ccl::set<ccl::Shader *> remove;
-			for( ccl::Shader *shader : m_scene->shaders )
-			{
-				if( IECoreCycles::ShaderNetworkAlgo::hasOSL( shader ) )
-				{
-					remove.insert( shader );
-				}
-			}
-			m_scene->delete_nodes( remove, m_scene );
 		}
 
 	private :
@@ -3290,22 +3267,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			{
 				//film->tag_update( m_scene );
 				integrator->tag_update( m_scene, ccl::Integrator::UPDATE_ALL );
-			}
-
-			// Check if an OSL shader exists & set the shadingsystem
-			if( m_sessionParams.shadingsystem == ccl::SHADINGSYSTEM_SVM && m_shaderCache->hasOSLShader() )
-			{
-				if( m_renderState != RENDERSTATE_RENDERING )
-				{
-					IECore::msg( IECore::Msg::Warning, "CyclesRenderer", "OSL Shader detected, forcing OSL shading-system (CPU-only)" );
-					m_sessionParams.shadingsystem = ccl::SHADINGSYSTEM_OSL;
-					m_sceneParams.shadingsystem = ccl::SHADINGSYSTEM_OSL;
-				}
-				else
-				{
-					IECore::msg( IECore::Msg::Error, "CyclesRenderer", "OSL Shader detected, this will cause problems in a running interactive render" );
-					m_shaderCache->removeOSLShaders();
-				}
 			}
 
 			// If anything changes in scene or session, we reset.

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2564,11 +2564,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 
 			init();
 
-			// CyclesOptions will set some values to these.
-			m_integrator = *(m_scene->integrator);
-			m_background = *(m_scene->background);
 			m_scene->background->set_transparent( true );
-			m_film = *(m_scene->film);
 
 			m_cameraCache = new CameraCache();
 			m_lightCache = new LightCache( m_scene );
@@ -3286,20 +3282,17 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			if( integrator->is_modified() )
 			{
 				integrator->tag_update( m_scene, ccl::Integrator::UPDATE_ALL );
-				m_integrator = *integrator;
 			}
 
 			if( background->is_modified() )
 			{
 				background->tag_update( m_scene );
-				m_background = *background;
 			}
 
 			if( film->is_modified() )
 			{
 				//film->tag_update( m_scene );
 				integrator->tag_update( m_scene, ccl::Integrator::UPDATE_ALL );
-				m_film = *film;
 			}
 
 			// Check if an OSL shader exists & set the shadingsystem
@@ -3558,20 +3551,24 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			m_scene->shaders.resize( m_shaderCache->numDefaultShaders() );
 			m_scene->lights.clear();
 
+			const ccl::Integrator integratorCopy = *m_scene->integrator;
+			const ccl::Background backgroundCopy = *m_scene->background;
+			const ccl::Film filmCopy = *m_scene->film;
+
 			init();
 
 			// Re-apply the settings for these.
 			for( const ccl::SocketType &socketType : m_scene->integrator->type->inputs )
 			{
-				m_scene->integrator->copy_value(socketType, m_integrator, *m_integrator.type->find_input( socketType.name ) );
+				m_scene->integrator->copy_value(socketType, integratorCopy, *integratorCopy.type->find_input( socketType.name ) );
 			}
 			for( const ccl::SocketType &socketType : m_scene->background->type->inputs )
 			{
-				m_scene->background->copy_value(socketType, m_background, *m_background.type->find_input( socketType.name ) );
+				m_scene->background->copy_value(socketType, backgroundCopy, *backgroundCopy.type->find_input( socketType.name ) );
 			}
 			for( const ccl::SocketType &socketType : m_scene->film->type->inputs )
 			{
-				m_scene->film->copy_value(socketType, m_film, *m_film.type->find_input( socketType.name ) );
+				m_scene->film->copy_value(socketType, filmCopy, *filmCopy.type->find_input( socketType.name ) );
 			}
 
 			m_scene->background->set_shader( m_scene->default_background );
@@ -3713,9 +3710,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		ccl::SceneParams m_sceneParams;
 		ccl::BufferParams m_bufferParams;
 		ccl::BufferParams m_bufferParamsModified;
-		ccl::Integrator m_integrator;
-		ccl::Background m_background;
-		ccl::Film m_film;
 
 		// Background shader
 		CyclesShaderPtr m_backgroundShader;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3655,6 +3655,10 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		AttributesCachePtr m_attributesCache;
 
 		// Nodes created to update to Cycles
+		/// \todo I don't see why these need to be state on the Renderer.
+		/// I think they could either be private data within `InstanceCache`
+		/// etc, or we could just stop deferring the addition of objects to
+		/// the `ccl::Scene`.
 		NodesCreated m_objectsCreated;
 		NodesCreated m_lightsCreated;
 		NodesCreated m_geometryCreated;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3208,9 +3208,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 
 			m_scene->camera->need_flags_update = true;
 			m_scene->camera->update( m_scene );
-
-			// Set a more sane default than the arbitrary 0.8f
-			m_scene->film->set_exposure( 1.0f );
 		}
 
 		void clearUnused()

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -459,11 +459,6 @@ BOOST_PYTHON_MODULE( _GafferCycles )
 	py::scope().attr( "lights" ) = getLights();
 	py::scope().attr( "passes" ) = getPasses();
 
-#ifdef WITH_CYCLES_TEXTURE_CACHE
-	py::scope().attr( "withTextureCache" ) = true;
-#else
-	py::scope().attr( "withTextureCache" ) = false;
-#endif
 	if( ccl::openimagedenoise_supported() )
 		py::scope().attr( "hasOpenImageDenoise" ) = true;
 	else


### PR DESCRIPTION
This simplifies the CyclesRenderer internals in preparation for refactoring the session reset code that has been causing so many problems. I've removed a bunch of redundant options and also some member variables that weren't necessary and which were making it harder to track the internal data dependencies. I'd like to get this reviewed separately so that a future session-reset-refactor PR can be focussed entirely on that topic, and not on this peripheral tidying.