### PR TITLE
Cycles Renderer : Defer creation of session until last point possible

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,9 @@ Fixes
 -----
 
 - Tractor : Fixed failure to import Tractor API [^1].
+- Cycles :
+  - Fixed hangs and crashes when using non-default session modes such as SVM shading.
+  - Fixed failure to render background light in batch renders (#5234).
 
 [^1]: To be omitted from final release notes for 1.4.0.0.
 

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - Cycles :
   - Fixed hangs and crashes when using non-default session modes such as SVM shading.
   - Fixed failure to render background light in batch renders (#5234).
+  - Fixed failure to update when reverting a background shader to previous values.
 
 [^1]: To be omitted from final release notes for 1.4.0.0.
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,11 @@ Fixes
   - Fixed failure to render background light in batch renders (#5234).
   - Fixed failure to update when reverting a background shader to previous values.
 
+Breaking Changes
+----------------
+
+- CyclesOptions : Changed `hairShape` default value to "ribbon", to match Cycles' and Blender's own defaults.
+
 [^1]: To be omitted from final release notes for 1.4.0.0.
 
 1.4.0.0b2 (relative to 1.4.0.0b1)

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -83,8 +83,8 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 
 				CapturedAttributes( const IECore::ConstCompoundObjectPtr &attributes );
 
-				int uneditableAttributeValue() const;
-				bool unrenderableAttributeValue() const;
+				static int uneditableAttributeValue( const CapturedAttributes *attributes );
+				static bool unrenderableAttributeValue( const CapturedAttributes *attributes );
 
 				friend class CapturingRenderer;
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -168,6 +168,14 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		///
 		/// Currently all ObjectInterfaces _must_ be destroyed prior to destruction
 		/// of the renderer itself.
+		///
+		/// \todo Having methods on ObjectInterface has turned out to make the API harder
+		/// to implement for many renderers, because each ObjectInterface needs to have
+		/// access to some central state that more naturally belongs in the renderer.
+		/// Consider making ObjectInterface into just an opaque handle, and then moving
+		/// the edit methods to Renderer like so :
+		///
+		/// `bool Renderer::editAttributes( ObjectInterface *object, const AttributesInterface *attributes )`
 		class GAFFERSCENE_API ObjectInterface : public IECore::RefCounted
 		{
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -259,12 +259,12 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// times passed to motionBegin() to specify motion blur. Defaults to 0,0 if unspecified.
 		///
 		/// May return a nullptr if the camera definition is not supported by the renderer.
-		virtual ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) = 0;
+		virtual ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes = nullptr ) = 0;
 		/// As above, but allowing animated camera parameters to be specified. A default implementation
 		/// that calls `camera( name, samples[0], attributes )` is provided for renderers which don't
 		/// support animated cameras. Renderers that do support animated cameras should implement a suitable
 		/// override.
-		virtual ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes );
+		virtual ObjectInterfacePtr camera( const std::string &name, const std::vector<const IECoreScene::Camera *> &samples, const std::vector<float> &times, const AttributesInterface *attributes = nullptr );
 
 		/// Adds a named light with the initially supplied set of attributes, which are expected
 		/// to provide at least a light shader. Object may be non-null to specify arbitrary geometry

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -2227,24 +2227,7 @@ class RendererTest( GafferTest.TestCase ) :
 					GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
 				)
 
-				renderer.output(
-					"testOutput",
-					IECoreScene.Output(
-						"test",
-						"ieDisplay",
-						"rgba",
-						{
-							"driverType" : "ImageDisplayDriver",
-							"handle" : "testThreads",
-						}
-					)
-				)
-
 				renderer.option( "cycles:session:threads", IECore.IntData( threads ) )
-				## \todo We currently need to do a render for the threads value to
-				# be flushed into the session params. But in future we should be able
-				# to remove that.
-				renderer.render()
 				self.assertEqual( renderer.command( "cycles:querySession", {} )["threads"].value, expectedThreads )
 
 	def testDevices( self ) :
@@ -2263,19 +2246,6 @@ class RendererTest( GafferTest.TestCase ) :
 					GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
 				)
 
-				renderer.output(
-					"testOutput",
-					IECoreScene.Output(
-						"test",
-						"ieDisplay",
-						"rgba",
-						{
-							"driverType" : "ImageDisplayDriver",
-							"handle" : "testThreads",
-						}
-					)
-				)
-
 				# Ideally we want clients to emit all options before doing anything else,
 				# to simplify our internal session management. But certain important clients
 				# (SceneGadget, RenderController, I'm looking at you) like to create a camera
@@ -2285,10 +2255,6 @@ class RendererTest( GafferTest.TestCase ) :
 
 				renderer.option( "cycles:shadingsystem", IECore.StringData( "SVM" ) )
 				renderer.option( "cycles:device", IECore.StringData( f"{deviceType}:{typeIndex:02d}" ) )
-				## \todo We currently need to do a render for the device to
-				# be flushed into the session params. But in future we should be
-				# able to remove that.
-				renderer.render()
 				self.assertEqual( renderer.command( "cycles:querySession", {} )["device"].value, device["id"] )
 
 	def testExposureEdit( self ) :

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -2078,22 +2078,28 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
+		with IECore.CapturingMessageHandler() as mh :
+			attributes = renderer.attributes( IECore.CompoundObject ( {
+					"cycles:surface" : IECoreScene.ShaderNetwork(
+						shaders = {
+							"output" : IECoreScene.Shader(
+								"Surface/Constant", "osl:shader",
+								{ "Cs" : imath.Color3f( 0, 1, 0 ) }
+							),
+						},
+						output = "output",
+					)
+				} ) )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, """Couldn't load OSL shader "Surface/Constant" as the shading system is not set to OSL.""" )
+
 		plane = renderer.object(
 			"/plane",
 			IECoreScene.MeshPrimitive.createPlane(
 				imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ),
 			),
-			renderer.attributes( IECore.CompoundObject ( {
-				"cycles:surface" : IECoreScene.ShaderNetwork(
-					shaders = {
-						"output" : IECoreScene.Shader(
-							"Surface/Constant", "osl:shader",
-							{ "Cs" : imath.Color3f( 0, 1, 0 ) }
-						),
-					},
-					output = "output",
-				)
-			} ) )
+			attributes
 		)
 		## \todo Default camera is facing down +ve Z but should be facing
 		# down -ve Z.

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -2209,8 +2209,23 @@ class RendererTest( GafferTest.TestCase ) :
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
 		)
 
+		renderer.output(
+			"testOutput",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testUnknownOptions",
+				}
+			)
+		)
+
 		with IECore.CapturingMessageHandler() as mh :
 			renderer.option( "cycles:invalid", IECore.IntData( 10 ) )
+			renderer.option( "someOtherRenderer:unknown", IECore.IntData( 10 ) )
+			renderer.render()
 
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
@@ -2356,6 +2371,8 @@ class RendererTest( GafferTest.TestCase ) :
 			renderer.pause()
 			renderer.option( "cycles:session:threads", IECore.IntData( 2 ) )
 			renderer.render()
+
+		self.assertEqual( renderer.command( "cycles:querySession", {} )["threads"].value, 1 )
 
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].context, "CyclesRenderer::option" )

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -420,7 +420,7 @@ class RendererTest( GafferTest.TestCase ) :
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
 		)
 
-		camera = renderer.camera( "test", IECoreScene.Camera(), renderer.attributes( IECore.CompoundObject() ) )
+		camera = renderer.camera( "test", IECoreScene.Camera() )
 
 		# Edit should succeed.
 		self.assertTrue( camera.attributes(
@@ -443,8 +443,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"resolution" : imath.V2i( 2000, 1000 ),
 					"cropWindow" : imath.Box2f( imath.V2f( 0.25 ), imath.V2f( 0.75 ) ),
 				}
-			),
-			renderer.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		renderer.output(
@@ -490,8 +489,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"resolution" : imath.V2i( 2000, 1000 ),
 					"cropWindow" : imath.Box2f( imath.V2f( 0.25 ), imath.V2f( 0.75 ) ),
 				}
-			),
-			renderer.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		fileName = self.temporaryDirectory() / "test.exr"
@@ -713,8 +711,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"projection" : "orthographic",
 					"screenWindow" : imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) )
 				}
-			),
-			renderer.attributes( IECore.CompoundObject() )
+			)
 		)
 		renderer.option( "camera", IECore.StringData( "testCamera" ) )
 
@@ -1259,8 +1256,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"projection" : "orthographic",
 					"screenWindow" : imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) )
 				}
-			),
-			renderer.attributes( IECore.CompoundObject() )
+			)
 		)
 		renderer.option( "camera", IECore.StringData( "testCamera" ) )
 
@@ -1679,8 +1675,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"projection" : "orthographic",
 					"screenWindow" : imath.Box2f( imath.V2f( -0.5 ), imath.V2f( 0.5 ) )
 				}
-			),
-			renderer.attributes( IECore.CompoundObject() )
+			)
 		)
 		renderer.option( "camera", IECore.StringData( "testCamera" ) )
 

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -210,7 +210,12 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		for objectName in capturingRenderer.capturedObjectNames():
 			co = capturingRenderer.capturedObject( objectName )
 			linkDict = { str(t) : [ i.capturedName() for i in co.capturedLinks( t ) or [] ] for t in co.capturedLinkTypes() }
-			capturedObject = CapturingRendererTest.__ExpandedCapture( co.capturedSamples(), co.capturedSampleTimes(), co.capturedTransforms(), co.capturedTransformTimes(), co.capturedAttributes().attributes(), linkDict )
+			capturedObject = CapturingRendererTest.__ExpandedCapture(
+				co.capturedSamples(), co.capturedSampleTimes(),
+				co.capturedTransforms(), co.capturedTransformTimes(),
+				co.capturedAttributes().attributes() if co.capturedAttributes() else None,
+				linkDict
+			)
 
 
 			isProcedural = isinstance( capturedObject.capturedSamples[0], GafferScene.Private.IECoreScenePreview.Procedural )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -112,8 +112,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"resolution" : imath.V2i( 2000, 1000 ),
 					"cropWindow" : imath.Box2f( imath.V2f( 0 ), imath.V2f( 1, 0.75 ) ),
 				}
-			),
-			r.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		r.option( "camera", IECore.StringData( "testCamera" ) )
@@ -810,8 +809,7 @@ class RendererTest( GafferTest.TestCase ) :
 					parameters = {
 						"projection" : "orthographic"
 					}
-				),
-				r.attributes( IECore.CompoundObject() )
+				)
 			)
 			c.transform( imath.M44f().translate( imath.V3f( i, 0, 0 ) ) )
 
@@ -877,8 +875,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"projection" : "uv_camera",
 					"mesh" : "testPlane"
 				}
-			),
-			r.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		r.option( "camera", IECore.StringData( "testCamera" ) )
@@ -2861,8 +2858,7 @@ class RendererTest( GafferTest.TestCase ) :
 				parameters = {
 					"projection" : "orthographic"
 				}
-			),
-			r.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		r.output(
@@ -3588,8 +3584,7 @@ class RendererTest( GafferTest.TestCase ) :
 				parameters = {
 					"shutter" : imath.V2f( 10.75, 11.25 )
 				}
-			),
-			r.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		r.object( "test_vdb", IECoreVDB.VDBObject(), r.attributes( attributes ) )
@@ -3752,8 +3747,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.camera(
 			"testCamera",
-			[ c1, c2 ], [ 1, 2 ],
-			r.attributes( IECore.CompoundObject() ),
+			[ c1, c2 ], [ 1, 2 ]
 		)
 
 		r.render()
@@ -4285,9 +4279,8 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
-		cameraAttributes = renderer.attributes( IECore.CompoundObject() )
-		camera1 = renderer.camera( "/camera1", IECoreScene.Camera(), cameraAttributes )
-		camera2 = renderer.camera( "/camera2", IECoreScene.Camera(), cameraAttributes )
+		camera1 = renderer.camera( "/camera1", IECoreScene.Camera() )
+		camera2 = renderer.camera( "/camera2", IECoreScene.Camera() )
 
 		# Render a plane with a camera projection referencing the
 		# camera by name.
@@ -4360,7 +4353,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		renderer.pause()
 		del camera1
-		camera1 = renderer.camera( "/camera1", IECoreScene.Camera(), cameraAttributes )
+		camera1 = renderer.camera( "/camera1", IECoreScene.Camera() )
 		renderer.render()
 		assertCameraParameter( renderer, "/camera1" )
 
@@ -4382,7 +4375,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.render()
 		assertCameraParameter( renderer, "/camera1" )
 
-		del camera1, cameraAttributes, plane
+		del camera1, plane
 		del renderer
 
 	def testBatchNodeParameters( self ) :
@@ -4395,7 +4388,7 @@ class RendererTest( GafferTest.TestCase ) :
 			str( self.temporaryDirectory() / "test.ass" )
 		)
 
-		renderer.camera( "/camera", IECoreScene.Camera(), renderer.attributes( IECore.CompoundObject() ) )
+		renderer.camera( "/camera", IECoreScene.Camera() )
 
 		shaderNetwork = IECoreScene.ShaderNetwork(
 			shaders = {

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -504,8 +504,7 @@ class RendererTest( GafferTest.TestCase ) :
 					"overscanLeft" : 0.1,
 					"overscanRight" : 0.2,
 				}
-			),
-			r.attributes( IECore.CompoundObject() )
+			)
 		)
 
 		r.option( "camera", IECore.StringData( "testCamera" ) )

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -76,7 +76,7 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:use_bvh_unaligned_nodes", new IECore::BoolData( true ), false, "useBvhUnalignedNodes" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:num_bvh_time_steps", new IECore::IntData( 0 ), false, "numBvhTimeSteps" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:hair_subdivisions", new IECore::IntData( 3 ), false, "hairSubdivisions" ) );
-	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:hair_shape", new IECore::StringData( "thick" ), false, "hairShape" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:hair_shape", new IECore::StringData( "ribbon" ), false, "hairShape" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:scene:texture_limit", new IECore::IntData( 0 ), false, "textureLimit" ) );
 
 	// Integrator

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2819,7 +2819,10 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			m_cameras[name] = camera;
 
 			ObjectInterfacePtr result = new CyclesCamera( ccamera );
-			result->attributes( attributes );
+			if( attributes )
+			{
+				result->attributes( attributes );
+			}
 			return result;
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2854,7 +2854,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		{
 			ccl::SceneParams params = defaultSceneParams( m_renderType );
 			params.bvh_layout = nameToBvhLayoutEnum( optionValue<string>( g_bvhLayoutOptionName, "auto", modified ) );
-			params.hair_shape = nameToCurveShapeTypeEnum( optionValue<string>( g_hairShapeOptionName, "thick", modified ) );
+			params.hair_shape = nameToCurveShapeTypeEnum( optionValue<string>( g_hairShapeOptionName, "ribbon", modified ) );
 			params.use_bvh_spatial_split = optionValue<bool>( g_useBvhSpatialSplitOptionName, params.use_bvh_spatial_split, modified );
 			params.use_bvh_unaligned_nodes = optionValue<bool>( g_useBvhUnalignedNodesOptionName, params.use_bvh_unaligned_nodes, modified );
 			params.num_bvh_time_steps = optionValue<int>( g_numBvhTimeStepsOptionName, params.num_bvh_time_steps, modified );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3059,8 +3059,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				}
 			}
 
-			ccl::Film *film = m_scene->film;
-
 			m_session->set_samples( m_sessionParams.samples );
 
 			if( m_backgroundShader )
@@ -3084,12 +3082,6 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			if( background->is_modified() )
 			{
 				background->tag_update( m_scene );
-			}
-
-			if( film->is_modified() )
-			{
-				//film->tag_update( m_scene );
-				integrator->tag_update( m_scene, ccl::Integrator::UPDATE_ALL );
 			}
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -795,8 +795,6 @@ class ShaderCache : public IECore::RefCounted
 					shaders.push_back( shader );
 				}
 				m_scene->shader_manager->tag_update( m_scene, ccl::ShaderManager::SHADER_ADDED );
-				// TODO: Optimise
-				m_scene->background->tag_update( m_scene );
 			}
 			nodes.clear();
 		}

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -722,32 +722,6 @@ class ShaderCache : public IECore::RefCounted
 			return m_numDefaultShaders;
 		}
 
-		void flushTextures()
-		{
-			for( ccl::Shader *shader : m_scene->shaders )
-			{
-				for( ccl::ShaderNode *node : shader->graph->nodes )
-				{
-					if( node->special_type == ccl::SHADER_SPECIAL_TYPE_IMAGE_SLOT )
-					{
-						static_cast<ccl::ImageSlotTextureNode*>( node )->handle.clear();
-					}
-					else if( node->type == ccl::SkyTextureNode::get_node_type() )
-					{
-						static_cast<ccl::SkyTextureNode*>( node )->handle.clear();
-					}
-					else if( node->type == ccl::PointDensityTextureNode::get_node_type() )
-					{
-						static_cast<ccl::PointDensityTextureNode*>( node )->handle.clear();
-					}
-					//else if( node->type == ccl::VolumeTextureNode::get_node_type() )
-					//{
-					//	static_cast<ccl::VolumeTextureNode*>( node )->handle.clear();
-					//}
-				}
-			}
-		}
-
 	private :
 
 		void updateShaders( NodesCreated &nodes )

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -756,7 +756,6 @@ class OpenGLCamera : public OpenGLObject
 	private :
 
 		IECoreGL::CameraPtr m_camera;
-		ConstOpenGLAttributesPtr m_attributes;
 		V2i m_resolution;
 
 };

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -923,7 +923,14 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 		{
 			IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
-			OpenGLCameraPtr result = new OpenGLCamera( name, camera, static_cast<const OpenGLAttributes *>( attributes ), m_editQueue );
+			ConstOpenGLAttributesPtr openGLAttributes = static_cast<const OpenGLAttributes *>( attributes );
+			if( !openGLAttributes )
+			{
+				ConstCompoundObjectPtr emptyAttributes = new CompoundObject;
+				openGLAttributes = new OpenGLAttributes( emptyAttributes.get() );
+			}
+
+			OpenGLCameraPtr result = new OpenGLCamera( name, camera, openGLAttributes, m_editQueue );
 			m_editQueue.push( [this, result, name]() {
 				m_objects.push_back( result );
 				m_cameras[name] = result;

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -148,7 +148,7 @@ Renderer::ObjectInterfacePtr CapturingRenderer::object( const std::string &name,
 
 	// To facilitate the testing of code that handles the return from the various object methods of
 	// a renderer, we return null if the `cr:unrenderable` attribute is set to true.
-	if( static_cast<const CapturedAttributes *>( attributes )->unrenderableAttributeValue() )
+	if( CapturedAttributes::unrenderableAttributeValue( static_cast<const CapturedAttributes *>( attributes ) ) )
 	{
 		return nullptr;
 	}
@@ -221,15 +221,15 @@ const IECore::CompoundObject *CapturingRenderer::CapturedAttributes::attributes(
 	return m_attributes.get();
 }
 
-int CapturingRenderer::CapturedAttributes::uneditableAttributeValue() const
+int CapturingRenderer::CapturedAttributes::uneditableAttributeValue( const CapturedAttributes *attributes )
 {
-	auto *data = m_attributes->member<IntData>( "cr:uneditable" );
+	auto *data = attributes ? attributes->m_attributes->member<IntData>( "cr:uneditable" ) : nullptr;
 	return data ? data->readable() : 0;
 }
 
-bool CapturingRenderer::CapturedAttributes::unrenderableAttributeValue() const
+bool CapturingRenderer::CapturedAttributes::unrenderableAttributeValue( const CapturedAttributes *attributes )
 {
-	auto *data = m_attributes->member<BoolData>( "cr:unrenderable" );
+	auto *data = attributes ? attributes->m_attributes->member<BoolData>( "cr:unrenderable" ) : nullptr;
 	return data && data->readable();
 }
 
@@ -344,12 +344,12 @@ bool CapturingRenderer::CapturedObject::attributes( const AttributesInterface *a
 	m_renderer->checkPaused();
 
 	auto capturedAttributes = static_cast<const CapturedAttributes *>( attributes );
-	if( capturedAttributes->unrenderableAttributeValue() )
+	if( CapturedAttributes::unrenderableAttributeValue( capturedAttributes ) )
 	{
 		return false;
 	}
 
-	if( m_capturedAttributes && m_capturedAttributes->uneditableAttributeValue() != capturedAttributes->uneditableAttributeValue() )
+	if( m_numAttributeEdits && CapturedAttributes::uneditableAttributeValue( m_capturedAttributes.get() ) != CapturedAttributes::uneditableAttributeValue( capturedAttributes ) )
 	{
 		return false;
 	}

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -200,7 +200,7 @@ Renderer::ObjectInterfacePtr CompoundRenderer::camera( const std::string &name, 
 	CompoundObjectInterfacePtr result = new CompoundObjectInterface;
 	for( size_t i = 0; i < m_renderers.size(); ++i )
 	{
-		result->objects[i] = m_renderers[i]->camera( name, camera, compoundAttributes->attributes[i].get() );
+		result->objects[i] = m_renderers[i]->camera( name, camera, compoundAttributes ? compoundAttributes->attributes[i].get() : nullptr );
 	}
 	return result;
 }

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1361,9 +1361,6 @@ RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer
 		m_lightLinks = std::make_unique<LightLinks>();
 	}
 
-	IECore::CompoundObjectPtr defaultAttributes = new CompoundObject();
-	m_defaultAttributes = m_renderer->attributes( defaultAttributes.get() );
-
 	setScene( scene );
 	setContext( context );
 }
@@ -1685,6 +1682,12 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 		m_dirtyGlobalComponents = NoGlobalComponent;
 
 		// Update scene graphs
+
+		if( !m_defaultAttributes )
+		{
+			IECore::CompoundObjectPtr defaultAttributes = new CompoundObject();
+			m_defaultAttributes = m_renderer->attributes( defaultAttributes.get() );
+		}
 
 		for( int i = SceneGraph::FirstType; i <= SceneGraph::LastType; ++i )
 		{

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1786,9 +1786,8 @@ void RenderController::updateDefaultCamera()
 
 	CameraPtr defaultCamera = new IECoreScene::Camera;
 	SceneAlgo::applyCameraGlobals( defaultCamera.get(), m_renderOptions.globals.get(), m_scene.get() );
-	IECoreScenePreview::Renderer::AttributesInterfacePtr defaultAttributes = m_renderer->attributes( m_scene->attributesPlug()->defaultValue() );
 	ConstStringDataPtr name = new StringData( "gaffer:defaultCamera" );
-	m_defaultCamera = m_renderer->camera( name->readable(), defaultCamera.get(), defaultAttributes.get() );
+	m_defaultCamera = m_renderer->camera( name->readable(), defaultCamera.get() );
 	m_renderer->option( "camera", name.get() );
 }
 

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -536,8 +536,8 @@ void GafferSceneModule::bindRender()
 
 			.def( "attributes", &Renderer::attributes )
 
-			.def( "camera", &rendererCamera1 )
-			.def( "camera", &rendererCamera2 )
+			.def( "camera", &rendererCamera2, ( arg( "name" ), arg( "samples" ), arg( "times" ), arg( "attributes" ) = object() ) )
+			.def( "camera", &rendererCamera1, ( arg( "name" ), arg( "camera" ), arg( "attributes" ) = object() ) )
 			.def( "light", &Renderer::light )
 			.def( "lightFilter", &Renderer::lightFilter )
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -177,7 +177,6 @@ namespace
 {
 
 const ConstStringDataPtr g_cameraName = new StringData( "/__sceneGadget:camera" );
-const ConstCompoundObjectPtr g_emptyCompoundObject = new CompoundObject();
 const IECore::StringDataPtr g_sceneColorSpace = new StringData( "scene" );
 const IECore::StringDataPtr g_displayColorSpace = new StringData( "display" );
 
@@ -1001,12 +1000,11 @@ void SceneGadget::updateCamera( GafferUI::ViewportGadget::CameraFlags changes )
 	cancelUpdateAndPauseRenderer();
 
 	const ViewportGadget *viewport = ancestor<ViewportGadget>();
-	IECoreScenePreview::Renderer::AttributesInterfacePtr cameraAttributes = m_renderer->attributes( g_emptyCompoundObject.get() );
 
 	if( !m_camera || static_cast<bool>( changes & ViewportGadget::CameraFlags::Camera ) )
 	{
 		m_camera.reset();
-		m_camera = m_renderer->camera( g_cameraName->readable(), viewport->getCamera().get(), cameraAttributes.get() );
+		m_camera = m_renderer->camera( g_cameraName->readable(), viewport->getCamera().get() );
 		changes |= ViewportGadget::CameraFlags::Transform;
 	}
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2149,7 +2149,7 @@ class InstanceCache : public IECore::RefCounted
 		{
 			const ArnoldAttributes *arnoldAttributes = static_cast<const ArnoldAttributes *>( attributes );
 
-			if( !arnoldAttributes->canInstanceGeometry( object ) )
+			if( !arnoldAttributes || !arnoldAttributes->canInstanceGeometry( object ) )
 			{
 				return Instance( convert( object, arnoldAttributes, nodeName ) );
 			}
@@ -2292,7 +2292,10 @@ class InstanceCache : public IECore::RefCounted
 				return SharedAtNodePtr();
 			}
 
-			attributes->applyGeometry( object, node );
+			if( attributes )
+			{
+				attributes->applyGeometry( object, node );
+			}
 
 			return SharedAtNodePtr( node, m_nodeDeleter );
 		}
@@ -2315,7 +2318,10 @@ class InstanceCache : public IECore::RefCounted
 				return SharedAtNodePtr();
 			}
 
-			attributes->applyGeometry( samples.front(), node );
+			if( attributes )
+			{
+				attributes->applyGeometry( samples.front(), node );
+			}
 
 			return SharedAtNodePtr( node, m_nodeDeleter );
 
@@ -4249,7 +4255,10 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::st
 	Instance instance = m_instanceCache->get( camera, attributes, name );
 
 	ObjectInterfacePtr result = new ArnoldObject( instance );
-	result->attributes( attributes );
+	if( attributes )
+	{
+		result->attributes( attributes );
+	}
 	return result;
 }
 
@@ -4260,7 +4269,10 @@ ArnoldRendererBase::ObjectInterfacePtr ArnoldRendererBase::camera( const std::st
 	Instance instance = m_instanceCache->get( vector<const IECore::Object *>( samples.begin(), samples.end() ), times, attributes, name );
 
 	ObjectInterfacePtr result = new ArnoldObject( instance );
-	result->attributes( attributes );
+	if( attributes )
+	{
+		result->attributes( attributes );
+	}
 	return result;
 }
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1417,7 +1417,10 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 				cameraHandle,
 				ownership()
 			);
-			result->attributes( attributes );
+			if( attributes )
+			{
+				result->attributes( attributes );
+			}
 			return result;
 		}
 


### PR DESCRIPTION
This is an alternate take on #5101, whereby we _never_ recreate the Cycles session, even if rendering hasn't started yet. Like #5101, this fixes hangs on Windows and problems rendering background lights in batch mode. But unlike #5101, it guarantees that we can't accidentally create Cycles objects containing pointers to the wrong scene or session - which as Alex [notes](https://github.com/GafferHQ/gaffer/pull/5101#issuecomment-1615656335) can at the very least cause assertion failures in debug builds (and which I suspect could also cause crashes in production builds).

My goal was to guarantee that we never _ever_ recreated a session, while also not requiring any changes to the Renderer API or clients. I didn't _quite_ succeed in the latter - see a47586d9833ef2630d478e16b196725bc6ac2155 and 6c3bc4a1f68e13af69c25dec919a1d7ab989f80d, but it's close enough to be practical I think. I also noted an approach that might improve things in the future in e9d1f5227367670ff0f39e36100bdb0f7ab5a82d.

Although things aren't quite as simple as I'd have liked, in conjunction with #5696 this does leave us with ~300 lines less in `Renderer.cpp` and with ~500 lines more in `RendererTest.py`, which I think demonstrates that we're going in a reasonable direction overall.