### PR TITLE
LightEditorTest Fix

### DIFF
--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -834,7 +834,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 		columnNames = [ c.headerData().value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
-		self.assertNotIn( "P.X", columnNames )
+		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )
 		self.assertIn( "Y", columnNames )
 		self.assertIn( "Z", columnNames )
@@ -846,7 +846,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 		columnNames = [ c.headerData().value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
-		self.assertNotIn( "P.X", columnNames )
+		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )
 		self.assertNotIn( "Y", columnNames )
 		self.assertIn( "Z", columnNames )
@@ -858,7 +858,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 		columnNames = [ c.headerData().value for c in widget.getColumns() ]
 		self.assertNotIn( "P", columnNames )
-		self.assertNotIn( "P.X", columnNames )
+		self.assertNotIn( "X", columnNames )
 		self.assertNotIn( "A", columnNames )
 		self.assertNotIn( "Y", columnNames )
 		self.assertNotIn( "Z", columnNames )


### PR DESCRIPTION
I think based on the improvement in the tests noted in https://github.com/GafferHQ/gaffer/pull/5891#discussion_r1647619894, these other tests should be checking for the absence of `X` instead of `P.X` (which will never be present)?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
