### PR TITLE
CodeWidget : Fix errors handling multi-line highlights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 -----
 
 - Arnold : Fixed rendering of `ai:volume` shaders loaded from USD (#5830).
+- CodeWidget : Fixed errors handling highlights which spanned more than one line, such as triple-quoted strings in the PythonEditor.
 
 API
 ---

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -314,7 +314,7 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 
 class Highlighter( object ) :
 
-	Type = enum.Enum(
+	Type = enum.IntEnum(
 		"Type",
 		[
 			"SingleQuotedString", "DoubleQuotedString", "Number",


### PR DESCRIPTION
The was broken by 77a679aaa95811baa01fac038a93d421240306b4, causing the following error :

```
Traceback (most recent call last):
  File "/home/john/dev/build/gaffer-1.4/python/GafferUI/CodeWidget.py", line 481, in highlightBlock
    self.setCurrentBlockState( int( h.type ) )
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Type'
Traceback (most recent call last):
  File "/home/john/dev/build/gaffer-1.4/python/GafferUI/CodeWidget.py", line 481, in highlightBlock
    self.setCurrentBlockState( int( h.type ) )
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Type'
```
