### PR TITLE
LazyMethod : Fix running idle callback without a valid Qt Widget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 1.3.16.x (relative to 1.3.16.5)
 ========
+Fixes
+-----
 
+- LazyMethod : Fixed error caused by running idle callbacks without a valid Qt Widget 
 
 
 1.3.16.5 (relative to 1.3.16.4)

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -157,7 +157,7 @@ class LazyMethod( object ) :
 	def __idle( cls, widgetWeakref, method ) :
 
 		widget = widgetWeakref()
-		if widget is None :
+		if widget is None or not GafferUI._qtObjectIsValid( widget._qtWidget() ):
 			return
 
 		cls.__doPendingCalls( widget, method )


### PR DESCRIPTION
We sometimes have issues when creating UI with `PlugValueWidgets` that when they are cleaned up after setting a plug value, they may try to still set the value on the widget via the `LazyMethod` idle callback even though the Qt widget is no longer around. By checking for a valid Qt widget as well here, we avoid instances in which the Gaffer widget is still around but the Qt widget has been cleaned up, which can cause issues when running the callback given that the Qt widget is the underlying widget for the Gaffer widget and one often relies on the other.

This PR is more of a suggestion/discussion as well since, while I believe this approach makes sense, there may be some other things this can affect that I am not too sure about.

This an example of the error we have been seeing related to this issue:

```
// Error: EventLoop.__qtIdleCallback : Traceback (most recent call last):
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/EventLoop.py", line 284, in __qtIdleCallback
    if not c() :
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LazyMethod.py", line 163, in __idle
    cls.__doPendingCalls( widget, method )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LazyMethod.py", line 176, in __doPendingCalls
    method( widget, *pendingCall.args, **pendingCall.kw )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/PlugValueWidget.py", line 568, in __callUpdateFromValues
    self._updateFromValues( self._valuesForUpdate( self.getPlugs(), self.__auxiliaryPlugs ), None )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/StringPlugValueWidget.py", line 79, in _updateFromValues
    if text != self.__textWidget.getText() :
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/TextWidget.py", line 68, in getText
    return self._qtWidget().text()
RuntimeError: Internal C++ object (_LineEdit) already deleted.
 // 
// Error: EventLoop.__qtIdleCallback : Traceback (most recent call last):
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/EventLoop.py", line 284, in __qtIdleCallback
    if not c() :
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LazyMethod.py", line 163, in __idle
    cls.__doPendingCalls( widget, method )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LazyMethod.py", line 176, in __doPendingCalls
    method( widget, *pendingCall.args, **pendingCall.kw )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/PlugValueWidget.py", line 568, in __callUpdateFromValues
    self._updateFromValues( self._valuesForUpdate( self.getPlugs(), self.__auxiliaryPlugs ), None )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LabelPlugValueWidget.py", line 133, in _updateFromValues
    self.__setValueChanged( any( values ) )
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LabelPlugValueWidget.py", line 163, in __setValueChanged
    if valueChanged == self.__getValueChanged() :
  File "/software/apps/gaffer/1.3.16.3/cent7.x86_64/cortex/10.5/maya/2022/python/GafferUI/LabelPlugValueWidget.py", line 171, in __getValueChanged
    if "gafferValueChanged" not in self.__label._qtWidget().dynamicPropertyNames() :
RuntimeError: Internal C++ object (PySide2.QtWidgets.QLabel) already deleted.
```

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
