### PR TITLE
Cycles : Tag tangent primitive variables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Improvements
 ------------
 
 - TweakPlug : `ListAppend`, `ListPrepend` and `ListRemove` modes are now supported for string values. In this case, the string is treated as a space-separated list.
-- Cycles : Changed default value for `principled_bsdf.specular_ior_level` to `0.5`, matching Blender.
+- Cycles :
+  - Changed default value for `principled_bsdf.specular_ior_level` to `0.5`, matching Blender.
+  - Added support for `uv.tangent` and `uv.tangent_sign` primitive variables to assist in rendering with normal maps (#5269).
 - AttributeQuery, PrimitiveVariableQuery, ContextQuery, OptionQuery, ShaderQuery : Added support for querying arrays of length 1 as their equivalent scalar types.
 
 Fixes

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -367,6 +367,14 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	{
 		attr->std = ccl::ATTR_STD_UV;
 	}
+	else if( name == "uv.tangent_sign" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeFloat )
+	{
+		attr->std = ccl::ATTR_STD_UV_TANGENT_SIGN;
+	}
+	else if( name == "uv.tangent" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeVector )
+	{
+		attr->std = ccl::ATTR_STD_UV_TANGENT;
+	}
 }
 
 } // namespace GeometryAlgo


### PR DESCRIPTION
This allows normal maps to be rendered using the procedure described in #5269. It's really just a stop-gap measure until we (or ideally Cycles) can generate tangents on demand based on the needs of the assigned shaders. It also differs from #5269 in that we require the names to be exactly `uv.tangent` and `uv.tangent_sign` rather than just ending with `tangent_sign` or `tangent`.