### PR TITLE
UIEditor : Add support for editing `iconScale` node metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- UI Editor : Added the ability to edit the scale of node icons.
+- UI Editor :
+  - Added the ability to edit the scale of node icons.
+  - Improved layout of Box node plug creator visibility toggles.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,15 @@
 1.4.x.x (relative to 1.4.11.0)
 =======
 
+Improvements
+------------
 
+- UI Editor : Added the ability to edit the scale of node icons.
+
+API
+---
+
+- MetadataWidget : Added `NumericMetadataWidget` class.
 
 1.4.11.0 (relative to 1.4.10.0)
 ========

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -111,6 +111,12 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 						MetadataWidget.FileSystemPathMetadataWidget( key = "icon" )
 					)
 
+					GafferUI.Label( "Scale" )
+
+					scaleWidget = MetadataWidget.NumericMetadataWidget( key = "iconScale", defaultValue = 1.5 )
+					scaleWidget.numericWidget()._qtWidget().setMaximumWidth( 60 )
+					self.__nodeMetadataWidgets.append( scaleWidget )
+
 				with _Row() as self.__plugAddButtons :
 
 					_Label( "Plug Creators" )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -122,7 +122,7 @@ class UIEditor( GafferUI.NodeSetEditor ) :
 					_Label( "Plug Creators" )
 
 					for side in ( "Top", "Bottom", "Left", "Right" ) :
-						_Label( side )._qtWidget().setFixedWidth( 40 )
+						GafferUI.Label( side )
 						self.__nodeMetadataWidgets.append( MetadataWidget.BoolMetadataWidget(
 							key = "noduleLayout:customGadget:addButton%s:visible" % side,
 							defaultValue = True
@@ -406,7 +406,7 @@ class _Row( GafferUI.ListContainer ) :
 
 	def __init__( self, *args, **kw ) :
 
-		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4, *args, **kw )
+		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 8, *args, **kw )
 
 ##########################################################################
 # Hierarchical representation of a plug layout, suitable for manipulating


### PR DESCRIPTION
As mentioned in #5998, we were missing the ability to edit `iconScale` metadata from the UI Editor.