### PR TITLE
OSL Image Sampler Prototype Update

### DIFF
--- a/include/GafferImage/Sampler.h
+++ b/include/GafferImage/Sampler.h
@@ -81,7 +81,7 @@ class GAFFERIMAGE_API Sampler
 		/// @param channelName The channel to sample.
 		/// @param sampleWindow The area from which samples may be requested. It is an error to request samples outside this area.
 		/// @param boundingMode The method of handling samples that fall outside the data window.
-		Sampler( const GafferImage::ImagePlug *plug, const std::string &channelName, const Imath::Box2i &sampleWindow, BoundingMode boundingMode = Black );
+		Sampler( const GafferImage::ImagePlug *plug, const std::string &channelName, const Imath::Box2i &sampleWindow, BoundingMode boundingMode = Black, bool rememberContext = false );
 
 		/// Uses `parallelProcessTiles()` to fill the internal tile cache
 		/// with all tiles in the sample window. Allows `sample()` and
@@ -135,6 +135,7 @@ class GAFFERIMAGE_API Sampler
 		const std::string m_channelName;
 		Imath::Box2i m_sampleWindow;
 		Imath::Box2i m_dataWindow;
+		Gaffer::ContextPtr m_overrideContext;
 
 		std::vector< IECore::ConstFloatVectorDataPtr > m_dataCache;
 		std::vector< const float * > m_dataCacheRaw;

--- a/include/GafferImage/Sampler.inl
+++ b/include/GafferImage/Sampler.inl
@@ -316,7 +316,15 @@ inline void Sampler::cachedData( Imath::V2i p, const float *& tileData, int &til
 		Imath::V2i tileOrigin( p.x & ~( ImagePlug::tileSize() - 1 ), p.y & ~( ImagePlug::tileSize() - 1 ) );
 
 		IECore::ConstFloatVectorDataPtr &cacheTilePtr = m_dataCache[ cacheIndex ];
-		cacheTilePtr = m_plug->channelData( m_channelName, tileOrigin );
+		if( m_overrideContext )
+		{
+			Gaffer::Context::Scope s( m_overrideContext.get() );
+			cacheTilePtr = m_plug->channelData( m_channelName, tileOrigin );
+		}
+		else
+		{
+			cacheTilePtr = m_plug->channelData( m_channelName, tileOrigin );
+		}
 		cacheTileRawPtr = &cacheTilePtr->readable()[0];
 	}
 

--- a/include/GafferOSL/OSLImage.h
+++ b/include/GafferOSL/OSLImage.h
@@ -84,6 +84,9 @@ class GAFFEROSL_API OSLImage : public GafferImage::ImageProcessor
 		GafferImage::Format computeFormat( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const override;
 		Imath::Box2i computeDataWindow( const Gaffer::Context *context, const GafferImage::ImagePlug *parent ) const override;
 
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
+
 	private :
 
 		GafferScene::ShaderPlug *shaderPlug();
@@ -104,6 +107,9 @@ class GAFFEROSL_API OSLImage : public GafferImage::ImageProcessor
 		// this will also evaluate shadingPlug()
 		Gaffer::StringVectorDataPlug *affectedChannelsPlug();
 		const Gaffer::StringVectorDataPlug *affectedChannelsPlug() const;
+
+		Gaffer::IntPlug *allImageDataNeededPlug();
+		const Gaffer::IntPlug *allImageDataNeededPlug() const;
 
 		void hashShading( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 		IECore::ConstCompoundDataPtr computeShading( const Gaffer::Context *context ) const;

--- a/include/GafferOSL/ShadingEngine.h
+++ b/include/GafferOSL/ShadingEngine.h
@@ -37,11 +37,16 @@
 #include "GafferOSL/Export.h"
 #include "GafferOSL/TypeIds.h"
 
+#include "GafferImage/ImagePlug.h"
+
 #include "IECoreScene/ShaderNetwork.h"
 
 #include "IECore/CompoundData.h"
 
+#include "OpenImageIO/ustring.h"
+
 #include "boost/container/flat_set.hpp"
+#include "boost/container/flat_map.hpp"
 
 namespace GafferOSL
 {
@@ -83,13 +88,17 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 		};
 
 		using Transforms = std::map<IECore::InternedString, Transform>;
+		using ImagePlugs = std::map<IECore::InternedString, const GafferImage::ImagePlug *>;
 
 		/// Append a unique hash representing this shading engine to `h`.
 		void hash( IECore::MurmurHash &h ) const;
-		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms = Transforms() ) const;
+		IECore::CompoundDataPtr shade( const IECore::CompoundData *points, const Transforms &transforms = Transforms(), const ImagePlugs &imagePlugs = ImagePlugs() ) const;
 
 		bool needsAttribute( const std::string &name ) const;
 		bool hasDeformation() const;
+		bool needsImageSamples() const;
+
+		IECore::MurmurHash hashPossibleImageSamples( const ImagePlugs &imagePlugs ) const;
 
 	private :
 
@@ -107,6 +116,10 @@ class GAFFEROSL_API ShadingEngine : public IECore::RefCounted
 		bool m_unknownAttributesNeeded;
 
 		bool m_hasDeformation;
+
+		std::vector< OIIO::ustring > m_gafferTexturesRequested;
+
+		boost::container::flat_map< OIIO::ustring, int> m_gafferTextureIndices;
 
 		void *m_shaderGroupRef;
 

--- a/python/GafferOSLTest/OSLImageTest.py
+++ b/python/GafferOSLTest/OSLImageTest.py
@@ -121,7 +121,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 				]
 
 			checkDirtiness( channelsDirtied + [
-					"channels", "__shader", "__shading",
+					"channels", "__shader", "__allImageDataNeeded", "__shading",
 					"__affectedChannels", "out.channelNames", "out.channelData", "out"
 			] )
 
@@ -155,13 +155,13 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 			getGreen["parameters"]["channelName"].setValue( "R" )
 			checkDirtiness( channelsDirtied + [
-					"channels", "__shader", "__shading",
+					"channels", "__shader", "__allImageDataNeeded", "__shading",
 					"__affectedChannels", "out.channelNames", "out.channelData", "out"
 			] )
 
 			floatToColor["parameters"]["r"].setInput( getRed["out"]["channelValue"] )
 			checkDirtiness( channelsDirtied + [
-					"channels", "__shader", "__shading",
+					"channels", "__shader", "__allImageDataNeeded", "__shading",
 					"__affectedChannels", "out.channelNames", "out.channelData", "out"
 			] )
 
@@ -178,14 +178,14 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 			image["in"].setInput( None )
 			checkDirtiness( [
 					'in.viewNames', 'in.format', 'in.dataWindow', 'in.metadata', 'in.deep', 'in.sampleOffsets', 'in.channelNames', 'in.channelData', 'in',
-					'out.viewNames', '__shading', '__affectedChannels',
+					'out.viewNames', '__allImageDataNeeded', '__shading', '__affectedChannels',
 					'out.channelNames', 'out.channelData', 'out.format', 'out.dataWindow', 'out.metadata', 'out.deep', 'out.sampleOffsets', 'out'
 			] )
 
 			image["defaultFormat"]["displayWindow"]["max"]["x"].setValue( 200 )
 			checkDirtiness( [
 					'defaultFormat.displayWindow.max.x', 'defaultFormat.displayWindow.max', 'defaultFormat.displayWindow', 'defaultFormat',
-					'__defaultIn.format', '__defaultIn.dataWindow', '__defaultIn', '__shading', '__affectedChannels',
+					'__defaultIn.format', '__defaultIn.dataWindow', '__defaultIn', '__allImageDataNeeded', '__shading', '__affectedChannels',
 					'out.channelNames', 'out.channelData', 'out.format', 'out.dataWindow', 'out'
 			] )
 
@@ -194,7 +194,7 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 
 			checkDirtiness( [
 					'in.viewNames', 'in.format', 'in.dataWindow', 'in.metadata', 'in.deep', 'in.sampleOffsets', 'in.channelNames', 'in.channelData', 'in',
-					'out.viewNames', '__shading', '__affectedChannels',
+					'out.viewNames', '__allImageDataNeeded', '__shading', '__affectedChannels',
 					'out.channelNames', 'out.channelData', 'out.format', 'out.dataWindow', 'out.metadata', 'out.deep', 'out.sampleOffsets', 'out'
 			] )
 
@@ -234,7 +234,6 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 				self.assertEqual( image["out"].channelNames(), IECore.StringVectorData(
 					[ "A", "B", "G", "R", "newLayer.B", "newLayer.G", "newLayer.R", "unchangedR" ]
 				) )
-
 
 
 	def testAcceptsShaderSwitch( self ) :
@@ -1006,6 +1005,195 @@ class OSLImageTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( testEval("R"), [ 1000, 1000, 929, 946, 795, 830, 750, 637, 797, 363, 614, 170, 214, 54, 0, 0 ])
 		self.assertEqual( testEval("G"), [ 250, 750, 239, 597, 230, 320, 300, 265, 457, 446, 652, 652, 882, 882, 1000, 1000 ] )
 		self.assertEqual( testEval("B"), [ 700, 700, 684, 666, 642, 608, 518, 632, 308, 742, 253, 697, 345, 505, 400, 400 ] )
+
+	def testImageSampling( self ):
+
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( os.path.expandvars( "$GAFFER_ROOT/python/GafferImageTest/images/rgbOverChecker.100x100.exr" ) )
+
+		switchWindow = GafferImage.Crop()
+		switchWindow["in"].setInput( reader["out"] )
+		switchWindow["area"].setValue( imath.Box2i( imath.V2i( 50, 50 ), imath.V2i( 100, 100 ) ) )
+		switchWindow["affectDataWindow"].setValue( False )
+		switchWindow["affectDisplayWindow"].setValue( False )
+
+		deleteChannels = GafferImage.DeleteChannels()
+		deleteChannels["in"].setInput( switchWindow["out"] )
+		deleteChannels["channels"].setValue( 'A' )
+
+		code = GafferOSL.OSLCode()
+		code["out"].addChild( Gaffer.Color3fPlug( "out", direction = Gaffer.Plug.Direction.Out ) )
+
+		# It can be pretty confusing to make syntax errors in this file unless we actually catch and report
+		# the errors manually.  I wonder if we could refactor OSLCode to not swallow exceptions ... I think
+		# we've moved to more CatchingSiganlCombiner since the comment there was written?
+		checkErrors = GafferTest.CapturingSlot( code.errorSignal() )
+
+		code["code"].setValue( """
+			out = pixel( "", P + vector( -5, -3, 0 ) );
+			out.g = pixel( "G", P + vector( -5, -3, 0 ) );
+		""")
+		self.assertEqual( list( checkErrors ), [] )
+
+		oslImage = GafferOSL.OSLImage()
+		oslImage["in"].setInput( deleteChannels["out"] )
+		oslImage["channels"].addChild( Gaffer.NameValuePlug( "", Gaffer.Color3fPlug( "value" ), True, "channel", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		oslImage["channels"]["channel"]["value"].setInput( code["out"]["out"] )
+
+		crop = GafferImage.Crop()
+		crop["in"].setInput( oslImage["out"] )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 5, 3 ), imath.V2i( 100, 100 ) ) )
+		crop["affectDisplayWindow"].setValue( False )
+
+		offset = GafferImage.Offset()
+		offset["in"].setInput( deleteChannels["out"] )
+		offset["offset"].setValue( imath.V2i( 5, 3 ) )
+
+		referenceCrop = GafferImage.Crop()
+		referenceCrop["in"].setInput( offset["out"] )
+		referenceCrop["area"].setInput( crop["area"] )
+		referenceCrop["affectDisplayWindow"].setValue( False )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		code["code"].setValue( """
+			out = pixel( "", P + vector( -4.6, -3.4, 0 ) );
+			out.g = pixel( "G", P + vector( -4.6, -3.4, 0 ) );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		code["code"].setValue( """
+			out = pixel( "", P + vector( -5.4, -2.6, 0 ) );
+			out.g = pixel( "G", P + vector( -5.4, -2.6, 0 ) );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		code["code"].setValue( """
+			out = pixel( "", P + vector( -5.6, -2.6, 0 ) );
+			out.g = pixel( "G", P + vector( -5.6, -2.6, 0 ) );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		with self.assertRaises( Exception ):
+			self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		code["code"].setValue( """
+			out = pixel( "", P + vector( -5.3, -2.6, 0 ) );
+			out.g = pixel( "G", P + vector( -5.3, -2.6, 0 ) );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		switchWindow["affectDisplayWindow"].setValue( True )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 5, 3 ), imath.V2i( 50, 50 ) ) )
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		switchWindow["affectDisplayWindow"].setValue( False )
+		switchWindow["affectDataWindow"].setValue( True )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 55, 53 ), imath.V2i( 100, 100 ) ) )
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True )
+
+		switchWindow["affectDataWindow"].setValue( False )
+
+		resample = GafferImage.Resample()
+		resample["in"].setInput( deleteChannels["out"] )
+		resample["filter"].setValue( "triangle" )
+		resample["matrix"].setValue( imath.M33f().translate( imath.V2f( 5, 3 ) ) )
+
+		referenceCrop["in"].setInput( resample["out"] )
+
+		crop["area"].setValue( imath.Box2i( imath.V2i( 5, 3 ), imath.V2i( 100, 100 ) ) )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.000001 )
+
+		resample["matrix"].setValue( imath.M33f().translate( imath.V2f( 4.7, 9.1 ) ) )
+
+		crop["area"].setValue( imath.Box2i( imath.V2i( 10, 10 ), imath.V2i( 100, 100 ) ) )
+
+		code["code"].setValue( """
+			out = pixelBilinear( "", P + vector( -4.7, -9.1, 0 ) );
+			out.g = pixelBilinear( "G", P + vector( -4.7, -9.1, 0 ) );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.00001 )
+
+		resample["matrix"].setValue( imath.M33f().scale( 1.5 ) * imath.M33f().translate( imath.V2f( -11.6, -13.3 ) ) )
+
+		code["code"].setValue( """
+			out = pixelBilinear( "", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5 );
+			out.g = pixelBilinear( "G", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5 );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+		crop["area"].setValue( imath.Box2i( imath.V2i( 0, 0 ), imath.V2i( 100, 100 ) ) )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.00001 )
+
+		code["code"].setValue( """
+			out = pixelFiltered( "", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 7, "gaussian" );
+			out.g = pixelFiltered( "G", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 7, "gaussian" );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+		resample["filter"].setValue( "sharp-gaussian" )
+		resample["filterScale"].setValue( imath.V2f( 7 ) )
+
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.00001 )
+
+		resample["filter"].setValue( "disk" )
+		code["code"].setValue( """
+			out = pixelFiltered( "", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 7, "disk" );
+			out.g = pixelFiltered( "G", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 7, "disk" );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.00001 )
+
+		resample["filterScale"].setValue( imath.V2f( 7, 2 ) )
+		code["code"].setValue( """
+			out = pixelFiltered( "", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 2, "disk" );
+			out.g = pixelFiltered( "G", ( P + vector( 11.6, 13.3, 0 ) ) / 1.5, 7, 2, "disk" );
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.00001 )
+
+
+		# Test a weird angled filter by rotating to an angle, applying an anisotropic filter, and rotating
+		# back
+		imageTransform = GafferImage.ImageTransform()
+		imageTransform["transform"]["rotate"].setValue( 30 )
+		imageTransform["in"].setInput( deleteChannels["out"] )
+
+		resample["in"].setInput( imageTransform["out"] )
+		resample["matrix"].setValue( imath.M33f() )
+		resample["filter"].setValue( "sharp-gaussian" )
+
+		imageTransformReverse = GafferImage.ImageTransform()
+		imageTransformReverse["in"].setInput( resample["out"] )
+		imageTransformReverse["transform"]["rotate"].setValue( -30 )
+		imageTransformReverse["transform"]["translate"].setValue( imath.V2f( 5.5, 7.5 ) )
+
+		referenceCrop["in"].setInput( imageTransformReverse["out"] )
+
+		# Note that the filter is larger than <7, 2>, in order to compensate for the extra smearing from
+		# the rotates
+		code["code"].setValue( """
+			vector dir = rotate( vector( 1, 0, 0 ), 30 * M_PI / 180, vector( 0, 0, -1 ) );
+			vector perp = vector( dir.y, -dir.x, 0 );
+			out = pixelFilteredWithDirections(
+				"", ( P + vector( -5.5, -7.5, 0 ) ), dir * 7.3, perp * 2.9, "gaussian"
+			);
+			out.g = pixelFilteredWithDirections(
+				"G", ( P + vector( -5.5, -7.5, 0 ) ), dir * 7.3, perp * 2.9, "gaussian"
+			);
+		""" )
+		self.assertEqual( list( checkErrors ), [] )
+
+		crop["area"].setValue( imath.Box2i( imath.V2i( 12, 12 ), imath.V2i( 95, 95 ) ) )
+
+		# With the imprecision of the rotate/smear/rotate approach, this isn't an exact match, but it's close
+		self.assertImagesEqual( crop["out"], referenceCrop["out"], ignoreChannelNamesOrder = True, maxDifference = 0.01 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -330,6 +330,9 @@ class _ErrorWidget( GafferUI.Widget ) :
 
 		self.__messageWidget.clear()
 		self.__messageWidget.messageHandler().handle( IECore.Msg.Level.Error, "Compilation error", error )
+
+		# TODO - for me, this does not actually trigger a redraw - I need to mouse over something that highlights
+		# in order to trigger a redraw and see the message
 		self.__messageWidget.setVisible( True )
 
 	def __shaderCompiled( self ) :

--- a/shaders/GafferOSL/ImageProcessing.h
+++ b/shaders/GafferOSL/ImageProcessing.h
@@ -81,4 +81,73 @@ closure color outLayer( string layerName, color layerColor )
 	return outChannel( redName, layerColor[0] ) + outChannel( greenName, layerColor[1] ) + outChannel( blueName, layerColor[2] );
 }
 
+
+string gafferFilterToOiioFilter( string s )
+{
+	if( s == "gaussian" )
+	{
+		return "smartcubic";
+	}
+	else if( s == "disk" )
+	{
+		return "cubic";
+	}
+	else
+	{
+		return "linear";
+	}
+}
+
+// TODO - figure out defaultValue
+// TODO - figure out alpha
+float pixel( string channelName, point p )
+{
+	return texture( concat( "gaffer:in.", channelName ), p[0] * Dx(u), p[1] * Dy(v), 0, 0, 0, 0, "interp", "closest" );
+}
+
+float pixelBilinear( string channelName, point p )
+{
+	return texture( concat( "gaffer:in.", channelName ), p[0] * Dx(u), p[1] * Dy(v), 0, 0, 0, 0, "interp", "bilinear" );
+}
+
+float pixelFiltered( string channelName, point p, float dx, float dy, string filter )
+{
+	return texture( concat( "gaffer:in.", channelName ), p[0] * Dx(u), p[1] * Dy(v),
+		dx * Dx(u), 0, 0, dy * Dy(v), "interp", gafferFilterToOiioFilter( filter )
+	);
+}
+
+float pixelFilteredWithDirections( string channelName, point p, vector dpdx, vector dpdy, string filter )
+{
+	return texture( concat( "gaffer:in.", channelName ), p[0] * Dx(u), p[1] * Dy(v),
+		dpdx[0] * Dx(u), dpdx[1] * Dx(u), dpdy[0] * Dy(v), dpdy[1] * Dy(v),
+		"interp", gafferFilterToOiioFilter( filter )
+	);
+}
+
+color pixel( string layerName, point p )
+{
+	return texture( concat( "gaffer:in.", layerName ), p[0] * Dx(u), p[1] * Dy(v), 0, 0, 0, 0, "interp", "closest" );
+}
+
+color pixelBilinear( string layerName, point p )
+{
+	return texture( concat( "gaffer:in.", layerName ), p[0] * Dx(u), p[1] * Dy(v), 0, 0, 0, 0, "interp", "bilinear" );
+}
+
+color pixelFiltered( string layerName, point p, float dx, float dy, string filter )
+{
+	return texture( concat( "gaffer:in.", layerName ), p[0] * Dx(u), p[1] * Dy(v),
+		dx * Dx(u), 0, 0, dy * Dy(v), "interp", gafferFilterToOiioFilter( filter )
+	);
+}
+
+color pixelFilteredWithDirections( string layerName, point p, vector dpdx, vector dpdy, string filter )
+{
+	return texture( concat( "gaffer:in.", layerName ), p[0] * Dx(u), p[1] * Dy(v),
+		dpdx[0] * Dx(u), dpdx[1] * Dx(u), dpdy[0] * Dy(v), dpdy[1] * Dy(v),
+		"interp", gafferFilterToOiioFilter( filter )
+	);
+}
+
 #endif // GAFFEROSL_IMAGEPROCESSING_H

--- a/src/GafferImage/Sampler.cpp
+++ b/src/GafferImage/Sampler.cpp
@@ -43,13 +43,15 @@ using namespace Imath;
 using namespace Gaffer;
 using namespace GafferImage;
 
-Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channelName, const Imath::Box2i &sampleWindow, BoundingMode boundingMode )
+Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channelName, const Imath::Box2i &sampleWindow, BoundingMode boundingMode, bool rememberContext )
 	: m_plug( plug ),
 	m_channelName( channelName ),
 	m_boundingMode( boundingMode )
 {
+	const Context *currentContext = Context::current();
+
 	{
-		ImagePlug::GlobalScope c( Context::current() );
+		ImagePlug::GlobalScope c( currentContext );
 
 		if( m_plug->deepPlug()->getValue() )
 		{
@@ -57,6 +59,11 @@ Sampler::Sampler( const GafferImage::ImagePlug *plug, const std::string &channel
 		}
 
 		m_dataWindow = m_plug->dataWindowPlug()->getValue();
+	}
+
+	if( rememberContext )
+	{
+		m_overrideContext = new Context( *currentContext );
 	}
 
 	// We only store the sample window to be able to perform
@@ -131,6 +138,12 @@ void Sampler::populate()
 
 void Sampler::hash( IECore::MurmurHash &h ) const
 {
+	std::unique_ptr< Context::Scope > contextScope;
+	if( m_overrideContext )
+	{
+		contextScope = std::make_unique<Context::Scope>( m_overrideContext.get() );
+	}
+
 	for ( int x = m_cacheWindow.min.x; x < m_cacheWindow.max.x; x += GafferImage::ImagePlug::tileSize() )
 	{
 		for ( int y = m_cacheWindow.min.y; y < m_cacheWindow.max.y; y += GafferImage::ImagePlug::tileSize() )

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -349,6 +349,13 @@ class CompileProcess : public Gaffer::Process
 			}
 			catch( ... )
 			{
+				// As per comment in updateShader(), we probably want to rework this
+				// so that compilation happens at evaluation time, and we can just throw
+				// an exception, but in the meantime, I think it's an improvement to
+				// blank out the shader when it fails, so we at least halt the calculation
+				// of whatever the OSLCode was previously doing
+				oslCode->namePlug()->setValue( "" );
+				oslCode->typePlug()->setValue( "osl:shader" );
 				handleException();
 			}
 		}

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -165,6 +165,7 @@ string generate( const OSLCode *shader, string &shaderName )
 	{
 		IECore::MurmurHash hash;
 		hash.append( result );
+		hash.append( 14 ); // Bump whenever headers change to avoid using stale oso's
 		shaderName = "oslCode" + hash.toString();
 	}
 

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -602,12 +602,14 @@ class RenderState
 			return false;
 		}
 
-		bool texture( size_t gafferTextureIndex,
-                          TextureOpt& options, float s,
-                          float t, float dsdx, float dtdx, float dsdy,
-                          float dtdy, int nchannels, float* result,
-                          float* dresultds, float* dresultdt,
-                          ustring* errormessage ) const
+		bool texture(
+			size_t gafferTextureIndex,
+			TextureOpt& options, float s,
+			float t, float dsdx, float dtdx, float dsdy,
+			float dtdy, int nchannels, float* result,
+			float* dresultds, float* dresultdt,
+			ustring* errormessage
+		) const
 		{
 			if( gafferTextureIndex >= m_gafferTextures.size() )
 			{
@@ -642,9 +644,10 @@ class RenderState
 						else if( ( dsdx == 0 && dtdy == 0 ) || ( dtdx == 0 && dsdy == 0 ) )
 						{
 							result[i] = GafferImage::FilterAlgo::sampleBox( *tex.channels[i], p,
-								( dsdx ? dsdx : dtdx ) * tex.dataWindowSize.x, ( dsdy ? dsdy : dtdy ) * tex.dataWindowSize.y,
+								( dsdx ? dsdx : dtdx ) * tex.dataWindowSize.x,
+								( dsdy ? dsdy : dtdy ) * tex.dataWindowSize.y,
 								g_filtersForInterpModes[ options.interpmode ], m_scratchMemory
-							 );
+							);
 						}
 						else
 						{
@@ -1049,13 +1052,15 @@ public:
 			//return texturesys()->get_texture_handle( filename, context->texture_thread_info() );
 		}
 
-		bool texture( ustring filename, TextureHandle* texture_handle,
-                          TexturePerthread* texture_thread_info,
-                          TextureOpt& options, ShaderGlobals* sg, float s,
-                          float t, float dsdx, float dtdx, float dsdy,
-                          float dtdy, int nchannels, float* result,
-                          float* dresultds, float* dresultdt,
-                          ustring* errormessage) override
+		bool texture(
+			ustring filename, TextureHandle* texture_handle,
+			TexturePerthread* texture_thread_info,
+			TextureOpt& options, ShaderGlobals* sg, float s,
+			float t, float dsdx, float dtdx, float dsdy,
+			float dtdy, int nchannels, float* result,
+			float* dresultds, float* dresultdt,
+			ustring* errormessage
+		) override
 		{
 			if( texture_handle )
 			{


### PR DESCRIPTION
This is the old prototype of image sampling in OSL, hacked to get it working on top of Gaffer 1.4.

It's not in a good state at all now - in particular, I've just disabled vectorization here, since the previous version of this predates vectorization support for OSL in Gaffer. If anyone is seriously investigating this, we should at least get it working with vectorization, since that will have a dramatic impact on performance.

Anyways, despite the caveats, this is probably still in a better place to look at than looking at the previous build on Gaffer-1.0.3.0 ... the basic functionality does seem to be working.