### PR TITLE
Render, InteractiveRender : Add `resolvedRenderer` output

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.3.x.x (relative to 1.3.14.0)
 =======
 
+Improvements
+------------
+
+- Render, InteractiveRender : Added `resolvedRenderer` plug, which outputs the name of the renderer that will be used, taking into account the influence of the `render:defaultRenderer` option.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.x.x (relative to 1.3.14.0)
 =======
 
+Fixes
+-----
 
+- InteractiveRender : Fixed context used to evaluate scene globals when renderer is set to "Default".
 
 1.3.14.0 (relative to 1.3.13.1)
 ========

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -83,6 +83,9 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 		GafferScene::ScenePlug *outPlug();
 		const GafferScene::ScenePlug *outPlug() const;
 
+		Gaffer::StringPlug *resolvedRendererPlug();
+		const Gaffer::StringPlug *resolvedRendererPlug() const;
+
 		Gaffer::ObjectPlug *messagesPlug();
 		const Gaffer::ObjectPlug *messagesPlug() const;
 

--- a/include/GafferScene/Render.h
+++ b/include/GafferScene/Render.h
@@ -80,6 +80,9 @@ class GAFFERSCENE_API Render : public GafferDispatch::TaskNode
 		ScenePlug *outPlug();
 		const ScenePlug *outPlug() const;
 
+		Gaffer::StringPlug *resolvedRendererPlug();
+		const Gaffer::StringPlug *resolvedRendererPlug() const;
+
 	protected :
 
 		// Constructor for derived classes which wish to hardcode the renderer type. Perhaps

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -2199,6 +2199,43 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		image = IECoreImage.ImageDisplayDriver.storedImage( "testRendererOption" )
 		self.assertIsInstance( image, IECoreImage.ImagePrimitive )
 
+	def testRendererOptionContext( self ):
+
+		script = Gaffer.ScriptNode()
+		script["variables"].addChild( Gaffer.NameValuePlug( "defaultRendererVariable", self.renderer ) )
+
+		script["outputs"] = GafferScene.Outputs()
+		script["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testRendererOptionContext",
+				}
+			)
+		)
+
+		script["standardOptions"] = GafferScene.StandardOptions()
+		script["standardOptions"]["in"].setInput( script["outputs"]["out"] )
+		script["standardOptions"]["options"]["defaultRenderer"]["enabled"].setValue( True )
+		script["standardOptions"]["options"]["defaultRenderer"]["value"].setValue( "${defaultRendererVariable}" )
+
+		script["renderer"] = self._createInteractiveRender( useNodeClass = False )
+		script["renderer"]["renderer"].setValue( "" )
+		script["renderer"]["in"].setInput( script["standardOptions"]["out"] )
+
+		# Check that the globals are evaluated in the right context to provide
+		# the `defaultRendererVariable` and enable the render.
+
+		script["renderer"]["state"].setValue( script["renderer"].State.Running )
+		time.sleep( 1.0 )
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testRendererOptionContext" )
+		self.assertIsInstance( image, IECoreImage.ImagePrimitive )
+
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -2236,6 +2236,22 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		image = IECoreImage.ImageDisplayDriver.storedImage( "testRendererOptionContext" )
 		self.assertIsInstance( image, IECoreImage.ImagePrimitive )
 
+	def testResolvedRenderer( self ) :
+
+		standardOptions = GafferScene.StandardOptions()
+
+		render = GafferScene.InteractiveRender()
+		render["in"].setInput( standardOptions["out"] )
+		self.assertEqual( render["renderer"].getValue(), "" )
+		self.assertEqual( render["resolvedRenderer"].getValue(), "" )
+
+		standardOptions["options"]["defaultRenderer"]["enabled"].setValue( True )
+		standardOptions["options"]["defaultRenderer"]["value"].setValue( self.renderer )
+		self.assertEqual( render["resolvedRenderer"].getValue(), self.renderer )
+
+		render["renderer"].setValue( "Other" )
+		self.assertEqual( render["resolvedRenderer"].getValue(), "Other" )
+
 	def tearDown( self ) :
 
 		GafferSceneTest.SceneTestCase.tearDown( self )

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -282,5 +282,21 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		render["task"].execute()
 		self.assertFalse( ( self.temporaryDirectory() / "test.exr" ).exists() )
 
+	def testResolvedRenderer( self ) :
+
+		standardOptions = GafferScene.StandardOptions()
+
+		render = GafferScene.Render()
+		render["in"].setInput( standardOptions["out"] )
+		self.assertEqual( render["renderer"].getValue(), "" )
+		self.assertEqual( render["resolvedRenderer"].getValue(), "" )
+
+		standardOptions["options"]["defaultRenderer"]["enabled"].setValue( True )
+		standardOptions["options"]["defaultRenderer"]["value"].setValue( self.renderer )
+		self.assertEqual( render["resolvedRenderer"].getValue(), self.renderer )
+
+		render["renderer"].setValue( "Other" )
+		self.assertEqual( render["resolvedRenderer"].getValue(), "Other" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -445,6 +445,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"resolvedRenderer" : [
+
+			"description",
+			"""
+			The renderer that will be used, accounting for the value of the
+			`render:defaultRenderer` option if `renderer` is set to "Default".
+			""",
+
+			"layout:section", "Advanced",
+
+		],
+
 		"messages" : [
 
 			"description",

--- a/python/GafferSceneUI/RenderUI.py
+++ b/python/GafferSceneUI/RenderUI.py
@@ -133,6 +133,18 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"resolvedRenderer" : [
+
+			"description",
+			"""
+			The renderer that will be used, accounting for the value of the
+			`render:defaultRenderer` option if `renderer` is set to "Default".
+			""",
+
+			"layout:section", "Advanced",
+
+		],
+
 	}
 )
 
@@ -152,17 +164,16 @@ class RendererPlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 		presets = GafferUI.PresetsPlugValueWidget._valuesForUpdate( plugs, [ [] for p in plugs ] )
 
 		result = []
-		for preset, globalsPlugs in zip( presets, auxiliaryPlugs ) :
+		for preset, resolvedRendererPlugs in zip( presets, auxiliaryPlugs ) :
 
-			defaultRenderer = ""
-			if len( globalsPlugs ) and preset == "Default" :
+			resolvedRenderer = ""
+			if len( resolvedRendererPlugs ) :
 				with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
-					defaultRenderer = globalsPlugs[0].getValue().get( "option:render:defaultRenderer" )
-					defaultRenderer = defaultRenderer.value if defaultRenderer is not None else ""
+					resolvedRenderer = resolvedRendererPlugs[0].getValue()
 
 			result.append( {
 				"preset" : preset,
-				"defaultRenderer" : defaultRenderer
+				"resolvedRenderer" : resolvedRenderer
 			} )
 
 		return result
@@ -172,11 +183,11 @@ class RendererPlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 		GafferUI.PresetsPlugValueWidget._updateFromValues( self, [ v["preset"] for v in values ], exception )
 
 		if self.menuButton().getText() == "Default" :
-			defaultRenderer = sole( v["defaultRenderer"] for v in values )
+			resolvedRenderer = sole( v["resolvedRenderer"] for v in values )
 			self.menuButton().setText(
 				"Default ({})".format(
-					defaultRenderer if defaultRenderer else
-					( "None" if defaultRenderer == "" else "---" )
+					resolvedRenderer if resolvedRenderer else
+					( "None" if resolvedRenderer == "" else "---" )
 				)
 			)
 
@@ -184,4 +195,4 @@ class RendererPlugValueWidget( GafferUI.PresetsPlugValueWidget ) :
 
 		node = plug.node()
 		if isinstance( node, ( GafferScene.Render, GafferScene.InteractiveRender ) ) :
-			return [ node["in"]["globals"] ]
+			return [ node["resolvedRenderer"] ]

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -298,6 +298,9 @@ void InteractiveRender::plugSet( const Gaffer::Plug *plug )
 
 void InteractiveRender::update()
 {
+	ConstContextPtr context = effectiveContext();
+	Context::Scope scope( context.get() );
+
 	const State requiredState = (State)statePlug()->getValue();
 
 	// Stop the current render if we've been asked to, or if

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -36,6 +36,7 @@
 
 #include "GafferScene/Render.h"
 
+#include "GafferScene/OptionQuery.h"
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 #include "GafferScene/Private/RendererAlgo.h"
 #include "GafferScene/SceneAlgo.h"
@@ -46,6 +47,7 @@
 #include "Gaffer/ApplicationRoot.h"
 #include "Gaffer/MonitorAlgo.h"
 #include "Gaffer/PerformanceMonitor.h"
+#include "Gaffer/Switch.h"
 
 #include "IECore/ObjectPool.h"
 
@@ -62,7 +64,6 @@ namespace
 {
 
 const InternedString g_performanceMonitorOptionName( "option:render:performanceMonitor" );
-const InternedString g_rendererOptionName( "option:render:defaultRenderer" );
 const InternedString g_sceneTranslationOnlyContextName( "scene:render:sceneTranslationOnly" );
 
 struct RenderScope : public Context::EditableScope
@@ -112,6 +113,7 @@ Render::Render( const IECore::InternedString &rendererType, const std::string &n
 	addChild( new IntPlug( "mode", Plug::In, RenderMode, RenderMode, SceneDescriptionMode ) );
 	addChild( new StringPlug( "fileName" ) );
 	addChild( new ScenePlug( "out", Plug::Out, Plug::Default & ~Plug::Serialisable ) );
+	addChild( new StringPlug( "resolvedRenderer", Plug::Out, "", Plug::Default & ~Plug::Serialisable ) );
 	addChild( new ScenePlug( "__adaptedIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
 
 	SceneProcessorPtr adaptors = GafferScene::SceneAlgo::createRenderAdaptors();
@@ -120,6 +122,26 @@ Render::Render( const IECore::InternedString &rendererType, const std::string &n
 	adaptedInPlug()->setInput( adaptors->outPlug() );
 
 	outPlug()->setInput( inPlug() );
+
+	// Internal network for `resolvedRenderer`. We use a Switch so that we don't
+	// even evaluate the scene globals if the renderer is overridden by `rendererPlug()`.
+
+	OptionQueryPtr optionQuery = new OptionQuery();
+	setChild( "__optionQuery", optionQuery );
+	optionQuery->scenePlug()->setInput( inPlug() );
+	NameValuePlug *rendererQuery = optionQuery->addQuery( rendererPlug() );
+	rendererQuery->namePlug()->setValue( "render:defaultRenderer" );
+
+	SwitchPtr querySwitch = new Switch();
+	setChild( "__querySwitch", querySwitch );
+	querySwitch->setup( rendererPlug() );
+	/// \todo Cast shouldn't be necessary - OptionQuery should provide a non-const accessor.
+	querySwitch->inPlugs()->getChild<Plug>( 0 )->setInput( const_cast<ValuePlug *>( optionQuery->valuePlugFromQuery( rendererQuery ) ) );
+	querySwitch->inPlugs()->getChild<Plug>( 1 )->setInput( rendererPlug() );
+	querySwitch->indexPlug()->setValue( 1 );
+	querySwitch->enabledPlug()->setInput( rendererPlug() );
+
+	resolvedRendererPlug()->setInput( querySwitch->outPlug() );
 }
 
 Render::~Render()
@@ -176,14 +198,24 @@ const ScenePlug *Render::outPlug() const
 	return getChild<ScenePlug>( g_firstPlugIndex + 4 );
 }
 
+Gaffer::StringPlug *Render::resolvedRendererPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
+const Gaffer::StringPlug *Render::resolvedRendererPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 5 );
+}
+
 ScenePlug *Render::adaptedInPlug()
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 5 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 6 );
 }
 
 const ScenePlug *Render::adaptedInPlug() const
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 5 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 6 );
 }
 
 void Render::preTasks( const Gaffer::Context *context, Tasks &tasks ) const
@@ -207,28 +239,15 @@ IECore::MurmurHash Render::hash( const Gaffer::Context *context ) const
 
 	RenderScope renderScope( context );
 
-	std::string rendererType = rendererPlug()->getValue();
-	if( rendererType.empty() )
-	{
-		ConstCompoundObjectPtr globals = adaptedInPlug()->globals();
-		if( auto rendererData = globals->member<const StringData>( g_rendererOptionName ) )
-		{
-			rendererType = rendererData->readable();
-		}
-		if( rendererType.empty() )
-		{
-			return IECore::MurmurHash();
-		}
-	}
-
+	const std::string rendererType = resolvedRendererPlug()->getValue();
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );
 	const std::string fileName = fileNamePlug()->getValue();
-	if( mode == SceneDescriptionMode && fileName.empty() )
+	if( rendererType.empty() || ( mode == SceneDescriptionMode && fileName.empty() ) )
 	{
 		return IECore::MurmurHash();
 	}
 
-	/// \todo Since we're computing the globals now (see above),
+	/// \todo Since we're computing the globals now (via `resolvedRenderer`),
 	/// maybe our hash should be the hash of the output definitions?
 	/// Then we'd know which parts of the context we were sensitive to
 	/// and wouldn't have such a pessimistic hash that includes all
@@ -274,25 +293,11 @@ void Render::executeInternal( bool flushCaches ) const
 	}
 
 	RenderScope renderScope( Context::current() );
-
-	std::string rendererType = rendererPlug()->getValue();
+	const std::string rendererType = resolvedRendererPlug()->getValue();
 	if( rendererType.empty() )
 	{
-		/// \todo We're evaluating the globals twice, once here and once in
-		/// `RenderOptions` below. When we remove the `scene:renderer` context
-		/// variable, we'll be able to move the RenderOptions here and only do
-		/// one evaluation.
-		ConstCompoundObjectPtr globals = adaptedInPlug()->globals();
-		if( auto rendererData = globals->member<const StringData>( g_rendererOptionName ) )
-		{
-			rendererType = rendererData->readable();
-		}
-		if( rendererType.empty() )
-		{
-			return;
-		}
+		return;
 	}
-
 	renderScope.set( g_rendererContextName, &rendererType );
 
 	const Mode mode = static_cast<Mode>( modePlug()->getValue() );


### PR DESCRIPTION
This tells you which renderer will actually be used, taking into account the fallback to the `render:defaultRenderer` option. The intention is to make it easy for folks to build task graphs that will act differently depending on the configuration of the upstream Render node.