### PR TITLE
Popup window colorspace fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
 - PrimitiveInspector : Fixed bug which claimed "Location does not exist" for objects without any primitive variables.
+- OpenColorIO : Fixed the display transform used to show colours in popups.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,11 @@ Fixes
 - HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
 - PrimitiveInspector : Fixed bug which claimed "Location does not exist" for objects without any primitive variables.
 
+API
+---
+
+- PopupWindow : Added `parent` argument to `popup()` method. This allows popup windows to inherit the display transform from the main UI.
+
 1.4.8.0 (relative to 1.4.7.0)
 =======
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -403,7 +403,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 							with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 								GafferUI.Image( "warningSmall.png" )
 								GafferUI.Label( "<h4>The " + column.headerData().value + " column can only be toggled for lights." )
-						self.__popup.popup()
+						self.__popup.popup( parent = self )
 						return
 
 					context["scene:path"] = path
@@ -419,7 +419,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>The selected cells cannot be edited in the current Edit Scope</h4>" )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 			return
 
@@ -437,7 +437,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 					if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
 						self.__popup.plugValueWidget().setNameVisible( False )
 
-					self.__popup.popup()
+					self.__popup.popup( parent = self )
 
 		else :
 
@@ -446,7 +446,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>{}</h4>".format( nonEditable[0].nonEditableReason() ) )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 	def __toggleBoolean( self, inspectors, inspections ) :
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -442,7 +442,7 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>The script is read-only.</h4>" )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 			return
 
 		if "renderPass" not in script["variables"] :
@@ -488,7 +488,7 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>The selected cells cannot be edited in the current Edit Scope</h4>" )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 			return
 
@@ -508,7 +508,7 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 
 					## \todo : Adjust popup width based on the inspector column width(s) to improve
 					# editing of long paths, similar to how we handle this in the Spreadsheet.
-					self.__popup.popup()
+					self.__popup.popup( parent = self )
 
 		else :
 
@@ -517,7 +517,7 @@ class RenderPassEditor( GafferUI.NodeSetEditor ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>{}</h4>".format( nonEditable[0].nonEditableReason() ) )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 	def __toggleBoolean( self, inspectors, inspections ) :
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -343,7 +343,8 @@ class _RendererSettingsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			center = imath.V2i(
 				bound.center().x,
 				bound.max().y + self.__window.bound().size().y / 2 + 8,
-			)
+			),
+			parent = self
 		)
 
 ##########################################################################

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -231,7 +231,7 @@ class _HistoryWindow( GafferUI.Window ) :
 			if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
 				self.__popup.plugValueWidget().setNameVisible( False )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 	def __dragBegin( self, pathListing, event ) :
 

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -414,7 +414,7 @@ class _InspectorWidget( GafferUI.Widget ) :
 			)
 			if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
 				self.__popup.plugValueWidget().setNameVisible( False )
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 		else :
 
@@ -425,7 +425,7 @@ class _InspectorWidget( GafferUI.Widget ) :
 						self.__formatWarnings( [ r.nonEditableReason() for r in self.__inspectorResults ] )
 					) )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 		return True
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -452,7 +452,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 					GafferUI.Image( "warningSmall.png" )
 					GafferUI.Label( "<h4>The Edit Scope cannot be set while nothing is viewed</h4>" )
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 		elif dropNode :
 			upstream = Gaffer.NodeAlgo.findAllUpstream( inputNode, self.__editScopePredicate )
 			if self.__editScopePredicate( inputNode ) :
@@ -465,7 +465,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 					with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 						GafferUI.Image( "warningSmall.png" )
 						GafferUI.Label( "<h4>{} cannot be used as it is not upstream of {}</h4>".format( dropNode.getName(), inputNode.getName() ) )
-				self.__popup.popup()
+				self.__popup.popup( parent = self )
 
 		self.__frame.setHighlighted( False )
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -339,7 +339,7 @@ class GraphEditor( GafferUI.Editor ) :
 						GafferUI.Image( "warningSmall.png" )
 						GafferUI.Label( "Node Graph Not Editable" )
 
-			self.__readOnlyPopup.popup( center = self.bound().center() )
+			self.__readOnlyPopup.popup( center = self.bound().center(), parent = self )
 
 	def __nodeMenuVisibilityChanged( self, widget ) :
 

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -118,9 +118,9 @@ class PlugPopup( GafferUI.PopupWindow ) :
 		self.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ), scoped = False )
 		self.focusChangedSignal().connect( Gaffer.WeakMethod( self.__focusChanged ), scoped = False )
 
-	def popup( self, center = None ) :
+	def popup( self, center = None, parent = None ) :
 
-		GafferUI.PopupWindow.popup( self, center )
+		GafferUI.PopupWindow.popup( self, center, parent )
 
 		# Attempt to focus the first text widget. This is done after making
 		# the window visible, as we check child widget visibility to avoid

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -1127,7 +1127,7 @@ class _PlugTableView( GafferUI.Widget ) :
 						return
 
 		self.__editorWidget = GafferUI.PlugPopup( plugs, title = "" )
-		self.__editorWidget.popup( plugBound.center() )
+		self.__editorWidget.popup( plugBound.center(), parent = self )
 
 		widget = self.__editorWidget.plugValueWidget()
 		if isinstance( widget, GafferUI.StringPlugValueWidget ) :

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -1484,7 +1484,7 @@ class _ColorDelegate( _Delegate ) :
 			self.__colorChooser = GafferUI.ColorChooser( value )
 			self.__popup = GafferUI.PopupWindow( "", child = self.__colorChooser )
 
-			self.__popup.popup()
+			self.__popup.popup( parent = self )
 
 			return self.__popup
 

--- a/python/GafferUITest/PopupWindowTest.py
+++ b/python/GafferUITest/PopupWindowTest.py
@@ -1,0 +1,80 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import weakref
+
+import GafferUI
+import GafferUITest
+
+class PopupWindowTest( GafferUITest.TestCase ) :
+
+	def testDisplayTransform( self ) :
+
+		displayTransform1 = lambda x : x * 2
+		displayTransform2 = lambda x : x * 3
+
+		window = GafferUI.Window()
+		self.assertIs( window.displayTransform(), GafferUI.Widget.identityDisplayTransform )
+		window.setDisplayTransform( displayTransform1 )
+		self.assertIs( window.displayTransform(), displayTransform1 )
+
+		popup = GafferUI.PopupWindow()
+		self.assertEqual( popup.displayTransform(), GafferUI.Widget.identityDisplayTransform )
+		popup.popup()
+		self.assertEqual( popup.displayTransform(), GafferUI.Widget.identityDisplayTransform )
+
+		popup.popup( parent = window )
+		self.assertEqual( popup.displayTransform(), displayTransform1 )
+
+		popup.setDisplayTransform( displayTransform2 )
+		self.assertEqual( popup.displayTransform(), displayTransform2 )
+
+	def testParentWindowLifetime( self ) :
+
+		window = GafferUI.Window()
+		popup = GafferUI.PopupWindow()
+		popup.popup( parent = window )
+
+		weakWindow = weakref.ref( window )
+		weakPopup = weakref.ref( popup )
+		del window, popup
+
+		self.assertIsNone( weakWindow() )
+		self.assertIsNone( weakPopup() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -132,6 +132,7 @@ from .LabelPlugValueWidgetTest import LabelPlugValueWidgetTest
 from .PythonEditorTest import PythonEditorTest
 from .BoxIOUITest import BoxIOUITest
 from .AnnotationsGadgetTest import AnnotationsGadgetTest
+from .PopupWindowTest import PopupWindowTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes a bug whereby the ephemeral `PlugPopup` windows we use to display temporary editors were not inheriting the correct display transform from the main UI.