### PR TITLE
PathColumn : Add `contextMenuSignal()` and `instanceCreatedSignal()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -48,6 +48,7 @@ API
   - A `DeprecationWarning` is now emitted by `_plugConnections()`. Use `_blockedUpdateFromValues()` instead.
 - NodeGadget, ConnectionGadget : Added `updateFromContextTracker()` virtual methods.
 - Path : Added `inspectionContext()` virtual method.
+- PathColumn : Added `contextMenuSignal()`, allowing the creation of custom context menus.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -48,7 +48,9 @@ API
   - A `DeprecationWarning` is now emitted by `_plugConnections()`. Use `_blockedUpdateFromValues()` instead.
 - NodeGadget, ConnectionGadget : Added `updateFromContextTracker()` virtual methods.
 - Path : Added `inspectionContext()` virtual method.
-- PathColumn : Added `contextMenuSignal()`, allowing the creation of custom context menus.
+- PathColumn :
+  - Added `contextMenuSignal()`, allowing the creation of custom context menus.
+  - Added `instanceCreatedSignal()`, providing an opportunity to connect to the signals on _any_ column, no matter how it is created.
 
 Breaking Changes
 ----------------

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -164,6 +164,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ButtonSignal &buttonDoubleClickSignal();
 
 		using ContextMenuSignal = Gaffer::Signals::Signal<void ( PathColumn &column, PathListingWidget &widget, MenuDefinition &menuDefinition ), Gaffer::Signals::CatchingCombiner<void>>;
+		/// To retain `widget` for use in MenuItem commands, use `PathListingWidgetPtr( &widget )`.
 		ContextMenuSignal &contextMenuSignal();
 
 		/// Creation
@@ -272,10 +273,12 @@ IE_CORE_DECLAREPTR( FileIconPathColumn )
 /// C++ interface for the `GafferUI.PathListingWidget` Python class. Provided for
 /// use in PathColumn event signals, so that event handling may be implemented
 /// from C++ if desired.
-class PathListingWidget
+class PathListingWidget : public IECore::RefCounted
 {
 
 	public :
+
+		IE_CORE_DECLAREMEMBERPTR( PathListingWidget )
 
 		using Columns = std::vector<PathColumnPtr>;
 		virtual void setColumns( const Columns &columns ) = 0;
@@ -286,6 +289,8 @@ class PathListingWidget
 		virtual Selection getSelection() const = 0;
 
 };
+
+IE_CORE_DECLAREPTR( PathListingWidget )
 
 /// C++ interface for the `IECore.MenuDefinition` Python class. Provided for use
 /// in `PathColumn::contextMenuSignal()`, so that event handling may be

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -50,6 +50,7 @@
 namespace GafferUI
 {
 
+class MenuDefinition;
 class PathListingWidget;
 
 /// Abstract class for extracting properties from a Path in a form
@@ -162,6 +163,9 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ButtonSignal &buttonReleaseSignal();
 		ButtonSignal &buttonDoubleClickSignal();
 
+		using ContextMenuSignal = Gaffer::Signals::Signal<void ( PathColumn &column, PathListingWidget &widget, MenuDefinition &menuDefinition ), Gaffer::Signals::CatchingCombiner<void>>;
+		ContextMenuSignal &contextMenuSignal();
+
 	private :
 
 		PathColumnSignal m_changedSignal;
@@ -169,6 +173,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ButtonSignal m_buttonPressSignal;
 		ButtonSignal m_buttonReleaseSignal;
 		ButtonSignal m_buttonDoubleClickSignal;
+		ContextMenuSignal m_contextMenuSignal;
 
 		SizeMode m_sizeMode;
 
@@ -271,6 +276,29 @@ class PathListingWidget
 		using Selection = std::variant<IECore::PathMatcher, std::vector<IECore::PathMatcher>>;
 		virtual void setSelection( const Selection &selection ) = 0;
 		virtual Selection getSelection() const = 0;
+
+};
+
+/// C++ interface for the `IECore.MenuDefinition` Python class. Provided for use
+/// in `PathColumn::contextMenuSignal()`, so that event handling may be
+/// implemented from C++ if desired.
+class MenuDefinition
+{
+
+	public :
+
+		struct MenuItem
+		{
+			using Command = std::function<void ()>;
+			Command command;
+			std::string description;
+			std::string icon;
+			std::string shortCut;
+			bool divider = false;
+			bool active = true;
+		};
+
+		virtual void append( const std::string &path, const MenuItem &item ) = 0;
 
 };
 

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -766,16 +766,15 @@ class PathListingWidget( GafferUI.Widget ) :
 
 	def __contextMenu( self, widget ) :
 
-		if not self.columnContextMenuSignal().numSlots() :
+		mousePosition = GafferUI.Widget.mousePosition( relativeTo = self )
+		column = self.columnAt( mousePosition )
+		if not column.contextMenuSignal().numSlots() and not self.columnContextMenuSignal().numSlots() :
 			# Allow legacy clients connected to `Widget.contextMenuSignal()` to
 			# do their own thing instead.
 			return False
 
 		# Select the path under the mouse, if it's not already selected.
 		# The user will expect to be operating on the thing under the mouse.
-
-		mousePosition = GafferUI.Widget.mousePosition( relativeTo = self )
-		column = self.columnAt( mousePosition )
 
 		path = self.pathAt( mousePosition )
 		if path is not None :
@@ -797,6 +796,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		# Use signals to build menu and display it.
 
 		menuDefinition = IECore.MenuDefinition()
+		column.contextMenuSignal()( column, self, menuDefinition )
 		self.columnContextMenuSignal()( column, self, menuDefinition )
 
 		if menuDefinition.size() :

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -110,6 +110,11 @@ PathColumn::ButtonSignal &PathColumn::buttonDoubleClickSignal()
 	return m_buttonDoubleClickSignal;
 }
 
+PathColumn::ContextMenuSignal &PathColumn::contextMenuSignal()
+{
+	return m_contextMenuSignal;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // StandardPathColumn
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -115,6 +115,12 @@ PathColumn::ContextMenuSignal &PathColumn::contextMenuSignal()
 	return m_contextMenuSignal;
 }
 
+PathColumn::PathColumnSignal &PathColumn::instanceCreatedSignal()
+{
+	static PathColumnSignal g_instanceCreatedSignal;
+	return g_instanceCreatedSignal;
+}
+
 //////////////////////////////////////////////////////////////////////////
 // StandardPathColumn
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -504,6 +504,8 @@ void GafferUIModule::bindPathColumn()
 		.def( "buttonReleaseSignal", &PathColumn::buttonReleaseSignal, return_internal_reference<1>() )
 		.def( "buttonDoubleClickSignal", &PathColumn::buttonDoubleClickSignal, return_internal_reference<1>() )
 		.def( "contextMenuSignal", &PathColumn::contextMenuSignal, return_internal_reference<1>() )
+		.def( "instanceCreatedSignal", &PathColumn::instanceCreatedSignal, return_value_policy<reference_existing_object>() )
+		.staticmethod( "instanceCreatedSignal" )
 		.def( "getSizeMode", (PathColumn::SizeMode (PathColumn::*)() const )&PathColumn::getSizeMode )
 		.def( "setSizeMode", &PathColumn::setSizeMode, ( arg( "sizeMode" ) ) )
 	;


### PR DESCRIPTION
This provides further options for PathColumn customisation/extension. I anticipate `instanceCreatedSignal()` being particularly useful to extend otherwise pure C++ columns with functionality that is easier to implement in Python.

Separately I'm faffing around with some stuff to try to get shortcuts from the menus triggering automatically instead of being implemented separately via `keyPressSignal()` as we're doing currently. If that works out, it will come in a separate PR...