### PR TITLE
ArnoldTextureBackTest : Hack around OSL bug

### DIFF
--- a/python/GafferArnoldTest/ArnoldTextureBakeTest.py
+++ b/python/GafferArnoldTest/ArnoldTextureBakeTest.py
@@ -370,7 +370,7 @@ class ArnoldTextureBakeTest( GafferSceneTest.SceneTestCase ) :
 		pickCode = GafferOSL.OSLCode()
 		pickCode["parameters"].addChild( Gaffer.IntPlug( "targetId" ) )
 		pickCode["out"].addChild( Gaffer.IntPlug( "cull", direction = Gaffer.Plug.Direction.Out ) )
-		pickCode["code"].setValue( 'int randomId; getattribute( "randomId", randomId ); cull = randomId != targetId;' )
+		pickCode["code"].setValue( 'int randomId; getattribute( "randomId", randomId ); cull = randomId != targetId ? 1 : 0;' )
 
 		expression = Gaffer.Expression()
 		pickCode.addChild( expression )


### PR DESCRIPTION
The reason this test was crashing was because of an OSL bug with assigning a boolean to an integer in batched mode.

This bug is known, we reported it here:
https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/issues/1716

But looking at the changelog, it looks like this fix may have only made it into 1.13, so I guess this is expected?

Anyway, it's easy to hack around.