### PR TITLE
SceneInspector : Fix icon names

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 - HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
 - PrimitiveInspector : Fixed bug which claimed "Location does not exist" for objects without any primitive variables.
 - OpenColorIO : Fixed the display transform used to show colours in popups.
+- SceneInspector : Fixed "Show History" menu items.
 
 API
 ---

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -1280,7 +1280,7 @@ class _Rail( GafferUI.ListContainer ) :
 			else :
 				GafferUI.Spacer( imath.V2i( 1 ) )
 
-			GafferUI.Image( "rail" + str( type ) + ".png" )
+			GafferUI.Image( "rail" + type.name + ".png" )
 
 			if type != self.Type.Bottom and type != self.Type.Single :
 				image = GafferUI.Image( "railLine.png" )


### PR DESCRIPTION
These were broken during the switch to `enum.Enum` in https://github.com/GafferHQ/gaffer/pull/5559. With a little bit of luck, this will be the last flick of the extremely long tail of bugs coming from that change.
