### PR TITLE
CI : Continue using Node16 for actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,10 @@ jobs:
       ARNOLD_LICENSE_ORDER: none # Don't waste time looking for a license that doesn't exist
       GAFFER_BUILD_DIR: "./build"
       GAFFER_CACHE_DIR: "./sconsCache"
+      # GitHub have moved to running actions on Node20, which prevents them from
+      # running on CentOS 7. The below allows actions to continue running on Node16
+      # until October.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
 


### PR DESCRIPTION
As of today, actions are now run on Node20 by default, but this requires glibc >=2.28 so actions no longer run in our CentOS 7 build container.

Setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` allows us to continue using Node16 for the near future, but support for this may be removed in October...

https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/
