### PR TITLE
ImageGadget : Convert ImageBuf to 8 bit before upload to OpenGL

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 - HierarchyView, LightEditor, PrimitiveInspector, SceneInspector : Fixed bug which allowed scenes from private plugs to be displayed.
 - PrimitiveInspector : Fixed bug which claimed "Location does not exist" for objects without any primitive variables.
 - OpenColorIO : Fixed the display transform used to show colours in popups.
+- ImageGadget : Fixed loading of non-8-bit images. Among other things, this fixes the display of 16 bit node icons in the GraphEditor.
 
 API
 ---

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -138,7 +138,7 @@ using TextureCache = IECorePreview::LRUCache<TextureCacheKey, ConstTexturePtr>;
 
 IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cost, const IECore::Canceller *canceller )
 {
-	const OIIO::ImageSpec config( OIIO::TypeDesc::UCHAR );
+	const OIIO::ImageSpec config( OIIO::TypeDesc::UINT8 );
 	const std::string fileName = resolvedFileName( key.fileName );
 	OIIO::ImageBuf imageBuf( fileName, /* subimage = */ 0, /* miplevel = */ 0, /* imagecache = */ nullptr, &config );
 	imageBuf = OIIO::ImageBufAlgo::flip( imageBuf );
@@ -153,6 +153,10 @@ IECoreGL::ConstTexturePtr textureGetter( const TextureCacheKey &key, size_t &cos
 	);
 
 	imageBuf = OIIO::ImageBufAlgo::colorconvert( imageBuf, colorProcessor.get(), true );
+	if( imageBuf.spec().format != OIIO::TypeDesc::UINT8 )
+	{
+		imageBuf = imageBuf.copy( OIIO::TypeDesc::UINT8 );
+	}
 
 	GLint pixelFormat;
 	switch( imageBuf.nchannels() )


### PR DESCRIPTION
We need to conform it to the format that we're telling OpenGL we're providing. Although in theory the ImageBuf might convert automatically using the hint we passed to the constructor, in practice it doesn't seem to. So we do a post conversion when necessary. This fixes corruption of 16 bit node icons in the GraphEditor.
