### PR TITLE
LightPositionTool : Add `Diffuse` mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - Cycles : Added support for CUDA and Optix devices on Windows [^1].
+- LightPositionTool : Added `Diffuse` mode for placing lights along the normal of the target position.
 
 Improvements
 ------------

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -79,13 +79,17 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 			const float targetDistance
 		);
 
+		// Positions the current selection to be `distance` away from `target`, along `normal`.
+		void positionAlongNormal( const Imath::V3f &target, const Imath::V3f &normal, const float targetDistance );
+
 		enum class Mode
 		{
 			Shadow,
 			Highlight,
+			Diffuse,
 
 			First = Shadow,
-			Last = Highlight
+			Last = Diffuse
 		};
 
 	protected :

--- a/python/GafferSceneUI/LightPositionToolUI.py
+++ b/python/GafferSceneUI/LightPositionToolUI.py
@@ -48,8 +48,10 @@ def __toolTip( tool ) :
 	result = None
 	if mode == GafferSceneUI.LightPositionTool.Mode.Shadow :
 		result = "Hold 'Shift' + 'V' to place shadow pivot\nHold 'V' to place shadow target"
-	else :
+	elif mode == GafferSceneUI.LightPositionTool.Mode.Highlight :
 		result = "Hold 'V' to place highlight target"
+	else :
+		result = "Hold 'V' to place diffuse target"
 
 	return result
 
@@ -89,6 +91,7 @@ Gaffer.Metadata.registerNode(
 
 			"preset:Shadow", GafferSceneUI.LightPositionTool.Mode.Shadow,
 			"preset:Highlight", GafferSceneUI.LightPositionTool.Mode.Highlight,
+			"preset:Diffuse", GafferSceneUI.LightPositionTool.Mode.Diffuse,
 
 			"viewer:cyclePresetShortcut", "O",
 

--- a/python/GafferSceneUITest/LightPositionToolTest.py
+++ b/python/GafferSceneUITest/LightPositionToolTest.py
@@ -273,6 +273,61 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 						places = 3
 					)
 
+	def __diffuseSource( self, lightP, diffuseP, normal ) :
+		d = ( lightP - diffuseP ).length()
+		return diffuseP + normal * d
+
+	def testPositionDiffuse( self ) :
+
+		random.seed( 42 )
+
+		script = Gaffer.ScriptNode()
+		script["light"] = GafferSceneTest.TestLight()
+
+		view = GafferSceneUI.SceneView()
+		view["in"].setInput( script["light"]["out"] )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light"] ) )
+
+		tool = GafferSceneUI.LightPositionTool( view )
+		tool["active"].setValue( True )
+
+		for i in range( 0, 5 ) :
+			lightP = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+			diffuseP = imath.V3f( random.random() * 10 - 5, random.random() * 10 - 5, random.random() * 10 - 5 )
+			normal = imath.V3f( random.random() * 2 - 1, random.random() * 2 - 1, random.random() * 2 - 1 ).normalized()
+
+			script["light"]["transform"]["translate"].setValue( lightP )
+
+			d0 = ( lightP - diffuseP ).length()
+			upDir = script["light"]["transform"].matrix().multDirMatrix( imath.V3f( 0, 1, 0 ) )
+
+			with Gaffer.Context() :
+				tool.positionAlongNormal( diffuseP, normal, d0 )
+
+			p = script["light"]["transform"]["translate"].getValue()
+
+			d1 = ( p - diffuseP ).length()
+			self.assertAlmostEqual( d0, d1, places = 4 )
+
+			desiredP = self.__diffuseSource( lightP, diffuseP, normal )
+
+			for j in range( 0, 3 ) :
+				self.assertAlmostEqual( p[j], desiredP[j], places = 4 )
+
+			desiredO = imath.M44f()
+			imath.M44f.rotationMatrixWithUpDir( desiredO, imath.V3f( 0, 0, -1 ), diffuseP - p, upDir )
+			rotationO = imath.V3f()
+			desiredO.extractEulerXYZ( rotationO )
+
+			o = script["light"]["transform"]["rotate"].getValue()
+
+			with self.subTest( f"Iteration {i}" ) :
+				self.assertAnglesAlmostEqual(
+					o,
+					IECore.radiansToDegrees( imath.V3f( rotationO ) ),
+					places = 3
+				)
+
 	def testEmptySelectionModeChange( self ) :
 
 		script = Gaffer.ScriptNode()

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -317,11 +317,13 @@ void GafferSceneUIModule::bindTools()
 			.def( init<SceneView *>() )
 			.def( "positionShadow", &LightPositionTool::positionShadow )
 			.def( "positionHighlight", &LightPositionTool::positionHighlight )
+			.def( "positionAlongNormal", &LightPositionTool::positionAlongNormal )
 		;
 
 		enum_<LightPositionTool::Mode>( "Mode" )
 			.value( "Shadow", LightPositionTool::Mode::Shadow )
 			.value( "Highlight", LightPositionTool::Mode::Highlight )
+			.value( "Diffuse", LightPositionTool::Mode::Diffuse )
 		;
 	}
 


### PR DESCRIPTION
This adds what I think is the final brick in the light placement tool wall - diffuse placement. Diffuse placement mode places the light along the normal at the target position, with the usual handle for dragging the distance of the light to the target.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
