### PR TITLE
Cycles ShaderNetworkAlgo : Translate UsdPreviewSurface to Cycles

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.0.0)
 =======
 
+Improvements
+------------
 
+- USD : Added automatic render-time translation of UsdPreviewSurface shaders to Cycles.
 
 1.4.0.0 (relative to 1.3.16.0)
 =======

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/ShaderNetworkAlgoTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/ShaderNetworkAlgoTest.py
@@ -35,6 +35,7 @@
 #
 ##########################################################################
 
+import math
 import unittest
 
 import imath
@@ -413,6 +414,452 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 		output = network.outputShader()
 		self.assertEqual( output.name, "point_light" )
 		self.assertEqual( output.parameters["size"].value, 1.0 )
+
+	def testConvertUSDPreviewSurfaceEmission( self ) :
+
+		for emissiveColor in ( imath.Color3f( 1 ), imath.Color3f( 0 ), None ) :
+
+			parameters = {}
+			if emissiveColor is not None :
+				parameters["emissiveColor"] = IECore.Color3fData( emissiveColor )
+
+			network = IECoreScene.ShaderNetwork(
+				shaders = {
+					"previewSurface" : IECoreScene.Shader(
+						"UsdPreviewSurface", "surface", parameters
+					)
+				},
+				output = "previewSurface",
+			)
+
+			convertedNetwork = network.copy()
+			IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+			convertedShader = convertedNetwork.getShader( "previewSurface" )
+			self.assertEqual( convertedShader.name, "principled_bsdf" )
+			self.assertEqual(
+				convertedShader.parameters["emission_color"].value,
+				emissiveColor if emissiveColor is not None else imath.Color3f( 0 )
+			)
+
+			if emissiveColor is not None and emissiveColor != imath.Color3f( 0 ) :
+				self.assertEqual( convertedShader.parameters["emission_strength"], IECore.FloatData( 1 ) )
+			else :
+				self.assertEqual( convertedShader.parameters["emission_strength"], IECore.FloatData( 0 ) )
+
+			# Repeat, but with an input connection as well as the parameter value
+
+			network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
+			network.addConnection( ( ( "texture", "rgb" ), ( "previewSurface", "emissiveColor" ) ) )
+
+			convertedNetwork = network.copy()
+			IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+			convertedShader = convertedNetwork.getShader( "previewSurface" )
+			self.assertEqual( convertedShader.name, "principled_bsdf" )
+
+			self.assertEqual(
+				convertedNetwork.input( ( "previewSurface", "emission_color" ) ),
+				( "texture", "color" ),
+			)
+			self.assertEqual( convertedShader.parameters["emission_strength"], IECore.FloatData( 1 ) )
+
+	def testConvertUSDFloat3ToColor3f( self ) :
+
+		# Although UsdPreviewSurface parameters are defined to be `color3f` in the spec,
+		# some USD files seem to provide `float3` values instead. For example :
+		#
+		# https://github.com/usd-wg/assets/blob/64ebce19c9a6c795862548066bc1070bf0f7f955/test_assets/AlphaBlendModeTest/AlphaBlendModeTest.usd#L27
+		#
+		# Make sure that we convert these to colours for consumption by Cycles.
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"previewSurface" : IECoreScene.Shader(
+					"UsdPreviewSurface", "surface",
+					{
+						"diffuseColor" : imath.V3f( 0, 0.25, 0.5 ),
+					}
+				)
+			},
+			output = "previewSurface",
+		)
+
+		IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( network )
+		self.assertEqual(
+			network.getShader( "previewSurface" ).parameters["base_color"],
+			IECore.Color3fData( imath.Color3f( 0, 0.25, 0.5 ) )
+		)
+
+	def testConvertUSDOpacity( self ) :
+
+		# The results of this type of conversion may also be verified visually using
+		# the AlphaBlendModeTest asset found here :
+		#
+		# https://github.com/usd-wg/assets/tree/main/test_assets/AlphaBlendModeTest
+		#
+		# > Note : the leftmost texture is incorrect, because USD expects the texture
+		# > (which has unpremultiplied alpha) to be loaded unmodified, but OIIO/Cycles
+		# > appear to premultiply it during loading.
+
+		for opacity in ( 0.25, 1.0, None ) :
+			for opacityThreshold in ( 0.0, 0.5, None ) :
+
+				parameters = {}
+				if opacity is not None :
+					parameters["opacity"] = IECore.FloatData( opacity )
+				if opacityThreshold is not None :
+					parameters["opacityThreshold"] = IECore.FloatData( opacityThreshold )
+
+				network = IECoreScene.ShaderNetwork(
+					shaders = {
+						"previewSurface" : IECoreScene.Shader(
+							"UsdPreviewSurface", "surface", parameters
+						)
+					},
+					output = "previewSurface",
+				)
+
+				convertedNetwork = network.copy()
+				IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+				convertedShader = convertedNetwork.getShader( "previewSurface" )
+				expectedOpacity = opacity if opacity is not None else 1.0
+				if opacityThreshold is not None :
+					expectedOpacity = expectedOpacity if expectedOpacity > opacityThreshold else 0
+
+				self.assertEqual(
+					convertedShader.parameters["alpha"].value,
+					expectedOpacity
+				)
+
+				# Repeat, but with an input connection as well as the parameter value
+
+				network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
+				network.addConnection( ( ( "texture", "a" ), ( "previewSurface", "opacity" ) ) )
+
+				convertedNetwork = network.copy()
+				IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+				if opacityThreshold :
+
+					self.assertEqual( len( convertedNetwork ), 4 )
+					opacityInput = convertedNetwork.input( ( "previewSurface", "alpha" ) )
+					self.assertEqual( opacityInput, ( "previewSurfaceOpacityMultiply", "value" ) )
+					self.assertEqual( convertedNetwork.getShader( opacityInput.shader ).name, "math" )
+					self.assertEqual(
+						convertedNetwork.input( ( "previewSurfaceOpacityMultiply", "value1" ) ),
+						( "texture", "alpha" )
+					)
+
+					self.assertEqual(
+						convertedNetwork.input( ( "previewSurfaceOpacityMultiply", "value2" ) ),
+						( "previewSurfaceOpacityCompare", "value" )
+					)
+
+					self.assertEqual(
+						convertedNetwork.input( ( "previewSurfaceOpacityCompare", "value1" ) ),
+						( "texture", "alpha" )
+					)
+
+					compareShader = convertedNetwork.getShader( "previewSurfaceOpacityCompare" )
+					self.assertEqual( compareShader.parameters["math_type"].value, "greater_than" )
+					self.assertEqual( compareShader.parameters["value2"].value, opacityThreshold )
+
+				else :
+
+					self.assertEqual( len( convertedNetwork ), 2 )
+					self.assertEqual(
+						convertedNetwork.input( ( "previewSurface", "alpha" ) ),
+						( "texture", "alpha" )
+					)
+
+	def testConvertUSDSpecular( self ) :
+
+		for useSpecularWorkflow in ( True, False ) :
+			for specularColor in ( imath.Color3f( 0, 0.25, 0.5 ), None ) :
+				with self.subTest( useSpecularWorkflow = useSpecularWorkflow, specularColor = specularColor ) :
+
+					parameters = {
+						"metallic" : 0.5,
+						"useSpecularWorkflow" : int( useSpecularWorkflow ),
+					}
+					if specularColor is not None :
+						parameters["specularColor"] = specularColor
+
+					network = IECoreScene.ShaderNetwork(
+						shaders = {
+							"previewSurface" : IECoreScene.Shader(
+								"UsdPreviewSurface", "surface", parameters
+							)
+						},
+						output = "previewSurface",
+					)
+
+					convertedNetwork = network.copy()
+					IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+					convertedShader = convertedNetwork.getShader( "previewSurface" )
+
+					if useSpecularWorkflow :
+						self.assertEqual(
+							convertedShader.parameters["specular_tint"].value,
+							specularColor if specularColor is not None else imath.Color3f( 0 )
+						)
+						self.assertEqual(
+							convertedShader.parameters["specular_ior_level"].value,
+							0.5
+						)
+						self.assertNotIn( "metallic", convertedShader.parameters )
+					else :
+						self.assertEqual( convertedShader.parameters["metallic"].value, 0.5 )
+						self.assertNotIn( "specularColor", convertedShader.parameters )
+
+					# Repeat with input connections
+
+					network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
+					network.addConnection( ( ( "texture", "rgb" ), ( "previewSurface", "specularColor" ) ) )
+					network.addConnection( ( ( "texture", "r" ), ( "previewSurface", "metallic" ) ) )
+
+					convertedNetwork = network.copy()
+					IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+					if useSpecularWorkflow :
+						self.assertEqual(
+							convertedNetwork.input( ( "previewSurface", "specular_tint" ) ),
+							( "texture", "color" ),
+						)
+						self.assertFalse( convertedNetwork.input( ( "previewSurface", "metallic" ) ) )
+					else :
+						self.assertEqual(
+							convertedNetwork.input( ( "previewSurface", "metallic" ) ),
+							( "texture", "color.r" ),
+						)
+						self.assertFalse( convertedNetwork.input( ( "previewSurface", "specular_tint" ) ) )
+
+					self.assertFalse( convertedNetwork.input( ( "previewSurface", "specularColor" ) ) )
+
+	def testConvertUSDClearcoat( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"previewSurface" : IECoreScene.Shader(
+					"UsdPreviewSurface", "surface",
+					{
+						"clearcoat" : 0.75,
+						"clearcoatRoughness" : 0.25,
+					}
+				)
+			},
+			output = "previewSurface",
+		)
+
+		convertedNetwork = network.copy()
+		IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+		convertedShader = convertedNetwork.getShader( "previewSurface" )
+
+		self.assertEqual( convertedShader.parameters["coat_weight"].value, 0.75 )
+		self.assertEqual( convertedShader.parameters["coat_roughness"].value, 0.25 )
+
+		# Repeat with input connections
+
+		network.addShader( "texture", IECoreScene.Shader( "UsdUVTexture" ) )
+		network.addConnection( ( ( "texture", "r" ), ( "previewSurface", "clearcoat" ) ) )
+		network.addConnection( ( ( "texture", "g" ), ( "previewSurface", "clearcoatRoughness" ) ) )
+
+		convertedNetwork = network.copy()
+		IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+		self.assertEqual(
+			convertedNetwork.input( ( "previewSurface", "coat_weight" ) ),
+			( "texture", "color.r" ),
+		)
+		self.assertEqual(
+			convertedNetwork.input( ( "previewSurface", "coat_roughness" ) ),
+			( "texture", "color.g" ),
+		)
+
+	def testConvertSimpleUSDUVTexture( self ) :
+
+		for uvPrimvar in ( "st", "customUV" ) :
+
+			network = IECoreScene.ShaderNetwork(
+				shaders = {
+					"previewSurface" : IECoreScene.Shader( "UsdPreviewSurface" ),
+					"texture" : IECoreScene.Shader(
+						"UsdUVTexture", "shader",
+						{
+							"file" : "test.png",
+							"wrapS" : "useMetadata",
+							"wrapT" : "repeat",
+							"sourceColorSpace" : "auto",
+						}
+					),
+					"uvReader" : IECoreScene.Shader(
+						"UsdPrimvarReader_float2", "shader",
+						{
+							"varname" : uvPrimvar,
+						}
+					),
+				},
+				connections = [
+					( ( "uvReader", "result" ), ( "texture", "st" ) ),
+					( ( "texture", "rgb" ), ( "previewSurface", "diffuseColor" ) ),
+				],
+				output = "previewSurface",
+			)
+
+			IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( network )
+
+			self.assertEqual( network.input( ( "previewSurface", "base_color" ) ), ( "texture", "color" ) )
+
+			texture = network.getShader( "texture" )
+			self.assertEqual( texture.name, "image_texture" )
+			self.assertEqual( texture.parameters["filename"].value, "test.png" )
+			self.assertEqual( texture.parameters["colorspace"].value, "auto" )
+			self.assertEqual( texture.parameters["extension"].value, "black" )
+
+	def testConvertTransformedUSDUVTexture( self ) :
+
+		# The results of this type of conversion may also be verified visually using
+		# the TextureTransformTest asset found here :
+		#
+		# https://github.com/usd-wg/assets/tree/main/test_assets/TextureTransformTest
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"previewSurface" : IECoreScene.Shader( "UsdPreviewSurface" ),
+				"texture" : IECoreScene.Shader(
+					"UsdUVTexture", "shader",
+					{
+						"file" : "test.png",
+						"wrapS" : "repeat",
+						"wrapT" : "repeat",
+						"sourceColorSpace" : "auto",
+					}
+				),
+				"transform" : IECoreScene.Shader(
+					"UsdTransform2d", "shader",
+					{
+						"rotation" : 90.0,
+					}
+				),
+				"uvReader" : IECoreScene.Shader(
+					"UsdPrimvarReader_float2", "shader",
+					{
+						"varname" : "st",
+					}
+				),
+			},
+			connections = [
+				( ( "uvReader", "result" ), ( "transform", "in" ) ),
+				( ( "transform", "result" ), ( "texture", "st" ) ),
+				( ( "texture", "rgb" ), ( "previewSurface", "diffuseColor" ) ),
+			],
+			output = "previewSurface",
+		)
+
+		convertedNetwork = network.copy()
+		IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+		texture = convertedNetwork.getShader( "texture" )
+		self.assertEqual( texture.name, "image_texture" )
+		self.assertEqual( texture.parameters["filename"].value, "test.png" )
+		self.assertEqual( texture.parameters["colorspace"].value, "auto" )
+		self.assertEqual( texture.parameters["extension"].value, "periodic" )
+
+		uvReader = convertedNetwork.getShader( "uvReader" )
+		self.assertEqual( uvReader.name, "uvmap" )
+
+		transform = convertedNetwork.getShader( "transform" )
+		self.assertEqual( transform.name, "mapping" )
+		self.assertEqual( transform.parameters["mapping_type"].value, "point" )
+		self.assertEqual( transform.parameters["location"].value, imath.V3f( 0, 0, 0 ) )
+		self.assertEqual( transform.parameters["rotation"].value, imath.V3f( 0, 0, math.radians( 90 ) ) )
+		self.assertEqual( transform.parameters["scale"].value, imath.V3f( 1, 1, 1 ) )
+
+		self.assertEqual( convertedNetwork.input( ( "transform", "vector" ) ), ( "uvReader", "UV" ) )
+
+	def testConvertUSDUVTextureColor4Parameters( self ) :
+
+		network = IECoreScene.ShaderNetwork(
+			shaders = {
+				"previewSurface" : IECoreScene.Shader( "UsdPreviewSurface" ),
+				"texture" : IECoreScene.Shader(
+					"UsdUVTexture", "shader",
+					{
+						"fallback" : imath.Color4f( 1, 2, 3, 4 ),
+						"scale" : imath.Color4f( 0.1, 0.2, 0.3, 0.4 ),
+						"bias" : imath.Color4f( 0.2, 0.4, 0.6, 0.8 ),
+					}
+				),
+			},
+			connections = [
+				( ( "texture", "rgb" ), ( "previewSurface", "diffuseColor" ) ),
+				( ( "texture", "a" ), ( "previewSurface", "roughness" ) ),
+				( ( "texture", "r" ), ( "previewSurface", "metallic" ) ),
+			],
+			output = "previewSurface",
+		)
+
+		convertedNetwork = network.copy()
+		IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( convertedNetwork )
+
+		texture = convertedNetwork.getShader( "texture" )
+		self.assertEqual( texture.name, "image_texture" )
+
+		# Setting scale or bias will result in `vector_math` and `math` shaders
+		# being inserted to apply the scale and bias offsets to the colour and
+		# alpha outputs of `image_texture`.
+
+		colorInput = convertedNetwork.input( ( "previewSurface", "base_color" ) )
+		multiplyAdd = convertedNetwork.getShader( colorInput.shader )
+		self.assertEqual( multiplyAdd.name, "vector_math" )
+		self.assertEqual( multiplyAdd.parameters["math_type"].value, "multiply_add" )
+		self.assertEqual( multiplyAdd.parameters["vector2"].value, imath.Color3f( 0.1, 0.2, 0.3 ) )
+		self.assertEqual( multiplyAdd.parameters["vector3"].value, imath.Color3f( 0.2, 0.4, 0.6 ) )
+
+		metallicInput = convertedNetwork.input( ( "previewSurface", "metallic" ) )
+		self.assertEqual( convertedNetwork.getShader( metallicInput.shader ), multiplyAdd )
+
+		roughnessInput = convertedNetwork.input( ( "previewSurface", "roughness" ) )
+		alphaMultiplyAdd = convertedNetwork.getShader( roughnessInput.shader )
+		self.assertEqual( alphaMultiplyAdd.name, "math" )
+		self.assertEqual( alphaMultiplyAdd.parameters["math_type"].value, "multiply_add" )
+		self.assertAlmostEqual( alphaMultiplyAdd.parameters["value2"].value, 0.4 )
+		self.assertAlmostEqual( alphaMultiplyAdd.parameters["value3"].value, 0.8 )
+
+	def testConvertUSDPrimvarReader( self ) :
+
+		for usdDataType, cyclesShaderType in [
+			( "float", "attribute" ),
+			( "float2", "uvmap" ),
+			( "float3", "attribute" ),
+			( "normal", "attribute" ),
+			( "point", "attribute" ),
+			( "vector", "attribute" ),
+			( "float4", "attribute" ),
+			( "int", "attribute" ),
+			( "string", "attribute" ),
+		] :
+
+			network = IECoreScene.ShaderNetwork(
+				shaders = {
+					"reader" : IECoreScene.Shader(
+						"UsdPrimvarReader_{}".format( usdDataType ), "shader",
+						{
+							"varname" : "test",
+						}
+					),
+				},
+				output = "reader",
+			)
+
+			IECoreCycles.ShaderNetworkAlgo.convertUSDShaders( network )
+
+			reader = network.getShader( "reader" )
+			self.assertEqual( reader.name, cyclesShaderType )
+			self.assertEqual( len( reader.parameters ), 1 )
+			self.assertEqual( reader.parameters["attribute"].value, "test" )
 
 	def __assertShadersEqual( self, shader1, shader2, message = None ) :
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -845,6 +845,7 @@ IECore::InternedString g_cyclesSurfaceShaderAttributeName( "cycles:surface" );
 IECore::InternedString g_oslSurfaceShaderAttributeName( "osl:surface" );
 IECore::InternedString g_oslShaderAttributeName( "osl:shader" );
 IECore::InternedString g_cyclesVolumeShaderAttributeName( "cycles:volume" );
+IECore::InternedString g_surfaceShaderAttributeName( "surface" );
 // Ray visibility
 IECore::InternedString g_cameraVisibilityAttributeName( "cycles:visibility:camera" );
 IECore::InternedString g_diffuseVisibilityAttributeName( "cycles:visibility:diffuse" );
@@ -930,6 +931,7 @@ class CyclesAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			const IECoreScene::ShaderNetwork *surfaceShaderAttribute = attribute<IECoreScene::ShaderNetwork>( g_cyclesSurfaceShaderAttributeName, attributes );
 			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECoreScene::ShaderNetwork>( g_oslSurfaceShaderAttributeName, attributes );
 			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECoreScene::ShaderNetwork>( g_oslShaderAttributeName, attributes );
+			surfaceShaderAttribute = surfaceShaderAttribute ? surfaceShaderAttribute : attribute<IECoreScene::ShaderNetwork>( g_surfaceShaderAttributeName, attributes );
 			const IECoreScene::ShaderNetwork *displacementShaderAttribute = attribute<IECoreScene::ShaderNetwork>( g_cyclesDisplacementShaderAttributeName, attributes );
 			const IECoreScene::ShaderNetwork *volumeShaderAttribute = attribute<IECoreScene::ShaderNetwork>( g_cyclesVolumeShaderAttributeName, attributes );
 			if( surfaceShaderAttribute || volumeShaderAttribute )


### PR DESCRIPTION
This does an initial conversion of UsdPreviewSurface shaders to Cycles. I got a bit of a head-start on this from some earlier investigations by @boberfly, many thanks!

![cyclesAlab](https://github.com/GafferHQ/gaffer/assets/50844517/96c38f4f-7c5c-46f1-8700-96b21760c491)

I've currently held off on converting `normal` inputs due to the whole "Cycles requiring mesh tangents to be provided to it in order for normal maps to work correctly" thing. Displacement is also not being converted, but we're not doing that for Arnold at present either.

In testing I've noticed some inconsistency rendering the [TextureCoordinateTest](https://github.com/usd-wg/assets/tree/main/test_assets/TextureCoordinateTest) asset even after deliberately disabling instancing of the geometry. The textures displayed on each card change randomly with each render. Though I see the same after replicating the test with native Cycles shaders, so that's likely another Cycles issue to investigate some other time...

There's also further work to be done in mapping the USD `sourceColorSpace` presets to values that mean something to Cycles/OCIO.
