### PR TITLE
CI : Increase Windows SCons cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
             containerImage:
             testRunner: Invoke-Expression
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest
-            sconsCacheMegabytes: 400
+            sconsCacheMegabytes: 800
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The existing limit of 400MB wasn't enough to cache a full build. While this new limit is double the previous, in testing, the resulting compressed Windows build cache is only about 20MB larger than the compressed Linux release build cache (~100MB vs ~80MB).