### PR TITLE
Instancer : Allow using Varying primvars as Vertex primvars

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Shuffle : Added the ability to load Shuffles from Gaffer 1.4.
+- Instancer : Added support for `Varying` primitive variables whenever they are equivalent to (have the same size as) a `Vertex` primitive variable.
 
 1.3.15.0 (relative to 1.3.14.0)
 ========

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -268,10 +268,18 @@ Gaffer.Metadata.registerNode(
 	"description",
 	"""
 	Copies from an input scene onto the vertices of a target
-	object, making one copy per vertex. Additional primitive
+	object, making one copy per vertex. Additional vertex primitive
 	variables on the target object can be used to choose between
-	multiple instances, and to specify their orientation and
-	scale. Note the target object will be removed from the scene.
+	multiple prototypes, to specify their orientation, scale
+	and attributes, and to modify the context in which the
+	prototypes are evaluated.
+
+	> Note : The target object will be removed from the scene.
+
+	> Tip : Primitive variables with `Varying` interpolation are
+	> supported wherever a variable with `Vertex` interpolation
+	> is expected, provided that the primitive variable has the
+	> same size as the equivalent `Vertex` variable.
 	""",
 
 	"layout:section:Settings.General:collapsed", False,


### PR DESCRIPTION
My approach here doesn't feel completely systemic - there are still some error messages and help text that make reference to "Vertex" variables ... I'm not sure if I need to find all of those and replace that with "Vertex variables or Varying variables if Varying means the same thing". And maybe there's some way to share more of this code ... should more things be using findVertexVariable ( should it be renamed )?

But  for now, my focus was just finding anywhere where the Instancer required a Vertex variable, and making sure we have test coverage that it will accept an equivalent Varying variable.

( I also did a very brief audit for whether there was anything else obvious I could spot in GafferScene where having Varying variables would cause problems, and I didn't spot anything, but maybe I didn't look closely enough. )