### PR TITLE
Support Arnold 7.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,7 @@ jobs:
         import sys
         import os
 
-        for arnoldVersion in [ "7.2.1.0" ] :
+        for arnoldVersion in [ "7.2.1.0", "7.3.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
           os.environ["ARNOLD_ROOT"] = arnoldRoot
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.0.0b5)
 =======
 
+Features
+--------
+
+- Arnold : Added support for Arnold 7.3. Note that a minimum of 7.3.1.0 is required, meaning that 7.3.0.0 is _not_ supported.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.0.0b5)
 =======
 
+Improvements
+------------
+
+- ArnoldShader : Added parameter tooltips based on `help` metadata provided by Arnold.
+
 Fixes
 -----
 

--- a/python/GafferArnoldTest/ArnoldColorManagerTest.py
+++ b/python/GafferArnoldTest/ArnoldColorManagerTest.py
@@ -36,6 +36,8 @@
 
 import unittest
 
+import arnold
+
 import IECore
 import IECoreScene
 
@@ -47,6 +49,21 @@ import GafferSceneTest
 import GafferArnold
 
 class ArnoldColorManagerTest( GafferSceneTest.SceneTestCase ) :
+
+	def __expectedOCIOParameters( self, **kw ) :
+
+		result = {
+			"color_space_linear" : "",
+			"color_space_narrow" : "",
+			"config" : "",
+		}
+
+		if [ int( x ) for x in arnold.AiGetVersion()[:2] ] >= [ 7, 3 ] :
+			result |= {
+				"ignore_environment_variable" : False,
+			}
+
+		return IECore.CompoundData( result | kw )
 
 	def test( self ) :
 
@@ -95,11 +112,7 @@ class ArnoldColorManagerTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( cm.outputShader().type, "ai:color_manager" )
 		self.assertEqual(
 			cm.outputShader().parameters,
-			IECore.CompoundData( {
-				"color_space_linear" : "linear",
-				"color_space_narrow" : "",
-				"config" : "",
-			} )
+			self.__expectedOCIOParameters( color_space_linear = "linear" )
 		)
 
 		colorManager["enabled"].setValue( False )
@@ -148,11 +161,7 @@ class ArnoldColorManagerTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( shader.type, "ai:color_manager" )
 			self.assertEqual(
 				shader.parameters,
-				IECore.CompoundData( {
-					"config" : config,
-					"color_space_linear" : linear,
-					"color_space_narrow" : narrow,
-				} )
+				self.__expectedOCIOParameters( config = config, color_space_linear = linear, color_space_narrow = narrow )
 			)
 
 		with Gaffer.Context() as context :

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -299,7 +299,8 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["Light"].loadShader( "quad_light" )
 		s["Light"]["transform"]["translate"]["z"].setValue( 2 )
 		s["Light"]["parameters"]["color"].setInput( s["Tex"]["out"] )
-		s["Light"]["parameters"]["exposure"].setValue( 4 )
+		s["Light"]["parameters"]["exposure"].setValue( 6 )
+		s["Light"]["parameters"]["samples"].setValue( 6 )
 
 		s["c"] = GafferScene.Camera()
 		s["c"]["transform"]["translate"]["z"].setValue( 2 )
@@ -341,7 +342,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		self.uiThreadCallHandler.waitFor( 1.0 )
 
 		initialColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
-		self.assertAlmostEqual( initialColor.r, 0.09, delta = 0.013 )
+		self.assertAlmostEqual( initialColor.r, 0.57, delta = 0.01 )
 		self.assertAlmostEqual( initialColor.g, 0, delta = 0.01 )
 
 		# Edit texture network and make sure the changes take effect
@@ -352,7 +353,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		updateColor = self._color4fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		self.assertAlmostEqual( updateColor.r, 0, delta = 0.01 )
-		self.assertAlmostEqual( updateColor.g, 0.06, delta = 0.022 )
+		self.assertAlmostEqual( updateColor.g, 0.3, delta = 0.01 )
 
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -205,6 +205,8 @@ def __translateNodeMetadata( nodeEntry ) :
 
 	# Shader description. We support Arnold-style "desc" and
 	# OSL style "help".
+	## \todo It seems that Arnold's standard is now "help", so
+	# we may be able to remove "desc".
 
 	description = __aiMetadataGetStr( nodeEntry, None, "desc",
 		defaultValue = __aiMetadataGetStr( nodeEntry, None, "help" )
@@ -245,7 +247,10 @@ def __translateNodeMetadata( nodeEntry ) :
 
 		# Parameter description
 
-		description = __aiMetadataGetStr( nodeEntry, paramName, "desc" )
+		description = __aiMetadataGetStr(
+			nodeEntry, paramName, "desc",
+			defaultValue = __aiMetadataGetStr( nodeEntry, paramName, "help" )
+		)
 		if description is not None :
 			__metadata[paramPath]["description"] = description
 

--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -46,6 +46,11 @@ import IECoreArnold
 import GafferUI
 import GafferArnold
 
+if [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 3, 1 ] :
+	__AI_NODE_IMAGER = arnold.AI_NODE_DRIVER
+else :
+	__AI_NODE_IMAGER = arnold.AI_NODE_IMAGER
+
 ## \todo Rename. This isn't about loading shaders, it's about loading all sorts
 # of Arnold node definitions.
 def appendShaders( menuDefinition, prefix="/Arnold" ) :
@@ -58,7 +63,7 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 	uncategorisedMenuItems = []
 	with IECoreArnold.UniverseBlock( writable = False ) :
 
-		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER | arnold.AI_NODE_DRIVER )
+		it = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER | __AI_NODE_IMAGER )
 
 		while not arnold.AiNodeEntryIteratorFinished( it ) :
 
@@ -88,11 +93,12 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 				nodeCreator = functools.partial( __colorManagerCreator, shaderName, nodeName )
 				displayName = displayName.replace( "Color Manager ", "" )
 			else :
-				assert( arnold.AiNodeEntryGetType( nodeEntry ) == arnold.AI_NODE_DRIVER )
-				# Imagers don't yet have their own node type, but we can
-				# identify them using metadata.
-				if __aiMetadataGetStr( nodeEntry, "", "subtype" ) != "imager" :
-					continue
+				assert( arnold.AiNodeEntryGetType( nodeEntry ) == __AI_NODE_IMAGER )
+				if [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 3, 1 ] :
+					# Imagers masquerade as drivers, but we can identify them
+					# using metadata.
+					if __aiMetadataGetStr( nodeEntry, "", "subtype" ) != "imager" :
+						continue
 				menuPath = "Globals/Imager"
 				nodeCreator = functools.partial( __shaderCreator, shaderName, GafferArnold.ArnoldShader, nodeName )
 				displayName = displayName.replace( "Imager ", "" )

--- a/python/IECoreArnoldTest/ParameterAlgoTest.py
+++ b/python/IECoreArnoldTest/ParameterAlgoTest.py
@@ -73,7 +73,7 @@ class ParameterAlgoTest( unittest.TestCase ) :
 				IECore.FloatData( arnold.AiNodeGetFlt( n, "base" ) )
 			)
 
-			IECore.FloatData( arnold.AiNodeSetStr( n, "name", "testString" ) )
+			arnold.AiNodeSetStr( n, "name", "testString" )
 			self.assertEqual(
 				IECoreArnold.ParameterAlgo.getParameter( n, "name" ),
 				IECore.StringData( "testString" ),

--- a/src/GafferArnold/ArnoldShader.cpp
+++ b/src/GafferArnold/ArnoldShader.cpp
@@ -53,6 +53,7 @@
 #include "fmt/format.h"
 
 #include "ai_metadata.h"
+#include "ai_version.h"
 
 using namespace std;
 using namespace boost;
@@ -62,6 +63,10 @@ using namespace GafferScene;
 using namespace GafferArnold;
 using namespace Gaffer;
 using namespace GafferOSL;
+
+#if ARNOLD_VERSION_NUM < 70301
+#define AI_NODE_IMAGER AI_NODE_DRIVER
+#endif
 
 namespace
 {
@@ -152,7 +157,7 @@ void ArnoldShader::loadShader( const std::string &shaderName, bool keepExistingV
 		case AI_NODE_COLOR_MANAGER :
 			type = "ai:color_manager";
 			break;
-		case AI_NODE_DRIVER :
+		case AI_NODE_IMAGER :
 			type = "ai:imager";
 			break;
 		default :

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -51,6 +51,7 @@
 #include "boost/container/flat_set.hpp"
 
 #include "ai_metadata.h"
+#include "ai_version.h"
 
 using namespace std;
 using namespace Imath;
@@ -58,6 +59,10 @@ using namespace boost;
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferArnold;
+
+#if ARNOLD_VERSION_NUM < 70301
+#define AI_NODE_IMAGER AI_NODE_DRIVER
+#endif
 
 namespace
 {
@@ -288,7 +293,7 @@ Gaffer::Plug *setupClosurePlug( const IECore::InternedString &parameterName, Gaf
 
 Gaffer::Plug *setupNodePlug( const AtNodeEntry *nodeEntry, const InternedString &parameterName, GraphComponent *plugParent, Plug::Direction direction )
 {
-	if( AiNodeEntryGetType( nodeEntry ) == AI_NODE_DRIVER && parameterName == "input" )
+	if( AiNodeEntryGetType( nodeEntry ) == AI_NODE_IMAGER && parameterName == "input" )
 	{
 		return setupPlug( parameterName, plugParent, direction );
 	}

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -137,12 +137,14 @@ if moduleSearchPath.find( "arnold" ) :
 
 		GafferArnoldUI.CacheMenu.appendDefinitions( scriptWindowMenu, "/Tools/Arnold" )
 
-		scriptWindowMenu.append(
-			"/Tools/Arnold/Populate GPU Cache",
-			{
-				"command" : GafferArnoldUI.GPUCache.populateGPUCache,
-			}
-		)
+		if [ int( x ) for x in arnold.AiGetVersion()[:2] ] < [ 7, 3 ] :
+			# `AiGPUCachePopulate` was removed in Arnold 7.3.0.0.
+			scriptWindowMenu.append(
+				"/Tools/Arnold/Populate GPU Cache",
+				{
+					"command" : GafferArnoldUI.GPUCache.populateGPUCache,
+				}
+			)
 
 	except Exception as m :
 


### PR DESCRIPTION
This makes the minor adjustments necessary for supporting Arnold 7.3.

There's a small bit of awkwardness here in that the AI_NODE_DRIVER -> AI_NODE_IMAGER transition happened in 7.3.1.0 and not in 7.3.0.0, despite them both being released on the same day. So code compiled with 7.3.1.0 will fail to recognise imagers in 7.3.0.0 (and vice versa). Rather than contort things further to deal with this or provide builds for minor versions (which are not generally needed, i checked), I've just documented that we don't support 7.3.0.0. HtoA and KtoA are apparently skipping 7.3.0.0 as well - the only reason it exists is because Arnold is the built-in renderer for Max/Maya, and a version needed to be locked down earlier for QA reasons (as far as I understand it anyway).