### PR TITLE
SceneAlgo : Don't destroy adaptor registry at shutdown

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - GafferTest, GafferImageTest : Fixed import of these modules if the `Gaffer` module had not been imported previously.
+- SceneAlgo : Fixed potential shutdown crashes caused by the adaptor registry.
 
 1.4.0.0b5 (relative to 1.4.0.0b4)
 =========

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -1331,11 +1331,11 @@ using RenderAdaptors = boost::container::flat_map<string, SceneAlgo::RenderAdapt
 
 RenderAdaptors &renderAdaptors()
 {
-	static RenderAdaptors a;
-	return a;
+	static RenderAdaptors *a = new RenderAdaptors;
+	return *a;
 }
 
-}
+} // namespace
 
 void GafferScene::SceneAlgo::registerRenderAdaptor( const std::string &name, SceneAlgo::RenderAdaptor adaptor )
 {


### PR DESCRIPTION
It contains Python-implemented adaptors, and Python doesn't take kindly to us deleting Python objects after Python has been shut down.
