### PR TITLE
SphereLevelSet : Don't add standard stats to the metadata

### DIFF
--- a/src/GafferVDB/SphereLevelSet.cpp
+++ b/src/GafferVDB/SphereLevelSet.cpp
@@ -161,7 +161,6 @@ IECore::ConstObjectPtr SphereLevelSet::computeSource( const Context *context ) c
 
 	Canceller::check( context->canceller() );
 
-	grid->addStatsMetadata();
 	grid->setName( gridPlug()->getValue() );
 
 	VDBObjectPtr newVDBObject = new VDBObject();


### PR DESCRIPTION
A companion commit if we end up going with: https://github.com/ImageEngine/cortex/pull/1423