### PR TITLE
Arnold metadata : Show int parameters in Graph Editor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,16 @@ Improvements
 
 - Cryptomatte : Renamed `__manifestScene` plug to `manifestScene` so it is no longer considered to be private.
 - EditScopePlugValueWidget : Width can now be configured via `<layoutName>:width` metadata. This enables customisation of the Edit Scope menu width by registering metadata in a startup file, such as `Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "editScope", "layout:width", 450 )` to double the standard width of the Edit Scope menu in the Render Pass Editor.
-- ArnoldShader : The `data_input` parameter of the `color_jitter` shader is now visible in the GraphEditor.
+- ArnoldShader :
+  - The following parameters are now visible in the GraphEditor :
+    - The `aov_input` parameter of the `aov_write_int` shader.
+    - The `data_input` parameter of the `color_jitter` shader.
+    - The `input_int` and `seed` parameters of the `random` shader.
+    - The `index` parameters of the `switch_rgba` and `switch_shader` shaders.
+    - The `default` parameter of the `user_data_int` shader.
+  - The following parameters can now be made visible in the GraphEditor :
+    - The `flake_layers` parameter of the `car_paint` shader.
+    - The `data_seed`, `proc_seed`, `obj_seed`, and `face_seed` parameters of the `color_jitter` shader.
 
 Fixes
 -----

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -919,6 +919,8 @@
 
 	gaffer.nodeMenu.category STRING "AOV"
 
+	[attr aov_input]
+		linkable BOOL true
 
 [node aov_write_rgb]
 
@@ -1095,6 +1097,7 @@
 		page STRING "Flake"
 	[attr flake_layers]
 		page STRING "Flake"
+		linkable BOOL true
 	[attr flake_normal_randomize]
 		page STRING "Flake"
 	[attr flake_coord_space]
@@ -1257,6 +1260,7 @@
 		page STRING "User Data"
 	[attr data_seed]
 		page STRING "User Data"
+		linkable BOOL true
 
 	[attr proc_gain_min]
 		page STRING "Procedural"
@@ -1272,6 +1276,7 @@
 		page STRING "Procedural"
 	[attr proc_seed]
 		page STRING "Procedural"
+		linkable BOOL true
 
 	[attr obj_gain_min]
 		page STRING "Object"
@@ -1287,6 +1292,7 @@
 		page STRING "Object"
 	[attr obj_seed]
 		page STRING "Object"
+		linkable BOOL true
 
 	[attr face_gain_min]
 		page STRING "Face"
@@ -1302,6 +1308,7 @@
 		page STRING "Face"
 	[attr face_seed]
 		page STRING "Face"
+		linkable BOOL true
 	[attr face_mode]
 		page STRING "Face"
 
@@ -2230,10 +2237,13 @@
 
 	[attr input_int]
 		gaffer.layout.activator STRING "isInt"
+		linkable BOOL true
 	[attr input_float]
 		gaffer.layout.activator STRING "isFloat"
 	[attr input_color]
 		gaffer.layout.activator STRING "isColor"
+	[attr seed]
+		linkable BOOL true
 
 [node range]
 
@@ -2766,12 +2776,16 @@
 	primaryInput STRING "input0"
 	gaffer.nodeMenu.category STRING "Utility"
 
+	[attr index]
+		linkable BOOL true
 
 [node switch_shader]
 
 	primaryInput STRING "input0"
 	gaffer.nodeMenu.category STRING "Surface"
 
+	[attr index]
+		linkable BOOL true
 
 [node toon]
 
@@ -2983,6 +2997,8 @@
 
 	gaffer.nodeMenu.category STRING "Utility"
 
+	[attr default]
+		linkable BOOL true
 
 [node user_data_rgb]
 


### PR DESCRIPTION
Similar to #5936, these are int shader parameters that are linkable in practice, but not specifically declared as such by Arnold.