### PR TITLE
Slider : Fix extra entries in undo queue on drag

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - ImageReader : Fixed crash caused by invalid OpenEXR `multiView` attributes.
 - LightEditor, RenderPassEditor : Added missing icon representing use of the `CreateIfMissing` tweak mode in the history window.
+- Slider : Fixed bug where two undo steps were needed to get back to the original value when dragging.
 
 1.3.16.6 (relative to 1.3.16.5)
 ========

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -429,6 +429,11 @@ class Slider( GafferUI.Widget ) :
 	def __dragBegin( self, widget, event ) :
 
 		if event.buttons == GafferUI.ButtonEvent.Buttons.Left and self.getSelectedIndex() is not None :
+			self.__setValueInternal(
+				self.getSelectedIndex(),
+				self.__eventValue( event ),
+				self.ValueChangedReason.DragBegin
+			)
 			return IECore.NullObject.defaultNullObject()
 
 		return None
@@ -450,7 +455,11 @@ class Slider( GafferUI.Widget ) :
 
 	def __dragEnd( self, widget, event ) :
 
-		self.__dragMove( widget, event )
+		self.__setValueInternal(
+			self.getSelectedIndex(),
+			self.__eventValue( event ),
+			self.ValueChangedReason.DragEnd
+		)
 
 	def __keyPress( self, widget, event ) :
 


### PR DESCRIPTION
This fixes a behavior requiring two undo steps when dragging a slider. We were not setting the value in `__dragBegin()`. This meant we were going from the `Click` reason to `DragMove` at the start of a drag, which is not merged in the undo queue by `changesShouldBeMerged()`.

We also wer reusing the `DragMove` reason in `__dragEnd()`, which wasn't causing issues with the undo queue (`DragMove` to `DragMove` reasons do get merged), but I changed for the sake of consistency.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
