### PR TITLE
AnnotationsGadget binding : Fix GIL management bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Fixes
 - Cycles : Fixed bug preventing a background light from being added to a light group.
 - LightEditor : Fixed regression (introduced in 1.4.8.0) causing the mute and solo icons to not show up for groups.
 - Windows : Fixed conflicts with other software installations on `PATH`. The `PXR_USD_WINDOWS_DLL_PATH` environment variable is now set to an empty string if it is not already set, preventing USD from adding all entries from `PATH` to Python's DLL search paths.
+- AnnotationsGadget : Fixed potential hang in `annotationText()` Python binding.
 
 API
 ---

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -184,6 +184,12 @@ tuple connectionAt( AuxiliaryConnectionsGadget &g, IECore::LineSegment3f positio
 	return make_tuple( nodeGadgets.first, nodeGadgets.second );
 }
 
+const std::string &annotationTextWrapper( const AnnotationsGadget &gadget, const Gaffer::Node &node, IECore::InternedString annotation )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return gadget.annotationText( &node, annotation );
+}
+
 bool connectNode( const GraphLayout &layout, GraphGadget &graph, Gaffer::Node &node, Gaffer::Set &potentialInputs )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -298,7 +304,7 @@ void GafferUIModule::bindGraphGadget()
 		.def_readonly( "untemplatedAnnotations", &AnnotationsGadget::untemplatedAnnotations )
 		.def( "setVisibleAnnotations", &AnnotationsGadget::setVisibleAnnotations )
 		.def( "getVisibleAnnotations", &AnnotationsGadget::getVisibleAnnotations, return_value_policy<copy_const_reference>() )
-		.def( "annotationText", &AnnotationsGadget::annotationText, return_value_policy<copy_const_reference>(), ( arg( "node" ), arg( "annotation" ) = "user" ) )
+		.def( "annotationText", &annotationTextWrapper, return_value_policy<copy_const_reference>(), ( arg( "node" ), arg( "annotation" ) = "user" ) )
 	;
 
 	IECorePython::RunTimeTypedClass<GraphLayout>()


### PR DESCRIPTION
The `annotationText()` method may call `BackgroundTask::cancelAndWait()`, in which case the background task might require the GIL before the cancellation can complete. The lack of GIL management was causing hangs in the unit tests, but is unlikely to have caused any real-world problems, because `annotationText()` is only intended for use in the tests.