### PR TITLE
DocumentationAlgo : Skip aliased nodes when exporting node reference

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,15 @@
 1.3.x.x (relative to 1.3.13.0)
 =======
 
+Fixes
+-----
 
+- DocumentationAlgo : Fixed generation of duplicate entries for aliased nodes in `exportNodeReference()`.
+
+Documentation
+-------------
+
+- Node Reference : Removed duplicate entries for nodes that have been aliased by compatibility configs.
 
 1.3.13.0 (relative to 1.3.12.0)
 ========

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -85,6 +85,11 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 				# another module by one of the compatibility config files.
 				continue
 
+			if name != node.typeName().rpartition( ":" )[2] :
+				# Skip nodes that look like they're aliases of other nodes
+				# injected by a compatibility config file.
+				continue
+
 			__makeDirs( directory + "/" + module.__name__ )
 			with open( "%s/%s/%s.md" % ( directory, module.__name__, name ), "w", encoding = "utf-8" ) as f :
 				f.write( __nodeDocumentation( node ) )


### PR DESCRIPTION
The node reference contains a number of duplicate entries for nodes that have been aliased in compatibility configs, such as [Switch](https://www.gafferhq.org/documentation/1.3.13.0/Reference/NodeReference/Gaffer/Switch.html) and [Switch (SwitchComputeNode)](https://www.gafferhq.org/documentation/1.3.13.0/Reference/NodeReference/Gaffer/SwitchComputeNode.html). 

This is a cheap and cheerful attempt to clean this up by only including entries in the node reference when their names match the node typeName.