### PR TITLE
GafferCycles : Refactored python bindings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,9 @@ Improvements
 - LightEditor : Values of inherited attributes are now displayed in the Light Editor. These are presented as dimmed "fallback" values.
 - LightEditor, RenderPassEditor : Fallback values shown in the history window are displayed with the same dimmed text colour used for fallback values in editor columns.
 - EditScope : Filtered the EditScope menu to show only nodes that are active in the relevant context.
+- GafferCycles :
+  - Refactored the python module so that the data needed for binding is all located in IECoreCycles and not dependent on linking with Cycles itself for that data.
+  - Added `majorVersion` `minorVersion` `patchVersion` and `version` to the python module to easily query the running Cycles version
 
 Fixes
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -1361,13 +1361,8 @@ libraries = {
 			"FRAMEWORKS" : [ "Foundation", "Metal", "IOKit" ],
 		},
 		"pythonEnvAppends" : {
-			"LIBPATH" : [ "$CYCLES_ROOT/lib" ],
 			"LIBS" : [
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferBindings", "GafferCycles", "IECoreScene",
-				"cycles_session", "cycles_scene", "cycles_graph", "cycles_bvh", "cycles_device", "cycles_kernel", "cycles_kernel_osl",
-				"cycles_integrator", "cycles_util", "cycles_subd", "extern_sky", "extern_cuew",
-				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
-				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : cyclesDefines,

--- a/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
+++ b/include/GafferCycles/IECoreCyclesPreview/IECoreCycles.h
@@ -36,10 +36,7 @@
 
 #include "GafferCycles/IECoreCyclesPreview/Export.h"
 
-// Cycles
-IECORE_PUSH_DEFAULT_VISIBILITY
-#include "device/device.h"
-IECORE_POP_DEFAULT_VISIBILITY
+#include "IECore/CompoundData.h"
 
 #include <string>
 
@@ -63,5 +60,20 @@ IECORECYCLES_API int minorVersion();
 IECORECYCLES_API int patchVersion();
 /// Returns a string of the form "major.minor.patch"
 IECORECYCLES_API const std::string &versionString();
+
+/// Returns all device data (for python bindings)
+IECORECYCLES_API const IECore::CompoundData *devices();
+/// Returns all node data (for python bindings)
+IECORECYCLES_API const IECore::CompoundData *nodes();
+/// Returns all shader data (for python bindings)
+IECORECYCLES_API const IECore::CompoundData *shaders();
+/// Returns all light data (for python bindings)
+IECORECYCLES_API const IECore::CompoundData *lights();
+/// Returns all pass data (for python bindings)
+IECORECYCLES_API const IECore::CompoundData *passes();
+/// Returns if OpenImageDenoise has been compiled in Cycles
+IECORECYCLES_API bool openImageDenoiseSupported();
+/// Returns if OptixDenoise has been compiled in Cycles
+IECORECYCLES_API bool optixDenoiseSupported();
 
 }

--- a/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
@@ -32,6 +32,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "boost/algorithm/string.hpp"
+
 #include "GafferCycles/IECoreCyclesPreview/IECoreCycles.h"
 
 // Cycles
@@ -40,16 +42,430 @@
 #include "util/version.h"
 
 #include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
 
 #include "fmt/format.h"
 
 #include <filesystem>
+
+// Cycles
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "device/device.h"
+#include "graph/node.h"
+#include "util/openimagedenoise.h"
+IECORE_POP_DEFAULT_VISIBILITY
 
 namespace
 {
 
 // Version
 std::string cyclesVersion = CYCLES_VERSION_STRING;
+
+// Data for binding
+IECore::CompoundDataPtr g_deviceData;
+IECore::CompoundDataPtr g_nodeData;
+IECore::CompoundDataPtr g_shaderData;
+IECore::CompoundDataPtr g_lightData;
+IECore::CompoundDataPtr g_passData;
+
+// Get sockets data
+IECore::CompoundDataPtr getSockets( const ccl::NodeType *nodeType, const bool output )
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &sockets = result->writable();
+
+	if( !output )
+	{
+		for( const ccl::SocketType &socketType : nodeType->inputs )
+		{
+			IECore::CompoundDataPtr socket = new IECore::CompoundData();
+			IECore::CompoundDataMap &s = socket->writable();
+			std::string name( socketType.name.c_str() );
+			std::string uiName( socketType.ui_name.c_str() );
+			if( boost::contains( name, "." ) )
+			{
+				std::vector<std::string> split;
+				boost::split( split, name, boost::is_any_of( "." ) );
+				if( split[0] == "tex_mapping" )
+				{
+					s["category"] = new IECore::StringData( "Texture Mapping" );
+				}
+			}
+			s["ui_name"] = new IECore::StringData( uiName );
+
+			s["type"] = new IECore::StringData( ccl::SocketType::type_name( socketType.type ).c_str() );
+			if( socketType.type == ccl::SocketType::ENUM )
+			{
+				const ccl::NodeEnum *enums = socketType.enum_values;
+				IECore::CompoundDataPtr enumData = new IECore::CompoundData();
+				IECore::CompoundDataMap &e = enumData->writable();
+				for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
+				{
+					std::string uiEnumName( it->first.c_str() );
+					uiEnumName[0] = toupper( uiEnumName[0] );
+					boost::replace_all( uiEnumName, "_", " " );
+
+					e[uiEnumName.c_str()] = new IECore::StringData( it->first.c_str() );
+				}
+				s["enum_values"] = std::move( enumData );
+			}
+			s["is_array"] = new IECore::BoolData( socketType.is_array() );
+			s["flags"] = new IECore::IntData( socketType.flags );
+
+			// Some of the texture mapping nodes have a dot in them, replace here with 2 underscores
+			std::string actualName = boost::replace_first_copy( name, ".", "__" );
+			sockets[actualName] = std::move( socket );
+		}
+	}
+	else
+	{
+		for( const ccl::SocketType &socketType : nodeType->outputs )
+		{
+			IECore::CompoundDataPtr socket = new IECore::CompoundData();
+			IECore::CompoundDataMap &s = socket->writable();
+			s["ui_name"] = new IECore::StringData( socketType.ui_name.c_str() );
+			s["type"] = new IECore::StringData( ccl::SocketType::type_name( socketType.type ).c_str() );
+			s["is_array"] = new IECore::BoolData( socketType.is_array() );
+			s["flags"] = new IECore::IntData( socketType.flags );
+			sockets[socketType.name.c_str()] = std::move( socket );
+		}
+	}
+
+	return IECore::CompoundDataPtr( result );
+}
+
+IECore::CompoundData *deviceData()
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &devices = result->writable();
+
+	for( const ccl::DeviceInfo &device : ccl::Device::available_devices() )
+	{
+		IECore::CompoundDataPtr dev = new IECore::CompoundData();
+		IECore::CompoundDataMap &d = dev->writable();
+
+		d["type"] = new IECore::StringData( ccl::Device::string_from_type( device.type ) );
+		d["description"] = new IECore::StringData( device.description );
+		d["id"] = new IECore::StringData( device.id );
+		d["num"] = new IECore::IntData( device.num );
+		d["display_device"] = new IECore::BoolData( device.display_device );
+		d["has_nanovdb"] = new IECore::BoolData( device.has_nanovdb );
+		d["has_osl"] = new IECore::BoolData( device.has_osl );
+		d["has_profiling"] = new IECore::BoolData( device.has_profiling );
+		d["has_peer_memory"] = new IECore::BoolData( device.has_peer_memory );
+		d["has_gpu_queue"] = new IECore::BoolData( device.has_gpu_queue );
+		d["cpu_threads"] = new IECore::IntData( device.cpu_threads );
+		d["denoisers"] = new IECore::IntData( device.denoisers );
+
+		devices[device.id] = std::move( dev );
+	}
+	return result;
+}
+
+IECore::CompoundData *nodeData()
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &nodes = result->writable();
+
+	for( const auto& nodeType : ccl::NodeType::types() )
+	{
+		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
+		if( cNodeType )
+		{
+			// We skip "ShaderNode" types here
+			if( cNodeType->type == ccl::NodeType::SHADER )
+				continue;
+
+			// The shader node we skip
+			if( nodeType.first == "shader" )
+				continue;
+
+			IECore::CompoundDataPtr node = new IECore::CompoundData();
+			IECore::CompoundDataMap &n = node->writable();
+			n["in"] = std::move( getSockets( cNodeType, false ) );
+			n["out"] = std::move( getSockets( cNodeType, true ) );
+			nodes[nodeType.first.c_str()] = std::move( node );
+		}
+	}
+	return result;
+}
+
+IECore::CompoundData *shaderData()
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &shaders = result->writable();
+
+	for( const auto& nodeType : ccl::NodeType::types() )
+	{
+		// Skip over the "output" ShaderNode, as this is a part of the main
+		// "shader" node.
+		if( std::string( nodeType.first.c_str() ) == "output" )
+			continue;
+
+		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
+		if( cNodeType )
+		{
+			if( cNodeType->type == ccl::NodeType::SHADER )
+			{
+				IECore::CompoundDataPtr shader = new IECore::CompoundData();
+				IECore::CompoundDataMap &s = shader->writable();
+				s["in"] = std::move( getSockets( cNodeType, false ) );
+				s["out"] = std::move( getSockets( cNodeType, true ) );
+
+				std::string type( nodeType.first.c_str() );
+
+				if( boost::ends_with( type, "bsdf" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::starts_with( type, "convert" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Converter" );
+				}
+				else if( boost::ends_with( type, "closure" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::equals( type, "subsurface_scattering" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::equals( type, "emission" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::equals( type, "background_shader" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::equals( type, "holdout" ) )
+				{
+					s["type"] = new IECore::StringData( "surface" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::ends_with( type, "volume" ) )
+				{
+					s["type"] = new IECore::StringData( "volume" );
+					s["category"] = new IECore::StringData( "Shader" );
+				}
+				else if( boost::ends_with( type, "texture" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Texture" );
+				}
+				else if( boost::ends_with( type, "displacement" ) )
+				{
+					s["type"] = new IECore::StringData( "displacement" );
+					s["category"] = new IECore::StringData( "Vector" );
+				}
+				else if( boost::starts_with( type, "combine" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Converter" );
+				}
+				else if( boost::starts_with( type, "separate" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Converter" );
+				}
+				else if( boost::ends_with( type, "info" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Input" );
+				}
+				else if( ( boost::equals( type, "ambient_occlusion" ) )
+					|| ( boost::equals( type, "attribute" ) )
+					|| ( boost::equals( type, "bevel" ) )
+					|| ( boost::equals( type, "camera" ) )
+					|| ( boost::equals( type, "fresnel" ) )
+					|| ( boost::equals( type, "geometry" ) )
+					|| ( boost::equals( type, "layer_weight" ) )
+					|| ( boost::equals( type, "light_path" ) )
+					|| ( boost::equals( type, "rgb" ) )
+					|| ( boost::equals( type, "tangent" ) )
+					|| ( boost::equals( type, "texture_coordinate" ) )
+					|| ( boost::equals( type, "uvmap" ) )
+					|| ( boost::equals( type, "value" ) )
+					|| ( boost::equals( type, "wireframe" ) )
+				)
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Input" );
+				}
+				else if( ( boost::equals( type, "brightness_contrast" ) )
+					|| ( boost::equals( type, "gamma" ) )
+					|| ( boost::equals( type, "hsv" ) )
+					|| ( boost::equals( type, "invert" ) )
+					|| ( boost::equals( type, "light_falloff" ) )
+					|| ( boost::equals( type, "mix" ) )
+					|| ( boost::equals( type, "rgb_curves" ) )
+				)
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Color" );
+				}
+				else if( ( boost::equals( type, "bump" ) )
+					|| ( boost::equals( type, "mapping" ) )
+					|| ( boost::equals( type, "normal" ) )
+					|| ( boost::equals( type, "normal_map" ) )
+					|| ( boost::equals( type, "vector_curves" ) )
+					|| ( boost::equals( type, "vector_transform" ) )
+				)
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Vector" );
+				}
+				else if( ( boost::equals( type, "blackbody" ) )
+					|| ( boost::equals( type, "rgb_ramp" ) )
+					|| ( boost::equals( type, "math" ) )
+					|| ( boost::equals( type, "rgb_to_bw" ) )
+					//|| type == "shader_to_rgb"
+					|| ( boost::equals( type, "vector_math" ) )
+					|| ( boost::equals( type, "wavelength" ) )
+				)
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Converter" );
+				}
+				else if( boost::equals( type, "ies_light" ) )
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Texture" );
+				}
+				else
+				{
+					s["type"] = new IECore::StringData( "emission" );
+					s["category"] = new IECore::StringData( "Misc" );
+				}
+
+				shaders[type] = std::move( shader );
+			}
+		}
+	}
+
+	return result;
+}
+
+IECore::CompoundData *lightData()
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &lights = result->writable();
+
+	const ccl::NodeType *cNodeType = ccl::NodeType::find( ccl::ustring( "light" ) );
+	if( cNodeType )
+	{
+		IECore::CompoundDataPtr _sockets = std::move( getSockets( cNodeType, false ) );
+		IECore::CompoundDataMap &_in = _sockets->writable();
+
+		const ccl::SocketType *socketType = cNodeType->find_input( ccl::ustring( "light_type" ) );
+		const ccl::NodeEnum *enums = socketType->enum_values;
+
+		int portalEnum = -1;
+
+		for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
+		{
+			IECore::CompoundDataPtr light = new IECore::CompoundData();
+			IECore::CompoundDataMap &l = light->writable();
+			IECore::CompoundDataPtr sockets = new IECore::CompoundData();
+			IECore::CompoundDataMap &in = sockets->writable();
+
+			std::string type( it->first.c_str() );
+			type += "_light";
+
+			in["size"] = _in["size"]->copy();
+			in["cast_shadow"] = _in["cast_shadow"]->copy();
+			in["use_camera"] = _in["use_camera"]->copy();
+			in["use_mis"] = _in["use_mis"]->copy();
+			in["use_diffuse"] = _in["use_diffuse"]->copy();
+			in["use_glossy"] = _in["use_glossy"]->copy();
+			in["use_transmission"] = _in["use_transmission"]->copy();
+			in["use_scatter"] = _in["use_scatter"]->copy();
+			in["use_caustics"] = _in["use_caustics"]->copy();
+			in["max_bounces"] = _in["max_bounces"]->copy();
+			in["strength"] = _in["strength"]->copy();
+			in["lightgroup"] = _in["lightgroup"]->copy();
+
+			if( type == "background_light" )
+			{
+				in["map_resolution"] = _in["map_resolution"]->copy();
+				l["in"] = std::move( sockets );
+				l["enum"] = new IECore::IntData( it->second );
+				lights[type] = std::move( light );
+			}
+			else if( type == "area_light" )
+			{
+				in["sizeu"] = _in["sizeu"]->copy();
+				in["sizev"] = _in["sizev"]->copy();
+				in["spread"] = _in["spread"]->copy();
+				l["in"] = std::move( sockets );
+				l["enum"] = new IECore::IntData( it->second );
+				portalEnum = it->second;
+				lights["disk_light"] = light->copy();
+				lights["quad_light"] = light->copy();
+			}
+			else if( type == "spot_light" )
+			{
+				in["spot_angle"] = _in["spot_angle"]->copy();
+				in["spot_smooth"] = _in["spot_smooth"]->copy();
+				l["in"] = std::move( sockets );
+				l["enum"] = new IECore::IntData( it->second );
+				lights[type] = std::move( light );
+			}
+			else
+			{
+				l["in"] = std::move( sockets );
+				l["enum"] = new IECore::IntData( it->second );
+				lights[type] = std::move( light );
+			}
+		}
+		// Portal
+		IECore::CompoundDataPtr light = new IECore::CompoundData();
+		IECore::CompoundDataMap &l = light->writable();
+		IECore::CompoundDataPtr sockets = new IECore::CompoundData();
+		IECore::CompoundDataMap &in = sockets->writable();
+
+		in["is_portal"] = _in["is_portal"]->copy();
+		in["sizeu"] = _in["sizeu"]->copy();
+		in["sizev"] = _in["sizev"]->copy();
+		l["enum"] = new IECore::IntData( portalEnum );
+		l["in"] = std::move( sockets );
+		lights["portal"] = std::move( light );
+	}
+	return result;
+}
+
+IECore::CompoundData *passData()
+{
+	IECore::CompoundData *result = new IECore::CompoundData();
+	IECore::CompoundDataMap &passes = result->writable();
+
+	const ccl::NodeEnum *enums = ccl::Pass::get_type_enum();
+
+	for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
+	{
+		IECore::CompoundDataPtr info = new IECore::CompoundData();
+		IECore::CompoundDataMap &i = info->writable();
+		ccl::PassInfo passInfo = ccl::Pass::get_info( static_cast<ccl::PassType>( it->second ) );
+
+		i["num_components"] = new IECore::IntData( passInfo.num_components );
+		i["use_filter"] = new IECore::BoolData( passInfo.use_filter );
+		i["use_exposure"] = new IECore::BoolData( passInfo.use_exposure );
+		i["is_written"] = new IECore::BoolData( passInfo.is_written );
+		i["use_compositing"] = new IECore::BoolData( passInfo.use_compositing );
+		i["use_denoising_albedo"] = new IECore::BoolData( passInfo.use_denoising_albedo );
+		i["support_denoise"] = new IECore::BoolData( passInfo.support_denoise );
+
+		passes[it->first.c_str()] = std::move( info );
+	}
+
+	return result;
+}
 
 }
 
@@ -85,6 +501,12 @@ bool init()
 	ccl::util_logging_start();
 	ccl::util_logging_verbosity_set( 0 );
 
+	// Store data for binding
+	g_deviceData = deviceData();
+	g_nodeData = nodeData();
+	g_shaderData = shaderData();
+	g_lightData = lightData();
+	g_passData = passData();
 
 	return true;
 }
@@ -107,6 +529,46 @@ int patchVersion()
 const std::string &versionString()
 {
 	return cyclesVersion;
+}
+
+const IECore::CompoundData *devices()
+{
+	return g_deviceData.get();
+}
+
+const IECore::CompoundData *nodes()
+{
+	return g_nodeData.get();
+}
+
+const IECore::CompoundData *shaders()
+{
+	return g_shaderData.get();
+}
+
+const IECore::CompoundData *lights()
+{
+	return g_lightData.get();
+}
+
+const IECore::CompoundData *passes()
+{
+	return g_passData.get();
+}
+
+bool openImageDenoiseSupported()
+{
+	return ccl::openimagedenoise_supported();
+}
+
+bool optixDenoiseSupported()
+{
+	for( const ccl::DeviceInfo &device : ccl::Device::available_devices() )
+	{
+		if( device.type == ccl::DEVICE_OPTIX )
+			return true;
+	}
+	return false;
 }
 
 }

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -34,7 +34,6 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/algorithm/string.hpp"
 #include "boost/python.hpp"
 
 #include "GafferBindings/DependencyNodeBinding.h"
@@ -52,13 +51,8 @@
 #include "GafferCycles/CyclesRender.h"
 #include "GafferCycles/InteractiveCyclesRender.h"
 
+#include "IECore/CompoundData.h"
 #include "IECore/MessageHandler.h"
-
-// Cycles
-#include "device/device.h"
-#include "graph/node.h"
-#include "util/openimagedenoise.h"
-#include "util/path.h"
 
 namespace py = boost::python;
 using namespace boost::python;
@@ -69,382 +63,87 @@ using namespace GafferCycles;
 namespace
 {
 
-py::list getDevices()
+py::dict makeDict( const IECore::CompoundData *data, const std::string &name )
 {
-	py::scope().attr( "hasOptixDenoise" ) = false;
-
-	py::list result;
-
-	for( const ccl::DeviceInfo &device : ccl::Device::available_devices() )
+	py::dict d;
+	const IECore::CompoundDataMap &cDataMap = data->readable();
+	for( IECore::CompoundDataMap::const_iterator it = cDataMap.begin(), eIt = cDataMap.end(); it != eIt; ++it )
 	{
-		py::dict d;
-		d["type"] = ccl::Device::string_from_type( device.type );
-		d["description"] = device.description;
-		d["id"] = device.id;
-		d["num"] = device.num;
-		d["display_device"] = device.display_device;
-		d["has_nanovdb"] = device.has_nanovdb;
-		d["has_osl"] = device.has_osl;
-		d["has_profiling"] = device.has_profiling;
-		d["has_peer_memory"] = device.has_peer_memory;
-		d["has_gpu_queue"] = device.has_gpu_queue;
-		d["cpu_threads"] = device.cpu_threads;
-		d["denoisers"] = device.denoisers;
-
-		if( device.type == ccl::DEVICE_OPTIX )
-			py::scope().attr( "hasOptixDenoise" ) = true;
-
-		result.append(d);
+		if( const IECore::FloatData *dt = IECore::runTimeCast<const IECore::FloatData>( it->second.get() ) )
+		{
+			d[it->first.string()] = dt->readable();
+		}
+		else if( const IECore::IntData *dt = IECore::runTimeCast<const IECore::IntData>( it->second.get() ) )
+		{
+			d[it->first.string()] = dt->readable();
+		}
+		else if( const IECore::BoolData *dt = IECore::runTimeCast<const IECore::BoolData>( it->second.get() ) )
+		{
+			d[it->first.string()] = dt->readable();
+		}
+		else if( const IECore::StringData *dt = IECore::runTimeCast<const IECore::StringData>( it->second.get() ) )
+		{
+			d[it->first.string()] = dt->readable();
+		}
+		else if( const IECore::CompoundData *dt = IECore::runTimeCast<const IECore::CompoundData>( it->second.get() ) )
+		{
+			d[it->first.string()] = makeDict( dt, it->first.string() );
+		}
+		else
+		{
+			IECore::msg( IECore::Msg::Warning, "GafferCyclesModule::makeDict",
+				fmt::format(
+					"Type {} is unsupported for binding {}'s \"{}\".",
+					it->second->typeName(), name.c_str(), it->first.c_str()
+				)
+			);
+		}
 	}
-	return result;
+	return d;
 }
 
-py::dict getSockets( const ccl::NodeType *nodeType, const bool output )
+py::list getDevices()
 {
-	py::dict result;
+	py::list result;
+	const IECore::CompoundDataMap &devices = IECoreCycles::devices()->readable();
 
-	if( !output )
+	for( IECore::CompoundDataMap::const_iterator it = devices.begin(), eIt = devices.end(); it != eIt; ++it )
 	{
-		for( const ccl::SocketType &socketType : nodeType->inputs )
+		if( const IECore::CompoundData *dt = IECore::runTimeCast<const IECore::CompoundData>( it->second.get() ) )
 		{
-			py::dict d;
-			std::string name( socketType.name.c_str() );
-			std::string uiName( socketType.ui_name.c_str() );
-			if( boost::contains( name, "." ) )
-			{
-				std::vector<std::string> split;
-				boost::split( split, name, boost::is_any_of( "." ) );
-				if( split[0] == "tex_mapping" )
-					d["category"] = "Texture Mapping";
-			}
-			d["ui_name"] = uiName;
-
-			d["type"] = ccl::SocketType::type_name( socketType.type ).c_str();
-			if( socketType.type == ccl::SocketType::ENUM )
-			{
-				const ccl::NodeEnum *enums = socketType.enum_values;
-				py::dict enumDict;
-				for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
-				{
-					std::string uiEnumName( it->first.c_str() );
-					uiEnumName[0] = toupper( uiEnumName[0] );
-					boost::replace_all( uiEnumName, "_", " " );
-
-					enumDict[uiEnumName.c_str()] = it->first.c_str();
-				}
-				d["enum_values"] = enumDict;
-			}
-			d["is_array"] = socketType.is_array();
-			d["flags"] = socketType.flags;
-
-			// Some of the texture mapping nodes have a dot in them, replace here with 2 underscores
-			std::string actualName = boost::replace_first_copy( name, ".", "__" );
-			result[actualName] = d;
+			result.append( makeDict( dt, "devices" ) );
+		}
+		else
+		{
+			IECore::msg( IECore::Msg::Warning, "GafferCyclesModule::getDevices",
+				fmt::format(
+					"Unexpected type data from IECoreCycles::getDevices {}.",
+					it->second->typeName()
+				)
+			);
 		}
 	}
-	else
-	{
-		for( const ccl::SocketType &socketType : nodeType->outputs )
-		{
-			py::dict d;
-			d["ui_name"] = socketType.ui_name.c_str();
-			d["type"] = ccl::SocketType::type_name( socketType.type ).c_str();
-			d["is_array"] = socketType.is_array();
-			d["flags"] = socketType.flags;
-			result[socketType.name.c_str()] = d;
-		}
-	}
-
 	return result;
 }
 
 py::dict getNodes()
 {
-	py::dict result;
-
-	for( const auto& nodeType : ccl::NodeType::types() )
-	{
-		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
-		if( cNodeType )
-		{
-			// We skip "ShaderNode" types here
-			if( cNodeType->type == ccl::NodeType::SHADER )
-				continue;
-
-			// The shader node we skip
-			if( nodeType.first == "shader" )
-				continue;
-
-			py::dict d;
-			d["in"] = getSockets( cNodeType, false );
-			d["out"] = getSockets( cNodeType, true );
-			result[nodeType.first.c_str()] = d;
-		}
-	}
-	return result;
+	return makeDict( IECoreCycles::nodes(), "nodes" );
 }
 
 py::dict getShaders()
 {
-	py::dict result;
-
-	for( const auto& nodeType : ccl::NodeType::types() )
-	{
-		// Skip over the "output" ShaderNode, as this is a part of the main
-		// "shader" node.
-		if( std::string( nodeType.first.c_str() ) == "output" )
-			continue;
-
-		const ccl::NodeType *cNodeType = ccl::NodeType::find( nodeType.first );
-		if( cNodeType )
-		{
-			if( cNodeType->type == ccl::NodeType::SHADER )
-			{
-				py::dict d;
-				d["in"] = getSockets( cNodeType, false );
-				d["out"] = getSockets( cNodeType, true );
-
-				std::string type = nodeType.first.c_str();
-
-				if( boost::ends_with( type, "bsdf" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::starts_with( type, "convert" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Converter";
-				}
-				else if( boost::ends_with( type, "closure" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::equals( type, "subsurface_scattering" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::equals( type, "emission" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::equals( type, "background_shader" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::equals( type, "holdout" ) )
-				{
-					d["type"] = "surface";
-					d["category"] = "Shader";
-				}
-				else if( boost::ends_with( type, "volume" ) )
-				{
-					d["type"] = "volume";
-					d["category"] = "Shader";
-				}
-				else if( boost::ends_with( type, "texture" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Texture";
-				}
-				else if( boost::ends_with( type, "displacement" ) )
-				{
-					d["type"] = "displacement";
-					d["category"] = "Vector";
-				}
-				else if( boost::starts_with( type, "combine" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Converter";
-				}
-				else if( boost::starts_with( type, "separate" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Converter";
-				}
-				else if( boost::ends_with( type, "info" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Input";
-				}
-				else if( ( boost::equals( type, "ambient_occlusion" ) )
-					|| ( boost::equals( type, "attribute" ) )
-					|| ( boost::equals( type, "bevel" ) )
-					|| ( boost::equals( type, "camera" ) )
-					|| ( boost::equals( type, "fresnel" ) )
-					|| ( boost::equals( type, "geometry" ) )
-					|| ( boost::equals( type, "layer_weight" ) )
-					|| ( boost::equals( type, "light_path" ) )
-					|| ( boost::equals( type, "rgb" ) )
-					|| ( boost::equals( type, "tangent" ) )
-					|| ( boost::equals( type, "texture_coordinate" ) )
-					|| ( boost::equals( type, "uvmap" ) )
-					|| ( boost::equals( type, "value" ) )
-					|| ( boost::equals( type, "wireframe" ) )
-				)
-				{
-					d["type"] = "emission";
-					d["category"] = "Input";
-				}
-				else if( ( boost::equals( type, "brightness_contrast" ) )
-					|| ( boost::equals( type, "gamma" ) )
-					|| ( boost::equals( type, "hsv" ) )
-					|| ( boost::equals( type, "invert" ) )
-					|| ( boost::equals( type, "light_falloff" ) )
-					|| ( boost::equals( type, "mix" ) )
-					|| ( boost::equals( type, "rgb_curves" ) )
-				)
-				{
-					d["type"] = "emission";
-					d["category"] = "Color";
-				}
-				else if( ( boost::equals( type, "bump" ) )
-					|| ( boost::equals( type, "mapping" ) )
-					|| ( boost::equals( type, "normal" ) )
-					|| ( boost::equals( type, "normal_map" ) )
-					|| ( boost::equals( type, "vector_curves" ) )
-					|| ( boost::equals( type, "vector_transform" ) )
-				)
-				{
-					d["type"] = "emission";
-					d["category"] = "Vector";
-				}
-				else if( ( boost::equals( type, "blackbody" ) )
-					|| ( boost::equals( type, "rgb_ramp" ) )
-					|| ( boost::equals( type, "math" ) )
-					|| ( boost::equals( type, "rgb_to_bw" ) )
-					//|| type == "shader_to_rgb"
-					|| ( boost::equals( type, "vector_math" ) )
-					|| ( boost::equals( type, "wavelength" ) )
-				)
-				{
-					d["type"] = "emission";
-					d["category"] = "Converter";
-				}
-				else if( boost::equals( type, "ies_light" ) )
-				{
-					d["type"] = "emission";
-					d["category"] = "Texture";
-				}
-				else
-				{
-					d["type"] = "emission";
-					d["category"] = "Misc";
-				}
-
-				result[type] = d;
-			}
-		}
-	}
-
-	return result;
+	return makeDict( IECoreCycles::shaders(), "shaders" );
 }
 
 py::dict getLights()
 {
-	py::dict result;
-
-	const ccl::NodeType *cNodeType = ccl::NodeType::find( ccl::ustring( "light" ) );
-	if( cNodeType )
-	{
-		py::dict _in;
-		_in = getSockets( cNodeType, false );
-
-		const ccl::SocketType *socketType = cNodeType->find_input( ccl::ustring( "light_type" ) );
-		const ccl::NodeEnum *enums = socketType->enum_values;
-
-		for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
-		{
-			py::dict d;
-			py::dict in;
-			std::string type = it->first.c_str();
-			type += "_light";
-
-			in["size"] = _in["size"];
-			in["cast_shadow"] = _in["cast_shadow"];
-			in["use_camera"] = _in["use_camera"];
-			in["use_mis"] = _in["use_mis"];
-			in["use_diffuse"] = _in["use_diffuse"];
-			in["use_glossy"] = _in["use_glossy"];
-			in["use_transmission"] = _in["use_transmission"];
-			in["use_scatter"] = _in["use_scatter"];
-			in["use_caustics"] = _in["use_caustics"];
-			in["max_bounces"] = _in["max_bounces"];
-			in["strength"] = _in["strength"];
-			in["lightgroup"] = _in["lightgroup"];
-
-			if( type == "background_light" )
-			{
-				in["map_resolution"] = _in["map_resolution"];
-				d["enum"] = it->second;
-				d["in"] = in;
-				result[type] = d;
-			}
-			else if( type == "area_light" )
-			{
-				in["sizeu"] = _in["sizeu"];
-				in["sizev"] = _in["sizev"];
-				in["spread"] = _in["spread"];
-				d["in"] = in;
-				d["enum"] = it->second;
-				result["disk_light"] = d;
-				result["quad_light"] = d;
-			}
-			else if( type == "spot_light" )
-			{
-				in["spot_angle"] = _in["spot_angle"];
-				in["spot_smooth"] = _in["spot_smooth"];
-				d["in"] = in;
-				d["enum"] = it->second;
-				result[type] = d;
-			}
-			else
-			{
-				d["in"] = in;
-				d["enum"] = it->second;
-				result[type] = d;
-			}
-		}
-		// Portal
-		py::dict d;
-		py::dict in;
-		in["is_portal"] = _in["is_portal"];
-		in["sizeu"] = _in["sizeu"];
-		in["sizev"] = _in["sizev"];
-		d["enum"] = result["quad_light"]["enum"];
-		d["in"] = in;
-		result["portal"] = d;
-	}
-	return result;
+	return makeDict( IECoreCycles::lights(), "lights" );
 }
 
 py::dict getPasses()
 {
-	py::dict result;
-
-	const ccl::NodeEnum *enums = ccl::Pass::get_type_enum();
-
-	for( auto it = enums->begin(), eIt = enums->end(); it != eIt; ++it )
-	{
-		py::dict info;
-		ccl::PassInfo passInfo = ccl::Pass::get_info( static_cast<ccl::PassType>( it->second ) );
-
-		info["num_components"] = passInfo.num_components;
-		info["use_filter"] = passInfo.use_filter;
-		info["use_exposure"] = passInfo.use_exposure;
-		info["is_written"] = passInfo.is_written;
-		info["use_compositing"] = passInfo.use_compositing;
-		info["use_denoising_albedo"] = passInfo.use_denoising_albedo;
-		info["support_denoise"] = passInfo.support_denoise;
-
-		result[it->first.c_str()] = info;
-	}
-
-	return result;
+	return makeDict( IECoreCycles::passes(), "passes" );
 }
 
 } // namespace
@@ -454,20 +153,17 @@ BOOST_PYTHON_MODULE( _GafferCycles )
 
 	IECoreCycles::init();
 
-	// Must be initialized to ensure the statically linked Cycles module
-	// we are linked to can find the binaries for GPU rendering.
-	ccl::path_init( IECoreCycles::cyclesRoot() );
-
+	py::scope().attr( "majorVersion" ) = IECoreCycles::majorVersion();
+	py::scope().attr( "minorVersion" ) = IECoreCycles::minorVersion();
+	py::scope().attr( "patchVersion" ) = IECoreCycles::patchVersion();
+	py::scope().attr( "version" ) = IECoreCycles::versionString();
 	py::scope().attr( "devices" ) = getDevices();
 	py::scope().attr( "nodes" ) = getNodes();
 	py::scope().attr( "shaders" ) = getShaders();
 	py::scope().attr( "lights" ) = getLights();
 	py::scope().attr( "passes" ) = getPasses();
-
-	if( ccl::openimagedenoise_supported() )
-		py::scope().attr( "hasOpenImageDenoise" ) = true;
-	else
-		py::scope().attr( "hasOpenImageDenoise" ) = false;
+	py::scope().attr( "hasOpenImageDenoise" ) = IECoreCycles::openImageDenoiseSupported();
+	py::scope().attr( "hasOptixDenoise" ) = IECoreCycles::optixDenoiseSupported();
 
 	DependencyNodeClass<CyclesAttributes>();
 	DependencyNodeClass<CyclesBackground>();


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- I've restructured the `GafferCyclesModule` python bindings so that the module is only dependent on `GafferCycles`
- This is achieved by storing the data that the module usually binds into CompoundDatas to later retrieve and make bindings from
- This probably should be in `main`, however I think this fixes an ongoing issue of linking eg. in #5870 - I can change this to `main` if this is too risky for `1.4_maintenance`
- I want to refactor `IECoreCyclesPreview` to `IECoreCycles` as its own library like the other renderers, so a following PR I can make that targets `main`

### Related issues ###

- [Don't link cycles libraries twice](https://github.com/GafferHQ/gaffer/pull/5870)

### Dependencies ###

- N/A

### Breaking changes ###

- API/ABI change to `GafferCycles`, the API adds a few functions to `IECoreCycles` to retrieve compound datas for binding
- The python bindings themselves should match but some extra testing doesn't hurt

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
