### PR TITLE
FormatPlug binding : Fix GIL management bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ Fixes
 - LightEditor : Fixed regression (introduced in 1.4.8.0) causing the mute and solo icons to not show up for groups.
 - Windows : Fixed conflicts with other software installations on `PATH`. The `PXR_USD_WINDOWS_DLL_PATH` environment variable is now set to an empty string if it is not already set, preventing USD from adding all entries from `PATH` to Python's DLL search paths.
 - AnnotationsGadget : Fixed potential hang in `annotationText()` Python binding.
+- FormatPlug : Fixed potential hang in `acquireDefaultFormatPlug()` Python binding.
 
 API
 ---

--- a/src/GafferImageModule/CoreBinding.cpp
+++ b/src/GafferImageModule/CoreBinding.cpp
@@ -287,6 +287,12 @@ Format getValue( const FormatPlug *plug )
 	return plug->getValue();
 }
 
+FormatPlugPtr acquireDefaultFormatPlugWrapper( Gaffer::ScriptNode &scriptNode )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return FormatPlug::acquireDefaultFormatPlug( &scriptNode );
+}
+
 class FormatPlugSerialiser : public GafferBindings::ValuePlugSerialiser
 {
 
@@ -431,7 +437,7 @@ void GafferImageModule::bindCore()
 		.staticmethod( "setDefaultFormat" )
 		.def( "getDefaultFormat", &FormatPlug::getDefaultFormat )
 		.staticmethod( "getDefaultFormat" )
-		.def( "acquireDefaultFormatPlug", &FormatPlug::acquireDefaultFormatPlug, return_value_policy<IECorePython::CastToIntrusivePtr>() )
+		.def( "acquireDefaultFormatPlug", &acquireDefaultFormatPlugWrapper )
 		.staticmethod( "acquireDefaultFormatPlug" )
 	;
 


### PR DESCRIPTION
`acquireDefaultFormatPlug()` modifies the graph, and therefore must release the GIL to allow cancellation of background tasks requiring Python.
