### PR TITLE
ImageGadget : Support 2-channel images

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,9 @@ Fixes
   - Fixed bugs caused by reordering images using `GraphComponent::reorderChildren()`.
 - InteractiveRender : Fixed context used to evaluate scene globals when renderer is set to "Default" [^1].
 - Instancer : Fixed handling of unindexed primvars in RootPerVertex mode [^1].
+- ImageGadget :
+  - Fixed loading of 2 channel images [^1].
+  - Fixed error message to include filename [^1].
 
 API
 ---

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -139,7 +139,8 @@ using TextureCache = IECorePreview::LRUCache<TextureCacheKey, ConstTexturePtr>;
 IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cost, const IECore::Canceller *canceller )
 {
 	const OIIO::ImageSpec config( OIIO::TypeDesc::UCHAR );
-	OIIO::ImageBuf imageBuf( resolvedFileName( key.fileName ), /* subimage = */ 0, /* miplevel = */ 0, /* imagecache = */ nullptr, &config );
+	const std::string fileName = resolvedFileName( key.fileName );
+	OIIO::ImageBuf imageBuf( fileName, /* subimage = */ 0, /* miplevel = */ 0, /* imagecache = */ nullptr, &config );
 	imageBuf = OIIO::ImageBufAlgo::flip( imageBuf );
 	if( imageBuf.has_error() )
 	{
@@ -159,6 +160,9 @@ IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cos
 		case 1 :
 			pixelFormat = GL_RED;
 			break;
+		case 2 :
+			pixelFormat = GL_LUMINANCE_ALPHA;
+			break;
 		case 3 :
 			pixelFormat = GL_RGB;
 			break;
@@ -166,7 +170,7 @@ IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cos
 			pixelFormat = GL_RGBA;
 			break;
 		default :
-			throw IECore::Exception( fmt::format( "Unsupported number of channels ({}) in \"{}\"", imageBuf.nchannels(), imageBuf.name() ) );
+			throw IECore::Exception( fmt::format( "Unsupported number of channels ({}) in \"{}\"", imageBuf.nchannels(), fileName ) );
 	}
 
 	GLuint id;


### PR DESCRIPTION
Although we never used them ourselves, the old TextureLoader-based code path prior to 8ea7d9f63e68759d6988afb280f464d94d742a41 did support them, and it turns out they are in use in the wild. I've used `GL_LUMINANCE_ALPHA` because that is what was used by the old code path, but technically it is deprecated - in future we'd need to use `GL_RG` and `GL_TEXTURE_SWIZZLE_RGBA` instead.

Also fixed an empty filename in the "Unsupported number of channels" error message - it seems the `ImageBuf` filename is lost during the `colorconvert()` call.
