### PR TITLE
SetUI : Fix Spreadsheet popup menus

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
   - Fixed handling of shader parameters not supported in USD, such as texture inputs to OpenGLShader.
 - SceneReader : Fixed duplicate loading of `arnold:*` attributes on lights. These are now omitted, since they are converted to parameters on the light shader itself.
 - ShaderTweaks : Fixed potential crash if a ShaderTweakProxy was used to accidentally create a cyclic connection.
+- Spreadsheet : Fixed "Sets", "Operators" and "Select Affected Objects" popup menu items, which were broken in 1.4.5.0.
 
 Build
 -----

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -35,7 +35,6 @@
 ##########################################################################
 
 import functools
-from collections import deque
 
 import IECore
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -182,24 +182,47 @@ def __setValue( plug, value, *unused ) :
 
 def __setText( textWidget, text, *unused ) :
 
-	textWidget.setText( text )
+	if textWidget.visible() :
+		textWidget.setText( text )
+	else :
+		# Invisible dummy widget created by SpreadsheetUI. Edit plug value
+		# directly because the user can't commit the text via the widget. We
+		# must use `ancestor()` to obtain the PlugValueWidget rather than pass
+		# it as a parameter, as the latter would cause a cyclic reference.
+		__setValue( textWidget.ancestor( GafferUI.PlugValueWidget ).getPlug(), text )
 
 def __insertText( textWidget, text ) :
 
-	if textWidget.getSelection() != ( 0, 0 ) :
-		prefix = textWidget.getText()[:textWidget.getSelection()[0]]
-		suffix = textWidget.getText()[textWidget.getSelection()[1]:]
+	if textWidget.visible() :
+
+		if textWidget.getSelection() != ( 0, 0 ) :
+			prefix = textWidget.getText()[:textWidget.getSelection()[0]]
+			suffix = textWidget.getText()[textWidget.getSelection()[1]:]
+		else :
+			## \todo This would be unnecessary if an empty selection used the cursor position.
+			prefix = textWidget.getText()[:textWidget.getCursorPosition()]
+			suffix = textWidget.getText()[textWidget.getCursorPosition():]
+
+		if prefix and prefix[-1] not in " \n" :
+			text = " " + text
+		if not suffix or suffix[0] != " " :
+			text = text + " "
+
+		textWidget.insertText( text )
+
 	else :
-		## \todo This would be unnecessary if an empty selection used the cursor position.
-		prefix = textWidget.getText()[:textWidget.getCursorPosition()]
-		suffix = textWidget.getText()[textWidget.getCursorPosition():]
 
-	if prefix and prefix[-1] not in " \n" :
-		text = " " + text
-	if not suffix or suffix[0] != " " :
-		text = text + " "
+		# Invisible dummy widget created by SpreadsheetUI. See `__setText`.
+		plugValueWidget = textWidget.ancestor( GafferUI.PlugValueWidget )
+		with plugValueWidget.getContext() :
+			value = plugValueWidget.getPlug().getValue()
 
-	textWidget.insertText( text )
+		__setValue(
+			plugValueWidget.getPlug(),
+			"{}{}{}".format(
+				value, " " if not value.endswith( " " ) else "", text
+			)
+		)
 
 def __scenePlugs( node ) :
 
@@ -282,9 +305,17 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 
 	menuDefinition.prepend( "/SetsDivider", { "divider" : True } )
 
+	if textWidget.visible() :
+		currentText = textWidget.getText()
+	else :
+		# The SpreadsheetUI makes an invisible widget in order to show the popup
+		# menu for a cell directly. The text in this may not be up to date.
+		with plugValueWidget.getContext() :
+			currentText = plugValueWidget.getPlug().getValue()
+
 	# `Select Affected` command
 
-	selectionSetExpression = textWidget.selectedText() or textWidget.getText()
+	selectionSetExpression = textWidget.selectedText() or currentText
 	menuDefinition.prepend(
 		"Select Affected Objects",
 		{
@@ -313,8 +344,6 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 	# `Sets` menu
 
 	pathFn = getMenuPathFunction()
-
-	currentText = textWidget.getText()
 	currentNames = set( currentText.split() )
 
 	if not setNames :


### PR DESCRIPTION
This fixes the Spreadsheet popup menus for set expression plugs, which I broke in https://github.com/GafferHQ/gaffer/commit/f52a358204d632d2c3777a62ed8e6b54a4d9d6c0. I don't think the approach could be described as anything other than hacky, but it's a logical consequence of the hack the Spreadsheet is using in the first place. I think I at least prefer these explicit hacks than I do the original approach, where there wasn't any real principle behind how we wanted to apply edits, and where the spreadsheet compatibility was implicit in the undocumented way we sometimes used the widget and sometimes didn't.