### PR TITLE
Render adaptor fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Fixes
 - Cryptomatte :
   - Fixed errors when the input image didn't contain the main `RGBA` channels.
   - Fixed inaccurate hash.
+- SceneAlgo : Fixed exception handling for Python render adaptors. Previously an exception during adaptor construction caused a `SystemError`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,9 @@ Fixes
   - Fixed errors when the input image didn't contain the main `RGBA` channels.
   - Fixed inaccurate hash.
 - SceneAlgo : Fixed exception handling for Python render adaptors. Previously an exception during adaptor construction caused a `SystemError`.
+- InteractiveRender :
+  - Fixed crash triggered by a render adaptor depending on its `renderer` input to adapt the scene globals.
+  - Removed unintentional ability for render adaptors to change the renderer being used.
 
 API
 ---

--- a/python/GafferSceneTest/SceneAlgoTest.py
+++ b/python/GafferSceneTest/SceneAlgoTest.py
@@ -2275,6 +2275,17 @@ class SceneAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( mh.messages[0].context, "SceneAlgo::createRenderAdaptors" )
 		self.assertEqual( mh.messages[0].message, "Adaptor \"Test\" returned null" )
 
+	def testAdaptorCreationException( self ) :
+
+		def a() :
+
+			raise RuntimeError( "Oops" )
+
+		GafferScene.SceneAlgo.registerRenderAdaptor( "Test", a )
+
+		with self.assertRaisesRegex( RuntimeError, "Oops" ) :
+			GafferScene.SceneAlgo.createRenderAdaptors()
+
 	def testValidateName( self ) :
 
 		for goodName in [ "obi", "lewis", "ludo" ] :

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -516,7 +516,7 @@ void InteractiveRender::compute( Gaffer::ValuePlug *output, const Gaffer::Contex
 		std::string renderer = rendererPlug()->getValue();
 		if( renderer.empty() )
 		{
-			ConstCompoundObjectPtr globals = adaptedInPlug()->globals();
+			ConstCompoundObjectPtr globals = inPlug()->globals();
 			if( auto rendererData = globals->member<const StringData>( g_rendererOptionName ) )
 			{
 				renderer = rendererData->readable();

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -47,6 +47,7 @@
 
 #include "IECoreScene/Camera.h"
 
+#include "IECorePython/ExceptionAlgo.h"
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
 #include "IECorePython/ScopedGILRelease.h"
@@ -330,8 +331,15 @@ struct RenderAdaptorWrapper
 	SceneProcessorPtr operator()()
 	{
 		IECorePython::ScopedGILLock gilLock;
-		SceneProcessorPtr result = extract<SceneProcessorPtr>( m_pythonAdaptor() );
-		return result;
+		try
+		{
+			SceneProcessorPtr result = extract<SceneProcessorPtr>( m_pythonAdaptor() );
+			return result;
+		}
+		catch( const boost::python::error_already_set & )
+		{
+			IECorePython::ExceptionAlgo::translatePythonException();
+		}
 	}
 
 	private :


### PR DESCRIPTION
A couple of important fixes to the render adaptor mechanism, including for a crash that is hindering usage at Cinesite. I've made the PR for `1.4_maintenance` since that it where the problem is most pronounced. But we could also backport to `1.3_maintenance` with the removal of the `InteractiveRenderTest.testAdaptorGlobalsDependingOnRenderer`.