### PR TITLE
Metadata : Allow path-based registrations on nodes to override plug registrations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - CameraTweaks : Added `ignoreMissing` plug to align behaviour with the other Tweaks nodes.
 - AttributeTweaks : The `{source}` substitution for `linkedLights` now expands to `defaultLights` if the attribute doesn't exist yet. This makes tweaks such as `({source}) - unwantedLights` reliable even if no light links have been authored yet.
 - ImageReader : Non-standard "r", "g", "b" and "a" channel names are now automatically renamed to "R", "G", "B" and "A" on loading. As with other heuristics, this can be disabled by setting `channelInterpretation` to "EXR Specification".
+- Metadata : Metadata registered to a node or plug targeting a descendant plug will now override metadata registered locally to the target.
 
 Breaking Changes
 ----------------
@@ -15,6 +16,7 @@ Breaking Changes
 - TweakPlug : Remove deprecated `MissingMode::IgnoreOrReplace`.
 - AttributeTweaks : `Replace` mode no longer errors if the `linkedLights` attribute doesn't exist.
 - ImageReader : Changed handling of lower-cased "r", "g", "b" and "a" channels.
+- Metadata : Path based registrations to a Node or Plug now override equivalent registrations on its descendants.
 
 1.4.x.x (relative to 1.4.7.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - AttributeTweaks : The `{source}` substitution for `linkedLights` now expands to `defaultLights` if the attribute doesn't exist yet. This makes tweaks such as `({source}) - unwantedLights` reliable even if no light links have been authored yet.
 - ImageReader : Non-standard "r", "g", "b" and "a" channel names are now automatically renamed to "R", "G", "B" and "A" on loading. As with other heuristics, this can be disabled by setting `channelInterpretation` to "EXR Specification".
 - Metadata : Metadata registered to a node or plug targeting a descendant plug will now override metadata registered locally to the target.
+- OptionTweaks, ContextVariableTweaks : Added `Remove` mode.
 
 Breaking Changes
 ----------------
@@ -17,7 +18,7 @@ Breaking Changes
 - AttributeTweaks : `Replace` mode no longer errors if the `linkedLights` attribute doesn't exist.
 - ImageReader : Changed handling of lower-cased "r", "g", "b" and "a" channels.
 - Metadata : Path based registrations to a Node or Plug now override equivalent registrations on its descendants.
-- TweakPlugValueWidget : Removed support for `tweakPlugValueWidget:allowCreate` metadata.
+- TweakPlugValueWidget : Removed support for `tweakPlugValueWidget:allowCreate` and `tweakPlugValueWidget:allowRemove` metadata.
 
 1.4.x.x (relative to 1.4.7.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Breaking Changes
 - AttributeTweaks : `Replace` mode no longer errors if the `linkedLights` attribute doesn't exist.
 - ImageReader : Changed handling of lower-cased "r", "g", "b" and "a" channels.
 - Metadata : Path based registrations to a Node or Plug now override equivalent registrations on its descendants.
+- TweakPlugValueWidget : Removed support for `tweakPlugValueWidget:allowCreate` metadata.
 
 1.4.x.x (relative to 1.4.7.0)
 =======

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -97,7 +97,6 @@ Gaffer.Metadata.registerNode(
 
 		"tweaks.*" : [
 
-			"tweakPlugValueWidget:allowRemove", True,
 			"tweakPlugValueWidget:propertyType", "attribute",
 
 		],

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -97,7 +97,6 @@ Gaffer.Metadata.registerNode(
 
 		"tweaks.*" : [
 
-			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:allowRemove", True,
 			"tweakPlugValueWidget:propertyType", "attribute",
 

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -98,7 +98,6 @@ Gaffer.Metadata.registerNode(
 		"tweaks.*" : [
 
 			"tweakPlugValueWidget:allowRemove", True,
-			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:propertyType", "parameter",
 
 		],

--- a/python/GafferSceneUI/CameraTweaksUI.py
+++ b/python/GafferSceneUI/CameraTweaksUI.py
@@ -97,7 +97,6 @@ Gaffer.Metadata.registerNode(
 
 		"tweaks.*" : [
 
-			"tweakPlugValueWidget:allowRemove", True,
 			"tweakPlugValueWidget:propertyType", "parameter",
 
 		],

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -119,7 +119,6 @@ Gaffer.Metadata.registerNode(
 
 		"tweaks.*" : [
 
-			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:propertyType", "option",
 
 		],

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -126,7 +126,6 @@ Gaffer.Metadata.registerNode(
 		"tweaks.*" : [
 
 			"noduleLayout:visible", False, # Can be shown individually using PlugAdder above
-			"tweakPlugValueWidget:allowRemove", True,
 			"tweakPlugValueWidget:propertyType", "parameter",
 			"plugValueWidget:type", "GafferSceneUI.ShaderTweaksUI._ShaderTweakPlugValueWidget",
 

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -126,7 +126,6 @@ Gaffer.Metadata.registerNode(
 		"tweaks.*" : [
 
 			"noduleLayout:visible", False, # Can be shown individually using PlugAdder above
-			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:allowRemove", True,
 			"tweakPlugValueWidget:propertyType", "parameter",
 			"plugValueWidget:type", "GafferSceneUI.ShaderTweaksUI._ShaderTweakPlugValueWidget",

--- a/python/GafferUI/ContextVariableTweaksUI.py
+++ b/python/GafferUI/ContextVariableTweaksUI.py
@@ -84,7 +84,6 @@ Gaffer.Metadata.registerNode(
 
 		"tweaks.*" : [
 
-			"tweakPlugValueWidget:allowCreate", True,
 			"tweakPlugValueWidget:propertyType", "context variable",
 
 		]

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -279,7 +279,6 @@ for key in [
 	"spreadsheet:columnWidth",
 	"plugValueWidget:type",
 	"presetsPlugValueWidget:allowCustom",
-	"tweakPlugValueWidget:allowRemove",
 ] :
 
 	Gaffer.Metadata.registerValue(

--- a/python/GafferUI/SpreadsheetUI/_Metadata.py
+++ b/python/GafferUI/SpreadsheetUI/_Metadata.py
@@ -280,7 +280,6 @@ for key in [
 	"plugValueWidget:type",
 	"presetsPlugValueWidget:allowCustom",
 	"tweakPlugValueWidget:allowRemove",
-	"tweakPlugValueWidget:allowCreate",
 ] :
 
 	Gaffer.Metadata.registerValue(

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -48,10 +48,9 @@ from Qt import QtWidgets
 # Widget for TweakPlug, which is used to build tweak nodes such as ShaderTweaks
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
 # a target parameter name, an enabled plug, and a mode.
-# The mode can be "Create", "CreateIfMissing", "Replace",
+# The mode can be "Create", "CreateIfMissing", "Replace", "Remove",
 # or "Add"/"Subtract"/"Multiply"/"Min"/"Max" if the plug is numeric,
-# or "ListAppend"/"ListPrepend"/"ListRemove" if the plug is a list or `PathMatcherPlug`,
-# or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set.
+# or "ListAppend"/"ListPrepend"/"ListRemove" if the plug is a list or `PathMatcherPlug`.
 class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plugs ) :
@@ -165,7 +164,12 @@ Gaffer.Metadata.registerValue(
 
 def __validModes( plug ) :
 
-	result = [ Gaffer.TweakPlug.Mode.Create, Gaffer.TweakPlug.Mode.CreateIfMissing, Gaffer.TweakPlug.Mode.Replace ]
+	result = [
+		Gaffer.TweakPlug.Mode.Create,
+		Gaffer.TweakPlug.Mode.CreateIfMissing,
+		Gaffer.TweakPlug.Mode.Replace,
+		Gaffer.TweakPlug.Mode.Remove,
+	]
 
 	if hasattr( plug.parent()["value"], "hasMinValue" ) :
 		result += [
@@ -197,9 +201,6 @@ def __validModes( plug ) :
 			Gaffer.TweakPlug.Mode.ListPrepend,
 			Gaffer.TweakPlug.Mode.ListRemove
 		]
-
-	if Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:allowRemove" ) :
-		result += [ Gaffer.TweakPlug.Mode.Remove ]
 
 	return result
 

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -48,9 +48,6 @@ from Qt import QtWidgets
 # Widget for TweakPlug, which is used to build tweak nodes such as ShaderTweaks
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
 # a target parameter name, an enabled plug, and a mode.
-# The mode can be "Create", "CreateIfMissing", "Replace", "Remove",
-# or "Add"/"Subtract"/"Multiply"/"Min"/"Max" if the plug is numeric,
-# or "ListAppend"/"ListPrepend"/"ListRemove" if the plug is a list or `PathMatcherPlug`.
 class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plugs ) :

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -47,11 +47,11 @@ from Qt import QtWidgets
 
 # Widget for TweakPlug, which is used to build tweak nodes such as ShaderTweaks
 # and CameraTweaks.  Shows a value plug that you can use to specify a tweak value, along with
-# a target parameter name, an enabled plug, and a mode.  The mode can be "Replace",
+# a target parameter name, an enabled plug, and a mode.
+# The mode can be "Create", "CreateIfMissing", "Replace",
 # or "Add"/"Subtract"/"Multiply"/"Min"/"Max" if the plug is numeric,
 # or "ListAppend"/"ListPrepend"/"ListRemove" if the plug is a list or `PathMatcherPlug`,
-# or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set,
-# or "Create" and "CreateIfMissing" if the metadata "tweakPlugValueWidget:allowCreate" is set.
+# or "Remove" if the metadata "tweakPlugValueWidget:allowRemove" is set.
 class TweakPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plugs ) :
@@ -165,11 +165,8 @@ Gaffer.Metadata.registerValue(
 
 def __validModes( plug ) :
 
-	result = []
-	if Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:allowCreate" ) :
-		result += [ Gaffer.TweakPlug.Mode.Create, Gaffer.TweakPlug.Mode.CreateIfMissing ]
+	result = [ Gaffer.TweakPlug.Mode.Create, Gaffer.TweakPlug.Mode.CreateIfMissing, Gaffer.TweakPlug.Mode.Replace ]
 
-	result += [ Gaffer.TweakPlug.Mode.Replace ]
 	if hasattr( plug.parent()["value"], "hasMinValue" ) :
 		result += [
 			Gaffer.TweakPlug.Mode.Add,

--- a/python/GafferUI/TweakPlugValueWidget.py
+++ b/python/GafferUI/TweakPlugValueWidget.py
@@ -149,11 +149,20 @@ GafferUI.PlugValueWidget.registerType( Gaffer.TweakPlug, TweakPlugValueWidget )
 # Metadata
 
 Gaffer.Metadata.registerValue( Gaffer.TweakPlug, "deletable", lambda plug : plug.getFlags( Gaffer.Plug.Flags.Dynamic ) )
+Gaffer.Metadata.registerValue( Gaffer.TweakPlug, "tweakPlugValueWidget:propertyType:promotable", False )
+
+def __propertyType( plug ) :
+
+	source = Gaffer.PlugAlgo.findDestination(
+		plug,
+		lambda p : p if Gaffer.Metadata.value( p.parent(), "tweakPlugValueWidget:propertyType" ) else None
+	) or plug
+
+	return Gaffer.Metadata.value( source.parent(), "tweakPlugValueWidget:propertyType" ) or "property"
 
 def __nameDescription( plug ) :
 
-	property = Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:propertyType" ) or "property"
-	return f"The name of the {property} to apply the tweak to."
+	return f"The name of the {__propertyType( plug )} to apply the tweak to."
 
 Gaffer.Metadata.registerValue( Gaffer.TweakPlug, "name", "description", __nameDescription )
 
@@ -283,7 +292,7 @@ __modeDescriptions = {
 
 def __modeDescription( plug ) :
 
-	property = Gaffer.Metadata.value( plug.parent(), "tweakPlugValueWidget:propertyType" ) or "property"
+	property = __propertyType( plug )
 
 	result =  "| Mode | Description |\n"
 	result += "| :--- | :---------- |\n"

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -799,13 +799,6 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireAttributeEdit( Gaffer::EditScope *
 	attributeTweaks->tweaksPlug()->addChild( tweakPlug );
 
 	size_t columnIndex = rows->addColumn( tweakPlug.get(), columnName, /* adoptEnabledPlug */ true );
-	MetadataAlgo::copyIf(
-		tweakPlug.get(), rows->defaultRow()->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug(),
-		[] ( const GraphComponent *from, const GraphComponent *to, const std::string &name ) {
-			return boost::starts_with( name, "tweakPlugValueWidget:" );
-		}
-	);
-
 	tweakPlug->setInput( processor->getChild<Spreadsheet>( "Spreadsheet" )->outPlug()->getChild<Plug>( columnIndex ) );
 
 	return row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug<TweakPlug>();
@@ -1425,13 +1418,6 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireRenderPassOptionEdit( Gaffer::Edit
 	optionTweaks->tweaksPlug()->addChild( tweakPlug );
 
 	size_t columnIndex = rows->addColumn( tweakPlug.get(), columnName, /* adoptEnabledPlug */ true );
-	MetadataAlgo::copyIf(
-		tweakPlug.get(), rows->defaultRow()->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug(),
-		[] ( const GraphComponent *from, const GraphComponent *to, const std::string &name ) {
-			return boost::starts_with( name, "tweakPlugValueWidget:" );
-		}
-	);
-
 	tweakPlug->setInput( processor->getChild<Spreadsheet>( "Spreadsheet" )->outPlug()->getChild<Plug>( columnIndex ) );
 
 	return row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnIndex )->valuePlug<TweakPlug>();


### PR DESCRIPTION
Putting this up as a draft targeted to `1.4_maintenance` in order to produce builds for testing, though we anticipate this change to be merged into `main` for release in Gaffer 1.5.

This change is primarily in response to the Spreadsheet RowsPlug "default.*..." metadata registrations in 45ab8c41acd01346db24a3e068809e6557cf78a5 causing issues as that metadata overrides specific registrations to "rows.default.cells.specificColumn.value" on a node using a RowsPlug.

Though outside of that specific issue we feel this change is logical because the node is the higher-level component and may have good reason to override the registration on a lower-level component such as a plug.

