### PR TITLE
AnnotationsGadget : Add `{plug}` syntax for substituting node values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ API
 ---
 
 - AnnotationsGadget : Added `annotationText()` method.
+- ParallelAlgoTest : Added `UIThreadCallHandler.receive()` method.
 
 1.4.7.0 (relative to 1.4.6.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ Fixes
 - Cycles : Fixed rendering to the Catalogue using the batch Render node (#5905). Note that rendering a mixture of Catalogue and file outputs is still not supported, and in this case any file outputs will be ignored.
 - CodeWidget : Fixed bug that could prevent changes from being committed while the completion menu was visible.
 
+API
+---
+
+- AnnotationsGadget : Added `annotationText()` method.
+
 1.4.7.0 (relative to 1.4.6.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,9 @@ Improvements
 
 - ColorChooser : Added channel names to identify sliders.
 - RenderPassEditor : Added "Select Affected Objects" popup menu item.
-- Annotations : Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> keyboard shortcut to annotation dialogue. This applies the annotation and closes the dialogue.
+- Annotations :
+  - Added support for `{plug}` value substitutions in node annotations.
+  - Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> keyboard shortcut to annotation dialogue. This applies the annotation and closes the dialogue.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - ColorChooser : Added channel names to identify sliders.
 - RenderPassEditor : Added "Select Affected Objects" popup menu item.
+- Annotations : Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> keyboard shortcut to annotation dialogue. This applies the annotation and closes the dialogue.
 
 Fixes
 -----

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -94,11 +94,12 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 
 	private :
 
-		GraphGadget *graphGadget();
-		const GraphGadget *graphGadget() const;
+		struct Annotations;
 
 		void graphGadgetChildAdded( GraphComponent *child );
 		void graphGadgetChildRemoved( const GraphComponent *child );
+		Annotations *annotations( const Gaffer::Node *node );
+		const Annotations *annotations( const Gaffer::Node *node ) const;
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
 		void update() const;
 

--- a/include/GafferUI/AnnotationsGadget.h
+++ b/include/GafferUI/AnnotationsGadget.h
@@ -74,6 +74,10 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 		void setVisibleAnnotations( const IECore::StringAlgo::MatchPattern &patterns );
 		const IECore::StringAlgo::MatchPattern &getVisibleAnnotations() const;
 
+		/// Returns the text currently being rendered for the specified
+		/// annotation. Only really intended for use in the unit tests.
+		const std::string &annotationText( const Gaffer::Node *node, IECore::InternedString annotation = "user" ) const;
+
 		bool acceptsParent( const GraphComponent *potentialParent ) const override;
 
 	protected :
@@ -98,10 +102,16 @@ class GAFFERUI_API AnnotationsGadget : public Gadget
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
 		void update() const;
 
+		struct StandardAnnotation : public Gaffer::MetadataAlgo::Annotation
+		{
+			StandardAnnotation( const Gaffer::MetadataAlgo::Annotation &a, IECore::InternedString name ) : Annotation( a ), name( name ) {}
+			IECore::InternedString name;
+		};
+
 		struct Annotations
 		{
 			bool dirty = true;
-			std::vector<Gaffer::MetadataAlgo::Annotation> standardAnnotations;
+			std::vector<StandardAnnotation> standardAnnotations;
 			bool bookmarked = false;
 			IECore::InternedString numericBookmark;
 			bool renderable = false;

--- a/python/GafferTest/ParallelAlgoTest.py
+++ b/python/GafferTest/ParallelAlgoTest.py
@@ -74,16 +74,22 @@ class ParallelAlgoTest( GafferTest.TestCase ) :
 
 			self.__queue.put( f )
 
-		# Waits for a single use of `callOnUIThread()`, raising
-		# a test failure if none arises before `timeout` seconds.
-		def assertCalled( self, timeout = 30.0 ) :
+		# Waits for a single use of `callOnUIThread()` and returns the functor
+		# that was passed. It is the caller's responsibility to call the
+		# functor. Raises a test failure if no call arises before `timeout`
+		# seconds.
+		def receive( self, timeout = 30.0 ) :
 
 			try :
-				f = self.__queue.get( block = True, timeout = timeout )
+				return self.__queue.get( block = True, timeout = timeout )
 			except queue.Empty :
 				raise AssertionError( "UIThread call not made within {} seconds".format( timeout ) )
 
-			f()
+		# Waits for and handles a single use of `callOnUIThread()`, raising a
+		# test failure if none arises before `timeout` seconds.
+		def assertCalled( self, timeout = 30.0 ) :
+
+			self.receive( timeout )()
 
 		# Asserts that no further uses of `callOnUIThread()` will
 		# be made with this handler. This is checked on context exit.

--- a/python/GafferUI/AnnotationsUI.py
+++ b/python/GafferUI/AnnotationsUI.py
@@ -91,6 +91,9 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 			self.__textWidget.textChangedSignal().connect(
 				Gaffer.WeakMethod( self.__updateButtonStatus ), scoped = False
 			)
+			self.__textWidget.activatedSignal().connect(
+				Gaffer.WeakMethod( self.__textActivated ), scoped = False
+			)
 
 			if not template :
 				self.__colorChooser = GafferUI.ColorChooser(
@@ -147,3 +150,8 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 			)
 		else :
 			return Gaffer.MetadataAlgo.Annotation( self.__textWidget.getText() )
+
+	def __textActivated( self, *unused ) :
+
+		if self.__annotateButton.getEnabled() :
+			self.__annotateButton.clickedSignal()( self.__annotateButton )

--- a/python/GafferUI/AnnotationsUI.py
+++ b/python/GafferUI/AnnotationsUI.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import functools
+import re
 import imath
 
 import IECore
@@ -71,6 +72,72 @@ def __annotate( node, name, menu ) :
 	dialogue = __AnnotationsDialogue( node, name )
 	dialogue.wait( parentWindow = menu.ancestor( GafferUI.Window ) )
 
+class _AnnotationsHighlighter( GafferUI.CodeWidget.Highlighter ) :
+
+	__substitutionRe = re.compile( r"(\{[^}]+\})" )
+
+	def __init__( self, node ) :
+
+		GafferUI.CodeWidget.Highlighter.__init__( self )
+		self.__node = node
+
+	def highlights( self, line, previousHighlightType ) :
+
+		result = []
+
+		l = 0
+		for token in self.__substitutionRe.split( line ) :
+			if (
+				len( token ) > 2 and
+				token[0] == "{" and token[-1] == "}" and
+				isinstance( self.__node.descendant( token[1:-1] ), Gaffer.ValuePlug )
+			) :
+				result.append(
+					self.Highlight( l, l + len( token ), self.Type.Keyword )
+				)
+			l += len( token )
+
+		return result
+
+class _AnnotationsCompleter( GafferUI.CodeWidget.Completer ) :
+
+	__incompleteSubstitutionRe = re.compile( r"\{([^.}][^}]*$)" )
+
+	def __init__( self, node ) :
+
+		GafferUI.CodeWidget.Completer.__init__( self )
+		self.__node = node
+
+	def completions( self, text ) :
+
+		m = self.__incompleteSubstitutionRe.search( text )
+		if m is None :
+			return []
+
+		parentPath, _, childName = m.group( 1 ).rpartition( "." )
+		parent = self.__node.descendant( parentPath ) if parentPath else self.__node
+		if parent is None :
+			return []
+
+		result = []
+		for plug in Gaffer.Plug.Range( parent ) :
+			if not hasattr( plug, "getValue" ) and not len( plug ) :
+				continue
+			if plug.getName().startswith( childName ) :
+				childPath = plug.relativeName( self.__node )
+				result.append(
+					self.Completion(
+						"{prefix}{{{childPath}{closingBrace}".format(
+							prefix = text[:m.start()],
+							childPath = childPath,
+							closingBrace = "}" if hasattr( plug, "getValue" ) else ""
+						),
+						label = childPath
+					)
+				)
+
+		return result
+
 class __AnnotationsDialogue( GafferUI.Dialogue ) :
 
 	def __init__( self, node, name ) :
@@ -85,9 +152,12 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 
 		with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) as layout :
 
-			self.__textWidget = GafferUI.MultiLineTextWidget(
+			self.__textWidget = GafferUI.CodeWidget(
 				text = annotation.text() if annotation else "",
+				placeholderText = "Tip : Use {plugName} to include plug values",
 			)
+			self.__textWidget.setHighlighter( _AnnotationsHighlighter( node ) )
+			self.__textWidget.setCompleter( _AnnotationsCompleter( node ) )
 			self.__textWidget.textChangedSignal().connect(
 				Gaffer.WeakMethod( self.__updateButtonStatus ), scoped = False
 			)

--- a/python/GafferUITest/AnnotationsGadgetTest.py
+++ b/python/GafferUITest/AnnotationsGadgetTest.py
@@ -60,5 +60,17 @@ class AnnotationsGadgetTest( GafferUITest.TestCase ) :
 		Gaffer.MetadataAlgo.removeAnnotation( script["node"], "user" )
 		self.assertEqual( gadget.annotationText( script["node"] ), "" )
 
+	def testExtendLifetimePastGraphGadget( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = Gaffer.Node()
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+		del graphGadget
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/AnnotationsGadgetTest.py
+++ b/python/GafferUITest/AnnotationsGadgetTest.py
@@ -34,9 +34,16 @@
 #
 ##########################################################################
 
+import inspect
+import threading
 import unittest
 
+import imath
+
+import IECore
+
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -71,6 +78,347 @@ class AnnotationsGadgetTest( GafferUITest.TestCase ) :
 
 		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test" ) )
 		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+	def testSubstitutedText( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test : {op1}" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : 0" )
+
+		script["node"]["op1"].setValue( 1 )
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : 1" )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{}" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{notAPlug}" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+	def testSubstitutionsByPlugType( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{plug}" ) )
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+
+		for plugType, value, substitution in [
+			( Gaffer.BoolPlug, True, "On" ),
+			( Gaffer.BoolPlug, False, "Off" ),
+			( Gaffer.IntPlug, 1, "1" ),
+			( Gaffer.FloatPlug, 1.1, "1.1" ),
+			( Gaffer.V2iPlug, imath.V2i( 1, 2 ), "1, 2" ),
+			( Gaffer.Color3fPlug, imath.Color3f( 1, 2, 3 ), "1, 2, 3" ),
+			( Gaffer.StringVectorDataPlug, IECore.StringVectorData( [ "1", "2", "3" ] ), "1, 2, 3" ),
+			( Gaffer.IntVectorDataPlug, IECore.IntVectorData( [ 1, 2, 3 ] ), "1, 2, 3" ),
+		] :
+
+			script["node"]["plug"] = plugType( defaultValue = value )
+			self.assertEqual( gadget.annotationText( script["node"] ), substitution )
+
+	def testInitialSubstitutedText( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test : {op1}" ) )
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : 0" )
+
+	def testComputedText( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+		script["errorNode"] = GafferTest.BadNode()
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test : {sum}" ) )
+
+		errorCondition = threading.Condition()
+		def error( *unused ) :
+			with errorCondition :
+				errorCondition.notify()
+		script["errorNode"].errorSignal().connect( error, scoped = False )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder
+			self.assertEqual( gadget.annotationText( script["node"] ), "test : ---" )
+
+			# But if we wait for the background update we should get some updated text.
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "test : 0" )
+
+			# Same applies when the plug is dirtied. We expect a placeholder first.
+			script["node"]["op1"].setValue( 1 )
+			self.assertEqual( gadget.annotationText( script["node"] ), "test : ---" )
+
+			# Then we get the real value when the computation is done.
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "test : 1" )
+
+			# And when the plug is dirtied by an upstream change we again expect
+			# placeholder text at first.
+			script["node"]["op1"].setInput( script["errorNode"]["out3"] )
+			self.assertEqual( gadget.annotationText( script["node"] ), "test : ---" )
+
+			# But this time we don't expect to get updated text, because the computation
+			# will error.
+			with errorCondition :
+				errorCondition.wait()
+
+			# Handle UI thread calls made by StandardNodeGadget to show errors,
+			# and assert that there are no more calls.
+			callHandler.assertCalled()
+			callHandler.assertCalled()
+
+			callHandler.assertDone()
+
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : ---" )
+
+	def testComputedTextCancellation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+		script["node2"] = GafferTest.AddNode()
+
+		AnnotationsGadgetTest.expressionStartedCondition = threading.Condition()
+		AnnotationsGadgetTest.expressionContinueCondition = threading.Condition()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			# Let the test know the expression has started running.
+			import GafferUITest
+			with GafferUITest.AnnotationsGadgetTest.expressionStartedCondition :
+				GafferUITest.AnnotationsGadgetTest.expressionStartedCondition.notify()
+
+			# And loop checking for cancellation until the test
+			# allows us to continue.
+			while True :
+				IECore.Canceller.check( context.canceller() )
+				with GafferUITest.AnnotationsGadgetTest.expressionContinueCondition :
+					if GafferUITest.AnnotationsGadgetTest.expressionContinueCondition.wait( timeout = 0.1 ) :
+						break
+
+			parent["node"]["op1"] = parent["node"]["op2"]
+			"""
+		) )
+
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{sum}" ) )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			viewportGadget = GafferUI.ViewportGadget( graphGadget )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+
+			# Wait for compute to start, and make a graph edit to cancel it.
+			with AnnotationsGadgetTest.expressionStartedCondition :
+				AnnotationsGadgetTest.expressionStartedCondition.wait()
+
+			script["node"]["op2"].setValue( 2 )
+
+			# We expect a call on the UI thread to re-dirty the annotation.
+
+			renderRequests = GafferTest.CapturingSlot( viewportGadget.renderRequestSignal() )
+			callHandler.assertCalled()
+			self.assertEqual( len( renderRequests ), 1 )
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+
+			# A new background task should have been launched to compute the
+			# text again. If we let the expression run to completion then we
+			# should get the final text.
+			with AnnotationsGadgetTest.expressionStartedCondition :
+				AnnotationsGadgetTest.expressionStartedCondition.wait()
+
+			with GafferUITest.AnnotationsGadgetTest.expressionContinueCondition :
+				GafferUITest.AnnotationsGadgetTest.expressionContinueCondition.notify()
+
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "4" )
+
+			# Try one more time. But this time do the cancellation by
+			# modifying a completely unrelated plug.
+
+			script["node"]["op2"].setValue( 3 )
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+			with AnnotationsGadgetTest.expressionStartedCondition :
+				AnnotationsGadgetTest.expressionStartedCondition.wait()
+
+			script["node2"]["op1"].setValue( 1 ) # Cancels
+
+			renderRequests = GafferTest.CapturingSlot( viewportGadget.renderRequestSignal() )
+			callHandler.assertCalled()
+			self.assertEqual( len( renderRequests ), 1 )
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+
+			with AnnotationsGadgetTest.expressionStartedCondition :
+				AnnotationsGadgetTest.expressionStartedCondition.wait()
+
+			with GafferUITest.AnnotationsGadgetTest.expressionContinueCondition :
+				GafferUITest.AnnotationsGadgetTest.expressionContinueCondition.notify()
+
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "6" )
+
+			callHandler.assertDone()
+
+	def testContextSensitiveText( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.FrameNode()
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{output}" ) )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+
+			# But if we wait for the background update we should get some updated text.
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "1" )
+
+			# Same applies when the context is changed. We expect a placeholder first.
+			script.context().setFrame( 10 )
+			self.assertEqual( gadget.annotationText( script["node"] ), "---" )
+
+			# Then we get the real value when the computation is done.
+			callHandler.assertCalled()
+			self.assertEqual( gadget.annotationText( script["node"] ), "10" )
+
+			callHandler.assertDone()
+
+	def testSubstitutedTextRenderRequests( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+		viewportGadget = GafferUI.ViewportGadget( graphGadget )
+		renderRequests = GafferTest.CapturingSlot( viewportGadget.renderRequestSignal() )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test" ) )
+		self.assertEqual( len( renderRequests ), 1 )
+		self.assertEqual( gadget.annotationText( script["node"] ), "test" )
+
+		script["node"]["op1"].setValue( 1 )
+		self.assertEqual( len( renderRequests ), 1 ) # No new request, because no substitutions
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test : {op1}" ) )
+		self.assertEqual( len( renderRequests ), 2 ) # New request, because annotations changed
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : 1" )
+
+		script["node"]["op1"].setValue( 2 )
+		self.assertEqual( len( renderRequests ), 3 ) # New request, because substitution changed
+
+		script["node"]["op2"].setValue( 2 )
+		self.assertEqual( len( renderRequests ), 3 ) # No new request, because plug doesn't affect substitution
+
+		script.context().setFrame( 10 )
+		self.assertEqual( len( renderRequests ), 4 ) # One new request, from unrelated code in GraphGadget
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test : {sum}" ) )
+		self.assertEqual( len( renderRequests ), 5 ) # New request, because annotation changed
+		self.assertEqual( gadget.annotationText( script["node"] ), "test : ---" )
+
+		script.context().setFrame( 11 )
+		# 2 new requests, one because substitution depends on compute, and one from unrelated code in GraphGadget.
+		self.assertEqual( len( renderRequests ), 7 )
+
+	def testDestroyGadgetWhileBackgroundThreadRuns( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "{sum}" ) )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder.
+			self.assertEqual( gadget.annotationText( script["node"], "user" ), "---" )
+
+			# Wait for the UI thread call that will be scheduled to update the gadget.
+			call = callHandler.receive()
+			# But then delete our references to the gadget _before_ we execute
+			# the call. This simulates a user removing a GraphEditor while the
+			# AnnotationsGadget is still updating. If we don't handle lifetimes
+			# well, then this could crash.
+			del graphGadget, gadget
+			call()
+
+			callHandler.assertDone()
+
+	def testRemoveNodeWhileBackgroundThreadRuns( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "test", Gaffer.MetadataAlgo.Annotation( "{sum}" ) )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder
+			self.assertEqual( gadget.annotationText( script["node"], "test" ), "---" )
+
+			# Wait for the UI thread call that will be scheduled to update the gadget.
+			call = callHandler.receive()
+			# But then delete the node _before_ we execute the call. This
+			# simulates a user deleting a node while the AnnotationsGadget is
+			# still updating. If we don't handle lifetimes well, then this could
+			# crash.
+			del script["node"]
+			call()
+
+			callHandler.assertDone()
+
+	def testRemoveAnnotationWhileBackgroundThreadRuns( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		numAnnotations = 100
+		for i in range( 0, numAnnotations ) :
+			Gaffer.MetadataAlgo.addAnnotation( script["node"], f"test{i}", Gaffer.MetadataAlgo.Annotation( "{sum}" ) )
+
+		with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as callHandler :
+
+			graphGadget = GafferUI.GraphGadget( script )
+			gadget = graphGadget["__annotations"]
+
+			# Value must be computed in background, so initially we expect a placeholder
+			self.assertEqual( gadget.annotationText( script["node"], "test0" ), "---" )
+
+			# Remove annotations while the background task runs.
+			for i in range( 0, numAnnotations ) :
+				Gaffer.MetadataAlgo.removeAnnotation( script["node"], f"test{i}" )
+			self.assertEqual( gadget.annotationText( script["node"], "test0" ), "" )
+
+			# And wait for the task to complete.
+			callHandler.assertCalled()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/AnnotationsGadgetTest.py
+++ b/python/GafferUITest/AnnotationsGadgetTest.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferUI
+import GafferUITest
+
+class AnnotationsGadgetTest( GafferUITest.TestCase ) :
+
+	def testSimpleText( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = Gaffer.Node()
+
+		graphGadget = GafferUI.GraphGadget( script )
+		gadget = graphGadget["__annotations"]
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "test" )
+
+		Gaffer.MetadataAlgo.addAnnotation( script["node"], "user", Gaffer.MetadataAlgo.Annotation( "test2" ) )
+		self.assertEqual( gadget.annotationText( script["node"] ), "test2" )
+
+		Gaffer.MetadataAlgo.removeAnnotation( script["node"], "user" )
+		self.assertEqual( gadget.annotationText( script["node"] ), "" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -131,6 +131,7 @@ from .StandardNodeToolbarTest import StandardNodeToolbarTest
 from .LabelPlugValueWidgetTest import LabelPlugValueWidgetTest
 from .PythonEditorTest import PythonEditorTest
 from .BoxIOUITest import BoxIOUITest
+from .AnnotationsGadgetTest import AnnotationsGadgetTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -116,7 +116,8 @@ string wrap( const std::string &text, size_t maxLineLength )
 
 	return result;
 }
-float g_offset = 0.5;
+
+const float g_offset = 0.5;
 
 } // namespace
 

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -688,8 +688,12 @@ void AnnotationsGadget::schedulePlugValueSubstitutions( const Gaffer::Node *node
 			// any could be destroyed before we get on to the UI thread. So
 			// maintain ownership and look up `annotations` again.
 
+			// Alias for `this` to work around MSVC bug that prevents capturing
+			// `this` again in a nested lambda.
+			AnnotationsGadget *that = this;
+
 			ParallelAlgo::callOnUIThread(
-				[gadget = Ptr( this ), node = ConstNodePtr( node ), renderText = std::move( renderText ), cancelled] {
+				[gadget = Ptr( that ), node = ConstNodePtr( node ), renderText = std::move( renderText ), cancelled] {
 
 					Annotations *annotations = gadget->annotations( node.get() );
 					if( !annotations )

--- a/src/GafferUI/AnnotationsGadget.cpp
+++ b/src/GafferUI/AnnotationsGadget.cpp
@@ -118,6 +118,7 @@ string wrap( const std::string &text, size_t maxLineLength )
 }
 
 const float g_offset = 0.5;
+const string g_emptyString;
 
 } // namespace
 
@@ -160,6 +161,33 @@ void AnnotationsGadget::setVisibleAnnotations( const IECore::StringAlgo::MatchPa
 const IECore::StringAlgo::MatchPattern &AnnotationsGadget::getVisibleAnnotations() const
 {
 	return m_visibleAnnotations;
+}
+
+const std::string &AnnotationsGadget::annotationText( const Gaffer::Node *node, IECore::InternedString annotation ) const
+{
+	const_cast<AnnotationsGadget *>( this )->update();
+
+	const NodeGadget *nodeGadget = graphGadget()->nodeGadget( node );
+	if( !nodeGadget )
+	{
+		return g_emptyString;
+	}
+
+	auto it = m_annotations.find( nodeGadget );
+	if( it == m_annotations.end() )
+	{
+		return g_emptyString;
+	}
+
+	for( const auto &a : it->second.standardAnnotations )
+	{
+		if( a.name == annotation )
+		{
+			return a.text();
+		}
+	}
+
+	return g_emptyString;
 }
 
 bool AnnotationsGadget::acceptsParent( const GraphComponent *potentialParent ) const
@@ -365,7 +393,7 @@ void AnnotationsGadget::update() const
 			}
 
 			annotations.standardAnnotations.push_back(
-				MetadataAlgo::getAnnotation( node, name, /* inheritTemplate = */ true )
+				StandardAnnotation( MetadataAlgo::getAnnotation( node, name, /* inheritTemplate = */ true ), name )
 			);
 			// Word wrap. It might be preferable to do this during
 			// rendering, but we have no way of querying the extent of

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -298,6 +298,7 @@ void GafferUIModule::bindGraphGadget()
 		.def_readonly( "untemplatedAnnotations", &AnnotationsGadget::untemplatedAnnotations )
 		.def( "setVisibleAnnotations", &AnnotationsGadget::setVisibleAnnotations )
 		.def( "getVisibleAnnotations", &AnnotationsGadget::getVisibleAnnotations, return_value_policy<copy_const_reference>() )
+		.def( "annotationText", &AnnotationsGadget::annotationText, return_value_policy<copy_const_reference>(), ( arg( "node" ), arg( "annotation" ) = "user" ) )
 	;
 
 	IECorePython::RunTimeTypedClass<GraphLayout>()


### PR DESCRIPTION
This allows `{plug}` syntax to be used to include the values of a Node's plugs in its annotations.

![image](https://github.com/GafferHQ/gaffer/assets/1133871/ac3c5e65-9939-404c-8e22-c77ffc87b47b)

A note on ABI : this does change the data members of AnnotationsGadget in a way which _technically_ breaks ABI. But since AnnotationsGadget is only created by GraphGadget, and shouldn't be created or subclassed by anyone else, I can't see any way in which this can cause real-world problems. I've therefore made the PR to 1.4_maintenance to get it into people's hands sooner.