### PR TITLE
Intel GPU selection investigation

### DIFF
--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -581,8 +581,6 @@ void StandardStyle::bind( const Style *currentStyle ) const
 		return;
 	}
 
-	glEnable( GL_BLEND );
-	glBlendFuncSeparate( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
 	glUseProgram( shader()->program() );
 
 	if( IECoreGL::Selector *selector = IECoreGL::Selector::currentSelector() )
@@ -591,6 +589,13 @@ void StandardStyle::bind( const Style *currentStyle ) const
 		{
 			selector->pushIDShader( shader() );
 		}
+	}
+	else
+	{
+		// Enable blending only for non-selection renders as it can
+		// corrupt the selection buffer on some graphics hardware.
+		glEnable( GL_BLEND );
+		glBlendFuncSeparate( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
 	}
 }
 
@@ -1129,8 +1134,6 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 {
 	glPushAttrib( GL_COLOR_BUFFER_BIT );
 
-	// As the image is already pre-multiplied we need to change our blend mode.
-	glEnable( GL_BLEND );
 	if( !IECoreGL::Selector::currentSelector() )
 	{
 		// Some users have reported crashes that were traced back to this call
@@ -1139,6 +1142,9 @@ void StandardStyle::renderImage( const Imath::Box2f &box, const IECoreGL::Textur
 		// didn't correspond to actual gadgets.
 		// Don't change it when rendering the selection pass since
 		// blending should not be applied to an integer buffer anyways.
+
+		// As the image is already pre-multiplied we need to change our blend mode.
+		glEnable( GL_BLEND );
 		glBlendFunc( GL_ONE, GL_ONE_MINUS_SRC_ALPHA );
 	}
 

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -1288,7 +1288,9 @@ void ViewportGadget::renderInternal( RenderReason reason, Gadget::Layer filterLa
 		if( reason != RenderReason::Draw )
 		{
 			// We're doing selection so post-processing doesn't matter. Just
-			// render direct to output buffer.
+			// render direct to output buffer without blending as that can
+			// corrupt the selection buffer on some graphics hardware.
+			glDisable( GL_BLEND );
 			renderLayerInternal( reason, layer, viewTransform, bound, selector );
 			continue;
 		}


### PR DESCRIPTION
Putting this up as a quick draft to narrow down the root cause of the selection issues with Intel graphics hardware reported on Discord. 

Following the lead of Eric's fix in #5268, disabling `GL_BLEND` entirely for selection renders appears to fix the issues on an Intel Arc A750 GPU, but maybe more GL savvy minds can suggest a better solution for these symptoms...