### PR TITLE
SetAlgo : Treat set expressions containing only whitespace as empty

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.10.0)
 =======
 
+Improvements
+------------
 
+- SetExpressions : Set Expressions containing only whitespace characters are now treated as empty rather than producing an error.
 
 1.4.10.0 (relative to 1.4.9.0)
 ========

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -134,6 +134,16 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		expressionCheck( '(setA - ((setC /group/group/sphere2) & setB))', [ '/group/group/sphere1' ] )
 		expressionCheck( 'setA - (/group/group/sphere1 /group/group/sphere2) | (setA setB setC) & setC', [ '/group/sphere3' ] )
 
+		# Test a selection of the above expressions with tab and newline whitespace characters inserted
+		expressionCheck( 'setA\nsetC', [ '/group/group/sphere1', '/group/group/sphere2', '/group/sphere3' ] )
+		expressionCheck( '\n\nsetA\tsetC\n\n\t', [ '/group/group/sphere1', '/group/group/sphere2', '/group/sphere3' ] )
+		expressionCheck( 'setA\t-\tsetB\n|\nsetC', [ '/group/group/sphere1', '/group/sphere3' ] )
+		expressionCheck( 'setA\n| setB\n& setC', [ '/group/group/sphere1', '/group/group/sphere2' ] )
+		expressionCheck( '/group/light1\n/group/light2', [ '/group/light1', '/group/light2' ] )
+		expressionCheck( '/group/light1\t/group/light2\n', [ '/group/light1', '/group/light2' ] )
+		expressionCheck( '(\n\t/group/light1\n\t/group/light2\n)\n|\nsetA', [ '/group/light1', '/group/light2', '/group/group/sphere1', '/group/group/sphere2' ] )
+		expressionCheck( '(\nsetA - \n(\n\t(\n\t\tsetC /group/group/sphere2\n\t)\n & setB)\n)\n', [ '/group/group/sphere1' ] )
+
 		# Test expressions containing only whitespace are treated as empty
 		expressionCheck( '', [] )
 		expressionCheck( ' ', [] )

--- a/python/GafferSceneTest/SetAlgoTest.py
+++ b/python/GafferSceneTest/SetAlgoTest.py
@@ -134,6 +134,16 @@ class SetAlgoTest( GafferSceneTest.SceneTestCase ) :
 		expressionCheck( '(setA - ((setC /group/group/sphere2) & setB))', [ '/group/group/sphere1' ] )
 		expressionCheck( 'setA - (/group/group/sphere1 /group/group/sphere2) | (setA setB setC) & setC', [ '/group/sphere3' ] )
 
+		# Test expressions containing only whitespace are treated as empty
+		expressionCheck( '', [] )
+		expressionCheck( ' ', [] )
+		expressionCheck( '\n', [] )
+		expressionCheck( ' \n ', [] )
+		expressionCheck( '\t', [] )
+		expressionCheck( ' \t ', [] )
+		expressionCheck( '\n \t', [] )
+		expressionCheck( '\t\n\t \n  \t\n', [] )
+
 		# Test if proper exception is thrown for invalid expression
 		with self.assertRaises( RuntimeError ) as e :
 			# note the missing )

--- a/src/GafferScene/SetAlgo.cpp
+++ b/src/GafferScene/SetAlgo.cpp
@@ -439,7 +439,7 @@ struct ExpressionGrammar : qi::grammar<Iterator, ExpressionAst(), ascii::space_t
 
 void expressionToAST( const std::string &setExpression, ExpressionAst &ast)
 {
-	if( setExpression == "" )
+	if( std::all_of( setExpression.begin(), setExpression.end(), isspace ) )
 	{
 		return;
 	}


### PR DESCRIPTION
A potential improvement based on user feedback about the new SetExpressionPlugValueWidget. As the widget is multi-line it seems it's fairly easy for users to end up in a situation where they remove all set/location identifiers from the Set Expression and leave only whitespace behind, such as newlines by accidentally pressing `Return` thinking that would commit the edit. Once the edit was committed, the set expression would error due to it containing invalid syntax.

```
ERROR : BackgroundTask : SetFilter2.__expressionResult : Syntax error in indicated part of SetExpression.
ERROR :
ERROR :
ERROR :
ERROR :
ERROR : |---|
ERROR : .
```

To avoid this situation, this improvement treats set expressions containing only whitespace the same as if they were an empty string so we don't attempt to produce an AST.