### PR TITLE
Editor : Fix deadlock caused by garbage collection of Settings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - SceneInspector :
   - Added support for dragging inspector labels, such as those containing the names of attributes, options, output parameters, parameters, primitive variables, and sets.
   - Set names beginning with "__" such as "__lights" or "__cameras" are now displayed as-is, rather than being transformed to "Lights" or "Cameras".
+- BackgroundTask : Added reporting of tasks attempting to wait for themselves.
 
 Fixes
 -----
@@ -36,7 +37,6 @@ API
 - TextWidget, MultilineTextWidget :
   - Added `setPlaceholderText()` and `getPlaceholderText()` methods.
   - Added `placeholderText` constructor argument.
-- BackgroundTask : Added mitigation against tasks attempting to wait for themselves.
 
 1.4.6.0 (relative to 1.4.5.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,11 @@ Fixes
 
 - Viewer : Fixed handling of Gaffer `${contextVariable}` references in OpenColorIO variable values. The Viewer now updates the Display Transform appropriately when the value of the context variable changes.
 
+Fixes
+-----
+
+- UI : Fixed hangs caused by garbage collection of removed Editors. One common example involved viewing a Catalogue in the NodeEditor after removing the ImageInspector (#5877).
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -36,6 +36,7 @@ API
 - TextWidget, MultilineTextWidget :
   - Added `setPlaceholderText()` and `getPlaceholderText()` methods.
   - Added `placeholderText` constructor argument.
+- BackgroundTask : Added mitigation against tasks attempting to wait for themselves.
 
 1.4.6.0 (relative to 1.4.5.0)
 =======

--- a/python/GafferTest/BackgroundTaskTest.py
+++ b/python/GafferTest/BackgroundTaskTest.py
@@ -255,24 +255,5 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 		# check for cancellation, and we'll deadlock.
 		del task
 
-	def testSelfWait( self ) :
-
-		def f( canceller ) :
-			# It makes zero sense for a task to wait for itself. Rather than
-			# allow it to deadlock, we want to emit a diagnostic message and
-			# continue.
-			task.wait()
-
-		mh = IECore.CapturingMessageHandler()
-		IECore.MessageHandler.setDefaultHandler( mh )
-
-		task = Gaffer.BackgroundTask( None, f )
-		task.wait()
-
-		self.assertEqual( len( mh.messages ), 1 )
-		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
-		self.assertEqual( mh.messages[0].context, "BackgroundTask::wait" )
-		self.assertEqual( mh.messages[0].message, "Task attempted to wait for itself" )
-
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/BackgroundTaskTest.py
+++ b/python/GafferTest/BackgroundTaskTest.py
@@ -255,5 +255,24 @@ class BackgroundTaskTest( GafferTest.TestCase ) :
 		# check for cancellation, and we'll deadlock.
 		del task
 
+	def testSelfWait( self ) :
+
+		def f( canceller ) :
+			# It makes zero sense for a task to wait for itself. Rather than
+			# allow it to deadlock, we want to emit a diagnostic message and
+			# continue.
+			task.wait()
+
+		mh = IECore.CapturingMessageHandler()
+		IECore.MessageHandler.setDefaultHandler( mh )
+
+		task = Gaffer.BackgroundTask( None, f )
+		task.wait()
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "BackgroundTask::wait" )
+		self.assertEqual( mh.messages[0].message, "Task attempted to wait for itself" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/Editor.py
+++ b/python/GafferUI/Editor.py
@@ -96,6 +96,17 @@ class Editor( GafferUI.Widget ) :
 
 		self.__setContextInternal( scriptNode.context(), callUpdate=False )
 
+	def __del__( self ) :
+
+		for attr in self.__dict__.values() :
+			if isinstance( attr, GafferUI.Editor.Settings ) :
+				# Remove connection to ScriptNode now, on the UI thread.
+				# Otherwise we risk deadlock if the Settings node gets garbage
+				# collected in a BackgroundTask, which would attempt
+				# cancellation of all tasks for the ScriptNode, including the
+				# task itself.
+				attr["__scriptNode"].setInput( None )
+
 	def scriptNode( self ) :
 
 		return self.__scriptNode

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -50,6 +50,8 @@
 
 #include "fmt/format.h"
 
+#include <thread>
+
 using namespace IECore;
 using namespace Gaffer;
 
@@ -155,9 +157,10 @@ struct BackgroundTask::TaskData : public boost::noncopyable
 
 	Function *function;
 	IECore::Canceller canceller;
-	std::mutex mutex; // Protects `conditionVariable` and `status`
+	std::mutex mutex; // Protects `conditionVariable`, `status` and `threadID`
 	std::condition_variable conditionVariable;
 	Status status;
+	std::thread::id threadId; // Thread that is executing `function`, if any
 };
 
 BackgroundTask::BackgroundTask( const Plug *subject, const Function &function )
@@ -186,6 +189,7 @@ BackgroundTask::BackgroundTask( const Plug *subject, const Function &function )
 			// Otherwise do the work.
 
 			taskData->status = Running;
+			taskData->threadId = std::this_thread::get_id();
 			lock.unlock();
 
 			// Reset thread state rather then inherit the random
@@ -225,6 +229,7 @@ BackgroundTask::BackgroundTask( const Plug *subject, const Function &function )
 
 			lock.lock();
 			taskData->status = status;
+			taskData->threadId = std::thread::id();
 			taskData->conditionVariable.notify_one();
 		}
 	);
@@ -248,6 +253,12 @@ void BackgroundTask::cancel()
 void BackgroundTask::wait()
 {
 	std::unique_lock<std::mutex> lock( m_taskData->mutex );
+	if( m_taskData->threadId == std::this_thread::get_id() )
+	{
+		IECore::msg( IECore::Msg::Error, "BackgroundTask::wait", "Task attempted to wait for itself" );
+		return;
+	}
+
 	m_taskData->conditionVariable.wait(
 		lock,
 		[this]{

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -255,8 +255,7 @@ void BackgroundTask::wait()
 	std::unique_lock<std::mutex> lock( m_taskData->mutex );
 	if( m_taskData->threadId == std::this_thread::get_id() )
 	{
-		IECore::msg( IECore::Msg::Error, "BackgroundTask::wait", "Task attempted to wait for itself" );
-		return;
+		IECore::msg( IECore::Msg::Error, "BackgroundTask::wait", "Deadlock detected : Task is attempting to wait for itself. Please provide stack trace in bug report." );
 	}
 
 	m_taskData->conditionVariable.wait(


### PR DESCRIPTION
I believe this fixes #5877. Either of the two commits is sufficient on its own to avoid the hang. I think we definitely want to keep the first one as it is dealing most directly with the cause. I'm in two minds about keeping the second one - have a read of the commit message and see what you think.

Would be good to get this into a release before anybody else gets hit by this problem...