### PR TITLE
Version Check : Run when PR target branch is edited

### DIFF
--- a/.github/workflows/versionCheck.yml
+++ b/.github/workflows/versionCheck.yml
@@ -1,5 +1,9 @@
 name: Version check
-on: [ pull_request ]
+on:
+  pull_request:
+    # Add `edited` to the default types, so that the check runs again
+    # when the target branch changes.
+    types: [opened, synchronize, reopened, edited]
 jobs:
 
   check:


### PR DESCRIPTION
Otherwise you won't be rewarded with a nice green tick when you choose the correct base branch after a failure.
