### PR TITLE
3Delight multipart render support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.3.0)
 =======
 
+Improvements
+------------
 
+- 3Delight : Added support for multipart EXR renders by using the same file name parameter on multiple outputs. 
 
 1.4.3.0 (relative to 1.4.2.0)
 =======

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -46,6 +46,8 @@ import math
 
 import imath
 
+import OpenImageIO
+
 import IECore
 import IECoreScene
 import IECoreDelight
@@ -100,6 +102,42 @@ class RendererTest( GafferTest.TestCase ) :
 		del r
 
 		self.assertTrue( ( self.temporaryDirectory() / "beauty.exr" ).exists() )
+
+	def testOutputMultipart( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"3Delight",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		r.output(
+			"layer_a",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "multipart.exr" ),
+				"exr",
+				"rgba"
+			)
+		)
+
+		r.output(
+			"layer_b",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "multipart.exr" ),
+				"exr",
+				"color shader:diffuse"
+			)
+		)
+
+		r.render()
+		del r
+
+		self.assertTrue( ( self.temporaryDirectory() / "multipart.exr" ).exists() )
+
+		i = OpenImageIO.ImageInput.open( os.path.join( self.temporaryDirectory(), "multipart.exr" ) )
+		subimages = i.spec().getattribute("oiio:subimages")
+		del i
+
+		self.assertEqual( subimages, 2 )
 
 	def testAOVs( self ) :
 

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -281,7 +281,10 @@ class DelightOutput : public IECore::RefCounted
 			driverParams.add( { "drivername", &typePtr, NSITypeString, 0, 1, 0 } );
 			driverParams.add( { "imagefilename", &namePtr, NSITypeString, 0, 1, 0 } );
 
-			m_driverHandle = DelightHandle( context, "outputDriver:" + name, ownership, "outputdriver", driverParams );
+			// Since NSICreate will return an existing node if the handle already exists, we can
+			// render multipart EXRs by constructing the NSI outputdriver node handle from the
+			// output file name parameter and then use the same file name on multiple outputs.
+			m_driverHandle = DelightHandle( context, "outputDriver:" + output->getName(), ownership, "outputdriver", driverParams );
 
 			// Layer
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Support for rendering to multipart EXRs by using the same file name output parameter across multiple outputs.
- Recreated PR against 1.4_maintenance branch.
- Addressed all the notes from the discussion in the main branch PR - https://github.com/GafferHQ/gaffer/pull/5844

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
