### PR TITLE
SceneAlgo : Add client/renderer-specific adaptor registrations 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,11 @@ Fixes
 
 - Arnold : Fixed rendering of `ai:volume` shaders loaded from USD (#5830).
 
+API
+---
+
+- SceneAlgo : Added mechanism for scoping render adaptors to specific clients and/or renderers.
+
 1.4.2.0 (relative to 1.4.1.0)
 =======
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -308,16 +308,39 @@ GAFFERSCENE_API void validateName( IECore::InternedString name );
 
 /// Render Adaptors
 /// ===============
+///
+/// Adaptors are nodes that are implicitly appended to the node graph
+/// before rendering, allowing them to make final modifications
+/// to the scene. They can be used to do "delayed resolution" of custom
+/// features, enforce pipeline policies or customise output for specific
+/// renderers or clients.
+///
+/// Adaptors are created by clients such as the Render and InteractiveRender
+/// nodes and the SceneView which implements Gaffer's 3D Viewer.
+///
+/// Adaptors are implemented as SceneProcessors with optional `client`
+/// and `renderer` input StringPlugs to inform them of the scope in
+/// which they are operating. Custom adaptors can be registered for
+/// any purpose by calling `registerRenderAdaptor()`. Examples include
+/// `startup/GafferScene/renderSetAdaptor.py` which implements features
+/// for the RenderPassEditor, and `startup/GafferArnold/ocio.py` which
+/// configures a default colour manager for Arnold.
 
 /// Function to return a SceneProcessor used to adapt the
 /// scene for rendering.
 using RenderAdaptor = std::function<SceneProcessorPtr ()>;
-/// Registers an adaptor.
+/// Registers an adaptor to be applied when `client` renders using `renderer`. Standard
+/// wildcards may be used to match multiple clients and/or renderers.
+GAFFERSCENE_API void registerRenderAdaptor( const std::string &name, RenderAdaptor adaptor, const std::string &client, const std::string &renderer );
+/// Equivalent to `registerRenderAdaptor( name, adaptor, "*", "*" )`.
+/// \todo Remove
 GAFFERSCENE_API void registerRenderAdaptor( const std::string &name, RenderAdaptor adaptor );
 /// Removes a previously registered adaptor.
 GAFFERSCENE_API void deregisterRenderAdaptor( const std::string &name );
 /// Returns a SceneProcessor that will apply all the currently
-/// registered adaptors.
+/// registered adaptors. It is the client's responsibility to set
+/// the adaptor's `client` and `renderer` string plugs to appropriate
+/// values before use.
 GAFFERSCENE_API SceneProcessorPtr createRenderAdaptors();
 
 /// Apply Camera Globals

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -172,6 +172,8 @@ InteractiveRender::InteractiveRender( const IECore::InternedString &rendererType
 	SceneProcessorPtr adaptors = SceneAlgo::createRenderAdaptors();
 	setChild( "__adaptors", adaptors );
 	adaptors->inPlug()->setInput( inPlug() );
+	adaptors->getChild<StringPlug>( "client" )->setValue( "InteractiveRender" );
+	adaptors->getChild<StringPlug>( "renderer" )->setInput( resolvedRendererPlug() );
 	adaptedInPlug()->setInput( adaptors->outPlug() );
 
 	outPlug()->setInput( inPlug() );

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -119,6 +119,8 @@ Render::Render( const IECore::InternedString &rendererType, const std::string &n
 	SceneProcessorPtr adaptors = GafferScene::SceneAlgo::createRenderAdaptors();
 	setChild( "__adaptors", adaptors );
 	adaptors->inPlug()->setInput( inPlug() );
+	adaptors->getChild<StringPlug>( "client" )->setValue( "Render" );
+	adaptors->getChild<StringPlug>( "renderer" )->setInput( resolvedRendererPlug() );
 	adaptedInPlug()->setInput( adaptors->outPlug() );
 
 	outPlug()->setInput( inPlug() );

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -340,9 +340,9 @@ struct RenderAdaptorWrapper
 
 };
 
-void registerRenderAdaptorWrapper( const std::string &name, object adaptor )
+void registerRenderAdaptorWrapper( const std::string &name, object adaptor, const std::string &client, const std::string &renderer )
 {
-	SceneAlgo::registerRenderAdaptor( name, RenderAdaptorWrapper( adaptor ) );
+	SceneAlgo::registerRenderAdaptor( name, RenderAdaptorWrapper( adaptor ), client, renderer );
 }
 
 void applyCameraGlobalsWrapper( IECoreScene::Camera &camera, const IECore::CompoundObject &globals, const ScenePlug &scene )
@@ -441,7 +441,7 @@ void bindSceneAlgo()
 
 	// Render adaptors
 
-	def( "registerRenderAdaptor", &registerRenderAdaptorWrapper );
+	def( "registerRenderAdaptor", &registerRenderAdaptorWrapper, ( arg( "name" ), arg( "adaptor" ), arg( "client" ) = "*", arg( "renderer" ) = "*" ) );
 	def( "deregisterRenderAdaptor", &SceneAlgo::deregisterRenderAdaptor );
 	def( "createRenderAdaptors", &SceneAlgo::createRenderAdaptors );
 

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -2015,6 +2015,7 @@ SceneView::SceneView( const std::string &name )
 
 	SceneProcessorPtr adaptors = SceneAlgo::createRenderAdaptors();
 	preprocessor->addChild( adaptors );
+	adaptors->getChild<StringPlug>( "client" )->setValue( "SceneView" );
 	adaptors->inPlug()->setInput( deleteObject->outPlug() );
 
 	// add in the node from the ShadingMode
@@ -2031,6 +2032,7 @@ SceneView::SceneView( const std::string &name )
 
 	preprocessor->addChild( m_renderer->preprocessor() );
 	m_renderer->preprocessor()->inPlug()->setInput( m_drawingMode->preprocessor()->outPlug() );
+	adaptors->getChild<StringPlug>( "renderer" )->setInput( getChild<Plug>( "renderer" )->getChild<StringPlug>( "name" ) );
 
 	// remove motion blur, because the opengl renderer doesn't support it.
 


### PR DESCRIPTION
This allows adaptors to be registered against specific clients (Render, InteractiveRender, SceneView) and/or renderers (Arnold, 3Delight etc). It also allows adaptors to query which client and renderer is the current one in the case that it is registered against multiple. We anticipate this being particularly useful for implementing delayed resolution of Render Pass Editor features, and for weaning folks off the `${renderer}` context variable which we are hoping to phase out.