### PR TITLE
LightPositionTool : Fix mode change crash

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - SceneAlgo : Fixed potential shutdown crashes caused by the adaptor registry [^1].
 - Dispatcher : Fixed shutdown crashes caused by Python slots connected to the dispatch signals [^1].
 - Display : Fixed shutdown crashes caused by Python slots connected to `driverCreatedSignal()` and `imageReceivedSignal()` [^1].
+- LightPositionTool : Fixed crash when changing the tool mode with nothing selected [^1].
 
 API
 ---

--- a/python/GafferSceneUITest/LightPositionToolTest.py
+++ b/python/GafferSceneUITest/LightPositionToolTest.py
@@ -273,5 +273,20 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 						places = 3
 					)
 
+	def testEmptySelectionModeChange( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["light"] = GafferSceneTest.TestLight()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["light"]["out"] )
+
+		tool = GafferSceneUI.LightPositionTool( view )
+		tool["active"].setValue( True )
+
+		# Should not raise an exception
+		tool["mode"].setValue( GafferSceneUI.LightPositionTool.Mode.Highlight )
+		self.assertEqual( tool["mode"].getValue(), GafferSceneUI.LightPositionTool.Mode.Highlight )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -659,7 +659,7 @@ bool LightPositionTool::affectsHandles( const Gaffer::Plug *input ) const
 		return true;
 	}
 
-	return input == scenePlug()->transformPlug();
+	return input == scenePlug()->transformPlug() || input == modePlug();
 }
 
 void LightPositionTool::updateHandles( float rasterScale )
@@ -704,6 +704,7 @@ void LightPositionTool::updateHandles( float rasterScale )
 	distanceHandle->setTransformToSceneSpace( sceneToTransformInverse );
 
 	const Mode mode = (Mode)modePlug()->getValue();
+	distanceHandle->setRequiresPivot( mode == Mode::Shadow );
 
 	if( !target || ( mode == Mode::Shadow && !pivot ) )
 	{
@@ -921,12 +922,6 @@ void LightPositionTool::plugSet( Plug *plug )
 	if( plug == activePlug() && !activePlug()->getValue() && getTargetMode() != TargetMode::None )
 	{
 		setTargetMode( TargetMode::None );
-	}
-	else if( plug == modePlug() )
-	{
-		auto h = static_cast<DistanceHandle *>( m_distanceHandle.get() );
-		h->setRequiresPivot( modePlug()->getValue() == (int)Mode::Shadow );
-		updateHandles( m_rotateHandle->getRasterScale() );
 	}
 }
 


### PR DESCRIPTION
This fixes a crash that would occur when changing the LightPositionTool mode with nothing selected. This was introduced in https://github.com/GafferHQ/gaffer/commit/1417404faad1c9eb1e17f4cd625dbff2e5349614 where we update the handles when changing the mode to take into account the different pivot / target requirements of different tool modes.

Except for this response to tool mode changes, `updateHandles()` is only called when something is selected, so we can safely assign `Selection s = selection().back();`. But now `updateHandles()` may be called with no selection, so we need to make sure `selection().back()` will exist.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
