### PR TITLE
Viewer config : Add diagnostic shading mode for usd:purpose

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,11 @@ Improvements
 - ArnoldShader :
   - Added a UI layout for the new `openpbr_surface` shader.
   - Moved Arnold 7.3.3.0's new `standard_volume.scatter_diffusion` parameters to a "Scatter Diffusion" section of the UI.
+- Viewer : Added diagnostic shading mode for visualising the values of the `usd:purpose` attribute as colours :
+  - White : Default
+  - Green : Render
+  - Blue : Proxy
+  - Red : Guide
 
 Fixes
 -----

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -139,6 +139,55 @@ def __createXRayShader() :
 
 GafferSceneUI.SceneView.registerShadingMode( "X-Ray", __createXRayShader )
 
+def __createPurposeShadingMode() :
+
+	result = GafferScene.SceneProcessor( "PurposeVisualiser" )
+
+	result["attributeQuery"] = GafferScene.AttributeQuery()
+	result["attributeQuery"].setup( Gaffer.StringPlug() )
+	result["attributeQuery"]["scene"].setInput( result["in"] )
+	result["attributeQuery"]["location"].setValue( "${scene:path}" )
+	result["attributeQuery"]["attribute"].setValue( "usd:purpose" )
+	result["attributeQuery"]["default"].setValue( "default" )
+	result["attributeQuery"]["inherit"].setValue( True )
+
+	result["customAttributes"] = GafferScene.CustomAttributes()
+	result["customAttributes"]["in"].setInput( result["in"] )
+
+	result["spreadsheet"] = Gaffer.Spreadsheet()
+	result["spreadsheet"]["selector"].setInput( result["attributeQuery"]["value"] )
+	result["spreadsheet"]["rows"].addColumn( result["customAttributes"]["extraAttributes"] )
+
+	result["customAttributes"]["extraAttributes"].setInput( result["spreadsheet"]["out"]["extraAttributes"] )
+
+	for purpose, color in {
+		"render" : imath.Color3f( 0, 1, 0 ),
+		"proxy" : imath.Color3f( 0, 0, 1 ),
+		"guide" : imath.Color3f( 1, 0, 0 ),
+		"default" : imath.Color3f( 1, 1, 1 )
+	}.items() :
+		row = result["spreadsheet"]["rows"].addRow()
+		row["name"].setValue( purpose )
+		row["cells"]["extraAttributes"]["value"].setValue(
+			IECore.CompoundObject( {
+				"gl:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"surface" : IECoreScene.Shader(
+							"FacingRatio", "gl:surface",
+							{ "facingColor" : color },
+						)
+					},
+					output = "surface",
+				)
+			} )
+		)
+
+	result["out"].setInput( result["customAttributes"]["out"] )
+
+	return result
+
+GafferSceneUI.SceneView.registerShadingMode( "Diagnostic/USD/Purpose", __createPurposeShadingMode )
+
 def __loadRendererSettings( fileName ) :
 
 	script = Gaffer.ScriptNode()

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -137,7 +137,7 @@ def __createXRayShader() :
 
 	return xray
 
-GafferSceneUI.SceneView.registerShadingMode( "X-Ray", functools.partial( __createXRayShader ) )
+GafferSceneUI.SceneView.registerShadingMode( "X-Ray", __createXRayShader )
 
 def __loadRendererSettings( fileName ) :
 


### PR DESCRIPTION
Some open questions here :

1. This suffers from a problem I've just discovered that all the diagnostic modes have : they are overridden by any `Cs` primitive variables on an object. It feels like we should fix this, but I'm not sure where - the easiest would be to use a different shader than `Constant`. Should this be a new shader, in which case what should it be called or should it be private ? Or should we use the existing `FacingRatio`?
2. Should this automatically turn all `includedPurposes` on so you are visualising, or is that surprising or at the very least a performance hazard.
3. What should the colours be?