### PR TITLE
SetFilterUI : Support dropping set names onto nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Group : Added `sets` plug, to control what sets the group belongs to.
 - USD : Added automatic render-time translation of UsdPreviewSurface shaders to Cycles.
+- SetEditor : Added support for dragging a set name onto a node in the Graph Editor to create or modify a connected `SetFilter` node. Holding <kbd>Shift</kbd> while dragging will add to the set expression. Holding <kbd>Control</kbd> will remove from the set expression. Only set expressions with a simple list of sets are supported. Expressions with boolean or hierarchy operators are not supported.
 
 1.4.0.0 (relative to 1.3.16.0)
 =======

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -88,6 +88,7 @@ def __nodeGadget( node ) :
 
 	nodeGadget = GafferUI.StandardNodeGadget( node )
 	GafferSceneUI.PathFilterUI.addObjectDropTarget( nodeGadget )
+	GafferSceneUI.SetFilterUI.addSetDropTarget( nodeGadget )
 
 	return nodeGadget
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -316,6 +316,9 @@ def __dragLeave( nodeGadget, event ) :
 
 	global __originalDragPointer
 
+	if __originalDragPointer is None :
+		return False
+
 	GafferUI.Pointer.setCurrent( __originalDragPointer )
 	__originalDragPointer = None
 

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -189,8 +189,12 @@ class SetEditor( GafferUI.NodeSetEditor ) :
 			# prevent the path itself from being dragged
 			return IECore.StringVectorData()
 
-		GafferUI.Pointer.setCurrent( "paths" )
 		column = self.__pathListing.columnAt( imath.V2f( event.line.p0.x, event.line.p0.y ) )
+		if isinstance( column, _GafferSceneUI._SetEditor.SetNameColumn ) :
+			GafferUI.Pointer.setCurrent( "sets" )
+		else :
+			GafferUI.Pointer.setCurrent( "paths" )
+
 		if column == self.__setMembersColumn :
 			return IECore.StringVectorData( self.__getSetMembers( setNames ).paths() )
 		elif column == self.__selectedSetMembersColumn :

--- a/python/GafferSceneUI/SetFilterUI.py
+++ b/python/GafferSceneUI/SetFilterUI.py
@@ -34,9 +34,15 @@
 #
 ##########################################################################
 
+import enum
+import imath
+
 import Gaffer
 import GafferUI
 import GafferScene
+import GafferSceneUI
+
+import IECore
 
 ##########################################################################
 # Metadata
@@ -94,3 +100,163 @@ Gaffer.Metadata.registerNode(
 	}
 
 )
+
+##########################################################################
+# NodeGadget drop handler
+##########################################################################
+
+GafferUI.Pointer.registerPointer( "sets", GafferUI.Pointer( "pointerSets.png", imath.V2i( 53, 14 ) ) )
+GafferUI.Pointer.registerPointer( "addSets", GafferUI.Pointer( "pointerAddSets.png", imath.V2i( 53, 14 ) ) )
+GafferUI.Pointer.registerPointer( "removeSets", GafferUI.Pointer( "pointerRemoveSets.png", imath.V2i( 53, 14 ) ) )
+GafferUI.Pointer.registerPointer( "replaceSets", GafferUI.Pointer( "pointerReplaceSets.png", imath.V2i( 53, 14 ) ) )
+
+__DropMode = enum.Enum( "__DropMode", [ "None_", "Add", "Remove", "Replace" ] )
+
+__originalDragPointer = None
+
+def __setsPlug( node ) :
+
+	for plug in Gaffer.Plug.InputRange( node ) :
+		if Gaffer.Metadata.value( plug, "ui:scene:acceptsSetNames" ) or Gaffer.Metadata.value( plug, "ui:scene:acceptsSetExpression" ) :
+			return plug
+
+	return None
+
+def __editable( plug ) :
+	if Gaffer.MetadataAlgo.readOnly( plug ) or not plug.settable() :
+		return False
+
+	if Gaffer.Metadata.value( plug, "ui:scene:acceptsSetNames" ) or Gaffer.Metadata.value( plug, "ui:scene:acceptsSetExpression" ) :
+		plugValue = plug.getValue()
+		if any( i in plugValue for i in [ "(", ")", "|", "-", "&"] ) :
+			return False
+
+		plugTokens = plugValue.split( " " )
+		if any( i in plugTokens for i in [ "in", "containing" ] ) :
+			return False
+
+	return True
+
+def __dropMode( nodeGadget, event ) :
+
+	setsPlug = __setsPlug( nodeGadget.node() )
+	if setsPlug is None :
+		filter = None
+		if nodeGadget.node()["filter"].getInput() is not None :
+			filter = nodeGadget.node()["filter"].source().node()
+		if filter is None :
+			return __DropMode.Replace if __editable( nodeGadget.node()["filter"] ) else __DropMode.None_
+		elif not isinstance( filter, GafferScene.SetFilter ) :
+			return __DropMode.None_
+		setsPlug = filter["setExpression"]
+
+	if not __editable( setsPlug ) :
+		return __DropMode.None_
+
+	if event.modifiers & event.Modifiers.Shift :
+		return __DropMode.Add
+	elif event.modifiers & event.Modifiers.Control :
+		return __DropMode.Remove
+	else :
+		return __DropMode.Replace
+
+def __dragEnter( nodeGadget, event ) :
+
+	if not isinstance( event.data, IECore.StringVectorData ) :
+		return False
+
+	if not (
+		all( i.startswith( "/" ) for i in event.data ) or
+		event.sourceWidget.ancestor( GafferSceneUI.SetEditor ) is not None
+	) :
+		return False
+
+	if not len ( event.data ) :
+		return False
+
+	if __dropMode( nodeGadget, event ) == __DropMode.None_ :
+		return False
+
+	global __originalDragPointer
+	__originalDragPointer = GafferUI.Pointer.getCurrent()
+
+	return True
+
+def __dragLeave( nodeGadget, event ) :
+
+	global __originalDragPointer
+
+	if __originalDragPointer is None :
+		return False
+
+	GafferUI.Pointer.setCurrent( __originalDragPointer )
+	__originalDragPointer = None
+
+	return True
+
+def __dragMove( nodeGadget, event ) :
+
+	global __originalDragPointer
+	if __originalDragPointer is None :
+		return False
+
+	GafferUI.Pointer.setCurrent( __dropMode( nodeGadget, event ).name.lower() + "Sets" )
+
+	return True
+
+def __drop( nodeGadget, event ) :
+
+	global __originalDragPointer
+	if __originalDragPointer is None :
+		return False
+
+	setsPlug = __setsPlug( nodeGadget.node() )
+	if setsPlug is None :
+		setsPlug = __setsPlug( nodeGadget.node()["filter"].source().node() )
+
+	dropSets = event.data
+
+	dropMode = __dropMode( nodeGadget, event )
+	if dropMode == __DropMode.Replace :
+		sets = sorted( dropSets )
+	elif dropMode == __DropMode.Add :
+		sets = set( setsPlug.getValue().split( " " ) )
+		sets.update( dropSets )
+		sets = sorted( sets )
+	else :
+		sets = set( setsPlug.getValue().split( " " ) )
+		sets.difference_update( dropSets )
+		sets = sorted( sets )
+
+	with Gaffer.UndoScope( nodeGadget.node().ancestor( Gaffer.ScriptNode ) ) :
+
+		if setsPlug is None :
+
+			setFilter = GafferScene.SetFilter()
+			nodeGadget.node().parent().addChild( setFilter )
+			nodeGadget.node()["filter"].setInput( setFilter["out"] )
+
+			setsPlug = setFilter["setExpression"]
+
+		setsPlug.setValue( " ".join( sets ) )
+
+	GafferUI.Pointer.setCurrent( __originalDragPointer )
+	__originalDragPointer = None
+
+	return True
+
+def addSetDropTarget( nodeGadget ) :
+
+	nodeGadget.dragEnterSignal().connect( __dragEnter, scoped = False )
+	nodeGadget.dragLeaveSignal().connect( __dragLeave, scoped = False )
+	nodeGadget.dragMoveSignal().connect( __dragMove, scoped = False )
+	nodeGadget.dropSignal().connect( __drop, scoped = False )
+
+def __nodeGadget( setFilter ) :
+
+	nodeGadget = GafferUI.StandardNodeGadget( setFilter )
+	addSetDropTarget( nodeGadget )
+
+	return nodeGadget
+
+GafferUI.NodeGadget.registerNodeGadget( GafferScene.SetFilter, __nodeGadget )

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -329,6 +329,7 @@ def __nodeGadget( node ) :
 
 	nodeGadget = GafferUI.StandardNodeGadget( node )
 	GafferSceneUI.PathFilterUI.addObjectDropTarget( nodeGadget )
+	GafferSceneUI.SetFilterUI.addSetDropTarget( nodeGadget )
 
 	return nodeGadget
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -51,7 +51,11 @@
 				"objects", # \todo prefix with 'pointer'
 				"addObjects", # \todo prefix with 'pointer'
 				"removeObjects", # \todo prefix with 'pointer'
-				"replaceObjects" # \todo prefix with 'pointer'
+				"replaceObjects", # \todo prefix with 'pointer'
+				"pointerSets",
+				"pointerReplaceSets",
+				"pointerAddSets",
+				"pointerRemoveSets",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -804,7 +804,8 @@
            y="983"
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1" /></flowRegion><flowPara
          id="flowPara2733"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">POINTERS - PathFilterUI</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">POINTERS - PathFilterUI, SetFilterUI</flowPara></flowRoot>
+    <rect
        y="1390"
        x="10"
        height="32"
@@ -1922,7 +1923,39 @@
          height="32"
          width="64"
          id="objects"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12103;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerReplaceSets"
+         width="64"
+         height="32"
+         x="418"
+         y="1444"
+         inkscape:label="pointerReplaceSets" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12103;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerAddSets"
+         width="64"
+         height="32"
+         x="486"
+         y="1444"
+         inkscape:label="pointerAddSets" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12103;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerRemoveSets"
+         width="64"
+         height="32"
+         x="554"
+         y="1444"
+         inkscape:label="pointerRemoveSets" />
+      <rect
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12103;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         id="pointerSets"
+         width="64"
+         height="32"
+         x="350"
+         y="1444"
+         inkscape:label="pointerSets" />
     </g>
     <g
        id="g2749"
@@ -9861,5 +9894,200 @@
        style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1.99937;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
        d="m 793.99968,1344.3619 a 8,8 0 0 0 -8,8 8,8 0 0 0 8,8 8,8 0 0 0 8,-8 8,8 0 0 0 -8,-8 z m 0,2.4277 a 5.5716791,5.571681 0 0 1 5.57227,5.5723 5.5716791,5.571681 0 0 1 -1.00391,3.1875 l -7.74023,-7.7422 a 5.5716791,5.571681 0 0 1 3.17187,-1.0176 z m -4.49805,2.3203 7.76563,7.7657 a 5.5716791,5.571681 0 0 1 -3.26758,1.0586 5.5716791,5.571681 0 0 1 -5.57227,-5.5723 5.5716791,5.571681 0 0 1 1.07422,-3.252 z"
        inkscape:label="notEditable" />
+    <g
+       id="g5886"
+       inkscape:label="pointerReplaceSets"
+       transform="translate(36,1311)">
+      <g
+         transform="matrix(1.9868196,0,0,1.999254,325.79782,-5424.7383)"
+         inkscape:label="populatedSet"
+         id="g54052"
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1">
+        <ellipse
+           cy="2785.0544"
+           cx="53.432369"
+           id="ellipse54044"
+           style="opacity:1;fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+           rx="5.7688141"
+           ry="5.7175803" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="51.435474"
+           id="circle54046"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="55.323334"
+           id="circle54048"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2783.2109"
+           cx="53.387413"
+           id="circle54050"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <rect
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;paint-order:fill markers stroke"
+         id="rect86375"
+         width="15"
+         height="4.0000005"
+         x="402.5"
+         y="141.86218" />
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path6230"
+         d="m 435.5,160.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 441 l -2.5,-5 z"
+         style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-dasharray:none;paint-order:fill markers stroke"
+         id="rect87104"
+         width="15"
+         height="4.0000005"
+         x="402.5"
+         y="147.86218" />
+    </g>
+    <g
+       id="g19520"
+       inkscape:label="pointerAddSets"
+       style="display:inline"
+       transform="translate(-383.5,150.76221)">
+      <g
+         transform="matrix(1.9868196,0,0,1.999254,813.29956,-4264.4988)"
+         inkscape:label="populatedSet"
+         id="g54798"
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1">
+        <ellipse
+           cy="2785.0544"
+           cx="53.432369"
+           id="ellipse54790"
+           style="opacity:1;fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.501749;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+           rx="5.7688141"
+           ry="5.7175803" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="51.435474"
+           id="circle54792"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="55.323334"
+           id="circle54794"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2783.2109"
+           cx="53.387413"
+           id="circle54796"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <path
+         style="display:inline;stroke:#3c3c3c;stroke-opacity:1;fill:#a4a4a4;fill-opacity:1;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter"
+         d="m 506.5,1402.5 h 5 v -5 h 5 v 5 h 5 v 5 c 0,0 -5,0 -5,0 v 5 h -5 v -5 h -5 z"
+         id="path90076"
+         transform="translate(383.5,-98.400027)" />
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path21726"
+         d="m 923,1320.6 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 h -2.5 l -2.5,-5 z"
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g18060"
+       inkscape:label="pointerRemoveSets"
+       transform="translate(-277.5,154.76221)">
+      <g
+         transform="matrix(1.9868196,0,0,1.999254,775.29956,-4268.4988)"
+         inkscape:label="populatedSet"
+         id="g56270"
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1">
+        <ellipse
+           cy="2785.0544"
+           cx="53.432369"
+           id="ellipse56262"
+           style="opacity:1;fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.501749;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+           rx="5.7688141"
+           ry="5.7175803" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="51.435474"
+           id="circle56264"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="55.323334"
+           id="circle56266"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2783.2109"
+           cx="53.387413"
+           id="circle56268"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <rect
+         style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.1027;stroke-linecap:round;stroke-dasharray:none;paint-order:fill markers stroke"
+         id="rect87832"
+         width="14.897302"
+         height="4.8973022"
+         x="852.05133"
+         y="1300.1" />
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path21738"
+         d="m 885,1316.6 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 h -2.5 l -2.5,-5 z"
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g5885"
+       inkscape:label="Sets"
+       transform="translate(-417.05808,91.465348)">
+      <g
+         transform="matrix(1.9868196,0,0,1.999254,710.85764,-4205.2019)"
+         inkscape:label="populatedSet"
+         id="g5883"
+         style="display:inline;opacity:0.5;fill:#a4a4a4;fill-opacity:1">
+        <ellipse
+           cy="2785.0544"
+           cx="53.432369"
+           id="circle5875"
+           style="opacity:1;fill:#a4a4a4;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.501749;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+           rx="5.7688141"
+           ry="5.7175803" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="51.435474"
+           id="circle5877"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2786.4141"
+           cx="55.323334"
+           id="circle5879"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <circle
+           r="0.5"
+           cy="2783.2109"
+           cx="53.387413"
+           id="circle5881"
+           style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4765"
+         d="m 820.55808,1379.8968 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 h -2.5 l -2.5,-5 z"
+         style="display:inline;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
This adds the ability to drag a list of set names onto a `FilterSceneProcessor` derived node, or a `SetFilter` node. As with dragging path lists, if the node does not have a `SetFilter`, one will be created and populated with the contents of the drag.

The handling of set expressions with anything but a simple list of set names is very simple for now. I'm just wrapping the existing expression in parenthesis before adding to the expression. As we talked about today, eventually it would be nice to parse the expression and come up with a cleaner expression.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
