### PR TITLE
NameSwitchUI : Fix NodeEditor tab order

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
 - USD : Added automatic render-time translation of UsdPreviewSurface shaders to Cycles.
 - SetEditor : Added support for dragging a set name onto a node in the Graph Editor to create or modify a connected `SetFilter` node. Holding <kbd>Shift</kbd> while dragging will add to the set expression. Holding <kbd>Control</kbd> will remove from the set expression. Only set expressions with a simple list of sets are supported. Expressions with boolean or hierarchy operators are not supported.
 
+Fixes
+-----
+
+- NameSwitch : Fixed NodeEditor tab order, so that the Settings tab precedes the Advanced tab.
+
 1.4.0.0 (relative to 1.3.16.0)
 =======
 

--- a/python/GafferUI/NameSwitchUI.py
+++ b/python/GafferUI/NameSwitchUI.py
@@ -79,6 +79,10 @@ Gaffer.Metadata.registerNode(
 
 			"nodule:type", "",
 			"divider", True,
+			# Needed to make sure the Settings tab comes first,
+			# because otherwise the first plug is `connectedInputs`
+			# which is in the Advanced tab.
+			"layout:index", 0,
 
 		],
 


### PR DESCRIPTION
This was broken when we added the `connectedInputs` plug.
