### PR TITLE
3Delight resolution multiplier fix and static sampling pattern option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,12 +7,15 @@ Improvements
 - Wireframe :
   - Improved performance ~3x.
   - Improved cancellation responsiveness.
+- 3Delight : Added NSI screen static sampling pattern option (`dl:staticsamplingpattern`).
 
 Fixes
 -----
 
-- 3Delight : Fixed failure to change sampling pattern per frame.
 - MeshTesselate : Fixed potential deadlock [^1].
+- 3Delight :
+  - Fixed failure to change sampling pattern per frame.
+  - Fixed Resolution Multiplier support.
 
 1.4.0.0b6 (relative to 1.4.0.0b5)
 =========

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -706,6 +706,7 @@ class RendererTest( GafferTest.TestCase ) :
 		options = [
 			( "dl:oversampling", IECore.IntData( 16 ), "int" ),
 			( "dl:importancesamplefilter", IECore.BoolData( True ), "int" ),
+			( "dl:staticsamplingpattern", IECore.BoolData( True ), "int" ),
 		]
 
 		for name, value, type in options :

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1173,6 +1173,7 @@ IECore::InternedString g_maxLengthVolumeOptionName( "dl:maximumraylength.volume"
 IECore::InternedString g_clampIndirectOptionName( "dl:clampindirect" );
 IECore::InternedString g_showMultipleScatteringOptionName( "dl:show.multiplescattering" );
 IECore::InternedString g_importancesamplefilterOptionName( "dl:importancesamplefilter" );
+IECore::InternedString g_staticsamplingpatternOptionName( "dl:staticsamplingpattern" );
 
 const char *g_screenHandle = "ieCoreDelight:defaultScreen";
 
@@ -1322,6 +1323,10 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 				setNSIScreenOption( m_context, name, value );
 			}
 			else if( name == g_importancesamplefilterOptionName )
+			{
+				setNSIScreenOption( m_context, name, value );
+			}
+			else if( name == g_staticsamplingpatternOptionName )
 			{
 				setNSIScreenOption( m_context, name, value );
 			}
@@ -1647,7 +1652,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 
 			ParameterList screeenParameters;
 
-			const V2i &resolution = camera->getResolution();
+			const V2i &resolution = camera->renderResolution();
 			screeenParameters.add( { "resolution", resolution.getValue(), NSITypeInteger, 2, 1, NSIParamIsArray } );
 
 			const bool &overscanOn = camera->getOverscan();


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Fix for StandardOptions / Camera Resolution Multiplier not affecting the render resolution. 
- Added support for NSI screen node's static sampling pattern parameter. In Gaffer we are treating this as a global option, but in NSI it is a parameter of the screen node, not the .global node (similar to oversampling and importance sample filter), so it has to be explicitly supported in the code. Per the Discord discussion I'm not exposing it in the GUI and leave it to be used from Gaffer's CustomOptions node. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
