### PR TITLE
InspectorColumn

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ API
   - A `DeprecationWarning` is now emitted for any subclasses still implementing the legacy `_updateFromPlug()` or `_updateFromPlugs()` methods. Implement `_updateFromValues()`, `_updateFromMetadata()` and `_updateFromEditable()` instead.
   - A `DeprecationWarning` is now emitted by `_plugConnections()`. Use `_blockedUpdateFromValues()` instead.
 - NodeGadget, ConnectionGadget : Added `updateFromContextTracker()` virtual methods.
+- Path : Added `inspectionContext()` virtual method.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,9 @@ Improvements
   - Improved highlighting of active nodes, with more accurate tracking of Loop node iterations.
   - Annotation `{plug}` substitutions are now evaluated in a context determined relative to the focus node.
   - The strike-through for disabled nodes is now evaluated in a context determined relative to the focus node.
+- LightEditor :
+  - Improved formatting of column headers containing whitespace.
+  - The "Double-click to toggle" tooltip is no longer displayed while hovering over non-editable cells, and a "Double-click to edit" tooltip is now displayed while hovering over other non-toggleable but editable cells.
 
 Fixes
 -----

--- a/include/Gaffer/Path.h
+++ b/include/Gaffer/Path.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include "Gaffer/Context.h"
 #include "Gaffer/Export.h"
 #include "Gaffer/Signals.h"
 #include "Gaffer/TypeIds.h"
@@ -189,6 +190,10 @@ class GAFFER_API Path : public IECore::RunTimeTyped
 		/// processing to be cancelled before node graph edits that affect the Path are
 		/// made.
 		virtual const Plug *cancellationSubject() const;
+
+		/// May be implemented by Paths to provide a Context useful for inspecting
+		/// data represented by the Path.
+		virtual ContextPtr inspectionContext( const IECore::Canceller *canceller = nullptr ) const;
 
 	protected :
 

--- a/include/GafferScene/ScenePath.h
+++ b/include/GafferScene/ScenePath.h
@@ -83,6 +83,8 @@ class GAFFERSCENE_API ScenePath : public Gaffer::Path
 
 		const Gaffer::Plug *cancellationSubject() const override;
 
+		Gaffer::ContextPtr inspectionContext( const IECore::Canceller *canceller = nullptr ) const override;
+
 		static Gaffer::PathFilterPtr createStandardFilter( const std::vector<std::string> &setNames = std::vector<std::string>(), const std::string &setsLabel = "" );
 
 	protected :

--- a/include/GafferSceneUI/Private/InspectorColumn.h
+++ b/include/GafferSceneUI/Private/InspectorColumn.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,37 +34,53 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "InspectorBinding.h"
-#include "SceneGadgetBinding.h"
-#include "LightEditorBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
-#include "QueryBinding.h"
-#include "SetEditorBinding.h"
-#include "RenderPassEditorBinding.h"
-#include "InspectorColumnBinding.h"
+#include "GafferSceneUI/Export.h"
+#include "GafferSceneUI/Private/Inspector.h"
 
-using namespace GafferSceneUIModule;
+#include "GafferUI/PathColumn.h"
 
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+#include "Gaffer/Path.h"
+
+using namespace IECore;
+
+namespace GafferSceneUI
 {
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindQueries();
-	bindInspector();
-	bindInspectorColumn();
-	bindLightEditor();
-	bindSetEditor();
-	bindRenderPassEditor();
+namespace Private
+{
 
-}
+/// Column type which makes use of an Inspector.
+class GAFFERSCENEUI_API InspectorColumn : public GafferUI::PathColumn
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( InspectorColumn )
+
+		InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector, const std::string &label, const std::string &toolTip = "", PathColumn::SizeMode sizeMode = Default );
+		InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector, const CellData &headerData, PathColumn::SizeMode sizeMode = Default );
+
+		/// Returns the inspector used by this column.
+		GafferSceneUI::Private::Inspector *inspector() const;
+
+		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
+		CellData headerData( const IECore::Canceller *canceller ) const override;
+
+	private :
+
+		void inspectorDirtied();
+
+		static IECore::ConstStringDataPtr headerValue( const std::string &columnName );
+
+		const Private::InspectorPtr m_inspector;
+		const CellData m_headerData;
+
+};
+
+IE_CORE_DECLAREPTR( InspectorColumn )
+
+} // namespace Private
+
+} // namespace GafferSceneUI

--- a/python/GafferSceneTest/ScenePathTest.py
+++ b/python/GafferSceneTest/ScenePathTest.py
@@ -292,5 +292,26 @@ class ScenePathTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaises( IECore.Cancelled ) :
 			path.isValid( canceller )
 
+	def testInspectionContext( self ) :
+
+		plane = GafferScene.Plane()
+		path = GafferScene.ScenePath( plane["out"], Gaffer.Context(), "/plane" )
+
+		inspectionContext = path.inspectionContext()
+		self.assertIsNotNone( inspectionContext )
+		self.assertIn( "scene:path", inspectionContext )
+		self.assertEqual( inspectionContext["scene:path"], GafferScene.ScenePlug.stringToPath( "/plane" ) )
+
+		context = Gaffer.Context()
+		context["foo"] = 123
+		path = GafferScene.ScenePath( plane["out"], context, "/plane/bogus" )
+
+		inspectionContext = path.inspectionContext()
+		self.assertIsNotNone( inspectionContext )
+		self.assertIn( "scene:path", inspectionContext )
+		self.assertEqual( inspectionContext["scene:path"], GafferScene.ScenePlug.stringToPath( "/plane/bogus" ) )
+		self.assertIn( "foo", inspectionContext )
+		self.assertEqual( inspectionContext["foo"], 123 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -154,7 +154,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		GafferSceneUI.LightEditor.registerColumn(
 			rendererKey,
 			".".join( x for x in [ parameter.shader, parameter.name ] if x ),
-			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
+			lambda scene, editScope : GafferSceneUI.Private.InspectorColumn(
 				GafferSceneUI.Private.ParameterInspector( scene, editScope, rendererKey, parameter ),
 				columnName if columnName is not None else ""
 			),
@@ -175,7 +175,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		GafferSceneUI.LightEditor.registerColumn(
 			rendererKey,
 			".".join( x for x in [ parameter.shader, parameter.name ] if x ),
-			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
+			lambda scene, editScope : GafferSceneUI.Private.InspectorColumn(
 				GafferSceneUI.Private.ParameterInspector( scene, editScope, shaderAttribute, parameter ),
 				columnName if columnName is not None else ""
 			),
@@ -189,7 +189,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		GafferSceneUI.LightEditor.registerColumn(
 			rendererKey,
 			attributeName,
-			lambda scene, editScope : _GafferSceneUI._LightEditorInspectorColumn(
+			lambda scene, editScope : GafferSceneUI.Private.InspectorColumn(
 				GafferSceneUI.Private.AttributeInspector( scene, editScope, attributeName ),
 				displayName
 			),
@@ -199,7 +199,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 	# Registers a column in the Light Editor.
 	# `inspectorFunction` is a callable object of the form
 	# `inspectorFunction( scene, editScope )` returning a
-	# `GafferSceneUI._LightEditorInspectorColumn` object.
+	# `GafferSceneUI.Private.InspectorColumn` object.
 	@classmethod
 	def registerColumn( cls, rendererKey, columnKey, inspectorFunction, section = None ) :
 
@@ -336,7 +336,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		with Gaffer.Context( self.context() ) as context :
 
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 					continue
 				for pathString in selection.paths() :
 					path = GafferScene.ScenePlug.stringToPath( pathString )
@@ -441,7 +441,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		with Gaffer.Context( self.context() ) as context :
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 					continue
 				for path in columnSelection.paths() :
 					context["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
@@ -490,7 +490,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		with Gaffer.Context( self.context() ) as context :
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 					continue
 				elif not columnSelection.isEmpty() and type( column.inspector() ) != GafferSceneUI.Private.AttributeInspector :
 					return []
@@ -533,7 +533,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 			if (
 				not columnSelection.isEmpty() and (
-					not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) or
+					not isinstance( column, GafferSceneUI.Private.InspectorColumn ) or
 					not (
 						Gaffer.Metadata.value( "attribute:" + column.inspector().name(), "ui:scene:acceptsSetName" ) or
 						Gaffer.Metadata.value( "attribute:" + column.inspector().name(), "ui:scene:acceptsSetNames" ) or
@@ -726,7 +726,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 
 		for i in range( 0, len( columns ) ) :
 			column = columns[ i ]
-			if not isinstance( column, _GafferSceneUI._LightEditorInspectorColumn ) :
+			if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 				continue
 
 			for path in selection[i].paths() :

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -161,7 +161,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		GafferSceneUI.RenderPassEditor.registerColumn(
 			groupKey,
 			optionName,
-			lambda scene, editScope : _GafferSceneUI._RenderPassEditor.OptionInspectorColumn(
+			lambda scene, editScope : GafferSceneUI.Private.InspectorColumn(
 				GafferSceneUI.Private.OptionInspector( scene, editScope, optionName ),
 				columnName,
 				toolTip
@@ -172,7 +172,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 	# Registers a column in the Render Pass Editor.
 	# `inspectorFunction` is a callable object of the form
 	# `inspectorFunction( scene, editScope )` returning a
-	# `GafferSceneUI._RenderPassEditor.OptionInspectorColumn` object.
+	# `GafferSceneUI.Private.InspectorColumn` object.
 	@classmethod
 	def registerColumn( cls, groupKey, columnKey, inspectorFunction, section = "Main" ) :
 
@@ -398,7 +398,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		with Gaffer.Context( self.context() ) as context :
 			renderPassPath = self.__pathListing.getPath().copy()
 			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 					continue
 				for path in selection.paths() :
 					renderPassPath.setFromString( path )
@@ -499,7 +499,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		with Gaffer.Context( self.context() ) as context :
 			renderPassPath = self.__pathListing.getPath().copy()
 			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 					continue
 				for path in columnSelection.paths() :
 					renderPassPath.setFromString( path )
@@ -553,7 +553,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 			if (
 				not columnSelection.isEmpty() and (
-					not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) or
+					not isinstance( column, GafferSceneUI.Private.InspectorColumn ) or
 					not (
 						Gaffer.Metadata.value( "option:" + column.inspector().name(), "ui:scene:acceptsSetName" ) or
 						Gaffer.Metadata.value( "option:" + column.inspector().name(), "ui:scene:acceptsSetNames" ) or
@@ -675,7 +675,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		for i in range( 0, len( columns ) ) :
 			column = columns[ i ]
-			if not isinstance( column, _GafferSceneUI._RenderPassEditor.OptionInspectorColumn ) :
+			if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
 				continue
 
 			for path in selection[i].paths() :

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -385,32 +385,30 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		renderPassPlug["value"].setValue( selectedPassNames[0] if selectedPassNames[0] != currentRenderPass else "" )
 
-	## \todo Consider consolidating this with `LightEditor.__editSelectedCells()`.
-	# The main difference being the name of the context variable that is set before inspection,
-	# (`renderPass` vs `scene:path`) and the source of data for that variable.
+	## \todo Replace this and `LightEditor.__editSelectedCells()` with common editing
+	# functionality to be provided by InspectorColumn in the future.
 	def __editSelectedCells( self, pathListing, quickBoolean = True ) :
 
 		# A dictionary of the form :
-		# { inspector : { renderPass1 : inspection, renderPass2 : inspection, ... }, ... }
+		# { inspector : { path1 : inspection, path2 : inspection, ... }, ... }
 		inspectors = {}
 		inspections = []
 
-		with Gaffer.Context( self.context() ) as context :
-			renderPassPath = self.__pathListing.getPath().copy()
-			for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
+		path = pathListing.getPath().copy()
+		for selection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
+			if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
+				continue
+			for pathString in selection.paths() :
+				path.setFromString( pathString )
+				inspectionContext = path.inspectionContext()
+				if inspectionContext is None :
 					continue
-				for path in selection.paths() :
-					renderPassPath.setFromString( path )
-					renderPassName = renderPassPath.property( "renderPassPath:name" )
-					if not renderPassName :
-						continue
 
-					context["renderPass"] = renderPassName
+				with inspectionContext :
 					inspection = column.inspector().inspect()
 
 					if inspection is not None :
-						inspectors.setdefault( column.inspector(), {} )[renderPassName] = inspection
+						inspectors.setdefault( column.inspector(), {} )[pathString] = inspection
 						inspections.append( inspection )
 
 		if len( inspectors ) == 0 :
@@ -496,18 +494,17 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		tweaks = []
 
-		with Gaffer.Context( self.context() ) as context :
-			renderPassPath = self.__pathListing.getPath().copy()
-			for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
-				if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
+		path = pathListing.getPath().copy()
+		for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
+			if not isinstance( column, GafferSceneUI.Private.InspectorColumn ) :
+				continue
+			for pathString in columnSelection.paths() :
+				path.setFromString( pathString )
+				inspectionContext = path.inspectionContext()
+				if inspectionContext is None :
 					continue
-				for path in columnSelection.paths() :
-					renderPassPath.setFromString( path )
-					renderPassName = renderPassPath.property( "renderPassPath:name" )
-					if not renderPassName :
-						continue
 
-					context["renderPass"] = renderPassName
+				with inspectionContext :
 					inspection = column.inspector().inspect()
 					if inspection is not None and inspection.editable() :
 						source = inspection.source()
@@ -519,7 +516,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 							) and
 							( editScope is None or editScope.node().isAncestorOf( source ) )
 						) :
-							tweaks.append( ( path, column.inspector() ) )
+							tweaks.append( ( pathString, column.inspector() ) )
 						else :
 							return []
 					else :
@@ -531,22 +528,22 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		edits = self.__disablableInspectionTweaks( pathListing )
 
-		with Gaffer.UndoScope( self.scriptNode() ), Gaffer.Context( self.context() ) as context :
-			renderPassPath = self.__pathListing.getPath().copy()
-			for path, inspector in edits :
-				renderPassPath.setFromString( path )
-				context["renderPass"] = renderPassPath.property( "renderPassPath:name" )
-				inspection = inspector.inspect()
-				if inspection is not None and inspection.editable() :
-					source = inspection.source()
+		path = pathListing.getPath().copy()
+		with Gaffer.UndoScope( self.scriptNode() ) :
+			for pathString, inspector in edits :
+				path.setFromString( pathString )
+				with path.inspectionContext() :
+					inspection = inspector.inspect()
+					if inspection is not None and inspection.editable() :
+						source = inspection.source()
 
-					if isinstance( source, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) :
-						source["enabled"].setValue( False )
+						if isinstance( source, ( Gaffer.TweakPlug, Gaffer.NameValuePlug ) ) :
+							source["enabled"].setValue( False )
 
 	def __selectedSetExpressions( self, pathListing ) :
 
 		# A dictionary of the form :
-		# { renderPass1 : set( setExpression1, setExpression2 ), renderPass2 : set( setExpression1 ), ... }
+		# { path1 : set( setExpression1, setExpression2 ), path2 : set( setExpression1 ), ... }
 		result = {}
 
 		renderPassPath = pathListing.getPath().copy()
@@ -569,7 +566,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 				renderPassPath.setFromString( path )
 				cellValue = column.cellData( renderPassPath ).value
 				if cellValue is not None :
-					result.setdefault( renderPassPath.property( "renderPassPath:name" ), set() ).add( cellValue )
+					result.setdefault( path, set() ).add( cellValue )
 				else :
 					# We only return set expressions if all selected paths are render passes.
 					return {}
@@ -580,11 +577,12 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		result = IECore.PathMatcher()
 
-		with Gaffer.Context( self.context() ) as context :
-			for renderPass, setExpressions in self.__selectedSetExpressions( pathListing ).items() :
-				# Evaluate set expressions within their render pass in the context
-				# as set membership could vary based on the render pass.
-				context["renderPass"] = renderPass
+		renderPassPath = pathListing.getPath().copy()
+		for path, setExpressions in self.__selectedSetExpressions( pathListing ).items() :
+			# Evaluate set expressions within their render pass in the context
+			# as set membership could vary based on the render pass.
+			renderPassPath.setFromString( path )
+			with renderPassPath.inspectionContext() :
 				for setExpression in setExpressions :
 					result.addPaths( GafferScene.SetAlgo.evaluateSetExpression( setExpression, self.settings()["in"] ) )
 
@@ -680,18 +678,16 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 			for path in selection[i].paths() :
 				renderPassPath.setFromString( path )
-				renderPassName = renderPassPath.property( "renderPassPath:name" )
-				if renderPassName is None :
+				inspectionContext = renderPassPath.inspectionContext()
+				if inspectionContext is None :
 					continue
 
-				historyContext = Gaffer.Context( self.context() )
-				historyContext["renderPass"] = renderPassName
 				window = _HistoryWindow(
 					column.inspector(),
 					"/",
-					historyContext,
+					inspectionContext,
 					self.ancestor( GafferUI.ScriptWindow ).scriptNode(),
-					"History : {} : {}".format( renderPassName, column.headerData().value )
+					"History : {} : {}".format( inspectionContext["renderPass"], column.headerData().value )
 				)
 				self.ancestor( GafferUI.Window ).addChildWindow( window, removeOnClose = True )
 				window.setVisible( True )

--- a/python/GafferSceneUITest/InspectorColumnTest.py
+++ b/python/GafferSceneUITest/InspectorColumnTest.py
@@ -58,7 +58,7 @@ class InspectorColumnTest( GafferUITest.TestCase ) :
 		c = GafferSceneUI.Private.InspectorColumn( inspector, "Fancy ( Label )", "" )
 		self.assertEqual( c.inspector(), inspector )
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
-		self.assertEqual( c.headerData().value, "Fancy (  Label )" )
+		self.assertEqual( c.headerData().value, "Fancy ( Label )" )
 		self.assertEqual( c.headerData().toolTip, "" )
 
 		c = GafferSceneUI.Private.InspectorColumn( inspector )

--- a/python/GafferSceneUITest/InspectorColumnTest.py
+++ b/python/GafferSceneUITest/InspectorColumnTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2024, Cinesite VFX Limited. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,36 +34,48 @@
 #
 ##########################################################################
 
-from .SceneViewTest import SceneViewTest
-from .ShaderAssignmentUITest import ShaderAssignmentUITest
-from .StandardGraphLayoutTest import StandardGraphLayoutTest
-from .SceneGadgetTest import SceneGadgetTest
-from .SceneInspectorTest import SceneInspectorTest
-from .HierarchyViewTest import HierarchyViewTest
-from .DocumentationTest import DocumentationTest
-from .ShaderViewTest import ShaderViewTest
-from .ShaderUITest import ShaderUITest
-from .TranslateToolTest import TranslateToolTest
-from .ScaleToolTest import ScaleToolTest
-from .RotateToolTest import RotateToolTest
-from .ContextAlgoTest import ContextAlgoTest
-from .CameraToolTest import CameraToolTest
-from .VisualiserTest import VisualiserTest
-from .TransformToolTest import TransformToolTest
-from .CropWindowToolTest import CropWindowToolTest
-from .NodeUITest import NodeUITest
-from .ParameterInspectorTest import ParameterInspectorTest
-from .AttributeInspectorTest import AttributeInspectorTest
-from .HistoryPathTest import HistoryPathTest
-from .LightEditorTest import LightEditorTest
-from .SetMembershipInspectorTest import SetMembershipInspectorTest
-from .SetEditorTest import SetEditorTest
-from .LightToolTest import LightToolTest
-from .OptionInspectorTest import OptionInspectorTest
-from .LightPositionToolTest import LightPositionToolTest
-from .RenderPassEditorTest import RenderPassEditorTest
-from .SelectionToolTest import SelectionToolTest
-from .InspectorColumnTest import InspectorColumnTest
+import unittest
+
+import GafferUI
+import GafferUITest
+import GafferSceneTest
+import GafferSceneUI
+
+class InspectorColumnTest( GafferUITest.TestCase ) :
+
+	def testInspectorColumnConstructors( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		inspector = GafferSceneUI.Private.AttributeInspector( light["out"], None, "gl:visualiser:scale" )
+
+		c = GafferSceneUI.Private.InspectorColumn( inspector, "label", "help!" )
+		self.assertEqual( c.inspector(), inspector )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
+		self.assertEqual( c.headerData().value, "Label" )
+		self.assertEqual( c.headerData().toolTip, "help!" )
+
+		c = GafferSceneUI.Private.InspectorColumn( inspector, "Fancy ( Label )", "" )
+		self.assertEqual( c.inspector(), inspector )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
+		self.assertEqual( c.headerData().value, "Fancy (  Label )" )
+		self.assertEqual( c.headerData().toolTip, "" )
+
+		c = GafferSceneUI.Private.InspectorColumn( inspector )
+		self.assertEqual( c.inspector(), inspector )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Default )
+		self.assertEqual( c.headerData().value, "Gl:visualiser:scale" )
+		self.assertEqual( c.headerData().toolTip, "" )
+
+		c = GafferSceneUI.Private.InspectorColumn(
+			inspector,
+			GafferUI.PathColumn.CellData( value = "Fancy ( Label )", toolTip = "help!" ),
+			GafferUI.PathColumn.SizeMode.Stretch
+		)
+		self.assertEqual( c.inspector(), inspector )
+		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
+		self.assertEqual( c.headerData().value, "Fancy ( Label )" )
+		self.assertEqual( c.headerData().toolTip, "help!" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -652,6 +652,10 @@ class LightEditorTest( GafferUITest.TestCase ) :
 			editor._LightEditor__updateColumns()
 			GafferSceneUI.LightEditor._LightEditor__updateColumns.flush( editor )
 
+			editor.setNodeSet( Gaffer.StandardSet( [ script["editScope"] ] ) )
+			editor._LightEditor__setPathListingPath()
+			GafferSceneUI.LightEditor._LightEditor__setPathListingPath.flush( editor )
+
 			widget = editor._LightEditor__pathListing
 			self.setLightEditorMuteSelection( widget, togglePaths )
 
@@ -704,6 +708,9 @@ class LightEditorTest( GafferUITest.TestCase ) :
 
 		widget = editor._LightEditor__pathListing
 		editor.setNodeSet( Gaffer.StandardSet( [ script["custAttr"] ] ) )
+		editor._LightEditor__setPathListingPath()
+		GafferSceneUI.LightEditor._LightEditor__setPathListingPath.flush( editor )
+
 		self.setLightEditorMuteSelection( widget, ["/group/light"] )
 
 		# This will raise an exception if the context is not scoped correctly.
@@ -711,6 +718,8 @@ class LightEditorTest( GafferUITest.TestCase ) :
 			widget,
 			True  # quickBoolean
 		)
+
+		del widget, editor
 
 	def testShaderParameterEditScope( self ) :
 

--- a/python/GafferSceneUITest/LightEditorTest.py
+++ b/python/GafferSceneUITest/LightEditorTest.py
@@ -751,7 +751,7 @@ class LightEditorTest( GafferUITest.TestCase ) :
 		addAInspector = None
 		exposureInspector = None
 		for c in widget.getColumns() :
-			if not isinstance( c, _GafferSceneUI._LightEditorInspectorColumn ) :
+			if not isinstance( c, GafferSceneUI.Private.InspectorColumn ) :
 				continue
 			if c.headerData().value == "A" :
 				addAInspector = c.inspector()

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -134,6 +134,39 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		with self.assertRaises( IECore.Cancelled ) :
 			path.property( "renderPassPath:enabled", canceller )
 
+	def testRenderPassPathInspectionContext( self ) :
+
+		def testFn( name ) :
+			return "/".join( name.split( "_" )[:-1] )
+
+		GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( testFn )
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "A_A", "B"] ) )
+
+		for path, renderPass, grouped in (
+			( "/A_A", "A_A", False ),
+			( "/A_A", None, True ),
+			( "/A", "A", False ),
+			( "/A", "A", True ),
+			( "/A/A_A", None, False ),
+			( "/A/A_A", "A_A", True ),
+			( "/B", "B", False ),
+			( "/B", "B", True ),
+			( "/BOGUS", None, False ),
+			( "/BOGUS", None, True ),
+			( "/B/OGUS", None, False ),
+			( "/B/OGUS", None, True ),
+		) :
+
+			path = _GafferSceneUI._RenderPassEditor.RenderPassPath( renderPasses["out"], Gaffer.Context(), path, grouped = grouped )
+			inspectionContext = path.inspectionContext()
+			if renderPass is not None :
+				self.assertIn( "renderPass", inspectionContext )
+				self.assertEqual( inspectionContext["renderPass"], renderPass )
+			else :
+				self.assertIsNone( inspectionContext )
+
 	def testSearchFilter( self ) :
 
 		renderPasses = GafferScene.RenderPasses()

--- a/src/Gaffer/Path.cpp
+++ b/src/Gaffer/Path.cpp
@@ -379,6 +379,11 @@ const Plug *Path::cancellationSubject() const
 	return nullptr;
 }
 
+ContextPtr Path::inspectionContext( const IECore::Canceller *canceller ) const
+{
+	return nullptr;
+}
+
 void Path::doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const
 {
 }

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -269,6 +269,27 @@ class PathWrapper : public IECorePython::RunTimeTypedWrapper<WrappedType>
 			return WrappedType::cancellationSubject();
 		}
 
+		ContextPtr inspectionContext( const IECore::Canceller *canceller = nullptr ) const override
+		{
+			if( this->isSubclassed() )
+			{
+				IECorePython::ScopedGILLock gilLock;
+				try
+				{
+					boost::python::object f = this->methodOverride( "inspectionContext" );
+					if( f )
+					{
+						return extract<ContextPtr>( f( boost::python::ptr( canceller ) ) );
+					}
+				}
+				catch( const error_already_set & )
+				{
+					ExceptionAlgo::translatePythonException();
+				}
+			}
+			return WrappedType::inspectionContext();
+		}
+
 		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller = nullptr ) const override
 		{
 			if( this->isSubclassed() )
@@ -554,6 +575,7 @@ void GafferModule::bindPath()
 			.def( "setFromString", &Path::setFromString, return_self<>() )
 			.def( "append", &Path::append, return_self<>() )
 			.def( "truncateUntilValid", &Path::truncateUntilValid, return_self<>() )
+			.def( "inspectionContext", &Path::inspectionContext, ( arg_( "path" ), arg_( "canceller" ) = object() ) )
 			.def( "__str__", &Path::string )
 			.def( "__repr__", &pathRepr )
 			.def( "__len__", &pathLength )

--- a/src/GafferScene/ScenePath.cpp
+++ b/src/GafferScene/ScenePath.cpp
@@ -134,6 +134,17 @@ const Gaffer::Context *ScenePath::getContext() const
 	return m_context.get();
 }
 
+Gaffer::ContextPtr ScenePath::inspectionContext( const IECore::Canceller *canceller ) const
+{
+	ScenePlug::PathScope scope( getContext(), &( names() ) );
+	if( canceller )
+	{
+		scope.setCanceller( canceller );
+	}
+
+	return new Context( *scope.context() );
+}
+
 bool ScenePath::isValid( const IECore::Canceller *canceller ) const
 {
 	if( !Path::isValid() )

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -1,0 +1,162 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/InspectorColumn.h"
+
+#include "GafferUI/PathColumn.h"
+
+#include "Gaffer/ScriptNode.h"
+
+#include "IECore/CamelCase.h"
+#include "IECore/SimpleTypedData.h"
+
+using namespace Gaffer;
+using namespace GafferUI;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+namespace
+{
+
+const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = {
+{ (int)Inspector::Result::SourceType::Upstream, nullptr },
+{ (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
+{ (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },
+{ (int)Inspector::Result::SourceType::Other, nullptr },
+{ (int)Inspector::Result::SourceType::Fallback, nullptr },
+};
+const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
+
+}  // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// InspectorColumn
+//////////////////////////////////////////////////////////////////////////
+
+InspectorColumn::InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector, const std::string &columnName, const std::string &columnToolTip, PathColumn::SizeMode sizeMode )
+	:	InspectorColumn( inspector, PathColumn::CellData( headerValue( columnName != "" ? columnName : inspector->name() ), nullptr, nullptr, new IECore::StringData( columnToolTip ) ), sizeMode )
+{
+}
+
+InspectorColumn::InspectorColumn( GafferSceneUI::Private::InspectorPtr inspector, const CellData &headerData, PathColumn::SizeMode sizeMode )
+	:	PathColumn( sizeMode ), m_inspector( inspector ), m_headerData( headerData )
+{
+	m_inspector->dirtiedSignal().connect( boost::bind( &InspectorColumn::inspectorDirtied, this ) );
+}
+
+GafferSceneUI::Private::Inspector *InspectorColumn::inspector() const
+{
+	return m_inspector.get();
+}
+
+PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
+{
+	CellData result;
+
+	const ContextPtr inspectionContext = path.inspectionContext( canceller );
+	if( !inspectionContext )
+	{
+		return result;
+	}
+
+	Context::Scope scope( inspectionContext.get() );
+	Inspector::ConstResultPtr inspectorResult = m_inspector->inspect();
+	if( !inspectorResult )
+	{
+		return result;
+	}
+
+	result.value = runTimeCast<const IECore::Data>( inspectorResult->value() );
+	/// \todo Should PathModel create a decoration automatically when we
+	/// return a colour for `Role::Value`?
+	result.icon = runTimeCast<const Color3fData>( inspectorResult->value() );
+	result.background = g_sourceTypeColors.at( (int)inspectorResult->sourceType() );
+	std::string toolTip;
+	if( inspectorResult->sourceType() == Inspector::Result::SourceType::Fallback )
+	{
+		toolTip = "Source : " + inspectorResult->fallbackDescription();
+		result.foreground = g_fallbackValueForegroundColor;
+	}
+	else if( const auto source = inspectorResult->source() )
+	{
+		toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
+	}
+
+	/// \todo Adding these "Double-click" prompts really only makes sense
+	/// once the column itself handles editing. Should we have the ability
+	/// to create read-only columns?
+	if( inspectorResult->editable() )
+	{
+		toolTip += !toolTip.empty() ? "\n\n" : "";
+		if( runTimeCast<const IECore::BoolData>( result.value ) )
+		{
+			toolTip += "Double-click to toggle";
+		}
+		else
+		{
+			toolTip += "Double-click to edit";
+		}
+	}
+
+	if( !toolTip.empty() )
+	{
+		result.toolTip = new StringData( toolTip );
+	}
+
+	return result;
+}
+
+PathColumn::CellData InspectorColumn::headerData( const IECore::Canceller *canceller ) const
+{
+	return m_headerData;
+}
+
+void InspectorColumn::inspectorDirtied()
+{
+	changedSignal()( this );
+}
+
+IECore::ConstStringDataPtr InspectorColumn::headerValue( const std::string &columnName )
+{
+	std::string name = columnName;
+	// Convert from snake case and/or camel case to UI case.
+	if( name.find( '_' ) != std::string::npos )
+	{
+		std::replace( name.begin(), name.end(), '_', ' ' );
+		name = CamelCase::fromSpaced( name );
+	}
+	return new StringData( CamelCase::toSpaced( name ) );
+}

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -151,6 +151,13 @@ void InspectorColumn::inspectorDirtied()
 
 IECore::ConstStringDataPtr InspectorColumn::headerValue( const std::string &columnName )
 {
+	if( columnName.find( ' ' ) != std::string::npos )
+	{
+		// Names already containing spaces are considered
+		// to be already formatted and are left as-is.
+		return new StringData( columnName );
+	}
+
 	std::string name = columnName;
 	// Convert from snake case and/or camel case to UI case.
 	if( name.find( '_' ) != std::string::npos )

--- a/src/GafferSceneUIModule/InspectorColumnBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorColumnBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,35 +36,44 @@
 
 #include "boost/python.hpp"
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "InspectorBinding.h"
-#include "SceneGadgetBinding.h"
-#include "LightEditorBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
-#include "QueryBinding.h"
-#include "SetEditorBinding.h"
-#include "RenderPassEditorBinding.h"
 #include "InspectorColumnBinding.h"
 
-using namespace GafferSceneUIModule;
+#include "GafferSceneUI/Private/Inspector.h"
+#include "GafferSceneUI/Private/InspectorColumn.h"
 
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+#include "GafferUI/PathColumn.h"
+
+#include "IECorePython/RefCountedBinding.h"
+
+using namespace boost::python;
+using namespace IECorePython;
+using namespace GafferUI;
+using namespace GafferSceneUI::Private;
+
+void GafferSceneUIModule::bindInspectorColumn()
 {
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindQueries();
-	bindInspector();
-	bindInspectorColumn();
-	bindLightEditor();
-	bindSetEditor();
-	bindRenderPassEditor();
+	object privateModule( borrowed( PyImport_AddModule( "GafferSceneUI.Private" ) ) );
+	scope().attr( "Private" ) = privateModule;
+	scope privateScope( privateModule );
+
+	RefCountedClass<GafferSceneUI::Private::InspectorColumn, GafferUI::PathColumn>( "InspectorColumn" )
+		.def( init<GafferSceneUI::Private::InspectorPtr, const std::string &, const std::string &, PathColumn::SizeMode>(
+			(
+				arg_( "inspector" ),
+				arg_( "label" ) = "",
+				arg_( "toolTip" ) = "",
+				arg( "sizeMode" ) = PathColumn::Default
+			)
+		) )
+		.def( init<GafferSceneUI::Private::InspectorPtr, const PathColumn::CellData &, PathColumn::SizeMode>(
+			(
+				arg_( "inspector" ),
+				arg_( "headerData" ),
+				arg_( "sizeMode" ) = PathColumn::Default
+			)
+		) )
+		.def( "inspector", &InspectorColumn::inspector, return_value_policy<CastToIntrusivePtr>() )
+	;
 
 }

--- a/src/GafferSceneUIModule/InspectorColumnBinding.h
+++ b/src/GafferSceneUIModule/InspectorColumnBinding.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2013, John Haddon. All rights reserved.
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,37 +34,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "ContextAlgoBinding.h"
-#include "HierarchyViewBinding.h"
-#include "InspectorBinding.h"
-#include "SceneGadgetBinding.h"
-#include "LightEditorBinding.h"
-#include "ToolBinding.h"
-#include "ViewBinding.h"
-#include "VisualiserBinding.h"
-#include "QueryBinding.h"
-#include "SetEditorBinding.h"
-#include "RenderPassEditorBinding.h"
-#include "InspectorColumnBinding.h"
-
-using namespace GafferSceneUIModule;
-
-BOOST_PYTHON_MODULE( _GafferSceneUI )
+namespace GafferSceneUIModule
 {
 
-	bindViews();
-	bindTools();
-	bindVisualisers();
-	bindHierarchyView();
-	bindSceneGadget();
-	bindContextAlgo();
-	bindQueries();
-	bindInspector();
-	bindInspectorColumn();
-	bindLightEditor();
-	bindSetEditor();
-	bindRenderPassEditor();
+void bindInspectorColumn();
 
-}
+} // namespace GafferSceneUIModule

--- a/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
+++ b/src/GafferSceneUIModule/RenderPassEditorBinding.cpp
@@ -346,6 +346,24 @@ class RenderPassPath : public Gaffer::Path
 			return m_scene.get();
 		}
 
+		Gaffer::ContextPtr inspectionContext( const IECore::Canceller *canceller ) const override
+		{
+			const auto renderPassName = runTimeCast<const IECore::StringData>( property( g_renderPassNamePropertyName, canceller ) );
+			if( !renderPassName )
+			{
+				return nullptr;
+			}
+
+			Context::EditableScope scope( getContext() );
+			scope.set( g_renderPassContextName, &( renderPassName->readable() ) );
+			if( canceller )
+			{
+				scope.setCanceller( canceller );
+			}
+
+			return new Context( *scope.context() );
+		}
+
 	protected :
 
 		void doChildren( std::vector<PathPtr> &children, const IECore::Canceller *canceller ) const override


### PR DESCRIPTION
This continues the work of removing duplication between the Light Editor and Render Pass Editor by replacing their specific implementations of "a PathColumn which makes use of an Inspector" with a new generic InspectorColumn that could be used by any editor with a PathListingWidget.

The intention from here is move much of the currently editor-specific editing interactions to the column itself, so that columns would become more portable between editors and we end up in a position where (for example) adding a column to the HierarchyView to inspect and edit the "scene:visible" attribute is just a matter of registering the column (or the attribute) to the editor and wouldn't require reimplementing all of the editing behaviour.

As an intermediate step towards this goal, the Light Editor and Render Pass Editor have been updated to replace their internal handling of mapping a path to a context-with-specific-variables to instead use the new `Path::inspectionContext()` virtual method which has been implemented by ScenePath and RenderPassPath to provide the editor with an appropriate context for each path being edited.