### PR TITLE
`TestLight` shader

### DIFF
--- a/include/GafferSceneTest/TestLight.h
+++ b/include/GafferSceneTest/TestLight.h
@@ -37,9 +37,11 @@
 #pragma once
 
 #include "GafferSceneTest/Export.h"
+#include "GafferSceneTest/TestShader.h"
 #include "GafferSceneTest/TypeIds.h"
 
 #include "GafferScene/Light.h"
+#include "GafferScene/ShaderPlug.h"
 
 namespace GafferSceneTest
 {
@@ -54,10 +56,24 @@ class GAFFERSCENETEST_API TestLight : public GafferScene::Light
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneTest::TestLight, TestLightTypeId, GafferScene::Light );
 
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+		void loadShader( const std::string &shaderName );
+
 	protected :
 
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+
+	private :
+
+		TestShader *shaderNode();
+		const TestShader *shaderNode() const;
+
+		GafferScene::ShaderPlug *shaderInPlug();
+		const GafferScene::ShaderPlug *shaderInPlug() const;
+
+		static size_t g_firstPlugIndex;
 
 };
 

--- a/include/GafferSceneTest/TestShader.h
+++ b/include/GafferSceneTest/TestShader.h
@@ -54,6 +54,11 @@ class GAFFERSCENETEST_API TestShader : public GafferScene::Shader
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneTest::TestShader, TestShaderTypeId, GafferScene::Shader );
 
+		// Populates the `parameters` with plugs for different test cases. Currently
+		// supports `simpleShader` and `simpleLight`. If `shaderName` is not recognized,
+		// it will create a shader with that name and no parameters.
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
+
 };
 
 } // namespace GafferSceneTest

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -1564,11 +1564,11 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		history = GafferScene.SceneAlgo.history( tweaks["out"]["attributes"], "/group/light" )
 		attributeHistory = GafferScene.SceneAlgo.attributeHistory( history, "light" )
 
-		self.__assertParameterHistory( attributeHistory, [], tweaks["out"], "/group/light", "light", "light", "exposure", 2.0, 1 )
-		self.__assertParameterHistory( attributeHistory, [ 0 ], tweaks["in"], "/group/light", "light", "light", "exposure", 0.0, 1 )
-		self.__assertParameterHistory( attributeHistory, [ 0, 0 ], group["out"], "/group/light", "light", "light", "exposure", 0.0, 1 )
-		self.__assertParameterHistory( attributeHistory, [ 0, 0, 0 ], group["in"][0], "/light", "light", "light", "exposure", 0.0, 1 )
-		self.__assertParameterHistory( attributeHistory, [ 0, 0, 0, 0 ], testLight["out"], "/light", "light", "light", "exposure", 0.0, 0 )
+		self.__assertParameterHistory( attributeHistory, [], tweaks["out"], "/group/light", "light", "__shader", "exposure", 2.0, 1 )
+		self.__assertParameterHistory( attributeHistory, [ 0 ], tweaks["in"], "/group/light", "light", "__shader", "exposure", 0.0, 1 )
+		self.__assertParameterHistory( attributeHistory, [ 0, 0 ], group["out"], "/group/light", "light", "__shader", "exposure", 0.0, 1 )
+		self.__assertParameterHistory( attributeHistory, [ 0, 0, 0 ], group["in"][0], "/light", "light", "__shader", "exposure", 0.0, 1 )
+		self.__assertParameterHistory( attributeHistory, [ 0, 0, 0, 0 ], testLight["out"], "/light", "light", "__shader", "exposure", 0.0, 0 )
 
 	def testAttributeHistoryWithMissingAttribute( self ) :
 

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -616,12 +616,12 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 
 		light1 = GafferSceneTest.TestLight()
 		light1["name"].setValue( "light1" )
-		light1["lightShaderName"].setValue( "SphereLight" ) # USDScene requires valid USD light type
+		light1.loadShader( "SphereLight" ) # USDScene requires valid USD light type
 		light1["parameters"]["intensity"] = Gaffer.FloatPlug( defaultValue = 1 ) # USD expects float, not colour
 		light1["defaultLight"].setValue( False )
 
 		light2 = GafferSceneTest.TestLight()
-		light2["lightShaderName"].setValue( "SphereLight" )
+		light2.loadShader( "SphereLight" )
 		light2["parameters"]["intensity"] = Gaffer.FloatPlug( defaultValue = 1 )
 		light2["name"].setValue( "light2" )
 

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -38,31 +38,106 @@
 
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/OptionalValuePlug.h"
+#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/SplinePlug.h"
+
+#include "IECore/Spline.h"
 
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferSceneTest;
+
+namespace
+{
+
+template<typename PlugType>
+Plug *setupTypedPlug(
+	const InternedString &parameterName,
+	GraphComponent *plugParent,
+	const typename PlugType::ValueType &defaultValue
+)
+{
+	PlugType *existingPlug = plugParent->getChild<PlugType>( parameterName );
+	if( existingPlug && existingPlug->defaultValue() == defaultValue )
+	{
+		return existingPlug;
+	}
+
+	typename PlugType::Ptr plug = new PlugType( parameterName, Plug::Direction::In, defaultValue );
+	PlugAlgo::replacePlug( plugParent, plug );
+
+	return plug.get();
+}
+
+template<typename ValuePlugType>
+Plug *setupOptionalValuePlug(
+	const InternedString &parameterName,
+	GraphComponent *plugParent,
+	const ValuePlugPtr &valuePlug
+)
+{
+	OptionalValuePlug *existingPlug = plugParent->getChild<OptionalValuePlug>( parameterName );
+
+	if( existingPlug && valuePlug->typeId() == ValuePlugType::staticTypeId() )
+	{
+		auto existingValuePlug = runTimeCast<ValuePlugType>( existingPlug->valuePlug() );
+		auto typedPlug = runTimeCast<ValuePlugType>( valuePlug );
+		if( existingValuePlug->defaultValue() == typedPlug->defaultValue() )
+		{
+			return existingPlug;
+		}
+	}
+
+	OptionalValuePlugPtr plug = new OptionalValuePlug( parameterName, valuePlug );
+	PlugAlgo::replacePlug( plugParent, plug );
+
+	return plug.get();
+}
+
+}  // namespace
 
 GAFFER_NODE_DEFINE_TYPE( TestShader )
 
 TestShader::TestShader( const std::string &name )
 	:	Shader( name )
 {
-	// The base class expects us to serialise a `loadShader()`
-	// call to set the values for these, but we just represent
-	// a fixed shader. Turn serialisation back on.
-	namePlug()->setFlags( Plug::Serialisable, true );
+	// The base class expects `loadShader()` to set `type`, but
+	// we don't want to make assumptions for the purposes of testing.
+	// Turn serialisation back on to preserve the user-specified type.
 	typePlug()->setFlags( Plug::Serialisable, true );
 
 	addChild( new Color3fPlug( "out", Plug::Out ) );
-	parametersPlug()->addChild( new IntPlug( "i" ) );
-	parametersPlug()->addChild( new Color3fPlug( "c" ) );
-	parametersPlug()->addChild( new SplinefColor3fPlug( "spline" ) );
-	parametersPlug()->addChild( new OptionalValuePlug( "optionalString", new Gaffer::StringPlug() ) );
+
+	loadShader( "simpleShader" );
 }
 
 TestShader::~TestShader()
 {
+}
+
+void TestShader::loadShader( const std::string &shaderName, bool keepExistingValues )
+{
+	Plug *parametersPlug = this->parametersPlug()->source<Plug>();
+
+	if( !keepExistingValues )
+	{
+		parametersPlug->clearChildren();
+	}
+
+	namePlug()->source<StringPlug>()->setValue( shaderName );
+
+	if( shaderName == "simpleLight" )
+	{
+		setupTypedPlug<Color3fPlug>( "intensity", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<FloatPlug>( "exposure", parametersPlug, 0.f );
+		setupTypedPlug<BoolPlug>( "__areaLight", parametersPlug, false );
+	}
+	else if( shaderName == "simpleShader" )
+	{
+		setupTypedPlug<IntPlug>( "i", parametersPlug, 0 );
+		setupTypedPlug<Color3fPlug>( "c", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<SplinefColor3fPlug>( "spline", parametersPlug, SplineDefinitionfColor3f() );
+		setupOptionalValuePlug<StringPlug>( "optionalString", parametersPlug, new StringPlug() );
+	}
 }

--- a/src/GafferSceneTestModule/GafferSceneTestModule.cpp
+++ b/src/GafferSceneTestModule/GafferSceneTestModule.cpp
@@ -67,7 +67,9 @@ BOOST_PYTHON_MODULE( _GafferSceneTest )
 
 	GafferBindings::DependencyNodeClass<CompoundObjectSource>();
 	GafferBindings::NodeClass<TestShader>();
-	GafferBindings::NodeClass<TestLight>();
+	GafferBindings::NodeClass<TestLight>()
+		.def( "loadShader", &TestLight::loadShader )
+	;
 	GafferBindings::NodeClass<TestLightFilter>();
 
 	def( "traverseScene", &traverseSceneWrapper );


### PR DESCRIPTION
This adds an internal shader to `TestLight` to use as its source of parameters, as other lights do. It was originally motivated by needing to create tests where shader nodes will be connected to a light.

I tried to keep as much backwards compatibility as possible so all the tests using `TestLight` don't need to add `loadShader()` calls, for example. Hopefully the result is a `TestLight` and `TestShader` that are more flexible but also have useful defaults.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
