### PR TITLE
Drop support for OpenEXR/Imath 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -830,38 +830,6 @@ if ( int( baseLibEnv["BOOST_MAJOR_VERSION"] ), int( baseLibEnv["BOOST_MINOR_VERS
 	# the reams of warnings triggered by that.
 	baseLibEnv.Append( CPPDEFINES = [ "BOOST_BIND_GLOBAL_PLACEHOLDERS" ] )
 
-# Determine Imath version. The transition between 2 and 3 is a bit of a mess.
-# Imath 3 provides `Imath/ImathConfig.h` for determining version, but that isn't
-# provided by Imath 2, which comes with `OpenEXR/IlmBaseConfig.h` instead. The
-# one thing we can rely on existing all the time is the conceptually unrelated
-# `OpenEXR/OpenEXRConfig.h`, so we use that, even though we don't directly
-# depend on OpenEXR ourselves.
-
-exrVersionHeader = baseLibEnv.FindFile(
-	"OpenEXR/OpenEXRConfig.h",
-	[ "$BUILD_DIR/include" ] +
-	baseLibEnv["LOCATE_DEPENDENCY_SYSTEMPATH"] +
-	baseLibEnv["LOCATE_DEPENDENCY_CPPPATH"]
-)
-
-if not exrVersionHeader :
-	sys.stderr.write( "ERROR : unable to find \"OpenEXR/OpenEXRConfig.h\".\n" )
-	Exit( 1 )
-
-for line in open( str( exrVersionHeader ) ) :
-	m = re.match( r'^#define OPENEXR_VERSION_STRING "(\d+)\.(\d+)\.(\d+)"$', line )
-	if m :
-		baseLibEnv["IMATH_MAJOR_VERSION"] = int( m.group( 1 ) )
-
-if baseLibEnv.get( "IMATH_MAJOR_VERSION", None ) is None :
-	sys.stderr.write( "ERROR : unable to determine version from \"{}\".\n".format( exrVersionHeader ) )
-	Exit( 1 )
-
-# Imath 2 came with a separate `Half` library but in Imath 3 everything is in
-# the `Imath` library.
-
-baseLibEnv["HALF_LIBRARY"] = "Half" if baseLibEnv["IMATH_MAJOR_VERSION"] < 3 else ""
-
 ###############################################################################################
 # The basic environment for building python modules
 ###############################################################################################
@@ -1039,11 +1007,7 @@ cyclesDefines = [
 
 libraries = {
 
-	"Gaffer" : {
-		"envAppends" : {
-			"LIBS" : [ "$HALF_LIBRARY" ],
-		},
-	},
+	"Gaffer" : {},
 
 	"GafferTest" : {
 		"envAppends" : {
@@ -1124,7 +1088,7 @@ libraries = {
 
 	"GafferScene" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "$HALF_LIBRARY", "osdCPU" ],
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "osdCPU" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],

--- a/include/Gaffer/BoxPlug.h
+++ b/include/Gaffer/BoxPlug.h
@@ -43,12 +43,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace Gaffer

--- a/include/Gaffer/CompoundNumericPlug.h
+++ b/include/Gaffer/CompoundNumericPlug.h
@@ -43,14 +43,8 @@
 #include "IECore/GeometricTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathColor.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace Gaffer

--- a/include/Gaffer/MetadataAlgo.h
+++ b/include/Gaffer/MetadataAlgo.h
@@ -43,12 +43,7 @@
 #include "IECore/StringAlgo.h"
 #include "IECore/TypeIds.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 
 #include <vector>
 

--- a/include/GafferImage/BufferAlgo.h
+++ b/include/GafferImage/BufferAlgo.h
@@ -39,12 +39,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace GafferImage

--- a/include/GafferImage/FilterAlgo.h
+++ b/include/GafferImage/FilterAlgo.h
@@ -43,12 +43,7 @@
 #include "OpenImageIO/filter.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace GafferImage

--- a/include/GafferImage/Format.h
+++ b/include/GafferImage/Format.h
@@ -42,12 +42,7 @@
 #include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/GafferImage/ImageAlgo.h
+++ b/include/GafferImage/ImageAlgo.h
@@ -46,12 +46,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -48,12 +48,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <unordered_set>

--- a/include/GafferSceneUI/RotateTool.h
+++ b/include/GafferSceneUI/RotateTool.h
@@ -41,12 +41,7 @@
 #include "GafferUI/Style.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathEuler.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace GafferSceneUI

--- a/include/GafferUI/Gadget.h
+++ b/include/GafferUI/Gadget.h
@@ -52,12 +52,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <functional>

--- a/include/GafferUI/GraphLayout.h
+++ b/include/GafferUI/GraphLayout.h
@@ -44,12 +44,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace Gaffer

--- a/include/GafferUI/KeyEvent.h
+++ b/include/GafferUI/KeyEvent.h
@@ -41,12 +41,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace GafferUI

--- a/include/GafferUI/RotateHandle.h
+++ b/include/GafferUI/RotateHandle.h
@@ -39,12 +39,7 @@
 #include "GafferUI/Handle.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathEuler.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace GafferUI

--- a/include/GafferUI/StandardStyle.h
+++ b/include/GafferUI/StandardStyle.h
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <array>

--- a/include/GafferUI/Style.h
+++ b/include/GafferUI/Style.h
@@ -49,12 +49,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -40,12 +40,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/Private/ScopedAssignment.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include <algorithm>
 #include <cassert>

--- a/src/Gaffer/NumericPlug.cpp
+++ b/src/Gaffer/NumericPlug.cpp
@@ -39,12 +39,7 @@
 
 #include "Gaffer/TypedPlug.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 using namespace IECore;
 using namespace Gaffer;

--- a/src/Gaffer/Random.cpp
+++ b/src/Gaffer/Random.cpp
@@ -40,14 +40,8 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/StringPlug.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColorAlgo.h"
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathColorAlgo.h"
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "boost/functional/hash.hpp"
 

--- a/src/Gaffer/RandomChoice.cpp
+++ b/src/Gaffer/RandomChoice.cpp
@@ -44,12 +44,7 @@
 
 #include "IECore/TypeTraits.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -62,12 +62,7 @@
 #include "IECore/StringAlgo.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/predicate.hpp"

--- a/src/GafferImage/Checkerboard.cpp
+++ b/src/GafferImage/Checkerboard.cpp
@@ -42,14 +42,8 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/Transform2DPlug.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathFun.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferImage/FormatQuery.cpp
+++ b/src/GafferImage/FormatQuery.cpp
@@ -36,12 +36,7 @@
 
 #include "GafferImage/FormatQuery.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include <cassert>
 

--- a/src/GafferImage/ImageAlgo.cpp
+++ b/src/GafferImage/ImageAlgo.cpp
@@ -38,12 +38,7 @@
 
 #include "IECore/CompoundData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -42,12 +42,7 @@
 
 #include "Gaffer/StringPlug.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include "OpenColorIO/OpenColorIO.h"
 

--- a/src/GafferImage/ImageTransform.cpp
+++ b/src/GafferImage/ImageTransform.cpp
@@ -46,12 +46,7 @@
 
 #include "IECore/AngleConversion.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 

--- a/src/GafferImage/VectorWarp.cpp
+++ b/src/GafferImage/VectorWarp.cpp
@@ -41,12 +41,7 @@
 
 #include "Gaffer/Context.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include <cmath>
 

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -73,14 +73,8 @@
 #include "IECore/BoxOps.h"
 #include "IECore/FastFloat.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColorAlgo.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathColorAlgo.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"

--- a/src/GafferOSL/ShadingEngineAlgo.cpp
+++ b/src/GafferOSL/ShadingEngineAlgo.cpp
@@ -41,12 +41,7 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 
 using namespace Imath;
 using namespace IECore;

--- a/src/GafferScene/AimConstraint.cpp
+++ b/src/GafferScene/AimConstraint.cpp
@@ -36,12 +36,7 @@
 
 #include "GafferScene/AimConstraint.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 using namespace Imath;
 using namespace Gaffer;

--- a/src/GafferScene/AttributeVisualiser.cpp
+++ b/src/GafferScene/AttributeVisualiser.cpp
@@ -41,12 +41,7 @@
 #include "IECoreScene/Shader.h"
 #include "IECoreScene/ShaderNetwork.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferScene/BoundQuery.cpp
+++ b/src/GafferScene/BoundQuery.cpp
@@ -36,12 +36,7 @@
 
 #include "GafferScene/BoundQuery.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include <cassert>
 #include <cmath>

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -56,12 +56,7 @@
 #include "IECore/AngleConversion.h"
 #include "IECore/CamelCase.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"

--- a/src/GafferScene/Group.cpp
+++ b/src/GafferScene/Group.cpp
@@ -47,12 +47,7 @@
 
 #include "IECore/NullObject.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 using namespace std;
 using namespace Imath;

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -68,14 +68,8 @@
 #include "IECore/StringAlgo.h"
 #include "IECore/Writer.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 

--- a/src/GafferScene/LightToCamera.cpp
+++ b/src/GafferScene/LightToCamera.cpp
@@ -48,14 +48,8 @@
 #include "IECore/AngleConversion.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/algorithm/string.hpp"

--- a/src/GafferScene/MapProjection.cpp
+++ b/src/GafferScene/MapProjection.cpp
@@ -43,12 +43,7 @@
 
 #include "IECore/AngleConversion.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferScene/MotionPath.cpp
+++ b/src/GafferScene/MotionPath.cpp
@@ -44,12 +44,7 @@
 
 #include "IECoreScene/CurvesPrimitive.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/GafferScene/ObjectSource.cpp
+++ b/src/GafferScene/ObjectSource.cpp
@@ -44,12 +44,7 @@
 #include "IECore/NullObject.h"
 #include "IECore/StringAlgo.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 using namespace GafferScene;
 

--- a/src/GafferScene/Orientation.cpp
+++ b/src/GafferScene/Orientation.cpp
@@ -49,16 +49,9 @@
 #include "IECore/AngleConversion.h"
 #include "IECore/MatrixAlgo.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferScene/PointConstraint.cpp
+++ b/src/GafferScene/PointConstraint.cpp
@@ -36,12 +36,7 @@
 
 #include "GafferScene/PointConstraint.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 using namespace Imath;
 using namespace Gaffer;

--- a/src/GafferScene/SetVisualiser.cpp
+++ b/src/GafferScene/SetVisualiser.cpp
@@ -45,14 +45,8 @@
 #include "IECoreScene/ShaderNetwork.h"
 #include "IECore/StringAlgo.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColorAlgo.h"
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathColorAlgo.h"
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 

--- a/src/GafferScene/TransformQuery.cpp
+++ b/src/GafferScene/TransformQuery.cpp
@@ -36,14 +36,8 @@
 
 #include "GafferScene/TransformQuery.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathEuler.h"
-#endif
 
 #include <cassert>
 #include <cmath>

--- a/src/GafferSceneUI/CameraTool.cpp
+++ b/src/GafferSceneUI/CameraTool.cpp
@@ -48,14 +48,8 @@
 
 #include "IECore/AngleConversion.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrix.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -57,16 +57,9 @@
 #include "IECore/AngleConversion.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathVecAlgo.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathVecAlgo.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/algorithm/string/predicate.hpp"

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -74,14 +74,8 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathSphere.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathSphere.h"
-#endif
 
 #include "fmt/format.h"
 

--- a/src/GafferSceneUI/OutputBuffer.cpp
+++ b/src/GafferSceneUI/OutputBuffer.cpp
@@ -39,12 +39,7 @@
 #include "IECoreImage/DisplayDriver.h"
 #include "IECoreImage/OpenImageIOAlgo.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "OpenImageIO/imageio.h"
 

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -49,14 +49,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/bind/bind.hpp"

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -44,12 +44,7 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/UndoScope.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -70,12 +70,7 @@
 #include "IECore/AngleConversion.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -55,12 +55,7 @@
 
 #include "IECore/AngleConversion.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -47,12 +47,7 @@
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/UndoScope.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -60,12 +60,7 @@
 
 #include "IECore/Math.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/bind/bind.hpp"

--- a/src/GafferUI/AuxiliaryConnectionsGadget.cpp
+++ b/src/GafferUI/AuxiliaryConnectionsGadget.cpp
@@ -46,12 +46,7 @@
 
 #include "IECoreGL/Selector.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"

--- a/src/GafferUI/Gadget.cpp
+++ b/src/GafferUI/Gadget.cpp
@@ -45,12 +45,7 @@
 
 #include "IECore/SimpleTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 #include "boost/lexical_cast.hpp"

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -73,12 +73,7 @@
 #include "IECore/NullObject.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathPlane.h"
-#else
 #include "Imath/ImathPlane.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/bind/bind.hpp"

--- a/src/GafferUI/Handle.cpp
+++ b/src/GafferUI/Handle.cpp
@@ -44,23 +44,11 @@
 #include "IECore/NullObject.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathLine.h"
-#include "OpenEXR/ImathPlane.h"
-#else
 #include "Imath/ImathLine.h"
 #include "Imath/ImathPlane.h"
-#endif
-IECORE_POP_DEFAULT_VISIBILITY
-
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathVecAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathVecAlgo.h"
-#endif
+IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"

--- a/src/GafferUI/RotateHandle.cpp
+++ b/src/GafferUI/RotateHandle.cpp
@@ -40,18 +40,10 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathSphere.h"
-#include "OpenEXR/ImathQuat.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathSphere.h"
 #include "Imath/ImathQuat.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/bind/bind.hpp"

--- a/src/GafferUI/StandardConnectionGadget.cpp
+++ b/src/GafferUI/StandardConnectionGadget.cpp
@@ -49,14 +49,8 @@
 #include "Gaffer/StandardSet.h"
 #include "Gaffer/UndoScope.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathFun.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"

--- a/src/GafferUI/StandardGraphLayout.cpp
+++ b/src/GafferUI/StandardGraphLayout.cpp
@@ -64,12 +64,7 @@
 #include "IECore/MessageHandler.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/graph/adjacency_list.hpp"

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -61,12 +61,7 @@
 
 #include "IECore/MessageHandler.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 // Don't include Qt macros that stomp over common names like "signals"
 #define QT_NO_KEYWORDS

--- a/src/GafferUI/StandardStyle.cpp
+++ b/src/GafferUI/StandardStyle.cpp
@@ -57,14 +57,8 @@
 #include "IECoreScene/Font.h"
 #include "IECoreScene/MeshPrimitive.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVecAlgo.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathVecAlgo.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/container/flat_map.hpp"
 #include "boost/tokenizer.hpp"

--- a/src/GafferUI/ViewportGadget.cpp
+++ b/src/GafferUI/ViewportGadget.cpp
@@ -52,14 +52,8 @@
 #include "IECore/NullObject.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"

--- a/src/GafferVDB/VolumeScatter.cpp
+++ b/src/GafferVDB/VolumeScatter.cpp
@@ -45,12 +45,7 @@
 #include "IECoreScene/PointsPrimitive.h"
 #include "IECoreVDB/VDBObject.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "openvdb/openvdb.h"
 #include "openvdb/tools/PointScatter.h"

--- a/src/IECoreArnold/CameraAlgo.cpp
+++ b/src/IECoreArnold/CameraAlgo.cpp
@@ -44,12 +44,7 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/SplineData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include "ai_array.h"
 #include "ai_msg.h" // Required for __AI_FILE__ macro used by `ai_array.h`


### PR DESCRIPTION
The last official builds we made with Imath 2 were for 1.2.x, which is no longer supported, and Image Engine will be building with Imath 3 exclusively for Gaffer 1.4. So it's more than safe to drop support for building against Imath 3 in Gaffer 1.5.