### PR TITLE
CI : Add `jobs` to matrix and increase to 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
             # test user rather than as root.
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
+            jobs: 4
 
           - name: linux-debug-gcc9
             os: ubuntu-20.04
@@ -58,6 +59,7 @@ jobs:
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
             sconsCacheMegabytes: 2500
+            jobs: 4
 
           - name: linux-gcc11
             os: ubuntu-20.04
@@ -70,6 +72,7 @@ jobs:
             # test user rather than as root.
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
+            jobs: 4
 
           - name: windows
             os: windows-2019
@@ -79,6 +82,7 @@ jobs:
             testRunner: Invoke-Expression
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 400
+            jobs: 4
 
     runs-on: ${{ matrix.os }}
 
@@ -170,7 +174,7 @@ jobs:
 
     - name: Build Gaffer
       run: |
-       scons -j 2 build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+       scons -j ${{ matrix.jobs }} build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
       env:
         PYTHONUTF8: 1
 
@@ -203,7 +207,7 @@ jobs:
             ]
           )
           #Build Arnold extension
-          subprocess.check_call( "scons -j 2 build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions", shell = True )
+          subprocess.check_call( "scons -j ${{ matrix.jobs }} build BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions", shell = True )
 
           if os.name != "nt" :
             # Test Arnold extension
@@ -235,7 +239,7 @@ jobs:
       run: |
         # Treats warnings-as-errors so we know about broken links
         echo "::add-matcher::./.github/workflows/main/problemMatchers/sphinx.json"
-        scons -j 2 package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
+        scons -j ${{ matrix.jobs }} package BUILD_TYPE=${{ matrix.buildType }} OPTIONS=.github/workflows/main/sconsOptions
         echo "::remove-matcher owner=sphinx::"
       env:
         PYTHONUTF8: 1


### PR DESCRIPTION
As discovered by John while we were setting up CI for GafferHQ/Dependencies, the standard public actions runners for Windows and Linux now provision [4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) so we might as well make use of them. 

This PR follows the Dependencies CI approach of adding `jobs` to the matrix, and while all values are currently 4, I think it makes sense to keep these setups consistent and we will need to start varying `jobs` in a future with macOS CI...