### PR TITLE
OptionTweaks / Spreadsheet / Render Pass Editor : Make use of metadata registered for options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - NodeEditor, UIEditor, PythonEditor : Added popup hint for the <kbd>Ctrl</kbd>+<kbd>Return</kbd> shortcut.
 - CodeWidget : Added highlighting of braces and operators.
 - RenderPassEditor : Added preset menu for choosing a render pass type from the list of available registered types. An "auto" type is included in the list when an auto type function has been registered.
+- OptionTweaks : Tweak `value` plugs can now access metadata registered globally to `option:{tweakName}`, where `{tweakName}` is the value of the tweak's `name` plug.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - CodeWidget : Added highlighting of braces and operators.
 - RenderPassEditor : Added preset menu for choosing a render pass type from the list of available registered types. An "auto" type is included in the list when an auto type function has been registered.
 - OptionTweaks : Tweak `value` plugs can now access metadata registered globally to `option:{tweakName}`, where `{tweakName}` is the value of the tweak's `name` plug.
+- Spreadsheet : Added support for metadata to be automatically forwarded from plugs downstream of a column's `out` plug to the column's default row.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - SetFilter, StandardAttributes, StandardOptions : Added syntax highlighting and auto-complete for set expressions.
 - NodeEditor, UIEditor, PythonEditor : Added popup hint for the <kbd>Ctrl</kbd>+<kbd>Return</kbd> shortcut.
 - CodeWidget : Added highlighting of braces and operators.
+- RenderPassEditor : Added preset menu for choosing a render pass type from the list of available registered types. An "auto" type is included in the list when an auto type function has been registered.
 
 Fixes
 -----
@@ -40,6 +41,7 @@ API
 - TextWidget : Added `selectedText()` convenience method.
 - MultiLineTextWidget : Added `setSelection()` and `getSelection()` methods.
 - SetExpressionPlugValueWidget : Added new editor for set expressions, with syntax highlighting and auto-complete.
+- RenderPassTypeAdaptor : Added `autoTypeFunction()` method.
 
 1.4.4.0 (relative to 1.4.3.0)
 =======

--- a/python/GafferScene/RenderPassTypeAdaptor.py
+++ b/python/GafferScene/RenderPassTypeAdaptor.py
@@ -137,6 +137,11 @@ class RenderPassTypeAdaptor( GafferScene.SceneProcessor ) :
 		cls.__autoTypeFunction = f
 
 	@classmethod
+	def autoTypeFunction( cls ) :
+
+		return cls.__autoTypeFunction
+
+	@classmethod
 	def resolvedType( cls, type, name ) :
 
 		if type == "auto" :

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -44,6 +44,41 @@ import Gaffer
 import GafferUI
 import GafferScene
 
+def __optionMetadata( plug, name ) :
+
+	option = plug.ancestor( Gaffer.TweakPlug )["name"].getValue()
+	return Gaffer.Metadata.value( "option:{}".format( option ), name )
+
+def __optionMetadataPresets( plug ) :
+
+	result = collections.OrderedDict()
+	option = plug.ancestor( Gaffer.TweakPlug )["name"].getValue()
+	source = "option:{}".format( option )
+
+	for n in Gaffer.Metadata.registeredValues( source ) :
+		if n.startswith( "preset:" ) :
+			result[n[7:]] = Gaffer.Metadata.value( source, n )
+
+	presetNames = Gaffer.Metadata.value( source, "presetNames" )
+	presetValues = Gaffer.Metadata.value( source, "presetValues" )
+	if presetNames and presetValues :
+		for presetName, presetValue in zip( presetNames, presetValues ) :
+			result.setdefault( presetName, presetValue )
+
+	return result
+
+def __optionMetadataPresetNames( plug ) :
+
+	names = list( __optionMetadataPresets( plug ).keys() )
+
+	return IECore.StringVectorData( names ) if names else None
+
+def __optionMetadataPresetValues( plug ) :
+
+	values = list( __optionMetadataPresets( plug ).values() )
+
+	return IECore.DataTraits.dataFromElement( values ) if values else None
+
 Gaffer.Metadata.registerNode(
 
 	GafferScene.OptionTweaks,
@@ -86,6 +121,18 @@ Gaffer.Metadata.registerNode(
 
 			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:propertyType", "option",
+
+		],
+
+		"tweaks.*.value" : [
+
+			"description", functools.partial( __optionMetadata, name = "description" ),
+			"plugValueWidget:type", functools.partial( __optionMetadata, name = "plugValueWidget:type" ),
+			"presetsPlugValueWidget:allowCustom", functools.partial( __optionMetadata, name = "presetsPlugValueWidget:allowCustom" ),
+			"ui:scene:acceptsSetExpression", functools.partial( __optionMetadata, name = "ui:scene:acceptsSetExpression" ),
+
+			"presetNames", __optionMetadataPresetNames,
+			"presetValues", __optionMetadataPresetValues,
 
 		],
 

--- a/python/GafferSceneUI/RenderUI.py
+++ b/python/GafferSceneUI/RenderUI.py
@@ -42,7 +42,7 @@ import GafferScene
 
 from GafferUI.PlugValueWidget import sole
 
-def rendererPresetNames( plug ) :
+def rendererPresetNames( plug = None ) :
 
 	blacklist = { "Capturing" }
 	return IECore.StringVectorData(

--- a/startup/GafferSceneUI/renderPassOptions.py
+++ b/startup/GafferSceneUI/renderPassOptions.py
@@ -34,59 +34,13 @@
 #
 ##########################################################################
 
-import IECore
-
 import Gaffer
-import GafferScene
+import GafferSceneUI
 
-def __renderPassTypes() :
-
-	types = sorted( list( GafferScene.RenderPassTypeAdaptor.registeredTypeNames() ) )
-
-	if callable( GafferScene.RenderPassTypeAdaptor.autoTypeFunction() ) :
-		types.insert( 0, "auto" )
-
-	return types
-
-def renderPassTypePresetNames() :
-
-	return IECore.StringVectorData( [ IECore.CamelCase.toSpaced( p ) for p in __renderPassTypes() ] )
-
-def renderPassTypePresetValues() :
-
-	return IECore.StringVectorData( __renderPassTypes() )
-
-Gaffer.Metadata.registerNode(
-
-	GafferScene.RenderPassTypeAdaptor,
-
-	"description",
-	"""
-	Adapts render pass types to a client and renderer. The behaviour of
-	how each render pass type is adapted is defined by one or more type
-	processors registered to this node.
-	""",
-
-	plugs = {
-
-		"client" : [
-
-			"description",
-			"""
-			The client to adapt render pass types to.
-			""",
-
-		],
-
-		"renderer" : [
-
-			"description",
-			"""
-			The renderer to adapt render pass types to.
-			""",
-
-		],
-
-	}
-
-)
+Gaffer.Metadata.registerValue( "option:renderPass:type", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:renderPass:type", "preset:Standard", "" )
+## \todo As part of the future great metadata reckoning, it would make more sense for renderPassTypePresetNames to be defined as
+# part of this global metadata rather than by GafferSceneUI.RenderPassTypeAdaptorUI and then called here. This would also allow
+# the registrations in this file to be combined with those in `startup/GafferScene/renderPassOptions.py`.
+Gaffer.Metadata.registerValue( "option:renderPass:type", "presetNames", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetNames )
+Gaffer.Metadata.registerValue( "option:renderPass:type", "presetValues", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetValues )

--- a/startup/GafferSceneUI/standardOptions.py
+++ b/startup/GafferSceneUI/standardOptions.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferSceneUI
+
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "preset:None", "" )
+## \todo As part of the future great metadata reckoning, it would make more sense for rendererPresetNames to be defined as
+# part of this global metadata rather than by GafferSceneUI.RenderUI and then called here. This would also allow the registrations
+# in this file to be combined with those in `startup/GafferScene/standardOptions.py`.
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "presetNames", GafferSceneUI.RenderUI.rendererPresetNames )
+Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "presetValues", GafferSceneUI.RenderUI.rendererPresetNames )
+
+Gaffer.Metadata.registerValue( "option:render:inclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:inclusions", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:exclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:exclusions", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:additionalLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:additionalLights", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:matteInclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:matteInclusions", "ui:scene:acceptsSetExpression", True )
+
+Gaffer.Metadata.registerValue( "option:render:matteExclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "option:render:matteExclusions", "ui:scene:acceptsSetExpression", True )


### PR DESCRIPTION
This adds the ability for OptionTweaks to make use of globally registered metadata on tweak `value` plugs, allowing tweaks to present a specific plugValueWidget, presets, etc based on metadata registered for the option being tweaked. In addition we also allow metadata to be automatically forwarded to the default row of spreadsheet columns. 

The motivation here is to present a consistent UI for edits made with editors such as the Render Pass Editor, where the same widgets and presets should be presented at all levels, from the editor itself, through to spreadsheets within the Edit Scope processors and finally the OptionTweak nodes making the edits.