### PR TITLE
Cryptomatte : Rename `__manifestScene` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.8.0)
 =======
 
+Improvements
+------------
+
+- Cryptomatte : Renamed `__manifestScene` plug to `manifestScene` so it is no longer considered to be private.
+
 Fixes
 -----
 

--- a/python/GafferSceneTest/CryptomatteTest.py
+++ b/python/GafferSceneTest/CryptomatteTest.py
@@ -438,7 +438,7 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		c["in"].setInput( r["out"] )
 
 		c["layer"].setValue( "crypto_object" )
-		self.assertSceneValid( c["__manifestScene"] )
+		self.assertSceneValid( c["manifestScene"] )
 
 	def testChildNames( self ) :
 
@@ -450,10 +450,10 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( c.plugDirtiedSignal() )
 		c["layer"].setValue( "crypto_object" )
-		self.assertTrue( c["__manifestScene"]["childNames"] in [ x[0] for x in cs ] )
+		self.assertTrue( c["manifestScene"]["childNames"] in [ x[0] for x in cs ] )
 
 		self.assertEqual(
-			c["__manifestScene"].childNames( "/GAFFERBOT/C_torso_GRP" ),
+			c["manifestScene"].childNames( "/GAFFERBOT/C_torso_GRP" ),
 			IECore.InternedStringVectorData( [ "C_head_GRP", "C_key_GRP", "C_torso_CPT", "L_armUpper_GRP", "L_legUpper_GRP", "R_armUpper_GRP", "R_legUpper_GRP" ] )
 		)
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -282,6 +282,15 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"manifestScene" : [
+
+			"description",
+			"""
+			A scene containing locations representing the contents of the Cryptomatte manifest.
+			""",
+
+		],
+
 	}
 
 )
@@ -410,7 +419,7 @@ def __selectAffected( node, context ) :
 	if not isinstance( node, GafferScene.Cryptomatte ) :
 		return
 
-	scene = node["__manifestScene"]
+	scene = node["manifestScene"]
 
 	with context :
 		pathMatcher = IECore.PathMatcher()

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -344,7 +344,7 @@ Cryptomatte::Cryptomatte( const std::string &name )
 	addChild( new FloatVectorDataPlug( "__matteValues", Gaffer::Plug::Out, new FloatVectorData() ) );
 	addChild( new AtomicCompoundDataPlug( "__manifest", Gaffer::Plug::Out, new CompoundData() ) );
 	addChild( new PathMatcherDataPlug( "__manifestPaths", Gaffer::Plug::Out, new PathMatcherData ) );
-	addChild( new ScenePlug( "__manifestScene", Gaffer::Plug::Out ) );
+	addChild( new ScenePlug( "manifestScene", Gaffer::Plug::Out ) );
 	addChild( new FloatVectorDataPlug( "__matteChannelData", Gaffer::Plug::Out, GafferImage::ImagePlug::blackTile() ) );
 
 	outPlug()->formatPlug()->setInput( inPlug()->formatPlug() );


### PR DESCRIPTION
This becomes necessary now that we make the Hierarchy View ignore private plugs in #5924. `__manifestScene` will now be ignored, resulting in the Hierarchy View no longer displaying the Cryptomatte manifest, so we rename the plug to `manifestScene` and hide both its nodeGadget and plugValueWidget.

Technically this is a breaking change, but then this is/was a private plug...