### PR TITLE
GraphEditor config : Improve pointer for targeting dragged locations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - Group : Added `sets` plug, to control what sets the group belongs to.
 - USD : Added automatic render-time translation of UsdPreviewSurface shaders to Cycles.
 - SetEditor : Added support for dragging a set name onto a node in the Graph Editor to create or modify a connected `SetFilter` node. Holding <kbd>Shift</kbd> while dragging will add to the set expression. Holding <kbd>Control</kbd> will remove from the set expression. Only set expressions with a simple list of sets are supported. Expressions with boolean or hierarchy operators are not supported.
+- GraphEditor : Improved pointer used to indicate when dropping a location would find the source node.
 
 1.4.0.0 (relative to 1.3.16.0)
 =======

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -52,6 +52,7 @@
 				"addObjects", # \todo prefix with 'pointer'
 				"removeObjects", # \todo prefix with 'pointer'
 				"replaceObjects", # \todo prefix with 'pointer'
+				"targetObjects", # \todo prefix with 'pointer'
 				"pointerSets",
 				"pointerReplaceSets",
 				"pointerAddSets",

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -2,21 +2,21 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="1000"
    height="1000"
    id="svg2"
    version="1.1"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
    sodipodi:docname="graphics.svg"
-   enable-background="new">
+   enable-background="new"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <title
      id="title2005">Gaffer Icons</title>
   <defs
@@ -228,10 +228,10 @@
        inkscape:collect="always"
        style="color-interpolation-filters:sRGB"
        id="filter2913"
-       x="-0.042472561"
-       y="-0.16729425"
+       x="-0.042472568"
+       y="-0.16729428"
        width="1.0849494"
-       height="1.3192038">
+       height="1.3192039">
       <feBlend
          inkscape:collect="always"
          mode="screen"
@@ -320,18 +320,19 @@
      inkscape:showpageshadow="2"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#4c4c4c"
-     showgrid="true"
-     inkscape:zoom="12.252835"
-     inkscape:cx="765.87417"
-     inkscape:cy="-313.66952"
-     inkscape:window-width="2148"
-     inkscape:window-height="1282"
-     inkscape:window-x="1806"
-     inkscape:window-y="30"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="324.5"
+     inkscape:cy="1455.5"
+     inkscape:window-width="2797"
+     inkscape:window-height="1368"
+     inkscape:window-x="1609"
+     inkscape:window-y="32"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g2711"
+     inkscape:current-layer="g1662"
      inkscape:snap-bbox="true"
-     inkscape:snap-to-guides="true">
+     inkscape:snap-to-guides="true"
+     inkscape:snap-grids="true">
     <inkscape:grid
        type="xygrid"
        id="grid3598"
@@ -681,7 +682,8 @@
          style="fill:#f8f8f8;fill-opacity:1"
          id="flowPara2575" /><flowPara
          style="fill:#f8f8f8;fill-opacity:1"
-         id="flowPara2579" /></flowRoot>    <path
+         id="flowPara2579" /></flowRoot>
+    <path
        style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M 0,1026 H 750"
        id="path2472"
@@ -703,7 +705,8 @@
            y="983"
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1" /></flowRegion><flowPara
          id="flowPara2470"
-         style="fill:#f4f4f4;fill-opacity:1">UI GRAPHICS</flowPara></flowRoot>    <text
+         style="fill:#f4f4f4;fill-opacity:1">UI GRAPHICS</flowPara></flowRoot>
+    <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="280"
@@ -730,7 +733,8 @@
          style="fill:#f8f8f8;fill-opacity:1"
          id="flowPara2634">- The x,y coordinate of the pointer should be set to the coordinates of the pixel to be used when computing mouse/object intersection.</flowPara><flowPara
          style="fill:#f8f8f8;fill-opacity:1"
-         id="flowPara2623">- All exports should use the 'pointer' prefix.</flowPara></flowRoot>    <path
+         id="flowPara2623">- All exports should use the 'pointer' prefix.</flowPara></flowRoot>
+    <path
        inkscape:label="hr1"
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
@@ -752,7 +756,8 @@
            width="343.75"
            id="rect2605" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
-         id="flowPara2609">POINTERS</flowPara></flowRoot>    <flowRoot
+         id="flowPara2609">POINTERS</flowPara></flowRoot>
+    <flowRoot
        xml:space="preserve"
        id="flowRoot2594"
        style="font-style:normal;font-weight:normal;font-size:8px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#f8f8f8;fill-opacity:1;stroke:none"
@@ -773,7 +778,8 @@
          style="fill:#f8f8f8;fill-opacity:1"
          id="flowPara2607">- Odd sized images are valid if its assists center alignment, especially at small scales.</flowPara><flowPara
          style="fill:#f8f8f8;fill-opacity:1"
-         id="flowPara2610">    - Use standard swatch fills/strokes where possible.</flowPara></flowRoot>    <rect
+         id="flowPara2610">    - Use standard swatch fills/strokes where possible.</flowPara></flowRoot>
+    <rect
        transform="translate(0,-52.362183)"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:1.91236579;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect2636"
@@ -835,7 +841,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
            id="rect2638" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
-         id="flowPara2642">ARROWS 10x10</flowPara></flowRoot>    <rect
+         id="flowPara2642">ARROWS 10x10</flowPara></flowRoot>
+    <rect
        y="1494"
        x="10"
        height="10"
@@ -865,7 +872,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara2632"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">CATALOGUE STATUS</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">CATALOGUE STATUS</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect2639"
@@ -895,7 +903,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
            id="rect2648" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
-         id="flowPara2652">SCENE VIEW</flowPara></flowRoot>    <rect
+         id="flowPara2652">SCENE VIEW</flowPara></flowRoot>
+    <rect
        y="1622"
        x="10"
        height="25"
@@ -925,7 +934,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara2850"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">IMAGE VIEW</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">IMAGE VIEW</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect2854"
@@ -955,7 +965,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
            id="rect3174" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
-         id="flowPara3178">TOOLS</flowPara></flowRoot>    <rect
+         id="flowPara3178">TOOLS</flowPara></flowRoot>
+    <rect
        y="1774"
        x="10"
        height="25"
@@ -985,7 +996,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara3316"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">BROWSER ICONS</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1">BROWSER ICONS</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect3320"
@@ -1021,7 +1033,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1"
            id="rect1810" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1"
-         id="flowPara1814">CONTROLS  - checkBox</flowPara></flowRoot>    <rect
+         id="flowPara1814">CONTROLS  - checkBox</flowPara></flowRoot>
+    <rect
        y="1922"
        x="10"
        height="20"
@@ -1051,7 +1064,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara2016"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00001">CONTROLS  - switch</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00001">CONTROLS  - switch</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect2020"
@@ -1081,7 +1095,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect2460" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
-         id="flowPara2464">Editor Focus Menu</flowPara></flowRoot>    <rect
+         id="flowPara2464">Editor Focus Menu</flowPara></flowRoot>
+    <rect
        y="2064"
        x="10"
        height="13"
@@ -1111,7 +1126,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara5604"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Viewer 25x25</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Viewer 25x25</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761447;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect5608"
@@ -1141,7 +1157,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect5816" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
-         id="flowPara5820">Notifications</flowPara></flowRoot>    <rect
+         id="flowPara5820">Notifications</flowPara></flowRoot>
+    <rect
        y="2204"
        x="10"
        height="28"
@@ -1430,7 +1447,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1988"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Tab icons</flowPara></flowRoot>    <flowRoot
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Tab icons</flowPara></flowRoot>
+    <flowRoot
        id="flowRoot2018-3"
        inkscape:label="docTitle"
        transform="matrix(1,0,0,0.99999439,288.10155,1282.8674)"
@@ -1445,7 +1463,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara2016-2"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00001">Color Inspector Icons</flowPara></flowRoot>    <rect
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00001">Color Inspector Icons</flowPara></flowRoot>
+    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
        id="rect2020-0"
@@ -1476,7 +1495,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1966"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">GraphEditor</flowPara></flowRoot>    <path
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">GraphEditor</flowPara></flowRoot>
+    <path
        id="path1880"
        inkscape:label="hr1"
        sodipodi:nodetypes="cc"
@@ -1498,7 +1518,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1886"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">PlugValueWidgets</flowPara></flowRoot>    <path
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">PlugValueWidgets</flowPara></flowRoot>
+    <path
        style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M -6,2589.3622 H 743.99999"
        inkscape:connector-curvature="0"
@@ -1521,7 +1542,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect1870" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
-         id="flowPara1874">LightEditor</flowPara></flowRoot>    <path
+         id="flowPara1874">LightEditor</flowPara></flowRoot>
+    <path
        id="path1211"
        inkscape:label="hr1"
        sodipodi:nodetypes="cc"
@@ -1543,7 +1565,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1217"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">TweakModes</flowPara></flowRoot>    <path
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">TweakModes</flowPara></flowRoot>
+    <path
        id="path1211-3"
        inkscape:label="hr1"
        sodipodi:nodetypes="cc"
@@ -1565,7 +1588,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara1217-3"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Menus</flowPara></flowRoot>    <path
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1">Menus</flowPara></flowRoot>
+    <path
        style="display:inline;opacity:1;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="M -6,2716 H 743.99999"
        inkscape:connector-curvature="0"
@@ -1587,7 +1611,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect8084" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1"
-         id="flowPara8088">HierarchyView</flowPara></flowRoot>    <text
+         id="flowPara8088">HierarchyView</flowPara></flowRoot>
+    <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
        x="-3.9325323"
@@ -1619,7 +1644,8 @@
            style="font-size:24px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
            id="rect8084-2" /></flowRegion><flowPara
          style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381"
-         id="flowPara8088-1">SetEditor</flowPara></flowRoot>    <path
+         id="flowPara8088-1">SetEditor</flowPara></flowRoot>
+    <path
        id="path2298"
        inkscape:label="hr1"
        sodipodi:nodetypes="cc"
@@ -1641,7 +1667,8 @@
            height="54.25"
            width="343.75" /></flowRegion><flowPara
          id="flowPara2304"
-         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">LocalJobs</flowPara></flowRoot>    <path
+         style="font-size:16px;fill:#f4f4f4;fill-opacity:1;stroke-width:1.00000381">LocalJobs</flowPara></flowRoot>
+    <path
        cx="5.5"
        cy="2857.5002"
        rx="9"
@@ -1683,7 +1710,7 @@
        inkscape:label="LocalJobs">
       <rect
          inkscape:label="localDispatcherStatusRunning"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="19"
          height="18.999878"
          x="16"
@@ -1695,11 +1722,11 @@
          x="36"
          height="18.999878"
          width="19"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="localDispatcherStatusComplete" />
       <rect
          inkscape:label="localDispatcherStatusKilled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="19"
          height="18.999878"
          x="56"
@@ -1711,7 +1738,7 @@
          x="76"
          height="18.999878"
          width="19"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="localDispatcherStatusFailed" />
     </g>
     <g
@@ -1724,10 +1751,10 @@
          height="32"
          width="32"
          id="plug"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.93652129;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.93652;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          transform="translate(0,-52.362183)"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.20689988;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10172999;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerPivot"
          width="32"
          height="32"
@@ -1741,9 +1768,9 @@
          height="32"
          width="32"
          id="values"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="rgba"
          width="32"
          height="32"
@@ -1757,9 +1784,9 @@
          height="32"
          width="32"
          id="nodes"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="paths"
          width="32"
          height="32"
@@ -1767,7 +1794,7 @@
          y="1290"
          inkscape:label="pointerPaths" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerContextMenu"
          width="32"
          height="32"
@@ -1781,9 +1808,9 @@
          height="32"
          width="32"
          id="pointerTab"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerDetachedPanel"
          width="32"
          height="32"
@@ -1797,7 +1824,7 @@
          height="32"
          width="32"
          id="move"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="pointerMoveVertically"
          y="1290"
@@ -1805,9 +1832,9 @@
          height="32"
          width="32"
          id="moveVertically"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="moveHorizontally"
          width="32"
          height="32"
@@ -1821,9 +1848,9 @@
          height="32"
          width="32"
          id="moveDiagonallyDown"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="moveDiagonallyUp"
          width="32"
          height="32"
@@ -1837,9 +1864,9 @@
          height="32"
          width="32"
          id="pointerTarget"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerCrossHair"
          width="32"
          height="32"
@@ -1847,7 +1874,7 @@
          y="1290"
          inkscape:label="pointerCrossHair" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.93652129;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.93652;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerAdd"
          width="32"
          height="32"
@@ -1861,9 +1888,9 @@
          height="32"
          width="32"
          id="pointerRemove"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.93652129;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.93652;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:2.20689678;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:2.2069;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerRotate"
          width="32"
          height="32"
@@ -1893,7 +1920,7 @@
        transform="translate(0,-54)"
        style="display:inline">
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:3.12102;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="removeObjects"
          width="64"
          height="32"
@@ -1907,9 +1934,9 @@
          height="32"
          width="64"
          id="addObjects"
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:3.12102;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:3.12102;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="replaceObjects"
          width="64"
          height="32"
@@ -1923,7 +1950,7 @@
          height="32"
          width="64"
          id="objects"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12102342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12102;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12103;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pointerReplaceSets"
@@ -1956,12 +1983,20 @@
          x="350"
          y="1444"
          inkscape:label="pointerSets" />
+      <rect
+         inkscape:label="targetObjects"
+         y="1484"
+         x="282"
+         height="32"
+         width="64"
+         id="targetObjects"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.12102;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        id="g2749"
        inkscape:label="arrows 10">
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="arrowDown10"
          width="10"
          height="10"
@@ -1975,9 +2010,9 @@
          height="10"
          width="10"
          id="arrowUp10"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="arrowLeft10"
          width="10"
          height="10"
@@ -1991,9 +2026,9 @@
          height="10"
          width="10"
          id="arrowRight10"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="collapsibleArrowDown"
          width="10"
          height="10"
@@ -2007,7 +2042,7 @@
          height="10"
          width="10"
          id="collapsibleArrowRight"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="collapsibleArrowDownHover"
          y="1494"
@@ -2015,9 +2050,9 @@
          height="10"
          width="10"
          id="collapsibleArrowDownHover"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="collapsibleArrowRightHover"
          width="10"
          height="10"
@@ -2025,7 +2060,7 @@
          y="1494"
          inkscape:label="collapsibleArrowRightHover" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="collapsibleArrowDownValueChanged"
          width="10"
          height="10"
@@ -2039,7 +2074,7 @@
          height="10"
          width="10"
          id="collapsibleArrowRightValueChanged"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="arrowDownDisabled10"
          y="1494"
@@ -2047,9 +2082,9 @@
          height="10"
          width="10"
          id="arrowDownDisabled10"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="arrowUpDisabled10"
          width="10"
          height="10"
@@ -2063,9 +2098,9 @@
          height="10"
          width="10"
          id="arrowLeftDisabled10"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="arrowRightDisabled10"
          width="10"
          height="10"
@@ -2083,9 +2118,9 @@
          height="13"
          width="13"
          id="catalogueStatusDisk"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueStatusDisplay"
          width="13"
          height="13"
@@ -2099,9 +2134,9 @@
          height="13"
          width="13"
          id="catalogueStatusBatchRenderRunning"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueStatusBatchRenderComplete"
          width="13"
          height="13"
@@ -2109,7 +2144,7 @@
          y="1556"
          inkscape:label="catalogueStatusBatchRenderComplete" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueStatusInteractiveRenderRunning"
          width="13"
          height="13"
@@ -2123,7 +2158,7 @@
          height="13"
          width="13"
          id="catalogueStatusInteractiveRenderComplete"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="catalogueOutputHeader"
          y="1556"
@@ -2131,9 +2166,9 @@
          height="13"
          width="13"
          id="catalogueOutputHeader"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput1"
          width="13"
          height="13"
@@ -2147,9 +2182,9 @@
          height="13"
          width="13"
          id="catalogueOutput2"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput3"
          width="13"
          height="13"
@@ -2163,7 +2198,7 @@
          height="13"
          width="13"
          id="catalogueOutput4"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="catalogueOutput1Highlighted"
          y="1556"
@@ -2171,9 +2206,9 @@
          height="13"
          width="13"
          id="catalogueOutput1Highlighted"
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput2Highlighted"
          width="13"
          height="13"
@@ -2187,9 +2222,9 @@
          height="13"
          width="13"
          id="catalogueOutput3Highlighted"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput4Highlighted"
          width="13"
          height="13"
@@ -2197,7 +2232,7 @@
          y="1556"
          inkscape:label="catalogueOutput4Highlighted" />
       <rect
-         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:#000000;fill-opacity:0;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="13"
          height="13"
          x="294"
@@ -2210,10 +2245,10 @@
          x="311"
          height="13"
          width="13"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput2HighlightedTransparent" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="13"
          height="13"
          x="328"
@@ -2226,14 +2261,14 @@
          x="345"
          height="13"
          width="13"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="catalogueOutput4HighlightedTransparent" />
     </g>
     <g
        id="g2691"
        inkscape:label="scene view">
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="shading"
          width="25"
          height="25"
@@ -2247,7 +2282,7 @@
          height="25"
          width="25"
          id="grid"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="drawingStyles"
          y="1622"
@@ -2255,9 +2290,9 @@
          height="25"
          width="25"
          id="drawingStyles"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="expansion"
          width="25"
          height="25"
@@ -2271,9 +2306,9 @@
          height="25"
          width="25"
          id="cameraOff"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="cameraOn"
          width="25"
          height="25"
@@ -2281,7 +2316,7 @@
          y="1622"
          inkscape:label="cameraOn" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="selectionMaskOff"
          width="25"
          height="25"
@@ -2295,7 +2330,7 @@
          height="25"
          width="25"
          id="selectionMaskOn"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        inkscape:label="image view button icons"
@@ -2307,9 +2342,9 @@
          height="13"
          width="13"
          id="compareModeNone"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="compareModeReplace"
          width="13"
          height="13"
@@ -2323,9 +2358,9 @@
          height="13"
          width="13"
          id="compareModeOver"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="compareModeUnder"
          width="13"
          height="13"
@@ -2339,9 +2374,9 @@
          height="13"
          width="13"
          id="compareModeDifference"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="compareModeSideBySide"
          width="13"
          height="13"
@@ -2355,9 +2390,9 @@
          height="13"
          width="13"
          id="wipeDisabled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.47718471;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.477185;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="wipeEnabled"
          width="13"
          height="13"
@@ -2375,9 +2410,9 @@
          height="25"
          width="25"
          id="exposureOff"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="exposureOn"
          width="25"
          height="25"
@@ -2385,7 +2420,7 @@
          y="1698"
          inkscape:label="exposureOn" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gammaOff"
          width="25"
          height="25"
@@ -2399,7 +2434,7 @@
          height="25"
          width="25"
          id="gammaOn"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="clippingOff"
          y="1698"
@@ -2407,9 +2442,9 @@
          height="25"
          width="25"
          id="clippingOff"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="clippingOn"
          width="25"
          height="25"
@@ -2423,9 +2458,9 @@
          height="25"
          width="25"
          id="soloChannel-1"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="soloChannel0"
          width="25"
          height="25"
@@ -2439,9 +2474,9 @@
          height="25"
          width="25"
          id="soloChannel1"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="soloChannel2"
          width="25"
          height="25"
@@ -2455,9 +2490,9 @@
          height="25"
          width="25"
          id="soloChannel3"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="soloChannel-2"
          width="25"
          height="25"
@@ -2469,7 +2504,7 @@
        id="g3230"
        inkscape:label="tools">
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gafferSceneUISelectionTool"
          width="25"
          height="25"
@@ -2483,10 +2518,10 @@
          height="25"
          width="25"
          id="gafferSceneUIRotateTool"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          transform="translate(0,-52.362183)"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.91766298;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10172999;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gafferSceneUILightPositionTool"
          width="25"
          height="25"
@@ -2494,7 +2529,7 @@
          y="1826.3622"
          inkscape:label="gafferSceneUILightPositionTool" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gafferSceneUITranslateTool"
          width="25"
          height="25"
@@ -2508,9 +2543,9 @@
          height="25"
          width="25"
          id="gafferSceneUIScaleTool"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gafferSceneUICameraTool"
          width="25"
          height="25"
@@ -2524,9 +2559,9 @@
          height="25"
          width="25"
          id="gafferSceneUICropWindowTool"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99607843;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.996078;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="gafferSceneUILightTool"
          width="25"
          height="25"
@@ -2544,9 +2579,9 @@
          height="14"
          width="14"
          id="pathChooser"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pathUpArrow"
          width="14"
          height="14"
@@ -2560,9 +2595,9 @@
          height="14"
          width="14"
          id="refresh"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="pathListingList"
          width="14"
          height="14"
@@ -2576,9 +2611,9 @@
          height="14"
          width="14"
          id="pathListingTree"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="bookmarks"
          width="14"
          height="14"
@@ -2590,7 +2625,7 @@
        id="g2008"
        inkscape:label="controls-checkBox">
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="checkBoxChecked"
          width="20"
          height="20"
@@ -2604,7 +2639,7 @@
          height="20"
          width="20"
          id="checkBoxUnchecked"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="checkBoxCheckedHover"
          y="1922"
@@ -2612,9 +2647,9 @@
          height="20"
          width="20"
          id="checkBoxCheckedHover"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="checkBoxUncheckedHover"
          width="20"
          height="20"
@@ -2622,7 +2657,7 @@
          y="1922"
          inkscape:label="checkBoxUncheckedHover" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="checkBoxCheckedDisabled"
          width="20"
          height="20"
@@ -2636,9 +2671,9 @@
          height="20"
          width="20"
          id="checkBoxUncheckedDisabled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="checkBoxIndeterminate"
          width="20"
          height="20"
@@ -2652,9 +2687,9 @@
          height="20"
          width="20"
          id="checkBoxIndeterminateHover"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="checkBoxIndeterminateDisabled"
          width="20"
          height="20"
@@ -2672,9 +2707,9 @@
          height="16"
          width="16"
          id="toggleOn"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="toggleOff"
          width="16"
          height="16"
@@ -2682,7 +2717,7 @@
          y="1996"
          inkscape:label="toggleOff" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="toggleOnHover"
          width="16"
          height="16"
@@ -2696,7 +2731,7 @@
          height="16"
          width="16"
          id="toggleOffHover"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          inkscape:label="toggleOnDisabled"
          y="1996"
@@ -2704,9 +2739,9 @@
          height="16"
          width="16"
          id="toggleOnDisabled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="toggleOffDisabled"
          width="16"
          height="16"
@@ -2720,9 +2755,9 @@
          height="16"
          width="16"
          id="toggleIndeterminate"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="toggleIndeterminateHover"
          width="16"
          height="16"
@@ -2736,7 +2771,7 @@
          height="16"
          width="16"
          id="toggleIndeterminateDisabled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766292;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        id="g2707"
@@ -2748,9 +2783,9 @@
          height="13"
          width="13"
          id="nodeSetNodeSelection"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="nodeSetStandardSet"
          width="13"
          height="13"
@@ -2758,7 +2793,7 @@
          y="2064"
          inkscape:label="nodeSetStandardSet" />
       <rect
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="nodeSetNumericBookmarkSet"
          width="13"
          height="13"
@@ -2772,7 +2807,7 @@
          height="13"
          width="13"
          id="nodeSetFocusNode"
-         style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.91766286;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          transform="scale(1,-1)" />
     </g>
     <g
@@ -2786,11 +2821,11 @@
          x="32"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="locationExpanded" />
       <rect
          inkscape:label="locationIncluded"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="52"
@@ -2798,7 +2833,7 @@
          id="locationIncluded" />
       <rect
          inkscape:label="locationIncludedTransparent"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="72"
@@ -2806,7 +2841,7 @@
          id="locationIncludedTransparent" />
       <rect
          inkscape:label="locationIncludedDisabled"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="92"
@@ -2814,7 +2849,7 @@
          id="locationIncludedDisabled" />
       <rect
          inkscape:label="descendantIncluded"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="112"
@@ -2826,11 +2861,11 @@
          x="132"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="descendantIncludedTransparent" />
       <rect
          inkscape:label="locationIncludedHighlightedTransparent"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="172"
@@ -2838,7 +2873,7 @@
          id="locationIncludedHighlightedTransparent" />
       <rect
          inkscape:label="locationIncludedHighlighted"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="152"
@@ -2846,7 +2881,7 @@
          id="locationIncludedHighlighted" />
       <rect
          inkscape:label="locationExcluded"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="192"
@@ -2854,7 +2889,7 @@
          id="locationExcluded" />
       <rect
          inkscape:label="descendantExcluded"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="232"
@@ -2862,7 +2897,7 @@
          id="descendantExcluded" />
       <rect
          inkscape:label="locationExcludedTransparent"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="212"
@@ -2870,7 +2905,7 @@
          id="locationExcludedTransparent" />
       <rect
          inkscape:label="locationExcludedHighlighted"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="252"
@@ -2878,7 +2913,7 @@
          id="locationExcludedHighlighted" />
       <rect
          inkscape:label="locationExcludedHighlightedTransparent"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="272"
@@ -2886,7 +2921,7 @@
          id="locationExcludedHighlightedTransparent" />
     </g>
     <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke markers fill"
        id="searchFocusOn"
        width="12"
        height="12"
@@ -2895,18 +2930,18 @@
        inkscape:label="#rect1670" />
     <circle
        id="path1663"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        cx="36"
        cy="68"
        r="4" />
     <circle
-       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#foreground);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#foreground);stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        id="path1659"
        cx="36"
        cy="68"
        r="3.75" />
     <circle
-       style="opacity:1;fill:url(#foreground);fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+       style="opacity:1;fill:url(#foreground);fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke markers fill"
        id="path1661"
        cx="36"
        cy="68"
@@ -2916,7 +2951,7 @@
        id="searchFocusOff"
        transform="translate(93,5.6378)">
       <rect
-         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke markers fill"
          id="rect1678"
          width="12"
          height="12"
@@ -2924,18 +2959,18 @@
          y="56.362183" />
       <circle
          id="path1680"
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.5999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#383838;stroke-width:3.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
          cx="-70"
          cy="62.362183"
          r="4" />
       <circle
-         style="opacity:1;fill:none;fill-opacity:1;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:#9e9e9e;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
          id="path1682"
          cx="-70"
          cy="62.362183"
          r="3.75" />
       <circle
-         style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke markers fill"
+         style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#383838;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke markers fill"
          id="path1684"
          cx="-70"
          cy="62.362183"
@@ -2948,9 +2983,9 @@
        height="25"
        width="25"
        id="viewPause"
-       style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.9176628;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     <rect
-       style="display:inline;opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:0.9176628;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:0.917663;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        id="viewPaused"
        width="25"
        height="25"
@@ -2964,9 +2999,9 @@
        height="16"
        width="10"
        id="lutGPU"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        id="lutCPU"
        width="10"
        height="16"
@@ -2986,7 +3021,7 @@
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
     <rect
-       style="fill:none;fill-opacity:1;stroke:none;stroke-width:3.77952766;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:none;stroke-width:3.77953;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="tabScrollMenu"
        width="17"
        height="19"
@@ -2995,7 +3030,7 @@
        inkscape:label="tabScrollMenu" />
     <rect
        inkscape:label="annotations"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        id="annotations"
        width="25"
        height="25"
@@ -3007,14 +3042,14 @@
        x="10"
        height="14"
        width="14"
-       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <g
        id="g3809"
        inkscape:label="SetEditor">
       <rect
          inkscape:label="populatedSetIcon"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="30"
@@ -3026,7 +3061,7 @@
          x="50"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="emptySetIcon" />
       <rect
          id="setFolder"
@@ -3034,7 +3069,7 @@
          x="70"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="setFolderIcon" />
     </g>
     <g
@@ -3046,7 +3081,7 @@
          x="10"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="sizeGuide" />
       <rect
          id="unMuteLight"
@@ -3054,11 +3089,11 @@
          x="253"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="unMuteLight" />
       <rect
          inkscape:label="muteLight"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="231"
@@ -3066,7 +3101,7 @@
          id="muteLight" />
       <rect
          inkscape:label="unMuteLightFaded"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="298"
@@ -3078,7 +3113,7 @@
          x="275"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="muteLightFaded" />
       <rect
          id="muteLightHighlighted"
@@ -3086,11 +3121,11 @@
          x="322"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="muteLightHighlighted" />
       <rect
          inkscape:label="unMuteLightHighlighted"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="344"
@@ -3098,7 +3133,7 @@
          id="unMuteLightHighlighted" />
       <rect
          inkscape:label="muteLightFadedHighlighted"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="364"
@@ -3110,11 +3145,11 @@
          x="386"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="unMuteLightFadedHighlighted" />
       <rect
          inkscape:label="muteLightUndefined"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="408"
@@ -3126,11 +3161,11 @@
          x="430"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="setMember" />
       <rect
          inkscape:label="setMemberHighlighted"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="450.95377"
@@ -3138,7 +3173,7 @@
          id="setMemberHighlighted" />
       <rect
          inkscape:label="setMemberFaded"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="473"
@@ -3150,7 +3185,7 @@
          x="494.91803"
          height="16"
          width="16"
-         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="setMemberFadedHighlighted" />
     </g>
     <g
@@ -3162,11 +3197,11 @@
          x="35"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="plusSmall" />
       <rect
          inkscape:label="minusSmall"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="14"
          height="14"
          x="53"
@@ -3178,11 +3213,11 @@
          x="71"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="multiplySmall" />
       <rect
          inkscape:label="replaceSmall"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="14"
          height="14"
          x="89"
@@ -3194,11 +3229,11 @@
          x="107"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="createSmall" />
       <rect
          inkscape:label="lessThanSmall"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="14"
          height="14"
          x="125"
@@ -3210,11 +3245,11 @@
          x="143"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="greaterThanSmall" />
       <rect
          inkscape:label="listAppendSmall"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="14"
          height="14"
          x="161"
@@ -3226,11 +3261,11 @@
          x="179"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="listPrependSmall" />
       <rect
          inkscape:label="listRemoveSmall"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="14"
          height="14"
          x="197"
@@ -3242,7 +3277,7 @@
          x="219"
          height="14"
          width="14"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="removeSmall" />
     </g>
     <g
@@ -3364,7 +3399,7 @@
        d="m 1493.1124,998.29268 h -194.015 c -16.789,0 -30.305,-13.51603 -30.305,-30.305 V 841.66962 c 0,-16.78897 13.516,-30.305 30.305,-30.305 h 424.4191 c 16.7889,0 30.305,13.51603 30.305,30.305 v 126.31806 c 0,16.78897 -13.5161,30.305 -30.305,30.305 h -194.402"
        style="opacity:1;fill:none;fill-opacity:1;stroke:#5e5e5e;stroke-width:12;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:16.64100456;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:16.641;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="viewerFocusPrompt"
        width="672"
        height="384"
@@ -3377,7 +3412,7 @@
        transform="translate(-236.58594,1205.4141)"
        style="paint-order:markers stroke fill">
       <rect
-         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:12.02084923;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:12.0208;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="rect2570"
          width="12.020849"
          height="12.020849"
@@ -3450,7 +3485,7 @@
        d="m 450,257.36218 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
        style="fill:#787878;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       style="fill:#575757;fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#575757;fill-opacity:1;stroke:#424242;stroke-width:0.842105;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(-1.1875,0,0,-1.1875007,427.15625,420.19865)"
        id="g4075" />
     <rect
@@ -3470,7 +3505,7 @@
        y="61.362183"
        inkscape:label="#rect3932" />
     <path
-       style="opacity:0.98999999;fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.99;fill:url(#backgroundLighter);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 201,30.5 c -4.97056,0 -9,4.029437 -9,9 0,4.970563 4.02944,9 9,9 4.97056,0 9,-4.029437 9,-9 0,-4.970563 -4.02944,-9 -9,-9 z m -0.0625,1.9375 c 0.75812,0 1.375,0.648126 1.375,1.40625 0,0.758123 -0.61688,1.375 -1.375,1.375 -0.77662,0 -1.40625,-0.629636 -1.40625,-1.40625 0,-0.776615 0.61114,-1.375 1.40625,-1.375 z m 1,4.34375 0.1875,0.125 v 6.75 c 0,0.998504 0.083,1.15052 0.65625,1.1875 l 0.65625,0.03125 v 0.6875 c -1.23889,-0.03698 -2.13019,-0.0625 -2.5,-0.0625 l -2.375,0.0625 V 44.875 l 0.65625,-0.03125 c 0.57317,-0.03698 0.65625,-0.188996 0.65625,-1.1875 v -4.0625 c 0,-1.090958 -0.0435,-1.24427 -0.46875,-1.28125 L 198.5625,38.25 v -0.65625 c 0.12943,-0.01849 0.22575,-0.03125 0.28125,-0.03125 0.77662,-0.09245 1.2208,-0.190092 1.8125,-0.375 z"
        transform="translate(0,52.362183)"
        id="info"
@@ -3479,7 +3514,7 @@
        inkscape:connector-curvature="0"
        id="menuCheckedShape"
        d="m 15.992825,2735.6842 c -0.32761,-0.083 -0.52423,-0.2743 -0.99517,-0.9661 -0.49858,-0.7323 -1.0141,-1.3951 -1.53792,-1.9772 -0.39857,-0.4429 -0.69502,-0.8823 -0.76123,-1.1282 -0.14507,-0.5387 0.30278,-1.1868 1.09926,-1.5908 0.35752,-0.1814 0.41634,-0.196 0.78864,-0.196 0.37755,0 0.4281,0.013 0.82179,0.2127 0.45178,0.2291 1.04314,0.7336 1.38454,1.1813 0.10373,0.136 0.20206,0.2472 0.21862,0.2472 0.0166,0 0.12472,-0.2086 0.24037,-0.4636 0.25544,-0.5633 1.31289,-2.5426 1.75455,-3.2842 1.63774,-2.75 3.44733,-5.0329 4.31459,-5.4432 0.3245,-0.1535 1.01672,-0.2908 1.81381,-0.3598 0.55651,-0.048 0.62125,-0.045 0.81712,0.042 0.13992,0.062 0.24167,0.1501 0.29727,0.2576 0.0971,0.1877 0.10594,0.5164 0.0185,0.685 -0.0328,0.063 -0.39478,0.4571 -0.80411,0.8748 -1.1208,1.1436 -1.74543,1.9126 -2.73766,3.3703 -1.32415,1.9454 -2.422,3.9547 -3.38197,6.1897 -0.73648,1.7146 -0.74612,1.7346 -0.93659,1.9455 -0.0953,0.1054 -0.28876,0.2425 -0.42999,0.3045 -0.22736,0.1 -0.34668,0.1144 -1.04066,0.1261 -0.43112,0.01 -0.85582,-0.01 -0.94379,-0.028 z"
-       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.00157475;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:url(#foreground);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.00157;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:label="#path3925" />
     <g
        id="g2739"
@@ -3498,12 +3533,12 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path2818"
-         style="fill:url(#arrowDefault);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#arrowDefault);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star"
          inkscape:label="down" />
       <path
          sodipodi:type="star"
-         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3612"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3520,7 +3555,7 @@
          inkscape:label="up" />
       <path
          sodipodi:type="star"
-         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path3618"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3537,7 +3572,7 @@
          inkscape:label="left" />
       <path
          sodipodi:type="star"
-         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         style="fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
          id="path2851"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3554,7 +3589,7 @@
          inkscape:label="right" />
       <path
          sodipodi:type="star"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path2835"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3584,7 +3619,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="down"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="collapsibleRightHover"
@@ -3601,11 +3636,11 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="fds"
-         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          sodipodi:type="star"
-         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#779cbd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path2918"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3622,7 +3657,7 @@
          inkscape:label="collapsibleDownHover" />
       <path
          sodipodi:type="star"
-         style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path4943"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3652,12 +3687,12 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path4945"
-         style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="down"
          sodipodi:type="star"
-         style="opacity:0.33000004;fill:url(#arrowDefault);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33;fill:url(#arrowDefault);fill-opacity:1;stroke:url(#backgroundDark);stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="path6330"
          sodipodi:sides="3"
          sodipodi:cx="117.14286"
@@ -3686,7 +3721,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6332"
-         style="opacity:0.33000004;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="left"
@@ -3703,7 +3738,7 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6334"
-         style="opacity:0.33000004;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="opacity:0.33;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:type="star" />
       <path
          inkscape:label="right"
@@ -3720,11 +3755,11 @@
          sodipodi:cx="117.14286"
          sodipodi:sides="3"
          id="path6336"
-         style="opacity:0.33000004;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+         style="opacity:0.33;fill:url(#arrowDefault);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
          sodipodi:type="star" />
     </g>
     <rect
-       style="display:inline;fill:url(#compoundEditorButtonDisabled);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.80000001;stroke-opacity:1"
+       style="display:inline;fill:url(#compoundEditorButtonDisabled);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.8;stroke-opacity:1"
        id="layoutButton"
        width="14.4"
        height="14.4"
@@ -3734,7 +3769,7 @@
        ry="1.6"
        inkscape:label="#rect3097" />
     <path
-       style="fill:none;stroke:#3c3c3c;stroke-width:0.80000001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:none;stroke:#3c3c3c;stroke-width:0.8px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 132.3,91.862184 h 14.42218 v 0 H 139.5 v -7.2 14.399998"
        id="path3885"
        inkscape:connector-curvature="0"
@@ -3742,7 +3777,7 @@
     <g
        transform="translate(21.93052,25.5)"
        id="g3874"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.49083519px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.4908px;line-height:125%;font-family:'URW Palladio L';-inkscape-font-specification:'URW Palladio L Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
       <path
          sodipodi:nodetypes="cccccsscccccccsccccsssc"
          inkscape:connector-curvature="0"
@@ -3753,7 +3788,7 @@
     <path
        id="path3882"
        d="m 201,82.862183 c -4.97056,0 -9,4.029437 -9,9 0,4.970563 4.02944,8.999997 9,8.999997 4.97056,0 9,-4.029434 9,-8.999997 0,-4.970563 -4.02944,-9 -9,-9 z"
-       style="opacity:0.98999999;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+       style="opacity:0.99;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssss" />
     <path
@@ -3913,16 +3948,16 @@
          height="14"
          width="4"
          id="rect3127"
-         style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1" />
+         style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
       <rect
-         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
          id="rect3897"
          width="4"
          height="14"
          x="336.5"
          y="62.862183" />
       <rect
-         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
          id="rect3211"
          width="4"
          height="14"
@@ -3930,20 +3965,20 @@
          y="62.862183" />
     </g>
     <path
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
        d="m 355.5,62.987183 v 4.875 l 2.5,2.125 -2.5,2.125 v 4.875 l 10.5,-7 z"
        id="rect3899"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccc" />
     <path
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
        d="m 374,62.924683 v 4.5625 l -3.5,-2.8125 v 10.5 l 3.5,-2.8125 v 4.5625 h 3 v -7 -7 z"
        id="rect3920"
        inkscape:connector-curvature="0" />
     <path
        id="path3926"
        d="m 348.5,62.799683 v 4.5625 l 3.5,-2.8125 v 10.5 l -3.5,-2.8125 v 4.5625 h -3 v -7 -7 z"
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
        inkscape:connector-curvature="0" />
     <rect
        inkscape:label="#rect3932"
@@ -4008,7 +4043,7 @@
        inkscape:label="#g3188"
        style="fill:url(#backgroundLighter)">
       <path
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M 257.09375,44.90625 253.4375,41.25 c 0.67769,-1.087575 1.0625,-2.372568 1.0625,-3.75 -0.004,-3.89216 -3.13671,-7.03125 -7,-7.03125 -3.86599,0 -7,3.136366 -7,7.03125 0,3.894884 3.13401,7.0625 7,7.0625 1.43426,0 2.76489,-0.440152 3.875,-1.1875 L 255,47 m -7.5,-14 c 2.46825,0 4.46631,2.012609 4.46875,4.5 0,2.489132 -1.99877,4.5 -4.46875,4.5 -2.46998,0 -4.46875,-2.010868 -4.46875,-4.5 0,-2.489132 1.99877,-4.5 4.46875,-4.5 z"
          transform="translate(-4.9651315e-6,52.407524)"
          id="path4173"
@@ -4038,7 +4073,7 @@
          inkscape:label="#g3187"
          id="fsdfsd">
         <rect
-           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4443"
            width="4"
            height="4.0000005"
@@ -4050,9 +4085,9 @@
            height="4.0000005"
            width="4"
            id="rect4445"
-           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4447"
            width="4"
            height="4.0000005"
@@ -4060,7 +4095,7 @@
            y="86.862183" />
         <g
            id="text4957"
-           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:9.18084049px;line-height:125%;font-family:Futura;-inkscape-font-specification:'Futura Medium';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
+           style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:9.18084px;line-height:125%;font-family:Futura;-inkscape-font-specification:'Futura Medium';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
           <path
              inkscape:connector-curvature="0"
              id="path3205"
@@ -4076,7 +4111,7 @@
         </g>
         <g
            id="text4957-2"
-           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:8.49427414px;line-height:125%;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
+           style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:8.49427px;line-height:125%;font-family:'Arial Black';-inkscape-font-specification:'Arial Black, Heavy';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none">
           <path
              inkscape:connector-curvature="0"
              id="path3198"
@@ -4096,7 +4131,7 @@
            height="3.9999995"
            width="4"
            id="rect5011"
-           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <path
          sodipodi:nodetypes="ccccccccc"
@@ -4120,9 +4155,9 @@
            height="9.000001"
            width="5"
            id="rect4443-7"
-           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#9c1d17;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#42ae45;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4445-9"
            width="5"
            height="9"
@@ -4134,9 +4169,9 @@
            height="9"
            width="5"
            id="rect4447-3"
-           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#5066c5;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#b3b3b3;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect5011-8"
            width="5"
            height="9.000001"
@@ -4159,7 +4194,7 @@
          style="opacity:0.5"
          id="g4016">
         <rect
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="rect4014"
            width="14"
            height="6"
@@ -4171,9 +4206,9 @@
            height="6"
            width="14"
            id="rect4012"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1" />
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
         <rect
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-opacity:1"
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="rect3231-9"
            width="14"
            height="6"
@@ -4197,7 +4232,7 @@
          inkscape:label="#g3288"
          id="g3288">
         <rect
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="rect3235-2"
            width="13.500001"
            height="2.0000005"
@@ -4209,9 +4244,9 @@
            height="2.0000005"
            width="13.500001"
            id="rect3282"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
         <rect
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
            id="rect3284"
            width="13.500001"
            height="2.0000005"
@@ -4223,7 +4258,7 @@
            height="2.0000005"
            width="13.500001"
            id="rect3286"
-           style="fill:#787878;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
+           style="fill:#787878;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1" />
       </g>
       <path
          sodipodi:nodetypes="ccccccccc"
@@ -4260,7 +4295,7 @@
        inkscape:label="#path3910"
        id="success"
        d="m 30.013395,193.54296 c -13.176684,0 -23.8585234,10.68182 -23.8585234,23.8585 0,13.17673 10.6818394,23.85853 23.8585234,23.85853 13.176684,0 23.858505,-10.6818 23.858505,-23.85853 0,-13.17668 -10.681821,-23.8585 -23.858505,-23.8585 z"
-       style="opacity:0.98999999;fill:#69ffa5;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       style="opacity:0.99;fill:#69ffa5;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssss" />
     <path
@@ -4273,29 +4308,29 @@
        transform="matrix(1.8253088,0,0,1.8253088,-39.283415,-210.61758)"
        inkscape:label="#g4022">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.09570503;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.09571;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
          d="m 68.96875,221.73718 c -0.63482,0.0493 -1.23606,0.42206 -1.5625,0.96875 l -13,21.5 c -0.7268,1.20821 0.30879,3.03461 1.71875,3.03125 h 26 c 1.40997,0.003 2.44556,-1.82304 1.71875,-3.03125 l -13,-21.5 c -0.37983,-0.6363 -1.13625,-1.02711 -1.875,-0.96875 z"
          id="path4012"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccccc"
          inkscape:label="#path3123" />
       <g
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:none"
          id="g4014"
          transform="translate(21.3125,110.25)" />
       <g
          id="g4018"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141006;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          transform="translate(17.3125,110.72937)" />
       <g
          transform="translate(17.3125,110.72937)"
-         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3c3c3c;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="g4029">
         <g
            id="g4034">
           <path
              d="m 51.72693,127.91715 -0.160179,-2.04229 c -0.0534,-0.54727 -0.186879,-1.58176 -0.400448,-3.10347 -0.200227,-1.53505 -0.300339,-2.42938 -0.300337,-2.68301 -2e-6,-1.0545 0.333705,-1.58176 1.001121,-1.58177 0.66741,1e-5 1.001116,0.51392 1.001121,1.54173 -5e-6,0.10679 -0.0067,0.22693 -0.02002,0.3604 -0.01335,0.12015 -0.02003,0.22026 -0.02002,0.30034 l -0.840941,7.20807 h -0.260292 z m -0.860959,2.52282 c -2e-6,-0.68076 0.340379,-1.02114 1.021143,-1.02114 0.680758,0 1.021139,0.32703 1.021143,0.98109 -4e-6,0.65407 -0.340385,0.9811 -1.021143,0.9811 -0.680764,0 -1.021145,-0.31368 -1.021143,-0.94105"
-             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141006;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.19141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="path4020"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cccsccccccccscsc" />
@@ -4311,7 +4346,7 @@
     <path
        sodipodi:nodetypes="sssss"
        inkscape:connector-curvature="0"
-       style="opacity:0.98999999;fill:#efc618;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       style="opacity:0.99;fill:#efc618;fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
        d="m 30.013395,253.54296 c -13.176684,0 -23.8585234,10.68182 -23.8585234,23.8585 0,13.17673 10.6818394,23.85853 23.8585234,23.85853 13.176684,0 23.858505,-10.6818 23.858505,-23.85853 0,-13.17668 -10.681821,-23.8585 -23.858505,-23.8585 z"
        id="successWarning"
        inkscape:label="#path3910" />
@@ -4346,7 +4381,7 @@
          id="path5134"
          transform="translate(0,52.362183)"
          d="m 342.96875,130.0625 -0.84375,1.40625 -2.96875,5 L 338.25,138 h 1.75 0.9375 c -0.0378,0.787 -0.0302,1.56573 0.28125,2.5 0.25149,0.75447 0.90647,1.59386 1.71875,2 0.81228,0.40614 1.64583,0.5 2.5625,0.5 h 11 c 0.19444,0 0.0886,-0.0143 0.125,0.0312 0.0364,0.0455 0.125,0.24375 0.125,0.46875 0,0.225 -0.0886,0.42324 -0.125,0.46875 -0.0364,0.0455 0.0694,0.0312 -0.125,0.0312 h -6 c -0.75833,0 -1.45648,0.0513 -2.1875,0.34375 -0.73102,0.29241 -1.43419,0.93088 -1.78125,1.625 C 345.83713,147.35709 346,148.5 346,150 h 4 c 0,-1.31282 0.10755,-1.8749 0.0937,-1.96875 0.11122,-0.018 0.11614,-0.0312 0.4063,-0.0312 h 6 c 1.30556,0 2.53641,-0.63926 3.25,-1.53125 0.71359,-0.89199 1,-1.94375 1,-2.96875 0,-1.025 -0.28641,-2.07676 -1,-2.96875 C 359.03641,139.63926 357.80556,139 356.5,139 h -11 c -0.36496,0 -0.36229,-0.0404 -0.46875,-0.0625 -8e-4,-0.0789 0.006,-0.69826 0,-0.96875 H 346 h 1.78125 l -0.9375,-1.53125 -3,-4.96875 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;marker:none;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#3c3c3c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
          inkscape:connector-curvature="0" />
       <path
          id="path5120"
@@ -4373,7 +4408,7 @@
          inkscape:connector-curvature="0" />
     </g>
     <path
-       style="fill:#787878;fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#787878;fill-opacity:0.992157;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 450,197.36218 c -2.76142,0 -5,-2.23858 -5,-5 0,-2.76142 2.23858,-5 5,-5 2.67905,0 4.88204,2.11157 4.99775,4.89411 0.002,2.86731 -2.23633,5.10589 -4.99775,5.10589 z"
        id="path4053"
        inkscape:connector-curvature="0"
@@ -4424,7 +4459,7 @@
          style="opacity:0.5"
          id="g4151">
         <rect
-           style="opacity:1;fill:#787878;fill-opacity:0.49803922;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="opacity:1;fill:#787878;fill-opacity:0.498039;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect3349"
            width="14"
            height="15"
@@ -4477,7 +4512,7 @@
     <circle
        transform="matrix(0.375,0,0,0.375,409.25,176.61218)"
        id="setMembershipDot"
-       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66666675;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#f9f9f9;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.66667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:label="#path3699"
        cx="158"
        cy="38"
@@ -4496,12 +4531,12 @@
        sodipodi:cx="117.14286"
        sodipodi:sides="3"
        id="menuIndicatorShape"
-       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="star"
        inkscape:label="menuIndicator" />
     <path
        sodipodi:type="star"
-       style="opacity:0.4;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852141;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="opacity:0.4;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.53852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="menuIndicatorDisabledShape"
        sodipodi:sides="3"
        sodipodi:cx="117.14286"
@@ -4521,7 +4556,7 @@
        transform="matrix(1.3868993,0,0,1.3868993,-57.129221,-84.589805)"
        style="fill:#779bbc;fill-opacity:1">
       <path
-         style="fill:#557490;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#557490;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.721033;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 128.38062,163.8549 -5.53956,1.63762 0.465,6.7526 4.93304,3.01239 5.17566,-2.93152 0.46499,-6.81326 z"
          id="path3284-0"
          inkscape:connector-curvature="0" />
@@ -4529,13 +4564,13 @@
          sodipodi:nodetypes="ccccc"
          id="path3286-5"
          d="m 123.30064,172.252 -0.45949,-6.76096 5.5138,2.19895 -0.11487,7.56506 z"
-         style="fill:#779bbc;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#779bbc;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.721033;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          sodipodi:nodetypes="ccccc"
          id="path3288-6"
          d="m 122.84115,165.49104 5.5138,2.19895 5.53021,-2.18254 -5.5138,-1.65742 z"
-         style="fill:#89accd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.72103286;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#89accd;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.721033;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:connector-curvature="0" />
     </g>
     <g
@@ -4553,7 +4588,7 @@
          transform="matrix(1.0229949,0,0,1.0572693,-4.4222807,-17.752239)"
          id="g3329">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773449;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bb2b2b;fill-opacity:1;fill-rule:nonzero;stroke:#313131;stroke-width:4.80773;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
            d="m 76.999384,319.35707 c -2.590589,0.20118 -5.044144,1.72235 -6.376289,3.9533 l -53.05072,87.73773 c -2.965943,4.93049 1.260118,12.38371 7.013918,12.37 H 130.68773 c 5.75384,0.0122 9.9799,-7.43951 7.01392,-12.37 L 84.65093,323.31037 c -1.55002,-2.59663 -4.636837,-4.19146 -7.651546,-3.9533 z"
            id="fsdffsd"
            inkscape:connector-curvature="0"
@@ -4561,7 +4596,7 @@
            inkscape:label="#path3123" />
         <path
            d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 h -1.062206 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026"
-           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928091;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:#313131;stroke-width:5.76928;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path3336"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccsccccccccscsc" />
@@ -4569,19 +4604,19 @@
            sodipodi:nodetypes="cccsccccccccscsc"
            inkscape:connector-curvature="0"
            id="path3338"
-           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.02241135px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:20.0224px;line-height:125%;font-family:'Apple LiSung';-inkscape-font-specification:'Apple LiSung Light';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#f9f9f9;fill-opacity:1;stroke:none"
            d="M 77.28782,388.36112 76.634158,380.0269 C 76.416242,377.79358 75.871538,373.57201 75,367.36218 c -0.817091,-6.26427 -1.225631,-9.91388 -1.225623,-10.94889 -8e-6,-4.30323 1.361792,-6.45489 4.0854,-6.45493 2.723583,4e-5 4.085378,2.09722 4.085399,6.29153 -2.1e-5,0.43579 -0.02734,0.92606 -0.0817,1.47073 -0.05448,0.49031 -0.08174,0.89884 -0.0817,1.22563 l -3.431733,29.41487 h -1.062206 z m -3.513422,10.29519 c -8e-6,-2.77806 1.389027,-4.16709 4.167105,-4.16709 2.778054,0 4.167089,1.33455 4.167106,4.00365 -1.7e-5,2.66915 -1.389052,4.0037 -4.167106,4.0037 -2.778078,0 -4.167113,-1.28007 -4.167105,-3.84026" />
       </g>
     </g>
     <path
        inkscape:connector-curvature="0"
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.992157"
        d="m 448,72.862183 h -8.5 v 3 l -7,-6 7,-6 v 3 h 8.5"
        id="gfsdf"
        sodipodi:nodetypes="ccccccs"
        inkscape:label="#rect2859" />
     <rect
-       style="opacity:0.5;fill:none;fill-opacity:0.99215686;stroke:none"
+       style="opacity:0.5;fill:none;fill-opacity:0.992157;stroke:none"
        id="shuffleArrow"
        width="20"
        height="15"
@@ -4590,7 +4625,7 @@
        transform="translate(0,52.362183)"
        inkscape:label="#rect3197" />
     <rect
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00011265;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00011;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3127-7"
        width="13.910246"
        height="13.999775"
@@ -4624,7 +4659,7 @@
       <circle
          transform="matrix(1.2149049,0,0,1.2149049,-258.34322,303.59787)"
          id="path3212"
-         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.82310975;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.82311;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          cx="385"
          cy="40"
          r="5" />
@@ -4639,7 +4674,7 @@
          inkscape:connector-curvature="0"
          id="path3216"
          d="M 217.93011,353.61057 226,351.86218 v 9 l -8,2.5 z"
-         style="fill:#6a6a6a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+         style="fill:#6a6a6a;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
       <path
          style="fill:#8e8e8e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
          d="m 212,350.86218 5.93008,2.74839 8.06992,-1.74839 -6.0625,-2.4375 z"
@@ -4649,7 +4684,7 @@
       <circle
          transform="matrix(1.1803568,0,0,1.1803568,-39.760304,-0.97781626)"
          id="path5609"
-         style="fill:#efc618;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.84720147;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#efc618;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:0.847201;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          cx="211.625"
          cy="289.875"
          r="2.9375" />
@@ -4722,7 +4757,7 @@
          sodipodi:nodetypes="cccccc"
          id="path4138"
          d="m 150,572.36218 25,-4e-4 V 722.3618 H 24.999999 V 572.36178 L 50,572.36218"
-         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:none;stroke:#e5e5e5;stroke-width:20;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          inkscape:connector-curvature="0" />
       <path
          id="path4156"
@@ -4735,14 +4770,14 @@
          height="75"
          width="30"
          id="rect4175"
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1" />
     </g>
     <g
        id="boxOutNode"
        inkscape:label="#g4200"
        transform="translate(-5.0000019,3.8586102e-4)">
       <path
-         style="fill:none;stroke:#e5e5e5;stroke-width:19.99999428;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:none;stroke:#e5e5e5;stroke-width:20;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          d="m 360,722.3618 h 15 V 572.36178 H 225 V 722.3618 h 15"
          id="path4166"
          sodipodi:nodetypes="cccccc"
@@ -4753,7 +4788,7 @@
          id="path4177"
          inkscape:connector-curvature="0" />
       <rect
-         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:#e5e5e5;fill-opacity:1;stroke:#e5e5e5;stroke-width:10;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          id="rect4179"
          width="30"
          height="75"
@@ -4764,7 +4799,7 @@
        id="export"
        inkscape:label="#g4666">
       <path
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          d="m 292.5,83.862183 v -1 h -12 v 14 h 12 v -1"
          id="path4640"
          sodipodi:nodetypes="cccccc"
@@ -4784,9 +4819,9 @@
          sodipodi:nodetypes="ccccc"
          id="path4647"
          d="m 315.50001,82.862183 h -10 v 11 h 10 z"
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1" />
       <path
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          d="m 318.50001,85.862183 h -10 v 11 h 10 z"
          id="path4645"
          sodipodi:nodetypes="ccccc"
@@ -4811,7 +4846,7 @@
        id="extract"
        inkscape:label="#g4666">
       <path
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1"
          d="m 292.5,83.862183 v -1 h -12 v 14 h 12 v -1"
          id="path4640-5"
          sodipodi:nodetypes="cccccc"
@@ -4867,18 +4902,18 @@
          id="cropWindow">
         <ellipse
            id="path4107"
-           style="opacity:0.35344831;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.353448;fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            cx="182.86104"
            cy="235.44888"
            rx="10.000001"
            ry="9.999999" />
         <path
-           style="fill:#a7a7a7;fill-opacity:0.99607843;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="fill:#a7a7a7;fill-opacity:0.996078;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            d="m 182.86104,225.44889 c -5.52285,0 -10,4.47715 -10,10 0,0.69036 0.0855,1.34902 0.21875,2 h 11.78125 v -11.8125 c -0.65057,-0.13304 -1.31013,-0.1875 -2,-0.1875 z"
            id="rect4109"
            inkscape:connector-curvature="0" />
         <rect
-           style="fill:none;stroke:#bb2b2b;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="fill:none;stroke:#bb2b2b;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect3319"
            width="13.999997"
            height="14"
@@ -4892,14 +4927,14 @@
         <g
            transform="translate(120.59619,-75.596198)"
            id="g4136"
-           style="opacity:0.66379311">
+           style="opacity:0.663793">
           <g
              transform="matrix(0.78155202,0,0,0.78155202,-82.582619,215.71206)"
              id="g5216"
-             style="opacity:0.71551723">
+             style="opacity:0.715517">
             <path
                id="path5125"
-               style="opacity:0.60344825;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27950537;stroke-opacity:1"
+               style="opacity:0.603448;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.27951;stroke-opacity:1"
                d="M 149.85406,152.50811 H 134.5 v 15.35407 l 15.35406,-1e-5 z"
                inkscape:connector-curvature="0"
                sodipodi:nodetypes="ccccc"
@@ -4937,7 +4972,7 @@
              inkscape:connector-curvature="0"
              id="path5182"
              d="m 29.50319,336.1243 6.524435,-4.49995 -6.5,-4 z"
-             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccc"
              inkscape:connector-curvature="0"
@@ -4952,7 +4987,7 @@
          transform="translate(-78.90381,1575.9038)">
         <g
            id="g5242"
-           style="opacity:0.70258622"
+           style="opacity:0.702586"
            transform="translate(4.5509813,97)">
           <path
              id="path5151"
@@ -5002,7 +5037,7 @@
              sodipodi:cx="117.14286"
              sodipodi:sides="3"
              id="path5232"
-             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              sodipodi:type="star" />
           <path
              style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -5017,7 +5052,7 @@
          id="g3402">
         <g
            id="g5259"
-           style="opacity:0.70689655"
+           style="opacity:0.706897"
            transform="translate(-0.380561,94.653783)">
           <path
              inkscape:transform-center-y="-2.5"
@@ -5025,7 +5060,7 @@
              sodipodi:nodetypes="ccccc"
              inkscape:connector-curvature="0"
              d="m 216,171.766 h -5 v 5 h 5 z"
-             style="opacity:0.56896548;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
+             style="opacity:0.568965;fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-opacity:1"
              id="path5153" />
           <path
              id="path5155"
@@ -5065,7 +5100,7 @@
            sodipodi:cx="117.14286"
            sodipodi:sides="3"
            id="path5255"
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149021;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.40149;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            sodipodi:type="star" />
         <path
            sodipodi:nodetypes="cccc"
@@ -5078,19 +5113,19 @@
          id="layer2"
          inkscape:label="spotlight">
         <path
-           style="fill:none;stroke:#efc618;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.99215686"
+           style="fill:none;stroke:#efc618;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.992157"
            d="m 222,1841.8622 10.5,-13.5 10.5,13.5"
            id="path6061"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccc" />
         <path
-           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 228.5,1840.8622 -6.5,4 6.52539,4.5 -0.0254,-3 h 7.96522 l 0.009,3 6.52539,-4.5 -6.5,-4 -0.0152,2.5 H 228.5 Z"
            id="path6000"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccccccccc" />
         <ellipse
-           style="fill:none;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#efc618;stroke-width:1.1381886;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+           style="fill:none;fill-opacity:0.992157;fill-rule:nonzero;stroke:#efc618;stroke-width:1.13819;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
            id="path5989"
            cx="232.5"
            cy="1842.3622"
@@ -5109,7 +5144,7 @@
              id="rect5222"
              transform="translate(0,52.362183)"
              d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.76159,0.53781 h -1.69536 c -1.662,0 -2.54305,1.30019 -2.54305,2.96219 v 7.19388 c 0,1.662 1.30489,2.53902 2.96689,2.53902 h 12.71523 c 1.662,0 2.96689,-0.87702 2.96689,-2.53902 V 203.5 c 0,-1.662 -0.88151,-2.92307 -2.54305,-2.96219 H 254.9106 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-             style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:#9b9b9b;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              inkscape:connector-curvature="0" />
           <ellipse
              ry="4.2313609"
@@ -5117,7 +5152,7 @@
              cy="258.82404"
              cx="249.82451"
              id="path5224"
-             style="fill:#2a2a2a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701049;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             style="fill:#2a2a2a;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.84701;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <ellipse
              ry="0.84633929"
              rx="0.84768224"
@@ -5157,7 +5192,7 @@
              sodipodi:cx="117.14286"
              sodipodi:sides="3"
              id="path5256"
-             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.7932142;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.79321;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              sodipodi:type="star" />
           <path
              style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
@@ -5176,16 +5211,16 @@
          inkscape:connector-curvature="0"
          id="path5997"
          d="m 296.97606,798.64087 -72.61352,21.46604 6.09529,88.5143 64.66314,39.48691 67.84329,-38.42686 6.0953,-89.30933 z"
-         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 224.3637,820.08758 72.27577,28.82424 72.49089,-28.60918 -72.27578,-21.72571 z"
          id="path5999"
          sodipodi:nodetypes="ccccc" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#000000;fill-opacity:0;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 230.38668,908.71144 -6.02298,-88.62386 72.27577,28.82424 -1.50574,99.16408 z"
          id="path6001"
          sodipodi:nodetypes="ccccc" />
@@ -5193,9 +5228,9 @@
          inkscape:connector-curvature="0"
          id="path6003"
          d="m 265.5,808.11218 65.5,25.75"
-         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
-         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.48;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m 265.5,808.11218 65.5,25.75"
          id="path6049"
          inkscape:connector-curvature="0" />
@@ -5209,15 +5244,15 @@
          inkscape:connector-curvature="0"
          id="path6017"
          d="m -193.51614,855.8158 3.97398,52.80541 64.66313,39.48691 67.84329,-38.42686 3.620426,-53.60044 m 2.331724,-35.97391 -71.94035,-21.46604 -72.61352,21.46604"
-         style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -123.36053,848.91182 -1.50574,99.16408"
          id="path6019"
          sodipodi:nodetypes="cc" />
       <path
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.48;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -141.78249,881.02344 18.42196,-32.11162 -72.27693,-28.80491 -18.00231,26.24957 z"
          id="path6023"
          inkscape:connector-curvature="0"
@@ -5227,11 +5262,11 @@
          inkscape:connector-curvature="0"
          id="path6025"
          d="m -104.93856,881.02344 -18.42197,-32.11162 72.27694,-28.80491 18.0023,26.24957 z"
-         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.47999954;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#e5e5e5;stroke-width:8.48;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
     <path
        sodipodi:type="star"
-       style="fill:#b6b6b6;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.49690738;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#b6b6b6;fill-opacity:1;fill-rule:nonzero;stroke:#262626;stroke-width:0.496907;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="bookmarkStar"
        sodipodi:sides="5"
        sodipodi:cx="298.875"
@@ -5248,7 +5283,7 @@
        inkscape:label="#path3064" />
     <path
        sodipodi:type="star"
-       style="fill:#efc618;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#262626;stroke-width:0.49683791;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#efc618;fill-opacity:0.992157;fill-rule:nonzero;stroke:#262626;stroke-width:0.496838;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="bookmarkStar2"
        sodipodi:sides="5"
        sodipodi:cx="298.875"
@@ -5266,13 +5301,13 @@
     <g
        id="g2745"
        inkscape:label="tab"
-       transform="translate(-32,2.9999999e-6)">
+       transform="translate(-32)">
       <path
          inkscape:connector-curvature="0"
          id="rect2127-3"
          transform="translate(0,52.362183)"
          d="m 306,1296 c -1.108,0 -2,0.892 -2,2 v 1 1.0254 V 1311 h 23 v -12 h -7 v -1 c 0,-1.108 -0.85684,-2 -1.96484,-2 z"
-         style="fill:url(#linearGradient2723);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#linearGradient2723);fill-opacity:1;stroke:none;stroke-width:0.935736;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:nodetypes="ssccccccsss" />
       <path
          style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
@@ -5289,10 +5324,10 @@
          inkscape:connector-curvature="0"
          id="path3271-4"
          d="m 410.75,205.36218 v 5 h -5 v 4 h 5 v 5 h 4 v -5 h 5 v -4 h -5 v -5 z"
-         style="fill:#737373;fill-opacity:0.7488152;fill-rule:nonzero;stroke:none"
+         style="fill:#737373;fill-opacity:0.748815;fill-rule:nonzero;stroke:none"
          sodipodi:nodetypes="ccccccccccccc" />
       <rect
-         style="fill:#ffffff;fill-opacity:0;stroke-width:1.46863997"
+         style="fill:#ffffff;fill-opacity:0;stroke-width:1.46864"
          id="deleteSmall"
          width="16.719854"
          height="12.727915"
@@ -5340,7 +5375,7 @@
     <path
        inkscape:connector-curvature="0"
        inkscape:label="#path3093"
-       style="fill:#9e9e9e;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99215686"
+       style="fill:#9e9e9e;fill-opacity:0.992157;fill-rule:nonzero;stroke:#3b3b3b;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
        d="m 494,150.86218 h -3.5 l 5,5.5 5,-5.5 H 497 v -7 h 3.5 l -5,-5.5 -5,5.5 h 3.5 z"
        id="reorderVertically"
        sodipodi:nodetypes="ccccccccccc" />
@@ -5348,7 +5383,7 @@
        inkscape:connector-curvature="0"
        id="circle2648"
        d="m 541,1343.3622 v 2.0605 a 9,9 0 0 0 -7.93359,7.9395 H 531 v 2 h 2.06055 A 9,9 0 0 0 541,1363.2958 v 2.0664 h 2 v -2.0605 a 9,9 0 0 0 7.93359,-7.9395 H 553 v -2 h -2.06055 A 9,9 0 0 0 543,1345.4286 v -2.0664 z m 0,4.0781 v 1.9219 h 2 v -1.9199 a 7,7 0 0 1 5.92188,5.9199 H 547 v 2 h 1.91992 A 7,7 0 0 1 543,1361.2841 v -1.9219 h -2 v 1.9199 a 7,7 0 0 1 -5.92188,-5.9199 H 537 v -2 h -1.91992 A 7,7 0 0 1 541,1347.4403 Z"
-       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="target" />
     <path
        style="opacity:1;fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill"
@@ -5358,7 +5393,7 @@
        inkscape:label="#pointerCrossHair" />
     <path
        inkscape:connector-curvature="0"
-       style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m -123.02344,798.64148 -72.61328,21.46484 -18.0039,26.25 20.14453,9.71875 3.95312,52.54688 64.66406,39.48632 67.843754,-38.42773 3.613281,-53.51172 20.339844,-9.8125 -18.001953,-26.25 z"
        id="path1560" />
     <path
@@ -5372,12 +5407,12 @@
        sodipodi:nodetypes="ccccccc"
        id="navigationArrow"
        d="m 456,112.36218 v 4 l 7,-6 -7,-6 v 4 c -5.5,0 -9.5,4.5 -9.5,4.5 0,0 6,-2 9.5,-0.5 z"
-       style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-linejoin:miter;stroke-opacity:0.99215686"
+       style="fill:url(#backgroundLighter);fill-opacity:0.992157;fill-rule:evenodd;stroke:#3c3c3c;stroke-linejoin:miter;stroke-opacity:0.992157"
        inkscape:connector-curvature="0" />
     <path
        id="editScopeNode"
        d="m -123.02344,798.64148 -72.61328,21.46484 -18.0039,26.25 20.14453,9.71875 3.95312,52.54688 64.66406,39.48632 67.843754,-38.42773 3.613281,-53.51172 20.339844,-9.8125 -18.001953,-26.25 z"
-       style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041153;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#e5e5e5;stroke-width:8.48041;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:connector-curvature="0"
        inkscape:label="#path1599" />
     <path
@@ -5399,7 +5434,7 @@
            sodipodi:nodetypes="cccccc"
            id="path2400"
            d="m 355.5,104.86218 h -6 l -6,6 v 6 h 12 z"
-           style="fill:url(#backgroundLight);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:142.99989319;stroke-opacity:1" />
+           style="fill:url(#backgroundLight);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:143;stroke-opacity:1" />
         <path
            style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 349.5,105.36218 v 5.5 H 344"
@@ -5559,7 +5594,7 @@
          id="g3278">
         <path
            sodipodi:nodetypes="ccccccccc"
-           style="opacity:1;fill:#818181;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+           style="opacity:1;fill:#818181;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
            d="m 426,45 v 4 h -10 v 1 h 10 v 4 h 1 v -9 z"
            transform="translate(0,52.362183)"
            id="rect3267"
@@ -5575,21 +5610,21 @@
            id="path3281"
            transform="translate(0,52.362183)"
            d="m 426,45 v 4 l -4,-2 v 2 h -6 v 1 h 6 v 2 l 4,-2 v 4 h 1 v -9 z"
-           style="opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="opacity:1;fill:#cccccc;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
       <path
          inkscape:label="interactiveComplete"
          inkscape:connector-curvature="0"
          id="3287"
          d="m 126.5,1609.3622 c -3.03164,0 -5.5,2.4683 -5.5,5.5 0,3.0316 2.46836,5.5 5.5,5.5 3.03164,0 5.5,-2.4684 5.5,-5.5 0,-3.0317 -2.46836,-5.5 -5.5,-5.5 z m 0,1 c 2.4912,0 4.5,2.0088 4.5,4.5 0,2.4912 -2.0088,4.5 -4.5,4.5 -2.4912,0 -4.5,-2.0088 -4.5,-4.5 0,-2.4912 2.0088,-4.5 4.5,-4.5 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#818181;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#818181;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
          inkscape:label="interactiveRunning"
          sodipodi:nodetypes="ssccscccsscscccsss"
          inkscape:connector-curvature="0"
          id="3219"
          d="m 109.5,1609.3622 c -3.03164,0 -5.5,2.4683 -5.5,5.5 0,0.9721 0.25638,1.8842 0.70117,2.6777 l 0.74805,-0.748 c -0.2791,-0.5864 -0.44922,-1.2353 -0.44922,-1.9297 0,-1.9618 1.24566,-3.6243 2.99162,-4.2424 l 1.00838,1.7424 3.17773,-2.2988 c -0.79347,-0.4448 -1.70561,-0.7012 -2.67773,-0.7012 z m 4.79883,2.8223 -0.74805,0.748 c 0.2791,0.5864 0.44922,1.2353 0.44922,1.9297 0,1.9685 -1.25432,3.6359 -3.00983,4.2488 L 110,1616.8622 l -3.17773,2.7988 c 0.79347,0.4448 1.70561,0.7012 2.67773,0.7012 3.03164,0 5.5,-2.4684 5.5,-5.5 0,-0.9721 -0.25638,-1.8843 -0.70117,-2.6777 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <g
          transform="translate(-398,-142)"
          style="display:inline"
@@ -5598,24 +5633,24 @@
            cx="545.5"
            cy="1756.8622"
            id="circle2086"
-           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515121;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            r="6.5065413" />
         <ellipse
            cx="545.5"
            cy="1756.8622"
            id="path2059"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            rx="5.9999995"
            ry="6.00003" />
         <g
            id="text2462"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66666698px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            aria-label="#">
           <path
              sodipodi:nodetypes="cccccccccccccccccccccccccccccccccc"
              inkscape:connector-curvature="0"
              id="path2464"
-             style="font-size:10.66666698px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              d="m 544,1758.3622 h -2 v -1 h 2 l -0.0104,-0.9995 -1.9896,-5e-4 v -1 h 1.99998 l 2e-5,-2 h 1 l -2e-5,2 H 546 l 2e-5,-2 h 1 l -2e-5,2 h 2 v 1 h -2 v 1 h 2 v 1 h -2 v 2 h -1 v -2 h -1 v 2 h -1 z m 1,-2 v 1 h 1 v -1 z" />
         </g>
       </g>
@@ -5625,7 +5660,7 @@
          id="g2140">
         <circle
            r="6.4999876"
-           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515121;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2061"
            cy="1756.8622"
            cx="562.5" />
@@ -5633,9 +5668,9 @@
            id="text2098"
            y="1760.3546"
            x="559.3783"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1760.3546"
              x="559.3783"
              id="tspan2096"
@@ -5657,10 +5692,10 @@
            cy="1756.8622"
            r="6.4597254"
            id="circle2063"
-           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="576.75281"
            y="1760.3546"
            id="text2108"><tspan
@@ -5668,18 +5703,18 @@
              id="tspan2106"
              x="576.75281"
              y="1760.3546"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">2</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">2</tspan></text>
         <circle
            cx="579.5"
            cy="1756.8622"
            r="5.99998"
            id="circle2106"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
       <g
          id="g2108">
         <circle
-           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974006;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2065"
            r="6.4857712"
            cy="1614.8622"
@@ -5688,15 +5723,15 @@
            id="text2212"
            y="1618.3546"
            x="195.75281"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1618.3546"
              x="195.75281"
              id="tspan2210"
              sodipodi:role="line">3</tspan></text>
         <circle
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2110"
            r="5.99998"
            cy="1614.8622"
@@ -5709,10 +5744,10 @@
            cy="1614.8622"
            r="6.4857712"
            id="circle2091"
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974006;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="263.75281"
            y="1618.3546"
            id="text2095"><tspan
@@ -5720,13 +5755,13 @@
              id="tspan2093"
              x="263.75281"
              y="1618.3546"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">3</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">3</tspan></text>
         <circle
            cx="266.5"
            cy="1614.8622"
            r="5.99998"
            id="circle2097"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
       <g
          transform="translate(-398,-142)"
@@ -5737,10 +5772,10 @@
            cy="1756.8622"
            r="6.4597254"
            id="circle2067"
-           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="609.83856"
            y="1760.3622"
            id="text2358"><tspan
@@ -5748,13 +5783,13 @@
              id="tspan2356"
              x="609.83856"
              y="1760.3622"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">4</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">4</tspan></text>
         <circle
            cx="613.5"
            cy="1756.8622"
            r="5.99998"
            id="circle2114"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
       <g
          id="g2078"
@@ -5764,11 +5799,11 @@
            cx="562.5"
            cy="1756.8622"
            id="circle2070"
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515121;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            r="6.4999876" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="559.3783"
            y="1760.3546"
            id="text2074"><tspan
@@ -5776,7 +5811,7 @@
              id="tspan2072"
              x="559.3783"
              y="1760.3546"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">1</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">1</tspan></text>
         <ellipse
            ry="6.0000157"
            rx="5.9999995"
@@ -5790,7 +5825,7 @@
          style="display:inline"
          transform="translate(-330,-142)">
         <circle
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2080"
            r="6.4597254"
            cy="1756.8622"
@@ -5799,15 +5834,15 @@
            id="text2084"
            y="1760.3546"
            x="576.75281"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1760.3546"
              x="576.75281"
              id="tspan2082"
              sodipodi:role="line">2</tspan></text>
         <circle
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2087"
            r="5.99998"
            cy="1756.8622"
@@ -5818,7 +5853,7 @@
          style="display:inline"
          transform="translate(-330,-142)">
         <circle
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2099"
            r="6.4597254"
            cy="1756.8622"
@@ -5827,15 +5862,15 @@
            id="text2103"
            y="1760.3622"
            x="609.83856"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1760.3622"
              x="609.83856"
              id="tspan2101"
              sodipodi:role="line">4</tspan></text>
         <circle
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2105"
            r="5.99998"
            cy="1756.8622"
@@ -5844,9 +5879,9 @@
       <g
          id="g2119"
          transform="translate(68)"
-         style="opacity:0.64299999">
+         style="opacity:0.643">
         <circle
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974006;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68974;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2111"
            r="6.4857712"
            cy="1614.8622"
@@ -5855,15 +5890,15 @@
            id="text2115"
            y="1618.3546"
            x="263.75281"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1618.3546"
              x="263.75281"
              id="tspan2113"
              sodipodi:role="line">3</tspan></text>
         <circle
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2117"
            r="5.99998"
            cy="1614.8622"
@@ -5871,11 +5906,11 @@
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.64299999"
+         style="display:inline;opacity:0.643"
          id="g2129">
         <circle
            r="6.4999876"
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515121;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69515;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="circle2121"
            cy="1756.8622"
            cx="562.5" />
@@ -5883,9 +5918,9 @@
            id="text2125"
            y="1760.3546"
            x="559.3783"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1"
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1"
              y="1760.3546"
              x="559.3783"
              id="tspan2123"
@@ -5900,17 +5935,17 @@
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.64299999"
+         style="display:inline;opacity:0.643"
          id="g2139">
         <circle
            cx="579.5"
            cy="1756.8622"
            r="6.4597254"
            id="circle2131"
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="576.75281"
            y="1760.3546"
            id="text2135"><tspan
@@ -5918,27 +5953,27 @@
              id="tspan2133"
              x="576.75281"
              y="1760.3546"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">2</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">2</tspan></text>
         <circle
            cx="579.5"
            cy="1756.8622"
            r="5.99998"
            id="circle2137"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
       <g
          transform="translate(-262,-142)"
-         style="display:inline;opacity:0.64299999"
+         style="display:inline;opacity:0.643"
          id="g2149">
         <circle
            cx="613.5"
            cy="1756.8622"
            r="6.4597254"
            id="circle2141"
-           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295431;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.68295;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.66670036px;line-height:100.40000677%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:100.4%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="609.83856"
            y="1760.3622"
            id="text2145"><tspan
@@ -5946,13 +5981,13 @@
              id="tspan2143"
              x="609.83856"
              y="1760.3622"
-             style="font-size:10.66670036px;line-height:10.00000015%;fill:#ffffff;fill-opacity:1">4</tspan></text>
+             style="font-size:10.6667px;line-height:10%;fill:#ffffff;fill-opacity:1">4</tspan></text>
         <circle
            cx="613.5"
            cy="1756.8622"
            r="5.99998"
            id="circle2147"
-           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+           style="display:inline;opacity:1;fill:none;fill-opacity:0;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       </g>
     </g>
     <g
@@ -5969,21 +6004,21 @@
            height="16.999998"
            width="24.999998"
            id="rect2692"
-           style="fill:url(#linearGradient2704);fill-opacity:1;stroke:none;stroke-width:1.03047383;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:url(#linearGradient2704);fill-opacity:1;stroke:none;stroke-width:1.03047;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
            y="74.69854"
            x="460.86862"
            height="4.0000863"
            width="25.000004"
            id="rect2694"
-           style="fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:0.90991908;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:0.909919;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <path
          inkscape:connector-curvature="0"
          id="rect2698"
          transform="translate(0,52.362183)"
          d="m 341.98242,1295.9863 c -1.108,0 -2,0.892 -2,2 v 1 1.0274 10.9746 h 23 v -12.002 l -6.99983,9e-4 v -1 c 0,-1.108 -0.85701,-2.0009 -1.96501,-2.0009 z"
-         style="fill:url(#linearGradient2706);fill-opacity:1;stroke:none;stroke-width:0.9357363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:url(#linearGradient2706);fill-opacity:1;stroke:none;stroke-width:0.935736;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:nodetypes="ssccccccsss" />
       <path
          sodipodi:nodetypes="ccccccccc"
@@ -6055,7 +6090,7 @@
                inkscape:connector-curvature="0"
                id="rect4067-8"
                d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
-               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
             <path
                style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
                d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
@@ -6146,7 +6181,7 @@
                inkscape:connector-curvature="0"
                sodipodi:nodetypes="ccccc" />
             <path
-               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
                d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
                id="path3050"
                inkscape:connector-curvature="0"
@@ -6250,7 +6285,7 @@
                inkscape:connector-curvature="0"
                id="path3068"
                d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
-               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
             <path
                style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
                d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
@@ -6306,7 +6341,7 @@
                inkscape:connector-curvature="0"
                sodipodi:nodetypes="ccccc" />
             <path
-               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
                d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
                id="path2032"
                inkscape:connector-curvature="0"
@@ -6328,6 +6363,73 @@
              style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal"
              d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
              id="path2040"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccccccc" />
+        </g>
+      </g>
+      <g
+         style="paint-order:stroke fill markers"
+         inkscape:label="targetObjects"
+         id="g1664"
+         transform="translate(68,40)">
+        <g
+           style="display:inline;paint-order:stroke fill markers"
+           id="g1662"
+           inkscape:label="objects"
+           transform="translate(-107,1371)">
+          <g
+             transform="translate(-21.93011,50.751613)"
+             style="opacity:0.5;paint-order:stroke fill markers"
+             inkscape:label="#g4081"
+             id="g1655">
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.93011,76.11057 6,12 h -12 z"
+               id="path1645"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="cccc" />
+            <circle
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+               id="circle1647"
+               cx="384.93011"
+               cy="88.610573"
+               r="5.9999995" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 386.43011,87.610588 6,3 v 9.500002 l -6,-3.500002 z"
+               id="path1649"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke"
+               d="m 392.43011,90.110588 8,-1.5 v 9 l -8,2.500002 z"
+               id="path1651"
+               inkscape:connector-curvature="0"
+               sodipodi:nodetypes="ccccc" />
+            <path
+               sodipodi:nodetypes="ccccc"
+               inkscape:connector-curvature="0"
+               id="path1653"
+               d="m 386.43011,87.610588 6,3 8,-2 -6,-2.5 z"
+               style="fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;paint-order:markers fill stroke" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path3266"
+             d="M 356.00325,144.36218 356,146.39244 c -2.0797,0.2357 -3.72049,1.88308 -3.95388,3.96975 L 350,150.36218 v 0.99999 l 2.04321,1e-5 c 0.23492,2.0865 1.87692,3.73265 3.95679,3.96682 l 0.003,2.03318 H 357 l -0.003,-2.03025 c 2.07969,-0.23572 3.72046,-1.88309 3.95385,-3.96975 l 2.0494,-1e-5 v -0.99999 l -2.04646,1e-5 c -0.23493,-2.08649 -1.87693,-3.73264 -3.95679,-3.9668 L 357,144.36218 Z M 356,147.40125 v 0.96093 h 0.99675 v -0.95994 c 1.52835,0.2225 2.729,1.42668 2.95129,2.95995 h -0.95781 v 0.99999 h 0.95682 c -0.22177,1.53335 -1.42202,2.73794 -2.9503,2.96096 v -0.96095 H 356 v 0.95995 c -1.52836,-0.2225 -2.72902,-1.42668 -2.9513,-2.95996 h 0.95781 v -0.99999 h -0.95684 c 0.22178,-1.53335 1.42204,-2.73793 2.95033,-2.96094 z"
+             style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
+             inkscape:label="target"
+             sodipodi:nodetypes="cccccccccccccccccccccccccccccccccc" />
+          <path
+             sodipodi:nodetypes="ccccccccc"
+             inkscape:connector-curvature="0"
+             id="path1657"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:stroke fill markers" />
+          <path
+             style="fill:#000000;fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;paint-order:normal"
+             d="m 374.5,154.36218 v -14.5 l 10,11 h -4 l 2,3.5 v 2.5 H 380 l -2.5,-5 z"
+             id="path1660"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccccc" />
         </g>
@@ -6360,45 +6462,45 @@
            style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <circle
            id="path4283"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            cx="61.679062"
            cy="165.94629"
            r="1.5" />
         <circle
            inkscape:transform-center-y="0.31250001"
            inkscape:transform-center-x="0.12500001"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            id="path4285"
            cx="78.679062"
            cy="165.94629"
            r="1.5" />
         <circle
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            id="path4289"
            cx="78.179062"
            cy="176.44629"
            r="1.5" />
         <circle
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            id="path4291"
            cx="70.179062"
            cy="163.44629"
            r="1.5" />
         <circle
            id="path4297"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            cx="70.179062"
            cy="180.94629"
            r="1.5" />
         <circle
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            id="path4299"
            cx="62.179062"
            cy="176.44629"
            r="1.5" />
         <circle
            id="path4301"
-           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931081"
+           style="fill:#3c3c3c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.66931"
            cx="70.179062"
            cy="169.44629"
            r="1.5" />
@@ -6449,7 +6551,7 @@
            inkscape:connector-curvature="0"
            id="path3246"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          inkscape:label="cameraOff"
@@ -6461,13 +6563,13 @@
            id="path5277"
            transform="translate(0,52.362183)"
            d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.70271,0.55404 H 243.5 c -1.662,0 -3.02703,1.36503 -3.02703,3.02703 v 6.91892 c 0,1.662 1.36502,3.02702 3.02703,3.02702 l 12.97297,-1e-5 c 1.662,0 3.02703,-1.36501 3.02703,-3.02701 v -6.91892 c -10e-6,-1.662 -1.36503,-3.02704 -3.02703,-3.02704 h -1.2973 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
-           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <circle
            r="4.3243241"
            cy="258.97028"
            cx="249.98648"
            id="ellipse5279"
-           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486495;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <circle
            r="0.86486489"
            cy="257.24054"
@@ -6508,12 +6610,12 @@
              inkscape:connector-curvature="0" />
         </g>
         <g
-           style="stroke-width:0.98703074"
+           style="stroke-width:0.987031"
            id="g4789"
            transform="matrix(0.58611117,0,0,0.58607293,193.6632,75.501411)">
           <ellipse
              id="path4780"
-             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70621657;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:#787878;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70622;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              inkscape:label="#path3352"
              cx="-40"
              cy="172.36218"
@@ -6521,7 +6623,7 @@
              ry="8.5310841" />
           <path
              inkscape:connector-curvature="0"
-             style="fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:0.98703074"
+             style="fill:#aaaaaa;fill-opacity:1;stroke:none;stroke-width:0.987031"
              d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
              id="path4782"
              sodipodi:nodetypes="csssc" />
@@ -6538,14 +6640,14 @@
          transform="matrix(1.15625,0,0,1.15625,-88.546872,1388.4278)"
          inkscape:label="cameraOn">
         <path
-           style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486483;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 247.5,198 c -1.108,0 -1.21653,1.21652 -2,2 l -0.70271,0.55404 H 243.5 c -1.662,0 -3.02703,1.36503 -3.02703,3.02703 v 6.91892 c 0,1.662 1.36502,3.02702 3.02703,3.02702 l 12.97297,-1e-5 c 1.662,0 3.02703,-1.36501 3.02703,-3.02701 v -6.91892 c -10e-6,-1.662 -1.36503,-3.02704 -3.02703,-3.02704 h -1.2973 L 254.5,200 c -0.78347,-0.78348 -0.892,-2 -2,-2 z"
            transform="translate(0,52.362183)"
            id="path2693"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="sccssssssssccss" />
         <circle
-           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.86486495;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#494949;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.864865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="circle2695"
            cx="249.98648"
            cy="258.97028"
@@ -6592,10 +6694,10 @@
         <g
            transform="matrix(0.58611117,0,0,0.58607293,193.6632,75.501411)"
            id="g2759"
-           style="stroke-width:0.98703074">
+           style="stroke-width:0.987031">
           <ellipse
              inkscape:label="#path3352"
-             style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70621657;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.70622;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="path2755"
              cx="-40"
              cy="172.36218"
@@ -6605,7 +6707,7 @@
              sodipodi:nodetypes="csssc"
              id="path2757"
              d="m -42.555019,168.57203 c -2.092886,1.37871 -2.641656,4.33859 -3.535981,3.1401 -0.894324,-1.19849 0.405111,-3.97228 1.59811,-4.87074 1.192994,-0.89844 4.11797,-1.89376 5.012295,-0.69526 0.894325,1.19848 -1.122142,0.79291 -3.074424,2.4259 z"
-             style="fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:0.98703074"
+             style="fill:#f4f4f4;fill-opacity:1;stroke:none;stroke-width:0.987031"
              inkscape:connector-curvature="0" />
         </g>
         <path
@@ -6653,7 +6755,7 @@
            style="fill:url(#greyedOut);fill-opacity:1"
            id="g4083">
           <g
-             style="fill:url(#greyedOut);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:url(#greyedOut);fill-opacity:1;stroke:#424242;stroke-width:0.842105;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
              id="g4052">
             <path
@@ -6661,7 +6763,7 @@
                inkscape:connector-curvature="0"
                id="path4041"
                d="m 203.5,184.70428 v 15.15789 h -15.15789 c 9.30458,-2.50716 12.79805,-4.98879 15.15789,-15.15789 z"
-               style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+               style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.842105;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           </g>
         </g>
       </g>
@@ -6670,7 +6772,7 @@
          transform="translate(-10.756168,1590.2548)"
          inkscape:label="exposureOn">
         <circle
-           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path3268"
            transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
            cx="187.11813"
@@ -6681,42 +6783,42 @@
            transform="matrix(1.2656733,0,0,1.2656392,-25.214957,-45.037563)"
            id="g3270">
           <path
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="1.2504885"
              d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
              id="path3272"
              inkscape:connector-curvature="0" />
           <path
              transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)"
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.92746;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="-1.25049"
              d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
              id="path3274"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccc" />
           <path
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="1.2504999"
              d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
              id="path3276"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccc" />
           <path
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="-1.2505016"
              d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
              id="path3278"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccc" />
           <path
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="1.2504858"
              d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
              id="path3280"
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="ccccccc" />
           <path
-             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              inkscape:transform-center-x="-1.2504877"
              d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
              id="path3282"
@@ -6738,7 +6840,7 @@
         <circle
            transform="matrix(0.11101843,0,0,0.11047078,70.600104,153.24998)"
            id="path2954"
-           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:9.02981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            cx="187.11813"
            cy="174.54121"
            r="33.499184" />
@@ -6751,14 +6853,14 @@
              id="path2956"
              d="m 99.597353,169.77492 v 8.58228 l -7.502966,-4.29114 z"
              inkscape:transform-center-x="1.2504885"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccccccc"
              inkscape:connector-curvature="0"
              id="path2958"
              d="m 268.97293,130.27541 v 31.94918 l -27.6688,-15.97459 6.9172,-3.99365 6.9172,-3.99365 6.9172,-3.99364 z"
              inkscape:transform-center-x="-1.25049"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.9274621;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:2.92746;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
              transform="matrix(0.13558531,-0.23263436,0.23484065,0.13431151,26.907388,209.48587)" />
           <path
              sodipodi:nodetypes="ccccccc"
@@ -6766,28 +6868,28 @@
              id="path2960"
              d="m 86.467162,166.55658 7.502966,-4.29115 v 8.58229 l -1.875741,-1.07279 -1.875742,-1.07278 -1.875741,-1.07279 z"
              inkscape:transform-center-x="1.2504999"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccccccc"
              inkscape:connector-curvature="0"
              id="path2962"
              d="m 84.591421,174.06607 v -8.58228 l 7.502966,4.29114 -1.875741,1.07278 -1.875742,1.07279 -1.875742,1.07279 z"
              inkscape:transform-center-x="-1.2505016"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccccccc"
              inkscape:connector-curvature="0"
              id="path2964"
              d="m 90.218646,179.42999 -7.502966,-4.29114 7.502966,-4.29114 v 2.14557 2.14557 2.14557 z"
              inkscape:transform-center-x="1.2504858"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="ccccccc"
              inkscape:connector-curvature="0"
              id="path2966"
              d="m 97.721612,177.28442 -7.502966,4.29114 v -8.58228 l 1.875741,1.07278 1.875742,1.07279 1.875741,1.07278 z"
              inkscape:transform-center-x="-1.2504877"
-             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.79010391;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+             style="fill:url(#greyedOut);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.790104;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
         </g>
         <circle
            style="fill:none;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -6812,9 +6914,9 @@
           <g
              id="g2994"
              transform="matrix(1.1875,0,0,1.1875007,-37.15625,-35.474284)"
-             style="fill:url(#foreground);fill-opacity:1;stroke:#424242;stroke-width:0.84210503;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+             style="fill:url(#foreground);fill-opacity:1;stroke:#424242;stroke-width:0.842105;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
             <path
-               style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.84210503;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               style="fill:url(#foreground);fill-opacity:1;fill-rule:evenodd;stroke:#3c3c3c;stroke-width:0.842105;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
                d="m 203.5,184.70428 v 15.15789 h -15.15789 c 9.30458,-2.50716 12.79805,-4.98879 15.15789,-15.15789 z"
                id="path2992"
                inkscape:connector-curvature="0"
@@ -6849,9 +6951,9 @@
            height="17.969265"
            width="6"
            id="rect4860"
-           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4862"
            width="6"
            height="17.969296"
@@ -6863,9 +6965,9 @@
            height="17.969296"
            width="6"
            id="rect4864"
-           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4866"
            width="6"
            height="17.969265"
@@ -6894,14 +6996,14 @@
          inkscape:label="soloChannel0"
          transform="translate(-36,1569.9707)">
         <rect
-           style="opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.41499996;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.415;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="rect1853"
            width="25"
            height="19"
            x="290"
            y="183.39149" />
         <rect
-           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#823631;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3042"
            width="6"
            height="17.969265"
@@ -6913,9 +7015,9 @@
            height="17.969296"
            width="6"
            id="rect3044"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3046"
            width="6"
            height="17.969296"
@@ -6927,14 +7029,14 @@
            height="17.969265"
            width="6"
            id="rect3048"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          transform="translate(-7,1569.9707)"
          inkscape:label="soloChannel1"
          id="g3062">
         <rect
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.41499996;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.415;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="rect1853-9"
            width="25"
            height="19"
@@ -6946,9 +7048,9 @@
            height="17.969265"
            width="6"
            id="rect3054"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#449645;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3056"
            width="6"
            height="17.969296"
@@ -6960,9 +7062,9 @@
            height="17.969296"
            width="6"
            id="rect3058"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3060"
            width="6"
            height="17.969265"
@@ -6974,14 +7076,14 @@
          inkscape:label="soloChannel2"
          transform="translate(22,1569.9707)">
         <rect
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.41499996;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.415;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="rect1853-8"
            width="25"
            height="19"
            x="290"
            y="183.39149" />
         <rect
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3066"
            width="6"
            height="17.969265"
@@ -6993,9 +7095,9 @@
            height="17.969296"
            width="6"
            id="rect3068"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#4a5ebd;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3070"
            width="6"
            height="17.969296"
@@ -7007,21 +7109,21 @@
            height="17.969265"
            width="6"
            id="rect3072"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          transform="translate(51,1569.9861)"
          inkscape:label="soloChannel3"
          id="g3086">
         <rect
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.41499996;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.415;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="rect1853-1"
            width="25"
            height="19"
            x="290"
            y="183.3761" />
         <rect
-           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#c6c6c6;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3084"
            width="6"
            height="17.969265"
@@ -7033,9 +7135,9 @@
            height="17.969265"
            width="6"
            id="rect3078"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3080"
            width="6"
            height="17.969296"
@@ -7047,7 +7149,7 @@
            height="17.969296"
            width="6"
            id="rect3082"
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          style="display:inline"
@@ -7055,7 +7157,7 @@
          inkscape:label="soloChannel-2"
          id="g4322-0">
         <rect
-           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.41499996;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           style="display:inline;opacity:1;fill:#000000;fill-opacity:0.00392157;fill-rule:nonzero;stroke:none;stroke-width:1.415;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
            id="rect1853-14"
            width="25"
            height="19"
@@ -7067,9 +7169,9 @@
            height="17.969265"
            width="6"
            id="rect4860-9"
-           style="fill:#505050;fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#505050;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:#848484;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#848484;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4862-7"
            width="6"
            height="17.969296"
@@ -7081,9 +7183,9 @@
            height="17.969296"
            width="6"
            id="rect4864-4"
-           style="fill:#3f4043;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#3f4043;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
-           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00000024;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4866-0"
            width="6"
            height="17.969265"
@@ -7100,10 +7202,10 @@
          sodipodi:nodetypes="cccccccc"
          id="p3423"
          d="m 31,1904.8622 h 3.5 c 1,0 1,2 1,2 h 5 v 8 h -11 v -8 c 0,0 0.3125,-2.125 1.5,-2 z"
-         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686" />
+         style="fill:url(#backgroundLighter);fill-opacity:0.992157;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.992157" />
       <path
          inkscape:connector-curvature="0"
-         style="fill:url(#backgroundLighter);fill-opacity:0.99215686;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.99215686"
+         style="fill:url(#backgroundLighter);fill-opacity:0.992157;fill-rule:evenodd;stroke:#3c3c3c;stroke-opacity:0.992157"
          d="m 50,1915.3622 v -4.5 h -3 l 6,-7 6,7 h -3 v 4.5"
          id="rect2859"
          sodipodi:nodetypes="ccccccc"
@@ -7140,21 +7242,21 @@
          inkscape:connector-curvature="0"
          id="rect3268"
          d="m 101.5,1904.8624 h 5 v 4 l 3,2e-4 v 3.9686 l 3,0.031 v 1.9688 h -5 v -3.9686 l -3,-2e-4 v -4 h -3 z"
-         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
+         style="fill:url(#backgroundLighter);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
       <path
          inkscape:label="bookmarks"
          sodipodi:nodetypes="ccccccccccc"
          inkscape:connector-curvature="0"
          id="3604"
          d="m 302.30329,18.508217 -3.42247,-2.655261 -3.42248,2.655261 1.28343,-3.982892 -3.42248,-2.655261 h 4.2781 l 1.28343,-3.9828915 1.28342,3.9828915 h 4.2781 l -3.42248,2.655261 z"
-         style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.87022853;stroke-linejoin:round;stroke-opacity:1"
+         style="fill:url(#backgroundLighter);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:0.870229;stroke-linejoin:round;stroke-opacity:1"
          transform="matrix(1.1687441,0,0,1.1298324,-224.31519,1894.451)" />
       <path
          inkscape:label="refresh"
          inkscape:connector-curvature="0"
          id="circle3363"
          d="m 70,1904.3622 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 v -2 a 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 3,3 0 0 1 3,3 h -2 l 3,4.5 3,-4.5 h -2 a 5,5 0 0 0 -5,-5 z"
-         style="opacity:1;fill:#9f9f9f;fill-opacity:0.97647059;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers" />
+         style="opacity:1;fill:#9f9f9f;fill-opacity:0.976471;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers" />
     </g>
     <g
        id="g2000"
@@ -7165,9 +7267,9 @@
         <g
            id="g5812"
            transform="matrix(0.99838132,0,0,0.99992227,-74.831121,1917.0046)"
-           style="stroke-width:1.00084925">
+           style="stroke-width:1.00085">
           <rect
-             style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00084925"
+             style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00085"
              ry="2"
              rx="2"
              y="59.362183"
@@ -7180,7 +7282,7 @@
              inkscape:connector-curvature="0"
              id="path5796"
              d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
-             style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         </g>
         <path
            style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -7192,9 +7294,9 @@
          inkscape:label="checkBoxUnchecked"
          id="g5812-5"
          transform="matrix(0.99838132,0,0,0.99992227,-22.859175,1917.0046)"
-         style="display:inline;stroke-width:1.00084925">
+         style="display:inline;stroke-width:1.00085">
         <rect
-           style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00084925"
+           style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00085"
            ry="2"
            rx="2"
            y="59.362183"
@@ -7207,13 +7309,13 @@
            inkscape:connector-curvature="0"
            id="path5796-2"
            d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
-           style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          id="g1918"
          transform="translate(103.98811,-0.06748539)">
         <g
-           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00084925"
+           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00085"
            transform="matrix(0.99838132,0,0,0.99992227,-74.347282,1916.5721)"
            id="g1914">
           <rect
@@ -7224,9 +7326,9 @@
              y="59.362183"
              rx="2"
              ry="2"
-             style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00084925" />
+             style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00085" />
           <path
-             style="fill:url(#brightColor);fill-opacity:1;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:url(#brightColor);fill-opacity:1;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
              id="path1912"
              inkscape:connector-curvature="0"
@@ -7239,7 +7341,7 @@
            style="fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
-         style="display:inline;stroke-width:1.00084925"
+         style="display:inline;stroke-width:1.00085"
          transform="matrix(0.99838132,0,0,0.99992227,53.156979,1916.9371)"
          id="g1924"
          inkscape:label="checkBoxUnchecked">
@@ -7251,9 +7353,9 @@
            y="59.362183"
            rx="2"
            ry="2"
-           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00084925" />
+           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00085" />
         <path
-           style="fill:none;stroke:#000000;stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.11764706"
+           style="fill:none;stroke:#000000;stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.117647"
            d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
            id="path1922"
            inkscape:connector-curvature="0"
@@ -7265,9 +7367,9 @@
         <g
            id="g1944"
            transform="matrix(0.99838132,0,0,0.99992227,-74.831121,1917.0046)"
-           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925">
+           style="fill:#000000;fill-opacity:0.117647;stroke-width:1.00085">
           <rect
-             style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925"
+             style="fill:#000000;fill-opacity:0.117647;stroke-width:1.00085"
              ry="2"
              rx="2"
              y="59.362183"
@@ -7277,7 +7379,7 @@
              id="rect1940" />
         </g>
         <path
-           style="fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#666666;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 15.646247,1992.8061 c -0.407839,-0.102 -0.652607,-0.3355 -1.238876,-1.1815 -0.620662,-0.8957 -1.262438,-1.7064 -1.914532,-2.4183 -0.496172,-0.5416 -0.865209,-1.079 -0.947644,-1.3798 -0.180586,-0.6589 0.376927,-1.4515 1.368445,-1.9456 0.44508,-0.2218 0.518292,-0.2397 0.98176,-0.2397 0.470009,0 0.532945,0.016 1.023045,0.2601 0.562407,0.2801 1.298583,0.8974 1.723594,1.4449 0.129065,0.1662 0.251534,0.3023 0.272143,0.3023 0.02058,0 0.155261,-0.2552 0.299241,-0.5671 0.317988,-0.6889 1.634406,-3.1097 2.184199,-4.0165 2.038801,-3.3635 4.291526,-6.1556 5.371174,-6.6575 0.403951,-0.1877 1.265682,-0.3556 2.257968,-0.4399 0.692795,-0.058 0.773381,-0.054 1.017219,0.05 0.174182,0.076 0.300853,0.1835 0.370073,0.3151 0.120856,0.2295 0.131909,0.6315 0.02307,0.8378 -0.04104,0.077 -0.491449,0.559 -1.001014,1.0698 -1.395263,1.3987 -2.172852,2.3393 -3.408058,4.122 -1.648424,2.3793 -3.015124,4.8368 -4.210168,7.5702 -0.916834,2.0971 -0.928827,2.1216 -1.165927,2.3795 -0.118599,0.1289 -0.359481,0.2965 -0.53531,0.3724 -0.283019,0.1223 -0.431569,0.14 -1.295489,0.1544 -0.536699,0.01 -1.065407,-0.01 -1.174908,-0.034 z"
            id="path1946"
            inkscape:connector-curvature="0" />
@@ -7286,9 +7388,9 @@
          inkscape:label="checkBoxUnchecked"
          id="g1954"
          transform="matrix(0.99838132,0,0,0.99992227,129.14083,1917.0046)"
-         style="display:inline;stroke-width:1.00084925">
+         style="display:inline;stroke-width:1.00085">
         <rect
-           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925"
+           style="fill:#000000;fill-opacity:0.117647;stroke-width:1.00085"
            ry="2"
            rx="2"
            y="59.362183"
@@ -7298,7 +7400,7 @@
            id="rect1950" />
       </g>
       <g
-         style="display:inline;stroke-width:1.00084925"
+         style="display:inline;stroke-width:1.00085"
          transform="matrix(0.99838132,0,0,0.99992227,1.166724,1917.0046)"
          id="g6499"
          inkscape:label="checkBoxUnchecked">
@@ -7310,15 +7412,15 @@
            y="59.362183"
            rx="2"
            ry="2"
-           style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00084925" />
+           style="fill:url(#backgroundLight);fill-opacity:1;stroke-width:1.00085" />
         <path
-           style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:url(#backgroundLightLowlight-5);stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
            id="path6497"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="cccc" />
         <rect
-           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00085;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
            id="rect1642"
            width="11.017835"
            height="3.0002327"
@@ -7331,9 +7433,9 @@
          inkscape:label="checkBoxUnchecked"
          id="g6509"
          transform="matrix(0.99838132,0,0,0.99992227,77.140825,1917.0046)"
-         style="display:inline;stroke-width:1.00084925">
+         style="display:inline;stroke-width:1.00085">
         <rect
-           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00084925"
+           style="fill:url(#brightColor);fill-opacity:1;stroke-width:1.00085"
            ry="2"
            rx="2"
            y="59.362183"
@@ -7346,9 +7448,9 @@
            inkscape:connector-curvature="0"
            id="path6507"
            d="M 89.504053,74.863419 H 101.0227 c 0.87409,0 1.50243,-0.579195 1.50243,-1.500116 V 61.862409"
-           style="fill:none;stroke:#000000;stroke-width:1.00242543;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.11764706" />
+           style="fill:none;stroke:#000000;stroke-width:1.00243;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.117647" />
         <rect
-           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#3c3c3c;stroke-width:1.00085;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
            id="rect1642-9"
            width="11.017835"
            height="3.0002327"
@@ -7358,7 +7460,7 @@
            ry="1.0000777" />
       </g>
       <g
-         style="display:inline;stroke-width:1.00084925"
+         style="display:inline;stroke-width:1.00085"
          transform="matrix(0.99838132,0,0,0.99992227,153.14083,1917.0046)"
          id="g6515"
          inkscape:label="checkBoxUnchecked">
@@ -7370,9 +7472,9 @@
            y="59.362183"
            rx="2"
            ry="2"
-           style="fill:#000000;fill-opacity:0.11764706;stroke-width:1.00084925" />
+           style="fill:#000000;fill-opacity:0.117647;stroke-width:1.00085" />
         <rect
-           style="display:inline;opacity:1;fill:#666666;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00084913;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+           style="display:inline;opacity:1;fill:#666666;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00085;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
            id="rect1642-99"
            width="11.017835"
            height="3.0002327"
@@ -7399,7 +7501,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.99;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect3875-3-9"
            width="8"
            height="15"
@@ -7429,7 +7531,7 @@
            height="15"
            width="8"
            id="rect2078"
-           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="opacity:0.99;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          inkscape:label="toglleOnHover"
@@ -7452,7 +7554,7 @@
            height="15"
            width="8"
            id="rect2090"
-           style="opacity:0.98999999;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="opacity:0.99;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          inkscape:label="toggleOffHover"
@@ -7468,7 +7570,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.99;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect2096"
            width="8"
            height="15"
@@ -7482,7 +7584,7 @@
          transform="matrix(-1,0,0,1,350,1939)"
          id="234234234">
         <rect
-           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#000000;fill-opacity:0.117647;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect2100"
            width="15"
            height="15"
@@ -7491,7 +7593,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.99;fill:#787878;fill-opacity:0.501961;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect2102"
            width="8"
            height="15"
@@ -7512,7 +7614,7 @@
            height="15"
            width="15"
            id="rect2106"
-           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:#000000;fill-opacity:0.117647;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
         <rect
            ry="2.5"
            rx="2.5"
@@ -7521,7 +7623,7 @@
            height="15"
            width="8"
            id="rect2108"
-           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="opacity:0.99;fill:#787878;fill-opacity:0.501961;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          inkscape:label="toggleIndeterminate"
@@ -7537,7 +7639,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.99;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect6467"
            width="7"
            height="11"
@@ -7567,14 +7669,14 @@
            height="11"
            width="7"
            id="rect6473"
-           style="opacity:0.98999999;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="opacity:0.99;fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          transform="matrix(-1,0,0,1,390,1939)"
          id="g6483"
          inkscape:label="toggleIndeterminateDisabled">
         <rect
-           style="fill:#000000;fill-opacity:0.11764706;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:#000000;fill-opacity:0.117647;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect6479"
            width="15"
            height="15"
@@ -7583,7 +7685,7 @@
            rx="2.5"
            ry="2.5" />
         <rect
-           style="opacity:0.98999999;fill:#787878;fill-opacity:0.50196078;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:0.99;fill:#787878;fill-opacity:0.501961;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect6481"
            width="7"
            height="11"
@@ -7604,7 +7706,7 @@
          style="fill:url(#foreground)">
         <path
            id="path1177"
-           style="fill:url(#foreground);stroke:url(#focusMenuBorder);stroke-width:1.33541918;stroke-miterlimit:1.5;stroke-dasharray:none"
+           style="fill:url(#foreground);stroke:url(#focusMenuBorder);stroke-width:1.33542;stroke-miterlimit:1.5;stroke-dasharray:none"
            d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
            inkscape:connector-curvature="0" />
       </g>
@@ -7614,7 +7716,7 @@
          style="fill:url(#foreground)">
         <path
            id="path1181"
-           style="fill:none;stroke:url(#focusMenuBorder);stroke-width:1.00156438;stroke-miterlimit:1.5;stroke-dasharray:none"
+           style="fill:none;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
            d="m 1108.5,339 v 7"
            inkscape:connector-curvature="0" />
       </g>
@@ -7624,7 +7726,7 @@
          style="fill:url(#foreground)">
         <path
            id="path1185"
-           style="fill:none;fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156438;stroke-miterlimit:1.5;stroke-dasharray:none"
+           style="fill:none;fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
            d="m 1108.5,339 v 7"
            inkscape:connector-curvature="0" />
       </g>
@@ -7644,7 +7746,7 @@
        sodipodi:cx="298.875"
        sodipodi:sides="5"
        id="ekr"
-       style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:url(#focusMenuBorder);stroke-width:0.9155302;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#e0e0e0;fill-opacity:1;fill-rule:nonzero;stroke:url(#focusMenuBorder);stroke-width:0.91553;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:type="star" />
     <g
        transform="translate(-216,2056.649)"
@@ -7702,13 +7804,13 @@
          cy="2152"
          cx="91.5"
          id="sdfgs"
-         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
       <path
          inkscape:label="#path2699"
          inkscape:connector-curvature="0"
          id="path2699"
          d="M 91.5,2140.5 A 11.5,11.5 0 0 0 80,2152 11.5,11.5 0 0 0 91.5,2163.5 11.5,11.5 0 0 0 103,2152 11.5,11.5 0 0 0 91.5,2140.5 Z m 0.5957,4.2656 c 0.38371,-0.01 0.69592,0.3057 0.69141,0.6895 v 5.0019 c 0.48437,0.1511 0.39206,0.1721 0.81055,0.4668 l 0.37695,-4.6855 c -0.004,-0.3753 0.47239,-0.6387 0.84766,-0.6446 0.38361,-0.01 0.6959,0.3059 0.6914,0.6895 v 6.3125 c 0.0846,0.1412 -0.002,0.1009 0.0684,0.252 l 1.08985,-1.4043 c 0.18216,-0.3268 0.52828,-0.527 0.90234,-0.5235 0.7905,0.01 1.27459,0.8683 0.86914,1.5469 l -2.16016,4.3027 c -0.33612,0.8126 -0.5361,1.0509 -0.89453,1.5586 -0.64414,0.9126 -1.77649,1.4356 -3.28125,1.4356 -1.41958,0 -2.85042,-0.1569 -4.01758,-0.752 -1.16716,-0.5951 -2.03515,-1.7526 -2.03515,-3.3359 0,0 -0.29326,-1.9064 -0.32031,-2.5489 -0.027,-0.6424 -0.196,-4.0426 -0.2754,-5.5644 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.8887 0.38361,-0.01 0.91857,0.4855 0.91406,0.8692 l 0.11914,3.75 c 0.19112,-0.1179 0.43504,0.181 0.69531,0.039 0.23634,-0.129 0.20352,0.01 0.4668,-0.1172 l 0.0449,-5.0996 c -0.004,-0.3753 0.42747,-0.75 0.80274,-0.7559 0.38362,-0.01 0.80723,0.3937 0.80273,0.7774 l 0.26562,4.2851 c 0.44701,-0.1251 0.15056,-0.1308 0.61133,-0.1308 l 0.17578,-4.5704 c -0.004,-0.3753 0.31808,-0.8613 0.69336,-0.8671 z"
-         style="opacity:1;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:#787878;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        style="display:inline"
@@ -7716,7 +7818,7 @@
        transform="translate(-43.5,47.362183)">
       <circle
          inkscape:label="#circle4126"
-         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="opacity:1;fill:#3c3c3c;fill-opacity:1;stroke:#3c3c3c;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          id="sdfsgdf"
          cx="123.5"
          cy="2152"
@@ -7726,10 +7828,10 @@
          inkscape:connector-curvature="0"
          id="path2699-8"
          d="m 123.5,2140.5 a 11.5,11.5 0 0 0 -11.5,11.5 11.5,11.5 0 0 0 11.5,11.5 11.5,11.5 0 0 0 11.5,-11.5 11.5,11.5 0 0 0 -11.5,-11.5 z m 0.5957,4.2656 c 0.38371,-0.01 0.69592,0.3057 0.69141,0.6895 v 5.0019 c 0.48437,0.1511 0.39206,0.1721 0.81055,0.4668 l 0.37695,-4.6855 c -0.004,-0.3753 0.47239,-0.6387 0.84766,-0.6446 0.38361,-0.01 0.6959,0.3059 0.6914,0.6895 v 6.3125 c 0.0846,0.1412 -0.002,0.1009 0.0684,0.252 l 1.08985,-1.4043 c 0.18216,-0.3268 0.52828,-0.527 0.90234,-0.5235 0.7905,0.01 1.27459,0.8683 0.86914,1.5469 l -2.16016,4.3027 c -0.33612,0.8126 -0.5361,1.0509 -0.89453,1.5586 -0.64414,0.9126 -1.77649,1.4356 -3.28125,1.4356 -1.41958,0 -2.85042,-0.1569 -4.01758,-0.752 -1.16716,-0.5951 -2.03515,-1.7526 -2.03515,-3.3359 0,0 -0.29326,-1.9064 -0.32031,-2.5489 -0.027,-0.6424 -0.196,-4.0426 -0.2754,-5.5644 -0.004,-0.3753 0.38254,-0.8828 0.75782,-0.8887 0.38361,-0.01 0.91857,0.4855 0.91406,0.8692 l 0.11914,3.75 c 0.19112,-0.1179 0.43504,0.181 0.69531,0.039 0.23634,-0.129 0.20352,0.01 0.4668,-0.1172 l 0.0449,-5.0996 c -0.004,-0.3753 0.42747,-0.75 0.80274,-0.7559 0.38362,-0.01 0.80723,0.3937 0.80273,0.7774 l 0.26562,4.2851 c 0.44701,-0.1251 0.15056,-0.1308 0.61133,-0.1308 l 0.17578,-4.5704 c -0.004,-0.3753 0.31808,-0.8613 0.69336,-0.8671 z"
-         style="opacity:1;fill:#d03232;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="opacity:1;fill:#d03232;fill-opacity:1;stroke:none;stroke-width:2;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <path
-       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:fill markers stroke"
        d="m 23,137.86219 3.427734,6 H 21.5 v 2 h 11 v -2 h -4.927734 l 3.427734,-6 z"
        id="scrollToBottom"
        inkscape:connector-curvature="0" />
@@ -7741,7 +7843,7 @@
        id="rect1650"
        style="fill:none;stroke:none" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:none;fill-opacity:0.105882;stroke:none;stroke-width:1.53206;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="renderStart"
        width="13"
        height="13"
@@ -7749,7 +7851,7 @@
        y="50.362183"
        inkscape:label="#rect2589-2" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:none;fill-opacity:0.105882;stroke:none;stroke-width:1.53206;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="renderResume"
        width="13"
        height="13"
@@ -7757,7 +7859,7 @@
        y="50.362183"
        inkscape:label="#rect2589-4" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:none;fill-opacity:0.105882;stroke:none;stroke-width:1.53206;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="renderPause"
        width="13"
        height="13"
@@ -7765,7 +7867,7 @@
        y="50.362183"
        inkscape:label="#rect2589-4-8" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.10588235;stroke:none;stroke-width:1.53206468;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:none;fill-opacity:0.105882;stroke:none;stroke-width:1.53206;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="renderStop"
        width="13"
        height="13"
@@ -7773,7 +7875,7 @@
        y="50.362183"
        inkscape:label="#rect2589" />
     <rect
-       style="opacity:1;fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect2735"
        width="8"
        height="8"
@@ -7782,7 +7884,7 @@
        ry="0"
        rx="0" />
     <path
-       style="fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 217.5,51.862183 v 10 l 8,-5 z"
        id="path2737"
        inkscape:connector-curvature="0"
@@ -7798,7 +7900,7 @@
          height="8"
          width="2"
          id="rect2735-7"
-         style="opacity:1;fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke" />
+         style="opacity:1;fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke" />
       <rect
          rx="0"
          ry="0"
@@ -7807,10 +7909,10 @@
          height="8"
          width="2"
          id="rect2735-7-9"
-         style="opacity:1;fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke" />
+         style="opacity:1;fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke" />
     </g>
     <rect
-       style="opacity:1;fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers fill stroke"
+       style="opacity:1;fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers fill stroke"
        id="rect2735-7-93"
        width="2"
        height="8"
@@ -7819,7 +7921,7 @@
        ry="0"
        rx="0" />
     <path
-       style="fill:#9e9e9e;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#9e9e9e;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 233.5,52.362183 v 9 l 7.5,-4.5 z"
        id="path2737-0"
        inkscape:connector-curvature="0"
@@ -7831,7 +7933,7 @@
       <g
          id="g5770">
         <rect
-           style="display:inline;opacity:1;fill:#888888;fill-opacity:0.74509804;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+           style="display:inline;opacity:1;fill:#888888;fill-opacity:0.745098;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:fill markers stroke"
            id="grid-8"
            width="20"
            height="15.999878"
@@ -7844,10 +7946,10 @@
            id="g41043"
            transform="matrix(0.78835689,0,0,0.73973705,260.57319,1560.6954)"
            inkscape:label="#g4104"
-           style="display:inline;stroke-width:1.40838981">
+           style="display:inline;stroke-width:1.40839">
           <path
              sodipodi:nodetypes="ccccc"
-             style="fill:#919191;fill-opacity:1;stroke:none;stroke-width:1.40838981"
+             style="fill:#919191;fill-opacity:1;stroke:none;stroke-width:1.40839"
              d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
              id="path3275-0"
              inkscape:connector-curvature="0" />
@@ -7857,23 +7959,23 @@
              inkscape:connector-curvature="0"
              id="path3292-2"
              d="m 41,116.88378 8.895356,4.80676"
-             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.971789;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              sodipodi:nodetypes="cc"
              transform="translate(0,52.362183)"
              inkscape:connector-curvature="0"
              id="path3296-4"
              d="m 39.955806,121.28466 9.066291,-4.38952"
-             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.97178906;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+             style="fill:#000000;fill-opacity:0;stroke:#4d4d4d;stroke-width:0.971789;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
           <path
              inkscape:connector-curvature="0"
              id="path4102-8"
              d="m 35.42406,171.23218 9.272,5.662 9.728,-5.51 L 45,167.36218 Z"
-             style="fill:none;stroke:#3c3c3c;stroke-width:1.40838981;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="fill:none;stroke:#3c3c3c;stroke-width:1.40839;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              sodipodi:nodetypes="ccccc" />
         </g>
         <rect
-           style="display:inline;opacity:1;fill:url(#backgroundLightLowlight-5-9);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:fill markers stroke"
+           style="display:inline;opacity:1;fill:url(#backgroundLightLowlight-5-9);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:fill markers stroke"
            id="rect1736"
            width="4"
            height="8"
@@ -7891,21 +7993,21 @@
        id="1644"
        transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,100.16121,339.08267)"
        inkscape:label="#g1644"
-       style="stroke-width:1.35712254">
+       style="stroke-width:1.35712">
       <path
          sodipodi:nodetypes="ccsscc"
          inkscape:connector-curvature="0"
          d="M 210.5,56.362183 214,54.36219 h 11.5 c 1.33333,0 1.33333,3.999982 0,3.999982 H 214 Z"
-         style="fill:#ababab;fill-opacity:0.99215686;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         style="fill:#ababab;fill-opacity:0.992157;stroke:#3b3b3b;stroke-width:1.35712px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
          id="path1619-5" />
       <path
          inkscape:connector-curvature="0"
          id="path1634-2"
          d="m 224.00314,54.424672 v 4"
-         style="fill:#3b3b3b;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         style="fill:#3b3b3b;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        id="editOff"
        width="10"
        height="10"
@@ -7913,18 +8015,18 @@
        y="248.86212"
        inkscape:label="#rect1698" />
     <g
-       style="stroke-width:1.35712254"
+       style="stroke-width:1.35712"
        inkscape:label="#g1644"
        transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,111.16121,339.08267)"
        id="g1708">
       <path
          id="path1704"
-         style="fill:url(#foreground);fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         style="fill:url(#foreground);fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
          d="M 210.5,56.362183 214,54.36219 h 11.5 c 1.33333,0 1.33333,3.999982 0,3.999982 H 214 Z"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccsscc" />
       <path
-         style="fill:#3b3b3b;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="fill:#3b3b3b;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 224.00314,54.424672 v 4"
          id="path1706"
          inkscape:connector-curvature="0" />
@@ -7935,10 +8037,10 @@
        height="10"
        width="10"
        id="editOn"
-       style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        inkscape:label="#rect1710" />
     <rect
-       style="opacity:1;fill:none;fill-opacity:0.99215686;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="opacity:1;fill:none;fill-opacity:0.992157;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        id="editDisabled"
        width="10"
        height="10"
@@ -7946,18 +8048,18 @@
        y="248.86212"
        inkscape:label="#rect1718" />
     <g
-       style="stroke-width:1.35712254;filter:url(#filter2913)"
+       style="stroke-width:1.35712;filter:url(#filter2913)"
        inkscape:label="#g1644"
        transform="matrix(0.51839037,-0.52369081,0.51839037,0.52369081,122.18526,339.10442)"
        id="g2887">
       <path
          id="path2883"
-         style="fill:#575757;fill-opacity:0.99215686;stroke:#3b3b3b;stroke-width:1.35925972;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#575757;fill-opacity:0.992157;stroke:#3b3b3b;stroke-width:1.35926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M 210.5,56.362183 214,54.36219 h 11.5 c 1.33333,0 1.33333,3.999982 0,3.999982 H 214 Z"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccsscc" />
       <path
-         style="fill:none;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712254px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;stroke:#3b3b3b;stroke-width:1.35712px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 224.00314,54.424672 v 4"
          id="path2885"
          inkscape:connector-curvature="0" />
@@ -7970,7 +8072,7 @@
        id="213223"
        inkscape:connector-curvature="0" />
     <rect
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:2.99999952;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:stroke fill markers"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers"
        id="clearSearch"
        width="15.999999"
        height="15.999999"
@@ -7981,7 +8083,7 @@
        id="valueChangedPath"
        cx="397"
        cy="70.362183"
-       style="fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-opacity:1"
+       style="fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-opacity:1"
        inkscape:label="valueChangedPath"
        r="3" />
     <g
@@ -8016,7 +8118,7 @@
        id="sourceCursor"
        style="display:inline">
       <rect
-         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.88923216;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.889232;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect3349-9"
          width="16"
          height="16"
@@ -8035,7 +8137,7 @@
        id="sourcePixel"
        style="display:inline">
       <rect
-         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.8892321;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.889232;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect3349-9-4"
          width="16"
          height="16"
@@ -8047,10 +8149,10 @@
          height="1"
          width="13"
          id="rect2073"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.44759464;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.44759;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <rect
          transform="rotate(90)"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.44759464;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.44759;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="rect2075"
          width="13"
          height="1"
@@ -8069,7 +8171,7 @@
        id="sourceArea"
        style="display:inline">
       <rect
-         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.88923204;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.889232;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          id="rect3349-9-4-7"
          width="16"
          height="16"
@@ -8077,7 +8179,7 @@
          y="140.36218" />
       <rect
          transform="rotate(90)"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15540838;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15541;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="rect2075-4"
          width="12"
          height="1"
@@ -8089,11 +8191,11 @@
          height="1"
          width="12"
          id="rect2107"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15541315;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15541;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          transform="rotate(90)" />
       <rect
          transform="skewY(-6.9197383e-5)"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15529442;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15529;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="rect2109"
          width="12"
          height="1"
@@ -8105,7 +8207,7 @@
          height="1"
          width="12"
          id="rect2111"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15541172;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:7.15541;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          transform="rotate(-6.919988e-5)" />
     </g>
     <rect
@@ -8114,7 +8216,7 @@
        height="25"
        width="25"
        id="rect1972"
-       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <g
        style="display:inline"
@@ -8155,13 +8257,13 @@
          id="path2019"
          style="fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <circle
-         style="fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333349;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1874"
          cx="492"
          cy="440.36218"
          r="56" />
       <circle
-         style="fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:2.66666675;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:2.66667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1878"
          cx="492"
          cy="440.36218"
@@ -8178,13 +8280,13 @@
          id="path2019-6-7"
          style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <circle
-         style="display:inline;opacity:1;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333349;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1874-9-0"
          cx="896"
          cy="440.36218"
          r="56" />
       <circle
-         style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:2.66666675;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:2.66667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1878-1-3"
          cx="896"
          cy="440.36218"
@@ -8202,13 +8304,13 @@
          id="path2019-6"
          style="display:inline;fill:url(#greyedOut);fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <circle
-         style="display:inline;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333349;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1874-9"
          cx="696"
          cy="440.36218"
          r="56" />
       <circle
-         style="display:inline;fill:url(#greyedOut);fill-opacity:1;stroke:none;stroke-width:2.66666675;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;fill:url(#greyedOut);fill-opacity:1;stroke:none;stroke-width:2.66667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1878-1"
          cx="696"
          cy="440.36218"
@@ -8225,13 +8327,13 @@
          id="path2019-6-2"
          style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <circle
-         style="display:inline;opacity:1;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333349;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:5.33333;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1874-9-5"
          cx="1088"
          cy="440.36218"
          r="56" />
       <circle
-         style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:2.66666675;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#brightColor);fill-opacity:1;stroke:none;stroke-width:2.66667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1878-1-1"
          cx="1088"
          cy="440.36218"
@@ -8241,7 +8343,7 @@
        id="g1870"
        inkscape:label="nodeSetFocusNode">
       <circle
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.61904764;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.619048;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="path2019-8"
          cx="-88.5"
          cy="-2122.8621"
@@ -8253,14 +8355,14 @@
          cy="-2122.8621"
          cx="-88.5"
          id="circle2088"
-         style="display:inline;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:0.42857143;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;fill:url(#nodeBorder);fill-opacity:1;stroke:none;stroke-width:0.428571;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
       <circle
          transform="scale(-1)"
          r="2"
          cy="-2122.8621"
          cx="-88.5"
          id="circle1060"
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.19047619;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.190476;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
     </g>
     <g
        id="g1929"
@@ -8268,20 +8370,20 @@
        transform="matrix(0.75404204,0,0,0.75404204,1279.6684,31.8831)"
        style="opacity:1;fill:#5e5e5e;fill-opacity:1">
       <path
-         style="display:inline;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:6.03233624;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:6.03234;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          d="m 1561.1777,825.45117 a 63.339531,63.339531 0 0 0 -63.3398,63.33789 63.339531,63.339531 0 0 0 63.3398,63.33985 63.339531,63.339531 0 0 0 63.3399,-63.33985 63.339531,63.339531 0 0 0 -63.3399,-63.33789 z m 0,21.11133 a 42.226354,42.226354 0 0 1 42.2266,42.22656 42.226354,42.226354 0 0 1 -42.2266,42.22656 42.226354,42.226354 0 0 1 -42.2265,-42.22656 42.226354,42.226354 0 0 1 42.2265,-42.22656 z"
          transform="matrix(1.326186,0,0,1.326186,-1374.4122,-738.33843)"
          id="circle1923"
          inkscape:connector-curvature="0" />
       <circle
-         style="display:inline;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:2.66666675;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:2.66667;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
          id="circle1927"
          cx="696"
          cy="440.36218"
          r="28" />
     </g>
     <path
-       style="display:inline;fill:#393939;fill-opacity:1;stroke:#898989;stroke-width:7.99616861px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       style="display:inline;fill:#393939;fill-opacity:1;stroke:#898989;stroke-width:7.99617px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
        d="M 1808.3979,481.4775 V 365.53301 l 79.9617,87.95789 h -31.9847 l 15.9923,27.9866 v 19.9904 h -19.9904 l -19.9904,-39.9808 z"
        id="path4086-7-0"
        inkscape:connector-curvature="0"
@@ -8305,9 +8407,9 @@
        height="384"
        width="672"
        id="viewerSelectPrompt"
-       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:16.64100456;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:16.641;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       style="display:inline;fill:#393939;fill-opacity:1;stroke:#898989;stroke-width:7.99616861px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       style="display:inline;fill:#393939;fill-opacity:1;stroke:#898989;stroke-width:7.99617px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
        d="M 1604.023,1028.3488 V 912.4043 l 79.9617,87.9579 H 1652 l 15.9923,27.9866 v 19.9904 h -19.9904 l -19.9904,-39.9808 z"
        id="path1934"
        inkscape:connector-curvature="0"
@@ -8332,17 +8434,17 @@
        height="20"
        width="20"
        id="rect1890"
-       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <path
-       style="display:inline;opacity:1;fill:#787878;fill-opacity:1;stroke:#434343;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:normal"
+       style="display:inline;opacity:1;fill:#787878;fill-opacity:1;stroke:#434343;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:normal"
        d="m 41,2494.5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 4.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 49 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 H 42.998047 A 2.5,2.4998784 0 0 0 41,2494.5 Z m 4.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 8.501953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 49 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 H 47.498047 A 2.5,2.4998784 0 0 0 45.5,2499.5 Z m -6.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 2.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 49 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 H 40.998047 A 2.5,2.4998784 0 0 0 39,2504.5 Z"
        transform="translate(0,52.362183)"
        id="rect1959"
        inkscape:connector-curvature="0" />
     <rect
        inkscape:label="sizeGuide"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        id="colorPlugValueWidgetSlidersOff"
        width="18"
        height="20"
@@ -8351,7 +8453,7 @@
     <path
        id="path2050"
        d="m 61,2546.8622 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 4.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -6.001953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z m 4.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 8.501953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -1.501953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z m -6.5,5 a 2.5,2.4998784 0 0 0 -1.996094,1 H 55 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 2.001953 a 2.5,2.4998784 0 0 0 1.998047,1 2.5,2.4998784 0 0 0 1.996094,-1 H 69 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -8.001953 a 2.5,2.4998784 0 0 0 -1.998047,-1 z"
-       style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#434343;stroke-width:0.99999988;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:normal"
+       style="display:inline;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:#434343;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:normal"
        inkscape:connector-curvature="0" />
     <rect
        y="2544.3623"
@@ -8359,11 +8461,11 @@
        height="20"
        width="18"
        id="colorPlugValueWidgetSlidersOn"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.74701792;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <rect
        inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="50"
@@ -8375,7 +8477,7 @@
        x="30"
        height="16"
        width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="" />
     <rect
        id="spotLight"
@@ -8383,11 +8485,11 @@
        x="110"
        height="16"
        width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="" />
     <rect
        inkscape:label="sizeGuide"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="50"
@@ -8399,11 +8501,11 @@
        x="70"
        height="16"
        width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="" />
     <rect
        inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="90"
@@ -8415,21 +8517,21 @@
        rx="4.7511191"
        cy="1825.3777"
        cx="-1822.606"
-       style="display:inline;fill:#efc618;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00009859;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:#efc618;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.0001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="ellipse1998" />
     <path
        sodipodi:nodetypes="cccccc"
        inkscape:connector-curvature="0"
        id="path2006"
        d="m 93.33398,2600.3524 c 0.003,2.768 -0.006,5.6147 0.004,8.3438 -5.3e-4,1.1964 1.9393,2.1663 4.33204,2.166 2.39196,-3e-4 4.33061,-0.97 4.33007,-2.166 0.005,-2.8522 0.007,-5.8455 0.006,-8.3438 z"
-       style="display:inline;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <ellipse
        ry="2.1655145"
        rx="4.3310289"
        cy="2600.0276"
        cx="97.668983"
        id="ellipse2010"
-       style="display:inline;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect
        transform="matrix(0.70966652,0.70453774,-0.70966652,0.70453774,0,0)"
        y="1790.016"
@@ -8437,10 +8539,10 @@
        height="6.5758076"
        width="11.273009"
        id="rect2018"
-       style="display:inline;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1.00001311;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect
        inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="130"
@@ -8451,7 +8553,7 @@
        transform="translate(100,20.000007)"
        id="g2035">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c717;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c717;fill-opacity:0.992157;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="M 39.331438,2577.8081 32,2584.6552 c -8e-6,-0.7846 -2.5e-5,-1.5845 0,-2.293 h -1 c -3.8e-5,1.0816 2e-5,2.3273 0,3.5 v 0.5 h 4 v -1 h -2.292969 l 7.331439,-6.8471 z"
          id="path2031"
          inkscape:connector-curvature="0"
@@ -8461,7 +8563,7 @@
          inkscape:connector-curvature="0"
          id="path2033"
          d="M 39.396484,2577.743 32,2584.6552 c -8e-6,-0.7846 -2.5e-5,-1.5845 0,-2.293 h -1 c -3.8e-5,1.0816 2e-5,2.3273 0,3.5 v 0.5 h 4 v -1 h -2.292969 l 7.396485,-6.9122 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f0c717;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f0c717;fill-opacity:0.992157;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     </g>
     <g
        style="display:inline"
@@ -8472,9 +8574,9 @@
          inkscape:connector-curvature="0"
          id="path2039"
          d="M 39.331438,2577.8081 32,2584.6552 c -8e-6,-0.7846 -2.5e-5,-1.5845 0,-2.293 h -1 c -3.8e-5,1.0816 2e-5,2.3273 0,3.5 v 0.5 h 4 v -1 h -2.292969 l 7.331439,-6.8471 z"
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c717;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c717;fill-opacity:0.992157;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f0c717;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f0c717;fill-opacity:0.992157;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="M 39.396484,2577.743 32,2584.6552 c -8e-6,-0.7846 -2.5e-5,-1.5845 0,-2.293 h -1 c -3.8e-5,1.0816 2e-5,2.3273 0,3.5 v 0.5 h 4 v -1 h -2.292969 l 7.396485,-6.9122 z"
          id="path2041"
          inkscape:connector-curvature="0"
@@ -8485,9 +8587,9 @@
        cy="2604.3623"
        cx="38"
        id="circle2069"
-       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:0.99215686;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.10055423;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:0.992157;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.10055;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
        d="m 124.33008,2597.8974 -12.37891,4.8359 c -0.30664,0.416 -0.21814,0.2959 -0.30664,0.416 -0.74706,0.7799 -0.86693,1.9353 -0.5664,3.0723 0.30038,1.137 1.01407,2.3123 2.06835,3.3222 1.05429,1.0098 2.26124,1.6727 3.41016,1.9239 1.14878,0.2513 2.29591,0.08 3.04297,-0.6993 0.29883,-0.1816 0.23348,-0.1419 0.29883,-0.1816 z m -2.17188,2.2539 -2.31836,6.6367 c -0.37863,-0.8401 -0.96531,-1.6719 -1.74023,-2.4141 -0.78545,-0.7524 -1.65436,-1.3115 -2.52148,-1.6523 z m -8.34179,3.289 c 0.19945,0.01 0.41425,0.034 0.64062,0.084 0.90554,0.198 1.95787,0.7585 2.88086,1.6426 0.92307,0.8842 1.5308,1.9144 1.76758,2.8105 0.0568,0.2151 0.0914,0.4175 0.10742,0.6094 l -0.52734,1.5098 c -0.41968,0.3508 -1.0642,0.4784 -1.89453,0.2968 -0.90547,-0.1981 -1.95975,-0.7603 -2.88282,-1.6445 -0.92299,-0.8841 -1.52878,-1.9125 -1.76562,-2.8086 -0.23251,-0.88 -0.11358,-1.5733 0.2793,-2.0039 0.4323,-0.1626 0.86461,-0.3253 1.29691,-0.4879 0.0343,-10e-5 0.0625,-0.01 0.0977,-0.01 z"
        id="path2078"
        inkscape:connector-curvature="0"
@@ -8497,17 +8599,17 @@
        inkscape:connector-curvature="0"
        id="path2080"
        d="m 124.33008,2597.8974 -12.37891,4.8359 c -0.30664,0.416 -0.21814,0.2959 -0.30664,0.416 -0.74706,0.7799 -0.86693,1.9353 -0.5664,3.0723 0.30038,1.137 1.01407,2.3123 2.06835,3.3222 1.05429,1.0098 2.26124,1.6727 3.41016,1.9239 1.14878,0.2513 2.29591,0.08 3.04297,-0.6993 0.29883,-0.1816 0.23348,-0.1419 0.29883,-0.1816 z m -2.17188,2.2539 -2.31836,6.6367 c -0.37863,-0.8401 -0.96531,-1.6719 -1.74023,-2.4141 -0.78545,-0.7524 -1.65436,-1.3115 -2.52148,-1.6523 z m -8.34179,3.289 c 0.19945,0.01 0.41425,0.034 0.64062,0.084 0.90554,0.198 1.95787,0.7585 2.88086,1.6426 0.92307,0.8842 1.5308,1.9144 1.76758,2.8105 0.0568,0.2151 0.0914,0.4175 0.10742,0.6094 l -0.52734,1.5098 c -0.41968,0.3508 -1.0642,0.4784 -1.89453,0.2968 -0.90547,-0.1981 -1.95975,-0.7603 -2.88282,-1.6445 -0.92299,-0.8841 -1.52878,-1.9125 -1.76562,-2.8086 -0.23251,-0.88 -0.11358,-1.5733 0.2793,-2.0039 0.4323,-0.1626 0.86461,-0.3253 1.29691,-0.4879 0.0343,-10e-5 0.0625,-0.01 0.0977,-0.01 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c816;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:1.10055423;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c816;fill-opacity:0.992157;fill-rule:nonzero;stroke:none;stroke-width:1.10055;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <rect
        inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="150"
        y="2596.3621"
        id="environmentLight" />
     <circle
-       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="circle2009"
        cx="158"
        cy="2604.3623"
@@ -8554,10 +8656,10 @@
        x="170"
        height="16"
        width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="" />
     <path
-       style="display:inline;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 182.19755,2598.3809 -1.89176,4.1438 4.1106,3.5798 -4.6354,5.1641 -6.69783,-1.9579 2.65188,-2.5904 -4.01678,-3.9878 2.39725,-3.4415 z"
        id="rect2093"
        inkscape:connector-curvature="0"
@@ -8582,20 +8684,20 @@
        sodipodi:nodetypes="cc" />
     <rect
        inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
        height="16"
        x="190"
        y="2596.3621"
        id="photometricLight" />
     <path
-       style="display:inline;fill:#f1c816;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.49889764;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:#f1c816;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:0.498898;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 196.04536,2601.2301 -4.54536,3.1321 c 0.0248,3.3547 3.5,7 6.5,7 3,0 6.5,-3.6343 6.5,-7 l -4.65395,-3.4856"
        id="path2142"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cczcc" />
     <circle
-       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="circle2140"
        cx="198"
        cy="2602.3623"
@@ -8606,7 +8708,7 @@
        x="210"
        height="16"
        width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="" />
     <g
        style="display:inline"
@@ -8683,7 +8785,7 @@
          style="fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          inkscape:label="plusSmall" />
       <path
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-opacity:1"
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
          d="m 139,2664.3622 v 3 l -8,4 8,4 v 3 l -14,-7 z"
          id="path4"
          inkscape:connector-curvature="0"
@@ -8745,14 +8847,14 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccccc" />
       <path
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 119,2668.3622 v 2 h -10 v -2 z"
          id="path6-7"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc"
          inkscape:label="minusSmall" />
       <path
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 119,2672.3622 v 2 h -10 v -2 z"
          id="path6-5"
          inkscape:connector-curvature="0"
@@ -8778,7 +8880,7 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccccccccc" />
       <path
-         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-opacity:1"
+         style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
          d="m 143,2664.3622 v 3 l 8,4 -8,4 v 3 l 14,-7 z"
          id="path4-1"
          inkscape:connector-curvature="0"
@@ -8791,7 +8893,7 @@
        inkscape:label="rotate"
        id="g1957">
       <path
-         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.20000005;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.92000002;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:2.2;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.92;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
          d="m 680,1294 c -3.30187,0 -6,2.6981 -6,6 0,3.3019 2.69813,6 6,6 3.30186,0 6,-2.6981 6,-6 h 2.5 l -3.5,-3.5 -3.5,3.5 h 2.5 c 0,2.221 -1.77902,4 -4,4 -2.22099,0 -4,-1.779 -4,-4 0,-2.221 1.77901,-4 4,-4 z"
          transform="translate(-87.41406,-1153.0519)"
          id="path5652"
@@ -8803,10 +8905,10 @@
       <g
          id="g2205-6"
          style="display:inline"
-         transform="translate(4e-6,-3.4667084e-6)">
+         transform="translate(4e-6)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="402.98151"
            y="1761.36"
            id="text2183-6"><tspan
@@ -8814,30 +8916,30 @@
              id="tspan2181-8"
              x="402.98151"
              y="1761.36"
-             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.30710199px">A</tspan></text>
+             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.307102px">A</tspan></text>
         <text
            id="text2187-8"
            y="1761.36"
            x="407.98151"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#aeaeae;fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.30710199px"
+             style="fill:#aeaeae;fill-opacity:1;stroke-width:0.307102px"
              y="1761.36"
              x="407.98151"
              id="tspan2185-3"
              sodipodi:role="line">B</tspan></text>
       </g>
       <g
-         transform="translate(17.000004,-3.4667084e-6)"
+         transform="translate(17.000004)"
          id="g2215-8"
          style="display:inline">
         <text
            id="text2209-0"
            y="1761.36"
            x="404.98151"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.30710199px"
+             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.307102px"
              y="1761.36"
              x="404.98151"
              id="tspan2207-2"
@@ -8845,22 +8947,22 @@
       </g>
       <g
          id="g2285-7"
-         transform="translate(34.000004,-3.4667084e-6)"
+         transform="translate(34.000004)"
          style="display:inline">
         <text
            id="text2283-2"
            y="1761.36"
            x="407.98151"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.30710199px"
+             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.307102px"
              y="1761.36"
              x="407.98151"
              id="tspan2281-9"
              sodipodi:role="line">B</tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="402.98151"
            y="1761.36"
            id="text2279-0"><tspan
@@ -8868,26 +8970,26 @@
              id="tspan2277-0"
              x="402.98151"
              y="1761.36"
-             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.30710199px">A</tspan></text>
+             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.307102px">A</tspan></text>
       </g>
       <g
-         transform="translate(51.000004,-3.4667084e-6)"
+         transform="translate(51.000004)"
          id="g2355-1"
          style="display:inline">
         <text
            id="text2349-9"
            y="1761.36"
            x="402.98151"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#backgroundDark);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.30710199px"
+             style="fill:url(#backgroundDark);fill-opacity:1;stroke-width:0.307102px"
              y="1761.36"
              x="402.98151"
              id="tspan2347-1"
              sodipodi:role="line">A</tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28409958px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.30710199px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="407.98151"
            y="1761.36"
            id="text2353-3"><tspan
@@ -8895,37 +8997,37 @@
              id="tspan2351-1"
              x="407.98151"
              y="1761.36"
-             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.30710199px">B</tspan></text>
+             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.307102px">B</tspan></text>
       </g>
       <g
          id="g2429-4"
-         transform="translate(68.000004,-3.4667084e-6)"
+         transform="translate(68.000004)"
          style="display:inline">
         <path
            inkscape:connector-curvature="0"
            id="text2423-4"
            transform="translate(-68.000004,52.362186)"
            d="m 474.40625,1700.2051 -3.42383,8.7929 h 1.88281 l 0.72461,-1.998 h 3.29102 v -5.3027 l -0.59766,-1.4922 z m 2.47461,1.4922 1.77539,4.4336 v -0.9668 h 1.43359 c 0.80775,0 1.33235,0.043 1.57227,0.1269 0.24392,0.084 0.42868,0.2184 0.55664,0.4024 0.12796,0.1839 0.19336,0.4079 0.19336,0.6718 0,0.3119 -0.084,0.5621 -0.25195,0.75 -0.16395,0.184 -0.37867,0.2997 -0.64258,0.3477 -0.17195,0.036 -0.577,0.053 -1.2168,0.053 h -1.08984 l 0.59375,1.4824 h 0.0703 c 1.13164,-0.01 1.84472,-0.029 2.14062,-0.061 0.47185,-0.052 0.86761,-0.1901 1.1875,-0.4141 0.3239,-0.2279 0.57778,-0.5284 0.76172,-0.9043 0.18794,-0.3798 0.28125,-0.77 0.28125,-1.1699 0,-0.5078 -0.14373,-0.9503 -0.43164,-1.3262 -0.2879,-0.3758 -0.69854,-0.6409 -1.23437,-0.7968 0.37988,-0.172 0.67851,-0.4315 0.89844,-0.7754 0.22392,-0.3439 0.33593,-0.721 0.33593,-1.1328 0,-0.3799 -0.0896,-0.7215 -0.26953,-1.0254 -0.17994,-0.3079 -0.40582,-0.5544 -0.67773,-0.7383 -0.26792,-0.1839 -0.57408,-0.3034 -0.91797,-0.3594 -0.33989,-0.06 -0.85696,-0.09 -1.55274,-0.09 h -3.51562 z m 2.33008,5.8183 -0.55469,-1.3847 v 1.3847 z M 476.88086,1707 v 1.998 h 0.99219 L 477.10547,1707 Z m 1.77539,-5.332 h 1.01953 c 0.83573,0 1.34164,0.01 1.51758,0.029 0.2959,0.036 0.51806,0.1405 0.66602,0.3125 0.15195,0.1679 0.22851,0.3882 0.22851,0.6601 0,0.2839 -0.0877,0.5135 -0.26367,0.6895 -0.17195,0.1719 -0.41094,0.2765 -0.71484,0.3125 -0.16795,0.02 -0.59729,0.029 -1.28907,0.029 h -1.16406 z m -3.33203,0.5879 1.21094,3.2636 h -2.39844 z"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.28407288px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.30710185px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.2841px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.307102px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       </g>
       <g
-         transform="translate(85.000004,-3.4667084e-6)"
+         transform="translate(85.000004)"
          id="g2503-4"
          style="display:inline">
         <text
            id="text2497-7"
            y="1759.5342"
            x="403.73593"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.18274021px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.17956901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.18274px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.179569px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.17956901px"
+             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.179569px"
              y="1759.5342"
              x="403.73593"
              id="tspan2495-2"
              sodipodi:role="line">A</tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.18274021px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.17956901px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.18274px;line-height:125%;font-family:Arial;-inkscape-font-specification:'Sans Bold';letter-spacing:0px;word-spacing:0px;fill:url(#foreground);fill-opacity:1;stroke:none;stroke-width:0.179569px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="410.50217"
            y="1759.5342"
            id="text2501-1"><tspan
@@ -8933,14 +9035,14 @@
              id="tspan2499-3"
              x="410.50217"
              y="1759.5342"
-             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.17956901px">B</tspan></text>
+             style="fill:url(#foreground);fill-opacity:1;stroke-width:0.179569px">B</tspan></text>
       </g>
       <g
-         transform="translate(102,-3.4667084e-6)"
+         transform="translate(102)"
          style="display:inline"
          id="g2115">
         <path
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#backgroundDark);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.66999996;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#backgroundDark);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.67;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 513.5,1699 -6.5,11 h 2.5 l 1.32227,-2.2383 c 0.42094,0.1906 0.8837,0.3047 1.37304,0.3047 1.84935,0 3.36719,-1.5178 3.36719,-3.3672 0,-1.0913 -0.53622,-2.0577 -1.34961,-2.6738 L 516,1699 Z m -0.13867,4.4648 c 0.32647,0.3077 0.53125,0.7433 0.53125,1.2344 0,0.9469 -0.75046,1.6973 -1.69727,1.6973 -0.18092,0 -0.35095,-0.037 -0.51367,-0.088 z"
            transform="translate(-102,52.362186)"
            id="path2103"
@@ -8949,17 +9051,17 @@
       <g
          id="g2219"
          style="display:inline"
-         transform="translate(119,-7.5e-6)">
+         transform="translate(119)">
         <path
            inkscape:connector-curvature="0"
-           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#foreground);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.66999996;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#foreground);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.67;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
            d="m 411.5,1751.3622 -6.5,11 h 2.5 l 1.32227,-2.2383 c 0.42094,0.1906 0.8837,0.3047 1.37304,0.3047 1.84935,0 3.36719,-1.5178 3.36719,-3.3672 0,-1.0913 -0.53622,-2.0577 -1.34961,-2.6738 L 414,1751.3622 Z m -0.13867,4.4648 c 0.32647,0.3077 0.53125,0.7433 0.53125,1.2344 0,0.9469 -0.75046,1.6973 -1.69727,1.6973 -0.18092,0 -0.35095,-0.037 -0.51367,-0.088 z"
            id="path2103-95" />
       </g>
     </g>
     <circle
        id="menuBreadCrumbShape"
-       style="display:inline;fill:#63ba86;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:label="menuBreadCrumb"
        cx="84"
        cy="2731.3623"
@@ -8974,7 +9076,7 @@
        transform="translate(0,-1.216875e-4)">
        style=&quot;display:inline&quot;&gt;
       <circle
-   style="opacity:1;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:1;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="path2261"
    cx="239.00079"
    cy="2604.3616"
@@ -8984,15 +9086,15 @@
    cy="2604.3616"
    cx="261.00079"
    id="circle2269"
-   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.50196078;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.501961;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 <circle
    r="5.5"
    cy="2604.3616"
    cx="283.00079"
    id="circle2273"
-   style="opacity:0.4;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:0.4;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 <circle
-   style="opacity:0.4;vector-effect:none;fill:#787878;fill-opacity:0.50196078;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:0.4;vector-effect:none;fill:#787878;fill-opacity:0.501961;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="circle2277"
    cx="306.00079"
    cy="2604.3616"
@@ -9002,21 +9104,21 @@
    cy="2604.3616"
    cx="330.00079"
    id="circle2279"
-   style="opacity:1;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:1;vector-effect:none;fill:url(#exclusionRed);fill-opacity:1;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 <circle
    r="5.5"
    cy="2604.3616"
    cx="352.00079"
    id="circle2289"
-   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.50196078;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.501961;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 <circle
-   style="opacity:1;vector-effect:none;fill:#ad5454;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:1;vector-effect:none;fill:#ad5454;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="circle2297"
    cx="371.9837"
    cy="2604.3787"
    r="5.5" />
 <circle
-   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.2;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:1;vector-effect:none;fill:#787878;fill-opacity:0.2;fill-rule:nonzero;stroke:url(#brightColor);stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="circle2303"
    cx="394.00079"
    cy="2604.3616"
@@ -9026,15 +9128,15 @@
    cy="2604.3787"
    cx="438.00079"
    id="circle6245"
-   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 <circle
-   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="circle6249"
    cx="459.00079"
    cy="2604.3787"
    r="5.5" />
 <circle
-   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
    id="circle6251"
    cx="481.00079"
    cy="2604.3787"
@@ -9044,7 +9146,7 @@
    cy="2604.3616"
    cx="503.00079"
    id="circle6253"
-   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+   style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
 </g>
     <path
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -9063,7 +9165,7 @@
        id="path2295"
        d="m 224,2665.8622 c 0,0 -3.5,0 -3.5,0 0,0 0,3.5 0,3.5"
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       transform="rotate(-180,226,2671.3622)" />
+       transform="rotate(180,226,2671.3622)" />
     <g
        id="g6430"
        inkscape:label="hierarchyView"
@@ -9071,7 +9173,7 @@
        style="display:inline">
       <rect
          inkscape:label="sizeGuide"
-         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
          x="10"
@@ -9122,7 +9224,7 @@
            inkscape:connector-curvature="0"
            id="path1343"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          style="display:inline"
@@ -9170,7 +9272,7 @@
            inkscape:connector-curvature="0"
            id="path3246-7"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          style="display:inline"
@@ -9218,12 +9320,12 @@
            inkscape:connector-curvature="0"
            id="path2270"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          id="g2314"
          transform="matrix(0.87222397,0,0,0.88353107,92.58087,2566.273)"
-         style="display:inline;opacity:0.64299999">
+         style="display:inline;opacity:0.643">
         <path
            style="fill:url(#brightColor);fill-opacity:1;stroke:#3c3c3c;stroke-width:0.567339;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 100.21875,172.68314 7.85546,3.92773 0.87283,-10.47395 -8.72829,-2.61849 z"
@@ -9262,7 +9364,7 @@
            id="path2310"
            sodipodi:nodetypes="ccccc" />
         <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
            id="path2312"
            inkscape:connector-curvature="0"
@@ -9310,7 +9412,7 @@
            id="path2348"
            sodipodi:nodetypes="ccccc" />
         <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
            id="path2350"
            inkscape:connector-curvature="0"
@@ -9341,7 +9443,7 @@
       <g
          id="g2358"
          transform="matrix(0.8889946,0,0,0.84492718,217.61121,2572.6299)"
-         style="opacity:0.63378996">
+         style="opacity:0.63379">
         <path
            id="path2351"
            d="m 70.21875,163.51843 -8.53969,2.42785 0.5,10.5 8,5 8,-5 0.5,-10.5 z"
@@ -9403,7 +9505,7 @@
            id="path2371"
            sodipodi:nodetypes="ccccc" />
         <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
            id="path2373"
            inkscape:connector-curvature="0"
@@ -9432,7 +9534,7 @@
            style="fill:url(#exclusionRed);fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
-         style="opacity:0.50083056"
+         style="opacity:0.500831"
          transform="matrix(0.8889946,0,0,0.84492718,157.61121,2572.6299)"
          id="g4046">
         <path
@@ -9500,7 +9602,7 @@
            inkscape:connector-curvature="0"
            id="path4061"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          style="display:inline;opacity:0.25"
@@ -9548,7 +9650,7 @@
            inkscape:connector-curvature="0"
            id="path10555"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <g
          id="g12187"
@@ -9592,7 +9694,7 @@
            id="path12183"
            sodipodi:nodetypes="ccccc" />
         <path
-           style="fill:none;stroke:#3c3c3c;stroke-width:0.87282926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#3c3c3c;stroke-width:0.872829;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 100.21875,163.51843 -8.728292,2.61849 0.872829,10.47395 7.855463,4.15958 7.85546,-4.15958 0.87283,-10.47395 z"
            id="path12185"
            inkscape:connector-curvature="0"
@@ -9616,7 +9718,7 @@
        id="path1479"
        d="m 224,2665.8622 c 0,0 -3.5,0 -3.5,0 0,0 0,3.5 0,3.5"
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       transform="rotate(-180,226,2671.3622)" />
+       transform="rotate(180,226,2671.3622)" />
     <g
        id="g7809"
        inkscape:label="SetEditor"
@@ -9627,7 +9729,7 @@
          x="10"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="sizeGuide" />
       <g
          style="fill:url(#backgroundLight);fill-opacity:1"
@@ -9638,14 +9740,14 @@
            cy="2784"
            cx="58"
            id="circle3880-5"
-           style="display:inline;opacity:1;vector-effect:none;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+           style="display:inline;opacity:1;vector-effect:none;fill:url(#backgroundLight);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
       </g>
       <g
          id="g7859"
          inkscape:label="setFolder"
          style="fill:url(#backgroundLight);fill-opacity:1">
         <rect
-           style="opacity:1;fill:url(#backgroundLight);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.23257422;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="opacity:1;fill:url(#backgroundLight);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.23257;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="rect4020"
            width="2.4729218"
            height="12.769132"
@@ -9664,7 +9766,7 @@
            cy="2784.8147"
            cx="53.141415"
            id="circle7861"
-           style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+           style="opacity:1;vector-effect:none;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
         <circle
            r="0.5"
            cy="2786.4141"
@@ -9690,7 +9792,7 @@
        inkscape:label="LocalJobs">
       <rect
          inkscape:label="sizeGuide"
-         style="display:inline;opacity:1;fill:url(#boundsTemplate-9);fill-opacity:1;stroke:none;stroke-width:0.59761435;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#boundsTemplate-9);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="19"
          height="18.999878"
          x="-4"
@@ -9701,7 +9803,7 @@
          cy="2837.5002"
          cx="45.5"
          inkscape:label="#path3352"
-         style="display:inline;opacity:1;fill:#69ffa5;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="display:inline;opacity:1;fill:#69ffa5;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="localDispatcherStatusComplete"
          rx="9"
          ry="9.0000181" />
@@ -9730,19 +9832,19 @@
          style="display:inline;opacity:1">
         <path
            inkscape:connector-curvature="0"
-           style="display:inline;fill:#69ffa5;fill-opacity:0.99215686;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           style="display:inline;fill:#69ffa5;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            d="m 5.5,2828.5 a 9,9.0000181 0 0 0 -9,9 9,9.0000181 0 0 0 9,9 9,9.0000181 0 0 0 9,-9 9,9.0000181 0 0 0 -9,-9 z m 0,2.5 a 6.5,6.5000134 0 0 1 6.5,6.5 6.5,6.5000134 0 0 1 -6.5,6.5 6.5,6.5000134 0 0 1 -6.5,-6.5 6.5,6.5000134 0 0 1 6.5,-6.5 z"
            id="ellipse2370" />
         <path
            inkscape:connector-curvature="0"
-           style="display:inline;fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.0999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.1, 2.1;stroke-dashoffset:0;stroke-opacity:1"
+           style="display:inline;fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.1, 2.1;stroke-dashoffset:0;stroke-opacity:1"
            d="m 5.5,2845.5 c -4.4182784,0 -8.0000006,-3.5817 -8,-8 -6e-7,-4.4183 3.5817216,-8 8,-8"
            id="path2405" />
         <path
            inkscape:connector-curvature="0"
            id="path2407"
            d="m 5.5,2845.5 c -4.4182784,0 -8.0000006,-3.5817 -8,-8 -6e-7,-4.4183 3.5817216,-8 8,-8"
-           style="display:inline;fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.0999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.1, 2.1;stroke-dashoffset:0;stroke-opacity:1" />
+           style="display:inline;fill:none;fill-opacity:1;stroke:#3c3c3c;stroke-width:2.1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.1, 2.1;stroke-dashoffset:0;stroke-opacity:1" />
       </g>
     </g>
     <g
@@ -9806,7 +9908,7 @@
            y="2783.4512"
            rx="0" />
         <rect
-           style="display:inline;fill:#cccccc;fill-opacity:0.992157;stroke:#3d3d3d;stroke-width:1.00692315;stroke-linejoin:miter;stroke-dasharray:none"
+           style="display:inline;fill:#cccccc;fill-opacity:0.992157;stroke:#3d3d3d;stroke-width:1.00692;stroke-linejoin:miter;stroke-dasharray:none"
            id="rect14"
            width="11.162248"
            height="2.3981025"
@@ -9849,7 +9951,7 @@
        inkscape:label="plane"
        inkscape:connector-curvature="0" />
     <ellipse
-       style="display:inline;fill:url(#foreground-9);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.33333004;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="display:inline;fill:url(#foreground-9);fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.33333;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path6796"
        cy="1841.6395"
        cx="265.7757"
@@ -9857,7 +9959,7 @@
        ry="3.3333335"
        inkscape:label="highlight" />
     <path
-       style="color:#000000;display:inline;fill:#f0c717;fill-opacity:0.99215698;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+       style="color:#000000;display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
        d="m 270.7757,1829.6386 v 1 h 4.79297 l -9.79297,9.793 -10.64648,-10.6465 -0.70704,0.707 11.35352,11.3536 10.5,-10.5 v 4.7929 h 1 v -6.5 z"
        id="path4996"
        inkscape:label="ray"
@@ -9987,7 +10089,7 @@
            style="display:inline;opacity:1;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
       <path
-         style="display:inline;stroke:#3c3c3c;stroke-opacity:1;fill:#a4a4a4;fill-opacity:1;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter"
+         style="display:inline;fill:#a4a4a4;fill-opacity:1;stroke:#3c3c3c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 506.5,1402.5 h 5 v -5 h 5 v 5 h 5 v 5 c 0,0 -5,0 -5,0 v 5 h -5 v -5 h -5 z"
          id="path90076"
          transform="translate(383.5,-98.400027)" />

--- a/startup/gui/graphEditor.py
+++ b/startup/gui/graphEditor.py
@@ -129,6 +129,8 @@ GafferUI.GraphEditor.connectionContextMenuSignal().connect( __connectionContextM
 # File drop handler
 ##########################################################################
 
+GafferUI.Pointer.registerPointer( "targetObjects", GafferUI.Pointer( "targetObjects.png", imath.V2i( 53, 14 ) ) )
+
 def __sceneFileHandler( fileName ) :
 
 	result = GafferScene.SceneReader()
@@ -269,7 +271,7 @@ def __locationDragEnter( graphGadget, event ) :
 	if __dropLocationData( event ) is None :
 		return False
 
-	GafferUI.Pointer.setCurrent( "target" )
+	GafferUI.Pointer.setCurrent( "targetObjects" )
 	return True
 
 def __locationDragLeave( graphGadget, event ) :


### PR DESCRIPTION
The old pointer felt too much of a departure from the "objects being dragged" pointer, and was too big of an emphasis for what is probably a pretty niche feature. It felt like you'd stopped dragging objects, making things less clear when you dragged onto a PathFilter, which is the far more common operations. The pointer now matches the "objects being dragged one" with the addition of a discrete targeting crosshair in the lower left.

![Peek 2024-04-19 12-12](https://github.com/GafferHQ/gaffer/assets/1133871/f6d5cedc-8e6a-40e0-ba35-a675f15e14ea)
