### PR TITLE
Scene Inspector : Support dragging of inspector labels

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - Added support for middle-dragging from the widget to access the current Edit Scope node.
 - ArnoldAttributes : Added syntax highlighting and auto-complete for set expressions on the `shadowGroup` plug.
 - OpenColorIO : When a script-level OpenColorIO variable contains a Gaffer `${contextVariable}` reference, its evaluation is now deferred to the point of use. This allows it to pick up overrides introduced by nodes such as ContextVariables and Wedge.
+- SceneInspector : Added support for dragging inspector labels, such as those containing the names of attributes, options, output parameters, parameters, primitive variables, and sets.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -16,7 +16,9 @@ Improvements
   - Added support for middle-dragging from the widget to access the current Edit Scope node.
 - ArnoldAttributes : Added syntax highlighting and auto-complete for set expressions on the `shadowGroup` plug.
 - OpenColorIO : When a script-level OpenColorIO variable contains a Gaffer `${contextVariable}` reference, its evaluation is now deferred to the point of use. This allows it to pick up overrides introduced by nodes such as ContextVariables and Wedge.
-- SceneInspector : Added support for dragging inspector labels, such as those containing the names of attributes, options, output parameters, parameters, primitive variables, and sets.
+- SceneInspector :
+  - Added support for dragging inspector labels, such as those containing the names of attributes, options, output parameters, parameters, primitive variables, and sets.
+  - Set names beginning with "__" such as "__lights" or "__cameras" are now displayed as-is, rather than being transformed to "Lights" or "Cameras".
 
 Fixes
 -----

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -793,6 +793,10 @@ class DiffRow( Row ) :
 				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) )
 			)
 
+			label.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
+			label.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
+			label.dragEndSignal().connect( Gaffer.WeakMethod( self.__dragEnd ), scoped = False )
+
 		self.__inspector = inspector
 		self.__diffCreator = diffCreator
 
@@ -1007,6 +1011,22 @@ class DiffRow( Row ) :
 
 		self.ancestor( GafferUI.Window ).addChildWindow( w, removeOnClose = True )
 		w.setVisible( True )
+
+	def __buttonPress( self, widget, event ) :
+
+		return event.buttons == event.Buttons.Left
+
+	def __dragBegin( self, widget, event ) :
+
+		if event.buttons != event.Buttons.Left :
+			return None
+
+		GafferUI.Pointer.setCurrent( "values" )
+		return self.__inspector.name() if self.__inspector else ""
+
+	def __dragEnd( self, widget, event ) :
+
+		GafferUI.Pointer.setCurrent( None )
 
 ##########################################################################
 # DiffColumn

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -2282,10 +2282,7 @@ class __SetMembershipSection( LocationSection ) :
 
 		def name( self ) :
 
-			if self.__setName.startswith( "__" ) :
-				return IECore.CamelCase.toSpaced( self.__setName[2:] )
-			else :
-				return self.__setName or ""
+			return self.__setName or ""
 
 		def supportsInheritance( self ) :
 
@@ -2590,10 +2587,7 @@ class _SetsSection( Section ) :
 
 		def name( self ) :
 
-			if self.__setName.startswith( "__" ) :
-				return IECore.CamelCase.toSpaced( self.__setName[2:] )
-			else :
-				return self.__setName or ""
+			return self.__setName or ""
 
 		def __call__( self, target ) :
 


### PR DESCRIPTION
This adds dragging of Scene Inspector labels containing the names of attributes, options, output parameters, parameters, primitive variables, and sets. 

One wrinkle was the existing transformation of set names beginning with "__" for display causing the wrong value to be dragged, such as "__lights" to "Lights" and "__cameras" to "Cameras". Seeing as we're already presenting these names as-is in the Set Editor, we've removed this transformation in the Scene Inspector for consistency.