### PR TITLE
RenderPassEditor : Add Select Affected Objects to context menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - ColorChooser : Added channel names to identify sliders.
+- RenderPassEditor : Added "Select Affected Objects" popup menu item.
 
 Fixes
 -----


### PR DESCRIPTION
This adds `Select Affected Objects` to the Render Pass Editor's context menu, using the various "ui:scene:acceptsSet[Name,Names,Expression]" metadata to define whether the action is enabled for an option. Might also be nice to extend support for options that contain paths, such as `render:camera`... 