### PR TITLE
EditScopePlugValueWidget : Draw icons representing Edit Scope node colours

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.5.0)
 =======
 
+Improvements
+------------
+
+- EditScopePlugValueWidget : Added icon representing the Edit Scope node colour.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Fixes
 - LightPositionTool : Fixed bug that caused the target/pivot positions to be lost when placing a light with Z scale not equal to 1.0.
 - SceneWriter : Fixed writing of locations with names that are not valid USD identifiers.
 
+API
+---
+
+- Menu : Menu items with "checkBox" enabled now draw their checked indicator in place of their "icon" when both are defined.
+
 1.4.5.0 (relative to 1.4.4.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ API
 ---
 
 - Menu : Menu items with "checkBox" enabled now draw their checked indicator in place of their "icon" when both are defined.
+- Image : Added `createSwatch()` static method.
 
 1.4.5.0 (relative to 1.4.4.0)
 =======

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1198,7 +1198,7 @@ class _CompareModePlugValueWidget( GafferUI.PlugValueWidget ) :
 				"/" + name,
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__setValue ), value ),
-					"icon" : self.__iconDict[value] if value != compareMode else None,
+					"icon" : self.__iconDict[value],
 					"checkBox" : value == compareMode,
 					"shortCut" : "Q" if value == hotkeyTarget else None,
 				}

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1143,11 +1143,10 @@ class _RenderPassCreationDialogue( GafferUI.Dialogue ) :
 			if editScope :
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 					GafferUI.Label( "Add render pass to" )
-					GafferUI.Label( "<h4>{}</h4>".format( editScope.relativeName( editScope.ancestor( Gaffer.ScriptNode ) ) ) )
 					editScopeColor = Gaffer.Metadata.value( editScope, "nodeGadget:color" )
 					if editScopeColor :
-						swatch = GafferUI.ColorSwatch( color = editScopeColor, displayTransform = GafferUI.Widget.identityDisplayTransform )
-						swatch._qtWidget().setFixedWidth( 13 )
+						GafferUI.Image.createSwatch( editScopeColor )
+					GafferUI.Label( "<h4>{}</h4>".format( editScope.relativeName( editScope.ancestor( Gaffer.ScriptNode ) ) ) )
 
 			self.__renderPassNameWidget = GafferSceneUI.RenderPassesUI.createRenderPassNameWidget()
 

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -47,8 +47,7 @@ from Qt import QtGui
 from Qt import QtWidgets
 
 ## The Image widget displays an image. This can be specified
-# as either a filename, in which case the image is loaded using
-# the IECore.Reader mechanism, or an IECore.ImagePrimitive.
+# as either a filename or an IECore.ImagePrimitive.
 class Image( GafferUI.Widget ) :
 
 	def __init__( self, imagePrimitiveOrFileName, **kw ) :

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -61,14 +61,36 @@ class Image( GafferUI.Widget ) :
 
 		if isinstance( imagePrimitiveOrFileName, str ) :
 			pixmap = self._qtPixmapFromFile( str( imagePrimitiveOrFileName ) )
-		else :
+		elif isinstance( imagePrimitiveOrFileName, IECoreImage.ImagePrimitive ) :
 			pixmap = self._qtPixmapFromImagePrimitive( imagePrimitiveOrFileName )
+		else :
+			pixmap = None
 
 		if pixmap is not None :
 			self._qtWidget().setPixmap( pixmap )
 
 		self.__pixmapHighlighted = None
 		self.__pixmapDisabled = None
+
+	## Creates an Image containing a color swatch useful for
+	# button and menu icons.
+	@staticmethod
+	def createSwatch( color ) :
+
+		pixmap = QtGui.QPixmap( 10, 10 )
+		pixmap.fill( QtGui.QColor( 0, 0, 0, 0 ) )
+
+		painter = QtGui.QPainter( pixmap )
+		painter.setRenderHint( QtGui.QPainter.Antialiasing )
+		painter.setPen( GafferUI._StyleSheet.styleColor( "backgroundDarkHighlight" ) )
+		painter.setBrush( QtGui.QColor.fromRgbF( color[0], color[1], color[2] ) )
+		painter.drawRoundedRect( QtCore.QRectF( 0.5, 0.5, 9, 9 ), 2, 2 )
+		del painter
+
+		swatch = GafferUI.Image( None )
+		swatch._qtWidget().setPixmap( pixmap )
+
+		return swatch
 
 	def _qtPixmap( self ) :
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -408,7 +408,10 @@ class Menu( GafferUI.Widget ) :
 
 		# when an icon file path is defined in the menu definition
 		icon = getattr( item, "icon", None )
-		if icon is not None :
+		# Qt is unable to display a checkbox and icon at the same time.
+		# Unhelpfully, the icon overrides the checkbox so we only display
+		# the icon when there is no checkbox.
+		if icon is not None and not qtAction.isChecked() :
 			if isinstance( icon, str ) :
 				image = GafferUI.Image( icon )
 			else :

--- a/python/GafferUITest/ImageTest.py
+++ b/python/GafferUITest/ImageTest.py
@@ -37,6 +37,8 @@
 import os
 import unittest
 
+import imath
+
 import GafferUI
 import GafferUITest
 
@@ -63,6 +65,13 @@ class ImageTest( GafferUITest.TestCase ) :
 	def testUnicode( self ) :
 
 		i = GafferUI.Image( u"info.png" )
+
+	def testCreateSwatch( self ) :
+
+		s = GafferUI.Image.createSwatch( imath.Color3f( 1, 0, 0 ) )
+
+		self.assertEqual( s._qtPixmap().width(), 10 )
+		self.assertEqual( s._qtPixmap().height(), 10 )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds a small indicator to the Edit Scope menu representing the colour of the Edit Scope currently chosen as well as those available for selection in the menu. I've opted for a minimally styled rectangle representing the Edit Scope node rather than a flat swatch, though this has required generating a GafferUI.Image from a QPixmap - maybe this is too much coupling with Qt?

![image](https://github.com/GafferHQ/gaffer/assets/50844517/0ad37742-2d5b-4003-a1c9-37b62d45d51c)

