### PR TITLE
GafferTractor : Fix import of `tractor.api.author`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,12 @@
 1.4.x.x (relative to 1.4.0.0b2)
 =======
 
+Fixes
+-----
 
+- Tractor : Fixed failure to import Tractor API [^1].
+
+[^1]: To be omitted from final release notes for 1.4.0.0.
 
 1.4.0.0b2 (relative to 1.4.0.0b1)
 =========

--- a/python/GafferTractor/__init__.py
+++ b/python/GafferTractor/__init__.py
@@ -41,7 +41,7 @@ from .TractorDispatcher import TractorDispatcher
 # to insert a mock API for testing in GafferTractorTest.
 def tractorAPI() :
 
-	from tractor.api.author import author
+	import tractor.api.author as author
 	return author
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferTractor" )


### PR DESCRIPTION
Well, this is embarrassing. Back when I added testing of TractorDispatcher in CI by [mocking](f7bf8f7d1b7b53dc0af81b3c1fccd8edb4d804a8) the `tractor.api.author` module, I accidentally completely broke the import for the _real_ module. The fix is simple, but the humiliation will last forever...
