### PR TITLE
SConstruct : Fix calls to `usdGenSchema` on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1862,7 +1862,9 @@ for libraryName, libraryDef in libraries.items() :
 		subprocess.check_call(
 			[
 				shutil.which( "gaffer.cmd" if sys.platform == "win32" else "gaffer", path = env["ENV"]["PATH"] ),
-				"env", "usdGenSchema", str( source[0] ), targetDir
+				"env",
+				"usdGenSchema.cmd" if sys.platform == "win32" else "usdGenSchema",
+				str( source[0] ), targetDir
 			],
 			env = env["ENV"]
 		)


### PR DESCRIPTION
Hopefully should fix a problem I introduced in #5801, which went unnoticed till now due to the lack of Arnold testing on general pull requests. I've remembered to make this PR from a GafferHQ branch, so we should get proper test coverage this time round.