### PR TITLE
DecayVisualiser improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,7 +7,8 @@ Improvements
 - ShaderTweaks, ShaderQuery : Improved performance of parameter selection dialogue. For some particularly large shader networks, speedups are greater than 100x.
 - UIEditor : Added code examples to button code placeholder text.
 - Arnold `light_decay` :
-  - The triangle indicators for the decay ranges are now scaled by the light's `gl:visualiser:scale` attribute.
+  - Increased the size of the triangle indicators for the decay ranges.
+  - The decay range indicators are now scaled by the light's `gl:visualiser:scale` attribute.
   - The decay range is now ignored when framing a light in the Viewer.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,9 @@ Improvements
 
 - ShaderTweaks, ShaderQuery : Improved performance of parameter selection dialogue. For some particularly large shader networks, speedups are greater than 100x.
 - UIEditor : Added code examples to button code placeholder text.
-- Arnold `light_decay` : The triangle indicators for the decay ranges are now scaled by the light's `gl:visualiser:scale` attribute.
+- Arnold `light_decay` :
+  - The triangle indicators for the decay ranges are now scaled by the light's `gl:visualiser:scale` attribute.
+  - The decay range is now ignored when framing a light in the Viewer.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - ShaderTweaks, ShaderQuery : Improved performance of parameter selection dialogue. For some particularly large shader networks, speedups are greater than 100x.
 - UIEditor : Added code examples to button code placeholder text.
+- Arnold `light_decay` : The triangle indicators for the decay ranges are now scaled by the light's `gl:visualiser:scale` attribute.
 
 API
 ---

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -165,8 +165,8 @@ void addKnot( IECoreGL::GroupPtr group, const Knot &knot, const float visualiser
 	V3fVectorDataPtr p = new V3fVectorData;
 	std::vector<V3f> &pVec = p->writable();
 	pVec.push_back( V3f(  0, 0,  0  ) );
-	pVec.push_back( V3f(  0, visualiserScale, -visualiserScale  ) );
-	pVec.push_back( V3f(  0, visualiserScale, visualiserScale  ) );
+	pVec.push_back( V3f(  0, visualiserScale * 2.f, -visualiserScale * 2.f  ) );
+	pVec.push_back( V3f(  0, visualiserScale * 2.f, visualiserScale * 2.f  ) );
 
 	IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
 	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -249,7 +249,14 @@ Visualisations DecayVisualiser::visualise( const IECore::InternedString &attribu
 	// render (this may need to be configurable later). The decay visualiser
 	// shouldn't scale with visualisation scale either. We scale the triangle
 	// indicators individually by the visualisation scale in `addKnot()`.
-	return { Visualisation( result, Visualisation::Scale::None ) };
+	return {
+		Visualisation(
+			result,
+			Visualisation::Scale::None,
+			Visualisation::Category::Generic,
+			/* affectsFramingBound = */ false
+		)
+	};
 }
 
 } // namespace

--- a/src/GafferArnoldUI/DecayVisualiser.cpp
+++ b/src/GafferArnoldUI/DecayVisualiser.cpp
@@ -60,6 +60,8 @@ namespace
 using Knot = std::pair<float, V3f>;
 using KnotVector = std::vector<Knot>;
 
+const InternedString g_glVisualiserScaleString( "gl:visualiser:scale" );
+
 const char *faceCameraVertexSource()
 {
 	return
@@ -146,7 +148,7 @@ void getKnotsToVisualize( const IECoreScene::ShaderNetwork *shaderNetwork, KnotV
 	}
 }
 
-void addKnot( IECoreGL::GroupPtr group, const Knot &knot )
+void addKnot( IECoreGL::GroupPtr group, const Knot &knot, const float visualiserScale )
 {
 	IECoreGL::GroupPtr markerGroup = new IECoreGL::Group();
 
@@ -163,8 +165,8 @@ void addKnot( IECoreGL::GroupPtr group, const Knot &knot )
 	V3fVectorDataPtr p = new V3fVectorData;
 	std::vector<V3f> &pVec = p->writable();
 	pVec.push_back( V3f(  0, 0,  0  ) );
-	pVec.push_back( V3f(  0, 1, -1  ) );
-	pVec.push_back( V3f(  0, 1,  1  ) );
+	pVec.push_back( V3f(  0, visualiserScale, -visualiserScale  ) );
+	pVec.push_back( V3f(  0, visualiserScale, visualiserScale  ) );
 
 	IECoreScene::MeshPrimitivePtr mesh = new IECoreScene::MeshPrimitive( vertsPerPoly, vertIds, "linear", p );
 	ToGLMeshConverterPtr meshConverter = new ToGLMeshConverter( mesh );
@@ -233,16 +235,20 @@ Visualisations DecayVisualiser::visualise( const IECore::InternedString &attribu
 		return {};
 	}
 
+	const FloatData *visualiserScaleData = attributes->member<FloatData>( g_glVisualiserScaleString );
+	const float visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.f;
+
 	IECoreGL::GroupPtr result = new IECoreGL::Group();
 
 	for( KnotVector::size_type i = 0; i < knots.size(); ++i )
 	{
-		addKnot( result, knots[i] );
+		addKnot( result, knots[i], visualiserScale );
 	}
 
 	// On the whole in Gaffer we assume that light scale doesn't affect the
-	// render (this may need to be configurable later). Decay shouldn't scale
-	// with visualisation scale either though.
+	// render (this may need to be configurable later). The decay visualiser
+	// shouldn't scale with visualisation scale either. We scale the triangle
+	// indicators individually by the visualisation scale in `addKnot()`.
 	return { Visualisation( result, Visualisation::Scale::None ) };
 }
 


### PR DESCRIPTION
This adds a couple of improvements to the Arnold DecayVisualiser, used for displaying `light_decay` shaders in the viewport.
- Adds scaling to the triangles indicating the decay ranges to match the `gl:visualiser:scale` attribute of the light.
- Changes the framing behavior to not take into account the decay indicators. For somewhat large decay values, this could cause the framing to be unexpectedly far away from the light in order to include the decay.

In real-world use cases, we've found that scene scales are often quite big, requiring relatively large `gl:visualiser:scale` values for lights to be usable. This caused the triangle indicators to become very hard to see. Scaling them along with the light visualiser makes them much more usable.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
