### PR TITLE
Arnold RendererTest : Account for Arnold prior to `7.2.3.0`

### DIFF
--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -4211,13 +4211,16 @@ class RendererTest( GafferTest.TestCase ) :
 			mix = arnold.AiNodeGetLink( range, "input" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( mix ) ), "mix_rgba" )
 
-			outputIndex = ctypes.c_int()
-			outputComponent = ctypes.c_int()
-			stateFloat = arnold.AiNodeGetLinkOutput( standardSurface, "base", ctypes.byref( outputIndex ), ctypes.byref( outputComponent ) )
-			stateFloatNodeEntry = arnold.AiNodeGetNodeEntry( stateFloat )
-			self.assertEqual( arnold.AiNodeEntryGetName( stateFloatNodeEntry ), "state_float" )
-			self.assertEqual( arnold.AiParamGetName( arnold.AiNodeEntryGetOutput( stateFloatNodeEntry, outputIndex.value ) ), "sx" )
-			self.assertEqual( outputComponent.value, -1 )
+			# Before Arnold 7.2.3.0, the `state_float` doesn't have multiple outputs.
+			if [ int( x ) for x in arnold.AiGetVersion()[:3] ] >= [ 7, 2, 3 ] :
+
+				outputIndex = ctypes.c_int()
+				outputComponent = ctypes.c_int()
+				stateFloat = arnold.AiNodeGetLinkOutput( standardSurface, "base", ctypes.byref( outputIndex ), ctypes.byref( outputComponent ) )
+				stateFloatNodeEntry = arnold.AiNodeGetNodeEntry( stateFloat )
+				self.assertEqual( arnold.AiNodeEntryGetName( stateFloatNodeEntry ), "state_float" )
+				self.assertEqual( arnold.AiParamGetName( arnold.AiNodeEntryGetOutput( stateFloatNodeEntry, outputIndex.value ) ), "sx" )
+				self.assertEqual( outputComponent.value, -1 )
 
 	def testOSLOutParameter( self ) :
 


### PR DESCRIPTION
Before then, the `state_float` shader didn't have multiple outputs, so we can't test them. We do still run these checks in CI though, because we are now building against Arnold 7.3.1.0 as well as 7.2.1.0.
