### PR TITLE
Inspector fallback values

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.9.0)
 =======
 
+Improvements
+------------
 
+- LightEditor : Values of inherited attributes are now displayed in the Light Editor. These are presented as dimmed "fallback" values.
 
 1.4.9.0 (relative to 1.4.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - LightEditor : Values of inherited attributes are now displayed in the Light Editor. These are presented as dimmed "fallback" values.
+- LightEditor, RenderPassEditor : Fallback values shown in the history window are displayed with the same dimmed text colour used for fallback values in editor columns.
 
 1.4.9.0 (relative to 1.4.8.0)
 =======

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -67,6 +67,7 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history ) const override;
 
 		bool attributeExists() const;
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -179,7 +179,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 
 		/// Can be implemented by derived classes to provide a fallback value for the inspection,
 		/// used when no value is returned from `value()`.
-		virtual IECore::ConstObjectPtr fallbackValue() const;
+		virtual IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history ) const;
 
 	protected :
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -126,8 +126,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 
 		/// Returns a `Path` representing the history for the inspected property
 		/// in the current context. The path has a child for each predecessor in
-		/// the history, and properties `history:value`, `history:operation`,
-		/// `history:source`, `history:editWarning` and `history:node`.
+		/// the history, and properties `history:value`, `history:fallbackValue`,
+		/// `history:operation`, `history:source`, `history:editWarning` and `history:node`.
 		Gaffer::PathPtr historyPath();
 
 	protected :

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -65,7 +65,7 @@ class GAFFERSCENEUI_API OptionInspector : public Inspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
-		IECore::ConstObjectPtr fallbackValue() const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -69,6 +69,7 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history ) const override;
 
 		const IECoreScene::ShaderNetwork::Parameter m_parameter;
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -81,6 +81,7 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 		/// those are found.
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -458,26 +458,7 @@ class LightEditor( GafferUI.NodeSetEditor ) :
 		# First we need to find out what the new value would be for each plug in isolation.
 		for inspector, pathInspections in inspectors.items() :
 			for path, inspection in pathInspections.items() :
-				currentValue = inspection.value().value if inspection.value() is not None else None
-
-				if isinstance( inspector, GafferSceneUI.Private.AttributeInspector ) :
-					fullAttributes = self.__settingsNode["in"].fullAttributes( path[:-1] )
-					parentValueData = fullAttributes.get( inspector.name(), None )
-					parentValue = parentValueData.value if parentValueData is not None else False
-
-					currentValues.append( currentValue if currentValue is not None else parentValue )
-				elif isinstance( inspector, GafferSceneUI.Private.SetMembershipInspector ) :
-					if currentValue is not None :
-						currentValues.append(
-							True if currentValue & (
-								IECore.PathMatcher.Result.ExactMatch |
-								IECore.PathMatcher.Result.AncestorMatch
-							) else False
-						)
-					else :
-						currentValues.append( False )
-				else :
-					currentValues.append( currentValue )
+				currentValues.append( inspection.value().value if inspection.value() is not None else False )
 
 		# Now set the value for all plugs, defaulting to `True` if they are not
 		# currently all the same.

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -201,6 +201,7 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 					"fullName",
 					"name",
 					"history:value",
+					"history:fallbackValue",
 					"history:operation",
 					"history:source",
 					"history:editWarning",
@@ -247,6 +248,7 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
 		self.assertEqual( c[0].property( "history:node" ), s["testLight"] )
 		self.assertEqual( c[0].property( "history:value" ), 0.0 )
+		self.assertEqual( c[0].property( "history:fallbackValue" ), None )
 		self.assertEqual( c[0].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
 		self.assertEqual( c[0].property( "history:source" ), s["testLight"]["parameters"]["exposure"] )
 		self.assertEqual( c[0].property( "history:editWarning" ), "" )
@@ -254,6 +256,7 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
 		self.assertEqual( c[1].property( "history:node" ), s["tweaks"] )
 		self.assertEqual( c[1].property( "history:value" ), 2.0 )
+		self.assertEqual( c[1].property( "history:fallbackValue" ), None )
 		self.assertEqual( c[1].property( "history:operation" ), Gaffer.TweakPlug.Mode.Add )
 		self.assertEqual( c[1].property( "history:source" ), exposureTweak )
 		self.assertEqual( c[1].property( "history:editWarning" ), "" )
@@ -261,6 +264,7 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( c[2].property( "name" ), str( c[2][-1] ) )
 		self.assertEqual( c[2].property( "history:node" ), s["editScope"]["LightEdits"]["ShaderTweaks"] )
 		self.assertEqual( c[2].property( "history:value" ), 3.0 )
+		self.assertEqual( c[2].property( "history:fallbackValue" ), None )
 		self.assertEqual( c[2].property( "history:operation" ), Gaffer.TweakPlug.Mode.Replace )
 		self.assertEqual( c[2].property( "history:source" ), edit )
 		self.assertEqual( c[2].property( "history:editWarning" ), "" )
@@ -354,6 +358,79 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( len( historyPath.children() ), 0 )
 
+	def testAttributeFallbackValues( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["testLight"] = GafferSceneTest.TestLight()
+
+		s["group"] = GafferScene.Group()
+		s["group"]["in"][0].setInput( s["testLight"]["out"] )
+
+		s["groupFilter"] = GafferScene.PathFilter()
+		s["groupFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group" ] ) )
+
+		s["tweaks"] = GafferScene.AttributeTweaks()
+		s["tweaks"]["in"].setInput( s["group"]["out"] )
+		s["tweaks"]["filter"].setInput( s["groupFilter"]["out"] )
+
+		groupTextureResolutionTweak = Gaffer.TweakPlug( "gl:visualiser:maxTextureResolution", 1024 )
+		groupTextureResolutionTweak["mode"].setValue( Gaffer.TweakPlug.Mode.Create )
+		s["tweaks"]["tweaks"].addChild( groupTextureResolutionTweak )
+
+		s["lightFilter"] = GafferScene.PathFilter()
+		s["lightFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/light" ] ) )
+
+		s["openGLAttributes"] = GafferScene.OpenGLAttributes()
+		s["openGLAttributes"]["in"].setInput( s["tweaks"]["out"] )
+		s["openGLAttributes"]["filter"].setInput( s["lightFilter"]["out"] )
+		s["openGLAttributes"]["attributes"]["visualiserMaxTextureResolution"]["enabled"].setValue( True )
+		s["openGLAttributes"]["attributes"]["visualiserMaxTextureResolution"]["value"].setValue( 1536 )
+
+		inspector = GafferSceneUI.Private.AttributeInspector(
+			s["openGLAttributes"]["out"], None, "gl:visualiser:maxTextureResolution",
+		)
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( [ "group", "light" ] )
+			historyPath = inspector.historyPath()
+
+		c = historyPath.children()
+
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertEqual( c[0].property( "history:node" ), s["openGLAttributes"] )
+		self.assertEqual( c[0].property( "history:value" ), 1536 )
+		self.assertEqual( c[0].property( "history:fallbackValue" ), 1536 )
+		self.assertEqual( c[0].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( c[0].property( "history:source" ), s["openGLAttributes"]["attributes"]["visualiserMaxTextureResolution"] )
+		self.assertEqual( c[0].property( "history:editWarning" ), "Edits to \"gl:visualiser:maxTextureResolution\" may affect other locations in the scene." )
+
+		s["openGLAttributes"]["enabled"].setValue( False )
+
+		with Gaffer.Context() as context :
+			context["scene:path"] = IECore.InternedStringVectorData( [ "group", "light" ] )
+			historyPath = inspector.historyPath()
+
+		c = historyPath.children()
+
+		self.assertEqual( c[0].property( "name" ), str( c[0][-1] ) )
+		self.assertEqual( c[0].property( "history:node" ), s["testLight"] )
+		self.assertEqual( c[0].property( "history:value" ), None )
+		self.assertEqual( c[0].property( "history:fallbackValue" ), None )
+		self.assertEqual( c[0].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( c[0].property( "history:source" ), s["testLight"]["visualiserAttributes"]["maxTextureResolution"] )
+		self.assertEqual( c[0].property( "history:editWarning" ), "" )
+
+		# Disabling the openGLAttributes node results in its `visualiserMaxTextureResolution` plug remaining
+		# in the history but providing no value. We'll be able to see the value set on /group as the fallback
+		# value.
+		self.assertEqual( c[1].property( "name" ), str( c[1][-1] ) )
+		self.assertEqual( c[1].property( "history:node" ), s["openGLAttributes"] )
+		self.assertEqual( c[1].property( "history:value" ), None )
+		self.assertEqual( c[1].property( "history:fallbackValue" ), 1024 )
+		self.assertEqual( c[1].property( "history:operation" ), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( c[1].property( "history:source" ), s["openGLAttributes"]["attributes"]["visualiserMaxTextureResolution"] )
+		self.assertEqual( c[1].property( "history:editWarning" ), "Edits to \"gl:visualiser:maxTextureResolution\" may affect other locations in the scene." )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -110,7 +110,21 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 		self.assertEqual(
 			self.__inspect( plane["out"], "/plane", "planeSet" ).value().value,
-			IECore.PathMatcher.Result.ExactMatch
+			True
+		)
+
+	def testFallbackValue( self ) :
+
+		plane = GafferScene.Plane()
+		group = GafferScene.Group()
+		group["sets"].setValue( "planeSet" )
+		group["in"][0].setInput( plane["out"] )
+
+		inspection = self.__inspect( group["out"], "/group/plane", "planeSet" )
+		self.assertEqual( inspection.value().value, True )
+		self.assertEqual(
+			inspection.sourceType(),
+			GafferSceneUI.Private.Inspector.Result.SourceType.Fallback
 		)
 
 	def testSourceAndEdits( self ) :
@@ -346,7 +360,7 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			self.__inspect( plane["out"], "/plane", "planeSet" ),
 			source = plane["sets"],
-			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Fallback,
 			editable = True
 		)
 

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -245,6 +245,11 @@ IECore::ConstObjectPtr AttributeInspector::value( const GafferScene::SceneAlgo::
 	return nullptr;
 }
 
+IECore::ConstObjectPtr AttributeInspector::fallbackValue( const GafferScene::SceneAlgo::History *history ) const
+{
+	return history->scene->fullAttributes( history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ) )->member( m_attribute );
+}
+
 Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
 {
 	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -56,6 +56,7 @@ using namespace GafferSceneUI::Private;
 using ConstPredecessors = std::vector<const SceneAlgo::History *>;
 
 static InternedString g_valuePropertyName( "history:value" );
+static InternedString g_fallbackValuePropertyName( "history:fallbackValue" );
 static InternedString g_operationPropertyName( "history:operation" );
 static InternedString g_sourcePropertyName( "history:source" );
 static InternedString g_editWarningPropertyName( "history:editWarning" );
@@ -441,6 +442,7 @@ void Inspector::HistoryPath::propertyNames( std::vector<InternedString> &names, 
 	if( isLeaf() )
 	{
 		names.push_back( g_valuePropertyName );
+		names.push_back( g_fallbackValuePropertyName );
 		names.push_back( g_operationPropertyName);
 		names.push_back( g_sourcePropertyName );
 		names.push_back( g_editWarningPropertyName );
@@ -466,6 +468,7 @@ ConstRunTimeTypedPtr Inspector::HistoryPath::property( const InternedString &nam
 	if(
 		isLeaf() && (
 			name == g_valuePropertyName ||
+			name == g_fallbackValuePropertyName ||
 			name == g_operationPropertyName ||
 			name == g_sourcePropertyName ||
 			name == g_editWarningPropertyName
@@ -485,6 +488,10 @@ ConstRunTimeTypedPtr Inspector::HistoryPath::property( const InternedString &nam
 			if( name == g_valuePropertyName )
 			{
 				return runTimeCast<const IECore::Data>( m_inspector->value( it->history.get() ) );
+			}
+			else if( name == g_fallbackValuePropertyName )
+			{
+				return runTimeCast<const IECore::Data>( m_inspector->fallbackValue( it->history.get() ) );
 			}
 			else if( name == g_operationPropertyName )
 			{

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -193,7 +193,7 @@ Inspector::ResultPtr Inspector::inspect() const
 	bool fallbackValue = false;
 	if( !value )
 	{
-		value = this->fallbackValue();
+		value = this->fallbackValue( history.get() );
 		fallbackValue = (bool)value;
 	}
 
@@ -365,7 +365,7 @@ Inspector::EditFunctionOrFailure Inspector::editFunction( Gaffer::EditScope *edi
 	return "Editing not supported";
 }
 
-IECore::ConstObjectPtr Inspector::fallbackValue() const
+IECore::ConstObjectPtr Inspector::fallbackValue( const GafferScene::SceneAlgo::History *history ) const
 {
 	return nullptr;
 }

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -215,7 +215,7 @@ IECore::ConstObjectPtr OptionInspector::value( const GafferScene::SceneAlgo::His
 	return nullptr;
 }
 
-IECore::ConstObjectPtr OptionInspector::fallbackValue() const
+IECore::ConstObjectPtr OptionInspector::fallbackValue( const GafferScene::SceneAlgo::History *history ) const
 {
 	if( const auto defaultValue = Gaffer::Metadata::value( g_optionPrefix + m_option.string(), g_defaultValue ) )
 	{

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -98,6 +98,12 @@ IECore::ConstObjectPtr ParameterInspector::value( const GafferScene::SceneAlgo::
 	return shader->parametersData()->member( m_parameter.name );
 }
 
+IECore::ConstObjectPtr ParameterInspector::fallbackValue( const GafferScene::SceneAlgo::History *history ) const
+{
+	// No fallback values are provided for parameters. Implemented to override AttributeInspector::fallbackValue().
+	return nullptr;
+}
+
 Gaffer::ValuePlugPtr ParameterInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const
 {
 	auto sceneNode = runTimeCast<SceneNode>( history->scene->node() );

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -211,7 +211,19 @@ IECore::ConstObjectPtr SetMembershipInspector::value( const GafferScene::SceneAl
 
 	auto matchResult = (PathMatcher::Result)setMembers->readable().match( path );
 
-	return new IntData( matchResult );
+	// Return nullptr for non-exact match so `fallbackValue()` has the opportunity to provide
+	// an AncestorMatch.
+	return matchResult & IECore::PathMatcher::Result::ExactMatch ? new BoolData( true ) : nullptr;
+}
+
+IECore::ConstObjectPtr SetMembershipInspector::fallbackValue( const GafferScene::SceneAlgo::History *history ) const
+{
+	const auto &path = history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+	ConstPathMatcherDataPtr setMembers = history->scene->set( m_setName );
+
+	auto matchResult = (PathMatcher::Result)setMembers->readable().match( path );
+
+	return new BoolData( matchResult & IECore::PathMatcher::Result::AncestorMatch );
 }
 
 Gaffer::ValuePlugPtr SetMembershipInspector::source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -177,6 +177,7 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 	{ (int)Inspector::Result::SourceType::Other, nullptr },
 	{ (int)Inspector::Result::SourceType::Fallback, nullptr },
 };
+const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
 
 class InspectorColumn : public PathColumn
 {
@@ -221,7 +222,12 @@ class InspectorColumn : public PathColumn
 			result.icon = runTimeCast<const Color3fData>( inspectorResult->value() );
 			result.background = g_sourceTypeColors.at( (int)inspectorResult->sourceType() );
 			std::string toolTip;
-			if( auto source = inspectorResult->source() )
+			if( inspectorResult->sourceType() == Inspector::Result::SourceType::Fallback )
+			{
+				toolTip = "Source : Fallback value";
+				result.foreground = g_fallbackValueForegroundColor;
+			}
+			else if( auto source = inspectorResult->source() )
 			{
 				toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
 			}

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -274,6 +274,8 @@ class InspectorColumn : public PathColumn
 
 };
 
+/// \todo `MuteColumn` and `SetMembershipColumn` should not exist and we intend
+/// to continue refactoring until it is possible to remove them entirely.
 class MuteColumn : public InspectorColumn
 {
 
@@ -340,6 +342,8 @@ class MuteColumn : public InspectorColumn
 			}
 
 			result.value = nullptr;
+			/// \todo Remove this once AttributeInspector can provide a default value when
+			/// no attribute exists, then InspectorColumn would always provide the toggle tooltip.
 			if( auto toolTipData = runTimeCast<const StringData>( result.toolTip ) )
 			{
 				std::string toolTip = toolTipData->readable();


### PR DESCRIPTION
This enables AttributeInspector to fall back to inspecting the values of inherited attributes, following the `Inspector::fallbackValue` approach already implemented by OptionInspector for falling back to default option values registered as metadata. The initial use-case for this is in the Light Editor, where we can now display inherited attribute values, but this would also be of use in a future where we include columns displaying attribute values in the Hierarchy View and other Editors.

![lightEditorInheritedAttributes](https://github.com/user-attachments/assets/755ba6fe-5496-4b37-9293-4041d84645d5)

This also gives SetMembershipInspector the same treatment of handling inheritance via a fallback value, which aligns the SetMembershipInspector behaviour more closely with AttributeInspector, and will help us to reduce the amount of special handling when dealing with each inspector in the future. A small example of the reducing special handling can be found in d907e64.