### PR TITLE
USDLight : Add Arnold-specific parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ API
 - BoxPlug : Added Python bindings for `ValueType`, `PointType` and `ChildType` type aliases.
 - RenderPassEditor : Added `deregisterColumn()` method.
 - DocumentationAlgo : Added table and strikethrough support to `markdownToHTML()`.
+- USDShader : Added support for loading from the UsdSchemaRegistry as well as from the SdrRegistry. This is now used when loading UsdLuxLights.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ API
 - BoxPlug : Added Python bindings for `ValueType`, `PointType` and `ChildType` type aliases.
 - RenderPassEditor : Added `deregisterColumn()` method.
 - DocumentationAlgo : Added table and strikethrough support to `markdownToHTML()`.
+- LightEditor : Added `columnName` parameter to `registerParameter()` method, matching the behaviour of `RenderPassEditor.registerOption()`.
 - USDShader : Added support for loading from the UsdSchemaRegistry as well as from the SdrRegistry. This is now used when loading UsdLuxLights.
 
 Build

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Improvements
 - USDLight :
   - Added Arnold-specific extension parameters.
   - Added parameter tooltips.
+- LightEditor : Added columns for Arnold-specific parameters on USD lights.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
   - Added support for a `{source}` token which is substituted with the original value when tweaking a string in `Replace` mode.
   - Added tooltips documenting the tweak modes.
 - 3Delight : Added automatic render-time translation of UsdPreviewSurface shaders to 3Delight.
+- USDLight : Added parameter tooltips.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,9 @@ Improvements
   - Added support for a `{source}` token which is substituted with the original value when tweaking a string in `Replace` mode.
   - Added tooltips documenting the tweak modes.
 - 3Delight : Added automatic render-time translation of UsdPreviewSurface shaders to 3Delight.
-- USDLight : Added parameter tooltips.
+- USDLight :
+  - Added Arnold-specific extension parameters.
+  - Added parameter tooltips.
 
 Fixes
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -1394,7 +1394,7 @@ libraries = {
 
 	"GafferUSD" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX" ] + [ "${USD_LIB_PREFIX}" + x for x in ( [ "sdf", "arch", "tf", "vt", "ndr", "sdr" ] if not env["USD_MONOLITHIC"] else [ "usd_ms" ] ) ],
+			"LIBS" : [ "Gaffer", "GafferDispatch", "GafferScene", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX" ] + [ "${USD_LIB_PREFIX}" + x for x in ( [ "sdf", "arch", "tf", "vt", "ndr", "sdr", "usd", "usdLux" ] if not env["USD_MONOLITHIC"] else [ "usd_ms" ] ) ],
 			# USD includes "at least one deprecated or antiquated header", so we
 			# have to drop our usual strict warning levels.
 			"CXXFLAGS" : [ "-Wno-deprecated" if env["PLATFORM"] != "win32" else "/wd4996" ],

--- a/SConstruct
+++ b/SConstruct
@@ -40,8 +40,8 @@ import os
 import re
 import sys
 import glob
+import inspect
 import locale
-import platform
 import shutil
 import subprocess
 import tempfile
@@ -1830,6 +1830,54 @@ for libraryName, libraryDef in libraries.items() :
 		)
 		stub = stubEnv.Command( stubFileName, "", buildClassStub )
 		stubEnv.Alias( "buildCore", stub )
+
+	# USD Schemas
+
+	def buildSchema( target, source, env ) :
+
+		# Write a basic `plugInfo.json` file.
+
+		targetDir = os.path.dirname( str( target[0] ) )
+		libraryName = os.path.basename( targetDir )
+		with open( os.path.join( targetDir, "plugInfo.json" ), "w" ) as plugInfo :
+			plugInfo.write( inspect.cleandoc(
+				"""
+				{{
+					"Plugins" : [
+						{{
+							"Name" : "{libraryName}",
+							"Type" : "resource",
+							"Root" : ".",
+							"ResourcePath" : ".",
+							"Info" : {{ }}
+						}}
+					]
+				}}
+				""".format( libraryName = libraryName )
+			) )
+
+		# Then call `usdGenSchema` to write `generatedSchema.usda` and
+		# update `plugInfo.json` in place.
+
+		subprocess.check_call(
+			[
+				shutil.which( "gaffer.cmd" if sys.platform == "win32" else "gaffer", path = env["ENV"]["PATH"] ),
+				"env", "usdGenSchema", str( source[0] ), targetDir
+			],
+			env = env["ENV"]
+		)
+
+	schemaSource = os.path.join( "usdSchemas", libraryName + ".usda" )
+	if os.path.isfile( schemaSource ) :
+		generatedSchema = commandEnv.Command(
+			[
+				os.path.join( installRoot, "plugin", libraryName, "generatedSchema.usda" ),
+				os.path.join( installRoot, "plugin", libraryName, "plugInfo.json" )
+			],
+			schemaSource,
+			buildSchema
+		)
+		commandEnv.Alias( "buildCore", generatedSchema )
 
 env.Alias( "build", "buildCore" )
 

--- a/python/GafferArnoldTest/USDLightTest.py
+++ b/python/GafferArnoldTest/USDLightTest.py
@@ -1,0 +1,172 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of Image Engine Design Inc nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import arnold
+
+import IECoreArnold
+
+import Gaffer
+import GafferUSD
+import GafferSceneTest
+
+class USDLightTest( GafferSceneTest.SceneTestCase ) :
+
+	def __assertArnoldParameters( self, name, expectedParameters ) :
+
+		light = GafferUSD.USDLight()
+		light.loadShader( name )
+
+		expectedParameters += [
+			# Parameters common to all lights.
+			( "arnold:aov", Gaffer.StringPlug, "default" ),
+			( "arnold:samples", Gaffer.IntPlug, 1 ),
+			( "arnold:volume_samples", Gaffer.IntPlug, 2 ),
+			( "arnold:sss", Gaffer.FloatPlug, 1.0 ),
+			( "arnold:indirect", Gaffer.FloatPlug, 1.0 ),
+			( "arnold:volume", Gaffer.FloatPlug, 1.0 ),
+			( "arnold:cast_volumetric_shadows", Gaffer.BoolPlug, True ),
+			( "arnold:max_bounces", Gaffer.IntPlug, 999 ),
+		]
+
+		allNames = set()
+		for name, plugType, defaultValue in expectedParameters :
+			with self.subTest( name = name ) :
+				allNames.add( name )
+				self.assertIn( name, light["parameters"] )
+				plug = light["parameters"][name]
+				self.assertIsInstance( plug, Gaffer.OptionalValuePlug )
+				self.assertEqual( plug.direction(), Gaffer.Plug.Direction.In )
+				self.assertEqual( plug.getFlags(), Gaffer.Plug.Flags.Default )
+				self.assertEqual( plug["enabled"].defaultValue(), False )
+				self.assertIs( type( plug["value"] ), plugType )
+				self.assertEqual( plug["value"].defaultValue(), defaultValue )
+				self.assertTrue( plug.isSetToDefault() )
+
+		self.assertEqual(
+			allNames, { k for k in light["parameters"].keys() if k.startswith( "arnold:" ) }
+		)
+
+	def testRectLightParameters( self ) :
+
+		self.__assertArnoldParameters(
+			"RectLight",
+			[
+				( "arnold:roundness", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:soft_edge", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:spread", Gaffer.FloatPlug, 1.0 ),
+				( "arnold:resolution", Gaffer.IntPlug, 512 ),
+				( "arnold:camera", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:transmission", Gaffer.FloatPlug, 0.0 ),
+			]
+		)
+
+	def testPointLightParameters( self ) :
+
+		self.__assertArnoldParameters(
+			"SphereLight",
+			[
+				( "arnold:camera", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:transmission", Gaffer.FloatPlug, 0.0 ),
+			]
+		)
+
+	def testRectLightParameters( self ) :
+
+		self.__assertArnoldParameters(
+			"RectLight",
+			[
+				( "arnold:roundness", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:soft_edge", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:spread", Gaffer.FloatPlug, 1.0 ),
+				( "arnold:resolution", Gaffer.IntPlug, 512 ),
+				( "arnold:camera", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:transmission", Gaffer.FloatPlug, 0.0 ),
+			]
+		)
+
+	def testDefaultParameterValues( self ) :
+
+		light = GafferUSD.USDLight()
+
+		for usdLight, arnoldLight in [
+			( "SphereLight", "point_light" ),
+			( "RectLight", "quad_light" ),
+			( "DiskLight", "disk_light" ),
+			( "DomeLight", "skydome_light" ),
+			( "CylinderLight", "cylinder_light" ),
+			( "DistantLight", "distant_light" ),
+		] :
+
+			with self.subTest( usdLight = usdLight ) :
+
+				light.loadShader( usdLight )
+
+				with IECoreArnold.UniverseBlock( writable = False ) :
+
+					arnoldNode = arnold.AiNodeEntryLookUp( arnoldLight )
+
+					for plug in light["parameters"].values() :
+
+						if not plug.getName().startswith( "arnold:" ) :
+							continue
+
+						param = arnold.AiNodeEntryLookUpParameter( arnoldNode, plug.getName().replace( "arnold:", "" ) )
+						self.assertIsNotNone( param )
+
+						match arnold.AiParamGetType( param ) :
+							case arnold.AI_TYPE_BOOLEAN :
+								paramDefault = arnold.AiParamGetDefault( param ).contents.BOOL
+							case arnold.AI_TYPE_INT :
+								paramDefault = arnold.AiParamGetDefault( param ).contents.INT
+							case arnold.AI_TYPE_FLOAT :
+								paramDefault = arnold.AiParamGetDefault( param ).contents.FLT
+							case arnold.AI_TYPE_STRING :
+								paramDefault = arnold.AtStringToStr( arnold.AiParamGetDefault( param ).contents.STR )
+							case arnold.AI_TYPE_ENUM :
+								enum = arnold.AiParamGetEnum( param )
+								paramDefault = arnold.AiEnumGetString(
+									arnold.AiParamGetEnum( param ),
+									arnold.AiParamGetDefault( param ).contents.INT
+								)
+							case _ :
+								self.fail( "Unhandled parameter type for {}".format( plug.getName() ) )
+
+						self.assertEqual( plug["value"].defaultValue(), paramDefault, plug.getName() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -141,7 +141,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 	# that will be matched against `self.__settingsNode["attribute"]` to determine if
 	# the column should be shown.
 	@classmethod
-	def registerParameter( cls, rendererKey, parameter, section = None ) :
+	def registerParameter( cls, rendererKey, parameter, section = None, columnName = None ) :
 
 		# We use `tuple` to store `ShaderNetwork.Parameter`, because
 		# the latter isn't hashable and we need to use it as a dict key.
@@ -155,7 +155,8 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 			rendererKey,
 			parameter,
 			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
-				GafferSceneUI.Private.ParameterInspector( scene, editScope, rendererKey, parameter )
+				GafferSceneUI.Private.ParameterInspector( scene, editScope, rendererKey, parameter ),
+				columnName if columnName is not None else ""
 			),
 			section
 		)

--- a/python/GafferUSDTest/USDLightTest.py
+++ b/python/GafferUSDTest/USDLightTest.py
@@ -53,6 +53,18 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 		light = GafferUSD.USDLight()
 		for name in ( "DistantLight", "DiskLight", "DomeLight", "RectLight", "SphereLight", "CylinderLight" ) :
 			light.loadShader( name )
+			for name, defaultValue in {
+				"intensity" : 1.0 if name != "DistantLight" else 50000.0,
+				"exposure" : 0.0,
+				"normalize" : False,
+				"specular" : 1.0,
+				"diffuse" : 1.0,
+				"enableColorTemperature" : False,
+				"colorTemperature" : 6500.0,
+			}.items() :
+				with self.subTest( name = name ) :
+					self.assertIn( name, light["parameters"] )
+					self.assertEqual( light["parameters"][name].defaultValue(), defaultValue )
 
 	def testShaderNetwork( self ) :
 
@@ -193,6 +205,14 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 			set( lc["out"].set( "__cameras" ).value.paths() ),
 			set( [ "/group/camera", "/group/sphere1", "/group/distant1", "/group/env1" ] )
 		)
+
+	def testLoadTokenParameter( self ) :
+
+		light = GafferUSD.USDLight()
+		light.loadShader( "DomeLight" )
+		self.assertIsInstance( light["parameters"]["texture:format"], Gaffer.StringPlug )
+		self.assertEqual( light["parameters"]["texture:format"].defaultValue(), "automatic" )
+		self.assertTrue( light["parameters"]["texture:format"].isSetToDefault() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUSDUI/USDLightUI.py
+++ b/python/GafferUSDUI/USDLightUI.py
@@ -45,32 +45,13 @@ Gaffer.Metadata.registerNode(
 
 	plugs = {
 
+		"parameters" : [
+
+			"layout:section:Basic:collapsed", False,
+
+		],
+
 		"parameters.colorTemperature" : [ "layout:activator", lambda plug : plug.parent()["enableColorTemperature"].getValue() ],
-
-		"parameters.width" : [ "layout:section", "Geometry" ],
-		"parameters.height" : [ "layout:section", "Geometry" ],
-		"parameters.radius" : [ "layout:section", "Geometry" ],
-		"parameters.length" : [ "layout:section", "Geometry" ],
-		"parameters.angle" : [ "layout:section", "Geometry" ],
-
-		"parameters.texture:file" : [ "layout:section", "Texture" ],
-		"parameters.texture:format" : [ "layout:section", "Texture" ],
-
-		"parameters.texture:*" : [
-			"label", lambda plug : IECore.CamelCase.toSpaced( plug.getName().replace( "texture:", "" ) )
-		],
-
-		"parameters.shaping:cone:angle" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:cone:softness" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:focus" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:focusTint" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:ies:file" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:ies:angleScale" : [ "layout:section", "Shaping" ],
-		"parameters.shaping:ies:normalize" : [ "layout:section", "Shaping" ],
-
-		"parameters.shaping:*" : [
-			"label", lambda plug : " ".join( IECore.CamelCase.toSpaced( t ) for t in plug.getName().split( ":" )[1:] )
-		],
 
 		"parameters.shaping:ies:file.value" : [
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",
@@ -79,16 +60,6 @@ Gaffer.Metadata.registerNode(
 			"path:value", True,
 			"fileSystemPath:extensions", "ies",
 		],
-
-		"parameters.shadow:enable" : [ "layout:section", "Shadow" ],
-		"parameters.shadow:color" : [ "layout:section", "Shadow" ],
-		"parameters.shadow:distance" : [ "layout:section", "Shadow" ],
-		"parameters.shadow:falloff" : [ "layout:section", "Shadow" ],
-		"parameters.shadow:falloffGamma" : [ "layout:section", "Shadow" ],
-
-		"parameters.shadow:*" : [
-			"label", lambda plug : IECore.CamelCase.toSpaced( plug.getName().replace( "shadow:", "" ) )
-		]
 
 	}
 )

--- a/python/GafferUSDUI/USDShaderUI.py
+++ b/python/GafferUSDUI/USDShaderUI.py
@@ -122,7 +122,12 @@ def __description( plug ) :
 
 	property = __primProperty( plug )
 	if property :
-		return property.GetMetadata( "documentation" )
+		description = property.GetMetadata( "documentation" )
+		if description is not None :
+			# Spare UsdLux from embarrassment until it defines what
+			# various parameters are actually intended to do.
+			description = description.replace( "TODO: clarify semantics", "" )
+		return description
 
 	## \todo Get USD to actually provide help metadata. It's defined in a `doc`
 	# attribute in `shaderDefs.usda`, but not actually converted to Sdr by

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -913,6 +913,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 						"specular" : 0.75,
 						"radius" : 0.5,
 						"normalize" : True,
+						"arnold:aov" : "test",
+						"arnold:samples" : 3,
 					}
 				),
 
@@ -926,6 +928,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 						"specular" : 0.75,
 						"radius" : 0.5,
 						"normalize" : True,
+						"aov" : "test",
+						"samples" : 3,
 					} )
 				),
 

--- a/src/GafferUSD/USDShader.cpp
+++ b/src/GafferUSD/USDShader.cpp
@@ -54,6 +54,9 @@
 #include "pxr/usd/sdr/registry.h"
 #include "pxr/usd/sdr/shaderNode.h"
 #include "pxr/usd/sdr/shaderProperty.h"
+#include "pxr/usd/usd/schemaRegistry.h"
+#include "pxr/usd/usdLux/boundableLightBase.h"
+#include "pxr/usd/usdLux/nonboundableLightBase.h"
 
 #include "boost/algorithm/string/predicate.hpp"
 
@@ -110,13 +113,12 @@ Plug::Direction direction( const SdrShaderProperty &property )
 // newly created plug.
 
 template<typename PlugType>
-PlugPtr acquireTypedPropertyPlug( const SdrShaderProperty &property, Plug *candidate )
+PlugPtr acquireTypedPlug( InternedString name, Plug::Direction direction, VtValue defaultVtValue, Plug *candidate )
 {
 	using ValueType = typename PlugType::ValueType;
 	using USDValueType = typename IECoreUSD::CortexTypeTraits<ValueType>::USDType;
 
 	ValueType defaultValue = ValueType();
-	VtValue defaultVtValue = property.GetDefaultValue();
 	if( !defaultVtValue.IsHolding<USDValueType>() )
 	{
 		// Workaround for various UsdLuxLight `bool` inputs which somehow
@@ -134,19 +136,18 @@ PlugPtr acquireTypedPropertyPlug( const SdrShaderProperty &property, Plug *candi
 		return existingPlug;
 	}
 
-	return new PlugType( property.GetName().GetString(), direction( property ), defaultValue );
+	return new PlugType( name, direction, defaultValue );
 }
 
 template<typename PlugType>
-PlugPtr acquireCompoundNumericPropertyPlug( const SdrShaderProperty &property, Plug *candidate )
+PlugPtr acquireCompoundNumericPlug( InternedString name, const SdfValueTypeName &type, Plug::Direction direction, const VtValue &defaultVtValue, Plug *candidate )
 {
-	IECore::GeometricData::Interpretation interpretation = ::interpretation( property.GetTypeAsSdfType().first.GetRole() );
+	IECore::GeometricData::Interpretation interpretation = ::interpretation( type.GetRole() );
 
 	using ValueType = typename PlugType::ValueType;
 	using USDValueType = typename IECoreUSD::CortexTypeTraits<ValueType>::USDType;
 
 	ValueType defaultValue( 0.0f );
-	VtValue defaultVtValue = property.GetDefaultValue();
 	if( !defaultVtValue.IsEmpty() )
 	{
 		defaultValue = IECoreUSD::DataAlgo::fromUSD( defaultVtValue.Get<USDValueType>() );
@@ -163,16 +164,15 @@ PlugPtr acquireCompoundNumericPropertyPlug( const SdrShaderProperty &property, P
 	}
 
 	return new PlugType(
-		property.GetName().GetString(), direction( property ), defaultValue,
+		name, direction, defaultValue,
 		ValueType( std::numeric_limits<float>::lowest() ), ValueType( std::numeric_limits<float>::max() ),
 		Plug::Default, interpretation
 	);
 }
 
-PlugPtr acquireAssetPropertyPlug( const SdrShaderProperty &property, Plug *candidate )
+PlugPtr acquireAssetPlug( InternedString name, Plug::Direction direction, VtValue defaultVtValue, Plug *candidate )
 {
 	string defaultValue;
-	VtValue defaultVtValue = property.GetDefaultValue();
 	if( !defaultVtValue.IsEmpty() )
 	{
 		defaultValue = defaultVtValue.Get<SdfAssetPath>().GetAssetPath();
@@ -184,33 +184,22 @@ PlugPtr acquireAssetPropertyPlug( const SdrShaderProperty &property, Plug *candi
 		return existingPlug;
 	}
 
-	return new StringPlug( property.GetName().GetString(), direction( property ), defaultValue );
+	return new StringPlug( name, direction, defaultValue );
 }
 
-PlugPtr acquireTokenPropertyPlug( const SdrShaderProperty &property, Plug *candidate )
+PlugPtr acquirePlug( InternedString name, Plug::Direction direction, Plug *candidate )
 {
-	// Sdr uses the `token` type to represent terminals, vstructs
-	// and unknown types. As I understand it, these don't carry values,
-	// so the Plug base class is the best way of representing them
-	// in Gaffer.
 	if( candidate && candidate->typeId() == Plug::staticTypeId() )
 	{
 		return candidate;
 	}
 
-	return new Plug( property.GetName().GetString(), direction( property ) );
+	return new Plug( name, direction );
 }
 
-Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
+Plug *loadParameter( InternedString name, const NdrSdfTypeIndicator &type, Plug::Direction direction, const VtValue &defaultValue, Plug *parent, bool optional = false )
 {
-	// We host properties from bolt-on schemas in OptionalValuePlugs, so users
-	// can opt in and out of authoring them.
-	const bool optional =
-		boost::starts_with( property.GetName().GetString(), "shaping:" ) ||
-		boost::starts_with( property.GetName().GetString(), "shadow:" )
-	;
-
-	Plug *candidatePlug = parent->getChild<Plug>( property.GetName().GetString() );
+	Plug *candidatePlug = parent->getChild<Plug>( name );
 	if( candidatePlug && optional )
 	{
 		if( auto optionalPlug = runTimeCast<OptionalValuePlug>( candidatePlug ) )
@@ -224,62 +213,68 @@ Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
 	}
 
 	PlugPtr acquiredPlug;
-	const SdfValueTypeName type = property.GetTypeAsSdfType().first;
-	if( type == SdfValueTypeNames->Bool )
+
+	if( !type.second.IsEmpty() )
 	{
-		acquiredPlug = acquireTypedPropertyPlug<BoolPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Int )
-	{
-		acquiredPlug = acquireTypedPropertyPlug<IntPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Float )
-	{
-		acquiredPlug = acquireTypedPropertyPlug<FloatPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Float2 )
-	{
-		acquiredPlug = acquireCompoundNumericPropertyPlug<V2fPlug>( property, candidatePlug );
-	}
-	else if(
-		type == SdfValueTypeNames->Point3f ||
-		type == SdfValueTypeNames->Vector3f ||
-		type == SdfValueTypeNames->Normal3f ||
-		type == SdfValueTypeNames->Float3
-	)
-	{
-		acquiredPlug = acquireCompoundNumericPropertyPlug<V3fPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Color3f )
-	{
-		acquiredPlug = acquireCompoundNumericPropertyPlug<Color3fPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Float4 )
-	{
-		acquiredPlug = acquireCompoundNumericPropertyPlug<Color4fPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->String )
-	{
-		acquiredPlug = acquireTypedPropertyPlug<StringPlug>( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Asset )
-	{
-		acquiredPlug = acquireAssetPropertyPlug( property, candidatePlug );
-	}
-	else if( type == SdfValueTypeNames->Token )
-	{
-		acquiredPlug = acquireTokenPropertyPlug( property, candidatePlug );
+		// An Sdr type such as `terminal` or `vstruct` that doesn't map cleanly
+		// to an Sdf type. We represent these just as bare plugs, since as I understand
+		// it, they are not expected to carry values.
+		acquiredPlug = acquirePlug( name, direction, candidatePlug );
 	}
 	else
 	{
-		IECore::msg(
-			IECore::Msg::Warning, "USDShader",
-			fmt::format(
-				"Unable to load property \"{}\" of type \"{}\"",
-				property.GetName().GetString(), type.GetAsToken().GetString()
-			)
-		);
-		return nullptr;
+		if( type.first == SdfValueTypeNames->Bool )
+		{
+			acquiredPlug = acquireTypedPlug<BoolPlug>( name, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Int )
+		{
+			acquiredPlug = acquireTypedPlug<IntPlug>( name, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Float )
+		{
+			acquiredPlug = acquireTypedPlug<FloatPlug>( name, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Float2 )
+		{
+			acquiredPlug = acquireCompoundNumericPlug<V2fPlug>( name, type.first, direction, defaultValue, candidatePlug );
+		}
+		else if(
+			type.first == SdfValueTypeNames->Point3f ||
+			type.first == SdfValueTypeNames->Vector3f ||
+			type.first == SdfValueTypeNames->Normal3f ||
+			type.first == SdfValueTypeNames->Float3
+		)
+		{
+			acquiredPlug = acquireCompoundNumericPlug<V3fPlug>( name, type.first, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Color3f )
+		{
+			acquiredPlug = acquireCompoundNumericPlug<Color3fPlug>( name, type.first, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Float4 )
+		{
+			acquiredPlug = acquireCompoundNumericPlug<Color4fPlug>( name, type.first, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->String || type.first == SdfValueTypeNames->Token )
+		{
+			acquiredPlug = acquireTypedPlug<StringPlug>( name, direction, defaultValue, candidatePlug );
+		}
+		else if( type.first == SdfValueTypeNames->Asset )
+		{
+			acquiredPlug = acquireAssetPlug( name, direction, defaultValue, candidatePlug );
+		}
+		else
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "USDShader",
+				fmt::format(
+					"Unable to load parameter \"{}\" of type \"{}\"",
+					name.string(), type.first.GetAsToken().GetString()
+				)
+			);
+			return nullptr;
+		}
 	}
 
 	assert( acquiredPlug );
@@ -292,12 +287,12 @@ Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
 			ValuePlugPtr acquiredValuePlug = runTimeCast<ValuePlug>( acquiredPlug );
 			if( !acquiredValuePlug )
 			{
-				throw IECore::Exception( fmt::format( "Cannot create OptionalValuePlug for property `{}`", property.GetName().GetString() ) );
+				throw IECore::Exception( fmt::format( "Cannot create OptionalValuePlug for parameter `{}`", name.string() ) );
 			}
 			PlugAlgo::replacePlug(
 				parent, new OptionalValuePlug(
-					property.GetName().GetString(), acquiredValuePlug, /* enabledPlugDefaultValue = */ false,
-					direction( property )
+					name, acquiredValuePlug, /* enabledPlugDefaultValue = */ false,
+					direction
 				)
 			);
 		}
@@ -308,6 +303,18 @@ Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
 	}
 
 	return optional ? acquiredPlug->parent<Plug>() : acquiredPlug.get();
+}
+
+Plug *loadShaderProperty( const SdrShaderProperty &property, Plug *parent )
+{
+	return loadParameter( property.GetName().GetString(), property.GetTypeAsSdfType(), ::direction( property ), property.GetDefaultValue(), parent );
+}
+
+Plug *loadPrimDefinitionAttribute( const UsdPrimDefinition::Attribute &attribute, InternedString name, Plug *parent, bool optional )
+{
+	VtValue defaultValue;
+	attribute.GetFallbackValue( &defaultValue );
+	return loadParameter( name, { attribute.GetTypeName(), pxr::TfToken() }, Plug::Direction::In, defaultValue, parent, optional );
 }
 
 const IECore::InternedString g_surface( "surface" );
@@ -329,31 +336,106 @@ USDShader::~USDShader()
 
 void USDShader::loadShader( const std::string &shaderName, bool keepExistingValues )
 {
-	SdrRegistry &registry = SdrRegistry::GetInstance();
-	SdrShaderNodeConstPtr shader = registry.GetShaderNodeByName( shaderName );
+	// Find the shader definition either in the SchemaRegistry or the SdrRegistry.
+	// UsdLux lights are available from either, but we prefer the SchemaRegistry
+	// because it includes the attributes from auto-apply schemas that are used
+	// for renderer-specific light extensions.
 
-	if( !shader )
+	const TfToken shaderNameToken( shaderName );
+
+	UsdSchemaRegistry &schemaRegistry = UsdSchemaRegistry::GetInstance();
+	vector<const UsdPrimDefinition *> primDefinitions;
+	vector<TfToken> autoAppliedPropertyNames;
+	if( auto primDefinition = schemaRegistry.FindConcretePrimDefinition( shaderNameToken ) )
 	{
-		throw Exception( fmt::format( "Shader \"{}\" not found in SdrRegistry", shaderName ) );
+		primDefinitions.push_back( primDefinition );
+		// The main prim definition contains properties from auto-applied API schemas, but doesn't
+		// provide a direct way of querying which they are. Make our own list, because we want to
+		// represent them using OptionalValuePlugs.
+		for( const auto &[apiSchema, autoAppliedTo] : schemaRegistry.GetAutoApplyAPISchemas() )
+		{
+			if( std::find( autoAppliedTo.begin(), autoAppliedTo.end(), shaderNameToken ) != autoAppliedTo.end() )
+			{
+				auto apiDefinition = schemaRegistry.FindAppliedAPIPrimDefinition( apiSchema );
+				autoAppliedPropertyNames.insert(
+					autoAppliedPropertyNames.end(),
+					apiDefinition->GetPropertyNames().begin(), apiDefinition->GetPropertyNames().end()
+				);
+			}
+		}
+
+		const TfType schemaType = schemaRegistry.GetTypeFromName( shaderNameToken );
+		if( schemaType.IsA<UsdLuxBoundableLightBase>() || schemaType.IsA<UsdLuxNonboundableLightBase>() )
+		{
+			primDefinitions.push_back( schemaRegistry.FindAppliedAPIPrimDefinition( TfToken( "ShadowAPI" ) ) );
+			primDefinitions.push_back( schemaRegistry.FindAppliedAPIPrimDefinition( TfToken( "ShapingAPI" ) ) );
+		}
 	}
+
+	SdrShaderNodeConstPtr shader = nullptr;
+	if( primDefinitions.empty() )
+	{
+		SdrRegistry &registry = SdrRegistry::GetInstance();
+		shader = registry.GetShaderNodeByName( shaderName );
+		if( !shader )
+		{
+			throw Exception( fmt::format( "Shader \"{}\" not found in SdrRegistry or UsdSchemaRegistry", shaderName ) );
+		}
+	}
+
+	// Set name and type and delete old parameters if necessary.
 
 	namePlug()->setValue( shaderName );
 	typePlug()->setValue( "surface" );
 
 	Plug *parametersPlug = this->parametersPlug()->source();
+	Plug *outPlug = this->outPlug();
 
 	if( !keepExistingValues )
 	{
 		parametersPlug->clearChildren();
-		outPlug()->clearChildren();
+		outPlug->clearChildren();
 	}
 
+	// Load parameters.
+
 	std::unordered_set<const Plug *> validPlugs;
-	for( const auto &name : shader->GetInputNames() )
+	if( primDefinitions.size() )
 	{
-		SdrShaderPropertyConstPtr property = shader->GetShaderInput( name );
-		validPlugs.insert( loadShaderProperty( *property, parametersPlug ) );
+		for( size_t i = 0; i < primDefinitions.size(); ++i )
+		{
+			for( const auto &name : primDefinitions[i]->GetPropertyNames() )
+			{
+				if( !boost::starts_with( name.GetString(), "inputs:" ) )
+				{
+					continue;
+				}
+				if( auto attribute = primDefinitions[i]->GetAttributeDefinition( name ) )
+				{
+					const bool optional = i > 0 || std::find( autoAppliedPropertyNames.begin(), autoAppliedPropertyNames.end(), name ) != autoAppliedPropertyNames.end();
+					validPlugs.insert(
+						loadPrimDefinitionAttribute( attribute, attribute.GetName().GetText() + strlen( "inputs:" ), parametersPlug, optional )
+					);
+				}
+			}
+		}
 	}
+	else
+	{
+		assert( shader );
+		for( const auto &name : shader->GetInputNames() )
+		{
+			SdrShaderPropertyConstPtr property = shader->GetShaderInput( name );
+			validPlugs.insert( loadShaderProperty( *property, parametersPlug ) );
+		}
+		for( const auto &name : shader->GetOutputNames() )
+		{
+			SdrShaderPropertyConstPtr property = shader->GetShaderOutput( name );
+			validPlugs.insert( loadShaderProperty( *property, outPlug ) );
+		}
+	}
+
+	// Remove old parameters we no longer need.
 
 	for( int i = parametersPlug->children().size() - 1; i >= 0; --i )
 	{
@@ -362,13 +444,6 @@ void USDShader::loadShader( const std::string &shaderName, bool keepExistingValu
 		{
 			parametersPlug->removeChild( child );
 		}
-	}
-
-	Plug *outPlug = this->outPlug();
-	for( const auto &name : shader->GetOutputNames() )
-	{
-		SdrShaderPropertyConstPtr property = shader->GetShaderOutput( name );
-		validPlugs.insert( loadShaderProperty( *property, outPlug ) );
 	}
 
 	for( int i = outPlug->children().size() - 1; i >= 0; --i )

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -717,6 +717,8 @@ const InternedString g_widthParameter( "width" );
 const InternedString g_wrapSParameter( "wrapS" );
 const InternedString g_wrapTParameter( "wrapT" );
 
+const string g_arnoldNamespace( "arnold:" );
+
 void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
 {
 	Color3f color = parameterValue( usdShader, g_colorParameter, Color3f( 1 ) );
@@ -734,6 +736,14 @@ void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHa
 
 	transferUSDParameter( network, shaderHandle, usdShader, g_shadowEnableParameter, shader, g_castShadowsParameter, true );
 	transferUSDParameter( network, shaderHandle, usdShader, g_shadowColorParameter, shader, g_shadowColorArnoldParameter, Color3f( 0 ) );
+
+	for( const auto &[name, value] : usdShader->parameters() )
+	{
+		if( boost::starts_with( name.string(), g_arnoldNamespace ) )
+		{
+			shader->parameters()[name.string().substr(g_arnoldNamespace.size())] = value;
+		}
+	}
 }
 
 void transferUSDShapingParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )

--- a/startup/GafferUSD/arnoldLights.py
+++ b/startup/GafferUSD/arnoldLights.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2012, John Haddon. All rights reserved.
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,28 +34,20 @@
 #
 ##########################################################################
 
-from .ArnoldShaderTest import ArnoldShaderTest
-from .ArnoldRenderTest import ArnoldRenderTest
-from .ArnoldOptionsTest import ArnoldOptionsTest
-from .ArnoldAttributesTest import ArnoldAttributesTest
-from .ArnoldVDBTest import ArnoldVDBTest
-from .ArnoldLightTest import ArnoldLightTest
-from .ArnoldMeshLightTest import ArnoldMeshLightTest
-from .InteractiveArnoldRenderTest import InteractiveArnoldRenderTest
-from .ArnoldDisplacementTest import ArnoldDisplacementTest
-from .LightToCameraTest import LightToCameraTest
-from .ArnoldAOVShaderTest import ArnoldAOVShaderTest
-from .ArnoldAtmosphereTest import ArnoldAtmosphereTest
-from .ArnoldBackgroundTest import ArnoldBackgroundTest
-from .ArnoldTextureBakeTest import ArnoldTextureBakeTest
-from .ModuleTest import ModuleTest
-from .ArnoldShaderBallTest import ArnoldShaderBallTest
-from .ArnoldCameraShadersTest import ArnoldCameraShadersTest
-from .ArnoldLightFilterTest import ArnoldLightFilterTest
-from .ArnoldColorManagerTest import ArnoldColorManagerTest
-from .ArnoldImagerTest import ArnoldImagerTest
-from .USDLightTest import USDLightTest
+import pathlib
 
-if __name__ == "__main__":
-	import unittest
-	unittest.main()
+from pxr import Plug
+
+# Register a USD plugin that adds Arnold-specific auto-apply schemas for
+# UsdLux lights. We deliberately don't add this to the `PXR_PLUGINPATH_NAME`
+# search path because we don't want it to be loaded in any third-party
+# applications that Gaffer might launch as subprocessses. So instead we
+# register it manually with `RegisterPlugins`. See `GafferArnold.usda`
+# for more details.
+
+try :
+	import GafferArnold
+	Plug.Registry().RegisterPlugins( str( pathlib.Path( GafferArnold.__file__ ).parents[2] / "plugin" / "GafferArnold" / "plugInfo.json" ) )
+except ImportError :
+	# GafferArnold not available
+	pass

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -90,15 +90,6 @@ with IECore.IgnoredExceptions( ImportError ) :
 	# If 3Delight is available, then assume it will be used in preference to Cycles.
 	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "osl:light" )
 
-with IECore.IgnoredExceptions( ImportError ) :
-
-	import GafferArnold
-	# Register Light Editor sections for Arnold before the generic "Visualisation" section
-	import GafferArnoldUI
-
-	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Arnold", "ai:light" )
-	# If Arnold is available, then assume it is the renderer of choice.
-	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "ai:light" )
 
 # UsdLux lights
 
@@ -137,6 +128,29 @@ GafferSceneUI.LightEditor.registerParameter( "light", "shadow:color", "Shadow" )
 GafferSceneUI.LightEditor.registerParameter( "light", "shadow:distance", "Shadow" )
 GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloff", "Shadow" )
 GafferSceneUI.LightEditor.registerParameter( "light", "shadow:falloffGamma", "Shadow" )
+
+# Arnold lights
+
+with IECore.IgnoredExceptions( ImportError ) :
+
+	import GafferArnold
+	# Register Light Editor sections for Arnold before the generic "Visualisation" section
+	import GafferArnoldUI
+
+	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:Arnold", "ai:light" )
+	# If Arnold is available, then assume it is the renderer of choice.
+	Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "ai:light" )
+
+	# Register Arnold-specific parameters for USD lights.
+	for parameter in [
+		"aov", "samples", "volume_samples", "sss", "indirect", "volume", "cast_volumetric_shadows",
+		"max_bounces", "camera", "transmission", "spread", "roundness", "soft_edge", "resolution",
+		"portal_mode", "aov_indirect"
+	] :
+		GafferSceneUI.LightEditor.registerParameter(
+			"light", f"arnold:{parameter}", "Arnold",
+			columnName = parameter.replace( "arnold:", "" )
+		)
 
 # Register generic light attributes
 for attributeName in [

--- a/startup/gui/usd.py
+++ b/startup/gui/usd.py
@@ -45,3 +45,13 @@ Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.shaping:cone:angl
 # `texture:format == automatic` isn't well supported at present, so default
 # user-created lights to `latlong`.
 Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.texture:format", "userDefault", "latlong" )
+
+# Put Arnold section last. We can't do that using the schemas in GafferArnold.usda
+# because they provide no control over property ordering.
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.arnold:*", "layout:index", -1 )
+# Open the sub-sections of Arnold light parameters by default, so everything is
+# visible as soon as you pop open the main Arnold section.
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Refine:collapsed", False )
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Geometry:collapsed", False )
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Sampling:collapsed", False )
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Shadows:collapsed", False )

--- a/startup/gui/usd.py
+++ b/startup/gui/usd.py
@@ -46,12 +46,11 @@ Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.shaping:cone:angl
 # user-created lights to `latlong`.
 Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.texture:format", "userDefault", "latlong" )
 
-# Put Arnold section last. We can't do that using the schemas in GafferArnold.usda
+# Put Arnold parameters last. We can't do that using the schemas in GafferArnold.usda
 # because they provide no control over property ordering.
-Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.arnold:*", "layout:index", -1 )
-# Open the sub-sections of Arnold light parameters by default, so everything is
-# visible as soon as you pop open the main Arnold section.
-Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Refine:collapsed", False )
-Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Geometry:collapsed", False )
-Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Sampling:collapsed", False )
-Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:section:Arnold.Shadows:collapsed", False )
+for i, parameter in enumerate( [
+	"aov", "aov_indirect", "portal_mode", "spread", "roundness", "soft_edge", "camera",
+	"transmission", "sss", "indirect", "volume", "max_bounces", "cast_volumetric_shadows",
+	"samples", "volume_samples", "resolution"
+] ) :
+	Gaffer.Metadata.registerValue( GafferUSD.USDLight, f"parameters.arnold:{parameter}", "layout:index", 1000 + i )

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -51,37 +51,37 @@ class "GafferArnoldLightAPI" (
 	)
 
 	int inputs:arnold:samples = 1 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Sampling"
 		displayName = "Samples"
 	)
 
 	int inputs:arnold:volume_samples = 2 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Sampling"
 		displayName = "Volume Samples"
 	)
 
 	float inputs:arnold:sss = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "SSS Multiplier"
 	)
 
 	float inputs:arnold:indirect = 1.0(
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Indirect Multiplier"
 	)
 
 	float inputs:arnold:volume = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Volume Multiplier"
 	)
 
 	bool inputs:arnold:cast_volumetric_shadows = true (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Shadows"
 		displayName = "Cast Volumetric Shadows"
 	)
 
 	int inputs:arnold:max_bounces = 999 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Max Bounces"
 	)
 
@@ -98,12 +98,12 @@ class "GafferArnoldCylinderLightAPI" (
 {
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Camera Multiplier"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Transmission Multiplier"
 	)
 
@@ -120,17 +120,17 @@ class "GafferArnoldDiskLightAPI" (
 {
 
 	float inputs:arnold:spread = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Geometry"
 		displayName = "Spread"
 	)
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Camera Multiplier"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Transmission Multiplier"
 	)
 
@@ -147,12 +147,12 @@ class "GafferArnoldPointLightAPI" (
 {
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Camera Multiplier"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Transmission Multiplier"
 	)
 
@@ -169,32 +169,32 @@ class "GafferArnoldQuadLightAPI" (
 {
 
 	float inputs:arnold:roundness = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Geometry"
 		displayName = "Roundness"
 	)
 
 	float inputs:arnold:soft_edge = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Geometry"
 		displayName = "Soft Edge"
 	)
 
 	float inputs:arnold:spread = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Geometry"
 		displayName = "Spread"
 	)
 
 	int inputs:arnold:resolution = 512 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Sampling"
 		displayName = "Resolution"
 	)
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Camera Multiplier"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Transmission Multiplier"
 	)
 
@@ -222,17 +222,17 @@ class "GafferArnoldSkydomeLightAPI" (
 	)
 
 	int inputs:arnold:resolution = 1000 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Sampling"
 		displayName = "Resolution"
 	)
 
 	float inputs:arnold:camera = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Camera Multiplier"
 	)
 
 	float inputs:arnold:transmission = 1.0 (
-		displayGroup = "Arnold"
+		displayGroup = "Arnold.Refine"
 		displayName = "Transmission Multiplier"
 	)
 

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -46,43 +46,43 @@ class "GafferArnoldLightAPI" (
 {
 
 	string inputs:arnold:aov = "default" (
-		displayGroup = "Arnold"
-		displayName = "AOV"
+		displayGroup = "Basic"
+		displayName = "AOV (Arnold)"
 	)
 
 	int inputs:arnold:samples = 1 (
-		displayGroup = "Arnold.Sampling"
-		displayName = "Samples"
+		displayGroup = "Sampling"
+		displayName = "Samples (Arnold)"
 	)
 
 	int inputs:arnold:volume_samples = 2 (
-		displayGroup = "Arnold.Sampling"
-		displayName = "Volume Samples"
+		displayGroup = "Sampling"
+		displayName = "Volume Samples (Arnold)"
 	)
 
 	float inputs:arnold:sss = 1.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "SSS Multiplier"
+		displayGroup = "Refine"
+		displayName = "SSS (Arnold)"
 	)
 
 	float inputs:arnold:indirect = 1.0(
-		displayGroup = "Arnold.Refine"
-		displayName = "Indirect Multiplier"
+		displayGroup = "Refine"
+		displayName = "Indirect (Arnold)"
 	)
 
 	float inputs:arnold:volume = 1.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Volume Multiplier"
+		displayGroup = "Refine"
+		displayName = "Volume (Arnold)"
 	)
 
 	bool inputs:arnold:cast_volumetric_shadows = true (
-		displayGroup = "Arnold.Shadows"
-		displayName = "Cast Volumetric Shadows"
+		displayGroup = "Shadows"
+		displayName = "Cast Volumetric (Arnold)"
 	)
 
 	int inputs:arnold:max_bounces = 999 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Max Bounces"
+		displayGroup = "Refine"
+		displayName = "Max Bounces (Arnold)"
 	)
 
 }
@@ -98,13 +98,13 @@ class "GafferArnoldCylinderLightAPI" (
 {
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Camera Multiplier"
+		displayGroup = "Refine"
+		displayName = "Camera (Arnold)"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Transmission Multiplier"
+		displayGroup = "Refine"
+		displayName = "Transmission (Arnold)"
 	)
 
 }
@@ -120,18 +120,18 @@ class "GafferArnoldDiskLightAPI" (
 {
 
 	float inputs:arnold:spread = 1.0 (
-		displayGroup = "Arnold.Geometry"
+		displayGroup = "Geometry"
 		displayName = "Spread"
 	)
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Camera Multiplier"
+		displayGroup = "Refine"
+		displayName = "Camera (Arnold)"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Transmission Multiplier"
+		displayGroup = "Refine"
+		displayName = "Transmission (Arnold)"
 	)
 
 }
@@ -147,13 +147,13 @@ class "GafferArnoldPointLightAPI" (
 {
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Camera Multiplier"
+		displayGroup = "Refine"
+		displayName = "Camera (Arnold)"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Transmission Multiplier"
+		displayGroup = "Refine"
+		displayName = "Transmission (Arnold)"
 	)
 
 }
@@ -169,33 +169,33 @@ class "GafferArnoldQuadLightAPI" (
 {
 
 	float inputs:arnold:roundness = 0.0 (
-		displayGroup = "Arnold.Geometry"
-		displayName = "Roundness"
+		displayGroup = "Geometry"
+		displayName = "Roundness (Arnold)"
 	)
 
 	float inputs:arnold:soft_edge = 0.0 (
-		displayGroup = "Arnold.Geometry"
-		displayName = "Soft Edge"
+		displayGroup = "Geometry"
+		displayName = "Soft Edge (Arnold)"
 	)
 
 	float inputs:arnold:spread = 1.0 (
-		displayGroup = "Arnold.Geometry"
-		displayName = "Spread"
+		displayGroup = "Geometry"
+		displayName = "Spread (Arnold)"
 	)
 
 	int inputs:arnold:resolution = 512 (
-		displayGroup = "Arnold.Sampling"
-		displayName = "Resolution"
+		displayGroup = "Sampling"
+		displayName = "Resolution (Arnold)"
 	)
 
 	float inputs:arnold:camera = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Camera Multiplier"
+		displayGroup = "Refine"
+		displayName = "Camera (Arnold)"
 	)
 
 	float inputs:arnold:transmission = 0.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Transmission Multiplier"
+		displayGroup = "Refine"
+		displayName = "Transmission (Arnold)"
 	)
 
 }
@@ -212,28 +212,28 @@ class "GafferArnoldSkydomeLightAPI" (
 
 	token inputs:arnold:portal_mode = "interior_only" (
 		allowedTokens = [ "off", "interior_only", "interior_exterior" ]
-		displayGroup = "Arnold"
-		displayName = "Portal Mode"
+		displayGroup = "Basic"
+		displayName = "Portal Mode (Arnold)"
 	)
 
 	bool inputs:arnold:aov_indirect = false (
-		displayGroup = "Arnold"
-		displayName = "AOV Indirect"
+		displayGroup = "Basic"
+		displayName = "AOV Indirect (Arnold)"
 	)
 
 	int inputs:arnold:resolution = 1000 (
-		displayGroup = "Arnold.Sampling"
-		displayName = "Resolution"
+		displayGroup = "Sampling"
+		displayName = "Resolution (Arnold)"
 	)
 
 	float inputs:arnold:camera = 1.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Camera Multiplier"
+		displayGroup = "Refine"
+		displayName = "Camera (Arnold)"
 	)
 
 	float inputs:arnold:transmission = 1.0 (
-		displayGroup = "Arnold.Refine"
-		displayName = "Transmission Multiplier"
+		displayGroup = "Refine"
+		displayName = "Transmission (Arnold)"
 	)
 
 }

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -1,0 +1,239 @@
+#usda 1.0
+(
+	subLayers = [
+		@usdLux/schema.usda@,
+		@usd/schema.usda@
+	]
+)
+
+over "GLOBAL" (
+	customData = {
+		string libraryName = "GafferArnold"
+		bool skipCodeGeneration = 1
+		bool useLiteralIdentifier = 1
+	}
+)
+{
+}
+
+# Here we define a bunch of codeless auto-apply API schemas for extending the
+# standard UsdLux lights with inputs specific to Arnold. This approach is
+# modelled on the one used by UsdRiPxr to add RenderMan-specific inputs, and
+# we believe is the one Pixar intends everyone to use.
+#
+# Ideally such schemas would be provided by the `arnold-usd` project, but while
+# it does have Arnold-specific light APIs they don't suit our purposes for
+# multiple reasons :
+#
+# - They use the `primvars:arnold:` namespace rather than `inputs:arnold:`.
+# - They are not auto-apply schemas.
+# - They include parameters like `motion_start` and `motion_end` which are not
+#   suitable to be exposed to users.
+#
+# Since applied API schemas are not allowed to inherit from one another we
+# apply a "base" GafferArnoldLightAPI schema to all light types, and then
+# apply a type-specific schema such as GafferArnoldDiskLightAPI to individual
+# types on top of that.
+
+class "GafferArnoldLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = [ "CylinderLight", "DistantLight", "DiskLight", "DomeLight", "RectLight", "SphereLight" ]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	string inputs:arnold:aov = "default" (
+		displayGroup = "Arnold"
+		displayName = "AOV"
+	)
+
+	int inputs:arnold:samples = 1 (
+		displayGroup = "Arnold"
+		displayName = "Samples"
+	)
+
+	int inputs:arnold:volume_samples = 2 (
+		displayGroup = "Arnold"
+		displayName = "Volume Samples"
+	)
+
+	float inputs:arnold:sss = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "SSS Multiplier"
+	)
+
+	float inputs:arnold:indirect = 1.0(
+		displayGroup = "Arnold"
+		displayName = "Indirect Multiplier"
+	)
+
+	float inputs:arnold:volume = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "Volume Multiplier"
+	)
+
+	bool inputs:arnold:cast_volumetric_shadows = true (
+		displayGroup = "Arnold"
+		displayName = "Cast Volumetric Shadows"
+	)
+
+	int inputs:arnold:max_bounces = 999 (
+		displayGroup = "Arnold"
+		displayName = "Max Bounces"
+	)
+
+}
+
+class "GafferArnoldCylinderLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = ["CylinderLight"]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldCylinderLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	float inputs:arnold:camera = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Camera Multiplier"
+	)
+
+	float inputs:arnold:transmission = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Transmission Multiplier"
+	)
+
+}
+
+class "GafferArnoldDiskLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = ["DiskLight"]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldDiskLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	float inputs:arnold:spread = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "Spread"
+	)
+
+	float inputs:arnold:camera = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Camera Multiplier"
+	)
+
+	float inputs:arnold:transmission = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Transmission Multiplier"
+	)
+
+}
+
+class "GafferArnoldPointLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = ["SphereLight"]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldPointLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	float inputs:arnold:camera = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Camera Multiplier"
+	)
+
+	float inputs:arnold:transmission = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Transmission Multiplier"
+	)
+
+}
+
+class "GafferArnoldQuadLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = ["RectLight"]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldQuadLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	float inputs:arnold:roundness = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Roundness"
+	)
+
+	float inputs:arnold:soft_edge = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Soft Edge"
+	)
+
+	float inputs:arnold:spread = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "Spread"
+	)
+
+	int inputs:arnold:resolution = 512 (
+		displayGroup = "Arnold"
+		displayName = "Resolution"
+	)
+
+	float inputs:arnold:camera = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Camera Multiplier"
+	)
+
+	float inputs:arnold:transmission = 0.0 (
+		displayGroup = "Arnold"
+		displayName = "Transmission Multiplier"
+	)
+
+}
+
+class "GafferArnoldSkydomeLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = ["DomeLight"]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldSkydomeLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	token inputs:arnold:portal_mode = "interior_only" (
+		allowedTokens = [ "off", "interior_only", "interior_exterior" ]
+		displayGroup = "Arnold"
+		displayName = "Portal Mode"
+	)
+
+	bool inputs:arnold:aov_indirect = false (
+		displayGroup = "Arnold"
+		displayName = "AOV Indirect"
+	)
+
+	int inputs:arnold:resolution = 1000 (
+		displayGroup = "Arnold"
+		displayName = "Resolution"
+	)
+
+	float inputs:arnold:camera = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "Camera Multiplier"
+	)
+
+	float inputs:arnold:transmission = 1.0 (
+		displayGroup = "Arnold"
+		displayName = "Transmission Multiplier"
+	)
+
+}


### PR DESCRIPTION
These are defined via additional auto-apply USD schemas. How best to present the Arnold parameters alongside the generic ones is a bit of an open question. There are two approaches in this PR, in 065113ccc83495acade20e6a1799f91264a02cfd and 0140300287c5d5d8898486099a82be5aabfa6bf8, which are the left and right images below respectively. The left one seems most convenient for folks who don't care about Arnold, and the right one seems most convenient for folks who do. The right one will get worse as we add other renderers, and the left one less so. Since our initial use cases involve Arnold, I think I'm inclined to go with the right one, with the intention of adding filtering and maybe replacing the text with icons in future. But I'm open to other opinions and brighter ideas...

![image](https://github.com/GafferHQ/gaffer/assets/1133871/3ebf8229-9f07-4af7-89ae-ac182d37a6ab)