### PR TITLE
MeshToLevelSet Rendering Fixes 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
 - OpenColorIO : Fixed the display transform used to show colours in popups.
 - SceneInspector : Fixed "Show History" menu items.
 - ImageGadget : Fixed loading of non-8-bit images. Among other things, this fixes the display of 16 bit node icons in the GraphEditor.
+- Arnold : Fixed rendering of VDB volumes without `file_mem_bytes` metadata.
 
 API
 ---

--- a/src/IECoreArnold/VDBAlgo.cpp
+++ b/src/IECoreArnold/VDBAlgo.cpp
@@ -87,32 +87,18 @@ struct UCharVectorDataSink
 
 UCharVectorDataPtr createMemoryBuffer(const IECoreVDB::VDBObject* vdbObject)
 {
-	// estimate the size of the memory required to hand the VDB to arnold.
-	// This is required so we can reserve the right amount of space in the output
-	// buffer.
-	int64_t totalSizeBytes = 0;
-	openvdb::GridCPtrVec gridsToWrite;
-	std::vector<std::string> gridNames = vdbObject->gridNames();
-	try
-	{
-		for( const std::string& gridName : gridNames )
-		{
-			openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridName );
-			totalSizeBytes += grid->metaValue<int64_t>( "file_mem_bytes" );
-			gridsToWrite.push_back( grid );
-		}
-	}
-	catch( const std::exception & )
-	{
-		IECore::msg( IECore::MessageHandler::Warning, "VDBObject::memoryBuffer", "Unable to estimate vdb size." );
-	}
-
 	IECore::UCharVectorDataPtr buffer = new IECore::UCharVectorData();
-	buffer->writable().reserve( totalSizeBytes );
 	UCharVectorDataSink sink( buffer.get() );
 	boost::iostreams::stream<UCharVectorDataSink> memoryStream( sink );
 
 	openvdb::io::Stream vdbStream( memoryStream );
+
+	openvdb::GridCPtrVec gridsToWrite;
+	std::vector<std::string> gridNames = vdbObject->gridNames();
+	for( const std::string& gridName : gridNames )
+	{
+		gridsToWrite.push_back( vdbObject->findGrid( gridName ) );
+	}
 	vdbStream.write( gridsToWrite );
 
 	return buffer;


### PR DESCRIPTION
Artists at ImageEngine were confused why they couldn't render the output from MeshToLevelSet in Arnold.

I started by not discarding the exception message when it fails to render, which revealed the exception: "LookupError: Cannot find metadata file_mem_bytes".

I think we can reasonably assume that any vdb loaded from disk should have this stats information, so there are two reasonable solutions: either make sure every volume produced in Gaffer has these stats computed, or make sure rendering falls back to using the `memUsage()` call that computes it if the metadata isn't found. I've currently gone with the first one, since there might be more of a possible performance hazard with the second ( there might be some sort of instancing setup where you could end up calling `memUsage()` many times? ), but I haven't thought too hard about it, and there might be an argument for the second approach.

The obvious next step is that if people actually want to render the result of these operations as volumes, then they need a way to convert them to fog volumes rather than level sets. We should probably have a LevelSetToVolume node - but it would be pretty wasteful to cache both versions, so there probably ought to be a MeshToVolume node as well ( which does what the current MeshToLevelSet does, and then calls openvdb::LevelSetUtil::sdfToFogVolume in place on it ).