### PR TITLE
ContextTracker and EditScopePlugValueWidget changes for 1.4.x

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 API
 ---
 
+- ContextTracker : Added a new class that determines what contexts nodes are evaluated in relative to the focus node. This allows UI components to provide improved context-sensitive feedback to the user.
 - Loop : Added `previousIteration()` method.
 
 1.4.9.0 (relative to 1.4.8.0)

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,11 @@ Fixes
 
 - LightEditor, RenderPassEditor : Added missing icon representing use of the `CreateIfMissing` tweak mode in the history window.
 
+API
+---
+
+- Loop : Added `previousIteration()` method.
+
 1.4.9.0 (relative to 1.4.8.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - LightEditor : Values of inherited attributes are now displayed in the Light Editor. These are presented as dimmed "fallback" values.
 - LightEditor, RenderPassEditor : Fallback values shown in the history window are displayed with the same dimmed text colour used for fallback values in editor columns.
+- EditScope : Filtered the EditScope menu to show only nodes that are active in the relevant context.
 
 Fixes
 -----

--- a/include/Gaffer/Loop.h
+++ b/include/Gaffer/Loop.h
@@ -85,6 +85,11 @@ class GAFFER_API Loop : public ComputeNode
 		/// the next iteration of the loop (relative to the current context).
 		ContextPtr nextIterationContext() const;
 
+		/// Returns the input plug and context that form the previous iteration of the loop
+		/// with respect to the `output` plug and the current context. Returns `{ nullptr, nullptr }`
+		/// if there is no such iteration.
+		std::pair<const ValuePlug *, ContextPtr> previousIteration( const ValuePlug *output ) const;
+
 		void affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const override;
 
 	protected :

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -52,6 +52,7 @@ namespace Gaffer
 {
 
 class BackgroundTask;
+class DependencyNode;
 class Plug;
 class ScriptNode;
 IE_CORE_FORWARDDECLARE( Node );
@@ -134,6 +135,10 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		Gaffer::ConstContextPtr context( const Gaffer::Plug *plug ) const;
 		Gaffer::ConstContextPtr context( const Gaffer::Node *node ) const;
 
+		/// If the node is tracked, returns the value of `node->enabledPlug()`
+		/// in `context( node )`. If the node is not tracked, returns `false`.
+		bool isEnabled( const Gaffer::DependencyNode *node ) const;
+
 	private :
 
 		void updateNode( const Gaffer::NodePtr &node );
@@ -154,6 +159,7 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		struct NodeData
 		{
 			Gaffer::ConstContextPtr context = nullptr;
+			bool dependencyNodeEnabled = false;
 			// If `true`, then all input plugs on the node are assumed to be
 			// active in the Node's context. This is just an optimisation that
 			// allows us to keep the size of `m_plugContexts` to a minimum.

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -49,6 +49,7 @@ namespace Gaffer
 {
 
 class Plug;
+class ScriptNode;
 IE_CORE_FORWARDDECLARE( Node );
 IE_CORE_FORWARDDECLARE( Context )
 
@@ -74,6 +75,24 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 
 		IE_CORE_DECLAREMEMBERPTR( ContextTracker );
 
+		/// Shared instances
+		/// ================
+		///
+		/// Tracking the upstream contexts can involve significant computation,
+		/// so it is recommended that ContextTracker instances are shared
+		/// between UI components. The `aquire()` methods maintain a pool of
+		/// instances for this purpose. Acquisition and destruction of shared
+		/// instances is not threadsafe, and must always be done on the UI
+		/// thread.
+
+		/// Returns a shared instance for the target `node`. The node must
+		/// belong to a ScriptNode, so that `ScriptNode::context()` can be used
+		/// to provide the target context.
+		static Ptr acquire( const Gaffer::NodePtr &node );
+		/// Returns an shared instance that will automatically track the focus
+		/// node in the specified `script`.
+		static Ptr acquireForFocus( Gaffer::ScriptNode *script );
+
 		/// Target
 		/// ======
 
@@ -96,6 +115,7 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 
 	private :
 
+		void updateNode( const Gaffer::NodePtr &node );
 		void plugDirtied( const Gaffer::Plug *plug );
 		void contextChanged( IECore::InternedString variable );
 		void update();
@@ -103,6 +123,7 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 
 		Gaffer::ConstNodePtr m_node;
 		Gaffer::ConstContextPtr m_context;
+		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;
 
 		struct NodeData
 		{

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -38,16 +38,20 @@
 
 #include "GafferUI/Export.h"
 
+#include "Gaffer/Context.h"
 #include "Gaffer/Set.h"
 #include "Gaffer/Signals.h"
 
+#include "IECore/Canceller.h"
 #include "IECore/RefCounted.h"
 
 #include <unordered_map>
+#include <unordered_set>
 
 namespace Gaffer
 {
 
+class BackgroundTask;
 class Plug;
 class ScriptNode;
 IE_CORE_FORWARDDECLARE( Node );
@@ -99,8 +103,25 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		const Gaffer::Node *targetNode() const;
 		const Gaffer::Context *targetContext() const;
 
+		/// Update and signalling
+		/// =====================
+		///
+		/// Updates are performed asynchronously in background tasks so that
+		/// the UI is never blocked. Clients should connect to `changedSignal()`
+		/// to be notified when updates are complete.
+
+		/// Returns true if an update is in-progress, in which case queries will
+		/// return stale values.
+		bool updatePending() const;
+		using Signal = Gaffer::Signals::Signal<void ( ContextTracker & ), Gaffer::Signals::CatchingCombiner<void>>;
+		/// Signal emitted when the results of any queries have changed.
+		Signal &changedSignal();
+
 		/// Queries
 		/// =======
+		///
+		/// Queries return immediately so will not block the UI waiting for computation.
+		/// But while `updatePending()` is `true` they will return stale values.
 
 		/// Returns true if the specified plug or node contributes to the
 		/// evaluation of the target.
@@ -118,12 +139,17 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		void updateNode( const Gaffer::NodePtr &node );
 		void plugDirtied( const Gaffer::Plug *plug );
 		void contextChanged( IECore::InternedString variable );
-		void update();
+		void scheduleUpdate();
+		void updateInBackground();
 		const Gaffer::Context *findPlugContext( const Gaffer::Plug *plug ) const;
 
 		Gaffer::ConstNodePtr m_node;
 		Gaffer::ConstContextPtr m_context;
 		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;
+
+		Gaffer::Signals::ScopedConnection m_idleConnection;
+		std::unique_ptr<Gaffer::BackgroundTask> m_updateTask;
+		Signal m_changedSignal;
 
 		struct NodeData
 		{
@@ -139,6 +165,11 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		using PlugContexts = std::unordered_map<Gaffer::ConstPlugPtr, Gaffer::ConstContextPtr>;
 		// Stores plug-specific contexts, which take precedence over `m_nodeContexts`.
 		PlugContexts m_plugContexts;
+
+		static void visit(
+			std::deque<std::pair<const Gaffer::Plug *, Gaffer::ConstContextPtr>> &toVisit,
+			NodeContexts &nodeContexts, PlugContexts &plugContexts, const IECore::Canceller *canceller
+		);
 
 };
 

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -1,0 +1,126 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferUI/Export.h"
+
+#include "Gaffer/Set.h"
+#include "Gaffer/Signals.h"
+
+#include "IECore/RefCounted.h"
+
+#include <unordered_map>
+
+namespace Gaffer
+{
+
+class Plug;
+IE_CORE_FORWARDDECLARE( Node );
+IE_CORE_FORWARDDECLARE( Context )
+
+} // namespace Gaffer
+
+namespace GafferUI
+{
+
+/// Utility class for UI components which display context-sensitive information
+/// to users. This tracks which upstream nodes contribute to the result at a
+/// particular target node, and also what context they should be evaluated in
+/// with respect to that node.
+class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaffer::Signals::Trackable
+{
+
+	public :
+
+		/// Constructs an instance that will track the graph upstream of the
+		/// target `node`, taking into account what connections are active in
+		/// the target `context`.
+		ContextTracker( const Gaffer::NodePtr &node, const Gaffer::ContextPtr &context );
+		~ContextTracker() override;
+
+		IE_CORE_DECLAREMEMBERPTR( ContextTracker );
+
+		/// Target
+		/// ======
+
+		const Gaffer::Node *targetNode() const;
+		const Gaffer::Context *targetContext() const;
+
+		/// Queries
+		/// =======
+
+		/// Returns true if the specified plug or node contributes to the
+		/// evaluation of the target.
+		bool isTracked( const Gaffer::Plug *plug ) const;
+		bool isTracked( const Gaffer::Node *node ) const;
+
+		/// Returns the most suitable context for the UI to evaluate a plug or
+		/// node in. This will always return a valid context, even if the plug
+		/// or node has not been tracked.
+		Gaffer::ConstContextPtr context( const Gaffer::Plug *plug ) const;
+		Gaffer::ConstContextPtr context( const Gaffer::Node *node ) const;
+
+	private :
+
+		void plugDirtied( const Gaffer::Plug *plug );
+		void contextChanged( IECore::InternedString variable );
+		void update();
+		const Gaffer::Context *findPlugContext( const Gaffer::Plug *plug ) const;
+
+		Gaffer::ConstNodePtr m_node;
+		Gaffer::ConstContextPtr m_context;
+
+		struct NodeData
+		{
+			Gaffer::ConstContextPtr context = nullptr;
+			// If `true`, then all input plugs on the node are assumed to be
+			// active in the Node's context. This is just an optimisation that
+			// allows us to keep the size of `m_plugContexts` to a minimum.
+			bool allInputsActive = false;
+		};
+
+		using NodeContexts = std::unordered_map<Gaffer::ConstNodePtr, NodeData>;
+		NodeContexts m_nodeContexts;
+		using PlugContexts = std::unordered_map<Gaffer::ConstPlugPtr, Gaffer::ConstContextPtr>;
+		// Stores plug-specific contexts, which take precedence over `m_nodeContexts`.
+		PlugContexts m_plugContexts;
+
+};
+
+IE_CORE_DECLAREPTR( ContextTracker )
+
+} // namespace GafferUI

--- a/python/GafferTest/LoopTest.py
+++ b/python/GafferTest/LoopTest.py
@@ -355,5 +355,25 @@ class LoopTest( GafferTest.TestCase ) :
 		loop["indexVariable"].setValue( "" )
 		self.assertIsNone( loop.nextIterationContext() )
 
+	def testPreviousIteration( self ) :
+
+		loop = self.intLoop()
+		loop["next"].setInput( loop["previous"] )
+		loop["iterations"].setValue( 10 )
+
+		iteration = loop.previousIteration( loop["out"] )
+		self.assertTrue( iteration[0].isSame( loop["next"] ) )
+		self.assertEqual( iteration[1]["loop:index"], 9 )
+
+		for i in range( 0, 9 ) :
+			with iteration[1] :
+				iteration = loop.previousIteration( loop["previous"] )
+				self.assertTrue( iteration[0].isSame( loop["next"] ) )
+				self.assertEqual( iteration[1]["loop:index"], 8 - i )
+
+		iteration = loop.previousIteration( loop["previous"] )
+		self.assertTrue( iteration[0].isSame( loop["in"] ) )
+		self.assertNotIn( "loop:index", iteration[1] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -150,9 +150,30 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# run the default dropSignal handler from PlugValueWidget.
 		self.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ), scoped = False )
 
+		self.__updatePlugInputChangedConnection()
+		self.__acquireContextTracker()
+
 	def hasLabel( self ) :
 
 		return True
+
+	def setPlugs( self, plugs ) :
+
+		GafferUI.PlugValueWidget.setPlugs( self, plugs )
+		self.__updatePlugInputChangedConnection()
+		self.__acquireContextTracker()
+
+	def getToolTip( self ) :
+
+		editScope = self.__editScope()
+		if editScope is None :
+			return "Edits will be made using the last relevant node, including nodes not in any EditScope."
+
+		unusableReason = self.__unusableReason( editScope )
+		if unusableReason :
+			return unusableReason
+		else :
+			return "Edits will be made in {}.".format( editScope.getName() )
 
 	# We don't actually display values, but this is also called whenever the
 	# input changes, which is when we need to update.
@@ -160,7 +181,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		editScope = self.__editScope()
 		editScopeActive = editScope is not None
-		self.__updateMenuButton( editScope )
+		self.__updateMenuButton()
 		self.__navigationMenuButton.setEnabled( editScopeActive )
 		if editScopeActive :
 			self.__editScopeNameChangedConnection = editScope.nameChangedSignal().connect(
@@ -177,19 +198,55 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			self._qtWidget().setProperty( "editScopeActive", GafferUI._Variant.toVariant( editScopeActive ) )
 			self._repolish()
 
-	def __updateMenuButton( self, editScope ) :
+	def __updatePlugInputChangedConnection( self ) :
 
+		self.__plugInputChangedConnection = self.getPlug().node().plugInputChangedSignal().connect(
+			Gaffer.WeakMethod( self.__plugInputChanged ), scoped = True
+		)
+
+	def __plugInputChanged( self, plug ) :
+
+		if plug.getName() == "in" and plug.parent() == self.getPlug().node() :
+			# The result of `__inputNode()` will have changed.
+			self.__acquireContextTracker()
+
+	def __acquireContextTracker( self ) :
+
+		self.__contextTracker = GafferUI.ContextTracker.acquire( self.__inputNode() )
+		self.__contextTrackerChangedConnection = self.__contextTracker.changedSignal().connect(
+			Gaffer.WeakMethod( self.__contextTrackerChanged ), scoped = True
+		)
+
+		if not self.__contextTracker.updatePending() :
+			self.__updateMenuButton()
+		else :
+			# We'll update later in `__contextTrackerChanged()`.
+			pass
+
+	def __updateMenuButton( self ) :
+
+		editScope = self.__editScope()
 		self.__menuButton.setText( editScope.getName() if editScope is not None else "None" )
-		self.__menuButton.setImage( self.__editScopeSwatch( editScope ) if editScope is not None else None )
+
+		if editScope is not None :
+			self.__menuButton.setImage(
+				self.__editScopeSwatch( editScope ) if not self.__unusableReason( editScope ) else "warningSmall.png"
+			)
+		else :
+			self.__menuButton.setImage( None )
 
 	def __editScopeNameChanged( self, editScope, oldName ) :
 
-		self.__updateMenuButton( editScope )
+		self.__updateMenuButton()
 
 	def __editScopeMetadataChanged( self, editScope, key, reason ) :
 
 		if key == "nodeGadget:color" :
-			self.__updateMenuButton( editScope )
+			self.__updateMenuButton()
+
+	def __contextTrackerChanged( self, contextTracker ) :
+
+		self.__updateMenuButton()
 
 	def __editScope( self ) :
 
@@ -231,6 +288,20 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return inputNode
 
+	def __activeEditScopes( self ) :
+
+		node = self.__inputNode()
+		if node is None :
+			return []
+
+		result = Gaffer.NodeAlgo.findAllUpstream( node, self.__editScopePredicate )
+		if self.__editScopePredicate( node ) :
+			result.insert( 0, node )
+
+		result = [ n for n in result if self.__contextTracker.isTracked( n ) ]
+
+		return result
+
 	def __buildMenu( self, result, path, currentEditScope ) :
 
 		result = IECore.MenuDefinition()
@@ -269,6 +340,8 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 						"label" : itemName,
 						"checkBox" : editScope == currentEditScope,
 						"icon" : self.__editScopeSwatch( editScope ),
+						"active" : not self.__unusableReason( editScope ),
+						"description" : self.__unusableReason( editScope ),
 					}
 				)
 			else :
@@ -290,16 +363,10 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		if self.getPlug().getInput() is not None :
 			currentEditScope = self.getPlug().getInput().parent()
 
-		node = self.__inputNode()
-		if node is not None :
-			upstream = Gaffer.NodeAlgo.findAllUpstream( node, self.__editScopePredicate )
-			if self.__editScopePredicate( node ) :
-				upstream.insert( 0, node )
+		activeEditScopes = self.__activeEditScopes()
 
-			downstream = Gaffer.NodeAlgo.findAllDownstream( node, self.__editScopePredicate )
-		else :
-			upstream = []
-			downstream = []
+		node = self.__inputNode()
+		downstream = Gaffer.NodeAlgo.findAllDownstream( node, self.__editScopePredicate ) if node is not None else []
 
 		# Each child of the root will get its own section in the menu
 		# if it has children. The section will be preceded by a divider
@@ -321,13 +388,11 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 				currentNode = currentNode.setdefault( n.getName(), {} )
 			currentNode[editScope.getName()] = editScope
 
-		if upstream :
-			for editScope in sorted( upstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
-				addToMenuHierarchy( editScope, "Upstream" )
+		for editScope in reversed( activeEditScopes ) :
+			addToMenuHierarchy( editScope, "Upstream" )
 
-		if downstream :
-			for editScope in sorted( downstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
-				addToMenuHierarchy( editScope, "Downstream" )
+		for editScope in sorted( downstream, key = lambda e : e.relativeName( e.scriptNode() ) ) :
+			addToMenuHierarchy( editScope, "Downstream" )
 
 		menuPath = Gaffer.DictPath( menuHierarchy, "/" )
 
@@ -447,31 +512,36 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __drop( self, widget, event ) :
 
-		inputNode = self.__inputNode()
 		dropNode = self.__dropNode( event )
-		if inputNode is None :
-			with GafferUI.PopupWindow() as self.__popup :
-				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
-					GafferUI.Image( "warningSmall.png" )
-					GafferUI.Label( "<h4>The Edit Scope cannot be set while nothing is viewed</h4>" )
-			self.__popup.popup( parent = self )
-		elif dropNode :
-			upstream = Gaffer.NodeAlgo.findAllUpstream( inputNode, self.__editScopePredicate )
-			if self.__editScopePredicate( inputNode ) :
-				upstream.insert( 0, inputNode )
+		if dropNode is not None :
 
-			if dropNode in upstream :
+			reason = self.__unusableReason( dropNode )
+			if reason is None :
 				self.__connectEditScope( dropNode )
 			else :
 				with GafferUI.PopupWindow() as self.__popup :
 					with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 						GafferUI.Image( "warningSmall.png" )
-						GafferUI.Label( "<h4>{} cannot be used as it is not upstream of {}</h4>".format( dropNode.getName(), inputNode.getName() ) )
+						GafferUI.Label( f"<h4>{reason}</h4>" )
 				self.__popup.popup( parent = self )
 
 		self.__frame.setHighlighted( False )
 
 		return True
+
+	def __unusableReason( self, editScope ) :
+
+		name = editScope.relativeName( editScope.scriptNode() )
+		inputNode = self.__inputNode()
+		if inputNode is None :
+			return f"{name} cannot be used while nothing is viewed."
+		elif not self.__contextTracker.isTracked( editScope ) :
+			inputNodeName = inputNode.relativeName( inputNode.scriptNode() )
+			return f"{name} cannot be used as it is not upstream of {inputNodeName}."
+		elif not self.__contextTracker.isEnabled( editScope ) :
+			return f"{name} cannot be used as it is disabled."
+		else :
+			return None
 
 # ProcessorWidget
 # ===============

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -127,6 +127,8 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 				GafferUI.Spacer( imath.V2i( 4, 1 ), imath.V2i( 4, 1 ) )
 				GafferUI.Label( "Edit Scope" )
+				self.__busyWidget = GafferUI.BusyWidget( size = 18 )
+				self.__busyWidget.setVisible( False )
 				self.__menuButton = GafferUI.MenuButton(
 					"",
 					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
@@ -247,6 +249,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __contextTrackerChanged( self, contextTracker ) :
 
 		self.__updateMenuButton()
+		self.__busyWidget.setVisible( False )
 
 	def __editScope( self ) :
 
@@ -409,12 +412,23 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			result.update( self.__buildMenu( result, category, currentEditScope ) )
 
 
+		if self.__contextTracker.updatePending() :
+			result.append( "/__RefreshDivider__", { "divider" : True } )
+			result.append( "/Refresh", { "command" : Gaffer.WeakMethod( self.__refreshMenu ) } )
+
 		result.append( "/__NoneDivider__", { "divider" : True } )
 		result.append(
 			"/None", { "command" : functools.partial( self.getPlug().setInput, None ) },
 		)
 
 		return result
+
+	def __refreshMenu( self ) :
+
+		if self.__contextTracker.updatePending() :
+			# An update will already be in progress so we just show our busy
+			# widget until it is done.
+			self.__busyWidget.setVisible( True )
 
 	def __navigationMenuDefinition( self ) :
 

--- a/python/GafferUITest/ContextTrackerTest.py
+++ b/python/GafferUITest/ContextTrackerTest.py
@@ -609,5 +609,102 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["addA"] ) )
 		self.assertFalse( tracker.isTracked( script["addB"] ) )
 
+	def testAcquire( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+
+		tracker1 = GafferUI.ContextTracker.acquire( script["add1"] )
+		self.assertTrue( tracker1.isSame( GafferUI.ContextTracker.acquire( script["add1"] ) ) )
+		self.assertTrue( tracker1.isTracked( script["add1"] ) )
+		self.assertFalse( tracker1.isTracked( script["add2"] ) )
+
+		tracker2 = GafferUI.ContextTracker.acquire( script["add2"] )
+		self.assertTrue( tracker2.isSame( GafferUI.ContextTracker.acquire( script["add2"] ) ) )
+		self.assertTrue( tracker2.isTracked( script["add2"] ) )
+		self.assertFalse( tracker2.isTracked( script["add1"] ) )
+
+	def testAcquireLifetime( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["node"] = GafferTest.MultiplyNode()
+		nodeSlots = script["node"].plugDirtiedSignal().numSlots()
+		nodeRefCount = script["node"].refCount()
+
+		tracker = GafferUI.ContextTracker.acquire( script["node"] )
+		del tracker
+
+		# Indicates that `tracker` was truly destroyed.
+		self.assertEqual( script["node"].plugDirtiedSignal().numSlots(), nodeSlots )
+		self.assertEqual( script["node"].refCount(), nodeRefCount )
+
+		# Should be a whole new instance.
+		tracker = GafferUI.ContextTracker.acquire( script["node"] )
+		self.assertTrue( tracker.isTracked( script["node"] ) )
+
+	def testAcquireForFocus( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+
+		tracker = GafferUI.ContextTracker.acquireForFocus( script )
+		self.assertTrue( tracker.isSame( GafferUI.ContextTracker.acquireForFocus( script ) ) )
+
+		self.assertFalse( tracker.isTracked( script["add1" ] ) )
+		self.assertFalse( tracker.isTracked( script["add2" ] ) )
+
+		script.setFocus( script["add1"] )
+		self.assertTrue( tracker.isTracked( script["add1" ] ) )
+		self.assertFalse( tracker.isTracked( script["add2" ] ) )
+
+		script.setFocus( script["add2"] )
+		self.assertFalse( tracker.isTracked( script["add1" ] ) )
+		self.assertTrue( tracker.isTracked( script["add2" ] ) )
+
+		script.setFocus( None )
+		self.assertFalse( tracker.isTracked( script["add1" ] ) )
+		self.assertFalse( tracker.isTracked( script["add2" ] ) )
+
+	def testAcquireForFocusLifetime( self ) :
+
+		script = Gaffer.ScriptNode()
+		contextSlots = script.context().changedSignal().numSlots()
+		contextRefCount = script.context().refCount()
+
+		tracker = GafferUI.ContextTracker.acquireForFocus( script )
+		del tracker
+
+		# Indicates that `tracker` was truly destroyed.
+		self.assertEqual( script.context().changedSignal().numSlots(), contextSlots )
+		self.assertEqual( script.context().refCount(), contextRefCount )
+
+		# Should be a whole new instance.
+		script["node"] = GafferTest.MultiplyNode()
+		script.setFocus( script["node"] )
+		tracker = GafferUI.ContextTracker.acquireForFocus( script )
+		self.assertTrue( tracker.isTracked( script["node"] ) )
+
+	def testAcquireNone( self ) :
+
+		tracker1 = GafferUI.ContextTracker.acquire( None )
+		self.assertTrue( tracker1.isSame( GafferUI.ContextTracker.acquire( None ) ) )
+
+		tracker2 = GafferUI.ContextTracker.acquireForFocus( None )
+		self.assertTrue( tracker2.isSame( GafferUI.ContextTracker.acquireForFocus( None ) ) )
+
+		self.assertTrue( tracker1.isSame( tracker2 ) )
+		self.assertEqual( tracker1.targetContext(), Gaffer.Context() )
+
+		node = GafferTest.AddNode()
+		self.assertFalse( tracker1.isTracked( node ) )
+		self.assertFalse( tracker1.isTracked( node["sum"] ) )
+		self.assertEqual( tracker1.context( node ), tracker1.targetContext() )
+		self.assertEqual( tracker1.context( node["sum"] ), tracker1.targetContext() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/ContextTrackerTest.py
+++ b/python/GafferUITest/ContextTrackerTest.py
@@ -1,0 +1,613 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+import GafferUI
+import GafferUITest
+
+class ContextTrackerTest( GafferUITest.TestCase ) :
+
+	def testSimpleNodes( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+		script["add3"] = GafferTest.AddNode()
+		script["add4"] = GafferTest.AddNode()
+		script["unconnected"] = GafferTest.AddNode()
+
+		script["add3"]["op1"].setInput( script["add1"]["sum"] )
+		script["add3"]["op2"].setInput( script["add2"]["sum"] )
+		script["add4"]["op1"].setInput( script["add3"]["sum"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["add4"], context )
+
+		def assertExpectedContexts() :
+
+			# Untracked nodes and plugs fall back to using the target
+			# context, so everything has the same context.
+
+			for node in Gaffer.Node.Range( script ) :
+				self.assertEqual( tracker.context( node ), context )
+				for plug in Gaffer.Plug.RecursiveRange( node ) :
+					self.assertEqual( tracker.context( plug ), context )
+
+		assertExpectedContexts( )
+
+		for node in [ script["add1"], script["add2"], script["add3"], script["add4"] ] :
+			for graphComponent in [ node, node["op1"], node["op2"], node["sum"], node["enabled"] ] :
+				self.assertTrue( tracker.isTracked( graphComponent ), graphComponent.fullName() )
+
+		for graphComponent in [ script["unconnected"], script["unconnected"]["op1"], script["unconnected"]["op2"], script["unconnected"]["sum"], script["unconnected"]["enabled"] ] :
+			self.assertFalse( tracker.isTracked( graphComponent ) )
+
+		script["add3"]["enabled"].setValue( False )
+
+		assertExpectedContexts( )
+
+		self.assertTrue( tracker.isTracked( script["add4"] ) )
+		self.assertTrue( tracker.isTracked( script["add3"] ) )
+		self.assertTrue( tracker.isTracked( script["add3"]["op1"] ) )
+		self.assertFalse( tracker.isTracked( script["add3"]["op2"] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+
+	def testSwitch( self ) :
+
+		# Static case - switch will have internal pass-through connections.
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+
+		script["switch"] = Gaffer.Switch()
+		script["switch"].setup( script["add1"]["sum"] )
+		script["switch"]["in"][0].setInput( script["add1"]["sum"] )
+		script["switch"]["in"][1].setInput( script["add2"]["sum"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["switch"], context )
+
+		def assertExpectedContexts() :
+
+			# Untracked nodes and plugs fall back to using the target
+			# context, so everything has the same context.
+
+			for node in [ script["add1"], script["add2"], script["switch"] ] :
+				self.assertEqual( tracker.context( node ), context, node.fullName() )
+				for plug in Gaffer.Plug.RecursiveRange( node ) :
+					self.assertEqual( tracker.context( plug ), context, plug.fullName() )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["index"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+
+		script["switch"]["index"].setValue( 1 )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["index"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertFalse( tracker.isTracked( script["add1"] ) )
+		self.assertTrue( tracker.isTracked( script["add2"] ) )
+
+		script["switch"]["enabled"].setValue( False )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["index"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+
+		# Dynamic case - switch will compute input on the fly.
+
+		script["add3"] = GafferTest.AddNode()
+		script["switch"]["index"].setInput( script["add3"]["sum"] )
+		script["switch"]["enabled"].setValue( True )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["index"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+		self.assertTrue( tracker.isTracked( script["add3"] ) )
+		self.assertEqual( tracker.context( script["add3"] ), context )
+
+		script["add3"]["op1"].setValue( 1 )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["index"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertFalse( tracker.isTracked( script["add1"] ) )
+		self.assertTrue( tracker.isTracked( script["add2"] ) )
+		self.assertTrue( tracker.isTracked( script["add3"] ) )
+		self.assertEqual( tracker.context( script["add3"] ), context )
+
+	def testNameSwitch( self ) :
+
+		# Static case - switch will have internal pass-through connections.
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"].setup( script["add1"]["sum"] )
+		script["switch"]["in"][0]["value"].setInput( script["add1"]["sum"] )
+		script["switch"]["in"][1]["value"].setInput( script["add2"]["sum"] )
+		script["switch"]["in"][1]["name"].setValue( "add2" )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["switch"], context )
+
+		def assertExpectedContexts() :
+
+			# Untracked nodes and plugs fall back to using the target
+			# context, so everything has the same context.
+
+			for node in [ script["add1"], script["add2"], script["switch"] ] :
+				self.assertEqual( tracker.context( node ), context )
+				for plug in Gaffer.Plug.RecursiveRange( node ) :
+					self.assertEqual( tracker.context( plug ), context )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["selector"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+
+		script["switch"]["selector"].setValue( "add2" )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["selector"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertFalse( tracker.isTracked( script["add1"] ) )
+		self.assertTrue( tracker.isTracked( script["add2"] ) )
+
+		script["switch"]["enabled"].setValue( False )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["selector"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+
+		# Dynamic case - switch will compute input on the fly.
+
+		stringNode = GafferTest.StringInOutNode()
+		script["switch"]["selector"].setInput( stringNode["out"] )
+		script["switch"]["enabled"].setValue( True )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["selector"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertTrue( tracker.isTracked( script["add1"] ) )
+		self.assertFalse( tracker.isTracked( script["add2"] ) )
+		self.assertTrue( tracker.isTracked( stringNode ) )
+		self.assertEqual( tracker.context( stringNode ), context )
+
+		stringNode["in"].setValue( "add2" )
+
+		assertExpectedContexts()
+
+		self.assertTrue( tracker.isTracked( script["switch"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["out"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["selector"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1] ) )
+		self.assertFalse( tracker.isTracked( script["add1"] ) )
+		self.assertTrue( tracker.isTracked( script["add2"] ) )
+		self.assertTrue( tracker.isTracked( stringNode ) )
+		self.assertEqual( tracker.context( stringNode ), context )
+
+	def testMultipleActiveNameSwitchBranches( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"].setup( script["add1"]["sum"] )
+		script["switch"]["in"][0]["value"].setInput( script["add1"]["sum"] )
+		script["switch"]["in"][1]["value"].setInput( script["add2"]["sum"] )
+		script["switch"]["in"][1]["name"].setValue( "add2" )
+		script["switch"]["selector"].setValue( "${selector}" )
+
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["switch"]["out"]["value"] )
+		script["contextVariables"]["in"].setInput( script["switch"]["out"]["value"] )
+		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "selector", "add2" ) )
+
+		script["add3"] = GafferTest.AddNode()
+		script["add3"]["op1"].setInput( script["switch"]["out"]["value"] )
+		script["add3"]["op2"].setInput( script["contextVariables"]["out"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["add3"], context )
+
+		self.assertEqual( tracker.context( script["add3"] ), context )
+		self.assertEqual( tracker.context( script["switch"] ), context )
+		self.assertEqual( tracker.context( script["switch"]["in"][0]["value"] ), context )
+		self.assertEqual( tracker.context( script["switch"]["in"][1]["value"] ), script["contextVariables"].inPlugContext() )
+		self.assertEqual( tracker.context( script["add1"] ), context )
+		self.assertEqual( tracker.context( script["add2"] ), script["contextVariables"].inPlugContext() )
+
+	def testNameSwitchNamesAndEnabled( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add1"] = GafferTest.AddNode()
+		script["add2"] = GafferTest.AddNode()
+		script["add3"] = GafferTest.AddNode()
+		script["add4"] = GafferTest.AddNode()
+		script["add5"] = GafferTest.AddNode()
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"]["selector"].setValue( "four" )
+		script["switch"].setup( script["add1"]["sum"] )
+		script["switch"]["in"].resize( 5 )
+		script["switch"]["in"][0]["value"].setInput( script["add1"]["sum"] )
+		script["switch"]["in"][0]["name"].setValue( "one" )
+		script["switch"]["in"][1]["value"].setInput( script["add2"]["sum"] )
+		script["switch"]["in"][1]["name"].setValue( "two" )
+		script["switch"]["in"][2]["value"].setInput( script["add3"]["sum"] )
+		script["switch"]["in"][2]["name"].setValue( "three" )
+		script["switch"]["in"][2]["enabled"].setValue( False )
+		script["switch"]["in"][3]["value"].setInput( script["add4"]["sum"] )
+		script["switch"]["in"][3]["name"].setValue( "four" )
+		script["switch"]["in"][4]["value"].setInput( script["add5"]["sum"] )
+		script["switch"]["in"][4]["name"].setValue( "five" )
+
+		script["add6"] = GafferTest.AddNode()
+		script["add6"]["op1"].setInput( script["switch"]["out"]["value"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["add6"], context )
+
+		# Default input `name` and `enabled` are never evaluated and `value`
+		# isn't currently active.
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0]["name"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][0]["value"] ) )
+		# Next input should be evaluated, but it doesn't match so `value`
+		# won't be active.
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][1]["name"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][1]["value"] ) )
+		# Next input would be evaluated, but it is disabled so `name` isn't evaluated.
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][2]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][2]["name"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][2]["value"] ) )
+		# Next input will be evaluated and will match, so `value` will be active too.
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][3]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][3]["name"] ) )
+		self.assertTrue( tracker.isTracked( script["switch"]["in"][3]["value"] ) )
+		# Last input will be ignored because a match has already been found.
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][4]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][4]["name"] ) )
+		self.assertFalse( tracker.isTracked( script["switch"]["in"][4]["value"] ) )
+
+		script["switch"]["enabled"].setValue( False )
+
+		for plug in list( Gaffer.NameValuePlug.Range( script["switch"]["in"] ) ) :
+			self.assertFalse( tracker.isTracked( plug["name"] ), plug["name"].fullName() )
+			self.assertFalse( tracker.isTracked( plug["enabled"] ), plug["enabled"].fullName() )
+			self.assertEqual(
+				tracker.isTracked( plug["value"] ),
+				plug["value"].isSame( script["switch"]["in"][0]["value"] ),
+				plug["value"].fullName()
+			)
+
+	def testContextProcessors( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add"] = GafferTest.AddNode()
+
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["add"]["sum"] )
+		script["contextVariables"]["in"].setInput( script["add"]["sum"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["contextVariables"], context )
+
+		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["variables"] ) )
+		self.assertEqual( tracker.context( script["contextVariables"] ), context )
+		self.assertTrue( tracker.isTracked( script["add"] ) )
+		self.assertEqual( tracker.context( script["add"] ), context )
+
+		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
+
+		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["variables"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["variables"][0] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["variables"][0]["name"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["variables"][0]["value"] ) )
+		self.assertEqual( tracker.context( script["contextVariables"] ), context )
+		self.assertTrue( tracker.isTracked( script["add"] ) )
+		self.assertEqual( tracker.context( script["add"] ), script["contextVariables"].inPlugContext() )
+
+		script["contextVariables"]["enabled"].setValue( False )
+
+		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
+		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
+		self.assertFalse( tracker.isTracked( script["contextVariables"]["variables"] ) )
+		self.assertFalse( tracker.isTracked( script["contextVariables"]["variables"][0] ) )
+		self.assertFalse( tracker.isTracked( script["contextVariables"]["variables"][0]["name"] ) )
+		self.assertFalse( tracker.isTracked( script["contextVariables"]["variables"][0]["value"] ) )
+		self.assertEqual( tracker.context( script["contextVariables"] ), context )
+		self.assertTrue( tracker.isTracked( script["add"] ) )
+		self.assertEqual( tracker.context( script["add"] ), context )
+
+	def testContextForInactiveInputs( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["add"] = GafferTest.AddNode()
+		script["add"]["enabled"].setValue( False )
+
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["add"]["sum"] )
+		script["contextVariables"]["in"].setInput( script["add"]["sum"] )
+		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["contextVariables"], context )
+
+		# Even though `op2` is inactive, it still makes most sense to evaluate it
+		# in the modified context, because that is the context it will be active in
+		# if the node is enabled.
+		self.assertFalse( tracker.isTracked( script["add"]["op2"] ) )
+		self.assertEqual( tracker.context( script["add"]["op2"] ), script["contextVariables"].inPlugContext() )
+
+	def testPlugWithoutNode( self ) :
+
+		plug = Gaffer.IntPlug()
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+		script["node"]["op1"].setInput( plug )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["node"], context )
+
+		self.assertTrue( tracker.isTracked( script["node"] ) )
+		self.assertEqual( tracker.context( script["node"] ), context )
+		self.assertTrue( tracker.isTracked( script["node"]["op1"] ) )
+		self.assertEqual( tracker.context( script["node"]["op1"] ), context )
+		self.assertTrue( tracker.isTracked( plug ) )
+		self.assertEqual( tracker.context( plug ), context )
+
+	def testLoop( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["loopSource"] = GafferTest.AddNode()
+		script["loopBody"] = GafferTest.AddNode()
+
+		script["loop"] = Gaffer.Loop()
+		script["loop"].setup( script["loopSource"]["sum"] )
+		script["loop"]["in"].setInput( script["loopSource"]["sum"] )
+
+		script["loopBody"]["op1"].setInput( script["loop"]["previous"] )
+		script["loopBody"]["op2"].setValue( 2 )
+		script["loop"]["next"].setInput( script["loopBody"]["sum"] )
+
+		script["loop"]["iterations"].setValue( 10 )
+		self.assertEqual( script["loop"]["out"].getValue(), 20 )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["loop"], context )
+
+		self.assertTrue( tracker.isTracked( script["loop"] ) )
+		self.assertEqual( tracker.context( script["loop"] ), context )
+		self.assertTrue( tracker.isTracked( script["loop"]["iterations"] ) )
+		self.assertEqual( tracker.context( script["loop"]["iterations"] ), context )
+		self.assertTrue( tracker.isTracked( script["loop"]["indexVariable"] ) )
+		self.assertEqual( tracker.context( script["loop"]["indexVariable"] ), context )
+		self.assertTrue( tracker.isTracked( script["loopSource"] ) )
+		self.assertEqual( tracker.context( script["loopSource"] ), context )
+		self.assertTrue( tracker.isTracked( script["loop"]["next"] ) )
+		lastIterationContext = script["loop"].previousIteration( script["loop"]["out"] )[1]
+		self.assertEqual( tracker.context( script["loop"]["next"] ), lastIterationContext )
+		self.assertTrue( tracker.isTracked( script["loopBody"] ) )
+		self.assertEqual( tracker.context( script["loopBody"] ), lastIterationContext )
+
+		def assertDisabledLoop() :
+
+			self.assertTrue( tracker.isTracked( script["loop"] ) )
+			self.assertEqual( tracker.context( script["loop"] ), context )
+			self.assertEqual( tracker.isTracked( script["loop"]["iterations"] ), script["loop"]["enabled"].getValue() )
+			self.assertEqual( tracker.context( script["loop"]["iterations"] ), context )
+			self.assertEqual( tracker.isTracked( script["loop"]["indexVariable"] ), script["loop"]["enabled"].getValue() )
+			self.assertEqual( tracker.context( script["loop"]["indexVariable"] ), context )
+			self.assertTrue( tracker.isTracked( script["loopSource"] ) )
+			self.assertEqual( tracker.context( script["loopSource"] ), context )
+			self.assertFalse( tracker.isTracked( script["loop"]["next"] ) )
+			self.assertEqual( tracker.context( script["loop"]["next"] ), context )
+			self.assertFalse( tracker.isTracked( script["loopBody"] ) )
+			self.assertEqual( tracker.context( script["loopBody"] ), context )
+
+		script["loop"]["enabled"].setValue( False )
+		assertDisabledLoop()
+
+		script["loop"]["enabled"].setValue( True )
+		script["loop"]["iterations"].setValue( 0 )
+		assertDisabledLoop()
+
+	def testLoopEvaluatesAllIterations( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["loopSource"] = GafferTest.AddNode()
+		script["loopBody"] = GafferTest.AddNode()
+
+		script["loopIndexQuery"] = Gaffer.ContextQuery()
+		indexQuery = script["loopIndexQuery"].addQuery( Gaffer.IntPlug() )
+		indexQuery["name"].setValue( "loop:index" )
+
+		script["loopSwitch"] = Gaffer.Switch()
+		script["loopSwitch"].setup( script["loopBody"]["op1"] )
+		script["loopSwitch"]["index"].setInput( script["loopIndexQuery"]["out"][0]["value"] )
+
+		script["loop"] = Gaffer.Loop()
+		script["loop"].setup( script["loopSource"]["sum"] )
+		script["loop"]["in"].setInput( script["loopSource"]["sum"] )
+
+		script["loopBody"]["op1"].setInput( script["loop"]["previous"] )
+		script["loopBody"]["op2"].setInput( script["loopSwitch"]["out"] )
+		script["loop"]["next"].setInput( script["loopBody"]["sum"] )
+
+		iterations = 10
+		script["loop"]["iterations"].setValue( iterations )
+
+		for i in range( 0, iterations ) :
+			switchInput = GafferTest.AddNode()
+			script[f"switchInput{i}"] = switchInput
+			switchInput["op1"].setValue( i )
+			script["loopSwitch"]["in"][i].setInput( switchInput["sum"] )
+
+		self.assertEqual( script["loop"]["out"].getValue(), sum( range( 0, iterations ) ) )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["loop"], context )
+
+		for i in range( 0, iterations ) :
+			switchInput = script["loopSwitch"]["in"][i]
+			self.assertTrue( tracker.isTracked( switchInput ), switchInput.fullName() )
+			self.assertEqual( tracker.context( switchInput )["loop:index"], i )
+			self.assertTrue( tracker.isTracked( switchInput.source() ), switchInput.source().fullName() )
+			self.assertEqual( tracker.context(  switchInput.source() )["loop:index"], i )
+			self.assertTrue( tracker.isTracked( switchInput.source().node() ), switchInput.source().node().fullName() )
+			self.assertEqual( tracker.context( switchInput.source().node() )["loop:index"], i )
+
+	def testMultiplexedBox( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["addA"] = GafferTest.AddNode()
+		script["addB"] = GafferTest.AddNode()
+
+		script["box"] = Gaffer.Box()
+		script["box"]["addA"] = GafferTest.AddNode()
+		script["box"]["addB"] = GafferTest.AddNode()
+
+		Gaffer.PlugAlgo.promoteWithName( script["box"]["addA"]["op1"], "opA" )
+		Gaffer.PlugAlgo.promoteWithName( script["box"]["addB"]["op1"], "opB" )
+		script["box"]["opA"].setInput( script["addA"]["sum"] )
+		script["box"]["opB"].setInput( script["addB"]["sum"] )
+
+		Gaffer.PlugAlgo.promoteWithName( script["box"]["addA"]["sum"], "sumA" )
+		Gaffer.PlugAlgo.promoteWithName( script["box"]["addB"]["sum"], "sumB" )
+		script["box"]["sumA"].setInput( script["box"]["addA"]["sum"] )
+		script["box"]["sumB"].setInput( script["box"]["addB"]["sum"] )
+
+		script["resultA"] = GafferTest.AddNode()
+		script["resultA"]["op1"].setInput( script["box"]["sumA"] )
+
+		script["resultB"] = GafferTest.AddNode()
+		script["resultB"]["op1"].setInput( script["box"]["sumB"] )
+
+		context = Gaffer.Context()
+		tracker = GafferUI.ContextTracker( script["resultA"], context )
+
+		self.assertTrue( tracker.isTracked( script["resultA"] ) )
+		self.assertFalse( tracker.isTracked( script["resultB"] ) )
+		self.assertTrue( tracker.isTracked( script["box"]["sumA"] ) )
+		self.assertFalse( tracker.isTracked( script["box"]["sumB"] ) )
+		self.assertTrue( tracker.isTracked( script["box"] ) )
+		self.assertTrue( tracker.isTracked( script["box"]["addA"] ) )
+		self.assertFalse( tracker.isTracked( script["box"]["addB"] ) )
+		self.assertTrue( tracker.isTracked( script["box"]["opA"] ) )
+		self.assertFalse( tracker.isTracked( script["box"]["opB"] ) )
+		self.assertTrue( tracker.isTracked( script["addA"] ) )
+		self.assertFalse( tracker.isTracked( script["addB"] ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUITest/ContextTrackerTest.py
+++ b/python/GafferUITest/ContextTrackerTest.py
@@ -34,7 +34,11 @@
 #
 ##########################################################################
 
+import inspect
+import threading
 import unittest
+
+import IECore
 
 import Gaffer
 import GafferTest
@@ -42,6 +46,15 @@ import GafferUI
 import GafferUITest
 
 class ContextTrackerTest( GafferUITest.TestCase ) :
+
+	class UpdateHandler( GafferTest.ParallelAlgoTest.UIThreadCallHandler ) :
+
+		def __exit__( self, type, value, traceBack ) :
+
+			GafferUITest.TestCase().waitForIdle()
+			self.assertCalled()
+
+			GafferTest.ParallelAlgoTest.UIThreadCallHandler.__exit__( self, type, value, traceBack )
 
 	def testSimpleNodes( self ) :
 
@@ -58,7 +71,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["add4"]["op1"].setInput( script["add3"]["sum"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["add4"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["add4"], context )
 
 		def assertExpectedContexts() :
 
@@ -79,7 +93,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		for graphComponent in [ script["unconnected"], script["unconnected"]["op1"], script["unconnected"]["op2"], script["unconnected"]["sum"], script["unconnected"]["enabled"] ] :
 			self.assertFalse( tracker.isTracked( graphComponent ) )
 
-		script["add3"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["add3"]["enabled"].setValue( False )
 
 		assertExpectedContexts( )
 
@@ -105,7 +120,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["switch"]["in"][1].setInput( script["add2"]["sum"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["switch"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["switch"], context )
 
 		def assertExpectedContexts() :
 
@@ -128,7 +144,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["add1"] ) )
 		self.assertFalse( tracker.isTracked( script["add2"] ) )
 
-		script["switch"]["index"].setValue( 1 )
+		with self.UpdateHandler()  :
+			script["switch"]["index"].setValue( 1 )
 
 		assertExpectedContexts()
 
@@ -141,7 +158,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertFalse( tracker.isTracked( script["add1"] ) )
 		self.assertTrue( tracker.isTracked( script["add2"] ) )
 
-		script["switch"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["switch"]["enabled"].setValue( False )
 
 		assertExpectedContexts()
 
@@ -156,9 +174,10 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 
 		# Dynamic case - switch will compute input on the fly.
 
-		script["add3"] = GafferTest.AddNode()
-		script["switch"]["index"].setInput( script["add3"]["sum"] )
-		script["switch"]["enabled"].setValue( True )
+		with self.UpdateHandler()  :
+			script["add3"] = GafferTest.AddNode()
+			script["switch"]["index"].setInput( script["add3"]["sum"] )
+			script["switch"]["enabled"].setValue( True )
 
 		assertExpectedContexts()
 
@@ -173,7 +192,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["add3"] ) )
 		self.assertEqual( tracker.context( script["add3"] ), context )
 
-		script["add3"]["op1"].setValue( 1 )
+		with self.UpdateHandler()  :
+			script["add3"]["op1"].setValue( 1 )
 
 		assertExpectedContexts()
 
@@ -204,7 +224,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["switch"]["in"][1]["name"].setValue( "add2" )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["switch"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["switch"], context )
 
 		def assertExpectedContexts() :
 
@@ -226,7 +247,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["add1"] ) )
 		self.assertFalse( tracker.isTracked( script["add2"] ) )
 
-		script["switch"]["selector"].setValue( "add2" )
+		with self.UpdateHandler()  :
+			script["switch"]["selector"].setValue( "add2" )
 
 		assertExpectedContexts()
 
@@ -238,7 +260,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertFalse( tracker.isTracked( script["add1"] ) )
 		self.assertTrue( tracker.isTracked( script["add2"] ) )
 
-		script["switch"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["switch"]["enabled"].setValue( False )
 
 		assertExpectedContexts()
 
@@ -252,9 +275,10 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 
 		# Dynamic case - switch will compute input on the fly.
 
-		stringNode = GafferTest.StringInOutNode()
-		script["switch"]["selector"].setInput( stringNode["out"] )
-		script["switch"]["enabled"].setValue( True )
+		with self.UpdateHandler()  :
+			stringNode = GafferTest.StringInOutNode()
+			script["switch"]["selector"].setInput( stringNode["out"] )
+			script["switch"]["enabled"].setValue( True )
 
 		assertExpectedContexts()
 
@@ -268,7 +292,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( stringNode ) )
 		self.assertEqual( tracker.context( stringNode ), context )
 
-		stringNode["in"].setValue( "add2" )
+		with self.UpdateHandler()  :
+			stringNode["in"].setValue( "add2" )
 
 		assertExpectedContexts()
 
@@ -306,7 +331,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["add3"]["op2"].setInput( script["contextVariables"]["out"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["add3"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["add3"], context )
 
 		self.assertEqual( tracker.context( script["add3"] ), context )
 		self.assertEqual( tracker.context( script["switch"] ), context )
@@ -345,7 +371,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["add6"]["op1"].setInput( script["switch"]["out"]["value"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["add6"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["add6"], context )
 
 		# Default input `name` and `enabled` are never evaluated and `value`
 		# isn't currently active.
@@ -370,7 +397,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertFalse( tracker.isTracked( script["switch"]["in"][4]["name"] ) )
 		self.assertFalse( tracker.isTracked( script["switch"]["in"][4]["value"] ) )
 
-		script["switch"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["switch"]["enabled"].setValue( False )
 
 		for plug in list( Gaffer.NameValuePlug.Range( script["switch"]["in"] ) ) :
 			self.assertFalse( tracker.isTracked( plug["name"] ), plug["name"].fullName() )
@@ -392,7 +420,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["contextVariables"]["in"].setInput( script["add"]["sum"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["contextVariables"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["contextVariables"], context )
 
 		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
 		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
@@ -401,7 +430,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["add"] ) )
 		self.assertEqual( tracker.context( script["add"] ), context )
 
-		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
+		with self.UpdateHandler()  :
+			script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
 
 		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
 		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
@@ -413,7 +443,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isTracked( script["add"] ) )
 		self.assertEqual( tracker.context( script["add"] ), script["contextVariables"].inPlugContext() )
 
-		script["contextVariables"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["contextVariables"]["enabled"].setValue( False )
 
 		self.assertTrue( tracker.isTracked( script["contextVariables"] ) )
 		self.assertTrue( tracker.isTracked( script["contextVariables"]["enabled"] ) )
@@ -438,7 +469,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "test", 2 ) )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["contextVariables"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["contextVariables"], context )
 
 		# Even though `op2` is inactive, it still makes most sense to evaluate it
 		# in the modified context, because that is the context it will be active in
@@ -455,7 +487,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["node"]["op1"].setInput( plug )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["node"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["node"], context )
 
 		self.assertTrue( tracker.isTracked( script["node"] ) )
 		self.assertEqual( tracker.context( script["node"] ), context )
@@ -483,7 +516,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertEqual( script["loop"]["out"].getValue(), 20 )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["loop"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["loop"], context )
 
 		self.assertTrue( tracker.isTracked( script["loop"] ) )
 		self.assertEqual( tracker.context( script["loop"] ), context )
@@ -514,11 +548,13 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 			self.assertFalse( tracker.isTracked( script["loopBody"] ) )
 			self.assertEqual( tracker.context( script["loopBody"] ), context )
 
-		script["loop"]["enabled"].setValue( False )
+		with self.UpdateHandler()  :
+			script["loop"]["enabled"].setValue( False )
 		assertDisabledLoop()
 
-		script["loop"]["enabled"].setValue( True )
-		script["loop"]["iterations"].setValue( 0 )
+		with self.UpdateHandler()  :
+			script["loop"]["enabled"].setValue( True )
+			script["loop"]["iterations"].setValue( 0 )
 		assertDisabledLoop()
 
 	def testLoopEvaluatesAllIterations( self ) :
@@ -556,7 +592,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertEqual( script["loop"]["out"].getValue(), sum( range( 0, iterations ) ) )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["loop"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["loop"], context )
 
 		for i in range( 0, iterations ) :
 			switchInput = script["loopSwitch"]["in"][i]
@@ -595,7 +632,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["resultB"]["op1"].setInput( script["box"]["sumB"] )
 
 		context = Gaffer.Context()
-		tracker = GafferUI.ContextTracker( script["resultA"], context )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker( script["resultA"], context )
 
 		self.assertTrue( tracker.isTracked( script["resultA"] ) )
 		self.assertFalse( tracker.isTracked( script["resultB"] ) )
@@ -616,12 +654,14 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		script["add1"] = GafferTest.AddNode()
 		script["add2"] = GafferTest.AddNode()
 
-		tracker1 = GafferUI.ContextTracker.acquire( script["add1"] )
+		with self.UpdateHandler()  :
+			tracker1 = GafferUI.ContextTracker.acquire( script["add1"] )
 		self.assertTrue( tracker1.isSame( GafferUI.ContextTracker.acquire( script["add1"] ) ) )
 		self.assertTrue( tracker1.isTracked( script["add1"] ) )
 		self.assertFalse( tracker1.isTracked( script["add2"] ) )
 
-		tracker2 = GafferUI.ContextTracker.acquire( script["add2"] )
+		with self.UpdateHandler()  :
+			tracker2 = GafferUI.ContextTracker.acquire( script["add2"] )
 		self.assertTrue( tracker2.isSame( GafferUI.ContextTracker.acquire( script["add2"] ) ) )
 		self.assertTrue( tracker2.isTracked( script["add2"] ) )
 		self.assertFalse( tracker2.isTracked( script["add1"] ) )
@@ -634,7 +674,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		nodeSlots = script["node"].plugDirtiedSignal().numSlots()
 		nodeRefCount = script["node"].refCount()
 
-		tracker = GafferUI.ContextTracker.acquire( script["node"] )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker.acquire( script["node"] )
 		del tracker
 
 		# Indicates that `tracker` was truly destroyed.
@@ -642,7 +683,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertEqual( script["node"].refCount(), nodeRefCount )
 
 		# Should be a whole new instance.
-		tracker = GafferUI.ContextTracker.acquire( script["node"] )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker.acquire( script["node"] )
 		self.assertTrue( tracker.isTracked( script["node"] ) )
 
 	def testAcquireForFocus( self ) :
@@ -658,11 +700,13 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertFalse( tracker.isTracked( script["add1" ] ) )
 		self.assertFalse( tracker.isTracked( script["add2" ] ) )
 
-		script.setFocus( script["add1"] )
+		with self.UpdateHandler()  :
+			script.setFocus( script["add1"] )
 		self.assertTrue( tracker.isTracked( script["add1" ] ) )
 		self.assertFalse( tracker.isTracked( script["add2" ] ) )
 
-		script.setFocus( script["add2"] )
+		with self.UpdateHandler()  :
+			script.setFocus( script["add2"] )
 		self.assertFalse( tracker.isTracked( script["add1" ] ) )
 		self.assertTrue( tracker.isTracked( script["add2" ] ) )
 
@@ -686,7 +730,8 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		# Should be a whole new instance.
 		script["node"] = GafferTest.MultiplyNode()
 		script.setFocus( script["node"] )
-		tracker = GafferUI.ContextTracker.acquireForFocus( script )
+		with self.UpdateHandler()  :
+			tracker = GafferUI.ContextTracker.acquireForFocus( script )
 		self.assertTrue( tracker.isTracked( script["node"] ) )
 
 	def testAcquireNone( self ) :
@@ -705,6 +750,156 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertFalse( tracker1.isTracked( node["sum"] ) )
 		self.assertEqual( tracker1.context( node ), tracker1.targetContext() )
 		self.assertEqual( tracker1.context( node["sum"] ), tracker1.targetContext() )
+
+	def testCancellation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["node"] = GafferTest.AddNode()
+
+		ContextTrackerTest.expressionStartedCondition = threading.Condition()
+
+		script["expression"] = Gaffer.Expression()
+		script["expression"].setExpression( inspect.cleandoc(
+			"""
+			import IECore
+			import GafferUITest
+
+			if context.get( "waitForCancellation", True ) :
+
+				# Let the test know the expression has started running.
+				with GafferUITest.ContextTrackerTest.expressionStartedCondition :
+					GafferUITest.ContextTrackerTest.expressionStartedCondition.notify()
+
+				# Loop forever unless we're cancelled
+				while True :
+					IECore.Canceller.check( context.canceller() )
+
+			parent["node"]["enabled"] = True
+			"""
+		) )
+
+		# Start an update, and wait for the expression to start on the
+		# background thread.
+
+		context = Gaffer.Context()
+		with ContextTrackerTest.expressionStartedCondition :
+			tracker = GafferUI.ContextTracker( script["node"], context )
+			self.waitForIdle()
+			ContextTrackerTest.expressionStartedCondition.wait()
+
+		# The update won't have completed because the expression is stuck.
+		self.assertFalse( tracker.isTracked( script["node"] ) )
+
+		# Make a graph edit that will cancel the expression and restart
+		# the background task.
+
+		with ContextTrackerTest.expressionStartedCondition :
+			with GafferTest.ParallelAlgoTest.UIThreadCallHandler() as handler :
+				script["node"]["op1"].setValue( 1 )
+				handler.assertCalled() # Handle UI thread call made when background task detects cancellation.
+				self.waitForIdle() # Handle idle event used to restart update.
+				ContextTrackerTest.expressionStartedCondition.wait()
+
+		# Again, the update won't have completed because the expression is stuck.
+		self.assertFalse( tracker.isTracked( script["node"] ) )
+
+		# Make a context edit that will cancel the expression and restart the
+		# background task.
+
+		with self.UpdateHandler() as handler :
+			context["waitForCancellation"] = False
+			# Handles UI thread call made when background task is cancelled.
+			handler.assertCalled()
+			# `handler.__exit__()` then handles the events needed to restart
+			# and successfully complete the update.
+
+		# This time we expect the update to have finished successfully.
+
+		self.assertTrue( tracker.isTracked( script["node"] ) )
+
+	def testNoCancellersInCapturedContexts( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["add"] = GafferTest.AddNode()
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["add"]["sum"] )
+		script["contextVariables"]["in"].setInput( script["add"]["sum"] )
+		script["contextVariables"].addChild( Gaffer.NameValuePlug( "test", "test" ) )
+
+		context = Gaffer.Context()
+		with self.UpdateHandler() :
+			tracker = GafferUI.ContextTracker( script["contextVariables"], context )
+
+		for g in Gaffer.GraphComponent.Range( script ) :
+			self.assertIsNone( tracker.context( g ).canceller(), g.fullName() )
+
+	def testBadChangedSlot( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["add"] = GafferTest.AddNode()
+
+		context = Gaffer.Context()
+		with self.UpdateHandler() :
+			tracker = GafferUI.ContextTracker( script["add"], context )
+
+		callsMade = 0
+		def slot( tracker ) :
+
+			nonlocal callsMade
+			callsMade += 1
+			if callsMade == 2 :
+				raise RuntimeError( "Bad callback" )
+
+		for i in range( 0, 10 ) :
+			tracker.changedSignal().connect( slot, scoped = False )
+
+		with IECore.CapturingMessageHandler() as mh :
+			with self.UpdateHandler() :
+				script["add"]["op1"].setValue( 1 )
+
+		# One bad slot in the middle shouldn't prevent other slots being
+		# invoked. Instead, the error should just be reported as a message.
+
+		self.assertEqual( callsMade, 10 )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertIn( "RuntimeError: Bad callback", mh.messages[0].message )
+
+	def testDeleteDuringUpdate( self ) :
+
+		for i in range( 0, 10 ) :
+
+			script = Gaffer.ScriptNode()
+			script["add"] = GafferTest.AddNode()
+
+			ContextTrackerTest.expressionStartedCondition = threading.Condition()
+
+			script["expression"] = Gaffer.Expression()
+			script["expression"].setExpression(
+				inspect.cleandoc(
+					"""
+					import GafferUITest
+					with GafferUITest.ContextTrackerTest.expressionStartedCondition :
+						GafferUITest.ContextTrackerTest.expressionStartedCondition.notify()
+
+					# Loop forever unless we're cancelled
+					while True :
+						IECore.Canceller.check( context.canceller() )
+
+					parent["add"]["enabled"] = True
+					"""
+				)
+			)
+
+			context = Gaffer.Context()
+
+			with ContextTrackerTest.expressionStartedCondition :
+				tracker = GafferUI.ContextTracker( script["add"], context )
+				# Wait for the background update to start.
+				GafferUITest.TestCase().waitForIdle()
+				ContextTrackerTest.expressionStartedCondition.wait()
+
+			# Blow everything away while the background update is still going on.
+			del tracker
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/__init__.py
+++ b/python/GafferUITest/__init__.py
@@ -134,6 +134,7 @@ from .BoxIOUITest import BoxIOUITest
 from .AnnotationsGadgetTest import AnnotationsGadgetTest
 from .PopupWindowTest import PopupWindowTest
 from .ColorChooserTest import ColorChooserTest
+from .ContextTrackerTest import ContextTrackerTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -443,7 +443,7 @@ IECore::MurmurHash Context::hash() const
 
 bool Context::operator == ( const Context &other ) const
 {
-	return m_map == other.m_map;
+	return this == &other || m_map == other.m_map;
 }
 
 bool Context::operator != ( const Context &other ) const

--- a/src/Gaffer/Loop.cpp
+++ b/src/Gaffer/Loop.cpp
@@ -193,6 +193,29 @@ ContextPtr Loop::nextIterationContext() const
 	return nullptr;
 }
 
+std::pair<const ValuePlug *, ContextPtr> Loop::previousIteration( const ValuePlug *output ) const
+{
+	int index = -1;
+	IECore::InternedString indexVariable;
+	if( const ValuePlug *plug = sourcePlug( output, Context::current(), index, indexVariable ) )
+	{
+		ContextPtr context = new Context( *Context::current() );
+
+		if( index >= 0 )
+		{
+			context->set( indexVariable, index );
+		}
+		else
+		{
+			context->remove( indexVariable );
+		}
+
+		return { plug, context };
+	}
+
+	return { nullptr, nullptr };
+}
+
 void Loop::affects( const Plug *input, DependencyNode::AffectedPlugsContainer &outputs ) const
 {
 	ComputeNode::affects( input, outputs );

--- a/src/GafferModule/ContextProcessorBinding.cpp
+++ b/src/GafferModule/ContextProcessorBinding.cpp
@@ -76,6 +76,17 @@ ContextPtr nextIterationContextWrapper( Loop &loop )
 	return loop.nextIterationContext();
 }
 
+object previousIterationWrapper( Loop &loop, const Gaffer::ValuePlug &output )
+{
+	std::pair<const ValuePlug *, ContextPtr> result;
+	{
+		IECorePython::ScopedGILRelease gilRelease;
+		result = loop.previousIteration( &output );
+	}
+	return boost::python::make_tuple( ValuePlugPtr( const_cast<ValuePlug *>( result.first ) ), result.second );
+}
+
+
 ContextPtr inPlugContext( const ContextProcessor &n )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -196,6 +207,7 @@ void GafferModule::bindContextProcessor()
 	DependencyNodeClass<Loop>()
 		.def( "setup", &setupLoop )
 		.def( "nextIterationContext", &nextIterationContextWrapper )
+		.def( "previousIteration", &previousIterationWrapper )
 	;
 
 	DependencyNodeClass<ContextProcessor>()

--- a/src/GafferUI/ContextTracker.cpp
+++ b/src/GafferUI/ContextTracker.cpp
@@ -1,0 +1,344 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferUI/ContextTracker.h"
+
+#include "Gaffer/Context.h"
+#include "Gaffer/ContextVariables.h"
+#include "Gaffer/Loop.h"
+#include "Gaffer/NameSwitch.h"
+#include "Gaffer/Switch.h"
+
+#include "boost/algorithm/string.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/bind/bind.hpp"
+#include "boost/bind/placeholders.hpp"
+
+#include <unordered_set>
+
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace IECore;
+using namespace boost::placeholders;
+using namespace std;
+
+ContextTracker::ContextTracker( const Gaffer::NodePtr &node, const Gaffer::ContextPtr &context )
+	:	m_node( node ), m_context( context )
+{
+	node->plugDirtiedSignal().connect( boost::bind( &ContextTracker::plugDirtied, this, ::_1 ) );
+	context->changedSignal().connect( boost::bind( &ContextTracker::contextChanged, this, ::_2 ) );
+	update();
+}
+
+ContextTracker::~ContextTracker()
+{
+	disconnectTrackedConnections();
+}
+
+const Gaffer::Node *ContextTracker::targetNode() const
+{
+	return m_node.get();
+}
+
+const Gaffer::Context *ContextTracker::targetContext() const
+{
+	return m_context.get();
+}
+
+bool ContextTracker::isTracked( const Gaffer::Plug *plug ) const
+{
+	if( findPlugContext( plug ) )
+	{
+		return true;
+	}
+
+	if( plug->direction() != Plug::In )
+	{
+		return false;
+	}
+
+	auto it = m_nodeContexts.find( plug->node() );
+	return it != m_nodeContexts.end() && it->second.allInputsActive;
+}
+
+bool ContextTracker::isTracked( const Gaffer::Node *node ) const
+{
+	return m_nodeContexts.find( node ) != m_nodeContexts.end();
+}
+
+Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Plug *plug ) const
+{
+	if( const Context *c = findPlugContext( plug ) )
+	{
+		return c;
+	}
+
+	return context( plug->node() );
+}
+
+Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Node *node ) const
+{
+	auto it = m_nodeContexts.find( node );
+	return it != m_nodeContexts.end() ? it->second.context : m_context;
+}
+
+void ContextTracker::plugDirtied( const Gaffer::Plug *plug )
+{
+	update();
+}
+
+void ContextTracker::contextChanged( IECore::InternedString variable )
+{
+	update();
+}
+
+void ContextTracker::update()
+{
+	m_nodeContexts.clear();
+	m_plugContexts.clear();
+
+	std::deque<std::pair<const Plug *, ConstContextPtr>> toVisit;
+
+	for( Plug::RecursiveOutputIterator it( m_node.get() ); !it.done(); ++it )
+	{
+		toVisit.push_back( { it->get(), m_context } );
+		it.prune();
+	}
+
+	std::unordered_set<MurmurHash> visited;
+
+	while( !toVisit.empty() )
+	{
+		// Get next plug to visit, and early out if we've already visited it in
+		// this context.
+
+		auto [plug, context] = toVisit.front();
+		toVisit.pop_front();
+
+		MurmurHash visitHash = context->hash();
+		visitHash.append( (uintptr_t)plug );
+		if( !visited.insert( visitHash ).second )
+		{
+			continue;
+		}
+
+		// If this is the first time we have visited the node and/or plug, then
+		// record the context.
+
+		const Node *node = plug->node();
+		NodeData &nodeData = m_nodeContexts[node];
+		if( !nodeData.context )
+		{
+			nodeData.context = context;
+		}
+
+		if( !node || plug->direction() == Plug::Out || !nodeData.allInputsActive || *context != *nodeData.context  )
+		{
+			m_plugContexts.insert( { plug, context } );
+		}
+
+		// Arrange to visit any inputs to this plug, including
+		// inputs to its descendants.
+
+		if( auto input = plug->getInput() )
+		{
+			toVisit.push_back( { input, context } );
+		}
+		else
+		{
+			for( Plug::RecursiveInputIterator it( plug ); !it.done(); ++it )
+			{
+				if( auto input = (*it)->getInput() )
+				{
+					toVisit.push_back( { input, context } );
+					it.prune();
+				}
+			}
+		}
+
+		// If the plug isn't an output plug on a node, or it has an input
+		// connection, then we're done here and can continue to the next one.
+
+		if( plug->direction() != Plug::Out || !plug->node() )
+		{
+			continue;
+		}
+
+		Context::Scope scopedContext( context.get() );
+
+		if( plug->getInput() )
+		{
+			// The plug value isn't computed, so we _should_ be done. But
+			// there's a wrinkle : switches have an optimisation where they make
+			// a pass-through connection to avoid the compute when the index is
+			// constant. We still consider the `index` plug to be active in this
+			// case, so need to manually add it to the traversal.
+			if( auto switchNode = runTimeCast<const Switch>( node ) )
+			{
+				if( plug == switchNode->outPlug() || switchNode->outPlug()->isAncestorOf( plug ) )
+				{
+					toVisit.push_back( { switchNode->enabledPlug(), context } );
+					if( switchNode->enabledPlug()->getValue() )
+					{
+						toVisit.push_back( { switchNode->indexPlug(), context } );
+					}
+				}
+			}
+			continue;
+		}
+
+		// Plug is an output whose value may be computed. We want to visit only
+		// the input plugs that will be used by the compute, accounting for any
+		// changes in context the compute will make. A few special cases for the
+		// most common nodes are sufficient to provide the user with good
+		// feedback about what parts of the graph are active.
+
+		if( auto dependencyNode = runTimeCast<const DependencyNode>( node ) )
+		{
+			if( auto enabledPlug = dependencyNode->enabledPlug() )
+			{
+				if( !enabledPlug->getValue() )
+				{
+					// Node is disabled, so we only need to visit the
+					// pass-through input, if any.
+					if( auto inPlug = dependencyNode->correspondingInput( plug ) )
+					{
+						toVisit.push_back( { inPlug, context } );
+						toVisit.push_back( { enabledPlug, context } );
+					}
+					continue;
+				}
+			}
+		}
+
+		if( auto nameSwitch = runTimeCast<const NameSwitch>( node ) )
+		{
+			if( plug == nameSwitch->getChild<Plug>( "__outIndex" ) )
+			{
+				toVisit.push_back( { nameSwitch->selectorPlug(), context } );
+				const string selector = nameSwitch->selectorPlug()->getValue();
+				if( const ArrayPlug *in = nameSwitch->inPlugs() )
+				{
+					for( int i = 1, e = in->children().size(); i < e; ++i )
+					{
+						auto p = in->getChild<NameValuePlug>( i );
+						toVisit.push_back( { p->enabledPlug(), context } );
+						if( !p->enabledPlug()->getValue() )
+						{
+							continue;
+						}
+						const string name = p->namePlug()->getValue();
+						toVisit.push_back( { p->namePlug(), context } );
+						if( !name.empty() && StringAlgo::matchMultiple( selector, name ) )
+						{
+							break;
+						}
+					}
+				}
+				continue;
+			}
+			// Fall through so other outputs are covered by the Switch
+			// base class handling below.
+		}
+
+		if( auto switchNode = runTimeCast<const Switch>( node ) )
+		{
+			if( const Plug *activeIn = switchNode->activeInPlug( plug ) )
+			{
+				toVisit.push_back( { switchNode->enabledPlug(), context } );
+				toVisit.push_back( { switchNode->indexPlug(), context } );
+				toVisit.push_back( { activeIn, context } );
+			}
+			continue;
+		}
+
+		if( auto contextProcessor = runTimeCast<const ContextProcessor>( node ) )
+		{
+			if( plug == contextProcessor->outPlug() )
+			{
+				// Assume all input plugs are used to generate the context.
+				nodeData.allInputsActive = true;
+				// Visit main input in processed context.
+				ConstContextPtr inContext = contextProcessor->inPlugContext();
+				toVisit.push_back( { contextProcessor->inPlug(), inContext } );
+			}
+			continue;
+		}
+
+		if( auto loop = runTimeCast<const Loop>( node ) )
+		{
+			if( auto valuePlug = runTimeCast<const ValuePlug>( plug ) )
+			{
+				auto [previousPlug, previousContext] = loop->previousIteration( valuePlug );
+				if( previousPlug )
+				{
+					toVisit.push_back( { loop->indexVariablePlug(), context } );
+					if( plug == loop->outPlug() || loop->outPlug()->isAncestorOf( plug ) )
+					{
+						toVisit.push_back( { loop->iterationsPlug(), context } );
+					}
+					toVisit.push_back( { previousPlug, previousContext } );
+				}
+			}
+			continue;
+		}
+
+		// Generic behaviour for all other nodes : assume the compute depends on
+		// every input plug.
+
+		for( const auto &inputPlug : Plug::InputRange( *node ) )
+		{
+			nodeData.allInputsActive = true;
+			toVisit.push_back( { inputPlug.get(), context } );
+		}
+	}
+}
+
+const Gaffer::Context *ContextTracker::findPlugContext( const Gaffer::Plug *plug ) const
+{
+	while( plug )
+	{
+		auto it = m_plugContexts.find( plug );
+		if( it != m_plugContexts.end() )
+		{
+			return it->second.get();
+		}
+
+		plug = plug->parent<Plug>();
+	}
+
+	return nullptr;
+}

--- a/src/GafferUI/ContextTracker.cpp
+++ b/src/GafferUI/ContextTracker.cpp
@@ -36,10 +36,15 @@
 
 #include "GafferUI/ContextTracker.h"
 
+#include "GafferUI/Gadget.h"
+
+#include "Gaffer/BackgroundTask.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextVariables.h"
 #include "Gaffer/Loop.h"
 #include "Gaffer/NameSwitch.h"
+#include "Gaffer/ParallelAlgo.h"
+#include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Switch.h"
 
@@ -122,6 +127,7 @@ ContextTracker::~ContextTracker()
 	sharedInstances().get<1>().erase( this );
 	sharedFocusInstances().get<1>().erase( this );
 	disconnectTrackedConnections();
+	m_updateTask.reset();
 }
 
 ContextTrackerPtr ContextTracker::acquire( const Gaffer::NodePtr &node )
@@ -172,6 +178,11 @@ ContextTrackerPtr ContextTracker::acquireForFocus( Gaffer::ScriptNode *script )
 
 void ContextTracker::updateNode( const Gaffer::NodePtr &node )
 {
+	if( node == m_node )
+	{
+		return;
+	}
+
 	m_plugDirtiedConnection.disconnect();
 	m_node = node;
 	if( m_node )
@@ -179,7 +190,7 @@ void ContextTracker::updateNode( const Gaffer::NodePtr &node )
 		m_plugDirtiedConnection = node->plugDirtiedSignal().connect( boost::bind( &ContextTracker::plugDirtied, this, ::_1 ) );
 	}
 
-	update();
+	scheduleUpdate();
 }
 
 const Gaffer::Node *ContextTracker::targetNode() const
@@ -190,6 +201,145 @@ const Gaffer::Node *ContextTracker::targetNode() const
 const Gaffer::Context *ContextTracker::targetContext() const
 {
 	return m_context.get();
+}
+
+void ContextTracker::scheduleUpdate()
+{
+	// Cancel old update.
+	m_updateTask.reset();
+
+	if( !m_node )
+	{
+		// Don't need a BackgroundTask, so just do the update directly on the UI
+		// thread.
+		m_nodeContexts.clear();
+		m_plugContexts.clear();
+		m_idleConnection.disconnect();
+		changedSignal()( *this );
+		return;
+	}
+
+	if( !m_node->scriptNode() )
+	{
+		// ScriptNode is dying. Can't use a BackgroundTask and no need for
+		// update anyway.
+		m_idleConnection.disconnect();
+		return;
+	}
+
+	if( m_idleConnection.connected() )
+	{
+		// Update already scheduled.
+		return;
+	}
+
+	// Arrange to do the update on the next idle event. This allows us to avoid
+	// redundant restarts when `plugDirtied()` or `contextChanged()` is called
+	// multiple times in quick succession.
+
+	m_idleConnection = Gadget::idleSignal().connect(
+		[thisRef = Ptr( this )] () {
+			thisRef->updateInBackground();
+		}
+	);
+}
+
+void ContextTracker::updateInBackground()
+{
+	m_idleConnection.disconnect();
+
+	// Seed the list of plugs to visit with all the outputs of our node.
+	// We must take a copy of the context for this, because it will be used
+	// on the background thread and the original context may be modified on
+	// the main thread.
+	ConstContextPtr contextCopy = new Context( *m_context );
+	std::deque<std::pair<const Plug *, ConstContextPtr>> toVisit;
+	if( m_node )
+	{
+		for( Plug::RecursiveOutputIterator it( m_node.get() ); !it.done(); ++it )
+		{
+			toVisit.push_back( { it->get(), contextCopy } );
+			it.prune();
+		}
+	}
+
+	Context::Scope scopedContext( contextCopy.get() );
+	m_updateTask = ParallelAlgo::callOnBackgroundThread(
+
+		/* subject = */ toVisit.empty() ? nullptr : toVisit.back().first,
+
+		// OK to capture `this` without incrementing reference count, because
+		// ~UpstreamContext cancels background task and waits for it to
+		// complete. Therefore `this` will always outlive the task.
+		[toVisit, this] () mutable {
+
+			PlugContexts plugContexts;
+			NodeContexts nodeContexts;
+
+			// Alias for `this` to work around MSVC bug that prevents capturing
+			// `this` again in a nested lambda.
+			ContextTracker *that = this;
+
+			try
+			{
+				ContextTracker::visit( toVisit, nodeContexts, plugContexts, Context::current()->canceller() );
+			}
+			catch( const IECore::Cancelled & )
+			{
+				// Cancellation could be for several reasons :
+				//
+				// 1. A graph edit is being made.
+				// 2. The context has changed or `updateNode()` has been called
+				//    and we're scheduling a new update.
+				// 3. Our reference count has dropped to 0 and we're being
+				//    deleted, and are cancelling the task from our destructor.
+				//
+				// In the first two cases we need to schedule a new update, but
+				// in the last case we mustn't do anything.
+				if( refCount() )
+				{
+					ParallelAlgo::callOnUIThread(
+						// Need to own a reference via `thisRef`, because otherwise we could be deleted
+						// before `callOnUIThread()` gets to us.
+						[thisRef = Ptr( that )] () {
+							thisRef->m_updateTask.reset();
+							thisRef->scheduleUpdate();
+						}
+					);
+				}
+				throw;
+			}
+			catch( const Gaffer::ProcessException &e )
+			{
+				IECore::msg( IECore::Msg::Error, "ContextTracker::updateInBackground", e.what() );
+			}
+
+			if( refCount() )
+			{
+				ParallelAlgo::callOnUIThread(
+					// Need to own a reference via `thisRef`, because otherwise we could be deleted
+					// before `callOnUIThread()` gets to us.
+					[thisRef = Ptr( that ), plugContexts = std::move( plugContexts ), nodeContexts = std::move( nodeContexts )] () mutable {
+						thisRef->m_nodeContexts.swap( nodeContexts );
+						thisRef->m_plugContexts.swap( plugContexts );
+						thisRef->m_updateTask.reset();
+						thisRef->changedSignal()( *thisRef );
+					}
+				);
+			}
+		}
+
+	);
+}
+
+bool ContextTracker::updatePending() const
+{
+	return m_idleConnection.connected() || m_updateTask;
+}
+
+ContextTracker::Signal &ContextTracker::changedSignal()
+{
+	return m_changedSignal;
 }
 
 bool ContextTracker::isTracked( const Gaffer::Plug *plug ) const
@@ -231,38 +381,30 @@ Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Node *node ) cons
 
 void ContextTracker::plugDirtied( const Gaffer::Plug *plug )
 {
-	update();
+	if( plug->direction() == Plug::Out )
+	{
+		scheduleUpdate();
+	}
 }
 
 void ContextTracker::contextChanged( IECore::InternedString variable )
 {
-	update();
+	if( !boost::starts_with( variable.string(), "ui:" ) )
+	{
+		scheduleUpdate();
+	}
 }
 
-void ContextTracker::update()
+void ContextTracker::visit( std::deque<std::pair<const Plug *, ConstContextPtr>> &toVisit, NodeContexts &nodeContexts, PlugContexts &plugContexts, const IECore::Canceller *canceller )
 {
-	m_nodeContexts.clear();
-	m_plugContexts.clear();
-
-	if( !m_node )
-	{
-		return;
-	}
-
-	std::deque<std::pair<const Plug *, ConstContextPtr>> toVisit;
-
-	for( Plug::RecursiveOutputIterator it( m_node.get() ); !it.done(); ++it )
-	{
-		toVisit.push_back( { it->get(), m_context } );
-		it.prune();
-	}
-
 	std::unordered_set<MurmurHash> visited;
 
 	while( !toVisit.empty() )
 	{
 		// Get next plug to visit, and early out if we've already visited it in
-		// this context.
+		// this context or if we have been cancelled.
+
+		IECore::Canceller::check( canceller );
 
 		auto [plug, context] = toVisit.front();
 		toVisit.pop_front();
@@ -277,8 +419,10 @@ void ContextTracker::update()
 		// If this is the first time we have visited the node and/or plug, then
 		// record the context.
 
+		assert( !context->canceller() );
+
 		const Node *node = plug->node();
-		NodeData &nodeData = m_nodeContexts[node];
+		NodeData &nodeData = nodeContexts[node];
 		if( !nodeData.context )
 		{
 			nodeData.context = context;
@@ -286,7 +430,7 @@ void ContextTracker::update()
 
 		if( !node || plug->direction() == Plug::Out || !nodeData.allInputsActive || *context != *nodeData.context  )
 		{
-			m_plugContexts.insert( { plug, context } );
+			plugContexts.insert( { plug, context } );
 		}
 
 		// Arrange to visit any inputs to this plug, including
@@ -316,7 +460,12 @@ void ContextTracker::update()
 			continue;
 		}
 
-		Context::Scope scopedContext( context.get() );
+		// Scope the context we're visiting before evaluating any plug
+		// values. We store contexts without a canceller (ready to return
+		// from `ContextTracker::context()`), so must also scope the canceller
+		// to allow any computes we trigger to be cancelled.
+		Context::EditableScope scopedContext( context.get() );
+		scopedContext.setCanceller( canceller );
 
 		if( plug->getInput() )
 		{
@@ -412,7 +561,7 @@ void ContextTracker::update()
 				nodeData.allInputsActive = true;
 				// Visit main input in processed context.
 				ConstContextPtr inContext = contextProcessor->inPlugContext();
-				toVisit.push_back( { contextProcessor->inPlug(), inContext } );
+				toVisit.push_back( { contextProcessor->inPlug(), new Context( *inContext, /* omitCanceller = */ true ) } );
 			}
 			continue;
 		}
@@ -429,7 +578,7 @@ void ContextTracker::update()
 					{
 						toVisit.push_back( { loop->iterationsPlug(), context } );
 					}
-					toVisit.push_back( { previousPlug, previousContext } );
+					toVisit.push_back( { previousPlug, new Context( *previousContext, /* omitCanceller = */ true ) } );
 				}
 			}
 			continue;

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -54,6 +54,7 @@
 
 #include "Gaffer/Context.h"
 #include "Gaffer/Node.h"
+#include "Gaffer/ScriptNode.h"
 
 using namespace boost::python;
 using namespace IECorePython;
@@ -349,6 +350,8 @@ void GafferUIModule::bindGraphGadget()
 
 	IECorePython::RefCountedClass<ContextTracker, IECore::RefCounted>( "ContextTracker" )
 		.def( init<const NodePtr &, const ContextPtr &>() )
+		.def( "acquire", &ContextTracker::acquire ).staticmethod( "acquire" )
+		.def( "acquireForFocus", &ContextTracker::acquireForFocus ).staticmethod( "acquireForFocus" )
 		.def( "targetNode", &targetNodeWrapper )
 		.def( "targetContext", &targetContextWrapper )
 		.def( "isTracked", (bool (ContextTracker::*)( const Plug *plug ) const)&ContextTracker::isTracked )

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -53,6 +53,7 @@
 #include "GafferBindings/SignalBinding.h"
 
 #include "Gaffer/Context.h"
+#include "Gaffer/DependencyNode.h"
 #include "Gaffer/Node.h"
 #include "Gaffer/ScriptNode.h"
 
@@ -375,6 +376,7 @@ void GafferUIModule::bindGraphGadget()
 			.def( "isTracked", (bool (ContextTracker::*)( const Node *node ) const)&ContextTracker::isTracked )
 			.def( "context", &contextWrapper1, ( arg( "node" ), arg( "_copy" ) = true ) )
 			.def( "context", &contextWrapper2, ( arg( "plug" ), arg( "_copy" ) = true ) )
+			.def( "isEnabled", &ContextTracker::isEnabled )
 			.def( "updatePending", &ContextTracker::updatePending )
 			.def( "changedSignal", &ContextTracker::changedSignal, return_internal_reference<1>() )
 		;

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -59,6 +59,7 @@
 using namespace boost::python;
 using namespace IECorePython;
 using namespace Gaffer;
+using namespace GafferBindings;
 using namespace GafferUI;
 using namespace GafferUIBindings;
 
@@ -233,6 +234,21 @@ ContextPtr targetContextWrapper( const ContextTracker &contextTracker )
 	return const_cast<Context *>( contextTracker.targetContext() );
 }
 
+struct ContextTrackerSlotCaller
+{
+	void operator()( boost::python::object slot, ContextTracker &contextTracker )
+	{
+		try
+		{
+			slot( ContextTrackerPtr( &contextTracker ) );
+		}
+		catch( const boost::python::error_already_set & )
+		{
+			ExceptionAlgo::translatePythonException();
+		}
+	}
+};
+
 ContextPtr contextWrapper1( const ContextTracker &contextTracker, const Node &node, bool copy = false )
 {
 	ConstContextPtr c = contextTracker.context( &node );
@@ -348,16 +364,23 @@ void GafferUIModule::bindGraphGadget()
 		.def( "getNodeSeparationScale", &StandardGraphLayout::getNodeSeparationScale )
 	;
 
-	IECorePython::RefCountedClass<ContextTracker, IECore::RefCounted>( "ContextTracker" )
-		.def( init<const NodePtr &, const ContextPtr &>() )
-		.def( "acquire", &ContextTracker::acquire ).staticmethod( "acquire" )
-		.def( "acquireForFocus", &ContextTracker::acquireForFocus ).staticmethod( "acquireForFocus" )
-		.def( "targetNode", &targetNodeWrapper )
-		.def( "targetContext", &targetContextWrapper )
-		.def( "isTracked", (bool (ContextTracker::*)( const Plug *plug ) const)&ContextTracker::isTracked )
-		.def( "isTracked", (bool (ContextTracker::*)( const Node *node ) const)&ContextTracker::isTracked )
-		.def( "context", &contextWrapper1, ( arg( "node" ), arg( "_copy" ) = true ) )
-		.def( "context", &contextWrapper2, ( arg( "plug" ), arg( "_copy" ) = true ) )
-	;
+	{
+		scope s = IECorePython::RefCountedClass<ContextTracker, IECore::RefCounted>( "ContextTracker" )
+			.def( init<const NodePtr &, const ContextPtr &>() )
+			.def( "acquire", &ContextTracker::acquire ).staticmethod( "acquire" )
+			.def( "acquireForFocus", &ContextTracker::acquireForFocus ).staticmethod( "acquireForFocus" )
+			.def( "targetNode", &targetNodeWrapper )
+			.def( "targetContext", &targetContextWrapper )
+			.def( "isTracked", (bool (ContextTracker::*)( const Plug *plug ) const)&ContextTracker::isTracked )
+			.def( "isTracked", (bool (ContextTracker::*)( const Node *node ) const)&ContextTracker::isTracked )
+			.def( "context", &contextWrapper1, ( arg( "node" ), arg( "_copy" ) = true ) )
+			.def( "context", &contextWrapper2, ( arg( "plug" ), arg( "_copy" ) = true ) )
+			.def( "updatePending", &ContextTracker::updatePending )
+			.def( "changedSignal", &ContextTracker::changedSignal, return_internal_reference<1>() )
+		;
+
+		SignalClass<ContextTracker::Signal, DefaultSignalCaller<ContextTracker::Signal>, ContextTrackerSlotCaller>( "Signal" );
+
+	}
 
 }


### PR DESCRIPTION
This contains the ContextTracker and EditScopePlugValueWidget changes from https://github.com/GafferHQ/gaffer/pull/5961, packaged for merging in isolation for 1.4.x. We think that there's enough value in these alone that we should roll them out sooner, while holding back the wider (and more ABI breaking) changes till 1.5. Changes to look out for from the previous PR :

- Renamed `ContextTracker::isActive()` to `ContextTracker::isTracked()`.
- Added `ContextTracker::isEnabled()` in https://github.com/GafferHQ/gaffer/commit/c280c282f0d95465f118e96b8ee7db33da1ac58e.
- Greyed-out disabled EditScopes in EditScopePlugValueWidget in https://github.com/GafferHQ/gaffer/commit/5bee0311df58034161fb0af149416ff8e19c4d39. Also consolidated the tooltip/menu/drop code to use the same descriptions for unusable EditScopes.

Other than the commits called out above (and the rename) everything else is the same, so it should be sufficient to focus review on just those two.