### PR TITLE
ListContainer alignment

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - LightEditor, RenderPassEditor : History windows now use a context determined relative to the current focus node.
 - NumericWidget : Added the ability to use <kbd>Ctrl</kbd> + scroll wheel to adjust values in the same manner as <kbd>Up</kbd> and <kbd>Down</kbd> (#6009). [^1]
 - NodeEditor : Improved performance when showing a node with many colour plugs. Showing the Arnold `standard_surface` shader is now almost 2x faster. [^1]
+- ListContainer : Adding a child widget with non-default alignment no longer causes the container to take up all available space.
 
 Fixes
 -----

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -74,12 +74,7 @@ class GraphEditor( GafferUI.Editor ) :
 		self.__gadgetWidget.getViewportGadget().preRenderSignal().connect( Gaffer.WeakMethod( self.__preRender ) )
 
 		with GafferUI.ListContainer( borderWidth = 8, spacing = 0 ) as overlay :
-			with GafferUI.ListContainer(
-				GafferUI.ListContainer.Orientation.Horizontal,
-				parenting = {
-					"verticalAlignment" : GafferUI.VerticalAlignment.Top,
-				}
-			) :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal ) :
 				GafferUI.Spacer( imath.V2i( 1 ) )
 				GafferUI.MenuButton(
 					image = "annotations.png", hasFrame = False,
@@ -88,6 +83,7 @@ class GraphEditor( GafferUI.Editor ) :
 						title = "Annotations"
 					)
 				)
+			GafferUI.Spacer( imath.V2i( 1 ) )
 
 		self.__gadgetWidget.addOverlay( overlay )
 

--- a/python/GafferUITest/ListContainerTest.py
+++ b/python/GafferUITest/ListContainerTest.py
@@ -370,5 +370,19 @@ class ListContainerTest( GafferUITest.TestCase ) :
 		self.assertEqual( c[0].s, "a" )
 		self.assertEqual( c[1].s, "b" )
 
+	def testAlignmentSize( self ) :
+
+		with GafferUI.Window( "Test" ) as w :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical ) as v :
+				l1 = GafferUI.Label( "test", parenting = { "verticalAlignment" : GafferUI.VerticalAlignment.Top } )
+				l2 = GafferUI.Label( "test" )
+
+		w._qtWidget().resize( 200, 200 )
+		w.setVisible( True )
+		self.waitForIdle()
+
+		self.assertEqual( v.size().y, l1.size().y + l2.size().y )
+		self.assertEqual( l2._qtWidget().pos().y(), l1.size().y )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes the excessive sizing of `ListContainers` when a child widget has non-default alignment. So far I've only seen one widget that now has incorrect placement, the annotations button in the Graph Editor, which is fixed in this PR. If anyone spots others, I can fix those up as well.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
