### PR TITLE
PathFilterUI : Drop onto Box and Reference nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
   - Updated the default output presets to include scalarformat, colorprofile, filter and filterwidth output parameters.
 - LightPositionTool : Changed the pointer to `notEditable` when using keyboard combinations that do not apply to the current tool mode.
 - LightEditor : Added the ability to register columns for editing any parameter in a light's shader network. The parameter to edit is registered in the form `shaderName.parameterName` when calling `GafferSceneUI.LightEditor.registerParameter`.
+- PathFilterUI : Added the ability to drag and drop scene paths onto Box and Reference nodes. Doing so will create a new PathFilter with the selected paths if none is connected, or update an existing connected PathFilter.
 
 Fixes
 -----

--- a/doc/source/WorkingWithTheNodeGraph/BoxNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/BoxNode/index.md
@@ -259,8 +259,3 @@ A very simple Box with in and out plugs, promoted plugs, and custom UI.
 ### Attribute history focus ###
 
 If you use the attribute history to find a node, and the node is inside a Box, the Graph Editor will focus on the whole node graph, rather than the Box.
-
-
-### Dragging scene locations ###
-
-When a Box has a promoted filter plug, you cannot drag a scene location from the Hierarchy View onto the Box to automatically add and connect a Path Filter node.

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -248,12 +248,24 @@ def __pathsPlug( node ) :
 
 	return None
 
+def __filterPlug( node ) :
+
+	filterPlugs = list( GafferScene.FilterPlug.Range( node ) )
+	if len( filterPlugs ) == 1 :
+		return filterPlugs[0]
+	return None
+
 def __dropMode( nodeGadget, event ) :
 
 	if __pathsPlug( nodeGadget.node() ) is None :
 		filter = None
-		if nodeGadget.node()["filter"].getInput() is not None :
-			filter = nodeGadget.node()["filter"].source().node()
+
+		filterPlug = __filterPlug( nodeGadget.node() )
+		if filterPlug is None :
+			return __DropMode.None_
+
+		if filterPlug.getInput() is not None :
+			filter = filterPlug.source().node()
 		if filter is None :
 			return __DropMode.Replace
 		elif not isinstance( filter, GafferScene.PathFilter ) :
@@ -342,7 +354,7 @@ def __drop( nodeGadget, event ) :
 
 	pathsPlug = __pathsPlug( nodeGadget.node() )
 	if pathsPlug is None :
-		pathsPlug = __pathsPlug( nodeGadget.node()["filter"].source().node() )
+		pathsPlug = __pathsPlug( __filterPlug( nodeGadget.node() ).source().node() )
 
 	dropPaths = __dropPaths( event.data, pathsPlug )
 
@@ -364,7 +376,7 @@ def __drop( nodeGadget, event ) :
 
 			pathFilter = GafferScene.PathFilter()
 			nodeGadget.node().parent().addChild( pathFilter )
-			nodeGadget.node()["filter"].setInput( pathFilter["out"] )
+			__filterPlug( nodeGadget.node() ).setInput( pathFilter["out"] )
 
 			pathsPlug = pathFilter["paths"]
 
@@ -390,3 +402,4 @@ def __nodeGadget( pathFilter ) :
 	return nodeGadget
 
 GafferUI.NodeGadget.registerNodeGadget( GafferScene.PathFilter, __nodeGadget )
+GafferUI.NodeGadget.registerNodeGadget( Gaffer.SubGraph, __nodeGadget )


### PR DESCRIPTION
This adds the ability to drag and drop scene paths onto Box and Reference nodes. I can think of a few complications, like having multiple filters connected to a Box / Reference, that might not make this ideal. I believe the request came from the lighting teams and my recent work on #5786 had me in the frame of mind to bubble up the request on my list.

If it proves to be more problematic than beneficial, I'm fine with dropping it, but might be worth pinging the lighting team first to see how often they think it would help.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
