### PR TITLE
CodeWidget : Dispose of completion menu on activatedSignal

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Cycles : Fixed rendering to the Catalogue using the batch Render node (#5905). Note that rendering a mixture of Catalogue and file outputs is still not supported, and in this case any file outputs will be ignored.
+- CodeWidget : Fixed bug that could prevent changes from being committed while the completion menu was visible.
 
 1.4.7.0 (relative to 1.4.6.0)
 =======

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -64,6 +64,7 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 		self.__highlighter = _QtHighlighter( self._qtWidget().document() )
 		self.__commentPrefix = None
 
+		self.activatedSignal().connect( Gaffer.WeakMethod( self.__activated ), scoped = False )
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
 		self.__textChangedConnection = self.textChangedSignal().connect( Gaffer.WeakMethod( self.__textChanged ), scoped = False )
 
@@ -105,6 +106,13 @@ class CodeWidget( GafferUI.MultiLineTextWidget ) :
 		# opportunity to emit the signal before the user navigates elsewhere.
 		if self.__completionMenu is None or not self.__completionMenu.visible() :
 			GafferUI.MultiLineTextWidget._emitEditingFinished( self )
+
+	def __activated( self, widget ) :
+
+		# Dispose of any visible completion menu, if kept it prevents us
+		# from emitting editingFinishedSignal via _emitEditingFinished above.
+		if self.__completionMenu is not None and self.__completionMenu.visible() :
+			self.__completionMenu = None
 
 	def __keyPress( self, widget, event ) :
 


### PR DESCRIPTION
This fixes the "`Ctrl`+`Return` doesn't always commit my changes when editing set expressions in the Render Pass Editor" issue reported recently. If the completion menu was visible while `Ctrl`+`Return` was pressed, changes would not be committed due to the loss of focus workaround in `CodeWidget._emitEditingFinished()`. Or in the case of a widget in a PlugPopup, the changes would not be committed and the PlugPopup would dismiss...

This was particularly apparent in scenes containing overlapping set names such as "LGT" and "LGT:ALL", and entering the shorter "LGT" set into a SetExpressionPlugValueWidget in a PlugPopup. Typing "LGT" would leave the completion menu up for "LGT:ALL", and then pressing `Ctrl`+`Return` would dismiss the PlugPopup without committing the change while often leaving the completion menu still visible afterwards.