### PR TITLE
SpreadsheetUI : Use ContextTracker

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - LightEditor :
   - Improved formatting of column headers containing whitespace.
   - The "Double-click to toggle" tooltip is no longer displayed while hovering over non-editable cells, and a "Double-click to edit" tooltip is now displayed while hovering over other non-toggleable but editable cells.
+- Spreadsheet : Added yellow underlining to the currently active row.
 
 Fixes
 -----

--- a/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableDelegate.py
@@ -64,6 +64,12 @@ class _PlugTableDelegate( QtWidgets.QStyledItemDelegate ) :
 			focusColour.setAlpha( 30 )
 			painter.fillRect( option.rect, focusColour )
 
+		if index.data( _PlugTableModel.ActiveRole ) :
+			pen = QtGui.QPen( QtGui.QColor( 240, 220, 40, 150 ) )
+			pen.setWidth( 2 )
+			painter.setPen( pen )
+			painter.drawLine( option.rect.bottomLeft(), option.rect.bottomRight() )
+
 		if enabled and cellPlugEnabled :
 			return
 

--- a/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
+++ b/python/GafferUI/SpreadsheetUI/_RowsPlugValueWidget.py
@@ -66,7 +66,7 @@ class _RowsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		GafferUI.PlugValueWidget.__init__( self, self.__grid, plug )
 
-		model = _PlugTableModel( plug, self.context(), self._qtWidget() )
+		model = _PlugTableModel( plug, self._qtWidget() )
 		selectionModel = QtCore.QItemSelectionModel( model, self._qtWidget() )
 
 		with self.__grid :


### PR DESCRIPTION
This lets us highlight the currently active row like so :

![spreadsheetA](https://github.com/user-attachments/assets/ba4f65bf-a76e-44bb-a31a-7448e7178933)

There is ample room for bikeshedding on the presentation, and opinions are welcome, but I am pretty sold on "context yellow" as a way of tying together all the upcoming context-aware features and linking with the existing colour for the current-frame indicator. @tomc-cinesite had some concerns that it could be confused for a warning, but in context I think it works pretty well, and used sparingly yellow works well to draw the eye without overwhelming. I don't know what other colour we'd use.

Tom also suggested a few alternative presentations, which I've tried out below...

**Adding an "overline" to the underline**

 To avoid any ambiguity about what the underline is associated with. I don't mind this one, but I'm not sure the underlining is too ambiguous, especially once you've seen it update in context once or twice.
 
![spreadsheetB](https://github.com/user-attachments/assets/ce20ac48-16d0-484a-b433-884664c86bb8)

**Using background colour**

I strongly dislike this on two counts :

- We're overloading background colour already, using it differentiate both even/odd rows and also disabled cells.
- When faded to a suitable luminance for the background, the colour just gets muddy.

![spreadsheetC](https://github.com/user-attachments/assets/544fd4c1-a509-4083-88d1-38b8507d537a)

**Using left/right lines**

I find this much harder to read than any other presentation. Note that we do need to highlight the left/right of every cell rather than just the row ends, because disabled cells don't get highlighting.

![spreadsheetD](https://github.com/user-attachments/assets/dd669e35-63f1-44a5-9374-66981e6371b7)
