### PR TITLE
OpenImageIOReader : Add `fileValid = False` metadata to missing frames

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.0.0b1)
 =======
 
+Improvements
+------------
+
+- ImageReader : Added `fileValid = False` metadata to images from missing frames, when `missingFrameMode` is `Black` or `Hold`.
+
 Fixes
 -----
 

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -294,7 +294,13 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		with context :
 			for i in range( 1000, 1006 ) :
 				context.setFrame( i )
-				self.assertEqual( reader["fileValid"].getValue(), i in ( 1001, 1002, 1004 ) )
+				fileValid = i in ( 1001, 1002, 1004 )
+				self.assertEqual( reader["fileValid"].getValue(), fileValid )
+				if fileValid :
+					self.assertNotIn( "fileValid", reader["out"].metadata() )
+				else :
+					with self.assertRaises( Gaffer.ProcessException ) :
+						reader["out"].metadata()
 
 		# test with frame mask set to hold with range 1001-1005
 		reader["start"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.ClampToFrame )
@@ -302,7 +308,13 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		with context :
 			for i in range( 1000, 1006 ) :
 				context.setFrame( i )
-				self.assertEqual( reader["fileValid"].getValue(), i in ( 1000, 1001, 1002, 1004 ) )
+				fileValid = i in ( 1000, 1001, 1002, 1004 )
+				self.assertEqual( reader["fileValid"].getValue(), fileValid )
+				if fileValid :
+					self.assertNotIn( "fileValid", reader["out"].metadata() )
+				else :
+					with self.assertRaises( Gaffer.ProcessException ) :
+						reader["out"].metadata()
 
 		# test with frame mask set to black with range 1001-1005
 		reader["start"]["mode"].setValue( GafferImage.ImageReader.FrameMaskMode.BlackOutside )
@@ -310,7 +322,29 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		with context :
 			for i in range( 1000, 1006 ) :
 				context.setFrame( i )
-				self.assertEqual( reader["fileValid"].getValue(), i in (1000, 1001, 1002, 1004) )
+				fileValid = i in ( 1000, 1001, 1002, 1004 )
+				self.assertEqual( reader["fileValid"].getValue(), fileValid )
+				if fileValid :
+					self.assertNotIn( "fileValid", reader["out"].metadata() )
+				else :
+					with self.assertRaises( Gaffer.ProcessException ) :
+						reader["out"].metadata()
+
+		# Test with `missingFrameMode == Hold` and `missingFrameMode == Black`
+
+		for mode in ( reader.MissingFrameMode.Hold, reader.MissingFrameMode.Black ) :
+
+			reader["missingFrameMode"].setValue( mode )
+			with context :
+				for i in range( 1000, 1006 ) :
+					context.setFrame( i )
+					fileValid = i in ( 1000, 1001, 1002, 1004 )
+					self.assertEqual( reader["fileValid"].getValue(), fileValid )
+					if fileValid :
+						self.assertNotIn( "fileValid", reader["out"].metadata() )
+					else :
+						self.assertIn( "fileValid", reader["out"].metadata() )
+						self.assertEqual( reader["out"].metadata()["fileValid"], IECore.BoolData( False ) )
 
 	def testFrameRangeMask( self ) :
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -372,30 +372,22 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		reader = GafferImage.OpenImageIOReader()
 		reader["fileName"].setValue( pathlib.Path( testSequence.fileName ) )
 
-		context = Gaffer.Context( Gaffer.Context.current() )
-
 		# get frame 1 data for comparison
-		context.setFrame( 1 )
-		with context :
-			f1Image = GafferImage.ImageAlgo.image( reader["out"] )
-			f1Format = reader["out"]["format"].getValue()
-			f1DataWindow = reader["out"]["dataWindow"].getValue()
-			f1Metadata = reader["out"]["metadata"].getValue()
-			f1ChannelNames = reader["out"]["channelNames"].getValue()
-			f1Tile = reader["out"].channelData( "R", imath.V2i( 0 ) )
+		frame1 = GafferImage.OpenImageIOReader()
+		frame1["fileName"].setValue( pathlib.Path( testSequence.fileNameForFrame( 1 ) ) )
 
 		# make sure the tile we're comparing isn't black
 		# so we can tell if MissingFrameMode::Black is working.
-		blackTile = IECore.FloatVectorData( [ 0 ] * GafferImage.ImagePlug.tileSize() * GafferImage.ImagePlug.tileSize() )
-		self.assertNotEqual( f1Tile, blackTile )
+		self.assertNotEqual( frame1["out"].channelData( "R", imath.V2i( 0 ) ), GafferImage.ImagePlug.blackTile() )
 
 		# set to a missing frame
+		context = Gaffer.Context( Gaffer.Context.current() )
 		context.setFrame( 2 )
 
 		# everything throws
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Error )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.tiles, reader["out"] )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
@@ -405,32 +397,20 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# everything matches frame 1
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), f1Image )
-			self.assertEqual( reader["out"]["format"].getValue(), f1Format )
-			self.assertEqual( reader["out"]["dataWindow"].getValue(), f1DataWindow )
-			self.assertEqual( reader["out"]["metadata"].getValue(), f1Metadata )
-			self.assertEqual( reader["out"]["channelNames"].getValue(), f1ChannelNames )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
+			self.assertImagesEqual( reader["out"], frame1["out"] )
 
 		# the windows match frame 1, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
-			self.assertNotEqual( GafferImage.ImageAlgo.image( reader["out"] ), f1Image )
-			self.assertEqual( reader["out"]["format"].getValue(), f1Format )
+			self.assertEqual( reader["out"]["format"].getValue(), frame1["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), GafferImage.ImagePlug.blackTile() )
 
 		# get frame 3 data for comparison
-		context.setFrame( 3 )
-		with context :
-			f3Image = GafferImage.ImageAlgo.image( reader["out"] )
-			f3Format = reader["out"]["format"].getValue()
-			f3DataWindow = reader["out"]["dataWindow"].getValue()
-			f3Metadata = reader["out"]["metadata"].getValue()
-			f3ChannelNames = reader["out"]["channelNames"].getValue()
-			f3Tile = reader["out"].channelData( "R", imath.V2i( 0 ) )
+		frame3 = GafferImage.OpenImageIOReader()
+		frame3["fileName"].setValue( pathlib.Path( testSequence.fileNameForFrame( 3 ) ) )
 
 		# set to a different missing frame
 		context.setFrame( 4 )
@@ -438,29 +418,16 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# everything matches frame 3
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertNotEqual( GafferImage.ImageAlgo.image( reader["out"] ), f1Image )
-			self.assertNotEqual( reader["out"]["format"].getValue(), f1Format )
-			self.assertNotEqual( reader["out"]["dataWindow"].getValue(), f1DataWindow )
-			self.assertNotEqual( reader["out"]["metadata"].getValue(), f1Metadata )
-			# same channel names is fine
-			self.assertEqual( reader["out"]["channelNames"].getValue(), f1ChannelNames )
-			self.assertNotEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
-			self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), f3Image )
-			self.assertEqual( reader["out"]["format"].getValue(), f3Format )
-			self.assertEqual( reader["out"]["dataWindow"].getValue(), f3DataWindow )
-			self.assertEqual( reader["out"]["metadata"].getValue(), f3Metadata )
-			self.assertEqual( reader["out"]["channelNames"].getValue(), f3ChannelNames )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f3Tile )
+			self.assertImagesEqual( reader["out"], frame3["out"] )
 
 		# the windows match frame 3, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
-			self.assertNotEqual( reader["out"]["format"].getValue(), f1Format )
-			self.assertEqual( reader["out"]["format"].getValue(), f3Format )
+			self.assertEqual( reader["out"]["format"].getValue(), frame3["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), GafferImage.ImagePlug.blackTile() )
 
 		# set to a missing frame before the start of the sequence
 		context.setFrame( 0 )
@@ -468,26 +435,22 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 		# everything matches frame 1
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertEqual( GafferImage.ImageAlgo.image( reader["out"] ), f1Image )
-			self.assertEqual( reader["out"]["format"].getValue(), f1Format )
-			self.assertEqual( reader["out"]["dataWindow"].getValue(), f1DataWindow )
-			self.assertEqual( reader["out"]["metadata"].getValue(), f1Metadata )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), f1Tile )
+			self.assertImagesEqual( reader["out"], frame1["out"] )
 
 		# the windows match frame 1, but everything else is default
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Black )
 		with context :
-			self.assertEqual( reader["out"]["format"].getValue(), f1Format )
+			self.assertEqual( reader["out"]["format"].getValue(), frame1["out"]["format"].getValue() )
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), GafferImage.ImagePlug.blackTile() )
 
 		# explicit fileNames do not support MissingFrameMode
-		reader["fileName"].setValue( testSequence.fileNameForFrame( 0 ) )
+		reader["fileName"].setValue( pathlib.Path( testSequence.fileNameForFrame( 0 ) ) )
 		reader["missingFrameMode"].setValue( GafferImage.OpenImageIOReader.MissingFrameMode.Hold )
 		with context :
-			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.image, reader["out"] )
+			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", GafferImage.ImageAlgo.tiles, reader["out"] )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["format"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["dataWindow"].getValue )
 			self.assertRaisesRegex( RuntimeError, ".*incompleteSequence.*.exr.*", reader["out"]["metadata"].getValue )
@@ -501,7 +464,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			self.assertEqual( reader["out"]["dataWindow"].getValue(), reader["out"]["dataWindow"].defaultValue() )
 			self.assertEqual( reader["out"]["metadata"].getValue(), reader["out"]["metadata"].defaultValue() )
 			self.assertEqual( reader["out"]["channelNames"].getValue(), reader["out"]["channelNames"].defaultValue() )
-			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), blackTile )
+			self.assertEqual( reader["out"].channelData( "R", imath.V2i( 0 ) ), GafferImage.ImagePlug.blackTile() )
 
 	def testHashesFrame( self ) :
 

--- a/python/GafferImageUI/ImageReaderUI.py
+++ b/python/GafferImageUI/ImageReaderUI.py
@@ -277,6 +277,10 @@ Gaffer.Metadata.registerNode(
 			value calculated per frame if an image sequence. Behaviour changes
 			if a frame mask of ClampToFrame or Black is selected, if outside
 			the frame mask fileValid will be set to True if the nearest frame is valid.
+
+			> Note : When the file is not valid, the image will also contain a `fileValid`
+			> metadata value of `False`. This can be easier to access from downstream
+			> nodes than the `fileValid` plug itself.
 			""",
 
 			"layout:section", "Frames",

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1088,6 +1088,14 @@ void metadataToImageSpecAttributes( const CompoundData *metadata, ImageSpec &spe
 			continue;
 		}
 
+		if( it->first == "fileValid" )
+		{
+			// Don't want to write `fileValid = False` into files! Dealt
+			// with separately from blacklist above because we don't need to
+			// emit a warning for it.
+			continue;
+		}
+
 		const IECoreImage::OpenImageIOAlgo::DataView dataView( it->second.get() );
 		if( dataView.data )
 		{


### PR DESCRIPTION
This is useful for determining downstream that an image has been replaced by `MissingFrameMode.Black` or `MissingFrameMode.Hold`. The plan is to use it to add a missing-frame check to a ContactSheet node I'm working on.

Not sure if I should add a namespace on the metadata name or not, and if so, what it should be - `gaffer:fileValid`?