### PR TITLE
Arnold metadata : Add `toon` `*_tonemap_hue_saturation` parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - UI Editor :
   - Added the ability to edit the scale of node icons.
   - Improved layout of Box node plug creator visibility toggles.
+- ArnoldShader : Moved the `toon` shader's `*_tonemap_hue_saturation` parameters to appropriate sections in the UI.
 
 API
 ---

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -3035,6 +3035,10 @@
 			gaffer.graphEditorLayout.visible BOOL true
 			page STRING "Edge"
 			gaffer.layout.activator STRING "edgeEnabled"
+		[attr edge_tonemap_hue_saturation]
+			page STRING "Edge"
+			label STRING "Tonemap Hue Saturation"
+			gaffer.layout.activator STRING "edgeEnabled"
 		[attr edge_opacity]
 			page STRING "Edge"
 			gaffer.layout.activator STRING "edgeEnabled"
@@ -3083,6 +3087,10 @@
 			gaffer.graphEditorLayout.visible BOOL true
 			page STRING "Silhouette"
 			gaffer.layout.activator STRING "silhouetteEnabled"
+		[attr silhouette_tonemap_hue_saturation]
+			page STRING "Silhouette"
+			label STRING "Tonemap Hue Saturation"
+			gaffer.layout.activator STRING "silhouetteEnabled"
 		[attr silhouette_opacity]
 			page STRING "Silhouette"
 			gaffer.layout.activator STRING "silhouetteEnabled"
@@ -3099,6 +3107,9 @@
 		[attr base_tonemap]
 			gaffer.graphEditorLayout.visible BOOL true
 			page STRING "Base"
+		[attr base_tonemap_hue_saturation]
+			page STRING "Base"
+			label STRING "Tonemap Hue Saturation"
 
 		[attr specular]
 			page STRING "Specular"
@@ -3112,6 +3123,9 @@
 			page STRING "Specular"
 		[attr specular_tonemap]
 			page STRING "Specular"
+		[attr specular_tonemap_hue_saturation]
+			page STRING "Specular"
+			label STRING "Tonemap Hue Saturation"
 
 		[attr lights]
 			page STRING "Stylized Highlight"


### PR DESCRIPTION
These `[edge/silhouette/base/specular]_tonemap_hue_saturation` toon shader parameters were introduced in Arnold [7.3.2.0](https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_core_7320_html).
