### PR TITLE
CI : Update to GafferHQ/dependencies 8.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
             os: ubuntu-20.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:2.1.1
+            containerImage: ghcr.io/gafferhq/build/build:2.1.2
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -52,7 +52,7 @@ jobs:
             os: ubuntu-20.04
             buildType: DEBUG
             publish: false
-            containerImage: ghcr.io/gafferhq/build/build:2.1.1
+            containerImage: ghcr.io/gafferhq/build/build:2.1.2
             testRunner: su testUser -c
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
@@ -63,7 +63,7 @@ jobs:
             os: ubuntu-20.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:3.0.0a6
+            containerImage: ghcr.io/gafferhq/build/build:3.0.0
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/8.0.0a10/gafferDependencies-8.0.0a10-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/8.0.0/gafferDependencies-8.0.0-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,13 @@ Improvements
 - USD : Added automatic render-time translation of UsdPreviewSurface shaders to Cycles.
 - SetEditor : Added support for dragging a set name onto a node in the Graph Editor to create or modify a connected `SetFilter` node. Holding <kbd>Shift</kbd> while dragging will add to the set expression. Holding <kbd>Control</kbd> will remove from the set expression. Only set expressions with a simple list of sets are supported. Expressions with boolean or hierarchy operators are not supported.
 
+Build
+-----
+
+- Cortex : Updated to version 10.5.7.0.
+- OpenEXR : Updated to version 3.1.13.
+- USD : Added `sdrOsl`, for inclusion of OSL shaders in the Sdr Registry.
+
 1.4.0.0 (relative to 1.3.16.0)
 =======
 


### PR DESCRIPTION
Putting this up as a draft to test the Linux `8.0.0` dependencies and `3.0.0` build container on CI while the Windows dependencies are building...