### PR TITLE
Windows wrapper : Remove "Error(s) running Gaffer" shutdown message

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.0.0b3)
 =======
 
+Fixes
+-----
+
+- Windows : Removed "Error(s) running Gaffer" shutdown message. It was misleading when errors originated in the renderer rather than Gaffer itself.
+
 Breaking Changes
 ----------------
 

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -161,7 +161,6 @@ if "%GAFFER_DEBUG%" NEQ "" (
 )
 
 if %ERRORLEVEL% NEQ 0 (
-	echo "Error(s) running Gaffer"
 	exit /B %ERRORLEVEL%
 )
 


### PR DESCRIPTION
It was ambiguous at best, and misleading at worst when the error originated in the renderer. We also don't have an equivalent in the Linux wrapper, so this brings both platforms closer to parity.

Conservatively targeting this to main as while I wouldn't consider it a breaking change, it is a change in behaviour.