### PR TITLE
Delight Renderer : Prefer `fmt::format()` to `boost::format()`

### DIFF
--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1635,7 +1635,7 @@ class DelightRenderer final : public IECoreScenePreview::Renderer
 		{
 			if( boost::starts_with( name.string(), "dl:" ) || name.string().find( ":" ) == string::npos )
 			{
-				IECore::msg( IECore::Msg::Warning, "IECoreDelight::Renderer::command", boost::format( "Unknown command \"%s\"." ) % name.c_str() );
+				IECore::msg( IECore::Msg::Warning, "IECoreDelight::Renderer::command", fmt::format( "Unknown command \"{}\".", name.c_str() ) );
 			}
 
 			return nullptr;


### PR DESCRIPTION
This one snuck in despite us ridding ourselves of `boost::format()` a while back.
