### PR TITLE
SetMembershipEdits summary

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
   - The following parameters can now be made visible in the GraphEditor :
     - The `flake_layers` parameter of the `car_paint` shader.
     - The `data_seed`, `proc_seed`, `obj_seed`, and `face_seed` parameters of the `color_jitter` shader.
+- EditScope : Added summaries of set membership edits in the NodeEditor.
 
 Fixes
 -----

--- a/python/GafferSceneUI/EditScopeUI.py
+++ b/python/GafferSceneUI/EditScopeUI.py
@@ -303,3 +303,31 @@ class __RenderPassOptionEditsWidget( GafferUI.EditScopeUI.SimpleProcessorWidget 
 
 
 GafferUI.EditScopeUI.ProcessorWidget.registerProcessorWidget( "RenderPassOptionEdits", __RenderPassOptionEditsWidget )
+
+class __SetMembershipEditsWidget( GafferUI.EditScopeUI.SimpleProcessorWidget ) :
+
+	@staticmethod
+	def _summary( processor, linkCreator ) :
+
+		enabledSetCount = 0
+		disabledSetCount = 0
+		for r in processor["edits"] :
+			if r.getName() == "default" :
+				continue
+			if r["enabled"].getValue() :
+				enabledSetCount += 1
+			else :
+				disabledSetCount += 1
+
+		summaries = []
+		if enabledSetCount > 0 :
+			summaries.append( "edits to {} set{}".format( enabledSetCount, "s" if enabledSetCount > 1 else "" ) )
+		if disabledSetCount > 0 :
+			summaries.append( "disabled edits to {} set{}".format( disabledSetCount, "s" if disabledSetCount > 1 else "" ) )
+
+		if not summaries :
+			return None
+		summaries[0] = summaries[0][0].upper() + summaries[0][1:]
+		return " and ".join( summaries )
+
+GafferUI.EditScopeUI.ProcessorWidget.registerProcessorWidget( "SetMembershipEdits", __SetMembershipEditsWidget )


### PR DESCRIPTION
This adds a summary widget for edits made through a `SetMembershipEdits` scene processor.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
