### PR TITLE
Set `PXR_USD_WINDOWS_DLL_PATH` on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - Arnold : Fixed rendering of VDB volumes without `file_mem_bytes` metadata.
 - Cycles : Fixed bug preventing a background light from being added to a light group.
 - LightEditor : Fixed regression (introduced in 1.4.8.0) causing the mute and solo icons to not show up for groups.
+- Windows : Fixed conflicts with other software installations on `PATH`. The `PXR_USD_WINDOWS_DLL_PATH` environment variable is now set to an empty string if it is not already set, preventing USD from adding all entries from `PATH` to Python's DLL search paths.
 
 API
 ---

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -19,6 +19,10 @@ call :prependToPath "%GAFFER_ROOT%\ops" IECORE_OP_PATHS
 
 call :prependToPath "%GAFFER_ROOT%\resources\IECoreUSD" PXR_PLUGINPATH_NAME
 call :prependToPath "%GAFFER_ROOT%\materialX" PXR_MTLX_STDLIB_SEARCH_PATHS
+rem Prevent USD from adding entries from `PATH` to Python binary search paths.
+if "%PXR_USD_WINDOWS_DLL_PATH%" EQU "" (
+	set PXR_USD_WINDOWS_DLL_PATH=""
+)
 
 call :prependToPath "%USERPROFILE%\gaffer\opPresets;%GAFFER_ROOT%\opPresets" IECORE_OP_PRESET_PATHS
 call :prependToPath "%USERPROFILE%\gaffer\procedurals;%GAFFER_ROOT%\procedurals" IECORE_PROCEDURAL_PATHS


### PR DESCRIPTION
This sets the `PXR_USD_WINDOWS_DLL_PATH` environment variable if it has not been set already. That variable helps USD setup the Python binary search paths, making sure it finds for our USD installation. Some users were finding that USD was attempting to load binaries from other installations they have on their system which was causing errors.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
