### PR TITLE
3Delight extended outputlayer attributes support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,10 @@
 Improvements
 ------------
 
-- 3Delight : Added support for multipart EXR renders by using the same file name parameter on multiple outputs. 
+- 3Delight :
+  - Added support for multipart EXR renders by using the same file name parameter on multiple outputs.
+  - Added support for scalarformat, colorprofile, filterwidth and arbitrary custom NSI outputlayer and outputdriver attributes.
+  - Updated the default output presets to include scalarformat, colorprofile, filter and filterwidth output parameters.
 
 1.4.3.0 (relative to 1.4.2.0)
 =======

--- a/python/IECoreDelightTest/RendererTest.py
+++ b/python/IECoreDelightTest/RendererTest.py
@@ -93,7 +93,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"rgba",
 				{
 					"filter" : "gaussian",
-					"filterwidth" : imath.V2f( 3.5 ),
+					"filterwidth" : 3.5,
 				}
 			)
 		)
@@ -194,7 +194,7 @@ class RendererTest( GafferTest.TestCase ) :
 					data,
 					{
 						"filter" : "gaussian",
-						"filterwidth" : imath.V2f( 3.5 ),
+						"filterwidth" : 3.5,
 					}
 				)
 			)
@@ -1547,6 +1547,56 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( nsi["outputLayer:diffuse"]["layername"], "diffuse" )
 		self.assertEqual( nsi["outputLayer:directDiffuse"]["layername"], "diffuse_direct" )
 		self.assertEqual( nsi["outputLayer:customLayerName"]["layername"], "myLayerName" )
+
+	def testOutputLayerAttributes( self ) :
+
+		for data, expected in {
+			"rgba" : {
+				"variablename": "Ci",
+				"variablesource": "shader",
+				"layertype": "color",
+				"withalpha": 1,
+				"filter": "gaussian",
+				"filterwidth": 3.5,
+				"scalarformat": "half",
+				"colorprofile": "sRGB",
+				"layername": "Test",
+				"dithering": 1
+			},
+		}.items() :
+
+			r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"3Delight",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+				str( self.temporaryDirectory() / "test.nsia" )
+			)
+
+			r.output(
+				"test",
+				IECoreScene.Output(
+					"beauty.exr",
+					"exr",
+					data,
+					{
+						"filter": "gaussian",
+						"filterwidth": 3.5,
+						"scalarformat": "half",
+						"colorprofile": "sRGB",
+						"layerName": "Test",
+						"dithering": 1
+					}
+				)
+			)
+
+			r.render()
+			del r
+
+			nsi = self.__parseDict( self.temporaryDirectory() / "test.nsia" )
+			self.assertIn( "outputLayer:test", nsi )
+			self.assertEqual( nsi["outputLayer:test"]["nodeType"], "outputlayer")
+			for k, v in expected.items() :
+				self.assertIn( k, nsi["outputLayer:test"] )
+				self.assertEqual( nsi["outputLayer:test"][k], v )
 
 	# Helper methods used to check that NSI files we write contain what we
 	# expect. The 3delight API only allows values to be set, not queried,

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -186,6 +186,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	# See `contrib/scripts/3delightOutputs.py` in this repository for a helper script.
 
 	for name, displayName, source, dataType in [
+		( "rgba", "Beauty", "", "" ),
 		( "Ci", "Ci", "shader", "color" ),
 		( "Ci.direct", "Ci (direct)", "shader", "color" ),
 		( "Ci.indirect", "Ci (indirect)", "shader", "color" ),
@@ -225,27 +226,46 @@ with IECore.IgnoredExceptions( ImportError ) :
 		( "motionvector", "Motion Vector", "builtin", "point" ),
 		( "occlusion", "Ambient Occlusion", "shader", "color" ),
 	] :
+		if name == "rgba" :
+			space = ""
+			separator = ""
+			slash = ""
+		else :
+			space = " "
+			separator = ":"
+			slash ="/"
+
 		GafferScene.Outputs.registerOutput(
-			"Interactive/3Delight/{}/{}".format( source.capitalize(), displayName ),
+			"Interactive/3Delight/{}{}{}".format( source.capitalize(), slash, displayName ),
 			IECoreScene.Output(
 				name,
 				"ieDisplay",
-				"{} {}:{}".format( dataType, source, name ),
+				"{}{}{}{}{}".format( dataType, space, source, separator, name ),
 				{
 					"driverType" : "ClientDisplayDriver",
 					"displayHost" : "localhost",
 					"displayPort" : "${image:catalogue:port}",
 					"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+					"scalarformat" : "half",
+					"colorprofile" : "linear",
+					"filter" : "blackman-harris",
+					"filterwidth" : 3.0,
 				}
 			)
 		)
 
 		GafferScene.Outputs.registerOutput(
-			"Batch/3Delight/{}/{}".format( source.capitalize(), displayName ),
+			"Batch/3Delight/{}{}{}".format( source.capitalize(), slash, displayName ),
 			IECoreScene.Output(
 				"${project:rootDirectory}/renders/${script:name}/${renderPass}/%s/%s.####.exr" % ( name, name ),
 				"exr",
-				"{} {}:{}".format( dataType, source, name ),
+				"{}{}{}{}{}".format( dataType, space, source, separator, name ),
+				{
+					"scalarformat" : "half",
+					"colorprofile" : "linear",
+					"filter" : "blackman-harris",
+					"filterwidth" : 3.0,
+				}
 			)
 		)
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Support for exporting Gaffer output parameters as both 3Delight outputdriver and outputlayer attributes. This enables direct control of 3Delight's outputlayer attributes like scalarformat and colorprofile (to set the rendered image bit-depth format and color space without the limitations of the quantize Gaffer parameter), filterwidth, etc.
- Updated output presets to expose the above functionality.
- Recreated PR against 1.4_maintenance branch.
- Addressed all the notes from the discussion in the main branch PR - https://github.com/GafferHQ/gaffer/pull/5843

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
