### PR TITLE
CyclesOptions : Remove `samplingPattern`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.0.0b3)
 =======
 
+Breaking Changes
+----------------
 
+- CyclesOptions : Removed `cycles:integrator:sampling_pattern` option. This is intended only for debugging, but is still available via a CustomOptions node.
 
 1.4.0.0b3 (relative to 1.4.0.0b2)
 =========

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -114,9 +114,6 @@ def __samplingSummary( plug ) :
 	if plug["samples"]["enabled"].getValue() :
 		info.append( "Samples {}".format( plug["samples"]["value"].getValue() ) )
 
-	if plug["samplingPattern"]["enabled"].getValue() :
-		info.append( "Sampling Pattern {}".format( Gaffer.NodeAlgo.currentPreset( plug["samplingPattern"]["value"] ) ) )
-
 	if plug["lightSamplingThreshold"]["enabled"].getValue() :
 		info.append( "Light Sampling Threshold {}".format( plug["lightSamplingThreshold"]["value"].getValue() ) )
 
@@ -677,27 +674,6 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Sampling",
 			"label", "Samples",
-
-		],
-
-		"options.samplingPattern" : [
-
-			"description",
-			"""
-			Random sampling pattern used by the integrator.
-			""",
-
-			"layout:section", "Sampling",
-
-		],
-
-		"options.samplingPattern.value" : [
-
-			"preset:Sobol", "sobol",
-			"preset:Correlated Multi-Jitter", "cmj",
-			"preset:Progressive Multi-Jitter", "pmj",
-
-			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 
 		],
 

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -113,9 +113,6 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_adaptive_sampling", new IECore::BoolData( false ), false, "useAdaptiveSampling" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:adaptive_threshold", new IECore::FloatData( 0.0f ), false, "adaptiveThreshold" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:adaptive_min_samples", new IECore::IntData( 0 ), false, "adaptiveMinSamples" ) );
-
-	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:sampling_pattern", new IECore::StringData( "sobol" ), false, "samplingPattern" ) );
-
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:denoiser_type", new IECore::StringData( "openimagedenoise" ), false, "denoiserType" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:denoise_start_sample", new IECore::IntData( 0 ), false, "denoiseStartSample" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_denoise_pass_albedo", new IECore::BoolData( true ), false, "useDenoisePassAlbedo" ) );


### PR DESCRIPTION
This is a debug-level field in Blender, so it's more appropriate to hide it while allowing a power user to specify it via CustomOptions. Moreover, the presets values we had were out of date and completely non-functional.

I've also verified that [Cycles' standalone default](https://github.com/blender/cycles/blob/v4.0.2/src/scene/integrator.cpp#L127) of `SAMPLING_PATTERN_TABULATED_SOBOL` matches [Blenders's UI default](), so when Gaffer doesn't specify anything, we are getting the intended sampling pattern.
