### PR TITLE
TweakPlug : Fix `CreateIfMissing` behaviour when fallback values are provided

### DIFF
--- a/include/Gaffer/TweakPlug.h
+++ b/include/Gaffer/TweakPlug.h
@@ -112,7 +112,8 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 		/// \returns true if any tweaks were applied
 		template<class GetDataFunctor, class SetDataFunctor>
 		bool applyTweak(
-			/// Signature : const IECore::Data *functor( const std::string &valueName ).
+			/// Signature : const IECore::Data *functor( const std::string &valueName, const bool withFallback ).
+			/// Passing `withFallback=False` specifies that no fallback value should be returned in place of missing data.
 			/// \returns `nullptr` if `valueName` is invalid.
 			GetDataFunctor &&getDataFunctor,
 			/// Signature : bool functor( const std::string &valueName, IECore::DataPtr newData).

--- a/include/Gaffer/TweakPlug.inl
+++ b/include/Gaffer/TweakPlug.inl
@@ -93,7 +93,7 @@ bool TweakPlug::applyTweak(
 		return setDataFunctor( name, newData );
 	}
 
-	const IECore::Data *currentValue = getDataFunctor( name );
+	const IECore::Data *currentValue = getDataFunctor( name, /* withFallback = */ mode != Gaffer::TweakPlug::CreateIfMissing );
 
 	if( IECore::runTimeCast<const IECore::InternedStringData>( currentValue ) )
 	{

--- a/python/GafferSceneTest/AttributeTweaksTest.py
+++ b/python/GafferSceneTest/AttributeTweaksTest.py
@@ -227,5 +227,28 @@ class AttributeTweaksTest( GafferSceneTest.SceneTestCase ) :
 		standardAttributes["attributes"]["linkedLights"]["value"].setValue( "someLights" )
 		self.assertEqual( tweaks["out"].attributes( "/plane" )["linkedLights"], IECore.StringData( "(someLights) - unwantedLights" ) )
 
+	def testLinkedLightsCreateIfMissing( self ) :
+
+		plane = GafferScene.Plane()
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		standardAttributes = GafferScene.StandardAttributes()
+		standardAttributes["in"].setInput( plane["out"] )
+		standardAttributes["filter"].setInput( planeFilter["out"] )
+
+		self.assertNotIn( "linkedLights", standardAttributes["out"].attributes( "/plane" ) )
+
+		tweaks = GafferScene.AttributeTweaks()
+		tweaks["in"].setInput( standardAttributes["out"] )
+		tweaks["filter"].setInput( planeFilter["out"] )
+
+		testTweak = Gaffer.TweakPlug( "linkedLights", "defaultLights" )
+		testTweak["mode"].setValue( Gaffer.TweakPlug.Mode.CreateIfMissing )
+		tweaks["tweaks"].addChild( testTweak )
+
+		self.assertEqual( tweaks["out"].attributes( "/plane" )["linkedLights"], IECore.StringData( "defaultLights" ) )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/Gaffer/ContextVariableTweaks.cpp
+++ b/src/Gaffer/ContextVariableTweaks.cpp
@@ -97,7 +97,7 @@ void ContextVariableTweaks::processContext( Context::EditableScope &context, IEC
 	IECore::ObjectVectorPtr storageVector = new ObjectVector();
 
 	tweaksPlug->applyTweaks(
-		[&context, &sourceData]( const std::string &valueName )
+		[&context, &sourceData]( const std::string &valueName, const bool withFallback )
 		{
 			DataPtr value = context.context()->getAsData( valueName, nullptr );
 			sourceData = value;

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -279,7 +279,7 @@ Gaffer::PlugPtr TweakPlug::createCounterpart( const std::string &name, Direction
 bool TweakPlug::applyTweak( IECore::CompoundData *parameters, MissingMode missingMode ) const
 {
 	return applyTweak(
-		[&parameters]( const std::string &valueName ) { return parameters->member( valueName ); },
+		[&parameters]( const std::string &valueName, const bool withFallback ) { return parameters->member( valueName ); },
 		[&parameters]( const std::string &valueName, DataPtr newData )
 		{
 			if( newData == nullptr )

--- a/src/GafferScene/AttributeTweaks.cpp
+++ b/src/GafferScene/AttributeTweaks.cpp
@@ -154,10 +154,10 @@ IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( cons
 	}
 
 	tweaksPlug->applyTweaks(
-		[&source]( const std::string &valueName ) -> const IECore::Data *
+		[&source]( const std::string &valueName, const bool withFallback ) -> const IECore::Data *
 		{
 			const Data *result = source->member<Data>( valueName );
-			if( !result && valueName == "linkedLights" )
+			if( withFallback && !result && valueName == "linkedLights" )
 			{
 				/// \todo Use a registry to provide default values for
 				/// all attributes.

--- a/src/GafferScene/CameraTweaks.cpp
+++ b/src/GafferScene/CameraTweaks.cpp
@@ -125,7 +125,7 @@ IECore::ConstObjectPtr CameraTweaks::computeProcessedObject( const ScenePath &pa
 	tweaksPlug->applyTweaks(
 
 		// Getter
-		[&] ( const std::string &name ) {
+		[&] ( const std::string &name, const bool withFallback ) {
 			if( name == "fieldOfView" )
 			{
 				virtualParameter = new FloatData( result->calculateFieldOfView()[0] );

--- a/src/GafferScene/OptionTweaks.cpp
+++ b/src/GafferScene/OptionTweaks.cpp
@@ -121,7 +121,7 @@ IECore::ConstCompoundObjectPtr OptionTweaks::computeProcessedGlobals(
 	result->members() = inputGlobals->members();
 
 	tweaksPlug->applyTweaks(
-		[&result]( const std::string &valueName )
+		[&result]( const std::string &valueName, const bool withFallback )
 		{
 			return result->member<Data>( g_namePrefix + valueName );
 		},

--- a/src/GafferScene/ShaderTweaks.cpp
+++ b/src/GafferScene/ShaderTweaks.cpp
@@ -332,7 +332,7 @@ bool ShaderTweaks::applyTweaks( IECoreScene::ShaderNetwork *shaderNetwork, Tweak
 
 			if(
 				tweakPlug->applyTweak(
-					[&parameter, &modifiedShader]( const std::string &valueName )
+					[&parameter, &modifiedShader]( const std::string &valueName, const bool withFallback )
 					{
 						return modifiedShader.first->second->parametersData()->member( parameter.name );
 					},


### PR DESCRIPTION
This works around the issue noticed yesterday on `main` with the AttributeTweaks `CreateIfMissing` mode where the recently added fallback value for "linkedLights" would prevent attributes from being created.