### PR TITLE
EditScopeUI : Respect `<layoutName>:width` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - Cryptomatte : Renamed `__manifestScene` plug to `manifestScene` so it is no longer considered to be private.
+- EditScopePlugValueWidget : Width can now be configured via `<layoutName>:width` metadata. This enables customisation of the Edit Scope menu width by registering metadata in a startup file, such as `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "editScope", "layout:width", 450 )` to double the standard width of the Edit Scope menu in the Render Pass Editor.
 
 Fixes
 -----

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -866,6 +866,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
+			"layout:width", 225,
 
 		],
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1012,6 +1012,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
+			"layout:width", 225,
 
 		],
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -103,8 +103,9 @@ Gaffer.Metadata.registerNode(
 
 		"editScope" : [
 
-			"toolbarLayout:index", -1,
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
+			"toolbarLayout:index", -1,
+			"toolbarLayout:width", 225,
 
 		],
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -47,6 +47,7 @@ import GafferUI
 
 from GafferUI._StyleSheet import _styleColors
 from Qt import QtGui
+from Qt import QtWidgets
 
 Gaffer.Metadata.registerNode(
 
@@ -131,7 +132,8 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
 					highlightOnOver = False
 				)
-				self.__menuButton._qtWidget().setFixedWidth( 120 )
+				# Ignore the width in X so MenuButton width is limited by the overall width of the widget
+				self.__menuButton._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
 				self.__navigationMenuButton = GafferUI.MenuButton(
 					image = "navigationArrow.png",
 					hasFrame = False,


### PR DESCRIPTION
Rather than setting a fixed width to the MenuButton, allow `<layoutName>:width` metadata to govern the overall width of the widget. This then allows customisation of the width via metadata registration in a startup file.
