### PR TITLE
Shuffle compatibility improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
   - Fixed loading of 2 channel images [^1].
   - Fixed error message to include filename [^1].
 - Expression : `setExpression()` now respects configs that provide backwards compatibility for old plug names.
+- Shuffle : Fixed default name for plugs constructed via the legacy `ChannelPlug( out, in )` constructor [^1].
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - ImageGadget :
   - Fixed loading of 2 channel images [^1].
   - Fixed error message to include filename [^1].
+- Expression : `setExpression()` now respects configs that provide backwards compatibility for old plug names.
 
 API
 ---

--- a/python/Gaffer/PythonExpressionEngine.py
+++ b/python/Gaffer/PythonExpressionEngine.py
@@ -69,19 +69,18 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 		plugDict = {}
 		for plugPath, plug in zip( self.__inPlugPaths, inputs ) :
 			parentDict = plugDict
-			plugPathSplit = plugPath.split( "." )
-			for p in plugPathSplit[:-1] :
+			for p in plugPath[:-1] :
 				parentDict = parentDict.setdefault( p, {} )
 			if isinstance( plug, Gaffer.CompoundDataPlug ) :
 				value = IECore.CompoundData()
 				plug.fillCompoundData( value )
 			else :
 				value = plug.getValue()
-			parentDict[plugPathSplit[-1]] = value
+			parentDict[plugPath[-1]] = value
 
 		for plugPath in self.__outPlugPaths :
 			parentDict = plugDict
-			for p in plugPath.split( "." )[:-1] :
+			for p in plugPath[:-1] :
 				parentDict = parentDict.setdefault( p, {} )
 
 		executionDict = { "imath" : imath, "IECore" : IECore, "parent" : plugDict, "context" : _ContextProxy( context ) }
@@ -91,17 +90,20 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 		result = IECore.ObjectVector()
 		for plugPath in self.__outPlugPaths :
 			parentDict = plugDict
-			plugPathSplit = plugPath.split( "." )
-			for p in plugPathSplit[:-1] :
+			for p in plugPath[:-1] :
 				parentDict = parentDict[p]
-			r = parentDict.get( plugPathSplit[-1], IECore.NullObject.defaultNullObject() )
+			r = parentDict.get( plugPath[-1], IECore.NullObject.defaultNullObject() )
 			try:
 				if isinstance( r, pathlib.Path ) :
 					result.append( r.as_posix() )
 				else :
 					result.append( r )
 			except:
-				raise TypeError( "Unsupported type for result \"%s\" for expression output \"%s\"" % ( str( r ), plugPath ) )
+				raise TypeError(
+					"Unsupported type for result \"{}\" for expression output \"{}\"".format(
+						r, ".".join( plugPath )
+					)
+				)
 
 		return result
 
@@ -204,14 +206,17 @@ class PythonExpressionEngine( Gaffer.Expression.Engine ) :
 
 	def __plug( self, node, plugPath ) :
 
-		plug = node.parent().descendant( plugPath )
+		try :
+			plug = node.parent()
+			for p in plugPath :
+				plug = plug[p]
+		except KeyError :
+			raise RuntimeError( "\"{}\" does not exist".format( ".".join( plugPath ) ) ) from None
+
 		if isinstance( plug, Gaffer.ValuePlug ) :
 			return plug
-
-		if plug is None :
-			raise RuntimeError( "\"%s\" does not exist" % plugPath )
 		else :
-			raise RuntimeError( "\"%s\" is not a ValuePlug" % plugPath )
+			raise RuntimeError( "\"{}\" is not a ValuePlug".format( ".".join( plugPath ) ) )
 
 	def __plugRegex( self, node, plug ) :
 
@@ -326,9 +331,9 @@ class _Parser( ast.NodeVisitor ) :
 	def __plugPath( self, path ) :
 
 		if len( path ) < 2 or path[0] != "parent" :
-			return ""
+			return ()
 		else :
-			return ".".join( path[1:] )
+			return tuple( path[1:] )
 
 	def __contextName( self, path ) :
 

--- a/python/GafferImageTest/ShuffleTest.py
+++ b/python/GafferImageTest/ShuffleTest.py
@@ -412,5 +412,25 @@ class ShuffleTest( GafferImageTest.ImageTestCase ) :
 		shuffle["missingSourceMode"].setValue( shuffle.MissingSourceMode.Ignore )
 		self.assertEqual( shuffle["out"].channelNames(), IECore.StringVectorData( [ "R", "G", "B", "A" ] ) )
 
+	def testLegacyChannelPlugConstructor( self ) :
+
+		p = GafferImage.Shuffle.ChannelPlug( "R", "R" )
+		self.assertEqual( p.getName(), "channel" )
+
+	def testCreateExpressionWithLegacyNames( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["shuffle"] = GafferImage.Shuffle()
+		script["shuffle"]["shuffles"].addChild( GafferImage.Shuffle.ChannelPlug( "R", "R" ) )
+		script["shuffle"]["shuffles"].addChild( GafferImage.Shuffle.ChannelPlug( "G", "G" ) )
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			'parent["shuffle"]["channels"]["channel"]["in"] = "X"; parent["shuffle"]["channels"]["channel1"]["in"] = "Y"'
+		)
+
+		self.assertEqual( script["shuffle"]["shuffles"][0]["source"].getValue(), "X" )
+		self.assertEqual( script["shuffle"]["shuffles"][1]["source"].getValue(), "Y" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1673,6 +1673,18 @@ class ExpressionTest( GafferTest.TestCase ) :
 
 		self.assertEqual( script["node"]["in"].getValue(), pathlib.Path.cwd().as_posix() )
 
+	def testCreateExpressionWithLegacyPlugName( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["random"] = Gaffer.Random()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression(
+			'parent["random"]["contextEntry"] = "x"'
+		)
+
+		self.assertEqual( script["random"]["seedVariable"].getValue(), "x" )
+
 	@GafferTest.TestRunner.CategorisedTestMethod( { "taskCollaboration:hashAliasing" } )
 	def testHashAliasing( self ) :
 

--- a/startup/GafferImage/shuffleCompatibility.py
+++ b/startup/GafferImage/shuffleCompatibility.py
@@ -46,6 +46,7 @@ class __ChannelPlug( Gaffer.ShufflePlug ) :
 			and isinstance( args[0], str ) and isinstance( args[1], str )
 		) :
 			Gaffer.ShufflePlug.__init__( self, args[1], args[0] )
+			self.setName( "channel" )
 		else :
 			Gaffer.ShufflePlug.__init__( self, *args, **kw )
 


### PR DESCRIPTION
This improves backwards compatibility for the recent improvements to the Shuffle node. As the tests now demonstrate, not only can you load old files (we had test coverage for this already), but you can now also create new expressions via the API using the legacy plug names. This should help Cinesite get over the upgrade hump, since they have nodes which create such expressions internally in their constructors.

The only difference between this PR and #5739 is that I've rebased to fix the Changes.md conflict and am making the PR from a branch on the main repo, to get GafferArnold in the build artifacts. @danieldresser-ie, this is still a priority for review.