### PR TITLE
Arnold metadata : Show `color_jitter.data_input` in Graph Editor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Cryptomatte : Renamed `__manifestScene` plug to `manifestScene` so it is no longer considered to be private.
 - EditScopePlugValueWidget : Width can now be configured via `<layoutName>:width` metadata. This enables customisation of the Edit Scope menu width by registering metadata in a startup file, such as `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "editScope", "layout:width", 450 )` to double the standard width of the Edit Scope menu in the Render Pass Editor.
+- ArnoldShader : The `data_input` parameter of the `color_jitter` shader is now visible in the GraphEditor.
 
 Fixes
 -----

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -1241,6 +1241,8 @@
 
 	[attr data_input]
 		page STRING "User Data"
+		linkable BOOL true
+		gaffer.graphEditorLayout.visible BOOL true
 	[attr data_gain_min]
 		page STRING "User Data"
 	[attr data_gain_max]


### PR DESCRIPTION
Arnold doesn't seem to be entirely consistent about whether it declares the `linkable` metadata for all parameters or not, and it wasn't declaring it in this case despite the parameter being linkable in practice. That meant that ArnoldShaderUI fell through to a heuristic that assumes that ints aren't linkable and so don't need to be shown in the GraphEditor. We now declare the `linkable` metadata ourselves, and for good measure, also make `data_input` visible by default rather than hidden behind the `+` button.
