### PR TITLE
Remove `%ERRORLEVEL%` conditional exit

### DIFF
--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -160,12 +160,8 @@ if "%GAFFER_DEBUG%" NEQ "" (
 	"%GAFFER_ROOT%"\bin\python.exe "%GAFFER_ROOT%"/bin/__gaffer.py %*
 )
 
-if %ERRORLEVEL% NEQ 0 (
-	exit /B %ERRORLEVEL%
-)
-
 ENDLOCAL
-exit /B 0
+exit /B %ERRORLEVEL%
 
 :prependToPath
 	set NewValue=%~1


### PR DESCRIPTION
In the past, we were echoing an error message when we exited with non-zero exit code. That was removed for clarity in 81012c86bc122cd7a69e8553b6ba5ba9e37503ac, and now this can be simplified even more to remove the check for a non-zero exit code and just forward to exit code as-is to the calling process.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
