### PR TITLE
ColorChooser Color Wheel

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - Light Editor : Added `is_sphere` column for Cycles lights.
 - Windows : Gaffer now uses the TBB memory allocator for significantly better performance.
+- ColorChooser : Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
 
 Breaking Changes
 ----------------


### PR DESCRIPTION
This changes the type of color field to a color wheel instead of the rectangular field when hue is being visualized. So it's active when the static color is set to saturation or value.

For drawing the field, the 50 pixel bitmap with bilinear scaling up to the widget size gives pretty good performance and doesn't introduce too much inaccuracy compared to drawing the field at the full resolution. But as we discussed yesterday, it probably could be much better if we did the drawing in GLSL or c++, which is probably worth investigating as a follow-up.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
