### PR TITLE
FramingConstraint : Fix crash when applied to non-camera locations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.16.x (relative to 1.3.16.4)
 ========
 
+Fixes
+-----
 
+- FramingConstraint : Fixed crash caused by attempts to constrain objects that were not cameras.
 
 1.3.16.4 (relative to 1.3.16.3)
 ========

--- a/python/GafferSceneTest/FramingConstraintTest.py
+++ b/python/GafferSceneTest/FramingConstraintTest.py
@@ -352,6 +352,24 @@ class FramingConstraintTest( GafferSceneTest.SceneTestCase ) :
 						else:
 							validateFrustumUsage( "/group/sphere", 0.03, 1.00002, 0.2, 0.04, True )
 
+	def testConstrainingGeometry( self ) :
+
+		cube = GafferScene.Cube()
+		plane = GafferScene.Plane()
+
+		parent = GafferScene.Parent()
+		parent["in"].setInput( cube["out"] )
+		parent["children"][0].setInput( plane["out"] )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		constraint = GafferScene.FramingConstraint()
+		constraint["in"].setInput( parent["out"] )
+		constraint["filter"].setInput( planeFilter["out"] )
+		constraint["target"].setValue( "/cube" )
+
+		self.assertEqual( constraint["out"].fullTransform( "/plane" ), constraint["in"].fullTransform( "/plane" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/FramingConstraintTest.py
+++ b/python/GafferSceneTest/FramingConstraintTest.py
@@ -40,7 +40,6 @@ import imath
 import IECore
 
 import Gaffer
-import GafferTest
 import GafferScene
 import GafferSceneTest
 


### PR DESCRIPTION
The crash was caused by calling `copy()` on a null pointer obtained from `runTimeCast()`. A call to `runTimeCast()` should always be accompanied by a null check, because the whole point is that it might fail.

I've also tidied up an unnecessary second copy that we were taking when we wanted to modify the camera : since we copied it already, we don't need to copy it again. Technically we could omit even the first copy when dealing with perspective cameras and not extending the clipping planes, but I don't think the extra fiddliness that would entail is worth it.