### PR TITLE
LightEditor : Fix missing icons for groups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
     - The `flake_layers` parameter of the `car_paint` shader.
     - The `data_seed`, `proc_seed`, `obj_seed`, and `face_seed` parameters of the `color_jitter` shader.
 - EditScope : Added summaries of set membership edits in the NodeEditor.
+- LightEditor : Mute and solo columns now accurately reflect the presence of the `light:mute` attribute (for the Mute column) and membership in the `soloLights` set (for the Solo column) for all scene locations, not just for lights.
 
 Fixes
 -----
@@ -27,6 +28,7 @@ Fixes
 - SceneInspector : Fixed "Show History" menu items.
 - ImageGadget : Fixed loading of non-8-bit images. Among other things, this fixes the display of 16 bit node icons in the GraphEditor.
 - Arnold : Fixed rendering of VDB volumes without `file_mem_bytes` metadata.
+- LightEditor : Fixed regression (introduced in 1.4.8.0) causing the mute and solo icons to not show up for groups.
 
 API
 ---

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -295,9 +295,9 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 				sectionColumns += [ c( self.__settingsNode["in"], self.__settingsNode["editScope"] ) for c in section.values() ]
 
 		nameColumn = self.__pathListing.getColumns()[0]
-		self.__muteColumn = self.__pathListing.getColumns()[1]
-		self.__soloColumn = self.__pathListing.getColumns()[2]
-		self.__pathListing.setColumns( [ nameColumn, self.__muteColumn, self.__soloColumn ] + sectionColumns )
+		muteColumn = self.__pathListing.getColumns()[1]
+		soloColumn = self.__pathListing.getColumns()[2]
+		self.__pathListing.setColumns( [ nameColumn, muteColumn, soloColumn ] + sectionColumns )
 
 	def __settingsPlugSet( self, plug ) :
 
@@ -385,26 +385,12 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		inspections = []
 
 		with Gaffer.Context( self.getContext() ) as context :
-			lightSetMembers = self.__settingsNode["in"].set( "__lights" ).value
 
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
 					continue
 				for pathString in selection.paths() :
 					path = GafferScene.ScenePlug.stringToPath( pathString )
-
-					if (
-						( column == self.__muteColumn or column == self.__soloColumn ) and
-						not ( lightSetMembers.match( path ) & (
-							IECore.PathMatcher.Result.ExactMatch | IECore.PathMatcher.Result.DescendantMatch
-						) )
-					) :
-						with GafferUI.PopupWindow() as self.__popup :
-							with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
-								GafferUI.Image( "warningSmall.png" )
-								GafferUI.Label( "<h4>The " + column.headerData().value + " column can only be toggled for lights." )
-						self.__popup.popup( parent = self )
-						return
 
 					context["scene:path"] = path
 					inspection = column.inspector().inspect()

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -752,6 +752,8 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			edit = lightFilter["filteredLights"]
 		)
 
+		self.assertIsNone( self.__inspect( editScope["out"], "/lightFilter", "bogusAttribute" ) )
+
 		inspection = self.__inspect( editScope["out"], "/lightFilter", "filteredLights", editScope )
 		edit = inspection.acquireEdit()
 		edit["enabled"].setValue( True )

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -868,32 +868,6 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		self.assertNotIn( "Y", columnNames )
 		self.assertNotIn( "Z", columnNames )
 
-	def testLightBlockerSoloDisabled( self ) :
-
-		script = Gaffer.ScriptNode()
-
-		script["blocker"] = GafferScene.Cube()
-		script["blocker"]["sets"].setValue( "__lightFilters" )
-
-		editor = GafferSceneUI.LightEditor( script )
-		editor._LightEditor__updateColumns()
-		GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
-
-		editor.setNodeSet( Gaffer.StandardSet( [ script["blocker"] ] ) )
-
-		widget = editor._LightEditor__pathListing
-
-		columns = widget.getColumns()
-		for i, c in zip( range( 0, len( columns ) ), columns ) :
-			if isinstance( c, _GafferSceneUI._LightEditorSetMembershipColumn ) :
-				selection = [ IECore.PathMatcher() for i in range( 0, len( columns ) ) ]
-				selection[i].addPath( "/cube" )
-				widget.setSelection( selection )
-
-				editor._LightEditor__editSelectedCells( widget )
-
-				self.assertTrue( script["blocker"]["out"].set( "soloLights" ).value.isEmpty() )
-
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -204,6 +204,7 @@ Gaffer::ValuePlugPtr attributePlug( const Gaffer::CompoundDataPlug *parentPlug, 
 //////////////////////////////////////////////////////////////////////////
 
 static InternedString g_lightMuteAttributeName( "light:mute" );
+static InternedString g_filteredLightsAttributeName( "filteredLights");
 
 AttributeInspector::AttributeInspector(
 	const GafferScene::ScenePlugPtr &scene,
@@ -263,7 +264,11 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 
 	else if( auto lightFilter = runTimeCast<LightFilter>( sceneNode ) )
 	{
-		return lightFilter->filteredLightsPlug();
+		if( m_attribute == g_filteredLightsAttributeName )
+		{
+			return lightFilter->filteredLightsPlug();
+		}
+		return nullptr;
 	}
 
 	else if( auto camera = runTimeCast<GafferScene::Camera>( sceneNode ) )

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -79,15 +79,7 @@ namespace
 {
 
 ConstStringDataPtr g_emptyLocation = new StringData( "emptyLocation.png" );
-const InternedString g_lightSetName( "__lights" );
-
-bool isLight( const ScenePath *scenePath, const Canceller *canceller )
-{
-	ScenePlug::SetScope scope( scenePath->getContext(), &g_lightSetName );
-	scope.setCanceller( canceller );
-	ConstPathMatcherDataPtr lightsData = scenePath->getScene()->setPlug()->getValue();
-	return lightsData->readable().match( scenePath->names() ) & PathMatcher::ExactMatch;
-}
+const InternedString g_lightFilterSetName( "__lightFilters" );
 
 class LocationNameColumn : public StandardPathColumn
 {
@@ -298,11 +290,6 @@ class MuteColumn : public InspectorColumn
 				return result;
 			}
 
-			if( !isLight( scenePath, canceller ) )
-			{
-				return CellData();
-			}
-
 			if( auto value = runTimeCast<const BoolData>( result.value ) )
 			{
 				result.icon = value->readable() ? m_muteIconData : m_unMuteIconData;
@@ -421,11 +408,6 @@ class SetMembershipColumn : public InspectorColumn
 			if( !scenePath )
 			{
 				return result;
-			}
-
-			if( !isLight( scenePath, canceller ) )
-			{
-				return CellData();
 			}
 
 			std::string toolTip;


### PR DESCRIPTION
This fixes a regression introduced in `1.4.8.0` when we added light blockers and filters to the Light Editor. In https://github.com/GafferHQ/gaffer/pull/5895/commits/85d93d31940fe72596ea072a6f8ae2ac4aa036b7, I hid the mute / solo icon for anything except lights, including groups. But we can mute and solo groups, so we should see the icon for that.

Additionally, the behavior for toggling was different. We allowed toggling a group's mute / solo status if it was an ancestor of at least one light. This meant you could toggle a group if it had a child light, but not see a visual indication that anything had changed.

There are two options for matching up the behavior to the UI and also showing mute / solo icons on groups :
1. Show the icon for anything _except_ light filters, and allow toggling on anything except light filters.
2. Show the icon for lights and locations that are ancestors for lights. Similar for toggling behavior.

I went with option 1 in this PR, on the reasoning that it's simpler for the user to understand. It does mean that you can toggle a group containing only light filters / blockers, which may be somewhat counter-intuitive. But groups containing light filters and those containing lights are not different in function or concept, so this seems like a reasonable choice to me.

Happy to discuss further, especially as it may relate to the Light Editor + Pass Editor unification @murraystevenson is working on.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
