### PR TITLE
Add Cancellelation Support To Wireframe 

### DIFF
--- a/python/GafferSceneTest/WireframeTest.py
+++ b/python/GafferSceneTest/WireframeTest.py
@@ -42,6 +42,7 @@ import IECore
 import IECoreScene
 
 import Gaffer
+import GafferTest
 import GafferScene
 import GafferSceneTest
 
@@ -170,6 +171,24 @@ class WireframeTest( GafferSceneTest.SceneTestCase ) :
 		wireframe["adjustBounds"].setValue( False )
 		self.assertScenesEqual( wireframe["in"], wireframe["out"], checks = { "bound" } )
 		self.assertSceneHashesEqual( wireframe["in"], wireframe["out"], checks = { "bound" } )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPerformance( self ) :
+
+		sphere = GafferScene.Sphere()
+		sphere["divisions"].setValue( imath.V2i( 1000 ) )
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		wireframe = GafferScene.Wireframe()
+		wireframe["in"].setInput( sphere["out"] )
+		wireframe["filter"].setInput( sphereFilter["out"] )
+
+		GafferSceneTest.traverseScene( wireframe["in"] )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			GafferSceneTest.traverseScene( wireframe["out"] )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/MeshTessellate.cpp
+++ b/src/GafferScene/MeshTessellate.cpp
@@ -162,5 +162,5 @@ IECore::ConstObjectPtr MeshTessellate::computeProcessedObject( const ScenePath &
 
 Gaffer::ValuePlug::CachePolicy MeshTessellate::processedObjectComputeCachePolicy() const
 {
-	return ValuePlug::CachePolicy::Default;
+	return ValuePlug::CachePolicy::TaskCollaboration;
 }


### PR DESCRIPTION
Got slightly distracted by Wireframe using a very inefficient method to remove duplicates from a list - sticking everything in a set is very inefficient compared to just sorting the list when the number of duplicates in not large ( generally no more than 2 duplicates edges ).

Unfortunately, this actually makes it harder to do really thorough canceller support - since the majority of the work is inside std::sort and std::unique. However, we can still reduce the worst case cancellation time by about 50% by putting in all the cancellation we can. Combined with the 3X speedup from before, that's a 6X reduction in worst case cancellation time.

To do better than this, we'd want to do a bunch of small partial sorts, check cancellation after sorting each subrange, and then do some sort of merge of all the sorted subranges. Unfortunately, the C++ standard library is notably missing an efficient way to combine N sorted lists. And if we were going to do this, it raises the question of whether we want to support multithreading - if we were doing a bunch of partial sorts, they could be done on different threads.

My conclusion for now is that this basic approach is probably good enough?

While thinking about which mesh operations we should support threading on, however, I did notice that MeshTessellate specifies the wrong compute policy, so I fixed that while I was at it.