### PR TITLE
MeshTessellate : Store subdivision scheme as string

### DIFF
--- a/include/GafferScene/MeshTessellate.h
+++ b/include/GafferScene/MeshTessellate.h
@@ -61,8 +61,8 @@ class GAFFERSCENE_API MeshTessellate : public ObjectProcessor
 		Gaffer::BoolPlug *tessellatePolygonsPlug();
 		const Gaffer::BoolPlug *tessellatePolygonsPlug() const;
 
-		Gaffer::IntPlug *schemePlug();
-		const Gaffer::IntPlug *schemePlug() const;
+		Gaffer::StringPlug *schemePlug();
+		const Gaffer::StringPlug *schemePlug() const;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferScene::MeshTessellate, MeshTessellateTypeId, ObjectProcessor );
 

--- a/include/GafferScene/Private/IECoreScenePreview/MeshAlgo.h
+++ b/include/GafferScene/Private/IECoreScenePreview/MeshAlgo.h
@@ -45,20 +45,9 @@ namespace IECoreScenePreview
 namespace MeshAlgo
 {
 
-enum class SubdivisionScheme
-{
-	FromMesh,
-	Bilinear,
-	CatmullClark,
-	Loop,
-
-	First = FromMesh,
-	Last = Loop
-};
-
 GAFFERSCENE_API IECoreScene::MeshPrimitivePtr tessellateMesh(
 	const IECoreScene::MeshPrimitive &mesh, int divisions,
-	bool calculateNormals = false, SubdivisionScheme scheme = SubdivisionScheme::FromMesh,
+	bool calculateNormals = false, IECore::InternedString scheme = "",
 	const IECore::Canceller *canceller = nullptr
 );
 

--- a/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
@@ -314,10 +314,10 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		# Basic tests for Loop subdivision
 
 		with self.assertRaisesRegex( RuntimeError, "Loop subdivision can only be applied to triangle meshes" ):
-			MeshAlgo.tessellateMesh( self.createTestData( 2, "linear" ), 1, scheme = MeshAlgo.SubdivisionScheme.Loop ),
+			MeshAlgo.tessellateMesh( self.createTestData( 2, "linear" ), 1, scheme = "loop" ),
 
 		self.assertMeshesPracticallyEqual(
-			MeshAlgo.tessellateMesh( self.createTestData( 2, "catmullClark", triangular = True ), 1, scheme = MeshAlgo.SubdivisionScheme.Loop ),
+			MeshAlgo.tessellateMesh( self.createTestData( 2, "catmullClark", triangular = True ), 1, scheme = "loop" ),
 			self.createTestData( 4, "linear", triangular = True ),
 			0.000002
 		)
@@ -370,12 +370,12 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		# odd tessellation rates introduce triangles that don't end up in exactly the same place during
 		# subsequent retessellations )
 
-		linearRate6 = MeshAlgo.tessellateMesh( source, 5, scheme = MeshAlgo.SubdivisionScheme.Bilinear, calculateNormals = True )
+		linearRate6 = MeshAlgo.tessellateMesh( source, 5, scheme = "bilinear", calculateNormals = True )
 
 		self.assertNotEqual( linearRate6, catmarkRate6 )
 
-		linearRate2 = MeshAlgo.tessellateMesh( source, 1, scheme = MeshAlgo.SubdivisionScheme.Bilinear, calculateNormals = True )
-		linearRate2x3 = MeshAlgo.tessellateMesh( linearRate2, 2, scheme = MeshAlgo.SubdivisionScheme.Bilinear, calculateNormals = True )
+		linearRate2 = MeshAlgo.tessellateMesh( source, 1, scheme = "bilinear", calculateNormals = True )
+		linearRate2x3 = MeshAlgo.tessellateMesh( linearRate2, 2, scheme = "bilinear", calculateNormals = True )
 
 		self.assertMeshesPracticallyEqual( linearRate6, linearRate2x3, 0.00001 )
 
@@ -385,7 +385,7 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		self.assertEqual( MeshAlgo.tessellateMesh( source, 5, calculateNormals = True ), linearRate6 )
 
 		# And test that we can override the scheme to CatmullClark
-		self.assertEqual( MeshAlgo.tessellateMesh( source, 5, scheme = MeshAlgo.SubdivisionScheme.CatmullClark, calculateNormals = True ), catmarkRate6 )
+		self.assertEqual( MeshAlgo.tessellateMesh( source, 5, scheme = "catmullClark", calculateNormals = True ), catmarkRate6 )
 
 	# Turn a mesh into a doubled up mesh, with copies of all vertices and faces shifted in P
 	def duplicateMesh( self, m ) :

--- a/python/GafferSceneTest/MeshTessellateTest.py
+++ b/python/GafferSceneTest/MeshTessellateTest.py
@@ -58,14 +58,14 @@ class MeshTessellateTest( GafferSceneTest.SceneTestCase ) :
 		if (
 			not node["tessellatePolygons"].getValue() and
 			source.interpolation == "linear" and
-			node["scheme"].getValue() == MeshAlgo.SubdivisionScheme.FromMesh
+			node["scheme"].getValue() == ""
 		):
 			reference = source
 		else:
 			reference = MeshAlgo.tessellateMesh(
 				source, node["divisions"].getValue(),
 				calculateNormals = node["calculateNormals"].getValue(),
-				scheme = MeshAlgo.SubdivisionScheme( node["scheme"].getValue() )
+				scheme = node["scheme"].getValue()
 			)
 
 		self.assertEqual( node["out"].object( path ), reference )
@@ -94,10 +94,10 @@ class MeshTessellateTest( GafferSceneTest.SceneTestCase ) :
 		tessellate["calculateNormals"].setValue( True )
 		self.assertNodeCorrect( tessellate, "object" )
 
-		tessellate["scheme"].setValue( MeshAlgo.SubdivisionScheme.Bilinear )
+		tessellate["scheme"].setValue( "bilinear" )
 		self.assertNodeCorrect( tessellate, "object" )
 
-		tessellate["scheme"].setValue( MeshAlgo.SubdivisionScheme.FromMesh )
+		tessellate["scheme"].setValue( "" )
 		sphere = GafferScene.Sphere()
 
 		tessellate["in"].setInput( sphere["out"] )
@@ -107,7 +107,7 @@ class MeshTessellateTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNodeCorrect( tessellate, "sphere" )
 
 		tessellate["tessellatePolygons"].setValue( False )
-		tessellate["scheme"].setValue( MeshAlgo.SubdivisionScheme.CatmullClark )
+		tessellate["scheme"].setValue( "catmullClark" )
 		self.assertNodeCorrect( tessellate, "sphere" )
 
 if __name__ == "__main__":

--- a/python/GafferSceneUI/MeshTessellateUI.py
+++ b/python/GafferSceneUI/MeshTessellateUI.py
@@ -61,7 +61,7 @@ Gaffer.Metadata.registerNode(
 
 	""",
 
-	"layout:activator:schemeNotOverridden", lambda node : node["scheme"].getValue() == MeshAlgo.SubdivisionScheme.FromMesh,
+	"layout:activator:schemeNotOverridden", lambda node : node["scheme"].getValue() == "",
 
 	plugs = {
 		"divisions" : [
@@ -90,10 +90,10 @@ Gaffer.Metadata.registerNode(
 			to be smooth, you can set scheme to CatmullClark ).
 			""",
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-			"preset:FromMesh", MeshAlgo.SubdivisionScheme.FromMesh,
-			"preset:Bilinear", MeshAlgo.SubdivisionScheme.Bilinear,
-			"preset:Catmull-Clark", MeshAlgo.SubdivisionScheme.CatmullClark,
-			"preset:Loop", MeshAlgo.SubdivisionScheme.Loop
+			"preset:From Mesh", "",
+			"preset:Bilinear", "bilinear",
+			"preset:Catmull-Clark", "catmullClark",
+			"preset:Loop", "loop",
 		],
 		"tessellatePolygons" : [
 			"description",

--- a/src/GafferScene/MeshTessellate.cpp
+++ b/src/GafferScene/MeshTessellate.cpp
@@ -58,7 +58,7 @@ MeshTessellate::MeshTessellate( const std::string &name )
 
 	addChild( new IntPlug( "divisions", Gaffer::Plug::In, 1, 1 ) );
 	addChild( new BoolPlug( "calculateNormals", Gaffer::Plug::In, false ) );
-	addChild( new IntPlug( "scheme", Gaffer::Plug::In, (int)MeshAlgo::SubdivisionScheme::FromMesh, (int)MeshAlgo::SubdivisionScheme::First, (int)MeshAlgo::SubdivisionScheme::Last ) );
+	addChild( new StringPlug( "scheme", Gaffer::Plug::In, "" ) );
 	addChild( new BoolPlug( "tessellatePolygons", Gaffer::Plug::In, false ) );
 
 }
@@ -87,14 +87,14 @@ const Gaffer::BoolPlug *MeshTessellate::calculateNormalsPlug() const
 	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 1 );
 }
 
-Gaffer::IntPlug *MeshTessellate::schemePlug()
+Gaffer::StringPlug *MeshTessellate::schemePlug()
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 2 );
 }
 
-const Gaffer::IntPlug *MeshTessellate::schemePlug() const
+const Gaffer::StringPlug *MeshTessellate::schemePlug() const
 {
-	return getChild<Gaffer::IntPlug>( g_firstPlugIndex + 2 );
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 2 );
 }
 
 Gaffer::BoolPlug *MeshTessellate::tessellatePolygonsPlug()
@@ -138,13 +138,12 @@ IECore::ConstObjectPtr MeshTessellate::computeProcessedObject( const ScenePath &
 		return inputObject;
 	}
 
-	IECoreScenePreview::MeshAlgo::SubdivisionScheme schemeValue =
-		(IECoreScenePreview::MeshAlgo::SubdivisionScheme)schemePlug()->getValue();
+	IECore::InternedString schemeValue = schemePlug()->getValue();
 
 	if(
 		inputMesh->interpolation() == "linear" &&
 		!tessellatePolygonsPlug()->getValue() &&
-		schemeValue == IECoreScenePreview::MeshAlgo::SubdivisionScheme::FromMesh
+		!schemeValue.string().size()
 	)
 	{
 		return inputObject;

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -482,17 +482,10 @@ void GafferSceneModule::bindIECoreScenePreview()
 
 		scope meshAlgoScope( meshAlgoModule );
 
-		enum_<MeshAlgo::SubdivisionScheme>( "SubdivisionScheme" )
-			.value( "FromMesh", MeshAlgo::SubdivisionScheme::FromMesh )
-			.value( "Bilinear", MeshAlgo::SubdivisionScheme::Bilinear )
-			.value( "CatmullClark", MeshAlgo::SubdivisionScheme::CatmullClark )
-			.value( "Loop", MeshAlgo::SubdivisionScheme::Loop )
-		;
-
 		def( "tessellateMesh", MeshAlgo::tessellateMesh,
 			(
 				arg( "mesh" ), arg( "divisions" ),
-				arg( "calculateNormals" ) = false, arg( "scheme" ) = MeshAlgo::SubdivisionScheme::FromMesh,
+				arg( "calculateNormals" ) = false, arg( "scheme" ) = "",
 				arg( "canceller" ) = object()
 			)
 		);


### PR DESCRIPTION
Switches our representation of subdivision scheme to just be a string rather than a custom enum. This is a bit simpler, and will be more consistent when other subdivision options are stored as strings ( the other options will come later, but we want to get this merged while 1.4 is still in beta, and it shouldn't cause problems to change this ).

All pretty straightforward - the only possible point of discussion I can think of is "bilinear" vs "linear". I think the approach of taken is correct - "bilinear" is the name of a subdivision scheme ( as is the convention in USD and OpenSubdiv ). "linear" is something we store in the interpolation property of a mesh, which means the mesh should be interpreted as simple polygons.

In the long term, we should support "bilinear" in the interpolation property of a mesh, to indicate a mesh which needs tessellation, but with a flat limit surface, and we should potentially rename "linear" to "none". I think this PR helps move us in that direction.

One tiny downside to this PR - in the UI, scheme = "" is represented as "From Mesh", so the UI is clear. But the API to MeshAlgo::tessellateMesh now just has scheme = "", which is a bit less clear that it's coming from the mesh than when it was scheme = SubdivisionScheme::FromMesh. There is maybe more of an argument now for naming it overrideScheme? But it's probably more important that the UI be nice and clear, and we want to match the name used in the UI, so this is probably fine?