### PR TITLE
Selection Modification

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,9 @@
 
 Features
 --------
-- SelectionTool : Added select mode plug. When set to anything except `Standard` using the SelectionTool causes the actual scene location selected to potentially be modified from the originally selected location. Selection modifiers work identically for deselection. Currently, USD Kind modifiers are implemented. When selecting, the first ancestor location with a `usd:kind` attribute matching the chosen list of USD Kind will ultimately be selected. USD's Kind Registry includes `Assembly`, `Component`, `Group`, `Model` and `SubComponent` by default and can be extended via USD startup scripts.
+- SelectionTool : Added select mode plug. When set to anything except `Standard` using the SelectionTool causes the actual scene location selected to potentially be modified from the originally selected location. Selection modifiers work identically for deselection. Currently, two selectors are implemented :
+  - USD Kind : When selecting, the first ancestor location with a `usd:kind` attribute matching the chosen list of USD Kind will ultimately be selected. USD's Kind Registry includes `Assembly`, `Component`, `Group`, `Model` and `SubComponent` by default and can be extended via USD startup scripts.
+  - Shader Assignment : When selecting, the first ancestor location with a renderable and direct (not inherited) shader attribute will ultimately be selected. This can be used to select either surface or displacement shaders.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,10 @@
 1.4.0.0b5 (relative to 1.4.0.0b4)
 =========
 
+Features
+--------
+- SelectionTool : Added select mode plug. When set to anything except `Standard` using the SelectionTool causes the actual scene location selected to potentially be modified from the originally selected location. Selection modifiers work identically for deselection. Currently, USD Kind modifiers are implemented. When selecting, the first ancestor location with a `usd:kind` attribute matching the chosen list of USD Kind will ultimately be selected. USD's Kind Registry includes `Assembly`, `Component`, `Group`, `Model` and `SubComponent` by default and can be extended via USD startup scripts.
+
 Improvements
 ------------
 
@@ -391,6 +395,11 @@ Fixes
 - Instancer : Fixed handling of unindexed primvars in RootPerVertex mode.
 - ArnoldShader : Fixed startup errors caused by unknown values in `widget` metadata.
 
+API
+---
+
+- SelectionTool : Added static `registerSelectMode()` method for registering a Python or C++ function that will modify a selected scene path location. Users can choose which mode is active when selecting.
+
 1.3.14.0 (relative to 1.3.13.1)
 ========
 
@@ -413,11 +422,6 @@ Documentation
 -------------
 
 - Node Reference : Removed duplicate entries for nodes that have been aliased by compatibility configs.
-
-API
----
-
-- SelectionTool : Added static `registerSelectMode()` method for registering a Python or C++ function that will modify a selected scene path location. Users can choose which mode is active when selecting.
 
 1.3.13.0 (relative to 1.3.12.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -414,6 +414,11 @@ Documentation
 
 - Node Reference : Removed duplicate entries for nodes that have been aliased by compatibility configs.
 
+API
+---
+
+- SelectionTool : Added static `registerSelectMode()` method for registering a Python or C++ function that will modify a selected scene path location. Users can choose which mode is active when selecting.
+
 1.3.13.0 (relative to 1.3.12.0)
 ========
 

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -39,6 +39,8 @@
 #include "GafferSceneUI/Export.h"
 #include "GafferSceneUI/TypeIds.h"
 
+#include "GafferScene/ScenePlug.h"
+
 #include "GafferUI/DragDropEvent.h"
 #include "GafferUI/Tool.h"
 
@@ -63,6 +65,19 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 
 		Gaffer::StringPlug *selectModePlug();
 		const Gaffer::StringPlug *selectModePlug() const;
+
+		using SelectFunction = std::function<GafferScene::ScenePlug::ScenePath(
+			const GafferScene::ScenePlug *,
+			const GafferScene::ScenePlug::ScenePath &
+		)>;
+		// Registers a select mode identified by `name`. `function` must accept
+		// the scene from which a selection will be made and the `ScenePath` the user
+		// initially selected. It returns the `ScenePath` to use as the actual selection.
+		static void registerSelectMode( const std::string &name, SelectFunction function );
+		// Returns the names of registered modes, in the order they were registered.
+		// The "/Standard" mode will always be first.
+		static std::vector<std::string> registeredSelectModes();
+		static void deregisterSelectMode( const std::string &mode );
 
 	private :
 

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -42,6 +42,8 @@
 #include "GafferUI/DragDropEvent.h"
 #include "GafferUI/Tool.h"
 
+#include "Gaffer/StringPlug.h"
+
 namespace GafferSceneUI
 {
 
@@ -58,6 +60,9 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 		~SelectionTool() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::SelectionTool, SelectionToolTypeId, GafferUI::Tool );
+
+		Gaffer::StringPlug *selectModePlug();
+		const Gaffer::StringPlug *selectModePlug() const;
 
 	private :
 
@@ -77,6 +82,8 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 
 		bool m_acceptedButtonPress = false;
 		bool m_initiatedDrag = false;
+
+		static size_t g_firstPlugIndex;
 };
 
 } // namespace GafferSceneUI

--- a/include/GafferSceneUI/SelectionTool.h
+++ b/include/GafferSceneUI/SelectionTool.h
@@ -83,6 +83,8 @@ class GAFFERSCENEUI_API SelectionTool : public GafferUI::Tool
 
 		static ToolDescription<SelectionTool, SceneView> g_toolDescription;
 
+		void plugSet( Gaffer::Plug *plug );
+
 		SceneGadget *sceneGadget();
 
 		class DragOverlay;

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -84,6 +84,13 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
+			"presetNames", lambda plug : IECore.StringVectorData(
+				GafferSceneUI.SelectionTool.registeredSelectModeLabels()
+			),
+			"presetValues", lambda plug : IECore.StringVectorData(
+				GafferSceneUI.SelectionTool.registeredSelectModes()
+			),
+
 			"label", "Select",
 
 			"toolbarLayout:section", "Bottom",

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -34,6 +34,7 @@
 #
 ##########################################################################
 
+import functools
 import imath
 
 import IECore
@@ -82,14 +83,7 @@ Gaffer.Metadata.registerNode(
 			which may differ from what is originally selected.
 			""",
 
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-
-			"presetNames", lambda plug : IECore.StringVectorData(
-				GafferSceneUI.SelectionTool.registeredSelectModeLabels()
-			),
-			"presetValues", lambda plug : IECore.StringVectorData(
-				GafferSceneUI.SelectionTool.registeredSelectModes()
-			),
+			"plugValueWidget:type", "GafferSceneUI.SelectionToolUI.SelectModePlugValueWidget",
 
 			"label", "Select",
 
@@ -112,3 +106,72 @@ class _RightSpacer( GafferUI.Spacer ) :
 	def __init__( self, imageView, **kw ) :
 
 		GafferUI.Spacer.__init__( self, size = imath.V2i( 0, 0 ) )
+
+class SelectModePlugValueWidget( GafferUI.PlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
+
+		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plugs, **kw )
+
+	def _updateFromValues( self, values, exception ) :
+
+		if exception is not None :
+			self.__menuButton.setText( "" )
+		else :
+			modes = GafferSceneUI.SelectionTool.registeredSelectModes()
+
+			assert( len( values ) == 1 )
+
+			if values[0] in modes :
+				self.__menuButton.setText( values[0].partition( "/" )[-1] )
+			else :
+				self.__menuButton.setText( "Invalid" )
+
+		self.__menuButton.setErrored( exception is not None )
+
+	def _updateFromEditable( self ) :
+
+		self.__menuButton.setEnabled( self._editable() )
+
+	def __menuDefinition( self ) :
+
+		result = IECore.MenuDefinition()
+
+		modes = GafferSceneUI.SelectionTool.registeredSelectModes()
+
+		# dict mapping category names to the last inserted menu item for that category
+		# so we know where to insert the next item for the category.
+		modifiedCategories = {}
+
+		with self.getContext() :
+			currentValue = self.getPlug().getValue()
+
+		for mode in modes :
+			category, sep, label = mode.partition( "/" )
+
+			if category != "" and category not in modifiedCategories.keys() :
+				dividerPath = f"/__{category}Dividier"
+				result.append( dividerPath, { "divider" : True, "label" : category } )
+				modifiedCategories[category] = dividerPath
+
+			itemPath = f"/{label}"
+			itemDefinition = {
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), mode ),
+				"checkBox" : mode == currentValue
+			}
+
+			if category in modifiedCategories.keys() :
+				result.insertAfter( itemPath, itemDefinition, modifiedCategories[category] )
+			else :
+				result.append( itemPath, itemDefinition )
+
+			modifiedCategories[category] = itemPath
+
+		return result
+
+	def __setValue( self, modifier, *unused ) :
+
+		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
+			self.getPlug().setValue( modifier )

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -34,7 +34,12 @@
 #
 ##########################################################################
 
+import imath
+
+import IECore
+
 import Gaffer
+import GafferUI
 import GafferSceneUI
 
 Gaffer.Metadata.registerNode(
@@ -52,7 +57,51 @@ Gaffer.Metadata.registerNode(
 		- Drag to PathFilter or Set node to add/remove their paths
 	""",
 
+	"nodeToolbar:bottom:type", "GafferUI.StandardNodeToolbar.bottom",
+
 	"viewer:shortCut", "Q",
 	"order", 0,
 
+	# So we don't obscure the corner gnomon
+	"toolbarLayout:customWidget:LeftSpacer:widgetType", "GafferSceneUI.SelectionToolUI._LeftSpacer",
+	"toolbarLayout:customWidget:LeftSpacer:section", "Bottom",
+	"toolbarLayout:customWidget:LeftSpacer:index", 0,
+
+	# So our layout doesn't jump around too much when our selection widget changes size
+	"toolbarLayout:customWidget:RightSpacer:widgetType", "GafferSceneUI.SelectionToolUI._RightSpacer",
+	"toolbarLayout:customWidget:RightSpacer:section", "Bottom",
+	"toolbarLayout:customWidget:RightSpacer:index", -1,
+
+	plugs = {
+
+		"selectMode" : [
+
+			"description",
+			"""
+			Determines the scene location that is ultimately selected or deselected,
+			which may differ from what is originally selected.
+			""",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+			"label", "Select",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 150,
+
+		],
+	},
+
 )
+
+class _LeftSpacer( GafferUI.Spacer ) :
+
+	def __init__( self, imageView, **kw ) :
+
+		GafferUI.Spacer.__init__( self, size = imath.V2i( 40, 1 ), maximumSize = imath.V2i( 40, 1 ) )
+
+class _RightSpacer( GafferUI.Spacer ) :
+
+	def __init__( self, imageView, **kw ) :
+
+		GafferUI.Spacer.__init__( self, size = imath.V2i( 0, 0 ) )

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -59,37 +59,15 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:SelectionWidget:widgetType", "GafferSceneUI.TransformToolUI._SelectionWidget",
 	"toolbarLayout:customWidget:SelectionWidget:section", "Bottom",
 
-	# So we don't obscure the corner gnomon
-	"toolbarLayout:customWidget:LeftSpacer:widgetType", "GafferSceneUI.TransformToolUI._LeftSpacer",
-	"toolbarLayout:customWidget:LeftSpacer:section", "Bottom",
-	"toolbarLayout:customWidget:LeftSpacer:index", 0,
-
-	# So our layout doesn't jump around too much when our selection widget changes size
-	"toolbarLayout:customWidget:RightSpacer:widgetType", "GafferSceneUI.TransformToolUI._RightSpacer",
-	"toolbarLayout:customWidget:RightSpacer:section", "Bottom",
-	"toolbarLayout:customWidget:RightSpacer:index", -1,
-
 	"nodeToolbar:top:type", "GafferUI.StandardNodeToolbar.top",
 	"toolbarLayout:customWidget:TargetTipWidget:widgetType", "GafferSceneUI.TransformToolUI._TargetTipWidget",
 	"toolbarLayout:customWidget:TargetTipWidget:section", "Top",
 
-	"toolbarLayout:customWidget:TopRightSpacer:widgetType", "GafferSceneUI.TransformToolUI._RightSpacer",
+	"toolbarLayout:customWidget:TopRightSpacer:widgetType", "GafferSceneUI.SelectionToolUI._RightSpacer",
 	"toolbarLayout:customWidget:TopRightSpacer:section", "Top",
 	"toolbarLayout:customWidget:TopRightSpacer:index", -1,
 
 )
-
-class _LeftSpacer( GafferUI.Spacer ) :
-
-	def __init__( self, imageView, **kw ) :
-
-		GafferUI.Spacer.__init__( self, size = imath.V2i( 40, 1 ), maximumSize = imath.V2i( 40, 1 ) )
-
-class _RightSpacer( GafferUI.Spacer ) :
-
-	def __init__( self, imageView, **kw ) :
-
-		GafferUI.Spacer.__init__( self, size = imath.V2i( 0, 0 ) )
 
 def _boldFormatter( graphComponents ) :
 

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -115,7 +115,7 @@ class _SelectionWidget( GafferUI.Frame ) :
 
 	def __init__( self, tool, **kw ) :
 
-		GafferUI.Frame.__init__( self, borderWidth = 4, **kw )
+		GafferUI.Frame.__init__( self, borderWidth = 1, **kw )
 
 		self.__tool = tool
 

--- a/python/GafferSceneUITest/SelectionToolTest.py
+++ b/python/GafferSceneUITest/SelectionToolTest.py
@@ -36,6 +36,8 @@
 
 import unittest
 
+import Gaffer
+import GafferScene
 import GafferUITest
 import GafferSceneUI
 
@@ -54,6 +56,29 @@ class SelectionToolTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( modifiers ), 3 )
 
 		self.assertEqual( modifiers, [ "/Standard", "testModifier", "testModifier2" ] )
+
+	def testSyncSelectMode( self ) :
+
+		GafferSceneUI.SelectionTool.registerSelectMode( "testModifier", self.modifierFunction )
+
+		script = Gaffer.ScriptNode()
+		script["cube"] = GafferScene.Cube()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["cube"]["out"] )
+
+		tool1 = GafferSceneUI.TranslateTool( view )
+		tool2 = GafferSceneUI.RotateTool( view )
+
+		self.assertEqual( len( [ i for i in view["tools"].children() if isinstance( i, GafferSceneUI.SelectionTool ) ] ), 2 )
+
+		tool1["selectMode"].setValue( "testModifier" )
+		self.assertEqual( tool1["selectMode"].getValue(), "testModifier" )
+		self.assertEqual( tool2["selectMode"].getValue(), "testModifier" )
+
+		tool2["selectMode"].setValue( "/Standard" )
+		self.assertEqual( tool1["selectMode"].getValue(), "/Standard" )
+		self.assertEqual( tool2["selectMode"].getValue(), "/Standard" )
 
 	def tearDown( self ) :
 

--- a/python/GafferSceneUITest/SelectionToolTest.py
+++ b/python/GafferSceneUITest/SelectionToolTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,35 +34,34 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
-from .ParameterInspectorTest import ParameterInspectorTest
-from .AttributeInspectorTest import AttributeInspectorTest
-from .HistoryPathTest import HistoryPathTest
-from .LightEditorTest import LightEditorTest
-from .SetMembershipInspectorTest import SetMembershipInspectorTest
-from .SetEditorTest import SetEditorTest
-from .LightToolTest import LightToolTest
-from .OptionInspectorTest import OptionInspectorTest
-from .LightPositionToolTest import LightPositionToolTest
-from .RenderPassEditorTest import RenderPassEditorTest
-from .SelectionToolTest import SelectionToolTest
+import unittest
 
-if __name__ == "__main__":
+import GafferUITest
+import GafferSceneUI
+
+class SelectionToolTest( GafferUITest.TestCase ) :
+
+	def modifierFunction( scene, path ) :
+
+		return path
+
+	def testRegisterSelectMode( self ) :
+
+		GafferSceneUI.SelectionTool.registerSelectMode( "testModifier", self.modifierFunction )
+		GafferSceneUI.SelectionTool.registerSelectMode( "testModifier2", self.modifierFunction )
+
+		modifiers = GafferSceneUI.SelectionTool.registeredSelectModes()
+		self.assertEqual( len( modifiers ), 3 )
+
+		self.assertEqual( modifiers, [ "/Standard", "testModifier", "testModifier2" ] )
+
+	def tearDown( self ) :
+
+		GafferUITest.TestCase.tearDown( self )
+
+		GafferSceneUI.SelectionTool.deregisterSelectMode( "testModifier" )
+		GafferSceneUI.SelectionTool.deregisterSelectMode( "testModifier2" )
+
+
+if __name__ == "__main__" :
 	unittest.main()

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -154,6 +154,10 @@ GAFFER_NODE_DEFINE_TYPE( SelectionTool );
 SelectionTool::ToolDescription<SelectionTool, SceneView> SelectionTool::g_toolDescription;
 static IECore::InternedString g_dragOverlayName( "__selectionToolDragOverlay" );
 
+size_t SelectionTool::g_firstPlugIndex = 0;
+
+const std::string g_noneSelectionModiferName = "None";
+
 SelectionTool::SelectionTool( SceneView *view, const std::string &name )
 	:	Tool( view, name )
 {
@@ -165,10 +169,24 @@ SelectionTool::SelectionTool( SceneView *view, const std::string &name )
 	sg->dragEnterSignal().connect( boost::bind( &SelectionTool::dragEnter, this, ::_1, ::_2 ) );
 	sg->dragMoveSignal().connect( boost::bind( &SelectionTool::dragMove, this, ::_2 ) );
 	sg->dragEndSignal().connect( boost::bind( &SelectionTool::dragEnd, this, ::_2 ) );
+
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "selectMode", Plug::Direction::In, g_anySelectModeName ) );
 }
 
 SelectionTool::~SelectionTool()
 {
+}
+
+StringPlug *SelectionTool::selectModePlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const StringPlug *SelectionTool::selectModePlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
 SceneGadget *SelectionTool::sceneGadget()

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -232,6 +232,8 @@ SelectionTool::SelectionTool( SceneView *view, const std::string &name )
 	sg->dragMoveSignal().connect( boost::bind( &SelectionTool::dragMove, this, ::_2 ) );
 	sg->dragEndSignal().connect( boost::bind( &SelectionTool::dragEnd, this, ::_2 ) );
 
+	plugSetSignal().connect( boost::bind( &SelectionTool::plugSet, this, ::_1 ) );
+
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new StringPlug( "selectMode", Plug::Direction::In, g_standardSelectModeName ) );
@@ -281,6 +283,18 @@ std::vector<std::string> SelectionTool::registeredSelectModes()
 void SelectionTool::deregisterSelectMode( const std::string &mode )
 {
 	selectModes().erase( mode );
+}
+
+void SelectionTool::plugSet( Plug *plug )
+{
+	if( plug == selectModePlug() )
+	{
+		const std::string value = selectModePlug()->getValue();
+		for( auto &tool : SelectionTool::Range( *parent() ) )
+		{
+			tool->selectModePlug()->setValue( value );
+		}
+	}
 }
 
 SelectionTool::DragOverlay *SelectionTool::dragOverlay()

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -316,11 +316,14 @@ bool SelectionTool::buttonPress( const GafferUI::ButtonEvent &event )
 	ScenePlug::ScenePath objectUnderMouse;
 	sg->objectAt( event.line, objectUnderMouse );
 
-	objectUnderMouse = modifyPath(
-		selectModePlug()->getValue(),
-		sceneGadget()->getScene(),
-		objectUnderMouse
-	) ;
+	{
+		Context::Scope scopedContext( sg->getContext() );
+		objectUnderMouse = modifyPath(
+			selectModePlug()->getValue(),
+			sceneGadget()->getScene(),
+			objectUnderMouse
+		);
+	}
 
 	PathMatcher selection = sg->getSelection();
 
@@ -455,6 +458,8 @@ bool SelectionTool::dragEnd( const GafferUI::DragDropEvent &event )
 		PathMatcher inDragRegionTransformed;
 		const ScenePlug *scene = sceneGadget()->getScene();
 		const std::string modeName = selectModePlug()->getValue();
+
+		Context::Scope scopedContext( sg->getContext() );
 		for( PathMatcher::Iterator it = inDragRegion.begin(), eIt = inDragRegion.end(); it != eIt; ++it )
 		{
 			ScenePlug::ScenePath modifiedPath = modifyPath( modeName, scene, *it );

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -45,6 +45,10 @@
 #include "GafferUI/Style.h"
 
 #include "boost/bind/bind.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/ordered_index.hpp"
+#include "boost/multi_index/sequenced_index.hpp"
+#include "boost/multi_index_container.hpp"
 
 using namespace boost::placeholders;
 using namespace Imath;
@@ -53,6 +57,66 @@ using namespace Gaffer;
 using namespace GafferUI;
 using namespace GafferScene;
 using namespace GafferSceneUI;
+
+namespace
+{
+
+using NamedSelectMode = std::pair<std::string, SelectionTool::SelectFunction>;
+using SelectModeMap = boost::multi_index::multi_index_container<
+	NamedSelectMode,
+	boost::multi_index::indexed_by<
+		boost::multi_index::ordered_unique<
+			boost::multi_index::member<NamedSelectMode, std::string, &NamedSelectMode::first>
+		>,
+		boost::multi_index::sequenced<>
+	>
+>;
+
+const std::string g_standardSelectModeName = "/Standard";
+
+SelectModeMap &selectModes()
+{
+	// Deliberately "leaking" map, as it may contain Python functors which
+	// cannot be destroyed during program exit (because Python will have been
+	// shut down first).
+	static auto g_selectModes = new SelectModeMap;
+
+	if( g_selectModes->empty() )
+	{
+		g_selectModes->insert(
+		{
+			g_standardSelectModeName,
+			[]( const ScenePlug *scene, const ScenePlug::ScenePath &path )
+			{
+				return path;
+			}
+		}
+	);
+	}
+	return *g_selectModes;
+}
+
+const GafferScene::ScenePlug::ScenePath modifyPath(
+	const std::string &modeName,
+	const ScenePlug *scene,
+	const GafferScene::ScenePlug::ScenePath &path
+)
+{
+	if( path.empty() || modeName.empty() )
+	{
+		return path;
+	}
+
+	auto it = selectModes().find( modeName );
+	if( it != selectModes().end() )
+	{
+		return it->second( scene, path );
+	}
+
+	return path;
+}
+
+}  // namespace
 
 //////////////////////////////////////////////////////////////////////////
 // DragOverlay implementation
@@ -156,8 +220,6 @@ static IECore::InternedString g_dragOverlayName( "__selectionToolDragOverlay" );
 
 size_t SelectionTool::g_firstPlugIndex = 0;
 
-const std::string g_noneSelectionModiferName = "None";
-
 SelectionTool::SelectionTool( SceneView *view, const std::string &name )
 	:	Tool( view, name )
 {
@@ -172,7 +234,7 @@ SelectionTool::SelectionTool( SceneView *view, const std::string &name )
 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
-	addChild( new StringPlug( "selectMode", Plug::Direction::In, g_anySelectModeName ) );
+	addChild( new StringPlug( "selectMode", Plug::Direction::In, g_standardSelectModeName ) );
 }
 
 SelectionTool::~SelectionTool()
@@ -192,6 +254,33 @@ const StringPlug *SelectionTool::selectModePlug() const
 SceneGadget *SelectionTool::sceneGadget()
 {
 	return runTimeCast<SceneGadget>( view()->viewportGadget()->getPrimaryChild() );
+}
+
+void SelectionTool::registerSelectMode( const std::string &name, SelectFunction function )
+{
+	auto &m = selectModes();
+	auto [it, inserted] = m.insert( { name, function } );
+
+	if( !inserted )
+	{
+		m.replace( it, { name, function } );
+	}
+}
+
+std::vector<std::string> SelectionTool::registeredSelectModes()
+{
+	std::vector<std::string> result;
+	for( const auto &m : selectModes().get<1>() )
+	{
+		result.push_back( m.first );
+	}
+
+	return result;
+}
+
+void SelectionTool::deregisterSelectMode( const std::string &mode )
+{
+	selectModes().erase( mode );
 }
 
 SelectionTool::DragOverlay *SelectionTool::dragOverlay()
@@ -226,6 +315,12 @@ bool SelectionTool::buttonPress( const GafferUI::ButtonEvent &event )
 	SceneGadget *sg = sceneGadget();
 	ScenePlug::ScenePath objectUnderMouse;
 	sg->objectAt( event.line, objectUnderMouse );
+
+	objectUnderMouse = modifyPath(
+		selectModePlug()->getValue(),
+		sceneGadget()->getScene(),
+		objectUnderMouse
+	) ;
 
 	PathMatcher selection = sg->getSelection();
 
@@ -357,13 +452,25 @@ bool SelectionTool::dragEnd( const GafferUI::DragDropEvent &event )
 
 	if( sg->objectsAt( dragOverlay()->getStartPosition(), dragOverlay()->getEndPosition(), inDragRegion ) )
 	{
+		PathMatcher inDragRegionTransformed;
+		const ScenePlug *scene = sceneGadget()->getScene();
+		const std::string modeName = selectModePlug()->getValue();
+		for( PathMatcher::Iterator it = inDragRegion.begin(), eIt = inDragRegion.end(); it != eIt; ++it )
+		{
+			ScenePlug::ScenePath modifiedPath = modifyPath( modeName, scene, *it );
+			if( modifiedPath.size() )
+			{
+				inDragRegionTransformed.addPath( modifiedPath );
+			}
+		}
+
 		if( event.modifiers & DragDropEvent::Control )
 		{
-			selection.removePaths( inDragRegion );
+			selection.removePaths( inDragRegionTransformed );
 		}
 		else
 		{
-			selection.addPaths( inDragRegion );
+			selection.addPaths( inDragRegionTransformed );
 		}
 
 		ContextAlgo::setSelectedPaths( view()->getContext(), selection );

--- a/startup/gui/selectionTool.py
+++ b/startup/gui/selectionTool.py
@@ -1,0 +1,118 @@
+##########################################################################
+#
+#  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+import IECoreScene
+
+from pxr import Kind
+
+import IECore
+
+import GafferSceneUI
+
+##########################################################################
+# USD Kind
+##########################################################################
+
+def __kindSelectionModifier( targetKind, scene, pathString ) :
+	path = pathString.split( "/" )[1:]
+
+	kind = None
+	while len( path ) > 0 :
+		attributes = scene.attributes( path )
+		kind = attributes.get( "usd:kind", None )
+
+		if kind is not None and Kind.Registry.IsA( kind.value, targetKind ) :
+			break
+		path.pop()
+
+	return path
+
+
+usdKinds = Kind.Registry.GetAllKinds()
+
+# Build a simplified hierarchy for sorting
+kindPaths = []
+for kind in usdKinds :
+	kindPath = kind
+	kindParent = Kind.Registry.GetBaseKind( kind )
+	while kindParent != "" :
+		kindPath = kindParent + "/" + kindPath
+		kindParent = Kind.Registry.GetBaseKind( kindParent )
+	kindPaths.append( kindPath )
+
+kindPaths.sort( reverse = True)
+
+# We prefer to have "subcomponent" at the end.
+try :
+	kindPaths.remove( "subcomponent" )
+	kindPaths.append( "subcomponent" )
+except :
+	pass
+
+for kindPath in kindPaths :
+	kind = kindPath.split( "/" )[-1]
+	GafferSceneUI.SelectionTool.registerSelectMode(
+		"USD Kind/" + IECore.CamelCase.toSpaced( kind ),
+		functools.partial( __kindSelectionModifier, kind ),
+	)
+
+##########################################################################
+# Shader Assignment
+##########################################################################
+
+def __shaderSource( attributeKeyword, scene, pathString ) :
+	path = pathString.split( "/" )[1:]
+
+	while len( path ) > 0 :
+		attributes = scene.attributes( path )
+		for k, v in attributes.items() :
+			if (
+				attributeKeyword in k.split( ':' ) and
+				k != "surface:full" and
+				k != "surface:preview" and
+				k != "displacement:full" and
+				k != "displacement:preview" and 
+				isinstance( v, IECoreScene.ShaderNetwork )
+			) :
+				return path
+		
+		path.pop()
+	
+	return []
+
+GafferSceneUI.SelectionTool.registerSelectMode( "Shader Assignment/Surface", functools.partial( __shaderSource, "surface" ) )
+GafferSceneUI.SelectionTool.registerSelectMode( "Shader Assignment/Displacement", functools.partial( __shaderSource, "displacement" ) )

--- a/startup/gui/usd.py
+++ b/startup/gui/usd.py
@@ -35,15 +35,7 @@
 #
 ##########################################################################
 
-import functools
-
-from pxr import Kind
-
-import IECore
-
 import Gaffer
-import GafferScene
-import GafferSceneUI
 import GafferUSD
 
 # Default cone angle is 90 (an entire hemisphere), so replace with something
@@ -53,49 +45,3 @@ Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.shaping:cone:angl
 # `texture:format == automatic` isn't well supported at present, so default
 # user-created lights to `latlong`.
 Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.texture:format", "userDefault", "latlong" )
-
-
-def __kindSelectionModifier( targetKind, scene, pathString ) :
-	path = pathString.split( "/" )[1:]
-	targetKind = targetKind[9:] # 9 = len( "USD Kind/" )
-
-	kind = None
-	while len( path ) > 0 :
-		attributes = scene.attributes( path )
-		kind = attributes.get( "usd:kind", None )
-
-		if kind is not None and Kind.Registry.IsA( kind.value, targetKind ) :
-			break
-		path.pop()
-
-	return path
-
-
-usdKinds = Kind.Registry.GetAllKinds()
-
-# Build a simplified hierarchy for sorting
-kindPaths = []
-for kind in usdKinds :
-	kindPath = kind
-	kindParent = Kind.Registry.GetBaseKind( kind )
-	while kindParent != "" :
-		kindPath = kindParent + "/" + kindPath
-		kindParent = Kind.Registry.GetBaseKind( kindParent )
-	kindPaths.append( kindPath )
-
-kindPaths.sort( reverse = True)
-
-# We prefer to have "subcomponent" at the end.
-try :
-	kindPaths.remove( "subcomponent" )
-	kindPaths.append( "subcomponent" )
-except :
-	pass
-
-for kindPath in kindPaths :
-	# Add `USD Kind/` prefix so these entries go under that sub-heading.
-	kind = "USD Kind/" + kindPath.split( "/" )[-1]
-	GafferSceneUI.SelectionTool.registerSelectMode(
-		kind,
-		functools.partial( __kindSelectionModifier, kind ),
-	)


### PR DESCRIPTION
This adds a mechanism for modifying what scene locations are actually selected when making a viewport selection. Users can register functions in Python or C++ that get a scene and the selection made by the user, and return the selection they want as a result.

It also includes a first use of the mechanism in the form of USD Kind selection. Starting at the viewport selected location, the first ancestor, or the original location itself, that is the USD Kind chosen in the `selectionModifier` plug is what is actually selected.

I tried a few different methods of presenting the USD Kinds in the `selectionModifier` widget. USD Kinds are hierarchical (https://openusd.org/dev/api/kind_page_front.html#mainpage_kind) so, for example, setting the `selectionModifier` to select USD Kind of `model` will also select `component`, `group` and `assembly`. Currently I'm expressing that by spelling out all the Kinds that will be considered a match in the menu item.

That was originally driven by using the standard presets metadata and dropdown. I think a nicer widget is what I have now, very similar to the `displayTransform.name` widget. Before settling on this presentation, I also looked at indenting based on the hierarchy, and even a little ASCII art to draw out elbows and lines to form a tree look.

Indenting with the default presets widget meant that when you make your selection, the label in the collapsed dropdown is indented too, which felt rather odd.

Now that I'm using a custom widget anyways, maybe the indented presentation is worth another look?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
