### PR TITLE
Fixes and alternates for #5737

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -39,7 +39,7 @@ API
   - ProcessorWidget provides a base class for custom widgets, and a factory mechanism for registering them against processors.
   - SimpleProcessorWidget provides a base class for widgets with a simple summary label and optional action links.
 - TractorDispatcher : The `preSpoolSignal()` now provides an additional `taskData` argument to slots, which maps from Tractor tasks to information about the Gaffer tasks they will execute.
-- LabelPlugValueWidget : Added optional `showValueChangedIndicator` metadata entry. If a plug has this entry set to `False`, the icon next to the label that indicates the value has changed will not be shown. Defaults to `True` if the value is not set.
+- LabelPlugValueWidget : Added optional `labelPlugValueWidget:showValueChangedIndicator` metadata entry. If a plug has this entry set to `False`, the icon next to the label that indicates the value has changed will not be shown. Defaults to `True` if the value is not set.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -39,7 +39,6 @@ API
   - ProcessorWidget provides a base class for custom widgets, and a factory mechanism for registering them against processors.
   - SimpleProcessorWidget provides a base class for widgets with a simple summary label and optional action links.
 - TractorDispatcher : The `preSpoolSignal()` now provides an additional `taskData` argument to slots, which maps from Tractor tasks to information about the Gaffer tasks they will execute.
-- LabelPlugValueWidget : Added optional `labelPlugValueWidget:showValueChangedIndicator` metadata entry. If a plug has this entry set to `False`, the icon next to the label that indicates the value has changed will not be shown. Defaults to `True` if the value is not set.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Fixes
 - Display : Fixed shutdown crashes caused by Python slots connected to `driverCreatedSignal()` and `imageReceivedSignal()` [^1].
 - LightPositionTool : Fixed crash when changing the tool mode with nothing selected [^1].
 - ViewportGadget : Fixed selection issues with Intel GPUs (#901, #2788).
+- TransformTool : Fixed alignment of green "value changed" icon for `orientation` plugs.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -39,6 +39,7 @@ API
   - ProcessorWidget provides a base class for custom widgets, and a factory mechanism for registering them against processors.
   - SimpleProcessorWidget provides a base class for widgets with a simple summary label and optional action links.
 - TractorDispatcher : The `preSpoolSignal()` now provides an additional `taskData` argument to slots, which maps from Tractor tasks to information about the Gaffer tasks they will execute.
+- LabelPlugValueWidget : Added optional `showValueChangedIndicator` metadata entry. If a plug has this entry set to `False`, the icon next to the label that indicates the value has changed will not be shown. Defaults to `True` if the value is not set.
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -74,13 +74,15 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__label._qtWidget().setFixedHeight( 20 )
 		layout.addWidget( self.__label._qtWidget() )
 
-		showIndicator = False
-		if all( p.direction() == Gaffer.Plug.Direction.In for p in self.getPlugs() ) :
-			showIndicator = Gaffer.Metadata.value( self.getPlug(), "showValueChangedIndicator" )
-			showIndicator = showIndicator if showIndicator is not None else True
 		self.__label._qtWidget().setProperty(
 			"gafferShowValueChangedIndicator",
-			GafferUI._Variant.toVariant( showIndicator )
+			all(
+				(
+					p.direction() == Gaffer.Plug.Direction.In and
+					Gaffer.Metadata.value( p, "showValueChangedIndicator" ) != False
+				)
+				for p in self.getPlugs()
+			)
 		)
 
 		self.__editableLabel = None # we'll make this lazily as needed

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -45,8 +45,6 @@ from Qt import QtWidgets
 # Supported plug metadata :
 #
 #  - "renameable"
-#  - "labelPlugValueWidget:showValueChangedIndicator" : If `False`, the indicator that the
-#  plug value has changed will not be shown. Defaults to `True` if not set.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## \todo Remove alignment arguments. Vertically the only alignment that looks good is `Center`, and
@@ -77,10 +75,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__label._qtWidget().setProperty(
 			"gafferShowValueChangedIndicator",
 			all(
-				(
-					p.direction() == Gaffer.Plug.Direction.In and
-					Gaffer.Metadata.value( p, "labelPlugValueWidget:showValueChangedIndicator" ) != False
-				)
+				p.direction() == Gaffer.Plug.Direction.In
 				for p in self.getPlugs()
 			)
 		)

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -45,6 +45,8 @@ from Qt import QtWidgets
 # Supported plug metadata :
 #
 #  - "renameable"
+#  - "showValueChangedIndicator" : If `False`, the indicator that the
+#  plug value has changed will not be shown. Defaults to `True` if not set.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## \todo Remove alignment arguments. Vertically the only alignment that looks good is `Center`, and
@@ -71,6 +73,15 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# 764eb379d99ff8418fbf2bb79a8231dafc57d8f1 for more details.
 		self.__label._qtWidget().setFixedHeight( 20 )
 		layout.addWidget( self.__label._qtWidget() )
+
+		showIndicator = False
+		if all( p.direction() == Gaffer.Plug.Direction.In for p in self.getPlugs() ) :
+			showIndicator = Gaffer.Metadata.value( self.getPlug(), "showValueChangedIndicator" )
+			showIndicator = showIndicator if showIndicator is not None else True
+		self.__label._qtWidget().setProperty(
+			"gafferShowValueChangedIndicator",
+			GafferUI._Variant.toVariant( showIndicator )
+		)
 
 		self.__editableLabel = None # we'll make this lazily as needed
 

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -45,7 +45,7 @@ from Qt import QtWidgets
 # Supported plug metadata :
 #
 #  - "renameable"
-#  - "showValueChangedIndicator" : If `False`, the indicator that the
+#  - "labelPlugValueWidget:showValueChangedIndicator" : If `False`, the indicator that the
 #  plug value has changed will not be shown. Defaults to `True` if not set.
 class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
@@ -79,7 +79,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 			all(
 				(
 					p.direction() == Gaffer.Plug.Direction.In and
-					Gaffer.Metadata.value( p, "showValueChangedIndicator" ) != False
+					Gaffer.Metadata.value( p, "labelPlugValueWidget:showValueChangedIndicator" ) != False
 				)
 				for p in self.getPlugs()
 			)

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -83,7 +83,6 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				spacing = 4
 			) :
 
-				Gaffer.Metadata.registerValue( plug.pointXPlug( 0 ), "showValueChangedIndicator", False )
 				self.__positionLabel = GafferUI.LabelPlugValueWidget(
 					plug.pointXPlug( 0 ),
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
@@ -93,7 +92,6 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
 				)
 
-				Gaffer.Metadata.registerValue( plug.pointYPlug( 0 ), "showValueChangedIndicator", False )
 				self.__valueLabel = GafferUI.LabelPlugValueWidget(
 					plug.pointYPlug( 0 ),
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -83,8 +83,9 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				spacing = 4
 			) :
 
-				self.__positionLabel = GafferUI.LabelPlugValueWidget(
+				self.__positionLabel = GafferUI.NameLabel(
 					plug.pointXPlug( 0 ),
+					formatter = lambda _ : "Position",
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
 				)
 				self.__positionField = GafferUI.NumericPlugValueWidget(
@@ -92,8 +93,9 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
 				)
 
-				self.__valueLabel = GafferUI.LabelPlugValueWidget(
+				self.__valueLabel = GafferUI.NameLabel(
 					plug.pointYPlug( 0 ),
+					formatter = lambda _ : "Value",
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
 				)
 				if isinstance( plug.pointYPlug( 0 ), Gaffer.FloatPlug ):
@@ -211,19 +213,16 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 		index = slider.getSelectedIndex()
 		if self.getPlug() is not None and index is not None :
 			pointPlug = self.getPlug().pointPlug( index )
-			self.__positionLabel.setPlug( pointPlug["x"] )
+			self.__positionLabel.setGraphComponent( pointPlug["x"] )
 			self.__positionField.setPlug( pointPlug["x"] )
-			self.__valueLabel.setPlug( pointPlug["y"] )
+			self.__valueLabel.setGraphComponent( pointPlug["y"] )
 			self.__valueField.setPlug( pointPlug["y"] )
 
 		else :
-			self.__positionLabel.setPlug( None )
+			self.__positionLabel.setGraphComponent( None )
 			self.__positionField.setPlug( None )
-			self.__valueLabel.setPlug( None )
+			self.__valueLabel.setGraphComponent( None )
 			self.__valueField.setPlug( None )
-
-		self.__positionLabel.label().setText( "Position" )
-		self.__valueLabel.label().setText( "Value" )
 
 # we don't register this automatically for any plugs, as it takes up a lot of room
 # in the node editor. this means the SplinePlugValueWidget will be used instead, and

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -83,6 +83,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 				spacing = 4
 			) :
 
+				Gaffer.Metadata.registerValue( plug.pointXPlug( 0 ), "showValueChangedIndicator", False )
 				self.__positionLabel = GafferUI.LabelPlugValueWidget(
 					plug.pointXPlug( 0 ),
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
@@ -92,6 +93,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }
 				)
 
+				Gaffer.Metadata.registerValue( plug.pointYPlug( 0 ), "showValueChangedIndicator", False )
 				self.__valueLabel = GafferUI.LabelPlugValueWidget(
 					plug.pointYPlug( 0 ),
 					parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top }

--- a/python/GafferUI/SplinePlugValueWidget.py
+++ b/python/GafferUI/SplinePlugValueWidget.py
@@ -98,6 +98,8 @@ for plugType in ( Gaffer.SplineffPlug, Gaffer.SplinefColor3fPlug, Gaffer.Splinef
 	Gaffer.Metadata.registerValue( plugType, "interpolation", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
 	for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
 		Gaffer.Metadata.registerValue( plugType, "interpolation", "preset:" + name, value )
+	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.x", "showValueChangedIndicator", False )
+	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.y", "showValueChangedIndicator", False )
 
 ## \todo See comments for `ColorSwatchPlugValueWidget._ColorPlugValueDialogue`.
 # I think the best approach is probably to move the `acquire()` mechanism to the

--- a/python/GafferUI/SplinePlugValueWidget.py
+++ b/python/GafferUI/SplinePlugValueWidget.py
@@ -98,8 +98,8 @@ for plugType in ( Gaffer.SplineffPlug, Gaffer.SplinefColor3fPlug, Gaffer.Splinef
 	Gaffer.Metadata.registerValue( plugType, "interpolation", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
 	for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
 		Gaffer.Metadata.registerValue( plugType, "interpolation", "preset:" + name, value )
-	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.x", "showValueChangedIndicator", False )
-	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.y", "showValueChangedIndicator", False )
+	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.x", "labelPlugValueWidget:showValueChangedIndicator", False )
+	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.y", "labelPlugValueWidget:showValueChangedIndicator", False )
 
 ## \todo See comments for `ColorSwatchPlugValueWidget._ColorPlugValueDialogue`.
 # I think the best approach is probably to move the `acquire()` mechanism to the

--- a/python/GafferUI/SplinePlugValueWidget.py
+++ b/python/GafferUI/SplinePlugValueWidget.py
@@ -98,8 +98,6 @@ for plugType in ( Gaffer.SplineffPlug, Gaffer.SplinefColor3fPlug, Gaffer.Splinef
 	Gaffer.Metadata.registerValue( plugType, "interpolation", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
 	for name, value in sorted( Gaffer.SplineDefinitionInterpolation.names.items() ):
 		Gaffer.Metadata.registerValue( plugType, "interpolation", "preset:" + name, value )
-	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.x", "labelPlugValueWidget:showValueChangedIndicator", False )
-	Gaffer.Metadata.registerValue( plugType, "p[0-9]*.y", "labelPlugValueWidget:showValueChangedIndicator", False )
 
 ## \todo See comments for `ColorSwatchPlugValueWidget._ColorPlugValueDialogue`.
 # I think the best approach is probably to move the `acquire()` mechanism to the

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -241,19 +241,16 @@ _styleSheet = string.Template(
 
 	QLabel#gafferPlugLabel {
 		/*
-		QLabel's text layout seems to lurch from one approach
-		to another in the presence of non-zero padding. So we
-		need some padding here so that we get a layout that
-		matches the `gafferValueChanged="true"` styling below.
+		Ensure that there is enough space reserved for the `valueChanged`
+		icon whether it is visible or not.
 		*/
-		padding-left: 1px;
+		padding-left: 10px;
 	}
 
 	QLabel#gafferPlugLabel[gafferValueChanged="true"] {
 		background-image: url(:/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;
-		padding-left: 16px;
 	}
 
 	QLabel#gafferDefaultRowLabel {

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -239,7 +239,7 @@ _styleSheet = string.Template(
 		color: #b0d8fb;
 	}
 
-	QLabel#gafferPlugLabel {
+	QLabel#gafferPlugLabel[gafferShowValueChangedIndicator="true"] {
 		/*
 		Ensure that there is enough space reserved for the `valueChanged`
 		icon whether it is visible or not.
@@ -247,7 +247,7 @@ _styleSheet = string.Template(
 		padding-left: 10px;
 	}
 
-	QLabel#gafferPlugLabel[gafferValueChanged="true"] {
+	QLabel#gafferPlugLabel[gafferShowValueChangedIndicator="true"][gafferValueChanged="true"] {
 		background-image: url(:/valueChanged.png);
 		background-repeat: no-repeat;
 		background-position: left;

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3309,6 +3309,14 @@
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="activeRenderPassFadedHighlightedIcon" />
     </g>
+    <rect
+       style="display:inline;fill:none;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="valueChanged"
+       width="9"
+       height="8"
+       x="392"
+       y="14"
+       inkscape:label="valueChanged" />
   </g>
   <g
      inkscape:label="Artwork"
@@ -7937,20 +7945,12 @@
        y="115.57742"
        inkscape:label="rect2708" />
     <circle
-       id="path6430"
+       id="valueChangedPath"
        cx="397"
        cy="70.362183"
        style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1"
-       inkscape:label="#path6430"
+       inkscape:label="valueChangedPath"
        r="3" />
-    <rect
-       style="fill:none;fill-opacity:0.99215686;stroke:none;stroke-opacity:1"
-       id="valueChanged"
-       width="10"
-       height="8"
-       x="391"
-       y="66.362183"
-       inkscape:label="#rect9457" />
     <g
        id="g2047"
        inkscape:label="tabScrollMenu"


### PR DESCRIPTION
This contains fixups addressing my review comments on #5737. Usually I wouldn't be doing this myself, but given that we want to include this in today's release, I thought it was worth getting something concrete up. There are a few categories of things...

Fixups : 7719c2e552c359f801849d18c630f90d34443d09 and 755ea10e9866bcce76738add14123fa607930a42 are fixups for comments I made on the original PR. I'm pretty sure these are legit, and should be included.
Metadata prefixing : bcb073a04bce18aa28a35762ab517015cbcb02f7 adds a prefix to the new metadata name, to make it clear it only applies to LabelPlugValueWidget. This matches our convention for most other widgets, but is very wordy. I think we should probably include it, but maybe that's open to debate.
Completely different approach : ad9a78bb1b221db11eeec728bfcbbaf8d9e6ef48 removes the metadata and just stops using LabelPlugValueWidget in the RampPlugValueWidget. It's simpler overall, but does result in a reduction in functionality for the user (no right-click menu on the labels). Probably isn't the way we want to go, but I wanted to provide it for consideration at least.