### PR TITLE
CodeWidget : Add shortcut for selecting the current line

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Changed default value for `principled_bsdf.specular_ior_level` to `0.5`, matching Blender.
   - Added support for `uv.tangent` and `uv.tangent_sign` primitive variables to assist in rendering with normal maps (#5269).
 - AttributeQuery, PrimitiveVariableQuery, ContextQuery, OptionQuery, ShaderQuery : Added support for querying arrays of length 1 as their equivalent scalar types.
+- CodeWidget : Added <kbd>Ctrl</kbd>+<kbd>L</kbd> shortcut for selecting all text on the current line.
 
 Fixes
 -----

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -347,6 +347,7 @@ Drop scene location path(s) into Python Editor   | {{leftClick}} and drag select
 Indent selection                                 | {kbd}`Ctrl` + {kbd}`]`
 Unindent selection                               | {kbd}`Ctrl` + {kbd}`[`
 Comment/uncomment selection                      | {kbd}`Ctrl` + {kbd}`/`
+Select current line                              | {kbd}`Ctrl` + {kbd}`L`
 
 
 ### Execution ###

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -111,6 +111,8 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 			return self.__commentPress()
 		elif event.key == "Return" and event.modifiers == event.Modifiers.None_ :
 			return self.__returnPress()
+		elif event.modifiers == event.Modifiers.Control and event.key == "L" :
+			return self.__extendSelectionPress()
 
 		return False
 
@@ -238,6 +240,33 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 			self._qtWidget().ensureCursorVisible()
 		finally :
 			cursor.endEditBlock()
+
+		return True
+
+	def __extendSelectionPress( self ) :
+
+		cursor = self._qtWidget().textCursor()
+
+		if cursor.hasSelection() :
+			# Extend an existing selection to contain the beginning of the
+			# first selected line through to the end of the last selected line.
+			selectionEnd = cursor.selectionEnd()
+			cursor.setPosition( cursor.selectionStart(), cursor.MoveAnchor )
+			cursor.movePosition( cursor.StartOfLine, cursor.MoveAnchor )
+			cursor.setPosition( selectionEnd, cursor.KeepAnchor )
+			cursor.movePosition( cursor.EndOfLine, cursor.KeepAnchor )
+		else :
+			# Select the entire line where the cursor is currently positioned.
+			cursor.movePosition( cursor.StartOfLine, cursor.MoveAnchor )
+			cursor.movePosition( cursor.EndOfLine, cursor.KeepAnchor )
+
+		if not cursor.atEnd() :
+			# Move the cursor to the start of the next line to allow
+			# repeated presses to extend the selection to subsequent lines.
+			cursor.movePosition( cursor.Down, cursor.KeepAnchor )
+			cursor.movePosition( cursor.StartOfLine, cursor.KeepAnchor )
+
+		self._qtWidget().setTextCursor( cursor )
 
 		return True
 


### PR DESCRIPTION
I find myself using this shortcut habitually in VSCode then missing it once I'm back in Gaffer, and it's raining on a Saturday...