### PR TITLE
FlatImageProcessor : Don't access input with invalid `image:viewName`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - 3Delight : Fixed startup errors on Windows when the `DELIGHT` environment variable wasn't defined [^1].
+- FlatImageProcessor : Fixed bug that could cause an input to be evaluated with an invalid `image:viewName`.
 
 Breaking Changes
 ----------------

--- a/src/GafferImage/FlatImageProcessor.cpp
+++ b/src/GafferImage/FlatImageProcessor.cpp
@@ -106,7 +106,10 @@ void FlatImageProcessor::hashDeep( const GafferImage::ImagePlug *parent, const G
 	{
 		// We need to append to the node hash, rather than just overriding with the upstream value,
 		// so that we can't reuse the plug value from upstream, and have to call compute()
-		h.append( inPlug()->deepPlug()->hash() );
+		if( ImageAlgo::viewIsValid( context, inPlug()->viewNames()->readable() ) )
+		{
+			h.append( inPlug()->deepPlug()->hash() );
+		}
 	}
 }
 
@@ -128,7 +131,10 @@ bool FlatImageProcessor::computeDeep( const Gaffer::Context *context, const Imag
 	}
 	else
 	{
-		if( inPlug()->deepPlug()->getValue() )
+		if(
+			ImageAlgo::viewIsValid( context, inPlug()->viewNames()->readable() ) &&
+			inPlug()->deepPlug()->getValue()
+		)
 		{
 			badInput = inPlug();
 		}


### PR DESCRIPTION
We were already performing this check for array inputs, but had omitted it for the single-input case.
