### PR TITLE
RenderPassEditor : Grouped display of render passes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,11 +5,16 @@ Improvements
 ------------
 
 - Viewer : Added <kbd>Ctrl</kbd>+<kbd>PgUp</kbd> shortcut for displaying the RGBA image layer (or the first available layer if RGBA doesn't exist).
+- RenderPassEditor :
+  - Added the ability to display render passes grouped in a hierarchy generated from the render pass name. The default grouping uses the first token delimited by "_" from the render pass name, such that render passes named "char_gafferBot" and "char_cow" would be displayed under a "/char" group, while "prop_ball" and "prop_box" would be displayed under a "/prop" group.
+  - Render pass grouping can be configured in a startup file by using `GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( f )`, where `f` is a function that receives a render pass name and returns the path that the render pass should be grouped under.
+  - Grouped display can be enabled by default in a startup file by using `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "displayGrouped", "userDefault", IECore.BoolData( True ) )`.
 
 API
 ---
 
 - ScenePath : Added automatic conversion of a list of Python strings to a ScenePath.
+- RenderPassEditor : Added `registerPathGroupingFunction()` method.
 
 1.3.12.0 (relative to 1.3.11.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -15,7 +15,7 @@ API
 ---
 
 - ScenePath : Added automatic conversion of a list of Python strings to a ScenePath.
-- RenderPassEditor : Added `registerPathGroupingFunction()` method.
+- RenderPassEditor : Added `registerPathGroupingFunction()` and `pathGroupingFunction()` methods.
 
 1.3.12.0 (relative to 1.3.11.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Viewer : Added <kbd>Ctrl</kbd>+<kbd>PgUp</kbd> shortcut for displaying the RGBA image layer (or the first available layer if RGBA doesn't exist).
 
+API
+---
+
+- ScenePath : Added automatic conversion of a list of Python strings to a ScenePath.
+
 1.3.12.0 (relative to 1.3.11.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Added the ability to display render passes grouped in a hierarchy generated from the render pass name. The default grouping uses the first token delimited by "_" from the render pass name, such that render passes named "char_gafferBot" and "char_cow" would be displayed under a "/char" group, while "prop_ball" and "prop_box" would be displayed under a "/prop" group.
   - Render pass grouping can be configured in a startup file by using `GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( f )`, where `f` is a function that receives a render pass name and returns the path that the render pass should be grouped under.
   - Grouped display can be enabled by default in a startup file by using `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "displayGrouped", "userDefault", IECore.BoolData( True ) )`.
+  - Dragging cells selected from the "Name" column now provides a list of the selected render pass names, rather than their paths.
 
 API
 ---

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -168,6 +168,20 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertRaises( TypeError, p["out"].boundHash, 10 )
 
+		self.assertEqual( p["out"].attributes( [ "plane" ] ), p["out"].attributes( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].transform( [ "plane" ] ), p["out"].transform( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].object( [ "plane" ] ), p["out"].object( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].bound( [ "plane" ] ), p["out"].bound( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].childNames( [ "plane" ] ), p["out"].childNames( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+
+		self.assertEqual( p["out"].attributesHash( [ "plane" ] ), p["out"].attributesHash( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].transformHash( [ "plane" ] ), p["out"].transformHash( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].objectHash( [ "plane" ] ), p["out"].objectHash( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].boundHash( [ "plane" ] ), p["out"].boundHash( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+		self.assertEqual( p["out"].childNamesHash( [ "plane" ] ), p["out"].childNamesHash( IECore.InternedStringVectorData( [ "plane" ] ) ) )
+
+		self.assertRaises( TypeError, p["out"].boundHash, [ 1 ] )
+
 	def testBoxPromotion( self ) :
 
 		b = Gaffer.Box()

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -153,6 +153,7 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
 			self.__pathListing.buttonPressSignal().connectFront( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
 			self.__pathListing.selectionChangedSignal().connect( Gaffer.WeakMethod( self.__selectionChanged ), scoped = False )
+			self.__pathListing.dragBeginSignal().connectFront( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
 
 			self.__settingsNode.plugSetSignal().connect( Gaffer.WeakMethod( self.__settingsPlugSet ), scoped = False )
 			self.__settingsNode.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__settingsPlugInputChanged ), scoped = False )
@@ -348,6 +349,13 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 					result.add( name )
 
 		return list( result )
+
+	def __dragBegin( self, widget, event ) :
+
+		# Return render pass names rather than the path when dragging the Name column.
+		selection = self.__pathListing.getSelection()[0]
+		if not selection.isEmpty() :
+			return IECore.StringVectorData( self.__selectedRenderPasses() )
 
 	def __setActiveRenderPass( self, pathListing ) :
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -199,6 +199,41 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 
 		section[columnKey] = inspectorFunction
 
+	__addRenderPassButtonMenuSignal = None
+	## This signal is emitted whenever the add render pass button is clicked.
+	# If the resulting menu definition has been populated with items,
+	# a popup menu will be presented from the button.
+	# If only a single item is present, its command will be called
+	# immediately instead of presenting a menu.
+	# If no items are present, then the default behaviour is to
+	# add a single new render pass with a user specified name.
+
+	@classmethod
+	def addRenderPassButtonMenuSignal( cls ) :
+
+		if cls.__addRenderPassButtonMenuSignal is None :
+			cls.__addRenderPassButtonMenuSignal = _AddButtonMenuSignal()
+
+		return cls.__addRenderPassButtonMenuSignal
+
+	## Registration of the function used to group render passes when
+	# `RenderPassEditor.Settings.displayGrouped` is enabled.
+	# 'f' should be a callable that takes a render pass name and returns
+	# a string or list of strings containing the path names that the
+	# render pass should be grouped under.
+	# For example: If "char_gafferBot_beauty" should be displayed grouped
+	# under `/char/gafferBot`, then `f( "char_gafferBot_beauty" )` should
+	# return `"/char/gafferBot" or `[ "char", "gafferBot" ]`.
+	@staticmethod
+	def registerPathGroupingFunction( f ) :
+
+		_GafferSceneUI._RenderPassEditor.RenderPassPath.registerPathGroupingFunction( f )
+
+	@staticmethod
+	def pathGroupingFunction() :
+
+		return _GafferSceneUI._RenderPassEditor.RenderPassPath.pathGroupingFunction()
+
 	def __repr__( self ) :
 
 		return "GafferSceneUI.RenderPassEditor( scriptNode )"
@@ -870,41 +905,6 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 
 		self.__addButton.setEnabled( editable )
 		self.__addButton.setToolTip( "Click to add render pass." if editable else "To add a render pass, first choose an editable Edit Scope." )
-
-	__addRenderPassButtonMenuSignal = None
-	## This signal is emitted whenever the add render pass button is clicked.
-	# If the resulting menu definition has been populated with items,
-	# a popup menu will be presented from the button.
-	# If only a single item is present, its command will be called
-	# immediately instead of presenting a menu.
-	# If no items are present, then the default behaviour is to
-	# add a single new render pass with a user specified name.
-
-	@classmethod
-	def addRenderPassButtonMenuSignal( cls ) :
-
-		if cls.__addRenderPassButtonMenuSignal is None :
-			cls.__addRenderPassButtonMenuSignal = _AddButtonMenuSignal()
-
-		return cls.__addRenderPassButtonMenuSignal
-
-	## Registration of the function used to group render passes when
-	# `RenderPassEditor.Settings.displayGrouped` is enabled.
-	# 'f' should be a callable that takes a render pass name and returns
-	# a string or list of strings containing the path names that the
-	# render pass should be grouped under.
-	# For example: If "char_gafferBot_beauty" should be displayed grouped
-	# under `/char/gafferBot`, then `f( "char_gafferBot_beauty" )` should
-	# return `"/char/gafferBot" or `[ "char", "gafferBot" ]`.
-	@staticmethod
-	def registerPathGroupingFunction( f ) :
-
-		_GafferSceneUI._RenderPassEditor.RenderPassPath.registerPathGroupingFunction( f )
-
-	@staticmethod
-	def pathGroupingFunction() :
-
-		return _GafferSceneUI._RenderPassEditor.RenderPassPath.pathGroupingFunction()
 
 GafferUI.Editor.registerType( "RenderPassEditor", RenderPassEditor )
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -842,6 +842,19 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 
 		return cls.__addRenderPassButtonMenuSignal
 
+	## Registration of the function used to group render passes when
+	# `RenderPassEditor.Settings.displayGrouped` is enabled.
+	# 'f' should be a callable that takes a render pass name and returns
+	# a string or list of strings containing the path names that the
+	# render pass should be grouped under.
+	# For example: If "char_gafferBot_beauty" should be displayed grouped
+	# under `/char/gafferBot`, then `f( "char_gafferBot_beauty" )` should
+	# return `"/char/gafferBot" or `[ "char", "gafferBot" ]`.
+	@staticmethod
+	def registerPathGroupingFunction( f ) :
+
+		_GafferSceneUI._RenderPassEditor.RenderPassPath.registerPathGroupingFunction( f )
+
 GafferUI.Editor.registerType( "RenderPassEditor", RenderPassEditor )
 
 ##########################################################################

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -206,6 +206,8 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 
 		# Register our grouping function and test a grouped path
 		GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( testFn )
+		self.assertEqual( testFn( "/char_bot_beauty" ), GafferSceneUI.RenderPassEditor.pathGroupingFunction()( "/char_bot_beauty" ) )
+
 		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], context, "/", grouped = True )
 
 		for parent, children in [

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -798,10 +798,17 @@ class DisabledRenderPassFilter : public Gaffer::PathFilter
 				leaf = std::all_of( c.begin(), c.end(), [this, canceller] ( const auto &p ) { return remove( p, canceller ); } );
 			}
 
-			bool enabled = true;
-			if( const auto enabledData = IECore::runTimeCast<const IECore::BoolData>( path->property( g_renderPassEnabledPropertyName, canceller ) ) )
+			bool enabled = false;
+			if( runTimeCast<const IECore::StringData>( path->property( g_renderPassNamePropertyName, canceller ) ) )
 			{
-				enabled = enabledData->readable();
+				if( const auto enabledData = IECore::runTimeCast<const IECore::BoolData>( path->property( g_renderPassEnabledPropertyName, canceller ) ) )
+				{
+					enabled = enabledData->readable();
+				}
+				else
+				{
+					enabled = true;
+				}
 			}
 
 			return leaf && !enabled;

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -126,6 +126,22 @@ void registerPathGroupingFunctionWrapper( object f )
 	registerPathGroupingFunction( PathGroupingFunctionWrapper( f ) );
 }
 
+string pathGroupingFunctionToString( const std::string &renderPassName )
+{
+	std::string result;
+	ScenePlug::pathToString( pathGroupingFunction()( renderPassName ), result );
+	return result;
+}
+
+object pathGroupingFunctionWrapper()
+{
+	return make_function(
+		pathGroupingFunctionToString,
+		default_call_policies(),
+		boost::mpl::vector<string, const string &>()
+	);
+}
+
 //////////////////////////////////////////////////////////////////////////
 // LRU cache of PathMatchers built from render passes
 //////////////////////////////////////////////////////////////////////////
@@ -864,6 +880,8 @@ void GafferSceneUIModule::bindRenderPassEditor()
 		.def( "getContext", (Context *(RenderPassPath::*)())&RenderPassPath::getContext, return_value_policy<CastToIntrusivePtr>() )
 		.def( "registerPathGroupingFunction", &registerPathGroupingFunctionWrapper )
 		.staticmethod( "registerPathGroupingFunction" )
+		.def( "pathGroupingFunction", &pathGroupingFunctionWrapper )
+		.staticmethod( "pathGroupingFunction" )
 	;
 
 	RefCountedClass<RenderPassNameColumn, GafferUI::PathColumn>( "RenderPassNameColumn" )

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -113,3 +113,11 @@ with IECore.IgnoredExceptions( ImportError ) :
 	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_transmission_depth", "Ray Depth", "Transmission" )
 	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_volume_depth", "Ray Depth", "Volume" )
 	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:auto_transparency_depth", "Ray Depth", "Transparency" )
+
+# Register the default grouping function used to display render passes in a hierarchy.
+# This groups render passes based on the first token in their name delimited by "_".
+def __defaultPathGroupingFunction( renderPassName ) :
+
+	return renderPassName.split( "_" )[0] if "_" in renderPassName else ""
+
+GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( __defaultPathGroupingFunction )


### PR DESCRIPTION
This adds the ability to optionally display render passes grouped into a hierarchy built from the names of each render pass. 

![renderPassEditorGrouping](https://github.com/GafferHQ/gaffer/assets/50844517/19eb324a-fc92-49e1-b629-5ed387de0933)

The default grouping configuration uses the first token of the render pass name, delimited by "_" such that "char_gafferBot" and "char_cow" would be grouped under "/char", and "prop_ball_shadow" would be grouped under "/prop". This grouping logic is configurable for specific workflows and naming conventions by registering a Python function via `GafferSceneUI.RenderPassEditor.registerPathGroupingFunction()`.

Selection is not currently maintained when switching between grouped and list views, do we think that important enough to include here?