### PR TITLE
3Delight distant light angle

### DIFF
--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -184,6 +184,12 @@ if moduleSearchPath.find( "nsi.py" ) and moduleSearchPath.find( "GafferDelight" 
 
 			visibilityPlug = Gaffer.NameValuePlug( "dl:visibility.camera", False, "cameraVisibility", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			node["attributes"].addChild( visibilityPlug )
+			if shape == "distant" :
+				anglePlug = Gaffer.NameValuePlug( "angle", 0.5, "angle", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+				node["attributes"].addChild( anglePlug )
+				Gaffer.Metadata.registerValue( anglePlug, "nameValuePlugPlugValueWidget:ignoreNamePlug", True )
+				Gaffer.MetadataAlgo.setReadOnly( anglePlug["name"], True )
+				node["geometryParameters"]["angle"].setInput( anglePlug )
 			Gaffer.Metadata.registerValue( visibilityPlug, "nameValuePlugPlugValueWidget:ignoreNamePlug", True )
 			Gaffer.MetadataAlgo.setReadOnly( visibilityPlug["name"], True )
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Even though 3Delight's distant light already had the angle attribute correctly supported by Gaffer during the NSI export, it was not exposed in the shader interface since the angle parameter is a child plug of the light's geometryParameters. In order to expose the angle parameter to the user, I created an angle plug under the light's attributes parameters and set it as an input to the geometryParameters angle plug. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
