### PR TITLE
ImageReader : Conform lower case "r", "g", "b" and "a" to upper

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - CameraTweaks : Added `ignoreMissing` plug to align behaviour with the other Tweaks nodes.
 - AttributeTweaks : The `{source}` substitution for `linkedLights` now expands to `defaultLights` if the attribute doesn't exist yet. This makes tweaks such as `({source}) - unwantedLights` reliable even if no light links have been authored yet.
+- ImageReader : Non-standard "r", "g", "b" and "a" channel names are now automatically renamed to "R", "G", "B" and "A" on loading. As with other heuristics, this can be disabled by setting `channelInterpretation` to "EXR Specification".
 
 Breaking Changes
 ----------------
@@ -13,6 +14,7 @@ Breaking Changes
 - CameraTweaks : `Replace` mode now errors if the input parameter does not exist. Use `Create` mode or the new `ignoreMissing` plug instead.
 - TweakPlug : Remove deprecated `MissingMode::IgnoreOrReplace`.
 - AttributeTweaks : `Replace` mode no longer errors if the `linkedLights` attribute doesn't exist.
+- ImageReader : Changed handling of lower-cased "r", "g", "b" and "a" channels.
 
 1.4.x.x (relative to 1.4.4.0)
 =======

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -980,5 +980,29 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 					for c, expected in zip( stats[stat].getValue(), imath.Color4f( 0.3, 0.6, 0.9, 0 ) ) :
 						self.assertAlmostEqual( c, expected, delta = 0.0001 )
 
+	def testConformLowerCaseRGBA( self ) :
+
+		constant = GafferImage.Constant()
+		constant["color"].setValue( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) )
+
+		shuffle = GafferImage.Shuffle()
+		shuffle["in"].setInput( constant["out"] )
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "R", "r", deleteSource = True ) )
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "G", "g", deleteSource = True ) )
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "B", "b", deleteSource = True ) )
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "A", "a", deleteSource = True ) )
+		self.assertEqual( set( shuffle["out"].channelNames( ) ), { "r", "g", "b", "a" } )
+
+		writer = GafferImage.ImageWriter()
+		writer["in"].setInput( shuffle["out"] )
+		writer["fileName"].setValue( self.temporaryDirectory() / "test.exr" )
+		writer["openexr"]["dataType"].setValue( "float" )
+		writer["task"].execute()
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setInput( writer["fileName"] )
+
+		self.assertImagesEqual( reader["out"], constant["out"], ignoreMetadata = True )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -227,20 +227,25 @@ std::string channelNameFromEXR( std::string view, std::string part, std::string 
 		}
 	), layerTokens.end() );
 
-	// Handle Nuke's horrible channel names
-	if( baseName == "red" )
+	// Nuke uses non-standard "red", "green", "blue" and "alpha", and other
+	// packages use lower case "r", "g", "b", "a". In some cases I suspect the
+	// latter is a workaround to thwart unwanted DWAA compression, which only
+	// applies to the uppercased names. And perhaps that is also the reason why
+	// the Cryptomatte specification uses lowercase names? Fix everything up so
+	// that Gaffer will recognise them as standard RGBA channels.
+	if( baseName == "red" || baseName == "r" )
 	{
 		baseName = "R";
 	}
-	else if( baseName == "green" )
+	else if( baseName == "green" || baseName == "g" )
 	{
 		baseName = "G";
 	}
-	else if( baseName == "blue" )
+	else if( baseName == "blue" || baseName == "b" )
 	{
 		baseName = "B";
 	}
-	else if( baseName == "alpha" )
+	else if( baseName == "alpha" || baseName == "a" )
 	{
 		baseName = "A";
 	}


### PR DESCRIPTION
The EXR standard states that it is only the upper case "R", "G", "B" and "A" that have a predefined interpretation, and that is how we treat channels in GafferImage. But in the last week I've received files from two different sources both using lower-case, so this seems worth fixing up on load.

In the latter case, the file was from Blender and only the Cryptomatte channels were lowercased. To my surprise, that is actually enshrined in the Cryptomatte specification. I can't find a source for _why_, but based on https://github.com/Psyop/Cryptomatte/issues/35 it seems that _maybe_ it's to disable lossy DWA compression when the DCC won't let you control that per-file or per-part? That seems to call into question the entire idea of using RGBA to represent ID and coverage in the first place, which I believe was originally to play well in apps that only recognised RGBA.

In conjunction with #5867, this fixes #5866.
