### PR TITLE
SceneReader : Avoid computation error for empty UsdVolumes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - FramingConstraint : Fixed crash caused by attempts to constrain objects that were not cameras.
+- SceneReader : Fixed error loading USD Volumes with empty fields. These will now issue a warning and load as empty locations.
 
 1.3.16.4 (relative to 1.3.16.3)
 ========

--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -813,5 +813,18 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertNotIn( "scene:path", contextMonitor.combinedStatistics().variableNames() )
 			self.assertNotIn( "scene:setName", contextMonitor.combinedStatistics().variableNames() )
 
+	def testEmptyUSDVolumeField( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( pathlib.Path( __file__ ).parent / "usdFiles" / "volumeWithEmptyField.usda" )
+
+		self.assertEqual( reader["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "volume" ] ) )
+
+		with IECore.CapturingMessageHandler() as mh :
+			self.assertEqual( reader["out"].object( "/volume" ), IECore.NullObject() )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, 'No file found for "/volume"' )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/usdFiles/volumeWithEmptyField.usda
+++ b/python/GafferSceneTest/usdFiles/volumeWithEmptyField.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def Volume "volume"
+{
+    custom rel field:density = </volume/density>
+
+    def OpenVDBAsset "density"
+    {
+    }
+}
+

--- a/src/GafferScene/SceneReader.cpp
+++ b/src/GafferScene/SceneReader.cpp
@@ -481,7 +481,14 @@ IECore::ConstObjectPtr SceneReader::computeObject( const ScenePath &path, const 
 		return parent->objectPlug()->defaultValue();
 	}
 
-	return s->readObject( timeAsDouble( context ), context->canceller() );
+	ConstObjectPtr o = s->readObject( timeAsDouble( context ), context->canceller() );
+	// We checked `hasObject()` already, so we shouldn't _really_ get a nullptr
+	// here. But it can currently happen in at least one circumstance : when a
+	// USDScene loads a UsdVolume with no valid field definitions. This could be
+	// dealt with in USDScene by extending the ObjectAlgo API and making
+	// `hasObject()` more expensive, but in the meantime it's simpler and
+	// cheaper to add some protection here.
+	return o ? o : parent->objectPlug()->defaultValue();
 }
 
 void SceneReader::hashChildNames( const ScenePath &path, const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const


### PR DESCRIPTION
In this case, `USDScene::hasObject()` returns true because it just does a shallow check that the prim type is one we know how to load. But when we actually come to load it, USDScene discovers that there is no VDB file actually being referenced, and so is forced to return `nullptr`. To deal with this in IECoreUSD we'd have to extend the ObjectAlgo API to allow deeper `hasObject()` checks. While that might be worthwhile in the long run, it also makes for more expensive checks. So it seems worthwhile having a cheap and cheerful backdrop in the SceneReader itself.
