### PR TITLE
Offset Widget click line by 0.5 pixel

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - ScenePath : Added automatic conversion of a list of Python strings to a ScenePath [^1].
 - RenderPassEditor : Added `registerPathGroupingFunction()` and `pathGroupingFunction()` methods [^1].
 - ExtensionAlgo : Added `exportNode()` and `exportNodeUI()` functions.
+- Widget : Added a 0.5 pixel offset to `ButtonEvent.line` objects passed to mouse event signals such as `buttonPressSignal()` and `dragMoveSignal()`
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1656,8 +1656,8 @@ class _EventFilter( QtCore.QObject ) :
 		cursorPos -= targetWidget.bound().min()
 
 		return IECore.LineSegment3f(
-			imath.V3f( cursorPos.x, cursorPos.y, 1 ),
-			imath.V3f( cursorPos.x, cursorPos.y, 0 )
+			imath.V3f( cursorPos.x + 0.5, cursorPos.y + 0.5, 1 ),
+			imath.V3f( cursorPos.x + 0.5, cursorPos.y + 0.5, 0 )
 		)
 
 # this single instance is used by all widgets

--- a/python/GafferUITest/WidgetTest.py
+++ b/python/GafferUITest/WidgetTest.py
@@ -604,5 +604,22 @@ class WidgetTest( GafferUITest.TestCase ) :
 		window1.addChildWindow( window3 )
 		self.assertEqual( window3.getChild().displayTransformChanges, [ displayTransform2 ] )
 
+	def testButtonPressSignalLine( self ) :
+
+		w = TestWidget()
+
+		def f( w, event ) :
+
+			self.assertEqual( event.line.p0.x - int( event.line.p0.x ), 0.5 )
+			self.assertEqual( event.line.p0.y - int( event.line.p0.y ), 0.5 )
+			self.assertEqual( event.line.p1.x - int( event.line.p1.x ), 0.5 )
+			self.assertEqual( event.line.p1.y - int( event.line.p1.y ), 0.5 )
+
+		w.buttonPressSignal().connect( f, scoped = False )
+
+		event = QtGui.QMouseEvent( QtCore.QEvent.MouseButtonPress, QtCore.QPoint( 10, 10 ), QtCore.Qt.LeftButton, QtCore.Qt.LeftButton, QtCore.Qt.NoModifier )
+
+		QtWidgets.QApplication.instance().sendEvent( w._qtWidget(), event )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds a 0.5 pixel offset to the line we send to `ButtonEvent` for the various mouse click signals.

The line representing the pixel location of a button press should go through the center of the pixel, not the corner. This was causing problems with getting precise object hit locations in `SceneGadget`.

Interactive testing with a variety of widget types suggests this hasn't made anything in the UI respond in unexpected ways to mouse clicks.

It may be a bit pedantic, but I also changed a couple of comparisons and a calculation that look as though they would be affected by this offset. I haven't been able to demonstrate a difference in actual usage, but they do seem technically correct and don't do any harm.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
