### PR TITLE
Catalogue improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - LightPosition Tool : The tool is now only visible for members of the `__lights` set, instead of all objects.
+- Catalogue : Added `imageNames` output plug, containing the names of all images in the Catalogue. Among other things this can be used to drive a Wedge or ContactSheet node and a CatalogueSelect.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,9 @@ Fixes
 
 - PlugAlgo : Updated `canSetValueFromData()`, `setValueFromData()` and `getValueAsData()` with support for missing types.
 - LightPosition Tool : Fixed lingering shadow pivot point after placing a shadow pivot, switching to highlight mode and switching back to shadow mode [^1].
-- Catalogue : Fixed bugs caused by reordering images using `GraphComponent::reorderChildren()`.
+- Catalogue :
+  - Fixed undo for image reordering via drag & drop.
+  - Fixed bugs caused by reordering images using `GraphComponent::reorderChildren()`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 
 - PlugAlgo : Updated `canSetValueFromData()`, `setValueFromData()` and `getValueAsData()` with support for missing types.
 - LightPosition Tool : Fixed lingering shadow pivot point after placing a shadow pivot, switching to highlight mode and switching back to shadow mode [^1].
+- Catalogue : Fixed bugs caused by reordering images using `GraphComponent::reorderChildren()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,11 @@ Fixes
 - LightPosition Tool : Fixed lingering shadow pivot point after placing a shadow pivot, switching to highlight mode and switching back to shadow mode [^1].
 - Catalogue : Fixed bugs caused by reordering images using `GraphComponent::reorderChildren()`.
 
+API
+---
+
+- Catalogue : Deprecated `image:index` metadata.
+
 Breaking Changes
 ----------------
 

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -125,6 +125,9 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 		Gaffer::StringPlug *directoryPlug();
 		const Gaffer::StringPlug *directoryPlug() const;
 
+		Gaffer::StringVectorDataPlug *imageNamesPlug();
+		const Gaffer::StringVectorDataPlug *imageNamesPlug() const;
+
 		/// All Catalogues share a single DisplayDriverServer instance
 		/// to receive rendered images. To send an image to the catalogues,
 		/// use an IECoreImage::ClientDisplayDriver with the "displayPort" parameter

--- a/include/GafferImage/Catalogue.h
+++ b/include/GafferImage/Catalogue.h
@@ -159,6 +159,7 @@ class GAFFERIMAGE_API Catalogue : public ImageNode
 
 		void imageAdded( GraphComponent *graphComponent );
 		void imageRemoved( GraphComponent *graphComponent );
+		void imagesReordered( const std::vector<size_t> &originalIndices );
 
 		void driverCreated( IECoreImage::DisplayDriver *driver, const IECore::CompoundData *parameters );
 		void imageReceived( Gaffer::Plug *plug );

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -1147,5 +1147,37 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 				script.undo()
 				assertPreconditions()
 
+	def testImageNames( self ) :
+
+		def assertImageNames( catalogue ) :
+
+			self.assertEqual(
+				catalogue["imageNames"].getValue(),
+				IECore.StringVectorData( catalogue["images"].keys() )
+			)
+
+		catalogue = GafferImage.Catalogue()
+		plugDirtiedSlot = GafferTest.CapturingSlot( catalogue.plugDirtiedSignal() )
+		assertImageNames( catalogue )
+
+		catalogue["images"].addChild( catalogue.Image.load( self.imagesPath() / "blurRange.exr" ) )
+		self.assertIn( catalogue["imageNames"], { x[0] for x in plugDirtiedSlot } )
+		assertImageNames( catalogue )
+
+		del plugDirtiedSlot[:]
+		catalogue["images"].addChild( catalogue.Image.load( self.imagesPath() / "blurRange.exr" ) )
+		self.assertIn( catalogue["imageNames"], { x[0] for x in plugDirtiedSlot } )
+		assertImageNames( catalogue )
+
+		del plugDirtiedSlot[:]
+		catalogue["images"][0].setName( "newName" )
+		self.assertIn( catalogue["imageNames"], { x[0] for x in plugDirtiedSlot } )
+		assertImageNames( catalogue )
+
+		del plugDirtiedSlot[:]
+		catalogue["images"].reorderChildren( reversed( catalogue["images"].children() ) )
+		self.assertIn( catalogue["imageNames"], { x[0] for x in plugDirtiedSlot } )
+		assertImageNames( catalogue )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -462,6 +462,21 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"imageNames" : [
+
+			"description",
+			"""
+			Output containing all the names of the images in the Catalogue.
+			Possible uses include :
+
+			- Looping over all images using a Wedge and a CatalogueSelect.
+			- Making a ContactSheet using the Collect mode and a CatalogueSelect.
+			""",
+
+			"layout:section", "Advanced"
+
+		],
+
 	},
 
 )

--- a/src/GafferImage/Catalogue.cpp
+++ b/src/GafferImage/Catalogue.cpp
@@ -822,6 +822,7 @@ Catalogue::Catalogue( const std::string &name )
 	addChild( new IntPlug( "imageIndex" ) );
 	addChild( new StringPlug( "name" ) );
 	addChild( new StringPlug( "directory" ) );
+	addChild( new StringVectorDataPlug( "imageNames", Plug::Out ) );
 	addChild( new IntPlug( "__imageIndex", Plug::Out ) );
 	addChild( new ObjectPlug( "__imageIndexMap", Plug::Out, IECore::NullObject::defaultNullObject() ) );
 	addChild( new StringPlug( "__invalidImageText", Plug::Out ) );
@@ -917,44 +918,54 @@ const Gaffer::StringPlug *Catalogue::directoryPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex + 3 );
 }
 
+Gaffer::StringVectorDataPlug *Catalogue::imageNamesPlug()
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
+const Gaffer::StringVectorDataPlug *Catalogue::imageNamesPlug() const
+{
+	return getChild<StringVectorDataPlug>( g_firstPlugIndex + 4 );
+}
+
 Gaffer::IntPlug *Catalogue::internalImageIndexPlug()
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 4 );
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
 }
 
 const Gaffer::IntPlug *Catalogue::internalImageIndexPlug() const
 {
-	return getChild<IntPlug>( g_firstPlugIndex + 4 );
+	return getChild<IntPlug>( g_firstPlugIndex + 5 );
 }
 
 Gaffer::ObjectPlug *Catalogue::imageIndexMapPlug()
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
 }
 
 const Gaffer::ObjectPlug *Catalogue::imageIndexMapPlug() const
 {
-	return getChild<ObjectPlug>( g_firstPlugIndex + 5 );
+	return getChild<ObjectPlug>( g_firstPlugIndex + 6 );
 }
 
 Gaffer::StringPlug *Catalogue::invalidImageTextPlug()
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
 }
 
 const Gaffer::StringPlug *Catalogue::invalidImageTextPlug() const
 {
-	return getChild<StringPlug>( g_firstPlugIndex + 6 );
+	return getChild<StringPlug>( g_firstPlugIndex + 7 );
 }
 
 Switch *Catalogue::imageSwitch()
 {
-	return getChild<Switch>( g_firstPlugIndex + 7 );
+	return getChild<Switch>( g_firstPlugIndex + 8 );
 }
 
 const Switch *Catalogue::imageSwitch() const
 {
-	return getChild<Switch>( g_firstPlugIndex + 7 );
+	return getChild<Switch>( g_firstPlugIndex + 8 );
 }
 
 Catalogue::InternalImage *Catalogue::imageNode( Image *image )
@@ -1254,11 +1265,16 @@ void Catalogue::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outp
 	ImageNode::affects( input, outputs );
 
 	auto image = input->parent<Image>();
-	if( image && image->parent() == imagesPlug() &&
-		( input == image->namePlug() || input == image->outputIndexPlug() )
-	)
+	if( image && image->parent() == imagesPlug() )
 	{
-		outputs.push_back( imageIndexMapPlug() );
+		if( input == image->namePlug() || input == image->outputIndexPlug() )
+		{
+			outputs.push_back( imageIndexMapPlug() );
+		}
+		if( input== image->namePlug() )
+		{
+			outputs.push_back( imageNamesPlug() );
+		}
 	}
 
 	if( input == imageIndexPlug() || input == imageIndexMapPlug() )
@@ -1296,6 +1312,13 @@ void Catalogue::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *co
 			Context::EditableScope mapScope( context );
 			mapScope.remove( g_imageNameContextName );
 			imageIndexMapPlug()->hash( h );
+		}
+	}
+	else if( output == imageNamesPlug() )
+	{
+		for( const auto &image : Image::Range( *imagesPlug() ) )
+		{
+			image->namePlug()->hash( h );
 		}
 	}
 }
@@ -1353,32 +1376,40 @@ void Catalogue::compute( ValuePlug *output, const Context *context ) const
 
 		static_cast<ObjectPlug *>( output )->setValue( result );
 	}
-
-	if( output != internalImageIndexPlug() )
+	else if( output == internalImageIndexPlug() )
 	{
-		ImageNode::compute( output, context );
-		return;
+		int index = -1;
+		const std::string &imageName = context->get<std::string>( g_imageNameContextName, g_emptyString );
+		if( imageName.empty() )
+		{
+			index = imageIndexPlug()->getValue();
+		}
+		else
+		{
+			Context::EditableScope mapScope( context );
+			mapScope.remove( g_imageNameContextName );
+			ConstImageIndexMapDataPtr imageIndexMap = boost::static_pointer_cast<const ImageIndexMapData>( imageIndexMapPlug()->getValue() );
+			auto it = imageIndexMap->map.find( imageName );
+			if( it != imageIndexMap->map.end() )
+			{
+				index = it->second;
+			}
+		}
+		static_cast<IntPlug *>( output )->setValue( index + 1 );
 	}
-
-	int index = -1;
-	const std::string &imageName = context->get<std::string>( g_imageNameContextName, g_emptyString );
-	if( imageName.empty() )
+	else if( output == imageNamesPlug() )
 	{
-		index = imageIndexPlug()->getValue();
+		StringVectorDataPtr result = new StringVectorData;
+		for( const auto &image : Image::Range( *imagesPlug() ) )
+		{
+			result->writable().push_back( image->getName().string() );
+		}
+		static_cast<StringVectorDataPlug *>( output )->setValue( result );
 	}
 	else
 	{
-		Context::EditableScope mapScope( context );
-		mapScope.remove( g_imageNameContextName );
-		ConstImageIndexMapDataPtr imageIndexMap = boost::static_pointer_cast<const ImageIndexMapData>( imageIndexMapPlug()->getValue() );
-		auto it = imageIndexMap->map.find( imageName );
-		if( it != imageIndexMap->map.end() )
-		{
-			index = it->second;
-		}
+		ImageNode::compute( output, context );
 	}
-
-	static_cast<IntPlug *>( output )->setValue( index + 1 );
 
 }
 


### PR DESCRIPTION
This adds an `imageNames` output plug to Catalogues, facilitating workflows which visit all images in a Catalogue via a Wedge or ContactSheet. It also improves the mechanism used for reordering images in the UI, so the order can be correctly reflected in the output.
