### PR TITLE
`CyclesRenderer::option()` refactor

### DIFF
--- a/include/GafferCycles/IECoreCyclesPreview/SocketAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/SocketAlgo.h
@@ -81,6 +81,9 @@ IECORECYCLES_API void setRampSocket( ccl::Node *node, const ccl::SocketType *soc
 // ParamValue
 IECORECYCLES_API ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore::Data *value );
 
+IECORECYCLES_API IECore::DataPtr getSocket( const ccl::Node *node, const ccl::SocketType *socket );
+IECORECYCLES_API IECore::CompoundDataPtr getSockets( const ccl::Node *node );
+
 } // namespace SocketAlgo
 
 } // namespace IECoreCycles

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -257,14 +257,6 @@ T parameter( const IECore::CompoundDataMap &parameters, const IECore::InternedSt
 		CATEGORY.OPTION = data->readable(); } \
 	return; }
 
-#define OPTION_STR(CATEGORY, OPTIONNAME, OPTION) if( name == OPTIONNAME ) { \
-	if( value == nullptr ) { \
-		CATEGORY.OPTION = CATEGORY ## Default.OPTION; \
-		return; } \
-	if ( const StringData *data = reportedCast<const StringData>( value, "option", name ) ) { \
-		CATEGORY.OPTION = data->readable().c_str(); } \
-	return; }
-
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2594,10 +2594,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-			auto *integrator = m_scene->integrator;
-			auto *background = m_scene->background;
-			auto *film = m_scene->film;
-
 			// Error about options that cannot be set while interactive rendering.
 			if( m_renderState == RENDERSTATE_RENDERING )
 			{
@@ -2715,22 +2711,10 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 			else if( boost::starts_with( name.string(), "cycles:background:" ) )
 			{
-				const ccl::SocketType *input = background->node_type->find_input( ccl::ustring( name.string().c_str() + 18 ) );
-				if( value && input )
-				{
-					if( const Data *data = reportedCast<const Data>( value, "option", name ) )
-					{
-						SocketAlgo::setSocket( (ccl::Node*)background, input, data );
-					}
-					else
-					{
-						background->set_default_value( *input );
-					}
-				}
-				else if( input )
-				{
-					background->set_default_value( *input );
-				}
+				SocketAlgo::setSocket(
+					m_scene->background, name.string().c_str() + 18,
+					value ? reportedCast<const Data>( value, "option", name ) : nullptr
+				);
 				return;
 			}
 			else if( name == g_cryptomatteDepthOptionName )
@@ -2741,42 +2725,18 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			}
 			else if( boost::starts_with( name.string(), "cycles:film:" ) )
 			{
-				const ccl::SocketType *input = film->node_type->find_input( ccl::ustring( name.string().c_str() + 12 ) );
-				if( value && input )
-				{
-					if( const Data *data = reportedCast<const Data>( value, "option", name ) )
-					{
-						SocketAlgo::setSocket( (ccl::Node*)film, input, data );
-					}
-					else
-					{
-						film->set_default_value( *input );
-					}
-				}
-				else if( input )
-				{
-					film->set_default_value( *input );
-				}
+				SocketAlgo::setSocket(
+					m_scene->film, name.string().c_str() + 12,
+					value ? reportedCast<const Data>( value, "option", name ) : nullptr
+				);
 				return;
 			}
 			else if( boost::starts_with( name.string(), "cycles:integrator:" ) )
 			{
-				const ccl::SocketType *input = integrator->node_type->find_input( ccl::ustring( name.string().c_str() + 18 ) );
-				if( value && input )
-				{
-					if( const Data *data = reportedCast<const Data>( value, "option", name ) )
-					{
-						SocketAlgo::setSocket( (ccl::Node*)integrator, input, data );
-					}
-					else
-					{
-						integrator->set_default_value( *input );
-					}
-				}
-				else if( input )
-				{
-					integrator->set_default_value( *input );
-				}
+				SocketAlgo::setSocket(
+					m_scene->integrator, name.string().c_str() + 18,
+					value ? reportedCast<const Data>( value, "option", name ) : nullptr
+				);
 				return;
 			}
 			else if( boost::starts_with( name.string(), "cycles:" ) )

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -411,6 +411,12 @@ void setSocket( ccl::Node *node, const ccl::SocketType *socket, const IECore::Da
 	if( socket == nullptr )
 		return;
 
+	if( !value )
+	{
+		node->set_default_value( *socket );
+		return;
+	}
+
 	switch( socket->type )
 	{
 		case ccl::SocketType::BOOLEAN:

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -630,6 +630,43 @@ ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore:
 	}
 }
 
+IECore::DataPtr getSocket( const ccl::Node *node, const ccl::SocketType *socket )
+{
+	switch( socket->type )
+	{
+		case ccl::SocketType::BOOLEAN :
+			return new BoolData( node->get_bool( *socket ) );
+		case ccl::SocketType::INT :
+			return new IntData( node->get_int( *socket ) );
+		case ccl::SocketType::FLOAT :
+			return new FloatData( node->get_float( *socket ) );
+		case ccl::SocketType::ENUM :
+			return new StringData( node->get_string( *socket ).string() );
+		default :
+			IECore::msg(
+				IECore::Msg::Warning, "Cycles::SocketAlgo::getSocket",
+				fmt::format(
+					"Unsupported socket type `{}` for socket `{}` on node `{}`.",
+					ccl::SocketType::type_name( socket->type ), socket->name, node->name
+				)
+			);
+	}
+	return nullptr;
+}
+
+IECore::CompoundDataPtr getSockets( const ccl::Node *node )
+{
+	IECore::CompoundDataPtr result = new IECore::CompoundData;
+	for( const ccl::SocketType &socket : node->type->inputs )
+	{
+		if( DataPtr d = getSocket( node, &socket ) )
+		{
+			result->writable()[socket.name.c_str()] = d;
+		}
+	}
+	return result;
+}
+
 } // namespace SocketAlgo
 
 } // namespace IECoreCycles


### PR DESCRIPTION
Another bit of refactoring before taking on the session reset code. This removes a bunch of repetition from the `CyclesRenderer::option()` function and adds a bunch of test cases for the same. Could we one day reach the glorious point where we have more code in CyclesRendererTest.py than in CyclesRenderer.cpp?