### PR TITLE
HistoryWindow : Add icon for `CreateIfMissing` tweak mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.16.x (relative to 1.3.16.6)
 ========
 
+Fixes
+-----
 
+- LightEditor, RenderPassEditor : Added missing icon representing use of the `CreateIfMissing` tweak mode in the history window.
 
 1.3.16.6 (relative to 1.3.16.5)
 ========

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -63,6 +63,7 @@ class _OperationIconColumn( GafferUI.PathColumn ) :
 			Gaffer.TweakPlug.Mode.Multiply : "multiplySmall.png",
 			Gaffer.TweakPlug.Mode.Remove : "removeSmall.png",
 			Gaffer.TweakPlug.Mode.Create : "createSmall.png",
+			Gaffer.TweakPlug.Mode.CreateIfMissing : "createIfMissingSmall.png",
 			Gaffer.TweakPlug.Mode.Min : "lessThanSmall.png",
 			Gaffer.TweakPlug.Mode.Max : "greaterThanSmall.png",
 			Gaffer.TweakPlug.Mode.ListAppend : "listAppendSmall.png",

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -380,6 +380,7 @@
 				"multiplySmall",
 				"replaceSmall",
 				"createSmall",
+				"createIfMissingSmall",
 				"lessThanSmall",
 				"greaterThanSmall",
 				"listAppendSmall",

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3146,6 +3146,14 @@
          width="14"
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.52291256;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173225;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="removeSmall" />
+      <rect
+         id="createIfMissingSmall"
+         y="2612"
+         x="241"
+         height="14"
+         width="14"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.522913;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="createIfMissingSmall" />
     </g>
     <g
        id="menus"
@@ -8735,6 +8743,12 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccccc"
          inkscape:label="lessThanSmall" />
+      <path
+         id="path1"
+         style="display:inline;font-size:16px;line-height:1.25;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro';fill:url(#foreground);stroke:url(#linearGradient10);stroke-width:0.245669"
+         d="M 250.11914 2613.4473 C 248.88714 2613.4473 247.89578 2613.9921 247.17578 2614.7441 L 247.95898 2615.4648 C 248.53498 2614.8888 249.22306 2614.5352 250.03906 2614.5352 C 251.20706 2614.5352 251.79883 2615.2079 251.79883 2616.0879 C 251.79883 2617.7199 248.91873 2618.3604 249.30273 2620.6484 L 250.4707 2620.6484 C 250.1827 2618.5684 253.0957 2618.1194 253.0957 2615.9434 C 253.0957 2614.4234 251.89514 2613.4473 250.11914 2613.4473 z M 243 2616 L 243 2618 L 247 2618 L 247 2616 L 243 2616 z M 243 2620 L 243 2622 L 247 2622 L 247 2620 L 243 2620 z M 250.00781 2622.0879 C 249.36781 2622.0879 248.83984 2622.5527 248.83984 2623.3047 C 248.83984 2624.0727 249.36781 2624.5527 250.00781 2624.5527 C 250.64781 2624.5527 251.17578 2624.0727 251.17578 2623.3047 C 251.17578 2622.5527 250.64781 2622.0879 250.00781 2622.0879 z "
+         transform="translate(0,52.3622)"
+         inkscape:label="createIfMissingSmall" />
     </g>
     <g
        style="opacity:1;paint-order:markers stroke fill"


### PR DESCRIPTION
This corrects the icon for the `CreateIfMissing` tweak mode, currently an error icon would be displayed in the History Window for entries using that mode.

![createIfMissingIcon](https://github.com/user-attachments/assets/e4726f9e-3c9e-4715-8e45-9b391ecf4203)
