### PR TITLE
Cycles renderer : Support background light `lightgroup` parameter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
 - SceneInspector : Fixed "Show History" menu items.
 - ImageGadget : Fixed loading of non-8-bit images. Among other things, this fixes the display of 16 bit node icons in the GraphEditor.
 - Arnold : Fixed rendering of VDB volumes without `file_mem_bytes` metadata.
+- Cycles : Fixed bug preventing a background light from being added to a light group.
 - LightEditor : Fixed regression (introduced in 1.4.8.0) causing the mute and solo icons to not show up for groups.
 
 API

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -3048,16 +3048,17 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				/// every render. This might be much easier if attribute edits
 				/// were performed by a renderer method instead of an ObjectInterface
 				/// method. Or can we use `scene->light_manager->need_update()`?
-				ccl::Shader *lightShader = nullptr;
+				ccl::Light *backgroundLight = nullptr;
 				for( ccl::Light *light : m_scene->lights )
 				{
 					if( light->get_light_type() == ccl::LIGHT_BACKGROUND )
 					{
-						lightShader = light->get_shader();
+						backgroundLight = light;
 						break;
 					}
 				}
-				m_scene->background->set_shader( lightShader ? lightShader : m_scene->default_background );
+				m_scene->background->set_shader( backgroundLight ? backgroundLight->get_shader() : m_scene->default_background );
+				m_scene->background->set_lightgroup( backgroundLight ? backgroundLight->get_lightgroup() : ccl::ustring( "" ) );
 			}
 
 			// Note : this is also responsible for tagging any changes


### PR DESCRIPTION
This is based on boberfly's #5396 but with an expanded test, updated for the Cycles backend changes in Gaffer 1.4, and simplified to address the existing bug but not introduce new options specific to CyclesBackground...