### PR TITLE
LightEditor support for light filters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - Annotations :
   - Added support for `{plug}` value substitutions in node annotations.
   - Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> keyboard shortcut to annotation dialogue. This applies the annotation and closes the dialogue.
+- LightEditor : Added support for Arnold light blockers.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ API
 - Loop : Added `nextIterationContext()` method.
 - AnnotationsGadget : Added `annotationText()` method.
 - ParallelAlgoTest : Added `UIThreadCallHandler.receive()` method.
+- LightEditor : Added `registerShaderParameter()` method for registering parameters for shader attributes that are not the same as the `rendererKey`.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -12,7 +12,7 @@ Improvements
 - Annotations :
   - Added support for `{plug}` value substitutions in node annotations.
   - Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> keyboard shortcut to annotation dialogue. This applies the annotation and closes the dialogue.
-- LightEditor : Added support for Arnold light blockers.
+- LightEditor : Added support for Arnold light blockers and barndoor, gobo and decay light filters.
 
 Fixes
 -----

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -345,6 +345,14 @@ def __translateNodeMetadata( nodeEntry ) :
 				"ai:light", paramName, page
 			)
 
+		if (
+			nodeName == "light_blocker" and
+			__aiMetadataGetStr( nodeEntry, paramName, "gaffer.plugType" ) != ""
+		) :
+			GafferSceneUI.LightEditor.registerShaderParameter(
+				"ai:light", paramName, "ai:lightFilter:filter", "Blocker"
+			)
+
 		# Label from OSL "label"
 		label = __aiMetadataGetStr( nodeEntry, paramName, "label" )
 		if label is None :

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -478,6 +478,9 @@ __metadata["quad_light.parameters.height"]["layout:index"] = 1
 GafferSceneUI.LightEditor.registerParameter( "ai:light", "width", "Shape" )
 GafferSceneUI.LightEditor.registerParameter( "ai:light", "height", "Shape" )
 
+# Manually add the `filteredLights` parameter for `light_blocker`
+GafferSceneUI.LightEditor.registerAttribute( "ai:light", "filteredLights", "Blocker" )
+
 ##########################################################################
 # Gaffer Metadata queries. These are implemented using the preconstructed
 # registry above.

--- a/python/GafferSceneUI/EditScopeUI.py
+++ b/python/GafferSceneUI/EditScopeUI.py
@@ -219,7 +219,7 @@ class __LocationEditsWidget( _SceneProcessorWidget ) :
 		summaries[0] = summaries[0][0].upper() + summaries[0][1:]
 		return " and ".join( summaries )
 
-GafferUI.EditScopeUI.ProcessorWidget.registerProcessorWidget( "AttributeEdits TransformEdits *LightEdits *SurfaceEdits", __LocationEditsWidget )
+GafferUI.EditScopeUI.ProcessorWidget.registerProcessorWidget( "AttributeEdits TransformEdits *LightEdits *SurfaceEdits *FilterEdits", __LocationEditsWidget )
 
 class __PruningEditsWidget( _SceneProcessorWidget ) :
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -292,9 +292,9 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 				sectionColumns += [ c( self.__settingsNode["in"], self.__settingsNode["editScope"] ) for c in section.values() ]
 
 		nameColumn = self.__pathListing.getColumns()[0]
-		muteColumn = self.__pathListing.getColumns()[1]
-		soloColumn = self.__pathListing.getColumns()[2]
-		self.__pathListing.setColumns( [ nameColumn, muteColumn, soloColumn ] + sectionColumns )
+		self.__muteColumn = self.__pathListing.getColumns()[1]
+		self.__soloColumn = self.__pathListing.getColumns()[2]
+		self.__pathListing.setColumns( [ nameColumn, self.__muteColumn, self.__soloColumn ] + sectionColumns )
 
 	def __settingsPlugSet( self, plug ) :
 
@@ -382,11 +382,27 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		inspections = []
 
 		with Gaffer.Context( self.getContext() ) as context :
+			lightSetMembers = self.__settingsNode["in"].set( "__lights" ).value
+
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
 					continue
 				for pathString in selection.paths() :
 					path = GafferScene.ScenePlug.stringToPath( pathString )
+
+					if (
+						( column == self.__muteColumn or column == self.__soloColumn ) and
+						not ( lightSetMembers.match( path ) & (
+							IECore.PathMatcher.Result.ExactMatch | IECore.PathMatcher.Result.DescendantMatch
+						) )
+					) :
+						with GafferUI.PopupWindow() as self.__popup :
+							with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+								GafferUI.Image( "warningSmall.png" )
+								GafferUI.Label( "<h4>The " + column.headerData().value + " column can only be toggled for lights." )
+						self.__popup.popup()
+						return
+
 					context["scene:path"] = path
 					inspection = column.inspector().inspect()
 

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -736,5 +736,34 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( row["name"].getValue(), "/parent/child" )
 
+	def testLightFilter( self ) :
+
+		lightFilter = GafferSceneTest.TestLightFilter()
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( lightFilter["out"] )
+		editScope["in"].setInput( lightFilter["out"] )
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "/lightFilter", "filteredLights" ),
+			source = lightFilter["filteredLights"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = True,
+			edit = lightFilter["filteredLights"]
+		)
+
+		inspection = self.__inspect( editScope["out"], "/lightFilter", "filteredLights", editScope )
+		edit = inspection.acquireEdit()
+		edit["enabled"].setValue( True )
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "/lightFilter", "filteredLights", editScope ),
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
+
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -708,8 +708,8 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 	def testShaderParameterEditScope( self ) :
 
-		GafferSceneUI.LightEditor.registerParameter( "light", "add.a" )
-		GafferSceneUI.LightEditor.registerParameter( "light", "exposure" )
+		GafferSceneUI.LightEditor.registerShaderParameter( "light", "add.a" )
+		GafferSceneUI.LightEditor.registerShaderParameter( "light", "exposure" )
 
 		script = Gaffer.ScriptNode()
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -371,6 +371,10 @@
 				"setMemberHighlighted",
 				"setMemberFaded",
 				"setMemberFadedHighlighted",
+				"boxBlocker",
+				"sphereBlocker",
+				"planeBlocker",
+				"cylinderBlocker",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3051,12 +3051,102 @@
        id="LightEditor"
        inkscape:label="LightEditor">
       <rect
+         inkscape:label="diskLight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="50"
+         y="2596.3621"
+         id="diskLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="pointLight"
+         y="2596.3621"
+         x="30"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="pointLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="spotLight"
+         y="2596.3621"
+         x="110"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="spotLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="quadLight"
+         y="2596.3621"
+         x="70"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="quadLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         inkscape:label="cylinderLight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="90"
+         y="2596.3621"
+         id="cylinderLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         inkscape:label="distantLight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="130"
+         y="2596.3623"
+         id="distantLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         inkscape:label="environmentLight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="150"
+         y="2596.3621"
+         id="environmentLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="meshLight"
+         y="2596.3621"
+         x="170"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="meshLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         inkscape:label="photometricLight"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="190"
+         y="2596.3621"
+         id="photometricLight"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="emptyLocation"
+         y="2596.3621"
+         x="210"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="emptyLocation"
+         transform="translate(0,-52.362183)" />
+      <rect
          id="rect2136"
          y="2544"
          x="10"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill;font-variation-settings:normal;vector-effect:none;stroke-linecap:butt;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
          inkscape:label="sizeGuide" />
       <rect
          id="unMuteLight"
@@ -3143,7 +3233,7 @@
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          width="16"
          height="16"
-         x="450.95377"
+         x="451"
          y="2544"
          id="setMemberHighlighted" />
       <rect
@@ -3156,8 +3246,8 @@
          id="setMemberFaded" />
       <rect
          id="setMemberFadedHighlighted"
-         y="2544.0928"
-         x="494.91803"
+         y="2544"
+         x="495"
          height="16"
          width="16"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
@@ -8449,30 +8539,6 @@
        style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        inkscape:label="sizeGuide" />
     <rect
-       inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="50"
-       y="2596.3621"
-       id="diskLight" />
-    <rect
-       id="pointLight"
-       y="2596.3621"
-       x="30"
-       height="16"
-       width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
-    <rect
-       id="spotLight"
-       y="2596.3621"
-       x="110"
-       height="16"
-       width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
-    <rect
        inkscape:label="sizeGuide"
        style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
        width="16"
@@ -8480,22 +8546,6 @@
        x="50"
        y="2596.3621"
        id="rect1992" />
-    <rect
-       id="quadLight"
-       y="2596.3621"
-       x="70"
-       height="16"
-       width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
-    <rect
-       inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="90"
-       y="2596.3621"
-       id="cylinderLight" />
     <ellipse
        transform="matrix(0.68452662,-0.72898786,0.71525608,0.69886246,0,0)"
        ry="7.7675056"
@@ -8525,14 +8575,6 @@
        width="11.273009"
        id="rect2018"
        style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1.00001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <rect
-       inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="130"
-       y="2596.3623"
-       id="distantLight" />
     <g
        style="display:inline"
        transform="translate(100,20.000007)"
@@ -8585,14 +8627,6 @@
        id="path2080"
        d="m 124.33008,2597.8974 -12.37891,4.8359 c -0.30664,0.416 -0.21814,0.2959 -0.30664,0.416 -0.74706,0.7799 -0.86693,1.9353 -0.5664,3.0723 0.30038,1.137 1.01407,2.3123 2.06835,3.3222 1.05429,1.0098 2.26124,1.6727 3.41016,1.9239 1.14878,0.2513 2.29591,0.08 3.04297,-0.6993 0.29883,-0.1816 0.23348,-0.1419 0.29883,-0.1816 z m -2.17188,2.2539 -2.31836,6.6367 c -0.37863,-0.8401 -0.96531,-1.6719 -1.74023,-2.4141 -0.78545,-0.7524 -1.65436,-1.3115 -2.52148,-1.6523 z m -8.34179,3.289 c 0.19945,0.01 0.41425,0.034 0.64062,0.084 0.90554,0.198 1.95787,0.7585 2.88086,1.6426 0.92307,0.8842 1.5308,1.9144 1.76758,2.8105 0.0568,0.2151 0.0914,0.4175 0.10742,0.6094 l -0.52734,1.5098 c -0.41968,0.3508 -1.0642,0.4784 -1.89453,0.2968 -0.90547,-0.1981 -1.95975,-0.7603 -2.88282,-1.6445 -0.92299,-0.8841 -1.52878,-1.9125 -1.76562,-2.8086 -0.23251,-0.88 -0.11358,-1.5733 0.2793,-2.0039 0.4323,-0.1626 0.86461,-0.3253 1.29691,-0.4879 0.0343,-10e-5 0.0625,-0.01 0.0977,-0.01 z"
        style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f1c816;fill-opacity:0.992157;fill-rule:nonzero;stroke:none;stroke-width:1.10055;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    <rect
-       inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="150"
-       y="2596.3621"
-       id="environmentLight" />
     <circle
        style="display:inline;opacity:1;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="circle2009"
@@ -8635,14 +8669,6 @@
        id="path2072"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
-    <rect
-       id="meshLight"
-       y="2596.3621"
-       x="170"
-       height="16"
-       width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
     <path
        style="display:inline;fill:#f0c717;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 182.19755,2598.3809 -1.89176,4.1438 4.1106,3.5798 -4.6354,5.1641 -6.69783,-1.9579 2.65188,-2.5904 -4.01678,-3.9878 2.39725,-3.4415 z"
@@ -8667,14 +8693,6 @@
        id="path2100"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
-    <rect
-       inkscape:label=""
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="190"
-       y="2596.3621"
-       id="photometricLight" />
     <path
        style="display:inline;fill:#f1c816;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:0.498898;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 196.04536,2601.2301 -4.54536,3.1321 c 0.0248,3.3547 3.5,7 6.5,7 3,0 6.5,-3.6343 6.5,-7 l -4.65395,-3.4856"
@@ -8687,14 +8705,6 @@
        cx="198"
        cy="2602.3623"
        r="2.5" />
-    <rect
-       id="emptyLocation"
-       y="2596.3621"
-       x="210"
-       height="16"
-       width="16"
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
     <g
        style="display:inline"
        id="g2064"

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -69,7 +69,7 @@
     </linearGradient>
     <linearGradient
        id="boundsTemplate"
-       gradientTransform="matrix(1.4488738,0,0,1.25,538.88253,5058.9564)"
+       gradientTransform="matrix(1.4488738,0,0,1.25,1103.8825,5058.9564)"
        inkscape:swatch="solid">
       <stop
          style="stop-color:#ff0101;stop-opacity:0.0787037;"
@@ -3050,6 +3050,38 @@
     <g
        id="LightEditor"
        inkscape:label="LightEditor">
+      <rect
+         id="cylinderBlocker"
+         y="2544"
+         x="575"
+         height="16"
+         width="16"
+         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:0.40000001;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         inkscape:label="cylinderBlocker" />
+      <rect
+         id="planeBlocker"
+         y="2544"
+         x="555"
+         height="16"
+         width="16"
+         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         inkscape:label="planeBlocker" />
+      <rect
+         id="sphereBlocker"
+         y="2544"
+         x="535"
+         height="16"
+         width="16"
+         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         inkscape:label="sphereBlocker" />
+      <rect
+         id="boxBlocker"
+         y="2544"
+         x="515"
+         height="16"
+         width="16"
+         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         inkscape:label="boxBlocker" />
       <rect
          inkscape:label="diskLight"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
@@ -9142,6 +9174,68 @@
    cx="503.00079"
    id="circle6253"
    style="opacity:1;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+<g
+   id="g61679"
+   inkscape:label="blockerBox">
+  <path
+     id="path128507"
+     style="fill:#1e1e1e;fill-opacity:1;stroke:#ffab0f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 520.5,2597.8623 h 9 v 9 l -4,4 h -9 v -9 z"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path69541"
+     style="fill:none;fill-opacity:1;stroke:#ffab0f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 525.5,2601.8623 v 9 m -9,-9 h 9 l 4,-4" />
+</g>
+<g
+   id="g94075"
+   inkscape:label="blockerSphere"
+   style="display:inline"
+   transform="matrix(1,0,0,-1,0,5208.7248)">
+  <circle
+     style="font-variation-settings:normal;display:inline;opacity:1;fill:#1e1e1e;fill-opacity:1;stroke:#ffab0f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:normal;stop-color:#000000;stop-opacity:1"
+     id="path78045"
+     cx="543"
+     cy="2604.3623"
+     r="6.5" />
+  <path
+     style="display:inline;opacity:1;fill:none;stroke:#ffab0f;stroke-width:0.737296;stroke-dashoffset:1.10173;stop-color:#000000;stop-opacity:1"
+     d="m 543,2610.9937 c -1.17712,0 -2.13136,-2.969 -2.13135,-6.6314 10e-6,-3.6624 0.95424,-6.6313 2.13135,-6.6313"
+     id="path130705" />
+  <path
+     style="display:inline;opacity:1;fill:none;stroke:#ffab0f;stroke-width:0.737;stroke-dashoffset:1.10173;stop-color:#000000;stop-opacity:1;stroke-dasharray:none"
+     d="m 549.63135,2604.2967 c 0,1.1771 -2.969,2.1313 -6.6314,2.1313 -3.6624,0 -6.6313,-0.9542 -6.6313,-2.1313"
+     id="path134760" />
+</g>
+<g
+   id="g94070"
+   inkscape:label="blockerPlane"
+   style="display:inline"
+   transform="translate(0,1.216875e-4)">
+  <path
+     style="fill:#1e1e1e;fill-opacity:1;stroke:#ffab0f;stroke-width:0.823789px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 559.91197,2598.0248 v 12.6748 l 6.1762,-2.925 v -6.8248 z"
+     id="path92073"
+     sodipodi:nodetypes="ccccc" />
+</g>
+<g
+   id="g97002"
+   inkscape:label="blockerCylinder"
+   transform="rotate(90,582.91836,2604.4439)">
+  <path
+     sodipodi:nodetypes="cccccc"
+     inkscape:connector-curvature="0"
+     id="path106455"
+     d="m 578.50087,2600.3525 c 0.003,2.768 -0.006,5.6147 0.004,8.3438 -5.3e-4,1.1964 1.9393,2.1663 4.33204,2.166 2.39196,-3e-4 4.33061,-0.97 4.33007,-2.166 0.005,-2.8522 0.007,-5.8455 0.006,-8.3438 z"
+     style="display:inline;fill:#1e1e1e;fill-opacity:1;stroke:#ffab0f;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <ellipse
+     ry="2.1655145"
+     rx="4.3310289"
+     cy="2600.0276"
+     cx="582.83105"
+     id="ellipse106457"
+     style="display:inline;fill:#1e1e1e;fill-opacity:1;stroke:#ffab0f;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</g>
 </g>
     <path
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -398,8 +398,23 @@ const boost::container::flat_map<string, string> g_rendererAttributePrefixes = {
 	{ "cycles", "Cycles" }
 };
 
+/// \todo Create a registration method for populating overrides.
+using ProcessorOverrideMap = std::unordered_map<std::string, std::string>;
+const ProcessorOverrideMap g_processorNameOverrides = {
+	{ "ai:lightFilter:filter", "ArnoldLightBlockerEdits" },
+	{ "ai:lightFilter:barndoor", "ArnoldBarndoorEdits" },
+	{ "ai:lightFilter:light_decay", "ArnoldLightDecayEdits" },
+	{ "ai:lightFilter:gobo", "ArnoldGoboEdits" }
+};
+
 string parameterProcessorName( const std::string &attribute )
 {
+	ProcessorOverrideMap::const_iterator override = g_processorNameOverrides.find( attribute );
+	if( override != g_processorNameOverrides.end() )
+	{
+		return override->second;
+	}
+
 	string rendererPrefix;
 	vector<string> parts;
 

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -401,10 +401,10 @@ const boost::container::flat_map<string, string> g_rendererAttributePrefixes = {
 /// \todo Create a registration method for populating overrides.
 using ProcessorOverrideMap = std::unordered_map<std::string, std::string>;
 const ProcessorOverrideMap g_processorNameOverrides = {
-	{ "ai:lightFilter:filter", "ArnoldLightBlockerEdits" },
-	{ "ai:lightFilter:barndoor", "ArnoldBarndoorEdits" },
-	{ "ai:lightFilter:light_decay", "ArnoldLightDecayEdits" },
-	{ "ai:lightFilter:gobo", "ArnoldGoboEdits" }
+	{ "ai:lightFilter:filter", "ArnoldLightBlockerFilterEdits" },
+	{ "ai:lightFilter:barndoor", "ArnoldBarndoorFilterEdits" },
+	{ "ai:lightFilter:light_decay", "ArnoldLightDecayFilterEdits" },
+	{ "ai:lightFilter:gobo", "ArnoldGoboFilterEdits" }
 };
 
 string parameterProcessorName( const std::string &attribute )

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -94,7 +94,8 @@ CreatableRegistry g_attributeRegistry {
 	{ "gl:visualiser:frustum", new IECore::StringData( "whenSelected" ) },
 	{ "gl:light:frustumScale", new IECore::FloatData( 1.0f ) },
 	{ "gl:light:drawingMode", new IECore::StringData( "texture" ) },
-	{ "light:mute", new IECore::BoolData( false ) }
+	{ "light:mute", new IECore::BoolData( false ) },
+	{ "filteredLights", new StringData( "" ) }
 };
 
 /// Entry keys for `g_optionRegistry` should not include the "option:" prefix.

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -41,6 +41,7 @@
 #include "GafferScene/Camera.h"
 #include "GafferScene/EditScopeAlgo.h"
 #include "GafferScene/Light.h"
+#include "GafferScene/LightFilter.h"
 #include "GafferScene/SceneAlgo.h"
 #include "GafferScene/SceneNode.h"
 
@@ -258,6 +259,11 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 			return light->mutePlug();
 		}
 		return attributePlug( light->visualiserAttributesPlug(), m_attribute );
+	}
+
+	else if( auto lightFilter = runTimeCast<LightFilter>( sceneNode ) )
+	{
+		return lightFilter->filteredLightsPlug();
 	}
 
 	else if( auto camera = runTimeCast<GafferScene::Camera>( sceneNode ) )

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -79,6 +79,15 @@ namespace
 {
 
 ConstStringDataPtr g_emptyLocation = new StringData( "emptyLocation.png" );
+const InternedString g_lightSetName( "__lights" );
+
+bool isLight( const ScenePath *scenePath, const Canceller *canceller )
+{
+	ScenePlug::SetScope scope( scenePath->getContext(), &g_lightSetName );
+	scope.setCanceller( canceller );
+	ConstPathMatcherDataPtr lightsData = scenePath->getScene()->setPlug()->getValue();
+	return lightsData->readable().match( scenePath->names() ) & PathMatcher::ExactMatch;
+}
 
 class LocationNameColumn : public StandardPathColumn
 {
@@ -289,6 +298,11 @@ class MuteColumn : public InspectorColumn
 				return result;
 			}
 
+			if( !isLight( scenePath, canceller ) )
+			{
+				return CellData();
+			}
+
 			if( auto value = runTimeCast<const BoolData>( result.value ) )
 			{
 				result.icon = value->readable() ? m_muteIconData : m_unMuteIconData;
@@ -407,6 +421,11 @@ class SetMembershipColumn : public InspectorColumn
 			if( !scenePath )
 			{
 				return result;
+			}
+
+			if( !isLight( scenePath, canceller ) )
+			{
+				return CellData();
 			}
 
 			std::string toolTip;

--- a/startup/GafferScene/arnoldLights.py
+++ b/startup/GafferScene/arnoldLights.py
@@ -102,3 +102,6 @@ Gaffer.Metadata.registerValue( "ai:light:photometric_light", "radiusParameter", 
 # Most profiles generally shine down -y
 Gaffer.Metadata.registerValue( "ai:light:photometric_light", "visualiserOrientation", imath.M44f().rotate( imath.V3f( -0.5 * math.pi, 0 , 0 ) ) )
 Gaffer.Metadata.registerValue( "ai:light:photometric_light", "type", "photometric" )
+
+Gaffer.Metadata.registerValue( "ai:lightFilter:filter:light_blocker", "typeParameter", "geometry_type" )
+Gaffer.Metadata.registerValue( "ai:lightFilter:filter:light_blocker", "type", "lightBlocker" )

--- a/startup/GafferSceneUI/lightFilter.py
+++ b/startup/GafferSceneUI/lightFilter.py
@@ -1,0 +1,40 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferSceneUI
+
+Gaffer.Metadata.registerValue( "attribute:filteredLights", "ui:scene:acceptsSetExpression", True )


### PR DESCRIPTION
This adds support for editing light filters in the Light Editor. This includes blockers, which are distinct scene locations apart from lights and filters applied to lights using `ShaderAssignment`.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
