### PR TITLE
ArnoldLight: Create sets for each light type

### DIFF
--- a/include/GafferArnold/ArnoldLight.h
+++ b/include/GafferArnold/ArnoldLight.h
@@ -66,8 +66,10 @@ class GAFFERARNOLD_API ArnoldLight : public GafferScene::Light
 		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
 
-	private :
+		void hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstInternedStringVectorDataPtr computeStandardSetNames() const override;
 
+	private :
 		ArnoldShader *shaderNode();
 		const ArnoldShader *shaderNode() const;
 

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -125,8 +125,7 @@ IECore::ConstInternedStringVectorDataPtr ArnoldLight::computeStandardSetNames() 
 {
 	IECore::ConstInternedStringVectorDataPtr baseSets = Light::computeStandardSetNames();
 	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
-	result->writable().insert(result->writable().end(), baseSets->readable().begin(), baseSets->readable().end());
+	result->writable().insert( result->writable().end(), baseSets->readable().begin(), baseSets->readable().end() );
 	result->writable().push_back( namePlug()->getValue() + "s" );
 	return result;
 }
-

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -118,6 +118,7 @@ IECoreScene::ConstShaderNetworkPtr ArnoldLight::computeLight( const Gaffer::Cont
 
 void ArnoldLight::hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
+	Light::hashStandardSetNames( context, h );
 	h.append( namePlug()->getValue() );
 }
 

--- a/src/GafferArnold/ArnoldLight.cpp
+++ b/src/GafferArnold/ArnoldLight.cpp
@@ -115,3 +115,18 @@ IECoreScene::ConstShaderNetworkPtr ArnoldLight::computeLight( const Gaffer::Cont
 	IECore::ConstCompoundObjectPtr shaderAttributes = shaderInPlug()->attributes();
 	return shaderAttributes->member<const IECoreScene::ShaderNetwork>( "ai:light" );
 }
+
+void ArnoldLight::hashStandardSetNames( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	h.append( namePlug()->getValue() );
+}
+
+IECore::ConstInternedStringVectorDataPtr ArnoldLight::computeStandardSetNames() const
+{
+	IECore::ConstInternedStringVectorDataPtr baseSets = Light::computeStandardSetNames();
+	IECore::InternedStringVectorDataPtr result = new IECore::InternedStringVectorData();
+	result->writable().insert(result->writable().end(), baseSets->readable().begin(), baseSets->readable().end());
+	result->writable().push_back( namePlug()->getValue() + "s" );
+	return result;
+}
+


### PR DESCRIPTION
Implements `computeStandardSetNames` to create sets for each type of Arnold light.

The current use case is that we want to filter out specific lights based on their sets. This PR enables the collection of Arnold lights into their repsective sets, i.e. all Arnold distant lights will be placed into the `distantLights` set. 

- Implement `hashStandardSetNames` and `computeStandardSetNames` for Arnold Lights.

If this doesn't suit the current design decisions then any help with implementing this inside IE or else where would be appreciated.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
