### PR TITLE
ShaderUI : Mark `type` plug as read-only

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - Arnold : Fixed bug preventing UI metadata for Imagers from being loaded for Arnold 7.3.
 - WidgetAlgo : Fixed issue preventing `grab()` from capturing popup menus on Windows.
 - ShowURL : Fixed opening of "file://" URLs on Windows (#5861).
+- Shader : Fixed "Revert to Defaults" menu item in NodeEditor (#1862).
 
 API
 ---

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -90,7 +90,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The name of the shader being represented. This should
-			be considered read-only. Use the Shader.loadShader()
+			be considered read-only. Use the `Shader.loadShader()`
 			method to load a shader.
 			""",
 
@@ -107,10 +107,11 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The type of the shader being represented. This should
-			be considered read-only. Use the Shader.loadShader()
+			be considered read-only. Use the `Shader.loadShader()`
 			method to load a shader.
 			""",
 
+			"readOnly", True,
 			"layout:section", "",
 			"nodule:type", "",
 			"plugValueWidget:type", "",


### PR DESCRIPTION
As with `name`, it is already considered read-only because `loadShader()` should be used to set it and load all the associated parameters at the same time. Marking it as read-only via metadata prevents the "Revert to Defaults" menu item from clobbering it, which previously was breaking the shader completely.

Also updated documentation to make use of Markdown code formatting.

Fixes #1862
