### PR TITLE
GafferUI : Fix crashes during shutdown

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 - ImageReader :
   - Fixed loading of OpenEXR images with 32 bit float data and DWA compression [^1].
   - Fixed loading of secondary layers in OpenEXR images with DWA compression [^1].
+- GUI : Fixed potential crashes during shutdown [^1].
 
 API
 ---

--- a/src/GafferUI/PlugAdder.cpp
+++ b/src/GafferUI/PlugAdder.cpp
@@ -203,14 +203,14 @@ void PlugAdder::updateDragEndPoint( const Imath::V3f position, const Imath::V3f 
 
 PlugAdder::PlugMenuSignal &PlugAdder::plugMenuSignal()
 {
-	static PlugMenuSignal s;
-	return s;
+	static PlugMenuSignal *s = new PlugMenuSignal;
+	return *s;
 }
 
 PlugAdder::MenuSignal &PlugAdder::menuSignal()
 {
-	static MenuSignal s;
-	return s;
+	static MenuSignal *s = new MenuSignal;
+	return *s;
 }
 
 void PlugAdder::renderLayer( Layer layer, const Style *style, RenderReason reason ) const

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -146,6 +146,6 @@ void Pointer::registerPointer( const std::string &name, ConstPointerPtr pointer 
 
 Pointer::ChangedSignal &Pointer::changedSignal()
 {
-	static ChangedSignal s;
-	return s;
+	static ChangedSignal *s = new ChangedSignal;
+	return *s;
 }


### PR DESCRIPTION
All these signals get connected to by Python functions, so will contain slots with a `PyObject *` in them. But Python shuts down _before_ static destructors are run, after which we can't delete the PyObject. The solution is one we've used elsewhere : just "leak" the signal and its connected slots. It's intended to live for the entire lifetime of the app anyway, so it doesn't matter if it's not cleaned up during shutdown.
