### PR TITLE
RenderPassEditor : Dim foreground colour of disabled render passes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
   - Render pass grouping can be configured in a startup file by using `GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( f )`, where `f` is a function that receives a render pass name and returns the path that the render pass should be grouped under.
   - Grouped display can be enabled by default in a startup file by using `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "displayGrouped", "userDefault", IECore.BoolData( True ) )`.
   - Dragging cells selected from the "Name" column now provides a list of the selected render pass names, rather than their paths.
+  - Disabled render pass names are now dimmed to more clearly indicate their state.
 
 API
 ---

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -444,6 +444,7 @@ RenderPassPath::Ptr constructor2( ScenePlug &scene, Context &context, const std:
 ConstStringDataPtr g_disabledRenderPassIcon = new StringData( "disabledRenderPass.png" );
 ConstStringDataPtr g_renderPassIcon = new StringData( "renderPass.png" );
 ConstStringDataPtr g_renderPassFolderIcon = new StringData( "renderPassFolder.png" );
+const Color4fDataPtr g_dimmedForegroundColor = new Color4fData( Imath::Color4f( 152, 152, 152, 255 ) / 255.0f );
 
 class RenderPassNameColumn : public StandardPathColumn
 {
@@ -471,6 +472,7 @@ class RenderPassNameColumn : public StandardPathColumn
 				if( const auto renderPassEnabled = runTimeCast<const IECore::BoolData>( path.property( g_renderPassEnabledPropertyName, canceller ) ) )
 				{
 					result.icon = renderPassEnabled->readable() ? g_renderPassIcon : g_disabledRenderPassIcon;
+					result.foreground = renderPassEnabled->readable() ? nullptr : g_dimmedForegroundColor;
 				}
 				else
 				{


### PR DESCRIPTION
This improves identification of disabled render passes.

![dimmedDisabledRenderPassNames](https://github.com/GafferHQ/gaffer/assets/50844517/e617becb-eae8-49dd-9a3c-64b1d3f29dd9)