### PR TITLE
ShaderUI : Fix poor scaling in _ShaderPath

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- ShaderTweaks, ShaderQuery : Improved performance of parameter selection dialogue. For some particularly large shader networks, speedups are greater than 100x.
 - UIEditor : Added code examples to button code placeholder text.
 
 API

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -503,7 +503,7 @@ class _ShaderPath( Gaffer.Path ) :
 
 				connections = {
 					c.source.shader for n in self.__shaderNetworks if (
-						self[0] in n.shaders()
+						n.getShader( self[0] ) is not None
 					) for c in n.inputConnections( self[0] ) if (
 						c.destination.name.split( '.' )[0] == self[1]
 					)
@@ -598,7 +598,7 @@ class _ShaderPath( Gaffer.Path ) :
 		if self.__connectedParametersOnly :
 			connectedParams = set()
 			for n in self.__shaderNetworks :
-				if self[0] in n.shaders() :
+				if n.getShader( self[0] ) is not None :
 					for c in n.inputConnections( self[0] ) :
 						connectedParams.add( c.destination.name )
 			return list( connectedParams )
@@ -609,7 +609,13 @@ class _ShaderPath( Gaffer.Path ) :
 	def __shaders( self ) :
 
 		if len( self ) > 0 :
-			uniqueShaders = { n.shaders()[ self[0] ].hash() : n.shaders()[ self[0] ] for n in self.__shaderNetworks if self[0] in n.shaders() }
+
+			uniqueShaders = {}
+			for network in self.__shaderNetworks :
+				shader = network.getShader( self[0] )
+				if shader is not None :
+					uniqueShaders[shader.hash()] = shader
+
 			return list( uniqueShaders.values() )
 
 		return None


### PR DESCRIPTION
The `ShaderNetwork.shaders()` function builds a Python dictionary containing copies of all the shaders in the network. And in several places, we were calling that at least once per shader, giving us extremely poor scaling for certain large production networks with around 700 individual shaders. This was bad enough that some users reported avoiding the dialogue entirely.

This commit replaces calls to `shaders()` with individual calls to `getShader()`. That gives around a 300x speedup when walking the entire _ShaderPath hierarchy for a problematic network and querying the `shader:inputs` property for each parameter found. This makes the shader dialogues for ShaderTweaks and ShaderQuery usable again.
