### PR TITLE
Prefer `std::variant` to `boost::variant`

### DIFF
--- a/include/GafferUI/NoduleLayout.h
+++ b/include/GafferUI/NoduleLayout.h
@@ -42,9 +42,8 @@
 
 #include "IECore/StringAlgo.h"
 
-#include "boost/variant.hpp"
-
 #include <functional>
+#include <variant>
 
 namespace Gaffer
 {
@@ -112,7 +111,7 @@ class GAFFERUI_API NoduleLayout : public Gadget
 			GadgetPtr gadget;
 		};
 		// Either a plug or the name of a custom widget
-		using GadgetKey = boost::variant<const Gaffer::Plug *, IECore::InternedString>;
+		using GadgetKey = std::variant<const Gaffer::Plug *, IECore::InternedString>;
 		// Map from plugs and custom gadget names to the gadgets
 		// that represent them.
 		using GadgetMap = std::map<GadgetKey, TypeAndGadget>;

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -48,11 +48,11 @@
 #include "boost/multi_index/member.hpp"
 #include "boost/multi_index/hashed_index.hpp"
 #include "boost/multi_index_container.hpp"
-#include "boost/variant.hpp"
 
 #include "fmt/format.h"
 
 #include <unordered_map>
+#include <variant>
 
 using namespace std;
 using namespace boost;
@@ -91,7 +91,7 @@ class RowsMap : public IECore::Data
 
 	public :
 
-		using Selector = boost::variant<const vector<InternedString> *, string>;
+		using Selector = std::variant<const vector<InternedString> *, string>;
 
 		RowsMap( const Spreadsheet::RowsPlug *rows )
 			:	m_enabledRowNames( new StringVectorData )
@@ -149,11 +149,11 @@ class RowsMap : public IECore::Data
 		// Hashes the contents of the selector.
 		static void hash( const Selector &selector, IECore::MurmurHash &h )
 		{
-			if( auto s = get<string>( &selector ) )
+			if( auto s = get_if<string>( &selector ) )
 			{
 				h.append( *s );
 			}
-			else if( auto p = get<const vector<InternedString> *>( &selector ) )
+			else if( auto p = get_if<const vector<InternedString> *>( &selector ) )
 			{
 				h.append( (*p)->data(), (*p)->size() );
 			}
@@ -162,7 +162,7 @@ class RowsMap : public IECore::Data
 		size_t rowIndex( const Selector &selector ) const
 		{
 			size_t result = 0;
-			if( auto s = get<string>( &selector ) )
+			if( auto s = get_if<string>( &selector ) )
 			{
 				auto it = m_plainRows.find( *s );
 				if( it != m_plainRows.end() )

--- a/src/GafferScene/SceneAlgo.cpp
+++ b/src/GafferScene/SceneAlgo.cpp
@@ -469,7 +469,7 @@ class CapturingMonitor : public Monitor
 				ProcessMap::const_iterator it = m_processMap.find( process->parent() );
 				if( it != m_processMap.end() )
 				{
-					CapturedProcess * const * parent = boost::get< CapturedProcess* >( &it->second );
+					CapturedProcess * const * parent = std::get_if<CapturedProcess *>( &it->second );
 					if( parent && *parent )
 					{
 						(*parent)->children.push_back( std::move( capturedProcess ) );
@@ -520,7 +520,7 @@ class CapturingMonitor : public Monitor
 
 		Mutex m_mutex;
 
-		using ProcessOrScope = boost::variant<CapturedProcess *, std::unique_ptr< Monitor::Scope>>;
+		using ProcessOrScope = std::variant<CapturedProcess *, std::unique_ptr<Monitor::Scope>>;
 		using ProcessMap = boost::unordered_map<const Process *, ProcessOrScope>;
 
 		ProcessMap m_processMap;

--- a/src/GafferUI/NoduleLayout.cpp
+++ b/src/GafferUI/NoduleLayout.cpp
@@ -148,7 +148,7 @@ bool visible( const GraphComponent *parent, const InternedString &gadgetName, IE
 
 // Plug metadata accessors. These affect the layout of individual nodules.
 
-using GadgetKey = boost::variant<const Gaffer::Plug *, IECore::InternedString>;
+using GadgetKey = std::variant<const Gaffer::Plug *, IECore::InternedString>;
 
 int layoutIndex( const Plug *plug, int defaultValue )
 {
@@ -194,15 +194,15 @@ bool visible( const Plug *plug, IECore::InternedString section )
 
 InternedString gadgetType( const GraphComponent *parent, const GadgetKey &gadgetKey )
 {
-	if( gadgetKey.which() == 0 )
+	if( gadgetKey.index() == 0 )
 	{
-		const Plug *plug = boost::get<const Plug *>( gadgetKey );
+		const Plug *plug = std::get<const Plug *>( gadgetKey );
 		ConstStringDataPtr d = Metadata::value<IECore::StringData>( plug, g_noduleTypeKey );
 		return d ? d->readable() : "GafferUI::StandardNodule";
 	}
 	else
 	{
-		const InternedString &name = boost::get<InternedString>( gadgetKey );
+		const InternedString &name = std::get<InternedString>( gadgetKey );
 		ConstStringDataPtr d = Metadata::value<StringData>( parent, "noduleLayout:customGadget:" + name.string() + ":gadgetType" );
 		return d ? d->readable() : "";
 	}
@@ -638,9 +638,9 @@ void NoduleLayout::updateNoduleLayout()
 		else
 		{
 			// No gadget created yet, or it's the wrong type
-			if( item.which() == 0 )
+			if( item.index() == 0 )
 			{
-				gadget = Nodule::create( const_cast<Plug *>( boost::get<const Plug *>( item ) ) ); /// \todo Fix cast
+				gadget = Nodule::create( const_cast<Plug *>( std::get<const Plug *>( item ) ) ); /// \todo Fix cast
 			}
 			else if( !gadgetType.string().empty() )
 			{


### PR DESCRIPTION
This removes all usage of `boost::variant`, except for one in SetAlgo, where the interaction with `boost::reference_wrapper` makes removal trickier.
