### PR TITLE
ArnoldShaderUI : Fix Imager metadata support for Arnold 7.3

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - SetExpressions : Set Expressions containing only whitespace characters are now treated as empty rather than producing an error.
 
+Fixes
+-----
+
+- Arnold : Fixed bug preventing UI metadata for Imagers from being loaded for Arnold 7.3.
+
 1.4.10.0 (relative to 1.4.9.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -972,7 +972,7 @@ if env["ARNOLD_ROOT"] :
 			shell = True
 		)
 
-		nodeDefRegex = re.compile( r"\s*([a-zA-Z0-9_]+)\s+(driver|color_manager|driver|filter|light|operator|options|override|shader|shape)" )
+		nodeDefRegex = re.compile( r"\s*([a-zA-Z0-9_]+)\s+(driver|color_manager|driver|filter|imager|light|operator|options|override|shader|shape)" )
 		nodes = set()
 		for line in kickOutput.split( "\n" ) :
 			m = nodeDefRegex.match( line )

--- a/python/GafferArnoldUI/ArnoldShaderUI.py
+++ b/python/GafferArnoldUI/ArnoldShaderUI.py
@@ -461,9 +461,14 @@ def __translateNodeMetadata( nodeEntry ) :
 			if value is not None :
 				__metadata[paramPath][gafferKey] = value
 
+if [ int( x ) for x in arnold.AiGetVersion()[:3] ] < [ 7, 3, 1 ] :
+	__AI_NODE_IMAGER = arnold.AI_NODE_DRIVER
+else :
+	__AI_NODE_IMAGER = arnold.AI_NODE_IMAGER
+
 with IECoreArnold.UniverseBlock( writable = False ) :
 
-	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER | arnold.AI_NODE_DRIVER )
+	nodeIt = arnold.AiUniverseGetNodeEntryIterator( arnold.AI_NODE_SHADER | arnold.AI_NODE_LIGHT | arnold.AI_NODE_COLOR_MANAGER | __AI_NODE_IMAGER )
 	while not arnold.AiNodeEntryIteratorFinished( nodeIt ) :
 
 		__translateNodeMetadata( arnold.AiNodeEntryIteratorGetNext( nodeIt ) )

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -127,6 +127,31 @@ class ArnoldShaderUITest( GafferUITest.TestCase ) :
 			Gaffer.Metadata.value( light["parameters"]["format"], "presetNames" ),
 		)
 
+	def testImagerMetadata( self ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "imager_white_balance" )
+
+		self.assertEqual(
+			Gaffer.Metadata.value( shader["parameters"]["mode"], "nodule:type" ),
+			""
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( shader["parameters"]["mode"], "plugValueWidget:type" ),
+			"GafferUI.PresetsPlugValueWidget"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( shader["parameters"]["mode"], "presetNames" ),
+			IECore.StringVectorData( [ "illuminant", "temperature", "custom" ] ),
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( shader["parameters"]["mode"], "presetValues" ),
+			Gaffer.Metadata.value( shader["parameters"]["mode"], "presetNames" ),
+		)
+
 	def testUserDefaultMetadata( self ) :
 
 		cacheFilePath =	self.temporaryDirectory() / "testShaderUserDefaults.scc"


### PR DESCRIPTION
The change of node type from 'driver' to 'imager' in Arnold 7.3 meant that we were filtering out the imager entries from `gaffer.mtd` and then not attempting to translate their metadata in ArnoldShaderUI.