### PR TITLE
LightPositionTool improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.0.0b4)
 =======
 
+Improvements
+------------
+
+- LightPosition Tool : The tool is now only visible for members of the `__lights` set, instead of all objects.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 -----
 
 - PlugAlgo : Updated `canSetValueFromData()`, `setValueFromData()` and `getValueAsData()` with support for missing types.
+- LightPosition Tool : Fixed lingering shadow pivot point after placing a shadow pivot, switching to highlight mode and switching back to shadow mode [^1].
 
 1.4.0.0b4 (relative to 1.4.0.0b3)
 =========

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -926,6 +926,7 @@ void LightPositionTool::plugSet( Plug *plug )
 	{
 		auto h = static_cast<DistanceHandle *>( m_distanceHandle.get() );
 		h->setRequiresPivot( modePlug()->getValue() == (int)Mode::Shadow );
+		updateHandles( m_rotateHandle->getRasterScale() );
 	}
 }
 

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -107,6 +107,8 @@ const float g_arrowHandleSelectionSize = g_circleHandleSelectionWidth * 2.f;
 
 const float g_unitConeHeight = 1.5f;
 
+InternedString g_lightsSetName( "__lights" );
+
 const char *constantFragSource()
 {
 	return
@@ -666,8 +668,14 @@ void LightPositionTool::updateHandles( float rasterScale )
 
 	handles()->setTransform( s.orientedTransform( Orientation::Local ) );
 
+	Context::Scope scopedContext( s.context() );
+
 	if( !m_drag )
 	{
+		bool isLight = s.scene()->set( g_lightsSetName )->readable().match( s.path() ) & IECore::PathMatcher::ExactMatch;
+		m_distanceHandle->setVisible( isLight );
+		m_rotateHandle->setVisible( isLight );
+
 		bool singleSelection = selection().size() == 1;
 
 		TranslationRotation trDistanceHandle( s, Orientation::World );
@@ -705,8 +713,6 @@ void LightPositionTool::updateHandles( float rasterScale )
 	// The user can control the distance along the line from target
 	// to pivot, and the rotation around the Z-axis. Any variance from those
 	// contraints invalidates the stored parameters.
-
-	Context::Scope scopedContext( s.context() );
 
 	const M44f transform = s.scene()->fullTransform( s.path() ) * sceneToTransform;
 	const V3f p = transform.translation();


### PR DESCRIPTION
This fixes a couple of small annoyances with the LightPositionTool :
1. It was previously possible to have anything selected when placing highlights or shadows. They were positioned properly, but since this is a light position tool, it seems useful to ensure it's only placing lights as it claims to.
2. Previously, if you did the following : position a light using the shadow placement tool, change mode to highlight, position a light based on highlight location (invalidating the previous shadow pivot location) then change back to shadow mode. We were not checking on mode change if the pivot and target are still valid, so there would be a rogue pivot location dot in the viewport.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
