### PR TITLE
Address Hangs With Dispatching GafferCortex Tasks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - NodeAlgo : Fixed presets inheritance for promoted plugs with multiple outputs.
+- TaskNode / GafferCortex : Fixed missing GIL releases that caused hang at ImageEngine
 
 1.3.16.0 (relative to 1.3.15.0)
 ========

--- a/include/GafferDispatchBindings/TaskNodeBinding.inl
+++ b/include/GafferDispatchBindings/TaskNodeBinding.inl
@@ -59,7 +59,12 @@ template<typename T>
 static boost::python::list preTasks( T &n, Gaffer::Context *context )
 {
 	GafferDispatch::TaskNode::Tasks tasks;
-	n.T::preTasks( context, tasks );
+
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		n.T::preTasks( context, tasks );
+	}
+
 	boost::python::list result;
 	for( GafferDispatch::TaskNode::Tasks::const_iterator tIt = tasks.begin(); tIt != tasks.end(); ++tIt )
 	{
@@ -72,7 +77,12 @@ template<typename T>
 static boost::python::list postTasks( T &n, Gaffer::Context *context )
 {
 	GafferDispatch::TaskNode::Tasks tasks;
-	n.T::postTasks( context, tasks );
+
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		n.T::postTasks( context, tasks );
+	}
+
 	boost::python::list result;
 	for( GafferDispatch::TaskNode::Tasks::const_iterator tIt = tasks.begin(); tIt != tasks.end(); ++tIt )
 	{
@@ -84,6 +94,7 @@ static boost::python::list postTasks( T &n, Gaffer::Context *context )
 template<typename T>
 static IECore::MurmurHash hash( T &n, const Gaffer::Context *context )
 {
+	IECorePython::ScopedGILRelease gilRelease;
 	return n.T::hash( context );
 }
 

--- a/src/GafferCortexModule/CompoundParameterHandlerBinding.cpp
+++ b/src/GafferCortexModule/CompoundParameterHandlerBinding.cpp
@@ -151,6 +151,9 @@ Gaffer::PlugPtr compoundParameterHandlerSetupPlug( CompoundParameterHandler &ph,
 
 void compoundParameterHandlerSetParameterValue( CompoundParameterHandler &ph )
 {
+	// Setting a parameter value involves evaluating the plug - we don't want to hold the GIL while evaluating
+	// the Gaffer graph.
+	IECorePython::ScopedGILRelease gilRelease;
 	return ph.CompoundParameterHandler::setParameterValue();
 }
 

--- a/src/GafferCortexModule/ParameterHandlerBinding.cpp
+++ b/src/GafferCortexModule/ParameterHandlerBinding.cpp
@@ -148,6 +148,15 @@ void registerParameterHandler( IECore::TypeId parameterType, object creator )
 	ParameterHandler::registerParameterHandler( parameterType, ParameterHandlerCreator( creator ) );
 }
 
+void parameterHandlerSetParameterValue( ParameterHandler &ph )
+{
+	// Setting a parameter value involves evaluating the plug - we don't want to hold the GIL while evaluating
+	// the Gaffer graph.
+	IECorePython::ScopedGILRelease gilRelease;
+	return ph.setParameterValue();
+}
+
+
 } // namespace
 
 void GafferCortexModule::bindParameterHandler()
@@ -172,7 +181,7 @@ void GafferCortexModule::bindParameterHandler()
 			(Gaffer::Plug *(ParameterHandler::*)())&ParameterHandler::plug,
 			return_value_policy<IECorePython::CastToIntrusivePtr>()
 		)
-		.def( "setParameterValue", &ParameterHandler::setParameterValue )
+		.def( "setParameterValue", &parameterHandlerSetParameterValue )
 		.def( "setPlugValue", &ParameterHandler::setPlugValue )
 		.def( "hash", &ParameterHandler::hash )
 		.def( "create", &ParameterHandler::create ).staticmethod( "create" )


### PR DESCRIPTION
I spent a while trying to get clean repros of this - I managed to repro without any of IE's task stuff, but my repro still has lots of IE asset management stuff - I don't think the specifics are important, but that is an extremely complex network with lots of Python nodes and scene nodes, and any attempt to make it simpler causes it to stop crashing.

Perhaps this is correct looking enough that it's reasonable to merge without exhaustive proof of why it's needed?

I think it is pretty reasonable to assume that a C++ subclass of TaskNode could trigger graph evaluations in its hash() method?

I'm not totally sure why this wasn't causing problems before, but I suspect that the "strict hashing" workaround in ImageEngine's custom Gaffer 1.2 build may have been masking it?

ImageEngine is now using a custom build with the TaskNode fix applied in order to prevent having to do a full rollback to 1.2, and artists have confirmed it is fixing their hang in production scenes. Would be great to get this into a bugfix release of 1.3 fairly quickly so IE can finally be using an official version.