### PR TITLE
ColorChooser : Add channel names to sliders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.7.0)
 =======
 
+Improvements
+------------
+
+- ColorChooser : Added channel names to identify sliders.
+
 Fixes
 -----
 

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -130,7 +130,10 @@ class ColorChooser( GafferUI.Widget ) :
 			for component in "rgbahsv" :
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 
-					numericWidget = GafferUI.NumericWidget( 0.0 )
+					with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 8 ) :
+						GafferUI.Label( component.capitalize() )
+						numericWidget = GafferUI.NumericWidget( 0.0 )
+
 					numericWidget.setFixedCharacterWidth( 6 )
 					numericWidget.component = component
 					self.__numericWidgets[component] = numericWidget


### PR DESCRIPTION
This does what the title suggests.

The additional `ListContainer` is there for the inline color chooser, to increase the spacing between the channel name and the `NumericWidget` to match that of plug names / widgets. The initial spacing of 4 seemed a bit crowded, making it 8 for the whole row felt like too much detachment between `NumericWidget` and the slider.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
