### PR TITLE
Cycles fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - TweakPlug : `ListAppend`, `ListPrepend` and `ListRemove` modes are now supported for string values. In this case, the string is treated as a space-separated list.
+- Cycles : Changed default value for `principled_bsdf.specular_ior_level` to `0.5`, matching Blender.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 Fixes
 -----
 
+- Viewer : Fixed Cycles shader balls.
 - TweakPlug : Fixed incorrect results and potential crashes in list modes.
 
 1.4.1.0 (relative to 1.4.0.0)

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -123,6 +123,12 @@ IECoreImage::DisplayDriverServer *displayDriverServer()
 
 GAFFER_NODE_DEFINE_TYPE( ShaderView );
 
+/// \todo Registering against `out` is not ideal. Most Shader subclasses represent outputs as children of `out`, and
+/// connecting directly from `Shader.out` to `View.in` results in a non-standard ShaderNetwork in which the name of
+/// the output parameter is not specified. Instead we want to register against `out.*`, so that the children are
+/// connected into `View.in`. We can't do that yet though, because ArnoldShader uses `out` directly - see #5542.
+/// Alternatively, we could omit this registration entirely in favour of specific registrations for each subclass,
+/// but that would be a breaking change (albeit a small one).
 ShaderView::ViewDescription<ShaderView> ShaderView::g_viewDescription( GafferScene::Shader::staticTypeId(), "out" );
 
 ShaderView::ShaderView( const std::string &name )

--- a/startup/GafferCycles/principledBSDFCompatibility.py
+++ b/startup/GafferCycles/principledBSDFCompatibility.py
@@ -77,3 +77,7 @@ def __cyclesShaderGetItem( originalGetItem ) :
 	return getItem
 
 GafferCycles.CyclesShader.__getitem__ = __cyclesShaderGetItem( GafferCycles.CyclesShader.__getitem__ )
+
+# The parameter defaults advertised by Cycles do not always match the actual defaults used by Blender.
+# Register user defaults with Blender's values where it makes sense.
+Gaffer.Metadata.registerValue( "cycles:surface:principled_bsdf:specular_ior_level", "userDefault", 0.5 )


### PR DESCRIPTION
This fixes the shader balls in the Viewer, and matches the default for `specular_ior_level` to Blender.