### PR TITLE
EditScopePlugValueWidget : Support drag and drop

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - EditScopePlugValueWidget :
   - When viewing the output of a Box, the menu now displays the Edit Scopes contained within.
   - Added support for dropping an Edit Scope node onto the widget to set it as the current Edit Scope.
+  - Added support for middle-dragging from the widget to access the current Edit Scope node.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Improvements
   - Increased the size of the triangle indicators for the decay ranges.
   - The decay range indicators are now scaled by the light's `gl:visualiser:scale` attribute.
   - The decay range is now ignored when framing a light in the Viewer.
-- EditScopePlugValueWidget : When viewing the output of a Box, the menu now displays the Edit Scopes contained within.
+- EditScopePlugValueWidget :
+  - When viewing the output of a Box, the menu now displays the Edit Scopes contained within.
+  - Added support for dropping an Edit Scope node onto the widget to set it as the current Edit Scope.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
   - Increased the size of the triangle indicators for the decay ranges.
   - The decay range indicators are now scaled by the light's `gl:visualiser:scale` attribute.
   - The decay range is now ignored when framing a light in the Viewer.
+- EditScopePlugValueWidget : When viewing the output of a Box, the menu now displays the Edit Scopes contained within.
 
 API
 ---

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -395,10 +395,6 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __dropNode( self,  event ) :
 
-		node = self.__inputNode()
-		if node is None :
-			return None
-
 		if isinstance( event.data, Gaffer.EditScope ) :
 			return event.data
 		elif (
@@ -449,10 +445,15 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __drop( self, widget, event ) :
 
+		inputNode = self.__inputNode()
 		dropNode = self.__dropNode( event )
-
-		if dropNode :
-			inputNode = self.__inputNode()
+		if inputNode is None :
+			with GafferUI.PopupWindow() as self.__popup :
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+					GafferUI.Image( "warningSmall.png" )
+					GafferUI.Label( "<h4>The Edit Scope cannot be set while nothing is viewed</h4>" )
+			self.__popup.popup()
+		elif dropNode :
 			upstream = Gaffer.NodeAlgo.findAllUpstream( inputNode, self.__editScopePredicate )
 			if self.__editScopePredicate( inputNode ) :
 				upstream.insert( 0, inputNode )

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -261,7 +261,14 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# (we can't start at _this_ node, as then we will visit our own input connection
 		# which may no longer be upstream of the viewed node).
 		if node["in"].getInput() is not None :
-			node = node["in"].getInput().node()
+			inputNode = node["in"].getInput().node()
+			if not isinstance( inputNode, Gaffer.EditScope ) and isinstance( inputNode, Gaffer.SubGraph ) :
+				# If we're starting from a SubGraph then attempt to begin the search from the
+				# first input of the node's output so we can find any Edit Scopes within.
+				output = node["in"].getInput().getInput()
+				node = output.node() if output and inputNode.isAncestorOf( output ) else inputNode
+			else :
+				node = inputNode
 		else :
 			node = None
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -407,11 +407,11 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __buttonPress( self, widget, event ) :
 
-		return event.buttons == event.Buttons.Middle and self.__editScope() is not None
+		return event.buttons & ( event.Buttons.Left | event.Buttons.Middle ) and self.__editScope() is not None
 
 	def __dragBegin( self, widget, event ) :
 
-		if event.buttons != event.Buttons.Middle :
+		if not event.buttons & ( event.Buttons.Left | event.Buttons.Middle ) :
 			return None
 
 		data = self.__editScope()

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -139,6 +139,9 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 				)
 				GafferUI.Spacer( imath.V2i( 4, 1 ), imath.V2i( 4, 1 ) )
 
+		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+		self.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
+		self.dragEndSignal().connect( Gaffer.WeakMethod( self.__dragEnd ), scoped = False )
 		self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
 		self.dragLeaveSignal().connect( Gaffer.WeakMethod( self.__dragLeave ), scoped = False )
 		# We connect to the front, and unconditionally return True to ensure that we never
@@ -406,7 +409,32 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		else:
 			return None
 
+	def __buttonPress( self, widget, event ) :
+
+		return event.buttons == event.Buttons.Middle and self.__editScope() is not None
+
+	def __dragBegin( self, widget, event ) :
+
+		if event.buttons != event.Buttons.Middle :
+			return None
+
+		data = self.__editScope()
+		if data is None :
+			return None
+
+		GafferUI.Pointer.setCurrent( "nodes" )
+		return data
+
+	def __dragEnd( self, widget, event ) :
+
+		GafferUI.Pointer.setCurrent( "" )
+
+		return True
+
 	def __dragEnter( self, widget, event ) :
+
+		if event.sourceWidget is self :
+			return False
 
 		if self.__dropNode( event ) :
 			self.__frame.setHighlighted( True )


### PR DESCRIPTION
This adds a couple of new interactions to the Edit Scope menu. Firstly, an Edit Scope node can now be dragged from the Graph Editor, Node Editor, etc. onto the widget to set it as the current Edit Scope. To maintain the semantics of selecting an Edit Scope from the menu, only those upstream of the viewed node can be set as the current Edit Scope, while dropping downstream/unrelated Edit Scopes will pop a warning mentioning that they can't be used as they aren't upstream.

![editScopeDropCompress](https://github.com/GafferHQ/gaffer/assets/50844517/7c361c1c-130d-4c27-bf1b-4c839bfc9efd)

This also adds support for dragging an Edit Scope node from the menu, which can then be dropped into the Graph Editor to frame the node, or dropped onto an Edit Scope menu in another editor to set that editor's Edit Scope (such as from a Viewer's Edit Scope menu to a Light Editor's). I've used middle-drag here to keep with the usual semantics of left-drag connects plugs, while middle drag transfers values.

Finally, this includes a small workaround for the slightly confusing case of the Edit Scope menu not displaying Edit Scopes within a Box if you're viewing its output. This stems from us treating upstream Edit Scopes as those upstream of the viewed node and not upstream of the viewed node's output...