### PR TITLE
ColorChooser : Maintain hue and saturation at zero

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- ColorChooser : Added channel names to identify sliders.
+- ColorChooser :
+  - Added channel names to identify sliders.
+  - Setting the saturation to zero no longer resets the hue and setting the value to zero no longer resets the hue and saturation.
 - RenderPassEditor : Added "Select Affected Objects" popup menu item.
 - Annotations :
   - Added support for `{plug}` value substitutions in node annotations.


### PR DESCRIPTION
This changes the behavior of the color chooser somewhat, so that setting the saturation to zero does not cause the hue to be reset to zero, and setting the value to zero does not cause the hue and saturation to be reset to zero.

I'm not super-excited about storing and syncing the HSV color to the RGB color, but I think it's better than the alternatives. We need some way of knowing what the HS value should be if we're deciding not to set it, and that's now coming from the synchronized `self.__colorHsv` variable.

I also looked at converting the whole `ColorChooser` to use HSV values internally and not store RGB. That worked also, but as we talked about, it also has the side effect that `ColorChooser.setColor( x ).getColor() != x` because of floating point round off, which does not seem like the right way to go.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
