### PR TITLE
3Delight render sets and lightgroups support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,10 @@ Improvements
 
 - CameraTweaks : Added `ignoreMissing` plug to align behaviour with the other Tweaks nodes.
 - AttributeTweaks : The `{source}` substitution for `linkedLights` now expands to `defaultLights` if the attribute doesn't exist yet. This makes tweaks such as `({source}) - unwantedLights` reliable even if no light links have been authored yet.
+- 3Delight :
+  - Added translation of Gaffer render:* sets to NSI sets.
+  - Added NSI lightset connections driven by Gaffer lightgroup output parameter supporting space separated light objects and render sets.
+  - Updated 3Delight output presets to include a lightgroup parameter (empty by default).
 
 Breaking Changes
 ----------------
@@ -13,6 +17,7 @@ Breaking Changes
 - CameraTweaks : `Replace` mode now errors if the input parameter does not exist. Use `Create` mode or the new `ignoreMissing` plug instead.
 - TweakPlug : Remove deprecated `MissingMode::IgnoreOrReplace`.
 - AttributeTweaks : `Replace` mode no longer errors if the `linkedLights` attribute doesn't exist.
+- 3Delight : Switched NSI outputs creation from after global options to after scene objects both for batch and interactive rendering.
 
 1.4.x.x (relative to 1.4.4.0)
 =======

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -51,6 +51,8 @@
 
 #include "IECore/ObjectPool.h"
 
+#include "boost/algorithm/string.hpp"
+
 #include <filesystem>
 #include <memory>
 
@@ -348,7 +350,10 @@ void Render::executeInternal( bool flushCaches ) const
 	Monitor::Scope performanceMonitorScope( performanceMonitor );
 
 	GafferScene::Private::RendererAlgo::outputOptions( renderOptions.globals.get(), renderer.get() );
-	GafferScene::Private::RendererAlgo::outputOutputs( inPlug(), renderOptions.globals.get(), renderer.get() );
+	if( !( boost::starts_with( rendererType, "3Delight" ) ) )
+	{
+		GafferScene::Private::RendererAlgo::outputOutputs( inPlug(), renderOptions.globals.get(), renderer.get() );
+	}
 
 	{
 		// Using nested scope so that we free the memory used by `renderSets`
@@ -361,6 +366,11 @@ void Render::executeInternal( bool flushCaches ) const
 		GafferScene::Private::RendererAlgo::outputLightFilters( adaptedInPlug(), renderOptions, renderSets, &lightLinks, renderer.get() );
 		lightLinks.outputLightFilterLinks( adaptedInPlug() );
 		GafferScene::Private::RendererAlgo::outputObjects( adaptedInPlug(), renderOptions, renderSets, &lightLinks, renderer.get() );
+	}
+
+	if( boost::starts_with( rendererType, "3Delight" ) )
+	{
+		GafferScene::Private::RendererAlgo::outputOutputs( inPlug(), renderOptions.globals.get(), renderer.get() );
 	}
 
 	if( renderScope.sceneTranslationOnly() )

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1620,12 +1620,20 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 {
 	try
 	{
+		RenderOptions dl_renderOptions;
 		// Update globals
 		if( m_dirtyGlobalComponents & GlobalsGlobalComponent )
 		{
 			RenderOptions renderOptions( m_scene.get() );
 			Private::RendererAlgo::outputOptions( renderOptions.globals.get(), m_renderOptions.globals.get(), m_renderer.get() );
-			Private::RendererAlgo::outputOutputs( m_scene.get(), renderOptions.globals.get(), m_renderOptions.globals.get(), m_renderer.get() );
+			if( !( boost::starts_with( m_renderer->name().string(), "3Delight" ) ) )
+			{
+				Private::RendererAlgo::outputOutputs( m_scene.get(), renderOptions.globals.get(), m_renderOptions.globals.get(), m_renderer.get() );
+			}
+			else
+			{
+				dl_renderOptions = m_renderOptions;
+			}
 			if( *renderOptions.globals != *m_renderOptions.globals )
 			{
 				m_changedGlobalComponents |= GlobalsGlobalComponent;
@@ -1715,6 +1723,11 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 		if( m_changedGlobalComponents & CameraOptionsGlobalComponent )
 		{
 			updateDefaultCamera();
+		}
+
+		if( m_changedGlobalComponents && boost::starts_with( m_renderer->name().string(), "3Delight" ) )
+		{
+			Private::RendererAlgo::outputOutputs( m_scene.get(), m_renderOptions.globals.get(), dl_renderOptions.globals.get(), m_renderer.get() );
 		}
 
 		if( !pathsToUpdate )

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -250,6 +250,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 					"colorprofile" : "linear",
 					"filter" : "blackman-harris",
 					"filterwidth" : 3.0,
+					"lightgroup" : "",
 				}
 			)
 		)
@@ -265,6 +266,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 					"colorprofile" : "linear",
 					"filter" : "blackman-harris",
 					"filterwidth" : 3.0,
+					"lightgroup" : "",
 				}
 			)
 		)


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- Added support for translation of Gaffer render:* sets to NSI sets.
- Added support for lightgroups (lightsets in 3Delight terminology) based on the discussion in https://github.com/GafferHQ/gaffer/pull/5641. The lightgroups output parameter expects a space separated list supporting both individual light objects and render sets.
- Updated the 3Delight output presets to include a lightgroup output parameter (empty by default).

### Breaking changes ###

- Changed `src/GafferScene/Render.cpp` and `src/GafferScene/RenderController.cpp` to create NSI outputs after scene objects instead of global options. This is required for NSI since in order for the light objects and render sets to be successfully connected to the lightset output attribute they need to be created before declaring the lightset connection. Unlike the previous implementation this is now limited to 3Delight and doesn't affect the other renderers. @johnhaddon I know you mentioned in https://github.com/GafferHQ/gaffer/pull/5641 that declaring the outputs after the scene objects doesn't sounds logical, but I checked the official Houdini NSI plugin and it exports the outputs after the scene as well (it even exports the global options after the outputs, but I don't think we need to do that on our end).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
