### PR TITLE
StandardOptions : Add `render:renderer` option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - Render, InteractiveRender : Added new nodes capable of rendering to any supported renderer, and using the`render:defaultRenderer` option to determine which to use by default.
+- StandardOptions : Added `render:defaultRenderer` option, allowing the scene globals to specify which renderer is used by the Render and InteractiveRender nodes.
 
 1.3.13.1 (relative to 1.3.13.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- Render : Added a new node capable of rendering to any supported renderer, and using the`render:defaultRenderer` option to determine which to use by default.
+- Render, InteractiveRender : Added new nodes capable of rendering to any supported renderer, and using the`render:defaultRenderer` option to determine which to use by default.
 
 1.3.13.1 (relative to 1.3.13.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Features
 
 - Render, InteractiveRender : Added new nodes capable of rendering to any supported renderer, and using the`render:defaultRenderer` option to determine which to use by default.
 - StandardOptions : Added `render:defaultRenderer` option, allowing the scene globals to specify which renderer is used by the Render and InteractiveRender nodes.
+- RenderPassEditor : Added a column for the `render:defaultRenderer` option, allowing each pass to be rendered in a different renderer.
 
 1.3.13.1 (relative to 1.3.13.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.3.x.x (relative to 1.3.13.1)
+=======
+
+Features
+--------
+
+- Render : Added a new node capable of rendering to any supported renderer, and using the`render:defaultRenderer` option to determine which to use by default.
+
 1.3.13.1 (relative to 1.3.13.0)
 ========
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -305,6 +305,10 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 		/// Performs an arbitrary renderer-specific action.
 		virtual IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters = IECore::CompoundDataMap() );
 
+		using Creator = std::function<Ptr ( RenderType, const std::string &, const IECore::MessageHandlerPtr & )>;
+		static void registerType( const IECore::InternedString &typeName, Creator creator );
+		static void deregisterType( const IECore::InternedString &typeName );
+
 	protected :
 
 		Renderer();
@@ -330,11 +334,6 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 				}
 
 		};
-
-	private :
-
-		static void registerType( const IECore::InternedString &typeName, Ptr (*creator)( RenderType, const std::string &, const IECore::MessageHandlerPtr & ) );
-
 
 };
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -56,6 +56,7 @@ import GafferArnold
 class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	interactiveRenderNodeClass = GafferArnold.InteractiveArnoldRender
+	renderer = "Arnold"
 
 	# Arnold outputs licensing warnings that would cause failures
 	failureMessageLevel = IECore.MessageHandler.Level.Error

--- a/python/GafferCyclesTest/CyclesRenderTest.py
+++ b/python/GafferCyclesTest/CyclesRenderTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of Image Engine Design Inc nor the names of
+#      * Neither the name of John Haddon nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,15 +34,13 @@
 #
 ##########################################################################
 
-from .CyclesLightTest import CyclesLightTest
-from .InteractiveCyclesRenderTest import InteractiveCyclesRenderTest
-from .ModuleTest import ModuleTest
-from .CyclesLightTest import CyclesLightTest
-from .CyclesShaderTest import CyclesShaderTest
-from .CyclesRenderTest import CyclesRenderTest
+import unittest
 
-from .IECoreCyclesPreviewTest import *
+import GafferSceneTest
+
+class CyclesRenderTest( GafferSceneTest.RenderTest ) :
+
+	renderer = "Cycles"
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -45,6 +45,7 @@ import GafferCycles
 class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	interactiveRenderNodeClass = GafferCycles.InteractiveCyclesRender
+	renderer = "Cycles"
 
 	@unittest.skip( "Resolution edits not supported yet" )
 	def testEditResolution( self ) :

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -34,76 +34,14 @@
 #
 ##########################################################################
 
-import pathlib
 import unittest
 
-import IECore
-import IECoreScene
-
-import Gaffer
-import GafferScene
 import GafferSceneTest
-import GafferDelight
 
-class DelightRenderTest( GafferSceneTest.SceneTestCase ) :
+class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
-	def testSceneDescriptionMode( self ) :
-
-		plane = GafferScene.Plane()
-		render = GafferDelight.DelightRender()
-		render["in"].setInput( plane["out"] )
-		render["mode"].setValue( render.Mode.SceneDescriptionMode )
-		render["fileName"].setValue( self.temporaryDirectory() / "test.nsi" )
-
-		render["task"].execute()
-		self.assertTrue( pathlib.Path( render["fileName"].getValue() ).exists() )
-
-	def testRenderMode( self ) :
-
-		plane = GafferScene.Plane()
-
-		outputs = GafferScene.Outputs()
-		outputs.addOutput(
-			"beauty",
-			IECoreScene.Output(
-				str( self.temporaryDirectory() / "test.exr" ),
-				"exr",
-				"rgba",
-				{}
-			)
-		)
-
-		render = GafferDelight.DelightRender()
-		render["in"].setInput( outputs["out"] )
-		render["mode"].setValue( render.Mode.RenderMode )
-
-		render["task"].execute()
-		self.assertTrue( ( self.temporaryDirectory() / "test.exr" ).exists() )
-
-	def testSceneTranslationOnly( self ) :
-
-		plane = GafferScene.Plane()
-
-		outputs = GafferScene.Outputs()
-		outputs.addOutput(
-			"beauty",
-			IECoreScene.Output(
-				str( self.temporaryDirectory() / "test.exr" ),
-				"exr",
-				"rgba",
-				{}
-			)
-		)
-
-		render = GafferDelight.DelightRender()
-		render["in"].setInput( outputs["out"] )
-		render["mode"].setValue( render.Mode.RenderMode )
-
-		with Gaffer.Context() as context :
-			context["scene:render:sceneTranslationOnly"] = IECore.BoolData( True )
-			render["task"].execute()
-
-		self.assertFalse( ( self.temporaryDirectory() / "test.exr" ).exists() )
+	renderer = "3Delight"
+	sceneDescriptionSuffix = ".nsi"
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -48,6 +48,7 @@ import GafferDelight
 class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	interactiveRenderNodeClass =  GafferDelight.InteractiveDelightRender
+	renderer = "3Delight"
 
 	# Temporarily disable this test (which is implemented in the
 	# base class) because it fails. The issue is that we're automatically

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -1,0 +1,238 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import pathlib
+import subprocess
+import unittest
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+## \todo Transfer more tests from subclasses to this base class, so that we
+# run them for all renderers.
+class RenderTest( GafferSceneTest.SceneTestCase ) :
+
+	# Derived classes should set `renderer` to the name of the renderer
+	# to be tested.
+	renderer = None
+	# And set this to the file extension used for scene description, if
+	# scene description is supported.
+	sceneDescriptionSuffix = None
+
+	@classmethod
+	def setUpClass( cls ) :
+
+		GafferSceneTest.SceneTestCase.setUpClass()
+
+		if cls.renderer is None :
+			# We expect derived classes to set the renderer, and will
+			# run the tests there.
+			raise unittest.SkipTest( "No renderer available" )
+
+	def testOutputDirectoryCreation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["variables"].addChild( Gaffer.NameValuePlug( "renderDirectory", ( self.temporaryDirectory() / "renderTest" ).as_posix() ) )
+
+		s["plane"] = GafferScene.Plane()
+
+		s["outputs"] = GafferScene.Outputs()
+		s["outputs"]["in"].setInput( s["plane"]["out"] )
+		s["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"$renderDirectory/test.####.exr",
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		s["render"] = GafferScene.Render()
+		s["render"]["renderer"].setValue( self.renderer )
+		s["render"]["in"].setInput( s["outputs"]["out"] )
+
+		self.assertFalse( ( self.temporaryDirectory() / "renderTest" ).exists() )
+		self.assertFalse( ( self.temporaryDirectory() / "renderTest" / "test.0001.exr" ).exists() )
+
+		for i in range( 0, 2 ) : # Test twice, to check we can cope with the directory already existing.
+
+			with s.context() :
+				s["render"]["task"].execute()
+
+			self.assertTrue( ( self.temporaryDirectory() / "renderTest" ).exists() )
+			self.assertTrue( ( self.temporaryDirectory() / "renderTest" / "test.0001.exr" ).exists() )
+
+	def testHash( self ) :
+
+		c = Gaffer.Context()
+		c.setFrame( 1 )
+		c2 = Gaffer.Context()
+		c2.setFrame( 2 )
+
+		s = Gaffer.ScriptNode()
+		s["plane"] = GafferScene.Plane()
+		s["outputs"] = GafferScene.Outputs()
+		s["outputs"]["in"].setInput( s["plane"]["out"] )
+		s["outputs"].addOutput( "beauty", IECoreScene.Output( "$renderDirectory/test.####.exr", "exr", "rgba", {} ) )
+		s["render"] = GafferScene.Render()
+		s["render"]["renderer"].setValue( self.renderer )
+
+		# no input scene produces no effect
+		self.assertEqual( s["render"].hash( c ), IECore.MurmurHash() )
+
+		# now theres an scene to render, we get some output
+		s["render"]["in"].setInput( s["outputs"]["out"] )
+		self.assertNotEqual( s["render"].hash( c ), IECore.MurmurHash() )
+
+		# output varies by time
+		self.assertNotEqual( s["render"].hash( c ), s["render"].hash( c2 ) )
+
+		# output varies by new Context entries
+		current = s["render"].hash( c )
+		c["renderDirectory"] = ( self.temporaryDirectory() / "renderTest" ).as_posix()
+		self.assertNotEqual( s["render"].hash( c ), current )
+
+		# output varies by changed Context entries
+		current = s["render"].hash( c )
+		c["renderDirectory"] = ( self.temporaryDirectory() / "renderTest2" ).as_posix()
+		self.assertNotEqual( s["render"].hash( c ), current )
+
+		# output doesn't vary by ui Context entries
+		current = s["render"].hash( c )
+		c["ui:something"] = "alterTheUI"
+		self.assertEqual( s["render"].hash( c ), current )
+
+		# also varies by input node
+		current = s["render"].hash( c )
+		s["render"]["in"].setInput( s["plane"]["out"] )
+		self.assertNotEqual( s["render"].hash( c ), current )
+
+	def testSceneTranslationOnly( self ) :
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		render = GafferScene.Render()
+		render["in"].setInput( outputs["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+		render["renderer"].setValue( self.renderer )
+
+		with Gaffer.Context() as context :
+			context["scene:render:sceneTranslationOnly"] = IECore.BoolData( True )
+			render["task"].execute()
+
+		self.assertFalse( ( self.temporaryDirectory() / "test.exr" ).exists() )
+
+	def testRenderMode( self ) :
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		render = GafferScene.Render()
+		render["in"].setInput( outputs["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+		render["renderer"].setValue( self.renderer )
+
+		render["task"].execute()
+		self.assertTrue( ( self.temporaryDirectory() / "test.exr" ).exists() )
+
+	def testSceneDescriptionMode( self ) :
+
+		if self.sceneDescriptionSuffix is None :
+			raise unittest.SkipTest( "Scene description not supported" )
+
+		plane = GafferScene.Plane()
+
+		render = GafferScene.Render()
+		render["in"].setInput( plane["out"] )
+		render["mode"].setValue( render.Mode.SceneDescriptionMode )
+		render["fileName"].setValue( ( self.temporaryDirectory() / "subdirectory" / f"test{self.sceneDescriptionSuffix}" ) )
+		render["renderer"].setValue( self.renderer )
+
+		for i in range( 0, 2 ) : # Test twice, to check we can cope with the directory already existing.
+
+			render["task"].execute()
+			self.assertTrue( pathlib.Path( render["fileName"].getValue() ).exists() )
+
+	def testExecute( self ) :
+
+		if self.sceneDescriptionSuffix is None :
+			raise unittest.SkipTest( "Scene description not supported" )
+
+		s = Gaffer.ScriptNode()
+
+		s["plane"] = GafferScene.Plane()
+		s["render"] = GafferScene.Render()
+		s["render"]["mode"].setValue( s["render"].Mode.SceneDescriptionMode )
+		s["render"]["renderer"].setValue( self.renderer )
+		s["render"]["fileName"].setValue( ( self.temporaryDirectory() / f"test.#{self.sceneDescriptionSuffix}" ) )
+		s["render"]["in"].setInput( s["plane"]["out"] )
+
+		scriptFileName = self.temporaryDirectory() / "test.gfr"
+		s["fileName"].setValue( scriptFileName )
+		s.save()
+
+		subprocess.check_call(
+			f"gaffer execute {scriptFileName} -frames 1-3",
+			shell=True,
+		)
+
+		for i in range( 1, 4 ) :
+			self.assertTrue( ( self.temporaryDirectory() / f"test.{i}{self.sceneDescriptionSuffix}" ).exists() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -234,5 +234,53 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		for i in range( 1, 4 ) :
 			self.assertTrue( ( self.temporaryDirectory() / f"test.{i}{self.sceneDescriptionSuffix}" ).exists() )
 
+	def testRendererOption( self ) :
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		customOptions = GafferScene.CustomOptions()
+		customOptions["in"].setInput( outputs["out"] )
+		customOptions["options"].addChild( Gaffer.NameValuePlug( "render:defaultRenderer", self.renderer ) )
+
+		render = GafferScene.Render()
+		render["in"].setInput( customOptions["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+		self.assertEqual( render["renderer"].getValue(), "" )
+
+		render["task"].execute()
+		self.assertTrue( ( self.temporaryDirectory() / "test.exr" ).exists() )
+
+	def testNoRenderer( self ) :
+
+		outputs = GafferScene.Outputs()
+		outputs.addOutput(
+			"beauty",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		render = GafferScene.Render()
+		render["in"].setInput( outputs["out"] )
+		render["mode"].setValue( render.Mode.RenderMode )
+		self.assertEqual( render["renderer"].getValue(), "" )
+
+		self.assertEqual( render["task"].hash(), IECore.MurmurHash() )
+
+		render["task"].execute()
+		self.assertFalse( ( self.temporaryDirectory() / "test.exr" ).exists() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -67,6 +67,7 @@ from .StandardOptionsTest import StandardOptionsTest
 from .ScenePathTest import ScenePathTest
 from .LightTest import LightTest
 from .OpenGLShaderTest import OpenGLShaderTest
+from .RenderTest import RenderTest
 from .OpenGLRenderTest import OpenGLRenderTest
 from .TransformTest import TransformTest
 from .AimConstraintTest import AimConstraintTest

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -41,6 +41,7 @@ from Qt import QtCore
 import Gaffer
 import GafferImage
 import GafferScene
+import GafferSceneUI
 import GafferUI
 import GafferImageUI
 
@@ -374,6 +375,13 @@ class _MessagesPlugValueWidget( GafferUI.PlugValueWidget ) :
 # Metadata for InteractiveRender node.
 ##########################################################################
 
+def __rendererPresetNames( plug ) :
+
+	return IECore.StringVectorData( [
+		x for x in GafferSceneUI.RenderUI.rendererPresetNames( plug )
+		if x != "OpenGL"
+	] )
+
 Gaffer.Metadata.registerNode(
 
 	GafferScene.InteractiveRender,
@@ -409,8 +417,19 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			The renderer to use.
+			The renderer to use. Default mode uses the `render:defaultRenderer` option from
+			the input scene globals to choose the renderer. This can be authored using
+			the StandardOptions node.
+
+			> Note : Changing renderer currently requires that the current render is
+			> manually stopped and restarted.
 			""",
+
+			"plugValueWidget:type", "GafferSceneUI.RenderUI.RendererPlugValueWidget",
+
+			"preset:Default", "",
+			"presetNames", __rendererPresetNames,
+			"presetValues", __rendererPresetNames,
 
 		],
 

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -42,6 +42,7 @@ import IECoreScene
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
 
 from GafferUI.PlugValueWidget import sole
 
@@ -76,6 +77,13 @@ def __cameraSummary( plug ) :
 		info.append( "DOF " + ( "On" if plug["depthOfField"]["value"].getValue() else "Off" ) )
 
 	return ", ".join( info )
+
+def __rendererSummary( plug ) :
+
+	if plug["defaultRenderer"]["enabled"].getValue() :
+		return plug["defaultRenderer"]["value"].getValue()
+
+	return ""
 
 def __renderSetSummary( plug ) :
 
@@ -123,6 +131,7 @@ plugsMetadata = {
 	"options" : [
 
 		"layout:section:Camera:summary", __cameraSummary,
+		"layout:section:Renderer:summary", __rendererSummary,
 		"layout:section:Render Set:summary", __renderSetSummary,
 		"layout:section:Motion Blur:summary", __motionBlurSummary,
 		"layout:section:Statistics:summary", __statisticsSummary,
@@ -340,7 +349,31 @@ plugsMetadata = {
 		"layout:section", "Camera",
 	],
 
-	# Purpose
+	# Renderer
+
+	"options.defaultRenderer" : [
+
+		"description",
+		"""
+		Specifies the default renderer to be used by the Render and
+		InteractiveRender nodes.
+		""",
+
+		"label", "Default Renderer",
+		"layout:section", "Renderer",
+
+	],
+
+	"options.defaultRenderer.value" : [
+
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"preset:None", "",
+		"presetNames", GafferSceneUI.RenderUI.rendererPresetNames,
+		"presetValues", GafferSceneUI.RenderUI.rendererPresetNames,
+
+	],
+
+	# Render Set
 
 	"options.includedPurposes" : [
 

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -63,6 +63,7 @@ from . import OutputsUI
 from . import OptionsUI
 from . import OpenGLAttributesUI
 from . import SceneWriterUI
+from . import RenderUI
 from . import StandardOptionsUI
 from . import StandardAttributesUI
 from . import ShaderUI
@@ -125,7 +126,6 @@ from . import CubeUI
 from . import AttributeVisualiserUI
 from . import FilterProcessorUI
 from . import MeshToPointsUI
-from . import RenderUI
 from . import ShaderBallUI
 from . import ShaderTweaksUI
 from . import CameraTweaksUI

--- a/src/GafferScene/StandardOptions.cpp
+++ b/src/GafferScene/StandardOptions.cpp
@@ -65,6 +65,10 @@ StandardOptions::StandardOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "render:overscanRight", new FloatPlug( "value", Plug::In, 0.1f, 0.0f, 1.0f ), false, "overscanRight" ) );
 	options->addChild( new Gaffer::NameValuePlug( "render:depthOfField", new IECore::BoolData( false ), false, "depthOfField" ) );
 
+	// Renderer
+
+	options->addChild( new Gaffer::NameValuePlug( "render:defaultRenderer", new IECore::StringData(), false, "defaultRenderer" ) );
+
 	// Render set
 
 	options->addChild( new Gaffer::NameValuePlug( "render:includedPurposes", new IECore::StringVectorData( { "default", "render" } ), false, "includedPurposes" ) );

--- a/startup/GafferScene/renderers.py
+++ b/startup/GafferScene/renderers.py
@@ -1,0 +1,68 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Cinesite VFX Ltd. nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import sys
+import functools
+
+import IECore
+import GafferScene
+
+# Register functions to load renderers on demand. This allows us to find a renderer
+# even if the relevant Python module hasn't been imported (in `gaffer execute` for instance).
+
+def __creator( renderType, fileName, messageHandler, renderer, module ) :
+
+ 	# Import module to replace ourselves with the true renderer creation function.
+	__import__( module )
+	# And then call `create()` again to use it.
+	return GafferScene.Private.IECoreScenePreview.Renderer.create( renderer, renderType, fileName, messageHandler )
+
+for renderer, module in [
+	( "Cycles", "GafferCycles" ),
+	( "Arnold", "IECoreArnold" ),
+	( "3Delight", "IECoreDelight" ),
+] :
+	if renderer in GafferScene.Private.IECoreScenePreview.Renderer.types() :
+		# Already registered
+		continue
+	if not IECore.SearchPath( sys.path ).find( module ) :
+		# Renderer not available
+		continue
+
+	# Register creator that will load module to provide renderer on demand.
+	GafferScene.Private.IECoreScenePreview.Renderer.registerType(
+		renderer, functools.partial( __creator, renderer = renderer, module = module )
+	)

--- a/startup/GafferScene/standardOptions.py
+++ b/startup/GafferScene/standardOptions.py
@@ -110,6 +110,17 @@ Gaffer.Metadata.registerValue(
 	"""
 )
 
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "label", "Renderer" )
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "defaultValue", "" )
+Gaffer.Metadata.registerValue(
+	"option:render:defaultRenderer",
+	"description",
+	"""
+	Specifies the default renderer to be used by the Render and
+	InteractiveRender nodes.
+	"""
+)
+
 Gaffer.Metadata.registerValue( "option:render:inclusions", "label", "Inclusions" )
 Gaffer.Metadata.registerValue( "option:render:inclusions", "defaultValue", IECore.StringData( "/" ) )
 Gaffer.Metadata.registerValue(

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -345,6 +345,7 @@ nodeMenu.append( "/Scene/Utility/Primitive Variable Query", GafferScene.Primitiv
 nodeMenu.append( "/Scene/Passes/Render Passes", GafferScene.RenderPasses, searchText = "RenderPasses" )
 nodeMenu.append( "/Scene/Passes/Delete Render Passes", GafferScene.DeleteRenderPasses, searchText = "DeleteRenderPasses" )
 nodeMenu.append( "/Scene/Passes/Render Pass Wedge", GafferScene.RenderPassWedge, searchText = "RenderPassWedge" )
+nodeMenu.append( "/Scene/Render/Render", GafferScene.Render )
 
 # Image nodes
 

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -346,6 +346,7 @@ nodeMenu.append( "/Scene/Passes/Render Passes", GafferScene.RenderPasses, search
 nodeMenu.append( "/Scene/Passes/Delete Render Passes", GafferScene.DeleteRenderPasses, searchText = "DeleteRenderPasses" )
 nodeMenu.append( "/Scene/Passes/Render Pass Wedge", GafferScene.RenderPassWedge, searchText = "RenderPassWedge" )
 nodeMenu.append( "/Scene/Render/Render", GafferScene.Render )
+nodeMenu.append( "/Scene/Render/Interactive Render", GafferScene.InteractiveRender, searchText = "InteractiveRender" )
 
 # Image nodes
 

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -45,6 +45,7 @@ GafferSceneUI.RenderPassEditor.registerOption( "*", "render:inclusions" )
 GafferSceneUI.RenderPassEditor.registerOption( "*", "render:exclusions" )
 GafferSceneUI.RenderPassEditor.registerOption( "*", "render:additionalLights" )
 
+GafferSceneUI.RenderPassEditor.registerOption( "*", "render:defaultRenderer", "Render" )
 GafferSceneUI.RenderPassEditor.registerOption( "*", "render:camera", "Render" )
 GafferSceneUI.RenderPassEditor.registerOption( "*", "render:resolution", "Render" )
 GafferSceneUI.RenderPassEditor.registerOption( "*", "render:resolutionMultiplier", "Render" )


### PR DESCRIPTION
This lets you specify which renderer you would like to use by default in new generic Render and InteractiveRender nodes. Which lets us add a "Renderer" column to the render pass editor to choose which renderer each pass is rendered with.

A few questions that aren't resolved fully for me :

- Is `render:renderer` the right name? I found myself referring to it as the "Default renderer" in tooltips and labels, and as soon as I did this things seemed clearer. It's not the one-and-only renderer, it's just the default one that will be used if you don't opt for something else. Maybe I should push this all the way through to the name of the option, and call it `render:defaultRenderer`?
- Should the new option be in a sub-section of StandardOptionsUI, and if so, what should it be called? I put it in a section because I wanted to avoid the implication that maybe you were setting some "mode" for StandardOptions if I put it at the top outside of the sections. But maybe if it had a "Default Renderer" rather than "Renderer" label, that might be less of a concern?
- How much should we worry about the cost of `Render::hash()` when using the default renderer? This new cost won't apply to any existing scenes which all have explicit values for the renderer. And folks who make their scene globals expensive really need to stop. So maybe it's OK to put that on them, as they adopt this new functionality? 
- Did I go too far in removing the non-generic nodes from the menus? Should that wait till 1.4?
- Might it be nice if there was a usable default value for `render:renderer`, so a vanilla Render node automatically rendered with Cycles for instance? This led me to uncertainty though - we don't yet have a standard method for querying the default, and we're not sure option defaults should be configurable (and folks would undoubtedly want this one to be).