### PR TITLE
Capsule, Unencapsulate : Fix cancellation handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,12 @@ Improvements
 - Shuffle : Added the ability to load Shuffles from Gaffer 1.4.
 - Instancer : Added support for `Varying` primitive variables whenever they are equivalent to (have the same size as) a `Vertex` primitive variable.
 
+Fixes
+-----
+
+- Encapsulate : Fixed bug which could cause unwanted cancellation when rendering or unencapsulating.
+- Unencapsulate : Fixed bug which prevented cancellation of long-running computes.
+
 1.3.15.0 (relative to 1.3.14.0)
 ========
 

--- a/python/GafferSceneTest/CapsuleTest.py
+++ b/python/GafferSceneTest/CapsuleTest.py
@@ -135,5 +135,20 @@ class CapsuleTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+	def testCancellerNotStored( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		hash = IECore.MurmurHash()
+		for path in ( "/", "/sphere" ) :
+			for method in ( "boundHash", "transformHash", "objectHash", "attributesHash" ) :
+				hash.append( getattr( sphere["out"], method )( path ) )
+
+		context = Gaffer.Context( Gaffer.Context(), IECore.Canceller() )
+		context["test"] = 1
+
+		capsule = GafferScene.Capsule( sphere["out"], "/", context, hash, sphere["out"].bound( "/" ) )
+		self.assertIsNone( capsule.context().canceller() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Capsule.cpp
+++ b/src/GafferScene/Capsule.cpp
@@ -59,7 +59,7 @@ namespace
 
 	Gaffer::Context *capsuleContext( const Context &context )
 	{
-		Gaffer::Context *result = new Gaffer::Context( context );
+		Gaffer::Context *result = new Gaffer::Context( context, /* omitCanceller = */ true );
 
 		// We don't want to include the scenePath of the original location of the capsule
 		// as part of the context used downstream to evaluate the insides of the capsule

--- a/src/GafferScene/Unencapsulate.cpp
+++ b/src/GafferScene/Unencapsulate.cpp
@@ -82,6 +82,7 @@ class CapsuleScope : boost::noncopyable
 			if( m_capsule )
 			{
 				m_scope.emplace( m_capsule->context() );
+				m_scope->setCanceller( context->canceller() );
 				m_capsulePath = concatScenePath( m_capsule->root(), branchPath );
 				m_scope->set( ScenePlug::scenePathContextName, &m_capsulePath );
 			}
@@ -95,6 +96,7 @@ class CapsuleScope : boost::noncopyable
 			if( m_capsule )
 			{
 				m_scope.emplace( m_capsule->context() );
+				m_scope->setCanceller( context->canceller() );
 				m_scope->set( ScenePlug::setNameContextName, setName );
 			}
 		}


### PR DESCRIPTION
We weren't omitting the canceller when copying the context in the Capsule constructor. This meant the Capsule could contain a dangling pointer to a long-since destructed Canceller, which among other things could cause `IECore::Cancelled` to be thrown when unencapsulating or rendering the capsule. Even if the Canceller wasn't dangling, it still wasn't suitable to be stored, because the Capsule is stored in Gaffer's cache and could be used subsequently by a client for which the original canceller doesn't apply.

A similar bug existed for the Unencapsulate node, which needs to ensure the _current_ Canceller is used when evaluating the Capsule contents. We do this in CapsuleScope by combining the current canceller with the Context stored in the Capsule, via an EditableScope.

There was one limited scenario in which the first bug could actually have worked in our favour, and which isn't matched by the fix. When rendering a freshly-minted capsule, the canceller might have still been valid, allowing cancellation of a capsule expansion. This wouldn't have applied to any of our current rendering mechanisms though; neither batch nor interative renders use cancellation, and the Viewer doesn't expand capsules. This does point out a limitation of Capsules though (and Procedurals more generally) - we need to add a mechanism to pass cancellers to the `render()` method.
