### PR TITLE
Arnold USD compatibility improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 ------------
 
 - EditScope : Added a summary of edits in the NodeEditor, with the ability to select the affected objects and quickly navigate to the processor nodes.
+- Arnold : OSL shaders with connections from multiple outputs are no longer duplicated on export to Arnold.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,11 @@ API
   - ProcessorWidget provides a base class for custom widgets, and a factory mechanism for registering them against processors.
   - SimpleProcessorWidget provides a base class for widgets with a simple summary label and optional action links.
 
+Breaking Changes
+----------------
+
+- InteractiveRenderTest : Subclasses must now return the shader output plug from creation methods such as `_createConstantShader()`.
+
 1.4.0.0b5 (relative to 1.4.0.0b4)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
 - Arnold :
   - Fixed rendering of shaders imported from HtoA via USD.
   - Fixed USD export of shaders to use `outputs:out` instead of `outputs:DEFAULT_OUTPUT`.
+  - Fixed rendering of `osl` shaders using the `code` parameter.
 - GafferTest, GafferImageTest : Fixed import of these modules if the `Gaffer` module had not been imported previously.
 - SceneAlgo : Fixed potential shutdown crashes caused by the adaptor registry [^1].
 - Dispatcher : Fixed shutdown crashes caused by Python slots connected to the dispatch signals [^1].

--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,9 @@ Improvements
 Fixes
 -----
 
-- Arnold : Fixed rendering of shaders imported from HtoA via USD.
+- Arnold :
+  - Fixed rendering of shaders imported from HtoA via USD.
+  - Fixed USD export of shaders to use `outputs:out` instead of `outputs:DEFAULT_OUTPUT`.
 - GafferTest, GafferImageTest : Fixed import of these modules if the `Gaffer` module had not been imported previously.
 - SceneAlgo : Fixed potential shutdown crashes caused by the adaptor registry [^1].
 - Dispatcher : Fixed shutdown crashes caused by Python slots connected to the dispatch signals [^1].

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
 Fixes
 -----
 
+- Arnold : Fixed rendering of shaders imported from HtoA via USD.
 - GafferTest, GafferImageTest : Fixed import of these modules if the `Gaffer` module had not been imported previously.
 - SceneAlgo : Fixed potential shutdown crashes caused by the adaptor registry [^1].
 - Dispatcher : Fixed shutdown crashes caused by Python slots connected to the dispatch signals [^1].

--- a/python/GafferArnoldTest/ArnoldLightFilterTest.py
+++ b/python/GafferArnoldTest/ArnoldLightFilterTest.py
@@ -78,7 +78,7 @@ class ArnoldLightFilterTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			network.inputConnections( network.getOutput().shader ),
 			[
-				network.Connection( ( "Checkerboard", "" ), ( network.getOutput().shader, "shader" ) ),
+				network.Connection( ( "Checkerboard", "out" ), ( network.getOutput().shader, "shader" ) ),
 			]
 		)
 

--- a/python/GafferArnoldTest/ArnoldLightTest.py
+++ b/python/GafferArnoldTest/ArnoldLightTest.py
@@ -103,8 +103,8 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			network.inputConnections( network.getOutput().shader ),
 			[
-				network.Connection( ( "sky", "" ), ( network.getOutput().shader, "color" ) ),
-				network.Connection( ( "matte", "" ), ( network.getOutput().shader, "shader" ) ),
+				network.Connection( ( "sky", "out" ), ( network.getOutput().shader, "color" ) ),
+				network.Connection( ( "matte", "out" ), ( network.getOutput().shader, "shader" ) ),
 			]
 		)
 
@@ -126,7 +126,7 @@ class ArnoldLightTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			network.inputConnections( network.getOutput().shader ),
 			[
-				network.Connection( ( "mockOSL", "" ), ( network.getOutput().shader, "color" ) )
+				network.Connection( ( "mockOSL", "out" ), ( network.getOutput().shader, "color" ) )
 			]
 		)
 

--- a/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
+++ b/python/GafferArnoldTest/InteractiveArnoldRenderTest.py
@@ -198,8 +198,8 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["ShaderAssignment"]["in"].setInput( s["s"]["out"] )
 		s["ShaderAssignment"]["filter"].setInput( s["PathFilter"]["out"] )
 
-		s["lambert"], _ = self._createMatteShader()
-		s["ShaderAssignment"]["shader"].setInput( s["lambert"]["out"] )
+		s["lambert"], _, lambertOut = self._createMatteShader()
+		s["ShaderAssignment"]["shader"].setInput( lambertOut )
 
 		s["StandardAttributes"] = GafferScene.StandardAttributes( "StandardAttributes" )
 		s["StandardAttributes"]["attributes"]["linkedLights"]["enabled"].setValue( True )
@@ -287,8 +287,8 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["ShaderAssignment"]["in"].setInput( s["s"]["out"] )
 		s["ShaderAssignment"]["filter"].setInput( s["PathFilter"]["out"] )
 
-		s["lambert"], _ = self._createMatteShader()
-		s["ShaderAssignment"]["shader"].setInput( s["lambert"]["out"] )
+		s["lambert"], _, lambertOut = self._createMatteShader()
+		s["ShaderAssignment"]["shader"].setInput( lambertOut )
 
 		s["Tex"] = GafferArnold.ArnoldShader( "image" )
 		s["Tex"].loadShader( "image" )
@@ -385,9 +385,9 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		s["Tex"]["parameters"]["filename"].setValue( tmpTextureFile )
 
 		# Create a constant shader
-		s["constant"], shaderColor = self._createConstantShader()
+		s["constant"], shaderColor, constantOut = self._createConstantShader()
 		shaderColor.setInput( s["Tex"]["out"] )
-		s["ShaderAssignment"]["shader"].setInput( s["constant"]["out"] )
+		s["ShaderAssignment"]["shader"].setInput( constantOut )
 
 		s["c"] = GafferScene.Camera()
 		s["c"]["transform"]["translate"]["z"].setValue( 2 )
@@ -919,14 +919,14 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		shader = GafferArnold.ArnoldShader()
 		shader.loadShader( "flat" )
-		return shader, shader["parameters"]["color"]
+		return shader, shader["parameters"]["color"], shader["out"]
 
 	def _createMatteShader( self ) :
 
 		shader = GafferArnold.ArnoldShader()
 		shader.loadShader( "lambert" )
 		shader["parameters"]["Kd"].setValue( 1 )
-		return shader, shader["parameters"]["Kd_color"]
+		return shader, shader["parameters"]["Kd_color"], shader["out"]
 
 	def _createTraceSetShader( self ) :
 		# It's currently pretty ugly how we need to disable the trace set when it is left empty,
@@ -965,7 +965,7 @@ class InteractiveArnoldRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		Gaffer.PlugAlgo.promote( switchShader["out"] )
 
-		return shaderBox, traceSetShader["parameters"]["trace_set"]
+		return shaderBox, traceSetShader["parameters"]["trace_set"], shaderBox["out"]
 
 	def _cameraVisibilityAttribute( self ) :
 

--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -123,13 +123,13 @@ class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 		shader = GafferCycles.CyclesShader()
 		shader.loadShader( "emission" )
 		shader["parameters"]["strength"].setValue( 1 )
-		return shader, shader["parameters"]["color"]
+		return shader, shader["parameters"]["color"], shader["out"]["emission"]
 
 	def _createMatteShader( self ) :
 
 		shader = GafferCycles.CyclesShader()
 		shader.loadShader( "diffuse_bsdf" )
-		return shader, shader["parameters"]["color"]
+		return shader, shader["parameters"]["color"], shader["out"]["BSDF"]
 
 	def _createTraceSetShader( self ) :
 

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -96,11 +96,11 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		shader = GafferOSL.OSLShader()
 		shader.loadShader( "Surface/Constant" )
-		return shader, shader["parameters"]["Cs"]
+		return shader, shader["parameters"]["Cs"], shader["out"]["out"]
 
 	def _createTraceSetShader( self ) :
 
-		return None, None
+		return None, None, None
 
 	def _cameraVisibilityAttribute( self ) :
 
@@ -110,7 +110,7 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		shader = GafferOSL.OSLShader()
 		shader.loadShader( "lambert" )
-		return shader, shader["parameters"]["i_color"]
+		return shader, shader["parameters"]["i_color"], shader["out"]["outColor"]
 
 	def _createPointLight( self ) :
 

--- a/python/GafferOSLTest/OSLShaderTest.py
+++ b/python/GafferOSLTest/OSLShaderTest.py
@@ -128,7 +128,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 
 		network = typesNode.attributes()["osl:surface"]
 		self.assertEqual( len( network ), 2 )
-		self.assertEqual( network.getOutput(), ( "types", "" ) )
+		self.assertEqual( network.getOutput(), ( "types", "out" ) )
 
 		types = network.getShader( "types" )
 		outputTypes = network.getShader( "outputTypes" )
@@ -1181,7 +1181,7 @@ class OSLShaderTest( GafferOSLTest.OSLTestCase ) :
 		network3 = shaderPlug.attributes()["osl:shader"]
 		hash3 = shaderPlug.attributesHash()
 
-		self.assertEqual( network1.getOutput(), IECoreScene.ShaderNetwork.Parameter( "globals" ) )
+		self.assertEqual( network1.getOutput(), IECoreScene.ShaderNetwork.Parameter( "globals", "out" ) )
 		self.assertEqual( network2.getOutput(), IECoreScene.ShaderNetwork.Parameter( "globals", "globalP" ) )
 		self.assertEqual( network3.getOutput(), IECoreScene.ShaderNetwork.Parameter( "globals", "globalN" ) )
 

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -561,12 +561,12 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["catalogue"] = GafferImage.Catalogue()
 		s["s"] = GafferScene.Sphere()
 
-		s["shader"], colorPlug = self._createConstantShader()
+		s["shader"], colorPlug, shaderOut = self._createConstantShader()
 		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
 
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["s"]["out"] )
-		s["a"]["shader"].setInput( s["shader"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["o"] = GafferScene.Outputs()
 		s["o"].addOutput(
@@ -942,10 +942,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["g"]["in"][1].setInput( s["p"]["out"] )
 		s["g"]["in"][2].setInput( s["c"]["out"] )
 
-		s["s"], unused = self._createMatteShader()
+		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
-		s["a"]["shader"].setInput( s["s"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(
@@ -1039,10 +1039,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["g"]["in"][1].setInput( s["p"]["out"] )
 		s["g"]["in"][2].setInput( s["c"]["out"] )
 
-		s["s"], unused = self._createMatteShader()
+		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
-		s["a"]["shader"].setInput( s["s"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(
@@ -1119,10 +1119,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["g"]["in"][1].setInput( s["p"]["out"] )
 		s["g"]["in"][2].setInput( s["c"]["out"] )
 
-		s["s"], unused = self._createMatteShader()
+		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
-		s["a"]["shader"].setInput( s["s"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(
@@ -1199,10 +1199,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["g"]["in"][1].setInput( s["p"]["out"] )
 		s["g"]["in"][2].setInput( s["c"]["out"] )
 
-		s["s"], unused = self._createMatteShader()
+		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
-		s["a"]["shader"].setInput( s["s"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(
@@ -1473,12 +1473,12 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["group"]["in"][0].setInput( s["reflector"]["out"] )
 		s["group"]["in"][1].setInput( s["reflected"]["out"] )
 
-		s["constant"], constantParameter = self._createConstantShader()
+		s["constant"], constantParameter, constantOut = self._createConstantShader()
 		s["constantAssignment"] = GafferScene.ShaderAssignment()
 		s["constantAssignment"]["in"].setInput( s["group"]["out"] )
-		s["constantAssignment"]["shader"].setInput( s["constant"]["out"] )
+		s["constantAssignment"]["shader"].setInput( constantOut )
 
-		traceShader, traceSetParameter = self._createTraceSetShader()
+		traceShader, traceSetParameter, traceShaderOut = self._createTraceSetShader()
 		if traceShader is None :
 			self.skipTest( "Trace set shader not available" )
 
@@ -1489,7 +1489,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["traceAssignment"] = GafferScene.ShaderAssignment()
 		s["traceAssignment"]["in"].setInput( s["constantAssignment"]["out"] )
-		s["traceAssignment"]["shader"].setInput( s["traceShader"]["out"] )
+		s["traceAssignment"]["shader"].setInput( traceShaderOut )
 		s["traceAssignment"]["filter"].setInput( s["traceAssignmentFilter"]["out"] )
 
 		s["set"] = GafferScene.Set()
@@ -1644,10 +1644,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		script["group"]["in"][2].setInput( script["cam"]["out"] )
 		script["group"]["in"][3].setInput( script["attributes"]["out"] )
 
-		script["shader"], unused = self._createMatteShader()
+		script["shader"], unused, shaderOut = self._createMatteShader()
 		script["assignment"] = GafferScene.ShaderAssignment()
 		script["assignment"]["in"].setInput( script["group"]["out"] )
-		script["assignment"]["shader"].setInput( script["shader"]["out"] )
+		script["assignment"]["shader"].setInput( shaderOut )
 
 		script["outputs"] = GafferScene.Outputs()
 		script["outputs"].addOutput(
@@ -1791,10 +1791,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["plane"] = GafferScene.Plane()
 
-		script["shader"], unused = self._createMatteShader()
+		script["shader"], unused, shaderOut = self._createMatteShader()
 		script["assignment"] = GafferScene.ShaderAssignment()
 		script["assignment"]["in"].setInput( script["plane"]["out"] )
-		script["assignment"]["shader"].setInput( script["shader"]["out"] )
+		script["assignment"]["shader"].setInput( shaderOut )
 
 		script["camera"] = GafferScene.Camera()
 		script["camera"]["transform"]["translate"]["z"].setValue( 1 )
@@ -1875,12 +1875,12 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 			result = GafferScene.SceneProcessor()
 
-			result["__shader"], colorPlug = self._createConstantShader()
+			result["__shader"], colorPlug, shaderOut = self._createConstantShader()
 			colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
 
 			result["__assignment"] = GafferScene.ShaderAssignment()
 			result["__assignment"]["in"].setInput( result["in"] )
-			result["__assignment"]["shader"].setInput( result["__shader"]["out"] )
+			result["__assignment"]["shader"].setInput( shaderOut )
 
 			result["out"].setInput( result["__assignment"]["out"] )
 
@@ -1936,10 +1936,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["g"]["in"][1].setInput( s["p"]["out"] )
 		s["g"]["in"][2].setInput( s["c"]["out"] )
 
-		s["s"], unused = self._createMatteShader()
+		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
 		s["a"]["in"].setInput( s["g"]["out"] )
-		s["a"]["shader"].setInput( s["s"]["out"] )
+		s["a"]["shader"].setInput( shaderOut )
 
 		s["d"] = GafferScene.Outputs()
 		s["d"].addOutput(
@@ -2023,10 +2023,10 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["group"]["in"][2].setInput( s["plane"]["out"] )
 		s["group"]["in"][3].setInput( s["camera"]["out"] )
 
-		s["shader"], unused = self._createMatteShader()
+		s["shader"], unused, shaderOut = self._createMatteShader()
 		s["shaderAssignment"] = GafferScene.ShaderAssignment()
 		s["shaderAssignment"]["in"].setInput( s["group"]["out"] )
-		s["shaderAssignment"]["shader"].setInput( s["shader"]["out"] )
+		s["shaderAssignment"]["shader"].setInput( shaderOut )
 
 		s["outputs"] = GafferScene.Outputs()
 		s["outputs"].addOutput(
@@ -2286,14 +2286,16 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 	## Should be implemented by derived classes to return an
 	# appropriate Shader node with a constant shader loaded,
-	# along with the plug for the colour parameter.
+	# along with the plug for the colour parameter and the output
+	# plug to be connected to a ShaderAssignment.
 	def _createConstantShader( self ) :
 
 		raise NotImplementedError
 
 	## Should be implemented by derived classes to return
 	# an appropriate Shader node with a matte shader loaded,
-	# along with the plug for the colour parameter.
+	# along with the plug for the colour parameter and the output
+	# plug to be connected to a ShaderAssignment.
 	def _createMatteShader( self ) :
 
 		raise NotImplementedError

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -423,3 +423,31 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 		controllerB.update()
 
 		GafferSceneTest.IECoreScenePreviewTest.CapturingRendererTest.assertRendersMatch( rendererA, rendererB, expandProcedurals = expandProcedurals, ignoreLinks = ignoreLinks )
+
+	## More useful than `assertEqual( networkA, networkB )`, because it provides
+	# information about what doesn't match specifically.
+	def assertShaderNetworksEqual( self, networkA, networkB, ignoreBlindData = False ) :
+
+		if not ignoreBlindData :
+			self.assertEqual( networkA.blindData(), networkB.blindData() )
+
+		self.assertEqual( networkA.shaders().keys(), networkB.shaders().keys() )
+		for handle in networkA.shaders().keys() :
+
+			shaderA = networkA.getShader( handle )
+			shaderB = networkB.getShader( handle )
+
+			self.assertEqual( shaderA.name, shaderB.name, handle )
+			self.assertEqual( shaderA.type, shaderB.type, handle )
+
+			if not ignoreBlindData :
+				self.assertEqual( shaderA.blindData(), shaderB.blindData(), handle )
+
+			self.assertEqual( shaderA.parameters.keys(), shaderB.parameters.keys(), handle )
+			for parameter in shaderA.parameters.keys() :
+				self.assertEqual( shaderA.parameters[parameter], shaderB.parameters[parameter], f"{handle}.{parameter}" )
+
+			self.assertEqual( networkA.inputConnections( handle ), networkB.inputConnections( handle ), handle )
+			self.assertEqual( networkA.outputConnections( handle ), networkB.outputConnections( handle ), handle )
+
+		self.assertEqual( networkA.getOutput(), networkB.getOutput() )

--- a/python/GafferSceneTest/ShaderSwitchTest.py
+++ b/python/GafferSceneTest/ShaderSwitchTest.py
@@ -175,7 +175,7 @@ class ShaderSwitchTest( GafferSceneTest.SceneTestCase ) :
 				)
 				self.assertEqual(
 					network.inputConnections( "n3" ),
-					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "" ), network.Parameter( "n3", "c" ) ) ]
+					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "out" ), network.Parameter( "n3", "c" ) ) ]
 				)
 
 if __name__ == "__main__":

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -176,8 +176,8 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( network ), 3 )
 		self.assertEqual(
 			network.inputConnections( "n3" ), [
-				network.Connection( network.Parameter( "n2", "", ), network.Parameter( "n3", "c" ) ),
-				network.Connection( network.Parameter( "n1", "r", ), network.Parameter( "n3", "i" ) )
+				network.Connection( network.Parameter( "n2", "out", ), network.Parameter( "n3", "c" ) ),
+				network.Connection( network.Parameter( "n1", "out.r", ), network.Parameter( "n3", "i" ) )
 			]
 		)
 
@@ -235,7 +235,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( len( network ), 2 )
 			self.assertEqual(
 				network.inputConnections( "n3" ),
-				[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "", ), network.Parameter( "n3", "c" ) ) ]
+				[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "out", ), network.Parameter( "n3", "c" ) ) ]
 			)
 
 	def testSwitchWithContextSensitiveIndex( self ) :
@@ -259,7 +259,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( network ), 2 )
 		self.assertEqual(
 			network.inputConnections( "n3" ),
-			[ network.Connection( network.Parameter( "n1", "", ), network.Parameter( "n3", "c" ) ) ]
+			[ network.Connection( network.Parameter( "n1", "out", ), network.Parameter( "n3", "c" ) ) ]
 		)
 
 		s["expression"] = Gaffer.Expression()
@@ -276,7 +276,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 				self.assertEqual( len( network ), 2 )
 				self.assertEqual(
 					network.inputConnections( "n3" ),
-					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "", ), network.Parameter( "n3", "c" ) ) ]
+					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "out", ), network.Parameter( "n3", "c" ) ) ]
 				)
 
 	def testSwitchWithComponentConnections( self ) :
@@ -310,7 +310,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 				self.assertEqual( len( network ), 2 )
 				self.assertEqual(
 					network.inputConnections( "n3" ),
-					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "r", ), network.Parameter( "n3", "c.r" ) ) ]
+					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "out.r", ), network.Parameter( "n3", "c.r" ) ) ]
 				)
 
 	def testComponentToComponentConnections( self ) :
@@ -327,9 +327,9 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual(
 			network.inputConnections( "n2" ),
 			[
-				( ( "n1", "r" ), ( "n2", "c.b" ) ),
-				( ( "n1", "b" ), ( "n2", "c.g" ) ),
-				( ( "n1", "g" ), ( "n2", "c.r" ) ),
+				( ( "n1", "out.r" ), ( "n2", "c.b" ) ),
+				( ( "n1", "out.b" ), ( "n2", "c.g" ) ),
+				( ( "n1", "out.g" ), ( "n2", "c.r" ) ),
 			]
 		)
 
@@ -358,7 +358,7 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( len( network ), 2 )
 			self.assertEqual(
 				network.inputConnections( "n3" ),
-				[ network.Connection( network.Parameter( n, "", ), network.Parameter( "n3", "c" ) ) ]
+				[ network.Connection( network.Parameter( n, "out", ), network.Parameter( "n3", "c" ) ) ]
 			)
 
 	def testSpline( self ) :
@@ -400,10 +400,10 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( network ), 2 )
 		self.assertEqual(
 			network.inputConnections( "n1" ), [
-				network.Connection( network.Parameter( "inN1", "", ), network.Parameter( "n1", "spline[0].y" ) ),
-				network.Connection( network.Parameter( "inN1", "", ), network.Parameter( "n1", "spline[1].y" ) ),
-				network.Connection( network.Parameter( "inN1", "g", ), network.Parameter( "n1", "spline[3].y.b" ) ),
-				network.Connection( network.Parameter( "inN1", "g", ), network.Parameter( "n1", "spline[4].y.b" ) )
+				network.Connection( network.Parameter( "inN1", "out", ), network.Parameter( "n1", "spline[0].y" ) ),
+				network.Connection( network.Parameter( "inN1", "out", ), network.Parameter( "n1", "spline[1].y" ) ),
+				network.Connection( network.Parameter( "inN1", "out.g", ), network.Parameter( "n1", "spline[3].y.b" ) ),
+				network.Connection( network.Parameter( "inN1", "out.g", ), network.Parameter( "n1", "spline[4].y.b" ) )
 			]
 		)
 
@@ -419,8 +419,8 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 		network = n1.attributes()["test:surface"]
 		self.assertEqual(
 			network.inputConnections( "n1" ), [
-				network.Connection( network.Parameter( "inN1", "", ), network.Parameter( "n1", "spline[0].y" ) ),
-				network.Connection( network.Parameter( "inN1", "g", ), network.Parameter( "n1", "spline[2].y.b" ) )
+				network.Connection( network.Parameter( "inN1", "out", ), network.Parameter( "n1", "spline[0].y" ) ),
+				network.Connection( network.Parameter( "inN1", "out.g", ), network.Parameter( "n1", "spline[2].y.b" ) )
 			]
 		)
 

--- a/python/GafferSceneTest/ShaderTweaksTest.py
+++ b/python/GafferSceneTest/ShaderTweaksTest.py
@@ -184,7 +184,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 
 		tweakedNetwork = tweaks["out"].attributes( "/plane" )["surface"]
 		self.assertEqual( len( tweakedNetwork ), 2 )
-		self.assertEqual( tweakedNetwork.input( ( "surface", "c" ) ), ( "texture", "" ) )
+		self.assertEqual( tweakedNetwork.input( ( "surface", "c" ) ), ( "texture", "out" ) )
 
 		tweakedNetwork.removeShader( "texture" )
 		self.assertEqual( tweakedNetwork, originalNetwork )
@@ -257,7 +257,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 
 		originalNetwork = assignment["out"].attributes( "/plane" )["surface"]
 		self.assertEqual( len( originalNetwork ), 2 )
-		self.assertEqual( originalNetwork.input( ( "surface", "c" ) ), ( "texture1", "" ) )
+		self.assertEqual( originalNetwork.input( ( "surface", "c" ) ), ( "texture1", "out" ) )
 
 		textureShader2 = GafferSceneTest.TestShader( "texture2" )
 
@@ -271,7 +271,7 @@ class ShaderTweaksTest( GafferSceneTest.SceneTestCase ) :
 
 		tweakedNetwork = tweaks["out"].attributes( "/plane" )["surface"]
 		self.assertEqual( len( tweakedNetwork ), 2 )
-		self.assertEqual( tweakedNetwork.input( ( "surface", "c" ) ), ( "texture2", "" ) )
+		self.assertEqual( tweakedNetwork.input( ( "surface", "c" ) ), ( "texture2", "out" ) )
 
 		textureShader2["enabled"].setValue( False )
 		tweakedNetwork = tweaks["out"].attributes( "/plane" )["surface"]

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -144,7 +144,7 @@ class RendererTest( GafferTest.TestCase ) :
 		for i in range( 0, 10 ) :
 
 			a = IECore.CompoundObject( {
-				"ai:surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat" ) }, output = "output" ),
+				"ai:surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat" ) }, output = ( "output", "out" ) ),
 			} )
 
 			r.object(
@@ -190,7 +190,7 @@ class RendererTest( GafferTest.TestCase ) :
 		# Replace the shader a few times.
 		for shader in ( "utility", "flat", "standard_surface" ) :
 			a = IECore.CompoundObject( {
-				"ai:surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( shader ) }, output = "output" ),
+				"ai:surface" : IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( shader ) }, output = ( "output", "out" ) ),
 			} )
 			o.attributes( r.attributes( a ) )
 			del a
@@ -216,9 +216,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"flat" : IECoreScene.Shader( "flat" ),
 			},
 			connections = [
-				( ( "myHandle", "" ), ( "flat", "color" ) ),
+				( ( "myHandle", "out" ), ( "flat", "color" ) ),
 			],
-			output = "flat"
+			output = ( "flat", "out" )
 		)
 
 		r.object(
@@ -237,9 +237,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"standard_surface" : IECoreScene.Shader( "standard_surface" ),
 			},
 			connections = [
-				( ( "myHandle", "" ), ( "standard_surface", "base_color" ) ),
+				( ( "myHandle", "out" ), ( "standard_surface", "base_color" ) ),
 			],
-			output = "standard_surface"
+			output = ( "standard_surface", "out" )
 		)
 
 		r.object(
@@ -279,9 +279,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"scalarColorTarget" : IECoreScene.Shader( "lambert" ),
 			},
 			connections = [
-				( ( "scalarColorSource", "" ), ( "scalarColorTarget", "Kd_color" ) )
+				( ( "scalarColorSource", "out" ), ( "scalarColorTarget", "Kd_color" ) )
 			],
-			output = "scalarColorTarget"
+			output = ( "scalarColorTarget", "out" )
 		)
 
 		arrayColorShader = IECoreScene.ShaderNetwork(
@@ -290,9 +290,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"arrayColorTarget" : IECoreScene.Shader( "ramp_rgb" ),
 			},
 			connections = [
-				( ( "arrayColorSource", "" ), ( "arrayColorTarget", "color[0]" ) )
+				( ( "arrayColorSource", "out" ), ( "arrayColorTarget", "color[0]" ) )
 			],
-			output = "arrayColorTarget"
+			output = ( "arrayColorTarget", "" )
 		)
 
 		for name,s in [ ( "scalarColor", scalarColorShader ), ( "arrayColor", arrayColorShader ) ] :
@@ -342,7 +342,7 @@ class RendererTest( GafferTest.TestCase ) :
 				# The HtoA convention, which will hopefully be phased out.
 				( ( "source", "rgba.b" ), ( "output", "color.r" ) ),
 			],
-			output = "output"
+			output = ( "output", "out" )
 		)
 
 		r.object(
@@ -398,7 +398,7 @@ class RendererTest( GafferTest.TestCase ) :
 				( ( "source", "out.g" ), ( "output", "a.b" ) ),
 				( ( "source", "out.b" ), ( "output", "a.r" ) ),
 			],
-			output = "output"
+			output = ( "output", "out" )
 		)
 
 		r.object(
@@ -456,7 +456,7 @@ class RendererTest( GafferTest.TestCase ) :
 			str( self.temporaryDirectory() / "test.ass" )
 		)
 
-		lightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "point_light", "ai:light" ), }, output = "light" )
+		lightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "point_light", "ai:light" ), }, output = ( "light", "out" ) )
 		r.light(
 			"testLight",
 			None,
@@ -488,7 +488,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		lightAttributes = r.attributes(
 			IECore.CompoundObject( {
-				"ai:light" : IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "point_light", "ai:light" ), }, output = "light" )
+				"ai:light" : IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "point_light", "ai:light" ), }, output = ( "light", "out" ) )
 			} )
 		)
 
@@ -539,7 +539,7 @@ class RendererTest( GafferTest.TestCase ) :
 			str( self.temporaryDirectory() / "test.ass" )
 		)
 
-		lightShader = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "point_light", "ai:light" ) }, output = "output" )
+		lightShader = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "point_light", "ai:light" ) }, output = ( "output", "out" ) )
 		lightAttributes = r.attributes(
 			IECore.CompoundObject( {
 				"ai:light" : lightShader
@@ -1632,7 +1632,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
-		noise = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "noise", "ai:displacement", {} ) }, output = "output" )
+		noise = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "noise", "ai:displacement", {} ) }, output = ( "output", "out" ) )
 
 		sharedAttributes = r.attributes(
 			IECore.CompoundObject( {
@@ -1850,7 +1850,7 @@ class RendererTest( GafferTest.TestCase ) :
 			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
 			r.attributes(
 				IECore.CompoundObject( {
-					"ai:light" : IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "mesh_light", "ai:light" ) }, output = "light" )
+					"ai:light" : IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "mesh_light", "ai:light" ) }, output = ( "light", "out" ) )
 				} )
 			)
 		)
@@ -1891,9 +1891,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"light" : IECoreScene.Shader( "mesh_light", "ai:light" ),
 			},
 			connections = [
-				( ( "colorHandle", "" ), ( "light", "color" ) )
+				( ( "colorHandle", "out" ), ( "light", "color" ) )
 			],
-			output = "light"
+			output = ( "light", "out" ),
 		)
 
 		l1 = r.light(
@@ -2018,7 +2018,7 @@ class RendererTest( GafferTest.TestCase ) :
 				( ( "globalsHandle", "globalP" ), ( "splineWithInputsHandle", "spline[0].y" ) ),
 				( ( "globalsHandle", "globalV" ), ( "splineWithInputsHandle", "spline[3].y.g" ) ),
 			],
-			output = "output"
+			output = ( "output", "out" ),
 		)
 
 		o = r.object(
@@ -2115,7 +2115,7 @@ class RendererTest( GafferTest.TestCase ) :
 			str( self.temporaryDirectory() / "test.ass" )
 		)
 
-		network = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "Pattern/Noise", "osl:shader" ) }, output = "output" )
+		network = IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "Pattern/Noise", "osl:shader" ) }, output = ( "output", "out" ) )
 
 		o = r.object(
 			"testPlane",
@@ -2163,7 +2163,7 @@ class RendererTest( GafferTest.TestCase ) :
 				( ( "colorToFloatHandle", "g" ), ( "output", "g" ) ),
 				( ( "colorToFloatHandle", "b" ), ( "output", "b" ) ),
 			],
-			output = "output"
+			output = ( "output", "out" ),
 		)
 
 		r.object(
@@ -3054,7 +3054,7 @@ class RendererTest( GafferTest.TestCase ) :
 					{
 						"output" : IECoreScene.Shader( "flat", "ai:surface",  { "color" : color } ),
 					},
-					output = "output"
+					output = ( "output", "out" )
 				)
 
 			return renderer.attributes( attributes )
@@ -3390,9 +3390,9 @@ class RendererTest( GafferTest.TestCase ) :
 				"output" : IECoreScene.Shader( "aov_write_rgb", "ai:shader" ),
 			},
 			connections = [
-				( ( "rgbSource", "" ), ( "output", "aov_input" ) ),
+				( ( "rgbSource", "out" ), ( "output", "aov_input" ) ),
 			],
-			output = "output"
+			output = ( "output", "out" )
 		) )
 
 		universe = ctypes.cast( r.command( "ai:queryUniverse", {} ), ctypes.POINTER( arnold.AtUniverse ) )
@@ -3402,11 +3402,11 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( source ) ), "float_to_rgb" )
 
 		# Add another
-		r.option( "ai:aov_shader:test2", IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "aov_write_float", "ai:shader" ) }, output = "output" ) )
+		r.option( "ai:aov_shader:test2", IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "aov_write_float", "ai:shader" ) }, output = ( "output", "out" ) ) )
 		self.assertEqual( set( self.__aovShaders( universe ).keys() ), set( [ "aov_write_rgb", "aov_write_float" ] ) )
 
 		# Add overwrite
-		r.option( "ai:aov_shader:test", IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "aov_write_int", "ai:shader" ) }, output = "output" ) )
+		r.option( "ai:aov_shader:test", IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "aov_write_int", "ai:shader" ) },output = ( "output", "out" ) ) )
 		self.assertEqual( set( self.__aovShaders( universe ).keys() ), set( [ "aov_write_int", "aov_write_float" ] ) )
 
 		r.option( "ai:aov_shader:test", None )
@@ -3430,7 +3430,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.option(
 			"ai:atmosphere",
-			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "atmosphere_volume", "ai:shader" ) }, output = "output" )
+			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "atmosphere_volume", "ai:shader" ) }, output = ( "output", "out" ) )
 		)
 
 		shader = arnold.AiNodeGetPtr( options, "atmosphere" )
@@ -3455,7 +3455,7 @@ class RendererTest( GafferTest.TestCase ) :
 
 		r.option(
 			"ai:background",
-			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat", "ai:shader" ) }, output = "output" )
+			IECoreScene.ShaderNetwork( { "output" : IECoreScene.Shader( "flat", "ai:shader" ) }, output = ( "output", "out" ) )
 		)
 
 		shader = arnold.AiNodeGetPtr( options, "background" )
@@ -3491,7 +3491,7 @@ class RendererTest( GafferTest.TestCase ) :
 						}
 					)
 				},
-				output = "output"
+				output = ( "output", "out" )
 			)
 		)
 
@@ -3523,7 +3523,7 @@ class RendererTest( GafferTest.TestCase ) :
 					shaders = {
 						"filter" : IECoreScene.Shader( "light_blocker", "ai:lightFilter" ),
 					},
-					output = "filter"
+					output = ( "filter", "out" ),
 				)
 			} ) )
 		)
@@ -3647,11 +3647,11 @@ class RendererTest( GafferTest.TestCase ) :
 				IECore.CompoundObject( {
 					"ai:filtermap" : IECoreScene.ShaderNetwork(
 						shaders = { "out" : IECoreScene.Shader( "noise" ) },
-						output = "out"
+						output = ( "out", "out" )
 					),
 					"ai:uv_remap" : IECoreScene.ShaderNetwork(
 						shaders = { "out" : IECoreScene.Shader( "flat" ) },
-						output = "out"
+						output = ( "out", "out" )
 					)
 				} )
 			),
@@ -3686,7 +3686,7 @@ class RendererTest( GafferTest.TestCase ) :
 		texParameters = { "multiply" : IECore.Color3fData( imath.Color3f(1,0,0) ) }
 		texParametersChanged = { "multiply" : IECore.Color3fData( imath.Color3f(0,1,0) ) }
 
-		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParameters ), }, output = "light" )
+		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParameters ), }, output = ( "light", "out" ) )
 		skydomeLight = r.light(
 			"skydomeLight",
 			None,
@@ -3697,7 +3697,7 @@ class RendererTest( GafferTest.TestCase ) :
 			)
 		)
 
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParameters ), }, output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParameters ), }, output = ( "light", "out" ) )
 		quadLight = r.light(
 			"quadLight",
 			None,
@@ -3709,25 +3709,25 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		# All edits of the skydome light should succeed ( The bug we're hacking around only affects quad_light )
-		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), }, output = "light" )
+		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), }, output = ( "light", "out" ) )
 		self.assertTrue( skydomeLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : skydomeLightShader } ) ) ) )
-		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParameters), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParameters), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertTrue( skydomeLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : skydomeLightShader } ) ) ) )
-		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertTrue( skydomeLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : skydomeLightShader } ) ) ) )
-		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParametersChanged) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		skydomeLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "skydome_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParametersChanged) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertTrue( skydomeLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : skydomeLightShader } ) ) ) )
 
 		# Most edits of the quad lights should succeed
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), }, output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), }, output = ( "light", "out" ) )
 		self.assertTrue( quadLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : quadLightShader } ) ) ) )
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParameters), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParameters), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertTrue( quadLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : quadLightShader } ) ) ) )
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParameters) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertTrue( quadLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : quadLightShader } ) ) ) )
 
 		# The one exception is changing a parameter of a shader upstream of the color parameter
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParametersChanged) }, [(("tex", ""), ("light", "color"))], output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", lightParametersChanged), "tex" : IECoreScene.Shader( "image", "ai:shader", texParametersChanged) }, [(("tex", "out"), ("light", "color"))], output = ( "light", "out" ) )
 		self.assertFalse( quadLight.attributes( r.attributes( IECore.CompoundObject( { "ai:light" : quadLightShader } ) ) ) )
 
 		# Must delete objects before the renderer.
@@ -3807,7 +3807,7 @@ class RendererTest( GafferTest.TestCase ) :
 				connections = [
 					( "exposure", ( "lensEffects", "input" ) )
 				],
-				output = "lensEffects",
+				output = ( "lensEffects", "out" ),
 			)
 		)
 
@@ -3859,7 +3859,7 @@ class RendererTest( GafferTest.TestCase ) :
 		)
 
 		# Make a light with a shader that doesn't exist.
-		badLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "NonexistentShader", "ai:light", {} ), }, output = "light" )
+		badLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "NonexistentShader", "ai:light", {} ), }, output = ( "light", "out" ) )
 		with IECore.CapturingMessageHandler() as mh :
 			light = r.light(
 				"test",
@@ -3878,7 +3878,7 @@ class RendererTest( GafferTest.TestCase ) :
 		# should fail, because lights must be updated in place
 		# and that's not possible if there was no light node in
 		# the first place.
-		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", {} ), }, output = "light" )
+		quadLightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "quad_light", "ai:light", {} ), }, output = ( "light", "out" ) )
 		self.assertFalse(
 			light.attributes(
 				r.attributes(
@@ -4023,7 +4023,7 @@ class RendererTest( GafferTest.TestCase ) :
 						{ "aov" : group }
 					),
 				},
-				output = "light"
+				output = ( "light", "out" )
 			)
 
 			r.light(
@@ -4082,7 +4082,7 @@ class RendererTest( GafferTest.TestCase ) :
 						{ "aov" : group }
 					),
 				},
-				output = "light"
+				output = ( "light", "out" )
 			)
 
 			r.light(
@@ -4135,7 +4135,7 @@ class RendererTest( GafferTest.TestCase ) :
 						( ( "standardShader1", "out" ), ( "layerShader", "input1" ) ),
 						( ( "standardShader2", "out" ), ( "layerShader", "input2" ) ),
 					],
-					output = "layerShader"
+					output = ( "layerShader", "out" ),
 				)
 			} ) ),
 		)
@@ -4187,7 +4187,7 @@ class RendererTest( GafferTest.TestCase ) :
 						# which are named according to the name of the output.
 						( ( "stateFloat", "sx" ), ( "standardSurface", "base" ) ),
 					],
-					output = "standardSurface"
+					output = ( "standardSurface", "out" )
 				)
 			} ) ),
 		)
@@ -4236,7 +4236,7 @@ class RendererTest( GafferTest.TestCase ) :
 					connections = [
 						( ( "colorSwitch", "out" ), ( "standardSurface", "base_color" ) ),
 					],
-					output = "standardSurface"
+					output = ( "standardSurface", "out" )
 				)
 			} ) ),
 		)
@@ -4290,7 +4290,7 @@ class RendererTest( GafferTest.TestCase ) :
 							}
 						),
 					},
-					output = "osl"
+					output = ( "osl", "colorOut" )
 				)
 			} ) ),
 		)
@@ -4411,7 +4411,7 @@ class RendererTest( GafferTest.TestCase ) :
 						{ "camera" : IECore.StringData( camera ) }
 					)
 				},
-				output = ( "output", "" )
+				output = ( "output", "out" )
 			)
 
 			return renderer.attributes( IECore.CompoundObject( { "ai:surface" : shaderNetwork } ) )
@@ -4514,7 +4514,7 @@ class RendererTest( GafferTest.TestCase ) :
 					{ "camera" : IECore.StringData( "/camera" ) }
 				)
 			},
-			output = ( "output", "" )
+			output = ( "output", "out" )
 		)
 
 		renderer.object(

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -2008,11 +2008,10 @@ class RendererTest( GafferTest.TestCase ) :
 				"output" : IECoreScene.Shader( "switch_rgba", "ai:surface" ),
 			},
 			connections = [
-				( ( "splineHandle", "" ), ( "output", "input1" ) ),
-				( ( "noiseHandle", "" ), ( "output", "input2" ) ),
-				( ( "floatSplineHandle", "" ), ( "output", "input3" ) ),
-				( ( "splineWithInputsHandle", "" ), ( "output", "input4" ) ),
-
+				( ( "splineHandle", "c" ), ( "output", "input1" ) ),
+				( ( "noiseHandle", "n" ), ( "output", "input2" ) ),
+				( ( "floatSplineHandle", "c" ), ( "output", "input3" ) ),
+				( ( "splineWithInputsHandle", "c" ), ( "output", "input4" ) ),
 				( ( "globalsHandle", "globalP" ), ( "splineWithInputsHandle", "spline[0].y" ) ),
 				( ( "globalsHandle", "globalV" ), ( "splineWithInputsHandle", "spline[3].y.g" ) ),
 			],

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -2098,10 +2098,8 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeGetRGB( splineWithInputsAdapter, "param_in2" ), arnold.AtRGB( 0.5, 0.5, 0.5 ) )
 
 			globalPInput = arnold.AiNodeGetLink( splineWithInputsAdapter, "param_in0" )
-			print( arnold.AiNodeGetLink( splineWithInputsAdapter, "param_in3" ) )
 			self.assertEqual( arnold.AiNodeGetStr( globalPInput, "shadername" ), "Utility/Globals" )
 			self.assertEqual( arnold.AiNodeGetStr( globalPInput, "output" ), "globalP" )
-
 
 			componentAdapterInput = arnold.AiNodeGetLink( splineWithInputsAdapter, "param_in3" )
 			self.assertEqual( arnold.AiNodeGetStr( componentAdapterInput, "shadername" ), "MaterialX/mx_pack_color" )

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -2098,13 +2098,11 @@ class RendererTest( GafferTest.TestCase ) :
 
 			globalPInput = arnold.AiNodeGetLink( splineWithInputsAdapter, "param_in0" )
 			self.assertEqual( arnold.AiNodeGetStr( globalPInput, "shadername" ), "Utility/Globals" )
-			self.assertEqual( arnold.AiNodeGetStr( globalPInput, "output" ), "globalP" )
 
 			componentAdapterInput = arnold.AiNodeGetLink( splineWithInputsAdapter, "param_in3" )
 			self.assertEqual( arnold.AiNodeGetStr( componentAdapterInput, "shadername" ), "MaterialX/mx_pack_color" )
 			globalVInput = arnold.AiNodeGetLink( componentAdapterInput, "param_in2" )
 			self.assertEqual( arnold.AiNodeGetStr( globalVInput, "shadername" ), "Utility/Globals" )
-			self.assertEqual( arnold.AiNodeGetStr( globalVInput, "output" ), "globalV" )
 
 	def testPureOSLShaders( self ) :
 
@@ -2183,23 +2181,27 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( floatToColor ) ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( floatToColor, "shadername" ), "Conversion/FloatToColor" )
 
-			colorToFloatR = arnold.AiNodeGetLink( floatToColor, "param_r" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatR ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( colorToFloatR, "output" ), "r" )
+			outputIndex = ctypes.c_int()
+			outputComponent = ctypes.c_int()
+			colorToFloatR = arnold.AiNodeGetLinkOutput( floatToColor, "param_r", ctypes.byref( outputIndex ), ctypes.byref( outputComponent ) )
+
+			colorToFloatNodeEntry = arnold.AiNodeGetNodeEntry( colorToFloatR )
+			self.assertEqual( arnold.AiNodeEntryGetName( colorToFloatNodeEntry ), "osl" )
 			self.assertEqual( arnold.AiNodeGetStr( colorToFloatR, "shadername" ), "Conversion/ColorToFloat" )
-			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatR, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatR, "param_c" ), arnold.AtRGB( 0.1, 0.2, 0.3 ) )
 
-			colorToFloatG = arnold.AiNodeGetLink( floatToColor, "param_g" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatG ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( colorToFloatG, "output" ), "g" )
-			self.assertEqual( arnold.AiNodeGetStr( colorToFloatG, "shadername" ), "Conversion/ColorToFloat" )
-			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatG, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+			self.assertEqual( arnold.AiParamGetName( arnold.AiNodeEntryGetOutput( colorToFloatNodeEntry, outputIndex.value ) ), "param_r" )
+			self.assertEqual( outputComponent.value, -1 )
 
-			colorToFloatB = arnold.AiNodeGetLink( floatToColor, "param_b" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( colorToFloatB ) ), "osl" )
-			self.assertEqual( arnold.AiNodeGetStr( colorToFloatB, "output" ), "b" )
-			self.assertEqual( arnold.AiNodeGetStr( colorToFloatB, "shadername" ), "Conversion/ColorToFloat" )
-			self.assertEqual( arnold.AiNodeGetRGB( colorToFloatB, "param_c" ),  arnold.AtRGB( 0.1, 0.2, 0.3 ))
+			colorToFloatG = arnold.AiNodeGetLinkOutput( floatToColor, "param_g", ctypes.byref( outputIndex ), ctypes.byref( outputComponent ) )
+			self.assertReferSameNode( colorToFloatG, colorToFloatR )
+			self.assertEqual( arnold.AiParamGetName( arnold.AiNodeEntryGetOutput( colorToFloatNodeEntry, outputIndex.value ) ), "param_g" )
+			self.assertEqual( outputComponent.value, -1 )
+
+			colorToFloatB = arnold.AiNodeGetLinkOutput( floatToColor, "param_b", ctypes.byref( outputIndex ), ctypes.byref( outputComponent ) )
+			self.assertReferSameNode( colorToFloatB, colorToFloatR )
+			self.assertEqual( arnold.AiParamGetName( arnold.AiNodeEntryGetOutput( colorToFloatNodeEntry, outputIndex.value ) ), "param_b" )
+			self.assertEqual( outputComponent.value, -1 )
 
 	def testTraceSets( self ) :
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -274,15 +274,23 @@ class Shader::NetworkBuilder
 			assert( isOutputParameter( parameter ) );
 
 			const Shader *shader = static_cast<const Shader *>( parameter->node() );
+			const Plug *outPlug = shader->outPlug();
+
 			IECore::InternedString outputName;
-			// Set up an output name if we are a descendant of the output plug.
-			// The alternative is a special case ( which should perhaps be removed
-			// in the future ), which is that for nodes with one output, parameter
-			// is the outPlug instead of being a descendant ( and then we use an
-			// empty name ).
-			if( shader->outPlug()->isAncestorOf( parameter ) )
+			if( outPlug->typeId() == Plug::staticTypeId() && parameter != outPlug )
 			{
-				outputName = parameter->relativeName( shader->outPlug() );
+				// Standard case where `out` is just a container, and individual
+				// outputs are parented under it.
+				outputName = parameter->relativeName( outPlug );
+			}
+			else
+			{
+				// Legacy case for subclasses which use `outPlug()` as the sole
+				// output.
+				/// \todo Enforce that `outPlug()` is always a container, and
+				/// all outputs are represented as `out.name` children, even if
+				/// there is only one output.
+				outputName = parameter->relativeName( shader );
 			}
 
 			return { this->handle( shader ), outputName };

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -62,6 +62,7 @@ using namespace IECoreArnold;
 namespace
 {
 
+const AtString g_codeArnoldString( "code" );
 const AtString g_emptyArnoldString( "" );
 const AtString g_outputArnoldString( "output" );
 const AtString g_shaderNameArnoldString( "shadername" );
@@ -109,6 +110,19 @@ AtNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECo
 			AtString( shader->getName().c_str() ),
 			AtString( nodeName.c_str() )
 		);
+		if( node && AiNodeEntryGetNameAtString( AiNodeGetNodeEntry( node ) ) == g_oslArnoldString )
+		{
+			// Need to set the `code` parameter on `osl` shaders _before_ we try to set
+			// the other parameters, because otherwise they don't exist yet.
+			// Note : This code path is different to the `isOSLShader` one. This code path
+			// deals with shaders authored explicitly to use Arnold's `osl` shader node (which
+			// therefore wouldn't work in other renderers). The `isOSLShader` code path deals
+			// with generically-authored OSL shaders that we are translating to Arnold.
+			if( auto *code = shader->parametersData()->member<StringData>( "code" ) )
+			{
+				AiNodeSetStr( node, g_codeArnoldString, AtString( code->readable().c_str() ) );
+			}
+		}
 	}
 
 	if( !node )


### PR DESCRIPTION
This makes various improvements to our import/export of Arnold shader networks via USD :

- Align our naming for outputs with the naming used by Maya-USD and Arnold-USD's Sdr Registry. This means we use `outputs:out` rather than `outputs:DEFAULT_OUTPUT` in USD. This also applies to the ShaderNetworks we pass around internally, where we now use `"out"` rather than `""` to refer to the default output.
- Cope with non-conforming outputs from USD files written by HtoA. These use a completely different convention for the naming of the default output - using `out:rgb`, `out:float` etc based on type. I've confirmed that this was _not_ intended to diverge from the Maya/SDR convention, and that it should be fixed in future. In the meantime, we can now translate such outputs to Arnold.
- Fix rendering of Arnold `osl` shaders with inline `code`. We don't author these in Gaffer, but we can now ingest and render them from HtoA and elsewhere.