### PR TITLE
Editor, NodeToolbar, PlugLayout, PlugValueWidget : Remove `setContext()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -42,6 +42,9 @@ Breaking Changes
 - Editor : Removed arguments from `Settings` constructor.
 - Unpremultiply : Removed `image:channelName` from the context used to evaluate the `alphaChannel` plug.
 - Shuffle, ShuffleAttributes, ShufflePrimitiveVariables : Changed behaviour when shuffling a source to itself.
+- Editor, NodeToolbar, PlugLayout, PlugValueWidget :
+  - Removed `setContext()` methods.
+  - Deprecated `getContext()` methods. Use `context()` instead.
 
 1.4.x.x (relative to 1.4.8.0)
 =======

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -184,7 +184,7 @@ class _CommandPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		node = self.__pythonCommandNode()
 		if node is not None :
-			with self.getContext() :
+			with self.context() :
 				self.__codeWidget.setCompleter(
 					GafferUI.CodeWidget.PythonCompleter( node._executionDict() )
 				)

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -1141,7 +1141,7 @@ class ImageListing( GafferUI.PlugValueWidget ) :
 			if image is None :
 				return False
 
-			with self.getContext() :
+			with self.context() :
 				fileName = self.__catalogue().generateFileName( image )
 				imageWriter = GafferImage.ImageWriter()
 				imageWriter["in"].setInput( image )

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -76,7 +76,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# sensitive to context changes and omits calls to `_updateFromValues()`. But the default
 		# format mechanism uses the context, so we must arrange to do updates ourselves when
 		# necessary.
-		self.getContext().changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = False )
+		self.context().changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = False )
 
 		self._addPopupMenu( self.__menuButton )
 
@@ -107,7 +107,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton.setText(
 			"Custom" if custom
 			else
-			( _formatLabel( self.__currentFormat, self.getContext() ) if self.__currentFormat is not None else "---" )
+			( _formatLabel( self.__currentFormat, self.context() ) if self.__currentFormat is not None else "---" )
 		)
 
 		nonZeroOrigin = any( v.getDisplayWindow().min() != imath.V2i( 0 ) for v in values )
@@ -150,7 +150,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		modeIsCustom = any( Gaffer.Metadata.value( p, "formatPlugValueWidget:mode" ) == "custom" for p in self.getPlugs() )
 		for fmt in formats :
 			result.append(
-				"/" + _formatLabel( fmt, self.getContext() ),
+				"/" + _formatLabel( fmt, self.context() ),
 				{
 					"command" : functools.partial( Gaffer.WeakMethod( self.__applyFormat ), fmt = fmt ),
 					"checkBox" : fmt == self.__currentFormat and not modeIsCustom,
@@ -186,7 +186,7 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# format and set it explicitly as a starting point for
 				# editing.
 				for p in self.getPlugs() :
-					p.setValue( GafferImage.FormatPlug.getDefaultFormat( self.getContext() ) )
+					p.setValue( GafferImage.FormatPlug.getDefaultFormat( self.context() ) )
 
 			# When we first switch to custom mode, the current value will
 			# actually be one of the registered formats. So we use this

--- a/python/GafferImageUI/ImageInspector.py
+++ b/python/GafferImageUI/ImageInspector.py
@@ -215,7 +215,7 @@ class ImageInspector( GafferUI.NodeSetEditor ) :
 		# lets us defer updates until playback stops, and also provides important
 		# thread-safety, because the PathListingWidget will access the context
 		# on a background thread.
-		context = Gaffer.Context( self.getContext() )
+		context = Gaffer.Context( self.context() )
 		self.__imagePathListing.setPath(
 			_ImagePath( self.scriptNode(), self.settings()["__sampleStats"]["in"], context, "/" ),
 		)

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -1181,7 +1181,7 @@ class _CompareModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __menuDefinition( self ) :
 
-		with self.getContext() :
+		with self.context() :
 			compareMode = self.getPlug().getValue()
 
 		hotkeyTarget = self.__hotkeyTarget()

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -156,13 +156,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plugs, **kw )
 
-		self.__updateContextConnection()
-		self.__ensureValidValue()
-
-	def setContext( self, context ) :
-
-		GafferUI.PlugValueWidget.setContext( self, context )
-		self.__updateContextConnection()
+		self.context().changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ), scoped = True )
 		self.__ensureValidValue()
 
 	def _updateFromValues( self, values, exception ) :
@@ -235,12 +229,6 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 			self.getPlug().setValue( f"{display}/{view}" )
-
-	def __updateContextConnection( self ) :
-
-		self.__contextChangedConnection = self.getContext().changedSignal().connect(
-			Gaffer.WeakMethod( self.__contextChanged ), scoped = True
-		)
 
 	def __contextChanged( self, context, key ) :
 

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -181,7 +181,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result = IECore.MenuDefinition()
 
 		activeViews = Gaffer.Metadata.value( self.getPlug(), "openColorIO:activeViews" ) or "*"
-		with self.getContext() :
+		with self.context() :
 
 			try :
 				config = GafferImage.OpenColorIOAlgo.currentConfig()
@@ -239,7 +239,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __ensureValidValue( self ) :
 
-		with self.getContext() :
+		with self.context() :
 			try :
 				config = GafferImage.OpenColorIOAlgo.currentConfig()
 			except :

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -396,7 +396,7 @@ def __exportOSLShader( nodeEditor, node ) :
 
 	with GafferUI.ErrorDialogue.ErrorHandler( title = "Error Exporting Shader", parentWindow = nodeEditor.ancestor( GafferUI.Window ) ) :
 		with open( path, "w", encoding = "utf-8" ) as f :
-			with nodeEditor.getContext() :
+			with nodeEditor.context() :
 				f.write( node.source( os.path.splitext( os.path.basename( path ) )[0] ) )
 
 GafferUI.NodeEditor.toolMenuSignal().connect( __toolMenu, scoped = False )

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -190,7 +190,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		assert( isinstance( node, GafferScene.AttributeTweaks ) )
 
 		pathMatcher = IECore.PathMatcher()
-		with self.getContext() :
+		with self.context() :
 			GafferScene.SceneAlgo.matchingPaths( node["filter"], node["in"], pathMatcher )
 
 		return self.__addFromPathsMenuDefinition( pathMatcher.paths() )
@@ -198,7 +198,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 	def __addFromSelectedMenuDefinition( self ) :
 
 		return self.__addFromPathsMenuDefinition(
-			GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() ).paths()
+			GafferSceneUI.ContextAlgo.getSelectedPaths( self.context() ).paths()
 	)
 
 	def __addFromPathsMenuDefinition( self, paths ) :
@@ -209,7 +209,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		assert( isinstance( node, GafferScene.AttributeTweaks ) )
 
 		attributes = {}
-		with self.getContext() :
+		with self.context() :
 			useFullAttr = node["localise"].getValue()
 			for path in paths :
 				attr = node["in"].fullAttributes( path ) if useFullAttr else node["in"].attributes( path )

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -115,7 +115,7 @@ class _StatusWidget( GafferUI.Frame ) :
 
 	def context( self ) :
 
-		return self.ancestor( GafferUI.NodeToolbar ).getContext()
+		return self.ancestor( GafferUI.NodeToolbar ).context()
 
 	def getToolTip( self ) :
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -77,7 +77,7 @@ class _CryptomatteNamesPlugValueWidget( GafferUI.VectorDataPlugValueWidget ) :
 
 		cryptomatteNode = _findCryptomatteNode( self.getPlug() )
 		if cryptomatteNode :
-			with self.getContext() :
+			with self.context() :
 				with IECore.IgnoredExceptions( Exception ) :
 					return cryptomatteNode["__manifest"].getValue()
 
@@ -438,7 +438,7 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 		return
 
 	menuDefinition.append( "/CryptomatteDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, graphEditor.getContext() ) } )
+	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, graphEditor.context() ) } )
 
 ##########################################################################
 # NodeEditor tool menu
@@ -450,4 +450,4 @@ def appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition ) :
 		return
 
 	menuDefinition.append( "/CryptomatteDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, nodeEditor.getContext() ) } )
+	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, nodeEditor.context() ) } )

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -108,7 +108,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 	if not acceptsAttributeName and not acceptsAttributeNames :
 		return
 
-	selectedPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.getContext() ).paths()
+	selectedPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.context() ).paths()
 	if not selectedPaths :
 		return
 
@@ -119,7 +119,7 @@ def __attributePopupMenu( menuDefinition, plugValueWidget ) :
 		nodes = [ node ]
 
 	attributeNames = set()
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 
 		if acceptsAttributeNames :
 			currentNames = set( plug.getValue().split() )

--- a/python/GafferSceneUI/DeleteGlobalsUI.py
+++ b/python/GafferSceneUI/DeleteGlobalsUI.py
@@ -107,7 +107,7 @@ def __namesPopupMenu( menuDefinition, plugValueWidget ) :
 	if plug != node["names"] :
 		return
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		globals = node["in"]["globals"].getValue()
 		currentNames = set( node["names"].getValue().split() )
 

--- a/python/GafferSceneUI/DeleteRenderPassesUI.py
+++ b/python/GafferSceneUI/DeleteRenderPassesUI.py
@@ -106,7 +106,7 @@ def __passPopupMenu( menuDefinition, plugValueWidget ) :
 	if not Gaffer.Metadata.value( plug, "ui:scene:acceptsRenderPassNames" ) :
 		return
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		globals = plug.node()["in"]["globals"].getValue()
 		currentNames = set( plug.getValue().split() )
 

--- a/python/GafferSceneUI/EditScopeUI.py
+++ b/python/GafferSceneUI/EditScopeUI.py
@@ -94,7 +94,7 @@ def __pruningKeyPress( viewer, event ) :
 
 	# \todo This needs encapsulating in EditScopeAlgo some how so we don't need
 	# to interact with processors directly.
-	with viewer.getContext() :
+	with viewer.context() :
 		if not editScope["enabled"].getValue() :
 			# Spare folks from deleting something when it won't be
 			# apparent what they've done until they reenable the
@@ -136,7 +136,7 @@ def __visibilityKeyPress( viewer, event ) :
 		"scene:visible"
 	)
 
-	with viewer.getContext() as context :
+	with viewer.context() as context :
 		attributeEdits = editScope.acquireProcessor( "AttributeEdits", createIfNecessary = False )
 		if not editScope["enabled"].getValue() or ( attributeEdits is not None and not attributeEdits["enabled"].getValue() ) :
 			# Spare folks from hiding something when it won't be

--- a/python/GafferSceneUI/FilteredSceneProcessorUI.py
+++ b/python/GafferSceneUI/FilteredSceneProcessorUI.py
@@ -122,7 +122,7 @@ def appendNodeContextMenuDefinitions( graphEditor, node, menuDefinition ) :
 		return
 
 	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, graphEditor.getContext() ) } )
+	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, graphEditor.context() ) } )
 
 ##########################################################################
 # NodeEditor tool menu
@@ -134,4 +134,4 @@ def appendNodeEditorToolMenuDefinitions( nodeEditor, node, menuDefinition ) :
 		return
 
 	menuDefinition.append( "/FilteredSceneProcessorDivider", { "divider" : True } )
-	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, nodeEditor.getContext() ) } )
+	menuDefinition.append( "/Select Affected Objects", { "command" : functools.partial( __selectAffected, node, nodeEditor.context() ) } )

--- a/python/GafferSceneUI/HierarchyView.py
+++ b/python/GafferSceneUI/HierarchyView.py
@@ -133,7 +133,7 @@ class HierarchyView( GafferSceneUI.SceneEditor ) :
 		# 2. Because the PathListingWidget uses a BackgroundTask to evaluate the Path, and it
 		#    would not be thread-safe to directly reference a context that could be modified by
 		#    the UI thread at any time.
-		contextCopy = Gaffer.Context( self.getContext() )
+		contextCopy = Gaffer.Context( self.context() )
 		for f in self.__filter.getFilters() :
 			f.setContext( contextCopy )
 		with Gaffer.Signals.BlockedConnection( self.__selectionChangedConnection ) :
@@ -144,16 +144,16 @@ class HierarchyView( GafferSceneUI.SceneEditor ) :
 		assert( pathListing is self.__pathListing )
 
 		with Gaffer.Signals.BlockedConnection( self._contextChangedConnection() ) :
-			visibleSet = ContextAlgo.getVisibleSet( self.getContext() )
+			visibleSet = ContextAlgo.getVisibleSet( self.context() )
 			visibleSet.expansions = pathListing.getExpansion()
-			ContextAlgo.setVisibleSet( self.getContext(), visibleSet )
+			ContextAlgo.setVisibleSet( self.context(), visibleSet )
 
 	def __selectionChanged( self, pathListing ) :
 
 		assert( pathListing is self.__pathListing )
 
 		with Gaffer.Signals.BlockedConnection( self._contextChangedConnection() ) :
-			ContextAlgo.setSelectedPaths( self.getContext(), pathListing.getSelection() )
+			ContextAlgo.setSelectedPaths( self.context(), pathListing.getSelection() )
 
 	def __keyPressSignal( self, widget, event ) :
 
@@ -214,14 +214,14 @@ class HierarchyView( GafferSceneUI.SceneEditor ) :
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferExpansionFromContext( self ) :
 
-		visibleSet = ContextAlgo.getVisibleSet( self.getContext() )
+		visibleSet = ContextAlgo.getVisibleSet( self.context() )
 		with Gaffer.Signals.BlockedConnection( self.__expansionChangedConnection ) :
 			self.__pathListing.setExpansion( visibleSet.expansions )
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferSelectionFromContext( self ) :
 
-		selection = ContextAlgo.getSelectedPaths( self.getContext() )
+		selection = ContextAlgo.getSelectedPaths( self.context() )
 		with Gaffer.Signals.BlockedConnection( self.__selectionChangedConnection ) :
 			self.__pathListing.setSelection( selection, scrollToFirst=False )
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -228,7 +228,7 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __startPauseClicked( self, button ) :
 
-		with self.getContext() :
+		with self.context() :
 			state = self.getPlug().getValue()
 
 		# When setting the plug value here, we deliberately don't use an UndoScope.

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -271,7 +271,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		# PathListing from updating automatically when the original context changes, and allows us to take
 		# control of updates ourselves in _updateFromContext(), using LazyMethod to defer the calls to this
 		# function until we are visible and playback has stopped.
-		contextCopy = Gaffer.Context( self.getContext() )
+		contextCopy = Gaffer.Context( self.context() )
 		self.__setFilter.setContext( contextCopy )
 		self.__pathListing.setPath( GafferScene.ScenePath( self.settings()["in"], contextCopy, "/", filter = self.__setFilter ) )
 
@@ -280,12 +280,12 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		assert( pathListing is self.__pathListing )
 
 		with Gaffer.Signals.BlockedConnection( self._contextChangedConnection() ) :
-			ContextAlgo.setSelectedPaths( self.getContext(), pathListing.getSelection()[0] )
+			ContextAlgo.setSelectedPaths( self.context(), pathListing.getSelection()[0] )
 
 	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
 	def __transferSelectionFromContext( self ) :
 
-		selectedPaths = ContextAlgo.getSelectedPaths( self.getContext() )
+		selectedPaths = ContextAlgo.getSelectedPaths( self.context() )
 		with Gaffer.Signals.BlockedConnection( self.__selectionChangedConnection ) :
 			selection = [selectedPaths] + ( [IECore.PathMatcher()] * ( len( self.__pathListing.getColumns() ) - 1 ) )
 			self.__pathListing.setSelection( selection, scrollToFirst=True )
@@ -333,7 +333,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		inspectors = {}
 		inspections = []
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
@@ -361,7 +361,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		nonEditable = [ i for i in inspections if not i.editable() ]
 
 		if len( nonEditable ) == 0 :
-			with Gaffer.Context( self.getContext() ) as context :
+			with Gaffer.Context( self.context() ) as context :
 				if not quickBoolean or not self.__toggleBoolean( inspectors, inspections ) :
 					edits = [ i.acquireEdit() for i in inspections ]
 					warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
@@ -458,7 +458,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		tweaks = []
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
 					continue
@@ -490,7 +490,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		edits = self.__disablableInspectionTweaks( pathListing )
 
-		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.context() ) as context :
 			for path, inspector in edits :
 				context["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
 
@@ -507,7 +507,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		inspections = []
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
 					continue
@@ -579,12 +579,12 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		result = IECore.PathMatcher()
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			for light, setExpressions in self.__selectedSetExpressions( pathListing ).items() :
 				for setExpression in setExpressions :
 					result.addPaths( GafferScene.SetAlgo.evaluateSetExpression( setExpression, self.settings()["in"] ) )
 
-		GafferSceneUI.ContextAlgo.setSelectedPaths( self.getContext(), result )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( self.context(), result )
 
 	def __buttonPress( self, pathListing, event ) :
 
@@ -638,7 +638,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 					# Pruning or the edit scope is read only
 					deleteEnabled = False
 				else :
-					with self.getContext() :
+					with self.context() :
 						if not editScopeNode["enabled"].getValue() :
 							# Edit scope is disabled
 							deleteEnabled = False
@@ -709,7 +709,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 	def __selectLinked (self, *unused ) :
 
-		context = self.getContext()
+		context = self.context()
 
 		dialogue = GafferUI.BackgroundTaskDialogue( "Selecting Linked Objects" )
 
@@ -752,7 +752,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 				window = _HistoryWindow(
 					column.inspector(),
 					path,
-					self.getContext(),
+					self.context(),
 					self.ancestor( GafferUI.ScriptWindow ).scriptNode(),
 					"History : {} : {}".format( path, column.headerData().value )
 				)

--- a/python/GafferSceneUI/OptionQueryUI.py
+++ b/python/GafferSceneUI/OptionQueryUI.py
@@ -366,7 +366,7 @@ class _OptionQueryFooter( GafferUI.PlugValueWidget ) :
 		node = self.getPlug().node()
 		assert( isinstance( node, GafferScene.OptionQuery ) )
 
-		with self.getContext() :
+		with self.context() :
 			options = node["scene"]["globals"].getValue()
 			existingQueries = { query["name"].getValue() for query in node["queries"] }
 

--- a/python/GafferSceneUI/OptionTweaksUI.py
+++ b/python/GafferSceneUI/OptionTweaksUI.py
@@ -218,7 +218,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 		node = self.getPlug().node()
 		assert( isinstance( node, GafferScene.OptionTweaks ) )
 
-		with self.getContext() :
+		with self.context() :
 			options = node["out"]["globals"].getValue()
 			existingTweaks = { tweak["name"].getValue() for tweak in node["tweaks"] }
 

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -204,7 +204,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 	if isinstance( node, Gaffer.Spreadsheet ) :
 		rowPlug = plug.ancestor( Gaffer.Spreadsheet.RowPlug )
 
-		with plugValueWidget.getContext() :
+		with plugValueWidget.context() :
 			if __targetFilterPlug( plug ) is not None :
 				cellPlug = plug.ancestor( Gaffer.Spreadsheet.CellPlug )
 				if cellPlug is None :

--- a/python/GafferSceneUI/PrimitiveInspector.py
+++ b/python/GafferSceneUI/PrimitiveInspector.py
@@ -236,9 +236,9 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 	@GafferUI.BackgroundMethod()
 	def __backgroundUpdate( self ) :
 
-		with self.getContext() :
+		with self.context() :
 
-			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
+			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.context() )
 
 			if not targetPath :
 				return None
@@ -273,7 +273,7 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 			self.__locationLabel.setText( "" )
 			self.__locationFrame._qtWidget().setProperty( "gafferDiff", "Other" )
 		else:
-			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
+			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.context() )
 			if targetPath :
 				self.__locationLabel.setText( targetPath )
 				self.__locationFrame._qtWidget().setProperty( "gafferDiff", "AB" )
@@ -291,7 +291,7 @@ class PrimitiveInspector( GafferSceneUI.SceneEditor ) :
 		self.__busyWidget.setBusy( False )
 
 		if self.settings()["in"].getInput() is not None :
-			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
+			targetPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.context() )
 			if targetPath:
 				if backgroundResult is not None :
 					self.__locationLabel.setText( targetPath )

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -263,7 +263,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		# PathListing from updating automatically when the original context changes, and allows us to take
 		# control of updates ourselves in _updateFromContext(), using LazyMethod to defer the calls to this
 		# function until we are visible and playback has stopped.
-		contextCopy = Gaffer.Context( self.getContext() )
+		contextCopy = Gaffer.Context( self.context() )
 		self.__pathListing.setPath( _GafferSceneUI._RenderPassEditor.RenderPassPath( self.settings()["in"], contextCopy, "/", filter = self.__filter, grouped = self.settings()["displayGrouped"].getValue() ) )
 
 	def __displayGroupedChanged( self ) :
@@ -395,7 +395,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		inspectors = {}
 		inspections = []
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			renderPassPath = self.__pathListing.getPath().copy()
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
@@ -426,7 +426,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		nonEditable = [ i for i in inspections if not i.editable() ]
 
 		if len( nonEditable ) == 0 :
-			with Gaffer.Context( self.getContext() ) as context :
+			with Gaffer.Context( self.context() ) as context :
 				if not quickBoolean or not self.__toggleBoolean( inspectors, inspections ) :
 					edits = [ i.acquireEdit() for i in inspections ]
 					warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
@@ -496,7 +496,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		tweaks = []
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			renderPassPath = self.__pathListing.getPath().copy()
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
@@ -531,7 +531,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		edits = self.__disablableInspectionTweaks( pathListing )
 
-		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.context() ) as context :
 			renderPassPath = self.__pathListing.getPath().copy()
 			for path, inspector in edits :
 				renderPassPath.setFromString( path )
@@ -580,7 +580,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		result = IECore.PathMatcher()
 
-		with Gaffer.Context( self.getContext() ) as context :
+		with Gaffer.Context( self.context() ) as context :
 			for renderPass, setExpressions in self.__selectedSetExpressions( pathListing ).items() :
 				# Evaluate set expressions within their render pass in the context
 				# as set membership could vary based on the render pass.
@@ -588,7 +588,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 				for setExpression in setExpressions :
 					result.addPaths( GafferScene.SetAlgo.evaluateSetExpression( setExpression, self.settings()["in"] ) )
 
-		GafferSceneUI.ContextAlgo.setSelectedPaths( self.getContext(), result )
+		GafferSceneUI.ContextAlgo.setSelectedPaths( self.context(), result )
 
 	def __buttonPress( self, pathListing, event ) :
 
@@ -684,7 +684,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 				if renderPassName is None :
 					continue
 
-				historyContext = Gaffer.Context( self.getContext() )
+				historyContext = Gaffer.Context( self.context() )
 				historyContext["renderPass"] = renderPassName
 				window = _HistoryWindow(
 					column.inspector(),
@@ -721,7 +721,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			# RenderPasses node or the edit scope is read only
 			return False
 		else :
-			with self.getContext() :
+			with self.context() :
 				if not editScope["enabled"].getValue() :
 					# Edit scope is disabled
 					return False
@@ -828,7 +828,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 	def __renderPassNames( self, plug ) :
 
-		with self.getContext() :
+		with self.context() :
 			return plug["globals"].getValue().get( "option:renderPass:names", IECore.StringVectorData() )
 
 	def __renderPassCreationDialogue( self ) :

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -197,14 +197,14 @@ def __viewerKeyPress( viewer, event ) :
 def __hierarchyViewKeyPress( hierarchyView, event ) :
 
 	if event == __editSourceKeyPress :
-		selectedPath = __contextSelectedPath( hierarchyView.getContext() )
+		selectedPath = __contextSelectedPath( hierarchyView.context() )
 		if selectedPath is not None :
-			__editSourceNode( hierarchyView.getContext(), hierarchyView.scene(), selectedPath )
+			__editSourceNode( hierarchyView.context(), hierarchyView.scene(), selectedPath )
 		return True
 	elif event == __editTweaksKeyPress :
-		selectedPath = __contextSelectedPath( hierarchyView.getContext() )
+		selectedPath = __contextSelectedPath( hierarchyView.context() )
 		if selectedPath is not None :
-			__editTweaksNode( hierarchyView.getContext(), hierarchyView.scene(), selectedPath )
+			__editTweaksNode( hierarchyView.context(), hierarchyView.scene(), selectedPath )
 		return True
 
 def __nodeEditorKeyPress( nodeEditor, event ) :

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -249,7 +249,7 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 
 		# The SceneInspector's internal context is not necessarily bound at this point, which can lead to errors
 		# if nodes in the graph are expecting special context variables, so we make sure it is:
-		with self.getContext():
+		with self.context():
 
 			scenes = [ s.getInput() for s in self.settings()["in"] if s.getInput() is not None ]
 			assert( len( scenes ) <= 2 )
@@ -258,10 +258,10 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 			if self.__targetPaths is not None :
 				paths = self.__targetPaths
 			else :
-				lastSelectedPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.getContext() )
+				lastSelectedPath = GafferSceneUI.ContextAlgo.getLastSelectedPath( self.context() )
 				if lastSelectedPath :
 					paths = [ lastSelectedPath ]
-					selectedPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.getContext() ).paths()
+					selectedPaths = GafferSceneUI.ContextAlgo.getSelectedPaths( self.context() ).paths()
 					if len( selectedPaths ) > 1 :
 						paths.insert( 0, next( p for p in selectedPaths if p != lastSelectedPath ) )
 
@@ -1054,7 +1054,7 @@ class DiffColumn( GafferUI.Widget ) :
 		# this doesn't always get called by SceneInspector.__update(), so we grab the
 		# context from the ancestor NodeSetEditor if it exists, and make it current:
 		nodeSetEditor = self.ancestor( GafferUI.NodeSetEditor )
-		context = nodeSetEditor.getContext() if nodeSetEditor else Gaffer.Context.current()
+		context = nodeSetEditor.context() if nodeSetEditor else Gaffer.Context.current()
 
 		with context:
 
@@ -2529,7 +2529,7 @@ class _SetDiff( Diff ) :
 
 		editor = self.ancestor( SceneInspector )
 
-		context = editor.getContext()
+		context = editor.context()
 		GafferSceneUI.ContextAlgo.setSelectedPaths( context, widget.paths )
 
 		return True

--- a/python/GafferSceneUI/SceneReaderUI.py
+++ b/python/GafferSceneUI/SceneReaderUI.py
@@ -143,7 +143,7 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 	if plug != node["tags"] :
 		return
 
-	fileName = plugValueWidget.getContext().substitute( node["fileName"].getValue() )
+	fileName = plugValueWidget.context().substitute( node["fileName"].getValue() )
 	try :
 		scene = IECoreScene.SharedSceneInterfaces.get( fileName )
 	except :
@@ -154,7 +154,7 @@ def __tagsPopupMenu( menuDefinition, plugValueWidget ) :
 		return
 	sceneTags = sorted( [ str( tag ) for tag in sceneTags ] )
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		currentTags = plug.getValue().split()
 
 	menuDefinition.prepend( "/TagsDivider", { "divider" : True } )

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -927,7 +927,7 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 		m = IECore.MenuDefinition()
 
 		try :
-			with self.getContext() :
+			with self.context() :
 				set = self.getPlug().node()["in"].set( setName )
 		except :
 			return m

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -145,7 +145,7 @@ class SelectModePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# so we know where to insert the next item for the category.
 		modifiedCategories = {}
 
-		with self.getContext() :
+		with self.context() :
 			currentValue = self.getPlug().getValue()
 
 		for mode in modes :

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -117,7 +117,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 		# 2. Because the PathListingWidget uses a BackgroundTask to evaluate the Path, and it
 		#    would not be thread-safe to directly reference a context that could be modified by
 		#    the UI thread at any time.
-		contextCopy = Gaffer.Context( self.getContext() )
+		contextCopy = Gaffer.Context( self.context() )
 		self.__searchFilterWidget.setScene( self.settings()["in"] )
 		self.__searchFilterWidget.setContext( contextCopy )
 		self.__pathListing.setPath( _GafferSceneUI._SetEditor.SetPath( self.settings()["in"], contextCopy, "/", filter = self.__filter ) )
@@ -226,7 +226,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 	def __getSetMembers( self, setNames, *unused ) :
 
 		result = IECore.PathMatcher()
-		with Gaffer.Context( self.getContext() ) :
+		with Gaffer.Context( self.context() ) :
 			for setName in setNames :
 				result.addPaths( self.settings()["in"].set( setName ).value )
 
@@ -236,21 +236,21 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 
 		setMembers = self.__getSetMembers( setNames )
 		return IECore.PathMatcher( [
-			p for p in ContextAlgo.getSelectedPaths( self.getContext() ).paths()
+			p for p in ContextAlgo.getSelectedPaths( self.context() ).paths()
 			if setMembers.match( p ) & ( IECore.PathMatcher.Result.ExactMatch | IECore.PathMatcher.Result.AncestorMatch )
 		] )
 
 	def __getIncludedSetMembers( self, setNames, *unused ) :
 
-		return self.__getSetMembers( setNames ).intersection( ContextAlgo.getVisibleSet( self.getContext() ).inclusions )
+		return self.__getSetMembers( setNames ).intersection( ContextAlgo.getVisibleSet( self.context() ).inclusions )
 
 	def __getExcludedSetMembers( self, setNames, *unused ) :
 
-		return self.__getSetMembers( setNames ).intersection( ContextAlgo.getVisibleSet( self.getContext() ).exclusions )
+		return self.__getSetMembers( setNames ).intersection( ContextAlgo.getVisibleSet( self.context() ).exclusions )
 
 	def __selectSetMembers( self, *unused ) :
 
-		ContextAlgo.setSelectedPaths( self.getContext(), self.__getSetMembers( self.__selectedSetNames() ) )
+		ContextAlgo.setSelectedPaths( self.context(), self.__getSetMembers( self.__selectedSetNames() ) )
 
 	def __copySetMembers( self, *unused ) :
 

--- a/python/GafferSceneUI/SetUI.py
+++ b/python/GafferSceneUI/SetUI.py
@@ -214,7 +214,7 @@ def __insertText( textWidget, text ) :
 
 		# Invisible dummy widget created by SpreadsheetUI. See `__setText`.
 		plugValueWidget = textWidget.ancestor( GafferUI.PlugValueWidget )
-		with plugValueWidget.getContext() :
+		with plugValueWidget.context() :
 			value = plugValueWidget.getPlug().getValue()
 
 		__setValue(
@@ -296,7 +296,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		nodes = { node }
 
 	setNames = set()
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		for node in nodes :
 			for scenePlug in __scenePlugs( node ) :
 				setNames.update( [ str( n ) for n in scenePlug["setNames"].getValue() if not str( n ).startswith( "__" ) ] )
@@ -310,7 +310,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 	else :
 		# The SpreadsheetUI makes an invisible widget in order to show the popup
 		# menu for a cell directly. The text in this may not be up to date.
-		with plugValueWidget.getContext() :
+		with plugValueWidget.context() :
 			currentText = plugValueWidget.getPlug().getValue()
 
 	# `Select Affected` command
@@ -321,7 +321,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		{
 			"command" : functools.partial(
 				__selectAffected,
-				plugValueWidget.getContext(),
+				plugValueWidget.context(),
 				nodes,
 				selectionSetExpression
 			),

--- a/python/GafferSceneUI/ShaderQueryUI.py
+++ b/python/GafferSceneUI/ShaderQueryUI.py
@@ -381,10 +381,10 @@ def _pathsFromSelection( plugValueWidget ) :
 	if node is None :
 		return []
 
-	paths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.getContext() )
+	paths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.context() )
 	paths = paths.paths() if paths else []
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		paths = [ p for p in paths if node["scene"].exists( p ) ]
 
 	return paths
@@ -397,7 +397,7 @@ def _shaderAttributes( plugValueWidget, paths, affectedOnly ) :
 	if node is None :
 		return result
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		useFullAttr = node["inherit"].getValue()
 		attributeNamePatterns = node["shader"].getValue() if affectedOnly else "*"
 

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -158,7 +158,7 @@ def _pathsFromAffected( plugValueWidget ) :
 		return []
 
 	pathMatcher = IECore.PathMatcher()
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		GafferScene.SceneAlgo.matchingPaths( node["filter"], node["in"], pathMatcher )
 
 	return pathMatcher.paths()
@@ -169,10 +169,10 @@ def _pathsFromSelection( plugValueWidget ) :
 	if node is None :
 		return []
 
-	paths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.getContext() )
+	paths = GafferSceneUI.ContextAlgo.getSelectedPaths( plugValueWidget.context() )
 	paths = paths.paths() if paths else []
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		paths = [ p for p in paths if node["in"].exists( p ) ]
 
 	return paths
@@ -184,7 +184,7 @@ def _shaderAttributes( plugValueWidget, paths, affectedOnly ) :
 	if node is None :
 		return result
 
-	with plugValueWidget.getContext() :
+	with plugValueWidget.context() :
 		useFullAttr = node["localise"].getValue()
 		attributeNamePatterns = node["shader"].getValue() if affectedOnly else "*"
 		for path in paths :

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -596,7 +596,7 @@ class _IncludedPurposesPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __togglePurpose( self, checked, purpose ) :
 
-		with self.getContext() :
+		with self.context() :
 			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
 				for plug in self.getPlugs() :
 					value = plug.getValue()

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -140,7 +140,7 @@ class _SelectionWidget( GafferUI.Frame ) :
 
 	def context( self ) :
 
-		return self.ancestor( GafferUI.NodeToolbar ).getContext()
+		return self.ancestor( GafferUI.NodeToolbar ).context()
 
 	def getToolTip( self ) :
 

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -52,7 +52,7 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 		self.__uvView = GafferSceneUI.UVView()
 		self.__uvView["in"].setInput( self.settings()["in"] )
 		Gaffer.NodeAlgo.applyUserDefaults( self.__uvView )
-		self.__uvView.setContext( self.getContext() )
+		self.__uvView.setContext( self.context() )
 
 		with column :
 

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -224,7 +224,7 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 	def _updateFromContext( self, modifiedItems ) :
 
-		self.__animationGadget.setContext( self.getContext() )
+		self.__animationGadget.setContext( self.context() )
 
 	def __updateGadgetSets( self, unused = None ) :
 

--- a/python/GafferUI/AnimationUI.py
+++ b/python/GafferUI/AnimationUI.py
@@ -127,7 +127,7 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 	if not isinstance( plug, Gaffer.ValuePlug ) or not Gaffer.Animation.canAnimate( plug ) :
 		return
 
-	context = plugValueWidget.getContext()
+	context = plugValueWidget.context()
 
 	menuDefinition.prepend( "/AnimationDivider", { "divider" : True } )
 

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -122,7 +122,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 					curve = Gaffer.Animation.acquire( plug )
 					curve.addKey(
 						Gaffer.Animation.Key(
-							time = self.getContext().getTime(),
+							time = self.context().getTime(),
 							value = value,
 							interpolation = Gaffer.Animation.Interpolation.Constant
 						)

--- a/python/GafferUI/ButtonPlugValueWidget.py
+++ b/python/GafferUI/ButtonPlugValueWidget.py
@@ -102,7 +102,7 @@ class ButtonPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with GafferUI.ErrorDialogue.ErrorHandler( title = "Button Error", parentWindow = self.ancestor( GafferUI.Window ) ) :
 			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
-				with self.getContext() :
+				with self.context() :
 					exec( code, executionDict, executionDict )
 
 	def __plugMetadataChanged( self, plug, key, reason ) :

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -101,7 +101,7 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if isinstance( value, IECore.Data ) and hasattr( value, "value" ) :
 			value = value.value
 			if hasattr( value, "dimensions" ) and isinstance( value.dimensions(), int ) :
-				with self.getContext() :
+				with self.context() :
 					result = sole( p.getValue() for p in self.getPlugs() )
 				if result is None :
 					return None

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -198,7 +198,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if ( shift and left ) or middle :
 			if len( self.getPlugs() ) == 1 and hasattr( self.getPlug(), "getValue" ) :
 				GafferUI.Pointer.setCurrent( "values" )
-				with self.getContext() :
+				with self.context() :
 					return self.getPlug().getValue()
 			else :
 				return None

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -126,10 +126,10 @@ class LazyMethod( object ) :
 
 		context = None
 		with IECore.IgnoredExceptions( AttributeError ) :
-			context = widget.getContext()
+			context = widget.context()
 		if context is None :
 			with IECore.IgnoredExceptions( AttributeError ) :
-				context = widget.context()
+				context = widget.getContext()
 
 		return GafferUI.Playback.acquire( context )
 

--- a/python/GafferUI/NodeToolbar.py
+++ b/python/GafferUI/NodeToolbar.py
@@ -59,13 +59,10 @@ class NodeToolbar( GafferUI.Widget ) :
 
 		return self.__node
 
-	def getContext( self ) :
+	## Returns the context in which the toolbar shows its plugs.
+	def context( self ) :
 
 		return self.__context
-
-	def setContext( self, context ) :
-
-		self.__context = context
 
 	## Creates a NodeToolbar instance for the specified node and edge.
 	# Note that not all nodes have toolbars, so None may be returned.

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -181,8 +181,8 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 					if Gaffer.Animation.isAnimated( plug ) :
 						curve = Gaffer.Animation.acquire( plug )
-						if self.__numericWidget.getText() != self.__numericWidget.valueToString( curve.evaluate( self.getContext().getTime() ) ) :
-							curve.insertKey( self.getContext().getTime(), self.__numericWidget.getValue() )
+						if self.__numericWidget.getText() != self.__numericWidget.valueToString( curve.evaluate( self.context().getTime() ) ) :
+							curve.insertKey( self.context().getTime(), self.__numericWidget.getValue() )
 					else :
 						try :
 							plug.setValue( self.__numericWidget.getValue() )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -135,25 +135,8 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		return next( iter( self.__plugs ), None )
 
-	## By default, PlugValueWidgets operate in the main context held by the script node
-	# for the script the plug belongs to. This function allows an alternative context
-	# to be provided, making it possible to view a plug at a custom frame (or with any
-	# other context modification).
-	## \todo To our knowledge, this has never been useful, and synchronising contexts
-	# between Editor/PlugLayout/PlugValueWidget has only been a pain. Consider
-	# removing it.
-	def setContext( self, context ) :
-
-		assert( isinstance( context, Gaffer.Context ) )
-		if context.isSame( self.__context ) :
-			return
-
-		self.__context = context
-		self.__updateContextConnection()
-		self.__callLegacyUpdateMethods()
-		self.__callUpdateFromValues()
-
-	def getContext( self ) :
+	## Returns the context in which the widget evaluates the plugs.
+	def context( self ) :
 
 		return self.__context
 
@@ -499,7 +482,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 				}
 			)
 
-		with self.getContext() :
+		with self.context() :
 			if any( Gaffer.NodeAlgo.presets( p ) for p in self.getPlugs() ) :
 				menuDefinition.append(
 					"/Preset", {
@@ -554,7 +537,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 			# `_updateFromPlug()` method instead.
 			return
 
-		with self.getContext() :
+		with self.context() :
 			if any(
 				isinstance( p, Gaffer.ValuePlug ) and Gaffer.PlugAlgo.dependsOnCompute( p )
 				for p in itertools.chain( self.getPlugs(), *self.__auxiliaryPlugs )
@@ -872,7 +855,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __applyPreset( self, presetName, *unused ) :
 
-		with self.getContext() :
+		with self.context() :
 			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
 				for p in self.getPlugs() :
 					Gaffer.NodeAlgo.applyPreset( p, presetName )

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -768,7 +768,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __copyValue( self ) :
 
-		with self.getContext() :
+		with self.context() :
 			value = self.getPlug().getValue()
 
 		if not isinstance( value, IECore.Object ) :
@@ -824,7 +824,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __presetsSubMenu( self ) :
 
-		with self.getContext() :
+		with self.context() :
 
 			currentPreset = sole( ( Gaffer.NodeAlgo.currentPreset( p ) or "" for p in self.getPlugs() ) )
 

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -128,7 +128,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			return result
 
 		# Required for context-sensitive dynamic presets
-		with self.getContext():
+		with self.context():
 
 			# Find the union of the presets across all plugs,
 			# and count how many times they occur.
@@ -179,7 +179,7 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __applyPreset( self, unused, preset ) :
 
 		# Required for context-sensitive dynamic presets
-		with self.getContext() :
+		with self.context() :
 			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
 				for plug in self.getPlugs() :
 					Gaffer.Metadata.deregisterValue( plug, "presetsPlugValueWidget:isCustom" )

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -130,7 +130,7 @@ class PythonEditor( GafferUI.Editor ) :
 		with self.__outputRedirection() :
 			with _MessageHandler( self.__outputWidget ) :
 				with Gaffer.UndoScope( self.scriptNode() ) :
-					with self.getContext() :
+					with self.context() :
 						try :
 							if len( parsed.body ) == 1 and isinstance( parsed.body[0], ast.Expr ) :
 								result = eval( toExecute, self.__executionDict, self.__executionDict )

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -231,7 +231,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		if pattern != "" :
 			model = self._qtWidget().model()
-			with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+			with self.ancestor( GafferUI.PlugValueWidget ).context() :
 				for i in range( 0, model.rowCount() ) :
 					plug = model.plugForIndex( model.index( i, 0 ) )
 					if plug is not None :
@@ -533,7 +533,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		if mode == self.__DropMode.Set :
 			return event.data
 
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			strings = set( destinationPlug["value"].getValue() )
 
 		if mode == self.__DropMode.Add :
@@ -560,7 +560,7 @@ class _PlugTableView( GafferUI.Widget ) :
 				return functools.partial(
 					_ClipboardAlgo.pasteCells,
 					dropData, [ [ destinationPlug ] ],
-					self.ancestor( GafferUI.PlugValueWidget ).getContext().getTime()
+					self.ancestor( GafferUI.PlugValueWidget ).context().getTime()
 				)
 		elif isinstance( event.data, Gaffer.Plug ) :
 			sourcePlug, targetPlug = self.__connectionPlugs( event.data, destinationPlug )
@@ -656,7 +656,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		if any( Gaffer.MetadataAlgo.getReadOnly( p ) for p in Gaffer.Plug.RecursiveRange( targetPlug ) ) :
 			return False
 
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			if not targetPlug.ancestor( Gaffer.Spreadsheet.RowPlug )["enabled"].getValue() :
 				return False
 
@@ -1047,7 +1047,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		if not plugMatrix or not _ClipboardAlgo.canCopyPlugs( plugMatrix ) :
 			return
 
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			clipboardData = _ClipboardAlgo.valueMatrix( plugMatrix )
 
 		self.__setClipboard( clipboardData )
@@ -1060,7 +1060,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		if not plugMatrix or not _ClipboardAlgo.canPasteCells( clipboard, plugMatrix ) :
 			return
 
-		context = self.ancestor( GafferUI.PlugValueWidget ).getContext()
+		context = self.ancestor( GafferUI.PlugValueWidget ).context()
 		with Gaffer.UndoScope( plugMatrix[0][0].ancestor( Gaffer.ScriptNode ) ) :
 			_ClipboardAlgo.pasteCells( clipboard, plugMatrix, context.getTime() )
 
@@ -1068,7 +1068,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		rowPlugs = _PlugTableView.__orderedRowsPlugs( self.selectedPlugs() )
 
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			clipboardData = _ClipboardAlgo.copyRows( rowPlugs )
 
 		self.__setClipboard( clipboardData )
@@ -1248,7 +1248,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		allSettable = all( [ plug.settable() for plug in enabledPlugs ] )
 
 		enabled = True
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			with IECore.IgnoredExceptions( Gaffer.ProcessException ) :
 				enabled = all( [ plug.getValue() for plug in enabledPlugs ] )
 
@@ -1262,7 +1262,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		if any( not p.settable() for p in plugs ) :
 			return
 
-		with self.ancestor( GafferUI.PlugValueWidget ).getContext() :
+		with self.ancestor( GafferUI.PlugValueWidget ).context() :
 			checked = sole( [ plug.getValue() for plug in plugs ] )
 		with Gaffer.UndoScope( next( iter( plugs ) ).ancestor( Gaffer.ScriptNode ) ) :
 			self.__setPlugValues( plugs, not checked )

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -66,7 +66,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug )
 
-		model = _PlugTableModel( plug, self.getContext(), self._qtWidget() )
+		model = _PlugTableModel( plug, self.context(), self._qtWidget() )
 		selectionModel = QtCore.QItemSelectionModel( model, self._qtWidget() )
 
 		with self.__grid :
@@ -409,7 +409,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if rowPlug == rowPlug.parent().defaultRow() :
 				rowName = "Default"
 			else :
-				with self.getContext() :
+				with self.context() :
 					rowName = rowPlug["name"].getValue() or "unnamed"
 
 			columnPlug = self.getPlug().defaultRow()["cells"][plug.getName()]

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -116,20 +116,18 @@ class Timeline( GafferUI.Editor ) :
 		playBackwards = QtWidgets.QShortcut( QtGui.QKeySequence( "Ctrl+Left" ), self._qtWidget() )
 		playBackwards.activated.connect( functools.partial( Gaffer.WeakMethod( self.__playPausePressed ), False ) )
 
-		self.__playback = None
-		self._updateFromContext( set() )
+		self.__playback = GafferUI.Playback.acquire( self.context() )
+		self.__playback.setFrameRange( self.__sliderRangeStart.getValue(), self.__sliderRangeEnd.getValue() )
+		self.__playback.stateChangedSignal().connect(
+			Gaffer.WeakMethod( self.__playbackStateChanged ), scoped = False
+		)
+		self.__playback.frameRangeChangedSignal().connect(
+			Gaffer.WeakMethod( self.__playbackFrameRangeChanged ), scoped = False
+		)
+
+		self._updateFromContext( { "frame" } )
 
 	def _updateFromContext( self, modifiedItems ) :
-
-		if self.__playback is None or not self.__playback.context().isSame( self.context() ) :
-			self.__playback = GafferUI.Playback.acquire( self.context() )
-			self.__playback.setFrameRange( self.__sliderRangeStart.getValue(), self.__sliderRangeEnd.getValue() )
-			self.__playbackStateChangedConnection = self.__playback.stateChangedSignal().connect(
-				Gaffer.WeakMethod( self.__playbackStateChanged ), scoped = True
-			)
-			self.__playbackFrameRangeChangedConnection = self.__playback.frameRangeChangedSignal().connect(
-				Gaffer.WeakMethod( self.__playbackFrameRangeChanged ), scoped = True
-			)
 
 		if "frame" not in modifiedItems :
 			return

--- a/python/GafferUI/Timeline.py
+++ b/python/GafferUI/Timeline.py
@@ -69,7 +69,7 @@ class Timeline( GafferUI.Editor ) :
 			self.__sliderRangeStartChangedConnection = self.__sliderRangeStart.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__sliderRangeChanged ), scoped = False )
 
 			self.__slider = _TimelineSlider(
-				value = self.getContext().getFrame(),
+				value = self.context().getFrame(),
 				min = float( scriptNode["frameRange"]["start"].getValue() ),
 				max = float( scriptNode["frameRange"]["end"].getValue() ),
 				parenting = { "expand" : True },
@@ -88,7 +88,7 @@ class Timeline( GafferUI.Editor ) :
 			self.__endButton = GafferUI.Button( image = "timelineEnd.png", hasFrame=False )
 			self.__endButton.clickedSignal().connect( Gaffer.WeakMethod( self.__startOrEndButtonClicked ), scoped = False )
 
-			self.__frame = GafferUI.NumericWidget( self.getContext().getFrame() )
+			self.__frame = GafferUI.NumericWidget( self.context().getFrame() )
 			self.__frame.setFixedCharacterWidth( 5 )
 			self.__frame.setToolTip( "Current frame" )
 			self.__frameChangedConnection = self.__frame.valueChangedSignal().connect( Gaffer.WeakMethod( self.__valueChanged ), scoped = False )
@@ -121,8 +121,8 @@ class Timeline( GafferUI.Editor ) :
 
 	def _updateFromContext( self, modifiedItems ) :
 
-		if self.__playback is None or not self.__playback.context().isSame( self.getContext() ) :
-			self.__playback = GafferUI.Playback.acquire( self.getContext() )
+		if self.__playback is None or not self.__playback.context().isSame( self.context() ) :
+			self.__playback = GafferUI.Playback.acquire( self.context() )
 			self.__playback.setFrameRange( self.__sliderRangeStart.getValue(), self.__sliderRangeEnd.getValue() )
 			self.__playbackStateChangedConnection = self.__playback.stateChangedSignal().connect(
 				Gaffer.WeakMethod( self.__playbackStateChanged ), scoped = True
@@ -136,8 +136,8 @@ class Timeline( GafferUI.Editor ) :
 
 		# update the frame counter and slider position
 		with Gaffer.Signals.BlockedConnection( [ self.__frameChangedConnection, self.__sliderValueChangedConnection ] ) :
-			self.__frame.setValue( self.getContext().getFrame() )
-			self.__slider.setValue( self.getContext().getFrame() )
+			self.__frame.setValue( self.context().getFrame() )
+			self.__slider.setValue( self.context().getFrame() )
 
 	def __sliderRangeChanged( self, widget ) :
 
@@ -177,7 +177,7 @@ class Timeline( GafferUI.Editor ) :
 			# may not change, so we need to update the value in the frame field manually
 			self.__frame.setValue( frame )
 
-		self.getContext().setFrame( frame )
+		self.context().setFrame( frame )
 
 	def __scriptNodePlugSet( self, plug ) :
 
@@ -233,9 +233,9 @@ class Timeline( GafferUI.Editor ) :
 		self.__playback.setState( self.__playback.State.Stopped )
 
 		if button is self.__startButton :
-			self.getContext().setFrame( self.__sliderRangeStart.getValue() )
+			self.context().setFrame( self.__sliderRangeStart.getValue() )
 		else :
-			self.getContext().setFrame( self.__sliderRangeEnd.getValue() )
+			self.context().setFrame( self.__sliderRangeEnd.getValue() )
 
 	def __playbackStateChanged( self, playback ) :
 

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -201,7 +201,7 @@ class _SoloChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __menuDefinition( self ) :
 
-		with self.getContext() :
+		with self.context() :
 			soloChannel = self.getPlug().getValue()
 
 		useShortCuts = Gaffer.Metadata.value( self.getPlug(), "view:displayTransform:useShortcuts" )
@@ -298,7 +298,7 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __clicked( self, button ) :
 
-		with self.getContext() :
+		with self.context() :
 			value = self.getPlug().getValue()
 
 		if value == self.getPlug().defaultValue() and self.__toggleValue is not None :

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -82,7 +82,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__viewToolbars, self.__nodeToolbars, self.__toolToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Top, self.getContext() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Top, self.context() ) )
 
 			# Bottom toolbars
 
@@ -95,7 +95,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__toolToolbars, self.__nodeToolbars, self.__viewToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Bottom, self.getContext() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Bottom, self.context() ) )
 
 		with GafferUI.ListContainer( borderWidth = 2, spacing = 0, orientation = GafferUI.ListContainer.Orientation.Horizontal ) as verticalToolbars :
 
@@ -115,7 +115,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 				)
 
 				for toolbarContainer in [ self.__viewToolbars, self.__nodeToolbars, self.__toolToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Left, self.getContext() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Left, self.context() ) )
 
 			# Right toolbars
 
@@ -128,7 +128,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__toolToolbars, self.__nodeToolbars, self.__viewToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Right, self.getContext() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Right, self.context() ) )
 
 		self.__gadgetWidget.addOverlay( horizontalToolbars )
 		self.__gadgetWidget.addOverlay( verticalToolbars )
@@ -187,7 +187,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 						self.__currentView = GafferUI.View.create( plug )
 						if self.__currentView is not None:
 							Gaffer.NodeAlgo.applyUserDefaults( self.__currentView )
-							self.__currentView.setContext( self.getContext() )
+							self.__currentView.setContext( self.context() )
 							self.__views.append( self.__currentView )
 					# if we succeeded in getting a suitable view, then
 					# don't bother checking the other plugs

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -82,7 +82,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__viewToolbars, self.__nodeToolbars, self.__toolToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Top, self.context() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Top ) )
 
 			# Bottom toolbars
 
@@ -95,7 +95,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__toolToolbars, self.__nodeToolbars, self.__viewToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Bottom, self.context() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Bottom ) )
 
 		with GafferUI.ListContainer( borderWidth = 2, spacing = 0, orientation = GafferUI.ListContainer.Orientation.Horizontal ) as verticalToolbars :
 
@@ -115,7 +115,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 				)
 
 				for toolbarContainer in [ self.__viewToolbars, self.__nodeToolbars, self.__toolToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Left, self.context() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Left ) )
 
 			# Right toolbars
 
@@ -128,7 +128,7 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			) :
 
 				for toolbarContainer in [ self.__toolToolbars, self.__nodeToolbars, self.__viewToolbars ] :
-					toolbarContainer.append( _Toolbar( GafferUI.Edge.Right, self.context() ) )
+					toolbarContainer.append( _Toolbar( GafferUI.Edge.Right ) )
 
 		self.__gadgetWidget.addOverlay( horizontalToolbars )
 		self.__gadgetWidget.addOverlay( verticalToolbars )
@@ -304,7 +304,7 @@ GafferUI.Editor.registerType( "Viewer", Viewer )
 # Internal widget to simplify the management of node toolbars.
 class _Toolbar( GafferUI.Frame ) :
 
-	def __init__( self, edge, context, **kw ) :
+	def __init__( self, edge, **kw ) :
 
 		GafferUI.Frame.__init__( self, borderWidth = 0, borderStyle = GafferUI.Frame.BorderStyle.None_, **kw )
 
@@ -319,7 +319,6 @@ class _Toolbar( GafferUI.Frame ) :
 		self._qtWidget().layout().setSizeConstraint( self._qtWidget().layout().SetDefaultConstraint )
 
 		self.__edge = edge
-		self.__context = context
 		self.__node = []
 
 	def setNode( self, node ) :

--- a/python/GafferUITest/EditorTest.py
+++ b/python/GafferUITest/EditorTest.py
@@ -67,16 +67,10 @@ class EditorTest( GafferUITest.TestCase ) :
 	def testContext( self ) :
 
 		s = Gaffer.ScriptNode()
-		c = Gaffer.Context()
-
 		editor = GafferUI.Viewer( s )
 
 		self.assertTrue( editor.scriptNode().isSame( s ) )
-		self.assertTrue( editor.getContext().isSame( s.context() ) )
-
-		editor.setContext( c )
-		self.assertTrue( editor.scriptNode().isSame( s ) )
-		self.assertTrue( editor.getContext().isSame( c ) )
+		self.assertTrue( editor.context().isSame( s.context() ) )
 
 	def testSerialisation( self ) :
 

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -187,16 +187,8 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		s["n"]["p"] = Gaffer.IntPlug()
 
 		l = GafferUI.PlugLayout( s["n"] )
-		self.assertTrue( l.getContext().isSame( s.context() ) )
-		self.assertTrue( l.plugValueWidget( s["n"]["p"] ).getContext().isSame( s.context() ) )
-
-		c = Gaffer.Context()
-		l.setContext( c )
-		self.assertTrue( l.getContext().isSame( c ) )
-		self.assertTrue( l.plugValueWidget( s["n"]["p"] ).getContext().isSame( c ) )
-
-		l = GafferUI.PlugLayout( s )
-		self.assertTrue( l.getContext().isSame( s.context() ) )
+		self.assertTrue( l.context().isSame( s.context() ) )
+		self.assertTrue( l.plugValueWidget( s["n"]["p"] ).context().isSame( s.context() ) )
 
 	def testContextWithoutScriptNode( self ) :
 
@@ -204,10 +196,10 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 		n["p"] = Gaffer.Plug()
 
 		l = GafferUI.PlugLayout( n )
-		self.assertTrue( isinstance( l.getContext(), Gaffer.Context ) )
+		self.assertTrue( isinstance( l.context(), Gaffer.Context ) )
 
 		l = GafferUI.PlugLayout( n["p"] )
-		self.assertTrue( isinstance( l.getContext(), Gaffer.Context ) )
+		self.assertTrue( isinstance( l.context(), Gaffer.Context ) )
 
 	def testContextSensitiveSummariesAndActivators( self ) :
 

--- a/startup/GafferUI/getContextCompatibility.py
+++ b/startup/GafferUI/getContextCompatibility.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2014, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -36,35 +36,14 @@
 
 import GafferUI
 
-class StandardNodeToolbar( GafferUI.NodeToolbar ) :
+def getContext( self ) :
 
-	def __init__( self, node, edge = GafferUI.Edge.Top, **kw ) :
+	## \todo Emit DeprecationWarning here once 1.6 is released,
+	# and we can expect most client code to have access to the
+	# `context()` method introduced in 1.5.
+	return self.context()
 
-		self.__layout = GafferUI.PlugLayout(
-			node,
-			orientation = GafferUI.ListContainer.Orientation.Horizontal if edge in ( GafferUI.Edge.Top, GafferUI.Edge.Bottom ) else GafferUI.ListContainer.Orientation.Vertical,
-			layoutName = "toolbarLayout",
-			rootSection = edge.name
-		)
-
-		GafferUI.NodeToolbar.__init__( self, node, self.__layout, **kw )
-
-	@staticmethod
-	def top( node ) :
-
-		return StandardNodeToolbar( node, edge = GafferUI.Edge.Top )
-
-	@staticmethod
-	def bottom( node ) :
-
-		return StandardNodeToolbar( node, edge = GafferUI.Edge.Bottom )
-
-	@staticmethod
-	def left( node ) :
-
-		return StandardNodeToolbar( node, edge = GafferUI.Edge.Left )
-
-	@staticmethod
-	def right( node ) :
-
-		return StandardNodeToolbar( node, edge = GafferUI.Edge.Right )
+GafferUI.PlugValueWidget.getContext = getContext
+GafferUI.PlugLayout.getContext = getContext
+GafferUI.Editor.getContext = getContext
+GafferUI.NodeToolbar.getContext = getContext


### PR DESCRIPTION
We have never used the flexibility this method was intended to provide, but it has been the source of unnecessary complexity and synchronisation bugs. Removing them now smooths the way for some "context aware" behaviours we're in the process of adding, whereby we want all the UI components to share the same context tracking utility, which necessitates sharing the same context.