### PR TITLE
PathListingWidget : Avoid blocking UI in `setPath( rootPath )`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - EditScope : Added summaries of set membership edits in the NodeEditor.
 - LightEditor : Mute and solo columns now accurately reflect the presence of the `light:mute` attribute (for the Mute column) and membership in the `soloLights` set (for the Solo column) for all scene locations, not just for lights.
 - RenderPassEditor : The currently active render pass can now be unset by double clicking on its green dot in the "Active" column.
+- HierarchyView, LightEditor, RenderPassEditor, SetEditor : Reduced potential UI stalls when first showing a scene.
 
 Fixes
 -----

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -477,6 +477,9 @@ class PathListingWidget( GafferUI.Widget ) :
 	def __dirPath( self ) :
 
 		p = self.__path.copy()
+		if not len( p ) :
+			return p
+
 		if p.isLeaf() :
 			# if it's a leaf then take the parent
 			del p[-1]
@@ -486,11 +489,10 @@ class PathListingWidget( GafferUI.Widget ) :
 				# it's not valid. if we can make it
 				# valid by trimming the last element
 				# then do that
-				if len( p ) :
-					pp = p.copy()
-					del pp[-1]
-					if pp.isValid() :
-						p = pp
+				pp = p.copy()
+				del pp[-1]
+				if pp.isValid() :
+					p = pp
 			else :
 				# it's valid and not a leaf, and
 				# that's what we want.


### PR DESCRIPTION
The root path is the only path that we ever display in fundamental UIs like the HierarchyView and RenderPassEditor. In this case we were needlessly invoking `Path.isLeaf()` and `Path.isValid()` on the UI thread, causing ScenePath and RenderPassPath to trigger arbitrary computation that could block the UI until complete. By taking an early-out for the root path can completely avoid that, with all the remaining work all happening in a BackgroundTask.

