### PR TITLE
HiddenFilePathFilter: Fix hidden sequences

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.3.16.x (relative to 1.3.16.1)
 ========
 
+Fixes
+-----
+
+- File Browser : Windows only : Fixed bug in `HiddenFilePathFilter` that caused sequences to be treated as though they are hidden files (#5810).
 
 
 1.3.16.1 (relative to 1.3.16.0)


### PR DESCRIPTION
Fixes #5810

When checking a path that has the `#` character for frame substitutions, `HiddenFilePathFilter` would always treat it as hidden. The file with `#` does not exist, so the Windows API would return `INVALID_FILE_ATTRIBUTES` whose value is `-1`. `FILE_ATTRIBUTE_HIDDEN` has a value of `2`. `-1 & 2 = 2`, so sequences would always be considered hidden.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
