### PR TITLE
Premult/Unpremult : Add ignoreMissingAlpha plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - ImageReader : Non-standard "r", "g", "b" and "a" channel names are now automatically renamed to "R", "G", "B" and "A" on loading. As with other heuristics, this can be disabled by setting `channelInterpretation` to "EXR Specification".
 - Metadata : Metadata registered to a node or plug targeting a descendant plug will now override metadata registered locally to the target.
 - OptionTweaks, ContextVariableTweaks : Added `Remove` mode.
+- Premultiply / Unpremultiply : Added ignoreMissingAlpha plug.
 
 Fixes
 -----
@@ -17,6 +18,7 @@ Fixes
 - UVInspector : Fixed `Unable to find ScriptNode for UVView` warnings.
 - Scene Editors : Fixed update when ScenePlugs are added to or removed from the node being viewed.
 - PrimitiveInspector : Fixed failure to update when the location being viewed ceases to exist, or is recreated.
+- Unpremultiply : Don't evaluate alphaChannel separately for each channel.
 
 API
 ---

--- a/include/GafferImage/Premultiply.h
+++ b/include/GafferImage/Premultiply.h
@@ -61,6 +61,9 @@ class GAFFERIMAGE_API Premultiply : public ChannelDataProcessor
 		Gaffer::StringPlug *alphaChannelPlug();
 		const Gaffer::StringPlug *alphaChannelPlug() const;
 
+		Gaffer::BoolPlug *ignoreMissingAlphaPlug();
+		const Gaffer::BoolPlug *ignoreMissingAlphaPlug() const;
+
 		Gaffer::BoolPlug *useDeepVisibilityPlug();
 		const Gaffer::BoolPlug *useDeepVisibilityPlug() const;
 		//@}

--- a/include/GafferImage/Unpremultiply.h
+++ b/include/GafferImage/Unpremultiply.h
@@ -60,6 +60,9 @@ class GAFFERIMAGE_API Unpremultiply : public ChannelDataProcessor
 		//@{
 		Gaffer::StringPlug *alphaChannelPlug();
 		const Gaffer::StringPlug *alphaChannelPlug() const;
+
+		Gaffer::BoolPlug *ignoreMissingAlphaPlug();
+		const Gaffer::BoolPlug *ignoreMissingAlphaPlug() const;
 		//@}
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;

--- a/python/GafferImageTest/PremultiplyTest.py
+++ b/python/GafferImageTest/PremultiplyTest.py
@@ -64,6 +64,13 @@ class PremultiplyTest( GafferImageTest.ImageTestCase ) :
 		h2 = premult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
+		premult["alphaChannel"].setValue("doesNotExist")
+		with self.assertRaisesRegex( Gaffer.ProcessException, "Channel 'doesNotExist' does not exist" ) :
+			GafferImageTest.processTiles( premult["out"] )
+
+		premult["ignoreMissingAlpha"].setValue( True )
+		self.assertImagesEqual( premult["out"], premult["in"] )
+
 	def testEnableBehaviour( self ) :
 
 		g = GafferImage.Premultiply()

--- a/python/GafferImageTest/UnpremultiplyTest.py
+++ b/python/GafferImageTest/UnpremultiplyTest.py
@@ -64,6 +64,14 @@ class UnpremultiplyTest( GafferImageTest.ImageTestCase ) :
 		h2 = unpremult["out"].channelData( "R", imath.V2i( 0 ) ).hash()
 		self.assertNotEqual( h1, h2 )
 
+		unpremult["alphaChannel"].setValue("doesNotExist")
+		with self.assertRaisesRegex( Gaffer.ProcessException, "Channel 'doesNotExist' does not exist" ) :
+			GafferImageTest.processTiles( unpremult["out"] )
+
+		unpremult["ignoreMissingAlpha"].setValue( True )
+		self.assertImagesEqual( unpremult["out"], unpremult["in"] )
+
+
 	def testEnableBehaviour( self ) :
 
 		g = GafferImage.Unpremultiply()

--- a/python/GafferImageUI/PremultiplyUI.py
+++ b/python/GafferImageUI/PremultiplyUI.py
@@ -65,6 +65,16 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"ignoreMissingAlpha" : [
+
+			"description",
+			"""
+			If set, this node will do nothing if the specified `alphaChannel`
+			is not found, instead of throwing an error.
+			""",
+
+		],
+
 		"useDeepVisibility" : [
 
 			"description",

--- a/python/GafferImageUI/UnpremultiplyUI.py
+++ b/python/GafferImageUI/UnpremultiplyUI.py
@@ -67,6 +67,16 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"ignoreMissingAlpha" : [
+
+			"description",
+			"""
+			If set, this node will do nothing if the specified `alphaChannel`
+			is not found, instead of throwing an error.
+			""",
+
+		],
+
 	}
 
 )


### PR DESCRIPTION
Was expecting this to be trivial, but ended up find a bunch of little things to fix to get better consistency between Unpremultiply/Premultiply, and between the hash and compute methods ( pretty sure that previously Unpremultiply::hashChannelData could trigger invalid computations by hashing the alpha channel even the channel doesn't exist ).

Was a little more complex than expected at the end of the day, so I should look through it myself tomorrow to double check things as well as whatever review you do.