### PR TITLE
PathColumn : Allow sorting of FileIconPathColumn

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
   - Added the ability to edit the scale of node icons.
   - Improved layout of Box node plug creator visibility toggles.
 - ArnoldShader : Moved the `toon` shader's `*_tonemap_hue_saturation` parameters to appropriate sections in the UI.
+- File Browser : The "Type" column can now be sorted. This sorts directories separately from files, which are sorted by their extension.
 
 API
 ---

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -241,6 +241,8 @@ FileIconPathColumn::FileIconPathColumn( SizeMode sizeMode )
 
 PathColumn::CellData FileIconPathColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
 {
+	CellData result;
+
 	std::string s = path.string();
 	if( const FileSystemPath *fileSystemPath = runTimeCast<const FileSystemPath>( &path ) )
 	{
@@ -256,7 +258,13 @@ PathColumn::CellData FileIconPathColumn::cellData( const Gaffer::Path &path, con
 		}
 	}
 
-	return CellData( /* value = */ nullptr, /* icon = */ new StringData( "fileIcon:" + s ) );
+	result.icon = new StringData( "fileIcon:" + s );
+	const auto p = std::filesystem::path( s );
+	// Use a sortValue of `extension:stem` to allow sorting by extension
+	// while maintaining a reasonable ordering within each extension.
+	result.sortValue = new StringData( ( std::filesystem::is_directory( p ) ? " " : p.extension().string() ) + ":" + p.stem().string() );
+
+	return result;
 }
 
 PathColumn::CellData FileIconPathColumn::headerData( const IECore::Canceller *canceller ) const


### PR DESCRIPTION
This makes the FileIconPathColumn sortable via the `CellData::sortValue` property. This sorts by file extension, which is an approximation of sorting by file type, but is likely enough for our purposes.

@ericmehl  In light of #6006, do you think we will need similar special handling here for non-english characters on Windows?