### PR TITLE
TractorDispatcher : Add `taskData` to `preSpoolSignal()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ API
 - EditScopeUI : Added an API for customising the EditScope's NodeEditor with summaries for each processor :
   - ProcessorWidget provides a base class for custom widgets, and a factory mechanism for registering them against processors.
   - SimpleProcessorWidget provides a base class for widgets with a simple summary label and optional action links.
+- TractorDispatcher : The `preSpoolSignal()` now provides an additional `taskData` argument to slots, which maps from Tractor tasks to information about the Gaffer tasks they will execute.
 
 Breaking Changes
 ----------------

--- a/startup/GafferTractor/signalCompatibility.py
+++ b/startup/GafferTractor/signalCompatibility.py
@@ -1,0 +1,78 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import inspect
+import warnings
+
+import GafferTractor
+
+# Backwards compatibility for slots written when `preSpoolSignal()` didn't
+# have the `taskData` argument.
+
+def __slotWrapper( slot ) :
+
+	signature = inspect.signature( slot )
+	try :
+		# Throws if not callable with three arguments
+		signature.bind( None, None, None )
+		# No need for a wrapper
+		return slot
+	except TypeError :
+		pass
+
+	# We'll need a wrapper
+
+	warnings.warn(
+		'Slot connected to `TractorDispatcher.preSpoolSignal() should have an additional `taskData` argument',
+		DeprecationWarning
+	)
+
+	def call( dispatcher, *args ) :
+
+		slot( dispatcher, *args[:-1] )
+
+	return call
+
+def __connectWrapper( originalConnect ) :
+
+	def connect( slot, scoped = None ) :
+
+		return originalConnect( __slotWrapper( slot ), scoped )
+
+	return connect
+
+GafferTractor.TractorDispatcher._TractorDispatcher__preSpoolSignal.connect = __connectWrapper( GafferTractor.TractorDispatcher._TractorDispatcher__preSpoolSignal.connect )
+GafferTractor.TractorDispatcher._TractorDispatcher__preSpoolSignal.connectFront = __connectWrapper( GafferTractor.TractorDispatcher._TractorDispatcher__preSpoolSignal.connectFront )


### PR DESCRIPTION
This allows slots to map from Tractor tasks to the Gaffer tasks that they will execute. I would have preferred to inject this information directly as additional attributes on the `tractor.api.author.Task` objects, but that isn't possible because they use Python's `__slots__` mechanism and therefore reject additional attributes. This means we need to pass a separate dictionary of `TaskData` objects to slots, but backwards compatibility is provided for legacy slots which don't accept that argument.

I deliberated a bit about whether we should just expose the protected `Dispatcher.TaskBatch` objects directly since they contain the same information as `TaskData`. But things like `TaskBatch.blindData()` are definitely meant to be private to the Dispatcher, and it'll be nice to be free to change TaskBatch in future with fewer worries about client code depending on it.
