### PR TITLE
Light tool disable click

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
   - Added support for multipart EXR renders by using the same file name parameter on multiple outputs.
   - Added support for scalarformat, colorprofile, filterwidth and arbitrary custom NSI outputlayer and outputdriver attributes.
   - Updated the default output presets to include scalarformat, colorprofile, filter and filterwidth output parameters.
+- LightPositionTool : Changed the pointer to `notEditable` when using keyboard combinations that do not apply to the current tool mode.
 
 Fixes
 -----
@@ -15,6 +16,7 @@ Fixes
 - SceneReader, SceneWriter : Fixed handling of Arnold-specific parameters on UsdLux lights.
 - SceneWriter : Fixed import of `treatAsPoint` and `treatAsLine` parameters on UsdLux lights.
 - Linux : Fixed crashes at startup on platforms - including RHEL 9.4 - with a more recent `glibc` (#5856).
+- LightPositionTool : Fixed bug that allowed a non-light object to be moved by clicking or dragging the target or pivot.
 
 1.4.3.0 (relative to 1.4.2.0)
 =======

--- a/include/GafferSceneUI/LightPositionTool.h
+++ b/include/GafferSceneUI/LightPositionTool.h
@@ -125,6 +125,8 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 		IECore::RunTimeTypedPtr handleDragBegin( GafferUI::Gadget *gadget );
 		bool handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool handleDragEnd();
+		bool handleEnter( const GafferUI::ButtonEvent &event );
+		void handleLeave();
 
 		IECore::RunTimeTypedPtr sceneGadgetDragBegin( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
 		bool sceneGadgetDragEnter( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event );
@@ -159,6 +161,7 @@ class GAFFERSCENEUI_API LightPositionTool : public GafferSceneUI::TransformTool
 
 		void setTargetMode( TargetMode mode );
 		TargetMode getTargetMode() const { return m_targetMode; }
+		void updatePointer() const;
 
 		void setPivot( const Imath::V3f &p, Gaffer::ScriptNodePtr scriptNode );
 		std::optional<Imath::V3f> getPivot() const;

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -821,7 +821,11 @@ bool LightPositionTool::handleDragEnd()
 
 RunTimeTypedPtr LightPositionTool::sceneGadgetDragBegin( Gadget *gadget, const DragDropEvent &event )
 {
-	if( !activePlug()->getValue() || getTargetMode() == TargetMode::None )
+	if(
+		!activePlug()->getValue() ||
+		getTargetMode() == TargetMode::None ||
+		!m_distanceHandle->visible()
+	)
 	{
 		return nullptr;
 	}
@@ -949,7 +953,7 @@ bool LightPositionTool::buttonPress( const ButtonEvent &event )
 
 	// We always return true to prevent the SelectTool defaults.
 
-	if( !selectionEditable() || !m_distanceHandle->enabled() )
+	if( !selectionEditable() || !m_distanceHandle->enabled() || !m_distanceHandle->visible() )
 	{
 		return true;
 	}
@@ -1111,15 +1115,23 @@ void LightPositionTool::setTargetMode( TargetMode targeted )
 
 	m_targetMode = targeted;
 
-	switch( m_targetMode )
+	if( m_targetMode == TargetMode::None )
 	{
-		case TargetMode::None : GafferUI::Pointer::setCurrent( "" ); break;
-		case TargetMode::Pivot :
-			GafferUI::Pointer::setCurrent(
-				modePlug()->getValue() == (int)Mode::Shadow ? "pivot" : ""
-			);
-			break;
-		case TargetMode::Target : GafferUI::Pointer::setCurrent( "target" ); break;
+		GafferUI::Pointer::setCurrent( "" );
+	}
+	else if( !m_distanceHandle->enabled() || !m_distanceHandle->visible() )
+	{
+		GafferUI::Pointer::setCurrent( "notEditable" );
+	}
+	else if( m_targetMode == TargetMode::Pivot )
+	{
+		GafferUI::Pointer::setCurrent(
+			modePlug()->getValue() == (int)Mode::Shadow ? "pivot" : "notEditable"
+		);
+	}
+	else if( m_targetMode == TargetMode::Target )
+	{
+		GafferUI::Pointer::setCurrent( "target" );
 	}
 }
 


### PR DESCRIPTION
Previously we were making the light position tool disabled and invisible if anything except a light is selected. This still allowed clicking and dragging, so users could still move a non-light object, which is not our intention.

I also changed the behavior when pressing the `V` / `Shift + V` key when the handle is visible but disabled (for example if more than one light is selected). Previously the pointer would change when pressing `V`, but you couldn't actually set the target since the tool is disabled. Now it won't change the pointer so the user won't expect an action when none is possible.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
