### PR TITLE
LightPositionTool : Fix bug with scaled lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- LightPositionTool : Fixed bug that caused the target/pivot positions to be lost when placing a light with Z scale not equal to 1.0.
 - SceneWriter : Fixed writing of locations with names that are not valid USD identifiers.
 
 1.4.5.0 (relative to 1.4.4.0)

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -760,7 +760,7 @@ void LightPositionTool::updateHandles( float rasterScale )
 	if(
 		!m_drag &&
 		(
-			!direction.equalWithAbsError( handleDir, 1e-4 ) ||
+			!direction.normalized().equalWithAbsError( handleDir, 1e-4 ) ||
 			handleLine.distanceTo( p ) > distanceHandle->getPivotDistance().value() * 1e-4
 		)
 	)


### PR DESCRIPTION
When placing pivots and targets for a light with a Z scale other than 1.0, the handles would be erroneously invalidated. This was from a check of the light direction that included the non-unit Z scale when calculating the direction. Comparing normalized directions correctly accounts for the difference.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
