### PR TITLE
GafferCortexUI : Adapt to new PlugValueWidget API

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 - PrimitiveInspector : Fixed failure to update when the location being viewed ceases to exist, or is recreated.
 - Shuffle, ShuffleAttributes, ShufflePrimitiveVariables : Fixed some special cases where shuffling a source to itself would fail to have the expected effect.
 - GraphEditor : Fixed dimming of labels for BoxIn and BoxOut nodes.
+- GafferCortexUI : Removed usage of legacy PlugValueWidget API.
 
 API
 ---

--- a/python/GafferCortexUI/CompoundPlugValueWidget.py
+++ b/python/GafferCortexUI/CompoundPlugValueWidget.py
@@ -107,8 +107,6 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__summary = summary
 
-		CompoundPlugValueWidget._updateFromPlug( self )
-
 	## Returns a PlugValueWidget representing the specified child plug.
 	def childPlugValueWidget( self, childPlug ) :
 
@@ -126,7 +124,7 @@ class CompoundPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return True
 
-	def _updateFromPlug( self ) :
+	def _updateFromValues( self, values, exception ) :
 
 		if self.__summary is not None and self.__collapsible is not None :
 			with self.getContext() :

--- a/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
+++ b/python/GafferCortexUI/CompoundVectorParameterValueWidget.py
@@ -43,6 +43,8 @@ import Gaffer
 import GafferUI
 import GafferCortexUI
 
+from GafferUI.PlugValueWidget import sole
+
 ## Supported userData entries :
 #
 # ["UI"]["sizeEditable"]
@@ -98,7 +100,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		self.__vectorDataWidget.editSignal().connect( Gaffer.WeakMethod( self.__edit ), scoped = False )
 		self.__vectorDataWidget.dataChangedSignal().connect( Gaffer.WeakMethod( self.__dataChanged ), scoped = False )
 
-		self._updateFromPlug()
+		self._requestUpdateFromValues()
 
 		return self.__vectorDataWidget
 
@@ -108,30 +110,25 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 		# need any plug widgets made by the base class.
 		return []
 
-	def _updateFromPlug( self ) :
+	@staticmethod
+	def _valuesForUpdate( plugs, auxiliaryPlugs ) :
 
-		GafferCortexUI.CompoundParameterValueWidget._PlugValueWidget._updateFromPlug( self )
+		result = []
+		for plug in plugs :
+			data = [ childPlug.getValue() for childPlug in plug.children() ]
+			result.append( data )
+
+		return result
+
+	def _updateFromValues( self, values, exception ) :
 
 		if self.__vectorDataWidget is None:
 			return
 
-		data = []
-		for plug in self._parameterHandler().plug().children() :
-			plugData = plug.getValue()
-			if len( data ) and len( plugData ) != len( data[0] ) :
-				# in __dataChanged we have to update the child plug values
-				# one at a time. when adding or removing rows, this means that the
-				# columns will have differing lengths until the last plug
-				# has been set. in this case we shortcut ourselves, and wait
-				# for the final plug to be set before updating the VectorDataWidget.
-				# \todo Now dirty propagation is batched via the UndoScope,
-				# we should remove this workaround, since _updateFromPlug()
-				# will only be called when the plug is in a valid state.
-				return
-			data.append( plugData )
-
+		data = sole( values ) or []
 		self.__vectorDataWidget.setData( data )
 		self.__vectorDataWidget.setEditable( self._editable() )
+		self.__vectorDataWidget.setErrored( exception is not None )
 
 		for columnIndex, childParameter in enumerate( self._parameter().values() ) :
 
@@ -163,7 +160,7 @@ class _PlugValueWidget( GafferCortexUI.CompoundParameterValueWidget._PlugValueWi
 
 		data = vectorDataWidget.getData()
 
-		with Gaffer.Signals.BlockedConnection( self._plugConnections() ) :
+		with self._blockedUpdateFromValues() :
 			with Gaffer.UndoScope( self.getPlug().ancestor( Gaffer.ScriptNode ) ) :
 				for d, p in zip( data, self._parameterHandler().plug().children() ) :
 					p.setValue( d )

--- a/python/GafferCortexUI/DateTimeParameterValueWidget.py
+++ b/python/GafferCortexUI/DateTimeParameterValueWidget.py
@@ -35,11 +35,15 @@
 #
 ##########################################################################
 
+import datetime
+
 import IECore
 
 import Gaffer
 import GafferUI
 import GafferCortexUI
+
+from GafferUI.PlugValueWidget import sole
 
 from Qt import QtCore
 from Qt import QtGui
@@ -75,13 +79,11 @@ class _DateTimePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self._addPopupMenu()
 
-		self._updateFromPlug()
-
-	def _updateFromPlug( self ) :
+	def _updateFromValues( self, values, exception ) :
 
 		# convert from the undelimited form boost likes (and the DateTimeParameterHandler uses)
 		# to the delimited form qt likes
-		undelimited = self.getPlug().getValue()
+		undelimited = sole( values ) or datetime.datetime.utcfromtimestamp( 0 ).strftime( "%Y%m%dT%H%M%S.%fZ" )
 		delimited = "%s-%s-%sT%s:%s:%s" % (
 			undelimited[0:4],
 			undelimited[4:6],

--- a/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
+++ b/python/GafferCortexUI/PresetsOnlyParameterValueWidget.py
@@ -67,14 +67,11 @@ class _PlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, self.__parameterHandler.plug(), **kw )
 
 		self._addPopupMenu( self.__menuButton )
-		self._updateFromPlug()
 
-	def _updateFromPlug( self ) :
+	def _updateFromValues( self, values, exception ) :
 
 		with self.getContext() :
 			self.__parameterHandler.setParameterValue()
-
-		self.__menuButton.setEnabled( self._editable() )
 
 		text = ""
 		if self.getPlug() is not None :
@@ -82,6 +79,10 @@ class _PlugValueWidget( GafferUI.PlugValueWidget ) :
 				text = self.__parameterHandler.parameter().getCurrentPresetName() or "Invalid"
 
 		self.__menuButton.setText( text )
+
+	def _updateFromEditable( self ) :
+
+		self.__menuButton.setEnabled( self._editable() )
 
 	def __menuDefinition( self ) :
 


### PR DESCRIPTION
As requested in #5953, I've adapted `GafferCortexUI` to the new `PlugValueWidget` API.

Give that I can only build 1.3 at IE, that's what I targeted. But feel free to redirect this to 1.4 or main.

Changes are fairly minimal, as I don't expect any of these widgets to be involved in heavy computation, and therefore benefit from the new asynchronous mechanisms.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
