### PR TITLE
Scene Editors : Ignore private plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.8.0)
 =======
 
+Fixes
+-----
 
+- HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
 
 1.4.8.0 (relative to 1.4.7.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
+- PrimitiveInspector : Fixed bug which claimed "Location does not exist" for objects without any primitive variables.
 
 1.4.8.0 (relative to 1.4.7.0)
 =======

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -111,7 +111,10 @@ class HierarchyView( GafferUI.NodeSetEditor ) :
 		self.__plugParentChangedConnection = None
 		node = self._lastAddedNode()
 		if node is not None :
-			self.__plug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			self.__plug = next(
+				( p for p in GafferScene.ScenePlug.RecursiveOutputRange( node ) if not p.getName().startswith( "__" ) ),
+				None
+			)
 			if self.__plug is not None :
 				self.__plugParentChangedConnection = self.__plug.parentChangedSignal().connect(
 					Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -244,7 +244,10 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		self.__plugParentChangedConnection = None
 		node = self._lastAddedNode()
 		if node is not None :
-			self.__plug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			self.__plug = next(
+				( p for p in GafferScene.ScenePlug.RecursiveOutputRange( node ) if not p.getName().startswith( "__" ) ),
+				None
+			)
 			if self.__plug is not None :
 				self.__plugParentChangedConnection = self.__plug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True )
 

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -227,7 +227,10 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		node = self._lastAddedNode()
 
 		if node :
-			self.__scenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			self.__scenePlug = next(
+				( p for p in GafferScene.ScenePlug.RecursiveOutputRange( node ) if not p.getName().startswith( "__" ) ),
+				None
+			)
 			if self.__scenePlug :
 				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True ) )
 				self.__parentChangedConnections.append( self.__scenePlug.parentChangedSignal().connect( Gaffer.WeakMethod( self.__plugParentChanged ), scoped = True ) )

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -326,7 +326,7 @@ class PrimitiveInspector( GafferUI.NodeSetEditor ) :
 		if self.__scenePlug:
 			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
 			if targetPath:
-				if backgroundResult:
+				if backgroundResult is not None :
 					self.__locationLabel.setText( targetPath )
 				else:
 					self.__locationFrame._qtWidget().setProperty( "gafferDiff", "Other" )

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -228,7 +228,10 @@ class SceneInspector( GafferUI.NodeSetEditor ) :
 		self.__plugDirtiedConnections = []
 		self.__parentChangedConnections = []
 		for node in self.getNodeSet()[-2:] :
-			outputScenePlug = next( GafferScene.ScenePlug.RecursiveOutputRange( node ), None )
+			outputScenePlug = next(
+				( p for p in GafferScene.ScenePlug.RecursiveOutputRange( node ) if not p.getName().startswith( "__" ) ),
+				None
+			)
 			if outputScenePlug :
 				self.__scenePlugs.append( outputScenePlug )
 				self.__plugDirtiedConnections.append( node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ), scoped = True ) )


### PR DESCRIPTION
We were happily displaying the output from private (`__` prefixed) plugs on nodes if they appeared before any non-private plugs. This wasn't a problem for any native Gaffer nodes, but a proprietary node at an undisclosed location has recently developed a bug whereby it accumulates unnecessary private scene plugs in front of any public ones, so this came to light. _That_ bug will need fixing, but it will be very helpful in the meantime if Gaffer ignores the extra plugs as it should have been doing in the first place.