### PR TITLE
ScriptNode : Support multi-line `if` in `tolerantExec()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
   - Fixed loading of OpenEXR images with 32 bit float data and DWA compression [^1].
   - Fixed loading of secondary layers in OpenEXR images with DWA compression [^1].
 - GUI : Fixed potential crashes during shutdown [^1].
+- ScriptNode : Fixed execution of multi-line `if :` statements in `.gfr` files [^1].
 
 API
 ---


### PR DESCRIPTION
Although we don't make use of any compound statements in our own serialisations, third parties have done so using custom serialisers. Parsing for those was broken by 9d15bd21c4049d89118faf3ac27d01c5799b8264 when we stopped using a legacy AST API for parsing. Here we do the absolute bare minimum necessary to get these legacy files loading. As noted in the comments, we do not intend to do more : rather our future intention is likely to be constrain the serialisation format further for improved performance.
