### PR TITLE
Delight Renderer : Set `.global.frame` parameter from "frame" option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.0.0b6)
 =======
 
+Fixes
+-----
 
+- 3Delight : Fixed failure to change sampling pattern per frame.
 
 1.4.0.0b6 (relative to 1.4.0.0b5)
 =========

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -1155,6 +1155,23 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( mesh["subdivision.cornervertices"], 3 )
 		self.assertEqual( mesh["subdivision.cornersharpness"], 5 )
 
+	def testFrameOption( self ) :
+
+		for frame in range( 0, 5 ) :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"3Delight",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+				str( self.temporaryDirectory() / "test.nsia" ),
+			)
+
+			renderer.option( "frame", IECore.IntData( frame ) )
+			renderer.render()
+
+			nsi = self.__parseDict( str( self.temporaryDirectory() / "test.nsia" ) )
+			self.assertEqual( nsi[".global"]["frame"], frame )
+			self.assertIsInstance( nsi[".global"]["frame"], float )
+
 	# `lightSettings` is a list of tuples of the form :
 	# ( USD light type, position, rotation (V3f, degrees), 3Delight geometry type,
 	# 3Delight geometry attributes, 3Delight shader, IECore light parameters, 3Delight parameters )

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1291,6 +1291,10 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 						m_frame = d->readable();
 					}
 				}
+				const double doubleFrame = m_frame;
+				ParameterList params;
+				params.add( { name.c_str(), &doubleFrame, NSITypeDouble, 0, 1, 0 } );
+				NSISetAttribute( m_context, NSI_SCENE_GLOBAL, params.size(), params.data() );
 			}
 			else if( name == g_cameraOptionName )
 			{
@@ -1506,6 +1510,8 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			const char *start = "start";
 			vector<NSIParam_t> params = {
 				{ "action", &start, NSITypeString, 0, 1, 0 },
+				/// \todo Is this argument needed? It was removed from `nsi.pdf` somewhere
+				/// between 3Delight 2.9.17 and 2.9.39.
 				{ "frame", &m_frame, NSITypeInteger, 0, 1, 0 }
 			};
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1226,7 +1226,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 	public :
 
 		DelightRenderer( RenderType renderType, const std::string &fileName, const IECore::MessageHandlerPtr &messageHandler )
-			:	m_renderType( renderType ), m_frame( 1 ), m_messageHandler( messageHandler )
+			:	m_renderType( renderType ), m_messageHandler( messageHandler )
 		{
 			const IECore::MessageHandler::Scope s( m_messageHandler.get() );
 
@@ -1283,17 +1283,16 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 			if( name == g_frameOptionName )
 			{
-				m_frame = 1;
+				double frame = 1;
 				if( value )
 				{
 					if( const IntData *d = reportedCast<const IntData>( value, "option", name ) )
 					{
-						m_frame = d->readable();
+						frame = d->readable();
 					}
 				}
-				const double doubleFrame = m_frame;
 				ParameterList params;
-				params.add( { name.c_str(), &doubleFrame, NSITypeDouble, 0, 1, 0 } );
+				params.add( { name.c_str(), &frame, NSITypeDouble, 0, 1, 0 } );
 				NSISetAttribute( m_context, NSI_SCENE_GLOBAL, params.size(), params.data() );
 			}
 			else if( name == g_cameraOptionName )
@@ -1510,9 +1509,6 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 			const char *start = "start";
 			vector<NSIParam_t> params = {
 				{ "action", &start, NSITypeString, 0, 1, 0 },
-				/// \todo Is this argument needed? It was removed from `nsi.pdf` somewhere
-				/// between 3Delight 2.9.17 and 2.9.39.
-				{ "frame", &m_frame, NSITypeInteger, 0, 1, 0 }
 			};
 
 			if( m_renderType == Interactive )
@@ -1738,7 +1734,6 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 		NSIContext_t m_context;
 		RenderType m_renderType;
 
-		int m_frame;
 		string m_camera;
 
 		bool m_rendering = false;


### PR DESCRIPTION
This is used by 3Delight to vary the sampling pattern per-frame. It's not clear if this has always been broken, or if at some point the `frame` argument to `NSIRenderControl` did the same thing. The latter is no longer documented in `nsi.pdf`, but there is no mention of why in the 3Delight change log, which appears not to have been updated for a year.
