### PR TITLE
PlugAlgo : Add `array[1]` -> scalar conversion

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ API
 ---
 
 - PlugAlgo : `setValueFromData()` and `canSetValueFromData()` now support conversion of arrays of length 1 to their equivalent scalar types.
+- BoxPlug : Added Python bindings for `ValueType`, `PointType` and `ChildType` type aliases.
 
 1.4.1.0 (relative to 1.4.0.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -6,12 +6,18 @@ Improvements
 
 - TweakPlug : `ListAppend`, `ListPrepend` and `ListRemove` modes are now supported for string values. In this case, the string is treated as a space-separated list.
 - Cycles : Changed default value for `principled_bsdf.specular_ior_level` to `0.5`, matching Blender.
+- AttributeQuery, PrimitiveVariableQuery, ContextQuery, OptionQuery, ShaderQuery : Added support for querying arrays of length 1 as their equivalent scalar types.
 
 Fixes
 -----
 
 - Viewer : Fixed Cycles shader balls.
 - TweakPlug : Fixed incorrect results and potential crashes in list modes.
+
+API
+---
+
+- PlugAlgo : `setValueFromData()` and `canSetValueFromData()` now support conversion of arrays of length 1 to their equivalent scalar types.
 
 1.4.1.0 (relative to 1.4.0.0)
 =======

--- a/python/GafferSceneTest/PrimitiveVariableQueryTest.py
+++ b/python/GafferSceneTest/PrimitiveVariableQueryTest.py
@@ -689,5 +689,36 @@ class PrimitiveVariableQueryTest( GafferSceneTest.SceneTestCase ):
 			self.assertEqual( output["type"].getValue(), dataType.staticTypeName() )
 			self.assertEqual( output["value"].getValue(), value )
 
+	def testArrayScalarConversion( self ) :
+
+		cube = GafferScene.Cube()
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ "/cube" ] ) )
+
+		primitiveVariables = GafferScene.PrimitiveVariables()
+		primitiveVariables["in"].setInput( cube["out"] )
+		primitiveVariables["filter"].setInput( cubeFilter["out"] )
+
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "testLengthZero", IECore.IntVectorData() ) )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "testLengthOne", IECore.IntVectorData( [ 2 ] ) ) )
+		primitiveVariables["primitiveVariables"].addChild( Gaffer.NameValuePlug( "testLengthTwo", IECore.IntVectorData( [ 3, 3 ] ) ) )
+
+		query = GafferScene.PrimitiveVariableQuery()
+		query["scene"].setInput( primitiveVariables["out"] )
+		query["location"].setValue( "/cube" )
+		query.addQuery( Gaffer.IntPlug( defaultValue = -1 ), "testLengthZero" )
+
+		self.assertEqual( query["out"][0]["exists"].getValue(), True )
+		self.assertTrue( query["out"][0]["value"].getValue(), -1 )
+
+		query["queries"][0]["name"].setValue( "testLengthOne" )
+		self.assertEqual( query["out"][0]["exists"].getValue(), True )
+		self.assertTrue( query["out"][0]["value"].getValue(), 2 )
+
+		query["queries"][0]["name"].setValue( "testLengthTwo" )
+		self.assertEqual( query["out"][0]["exists"].getValue(), True )
+		self.assertTrue( query["out"][0]["value"].getValue(), -1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BoxPlugTest.py
+++ b/python/GafferTest/BoxPlugTest.py
@@ -171,5 +171,11 @@ class BoxPlugTest( GafferTest.TestCase ) :
 		s["n"]["user"]["b2"].setInput( s["n"]["user"]["b1"] )
 		assertExpectedInputs( 1 )
 
+	def testTypes( self ) :
+
+		self.assertIs( Gaffer.Box3fPlug.ValueType, imath.Box3f )
+		self.assertIs( Gaffer.Box3fPlug.PointType, imath.V3f )
+		self.assertIs( Gaffer.Box3fPlug.ChildType, Gaffer.V3fPlug )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1079,6 +1079,47 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 						self.assertTrue( childPlug.isSetToDefault() )
 					self.assertTrue( plug.isSetToDefault() )
 
+	def testSetTypedValueFromVectorData( self ) :
+
+		for plugType, value in [
+			( Gaffer.StringPlug, "test" ),
+			( Gaffer.StringPlug, IECore.InternedString( "test" ) ),
+			( Gaffer.M33fPlug, imath.M33f( 1 ) ),
+			( Gaffer.M44fPlug, imath.M44f( 1 ) ),
+			( Gaffer.AtomicBox2fPlug, imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) ),
+			( Gaffer.AtomicBox3fPlug, imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) ),
+			( Gaffer.AtomicBox2iPlug, imath.Box2i( imath.V2i( 0 ), imath.V2i( 1 ) ) ),
+		] :
+
+			with self.subTest( plugType = plugType, value = value ) :
+
+				plug = plugType()
+				data = IECore.DataTraits.dataFromElement( [ value ] )
+				self.assertEqual( len( data ), 1 )
+
+				# Array length 1, can set
+
+				self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertEqual( plug.getValue(), value )
+				self.assertFalse( plug.isSetToDefault() )
+
+				# Array length 2, can't set
+
+				data.append( data[0] )
+				plug.setToDefault()
+				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertTrue( plug.isSetToDefault() )
+
+				# Array length 0, can't set
+
+				data.resize( 0 )
+				plug.setToDefault()
+				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertTrue( plug.isSetToDefault() )
+
 	def testDependsOnCompute( self ) :
 
 		add = GafferTest.AddNode()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -961,6 +961,43 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 					self.assertEqual( plug.getValue(), data.value )
 				self.assertEqual( Gaffer.PlugAlgo.getValueAsData( plug ), data )
 
+	def testSetNumericValueFromVectorData( self ) :
+
+		for plugType in Gaffer.FloatPlug, Gaffer.IntPlug, Gaffer.BoolPlug :
+			plug = plugType()
+			for dataType in [
+				IECore.HalfVectorData,
+				IECore.FloatVectorData,
+				IECore.DoubleVectorData,
+				IECore.UCharVectorData,
+				IECore.ShortVectorData,
+				IECore.UShortVectorData,
+				IECore.IntVectorData,
+				IECore.UIntVectorData,
+				IECore.Int64VectorData,
+				IECore.UInt64VectorData,
+				IECore.BoolVectorData,
+			] :
+				with self.subTest( plugType = plugType, dataType = dataType ) :
+					for value in ( 0, 1 ) :
+						data = dataType()
+						# Array length 0, can't set.
+						self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+						plug.setToDefault()
+						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+						self.assertTrue( plug.isSetToDefault() )
+						# Array length 1, can set.
+						data.append( value )
+						self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+						self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+						self.assertEqual( plug.getValue(), value )
+						# Array length > 1, can't set.
+						data.append( value )
+						self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+						plug.setToDefault()
+						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+						self.assertTrue( plug.isSetToDefault() )
+
 	def testDependsOnCompute( self ) :
 
 		add = GafferTest.AddNode()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -929,9 +929,6 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 
 	def testDataConversionsForAllTypes( self ) :
 
-		import GafferScene
-		import GafferImage
-
 		for plugType in Gaffer.ValuePlug.__subclasses__() :
 
 			valueType = getattr( plugType, "ValueType", None )

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1120,6 +1120,63 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
 				self.assertTrue( plug.isSetToDefault() )
 
+	def testSetBoxValueFromVectorData( self ) :
+
+		for plugType in [
+			Gaffer.Box2fPlug, Gaffer.Box3fPlug,
+			Gaffer.Box2iPlug, Gaffer.Box3iPlug,
+		] :
+
+			with self.subTest( plugType = plugType ) :
+
+				plug = plugType()
+
+				minValue = plugType.PointType()
+				maxValue = plugType.PointType()
+				for i in range( 0, minValue.dimensions() ) :
+					minValue[i] = i
+					maxValue[i] = i + 1
+				value = plugType.ValueType( minValue, maxValue )
+				data = IECore.DataTraits.dataFromElement( [ value ] )
+
+				# Array length 1, can set
+
+				self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertTrue( plug.isSetToDefault() )
+				self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertEqual( plug.getValue(), value )
+				self.assertFalse( plug.isSetToDefault() )
+
+				# And can set individual children
+
+				plug.setToDefault()
+				for childPlug in plug :
+					for componentPlug in childPlug :
+						self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertEqual( plug.getValue(), value )
+				self.assertFalse( plug.isSetToDefault() )
+
+				# Array length 2, can't set
+
+				data.append( data[0] )
+				plug.setToDefault()
+				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				for childPlug in plug :
+					for componentPlug in childPlug :
+						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertTrue( plug.isSetToDefault() )
+
+				# Array length 0, can't set
+
+				data.resize( 0 )
+				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				for childPlug in plug :
+					for componentPlug in childPlug :
+						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertTrue( plug.isSetToDefault() )
+
 	def testDependsOnCompute( self ) :
 
 		add = GafferTest.AddNode()

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -692,6 +692,16 @@ bool setCompoundNumericChildPlugValue( const PlugType *plug, typename PlugType::
 	return false;
 }
 
+template<typename PlugType, typename DataType>
+bool setCompoundNumericChildPlugValueFromVectorData( const PlugType *plug, typename PlugType::ChildType *child, const DataType *data )
+{
+	if( data->readable().size() != 1 )
+	{
+		return false;
+	}
+	return setCompoundNumericChildPlugValue( plug, child, data->readable()[0] );
+}
+
 template<typename PlugType>
 bool setCompoundNumericPlugValue( const PlugType *plug, Gaffer::ValuePlug *leafPlug, const Data *value )
 {
@@ -722,6 +732,37 @@ bool setCompoundNumericPlugValue( const PlugType *plug, Gaffer::ValuePlug *leafP
 			{
 				typedChild->setValue( 1 );
 				return true;
+			}
+		case Color4fVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const Color4fVectorData *>( value ) );
+		case Color3fVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const Color3fVectorData *>( value ) );
+		case V3fVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const V3fVectorData *>( value ) );
+		case V2fVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const V2fVectorData *>( value ) );
+		case V3iVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const V3iVectorData *>( value ) );
+		case V2iVectorDataTypeId :
+			return setCompoundNumericChildPlugValueFromVectorData( plug, typedChild, static_cast<const V2iVectorData *>( value ) );
+		case FloatVectorDataTypeId :
+		case IntVectorDataTypeId :
+		case BoolVectorDataTypeId :
+			if( plug->children().size() < 4 || leafPlug != plug->getChild( 3 ) )
+			{
+				return setNumericPlugValue( typedChild, value );
+			}
+			else
+			{
+				if( IECore::size( value ) == 1 )
+				{
+					typedChild->setValue( 1 );
+					return true;
+				}
+				else
+				{
+					return false;
+				}
 			}
 		default :
 			return false;
@@ -874,6 +915,16 @@ bool canSetCompoundNumericPlugValue( const Data *value )
 		case IntDataTypeId :
 		case BoolDataTypeId :
 			return true;
+		case Color4fVectorDataTypeId :
+		case Color3fVectorDataTypeId :
+		case V3fVectorDataTypeId :
+		case V2fVectorDataTypeId :
+		case V3iVectorDataTypeId :
+		case V2iVectorDataTypeId :
+		case FloatVectorDataTypeId :
+		case IntVectorDataTypeId :
+		case BoolVectorDataTypeId :
+			return IECore::size( value ) == 1;
 		default :
 			return false;
 	}

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/TypedObjectPlug.h"
 #include "Gaffer/ValuePlug.h"
 
+#include "IECore/DataAlgo.h"
 #include "IECore/SplineData.h"
 
 #include "boost/algorithm/string/predicate.hpp"
@@ -565,6 +566,17 @@ IECore::DataPtr extractDataFromPlug( const ValuePlug *plug )
 namespace
 {
 
+template<typename PlugType, typename DataType>
+bool setNumericPlugValueFromVectorData( PlugType *plug, const DataType *value )
+{
+	if( value->readable().size() == 1 )
+	{
+		plug->setValue( value->readable()[0] );
+		return true;
+	}
+	return false;
+}
+
 template<typename PlugType>
 bool setNumericPlugValue( PlugType *plug, const Data *value )
 {
@@ -606,6 +618,30 @@ bool setNumericPlugValue( PlugType *plug, const Data *value )
 		case BoolDataTypeId :
 			plug->setValue( static_cast<const BoolData *>( value )->readable() );
 			return true;
+		case HalfVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const HalfVectorData *>( value ) );
+		case FloatVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const FloatVectorData *>( value ) );
+		case DoubleVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const DoubleVectorData *>( value ) );
+		case CharVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const CharVectorData *>( value ) );
+		case UCharVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const UCharVectorData *>( value ) );
+		case ShortVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const ShortVectorData *>( value ) );
+		case UShortVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const UShortVectorData *>( value ) );
+		case IntVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const IntVectorData *>( value ) );
+		case UIntVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const UIntVectorData *>( value ) );
+		case Int64VectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const Int64VectorData *>( value ) );
+		case UInt64VectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const UInt64VectorData *>( value ) );
+		case BoolVectorDataTypeId :
+			return setNumericPlugValueFromVectorData( plug, static_cast<const BoolVectorData *>( value ) );
 		default :
 			return false;
 	}
@@ -774,6 +810,19 @@ bool canSetNumericPlugValue( const Data *value )
 		case UInt64DataTypeId :
 		case BoolDataTypeId :
 			return true;
+		case HalfVectorDataTypeId :
+		case FloatVectorDataTypeId :
+		case DoubleVectorDataTypeId :
+		case CharVectorDataTypeId :
+		case UCharVectorDataTypeId :
+		case ShortVectorDataTypeId :
+		case UShortVectorDataTypeId :
+		case IntVectorDataTypeId :
+		case UIntVectorDataTypeId :
+		case Int64VectorDataTypeId :
+		case UInt64VectorDataTypeId :
+		case BoolVectorDataTypeId :
+			return IECore::size( value ) == 1;
 		default :
 			return false;
 	}

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -838,6 +838,16 @@ bool setBoxChildPlugValue( const PlugType *plug, typename PlugType::ChildType::C
 	}
 }
 
+template<typename PlugType, typename DataType>
+bool setBoxChildPlugValueFromVectorData( const PlugType *plug, typename PlugType::ChildType::ChildType *child, const DataType *data )
+{
+	if( data->readable().size() != 1 )
+	{
+		return false;
+	}
+	return setBoxChildPlugValue( plug, child, data->readable()[0] );
+}
+
 template<typename PlugType>
 bool setBoxPlugValue( const PlugType *plug, Gaffer::ValuePlug *leafPlug, const Data *value )
 {
@@ -852,6 +862,14 @@ bool setBoxPlugValue( const PlugType *plug, Gaffer::ValuePlug *leafPlug, const D
 			return setBoxChildPlugValue( plug, typedPlug, static_cast<const Box3iData *>( value )->readable() );
 		case Box2iDataTypeId :
 			return setBoxChildPlugValue( plug, typedPlug, static_cast<const Box2iData *>( value )->readable() );
+		case Box3fVectorDataTypeId :
+			return setBoxChildPlugValueFromVectorData( plug, typedPlug, static_cast<const Box3fVectorData *>( value ) );
+		case Box2fVectorDataTypeId :
+			return setBoxChildPlugValueFromVectorData( plug, typedPlug, static_cast<const Box2fVectorData *>( value ) );
+		case Box3iVectorDataTypeId :
+			return setBoxChildPlugValueFromVectorData( plug, typedPlug, static_cast<const Box3iVectorData *>( value ) );
+		case Box2iVectorDataTypeId :
+			return setBoxChildPlugValueFromVectorData( plug, typedPlug, static_cast<const Box2iVectorData *>( value ) );
 		default :
 			return false;
 	}
@@ -1018,6 +1036,14 @@ bool canSetBoxPlugValue( const Data *value )
 		case Box3iDataTypeId :
 		case Box2iDataTypeId :
 			return true;
+		case Box3fVectorDataTypeId :
+			return static_cast<const Box3fVectorData *>( value )->readable().size() == 1;
+		case Box2fVectorDataTypeId :
+			return static_cast<const Box2fVectorData *>( value )->readable().size() == 1;
+		case Box3iVectorDataTypeId :
+			return static_cast<const Box3iVectorData *>( value )->readable().size() == 1;
+		case Box2iVectorDataTypeId :
+			return static_cast<const Box2iVectorData *>( value )->readable().size() == 1;
 		default :
 			return false;
 	}

--- a/src/GafferModule/BoxPlugBinding.cpp
+++ b/src/GafferModule/BoxPlugBinding.cpp
@@ -75,7 +75,7 @@ void bind()
 	using P = typename T::PointType;
 	using B = typename P::BaseType;
 
-	PlugClass<T>()
+	scope s = PlugClass<T>()
 		.def( init<const std::string &, Plug::Direction, const V&, unsigned>(
 				(
 					boost::python::arg_( "name" )=GraphComponent::defaultName<T>(),
@@ -104,6 +104,16 @@ void bind()
 		.def( "setValue", &setValue<T> )
 		.def( "getValue", &getValue<T> )
 	;
+
+	const PyTypeObject *valueType = boost::python::to_python_value<const V &>().get_pytype();
+	s.attr( "ValueType" ) = boost::python::object( boost::python::handle<>( boost::python::borrowed( const_cast<PyTypeObject *>( valueType ) ) ) );
+
+	const PyTypeObject *pointType = boost::python::to_python_value<const P &>().get_pytype();
+	s.attr( "PointType" ) = boost::python::object( boost::python::handle<>( boost::python::borrowed( const_cast<PyTypeObject *>( pointType ) ) ) );
+
+	const PyTypeObject *childType = boost::python::to_python_value<const typename T::ChildType &>().get_pytype();
+	s.attr( "ChildType" ) = boost::python::object( boost::python::handle<>( boost::python::borrowed( const_cast<PyTypeObject *>( childType ) ) ) );
+
 }
 
 } // namespace


### PR DESCRIPTION
This conversion is available in the various query nodes, and is particularly useful when querying attributes and primitive variables from certain DCCs which like to write everything as arrays, even if they make more sense as scalars.

I've only implemented this for FloatPlug, IntPlug and BoolPlug so far. If there's general support for the idea then I'll update to include other types too. Part of me dislikes the conversion and wishes everything was just typed more logically in the first place. And I worry that the existence of the conversion only for length 1 might lead to a surprise or two for things with animated array lengths. But on balance I think this is probably the most pragmatic thing to do - it lets users deal easily with a bunch of common problem scenarios without resorting to the performance hit of expressions.