### PR TITLE
SConstruct : Ensure `Python.framework` can be found on macOS

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,11 @@ API
 - BoxPlug : Added Python bindings for `ValueType`, `PointType` and `ChildType` type aliases.
 - RenderPassEditor : Added `deregisterColumn()` method.
 
+Build
+-----
+
+- MacOS : Fixed issue where `Python.framework` may not be found when building with a prebuilt dependencies package.
+
 1.4.1.0 (relative to 1.4.0.0)
 =======
 

--- a/SConstruct
+++ b/SConstruct
@@ -751,10 +751,13 @@ commandEnv["ENV"]["PATH"] = commandEnv.subst( "$BUILD_DIR/bin" + os.path.pathsep
 if env["PLATFORM"] == "win32" :
 	commandEnv["ENV"]["PATH"] = commandEnv.subst( "$BUILD_DIR/lib" + os.path.pathsep ) + commandEnv["ENV"]["PATH"]
 
-if commandEnv["PLATFORM"]=="darwin" :
+if commandEnv["PLATFORM"] == "darwin" :
 	commandEnv["ENV"]["DYLD_LIBRARY_PATH"] = commandEnv.subst( ":".join(
 		[ "/System/Library/Frameworks/ImageIO.framework/Resources", "$BUILD_DIR/lib" ] +
 		split( commandEnv["LOCATE_DEPENDENCY_LIBPATH"] )
+	) )
+	commandEnv["ENV"]["DYLD_FRAMEWORK_PATH"] = commandEnv.subst( ":".join(
+		[ "$BUILD_DIR/lib" ] + split( commandEnv["LOCATE_DEPENDENCY_LIBPATH"] )
 	) )
 elif commandEnv["PLATFORM"] == "win32" :
 	commandEnv["ENV"]["PATH"] = commandEnv.subst( ";".join( [ "$BUILD_DIR/lib" ] + split( commandEnv[ "LOCATE_DEPENDENCY_LIBPATH" ] ) + [ commandEnv["ENV"]["PATH"] ] ) )


### PR DESCRIPTION
Frameworks are not found when building on macOS with a prebuilt dependencies package (or locally built dependencies that have been moved or renamed). Adding `$BUILD_DIR/lib`to `DYLD_FRAMEWORK_PATH` is equivalent to what we already do in the `gaffer` wrapper on macOS:

https://github.com/GafferHQ/gaffer/blob/35190d2e4cf9ad28997a1083f18030638af57018/bin/gaffer#L182
