### PR TITLE
3Delight capsule support

### DIFF
--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -35,6 +35,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+#include "GafferScene/Private/IECoreScenePreview/Procedural.h"
 
 #include "Gaffer/Private/IECorePreview/LRUCache.h"
 
@@ -58,6 +59,8 @@
 #include "tbb/concurrent_hash_map.h"
 
 #include "fmt/format.h"
+
+#include <filesystem>
 
 #include <unordered_map>
 
@@ -683,17 +686,15 @@ class DelightAttributes : public IECoreScenePreview::Renderer::AttributesInterfa
 
 			NSISetAttribute( m_handle.context(), m_handle.name(), params.size(), params.data() );
 
-			if( !m_surfaceShader )
+			if( m_surfaceShader )
 			{
-				m_surfaceShader = shaderCache->defaultSurface();
+				NSIConnect(
+					context,
+					m_surfaceShader->handle().name(), "",
+					m_handle.name(), "surfaceshader",
+					0, nullptr
+				);
 			}
-
-			NSIConnect(
-				context,
-				m_surfaceShader->handle().name(), "",
-				m_handle.name(), "surfaceshader",
-				0, nullptr
-			);
 
 			if( m_volumeShader )
 			{
@@ -826,6 +827,9 @@ IE_CORE_DECLAREPTR( AttributesCache )
 namespace
 {
 
+// Forward declaration
+bool convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, NSIContext_t context, DelightHandle::Ownership ownership, const char *handle );
+
 class InstanceCache : public IECore::RefCounted
 {
 
@@ -846,7 +850,19 @@ class InstanceCache : public IECore::RefCounted
 			if( !a->second )
 			{
 				const std::string &name = "instance:" + hash.toString();
-				if( NodeAlgo::convert( object, m_context, name.c_str() ) )
+
+				if( const IECoreScenePreview::Procedural *procedural = IECore::runTimeCast<const IECoreScenePreview::Procedural>( object ) )
+				{
+					if( convertProcedural( procedural, m_context, m_ownership, name.c_str() ) )
+					{
+						a->second = make_shared<DelightHandle>( m_context, name, m_ownership );
+					}
+					else
+					{
+						a->second = nullptr;
+					}
+				}
+				else if( NodeAlgo::convert( object, m_context, name.c_str() ) )
 				{
 					a->second = make_shared<DelightHandle>( m_context, name, m_ownership );
 				}
@@ -878,7 +894,19 @@ class InstanceCache : public IECore::RefCounted
 			if( !a->second )
 			{
 				const std::string &name = "instance:" + hash.toString();
-				if( NodeAlgo::convert( samples, times, m_context, name.c_str() ) )
+
+				if( const IECoreScenePreview::Procedural *procedural = IECore::runTimeCast<const IECoreScenePreview::Procedural>( samples.front() ) )
+				{
+					if( convertProcedural( procedural, m_context, m_ownership, name.c_str() ) )
+					{
+						a->second = make_shared<DelightHandle>( m_context, name, m_ownership );
+					}
+					else
+					{
+						a->second = nullptr;
+					}
+				}
+				else if( NodeAlgo::convert( samples, times, m_context, name.c_str() ) )
 				{
 					a->second = make_shared<DelightHandle>( m_context, name, m_ownership );
 				}
@@ -1149,6 +1177,214 @@ class DelightLight : public DelightObject
 };
 
 IE_CORE_DECLAREPTR( DelightLight );
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// DelightProceduralRenderer
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+IE_CORE_FORWARDDECLARE( DelightProceduralRenderer )
+
+class DelightProceduralRenderer final : public IECoreScenePreview::Renderer
+{
+
+	public :
+
+		DelightProceduralRenderer( NSIContext_t context, DelightHandle::Ownership ownership, const char *handle )
+			:	m_context( context ), m_ownership( ownership ), m_frame( 1 )
+		{
+			vector<NSIParam_t> params;
+
+			m_ownership = DelightHandle::Unowned;
+
+			const char *apistream = "apistream";
+			const char *streamformat = "binarynsi";
+			const char *streamcompression = "gzip";
+			std::string filename = handle;
+			boost::replace_all( filename, ":", "_" );
+			std::string temppath = std::filesystem::temp_directory_path();
+			filename = temppath + "/gaffer/" + filename + ".nsi.gz";
+			const char *fileNamePtr = filename.c_str();
+
+			params = {
+				{ "type", &apistream, NSITypeString, 0, 1, 0 },
+				{ "streamformat", &streamformat, NSITypeString, 0, 1, 0 },
+				{ "streamfilename", &fileNamePtr, NSITypeString , 0, 1, 0 },
+				{ "streamcompression", &streamcompression, NSITypeString , 0, 1, 0 }
+			};
+
+			m_context = NSIBegin( params.size(), params.data() );
+			m_instanceCache = new InstanceCache( m_context, m_ownership );
+			m_attributesCache = new AttributesCache( m_context, m_ownership );
+		}
+
+		~DelightProceduralRenderer() override
+		{
+			m_attributesCache.reset();
+			m_instanceCache.reset();
+			NSIEnd( m_context );
+		}
+
+		IECore::InternedString name() const override
+		{
+			return "3Delight";
+		}
+
+		void option( const IECore::InternedString &name, const IECore::Object *value ) override
+		{
+			IECore::msg( IECore::Msg::Warning, "DelightRenderer", "Procedurals can not call option()" );
+		}
+
+		void output( const IECore::InternedString &name, const IECoreScene::Output *output ) override
+		{
+			IECore::msg( IECore::Msg::Warning, "DelightRenderer", "Procedurals can not call output()" );
+		}
+
+		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override
+		{
+			IECore::CompoundObject* fullAttributes = new IECore::CompoundObject;
+			for( const auto &a : attributes->members() )
+			{
+				fullAttributes->members()[a.first] = a.second;
+			}
+			return m_attributesCache->get( fullAttributes );
+		}
+
+		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		{
+			IECore::msg( IECore::Msg::Warning, "DelightRenderer", "Procedurals can not call camera()" );
+			return nullptr;
+		}
+
+		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+
+			DelightHandleSharedPtr instance;
+			if( object )
+			{
+				instance = m_instanceCache->get( object );
+			}
+
+			ObjectInterfacePtr result = new DelightLight( m_context, name, instance, m_ownership );
+			result->attributes( attributes );
+
+			return result;
+		}
+
+		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			return nullptr;
+		}
+
+		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			if( !object )
+			{
+				return nullptr;
+			}
+
+			DelightHandleSharedPtr instance = m_instanceCache->get( object );
+			if( !instance )
+			{
+				return nullptr;
+			}
+
+			ObjectInterfacePtr result = new DelightObject( m_context, name, instance, m_ownership );
+			result->attributes( attributes );
+			return result;
+		}
+
+		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		{
+
+			DelightHandleSharedPtr instance = m_instanceCache->get( samples, times );
+			if( !instance )
+			{
+				return nullptr;
+			}
+
+			ObjectInterfacePtr result = new DelightObject( m_context, name, instance, m_ownership );
+			result->attributes( attributes );
+			return result;
+		}
+
+		void render() override
+		{
+			m_instanceCache->clearUnused();
+			m_attributesCache->clearUnused();
+
+			const char *start = "start";
+			vector<NSIParam_t> params = {
+				{ "action", &start, NSITypeString, 0, 1, 0 },
+				{ "frame", &m_frame, NSITypeInteger, 0, 1, 0 }
+			};
+
+			NSIRenderControl(
+				m_context,
+				params.size(), params.data()
+			);
+		}
+
+		void pause() override
+		{
+			// In theory we could use NSIRenderControl "suspend"
+			// here, but despite documenting it, 3delight does not
+			// support it. Instead we let 3delight waste cpu time
+			// while we make our edits.
+		}
+
+	private :
+
+		NSIContext_t m_context;
+		DelightHandle::Ownership m_ownership;
+
+		int m_frame;
+
+		InstanceCachePtr m_instanceCache;
+		AttributesCachePtr m_attributesCache;
+
+		// Registration with factory
+
+		static Renderer::TypeDescription<DelightProceduralRenderer> g_typeDescription;
+
+};
+
+IE_CORE_DECLAREPTR( DelightProceduralRenderer )
+
+bool convertProcedural( IECoreScenePreview::ConstProceduralPtr procedural, NSIContext_t context, DelightHandle::Ownership ownership, const char *handle )
+{
+	NSICreate( context, handle, "procedural", 0, nullptr );
+
+	ParameterList procParameters;
+
+	std::string type = "apistream";
+	std::string filename = handle;
+	boost::replace_all( filename, ":", "_" );
+	std::string temppath = std::filesystem::temp_directory_path();
+	filename = temppath + "/gaffer/" + filename + ".nsi.gz";
+
+	procParameters.add( "type", type );
+	procParameters.add( "filename", filename );
+
+	NSISetAttribute( context, handle, procParameters.size(), procParameters.data() );
+
+	DelightProceduralRendererPtr renderer = new DelightProceduralRenderer( context, ownership, handle );
+
+	tbb::this_task_arena::isolate(
+		// Isolate in case procedural spawns TBB tasks, because
+		// `convertProcedural()` is called behind a lock in
+		// `InstanceCache.get()`.
+		[&]() {
+			procedural->render( renderer.get() );
+		}
+	);
+
+	return true;
+}
 
 } // namespace
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- 3Delight support for capsules by exporting the encapsulated scene as a gzipped binary NSI file in the operating system's temp folder and reading it back in the main scene as a NSI apistream procedural. 
- Removed the default surface shader assignment, since it overrides any external surface shader assignments to the encapsulated object. 
- Still have to update the test suite, but wanted to check with everyone if the implementation looks OK and to check if the CI Windows build would work. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
