### PR TITLE
ArrayPlug improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Fixes
 - ArrayPlug :
   - Fixed error when `resize()` removed plugs with input connections.
   - Fixed error when `resize()` was used on an output plug.
+- CreateViews : Fixed redundant serialisation of internal connections.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -55,6 +55,9 @@ API
 - PathColumn :
   - Added `contextMenuSignal()`, allowing the creation of custom context menus.
   - Added `instanceCreatedSignal()`, providing an opportunity to connect to the signals on _any_ column, no matter how it is created.
+- ArrayPlug :
+  - It is now legal to construct an ArrayPlug with a minimum size of 0. Previously the minimum size was 1.
+  - Added `elementPrototype()` method.
 
 Breaking Changes
 ----------------
@@ -73,6 +76,9 @@ Breaking Changes
   - Deprecated `getContext()` methods. Use `context()` instead.
 - Loop : Removed `nextIterationContext()` method.
 - NodeGadget, ConnectionGadget : Removed `activeForFocusNode()` virtual methods. Override `updateFromContextTracker()` instead.
+- ArrayPlug :
+  - Renamed `element` constructor argument to `elementPrototype`.
+  - Deprecated the passing of `element = nullptr` to the constructor.
 
 1.4.x.x (relative to 1.4.11.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,9 @@ Fixes
   - Fixed update of custom context-sensitive labels on Dot nodes.
 - GafferCortexUI : Removed usage of legacy PlugValueWidget API.
 - Dispatcher : Fixed crashes caused by a dispatcher's `SetupPlugsFn` attempting to access the TaskNode it was being called for. Dispatchers may now introspect the TaskNode and add different plugs based on type (#915).
+- ArrayPlug :
+  - Fixed error when `resize()` removed plugs with input connections.
+  - Fixed error when `resize()` was used on an output plug.
 
 API
 ---

--- a/include/Gaffer/ArrayPlug.h
+++ b/include/Gaffer/ArrayPlug.h
@@ -49,17 +49,17 @@ class GAFFER_API ArrayPlug : public Plug
 
 	public :
 
-		/// The element plug is used as the first array element,
-		/// and all new array elements are created by calling
-		/// element->createCounterpart(). Currently the element
-		/// names are derived from the name of the first element,
-		/// but this may change in the future. It is strongly
-		/// recommended that ArrayPlug children are only accessed
-		/// through numeric indexing and never via names.
+		/// All array elements are created by calling
+		/// `elementPrototype->createCounterpart()`. Currently the element names
+		/// are derived from the name of the prototype, but this may change in
+		/// the future. It is strongly recommended that ArrayPlug children are
+		/// only accessed through numeric indexing and never via names.
 		explicit ArrayPlug(
 			const std::string &name = defaultName<ArrayPlug>(),
 			Direction direction = In,
-			PlugPtr element = nullptr,
+			/// > Caution : `elementPrototype` should not be null. It only defaults
+			/// > that way to support the loading of legacy serialisations.
+			ConstPlugPtr elementPrototype = nullptr,
 			size_t minSize = 1,
 			size_t maxSize = std::numeric_limits<size_t>::max(),
 			unsigned flags = Default,
@@ -75,8 +75,10 @@ class GAFFER_API ArrayPlug : public Plug
 		void setInput( PlugPtr input ) override;
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 
+		const Plug *elementPrototype() const;
 		size_t minSize() const;
 		size_t maxSize() const;
+		/// Resizes the array. This should be preferred to `addChild()`.
 		void resize( size_t size );
 		bool resizeWhenInputsChange() const;
 		/// Returns an unconnected element at the end of the array, adding one
@@ -91,7 +93,9 @@ class GAFFER_API ArrayPlug : public Plug
 	private :
 
 		void inputChanged( Gaffer::Plug *plug );
+		void childAdded();
 
+		ConstPlugPtr m_elementPrototype;
 		size_t m_minSize;
 		size_t m_maxSize;
 		bool m_resizeWhenInputsChange;

--- a/python/GafferDispatchTest/DebugDispatcher.py
+++ b/python/GafferDispatchTest/DebugDispatcher.py
@@ -111,7 +111,7 @@ class DebugDispatcher( GafferDispatch.Dispatcher ) :
 		node = Gaffer.Node()
 		node.setName( name.replace( ".", "_" ) )
 
-		node["preTasks"] = Gaffer.ArrayPlug( element = Gaffer.Plug( "preTask0" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		node["preTasks"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.Plug( "preTask0" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		node["task"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		node["node"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		node["frames"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )

--- a/python/GafferImageTest/AnaglyphTest.py
+++ b/python/GafferImageTest/AnaglyphTest.py
@@ -67,10 +67,11 @@ class AnaglyphTest( GafferImageTest.ImageTestCase ) :
 		right['transform']['translate'].setValue( imath.V2f( 10, 0 ) )
 
 		createViews = GafferImage.CreateViews()
-		createViews["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews["views"].resize( 2 )
 		createViews["views"][0]["value"].setInput( left["out"] )
+		createViews["views"][0]["name"].setValue( "left" )
 		createViews["views"][1]["value"].setInput( right["out"] )
+		createViews["views"][1]["name"].setValue( "right" )
 
 		anaglyph = GafferImage.Anaglyph()
 		anaglyph["in"].setInput( createViews["out"] )

--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -917,10 +917,11 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 
 		# Check that two multi-view images match only if all views are identical
 		createViews = GafferImage.CreateViews()
-		createViews["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews["views"].resize( 2 )
 		createViews["views"][0]["value"].setInput( constant1["out"] )
+		createViews["views"][0]["name"].setValue( "left" )
 		createViews["views"][1]["value"].setInput( constant2["out"] )
+		createViews["views"][1]["name"].setValue( "right" )
 
 		f3 = catalogue.generateFileName( createViews["out"] )
 		self.assertNotIn( f3, [f1, f2] )

--- a/python/GafferImageTest/ContactSheetCoreTest.py
+++ b/python/GafferImageTest/ContactSheetCoreTest.py
@@ -124,8 +124,9 @@ class ContactSheetCoreTest( GafferImageTest.ImageTestCase ) :
 
 		checker = GafferImage.Checkerboard()
 		createViews = GafferImage.CreateViews()
-		createViews["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "left", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews["views"].resize( 1 )
 		createViews["views"][0]["value"].setInput( checker["out"] )
+		createViews["views"][0]["name"].setValue( "left" )
 		self.assertEqual( createViews["out"].viewNames(), IECore.StringVectorData( [ "left" ] ) )
 
 		contactSheet = GafferImage.ContactSheetCore()

--- a/python/GafferImageTest/CopyViewsTest.py
+++ b/python/GafferImageTest/CopyViewsTest.py
@@ -66,8 +66,9 @@ class CopyViewsTest( GafferImageTest.ImageTestCase ) :
 					name = "source%iview%i" % ( i, j )
 
 				createViews[i].addChild( constant )
-				createViews[i]["views"].addChild( Gaffer.NameValuePlug( name, GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-				createViews[i]["views"][-1]["value"].setInput( constant["out"] )
+				view = createViews[i]["views"].next()
+				view["name"].setValue( name )
+				view["value"].setInput( constant["out"] )
 
 		copyViews = GafferImage.CopyViews()
 		copyViews["in"][0].setInput( createViews[0]["out"] )

--- a/python/GafferImageTest/CreateViewsTest.py
+++ b/python/GafferImageTest/CreateViewsTest.py
@@ -37,12 +37,10 @@
 import unittest
 import imath
 import inspect
-import os
 
 import IECore
 
 import Gaffer
-import GafferTest
 import GafferImage
 import GafferImageTest
 
@@ -223,6 +221,12 @@ class CreateViewsTest( GafferImageTest.ImageTestCase ) :
 			# Although the `enabled` plug itself does see the new context, so the node is disabled
 			# for this particular view.
 			self.assertFalse( script["constant"]["enabled"].getValue() )
+
+	def testNoRedundantSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["createViews"] = GafferImage.CreateViews()
+		self.assertNotIn( "setInput", script.serialise() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/DeleteViewsTest.py
+++ b/python/GafferImageTest/DeleteViewsTest.py
@@ -63,9 +63,10 @@ class DeleteViewsTest( GafferImageTest.ImageTestCase ) :
 
 		createViews = GafferImage.CreateViews()
 
-		createViews["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "default", GafferImage.ImagePlug(), True, "view2", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews["views"].resize( 3 )
+		createViews["views"][0]["name"].setValue( "left" )
+		createViews["views"][1]["name"].setValue( "right" )
+		createViews["views"][2]["name"].setValue( "default" )
 
 		createViews["views"]["view0"]["value"].setInput( reader["out"] )
 		createViews["views"]["view1"]["value"].setInput( constant1["out"] )

--- a/python/GafferImageTest/FormatQueryTest.py
+++ b/python/GafferImageTest/FormatQueryTest.py
@@ -99,8 +99,9 @@ class FormatQueryTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( self.imagesPath() / "checkerboard.100x100.exr" )
 
 		views = GafferImage.CreateViews()
-		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )
-		views["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True ) )
+		views["views"].resize( 2 )
+		views["views"][0]["name"].setValue( "left" )
+		views["views"][1]["name"].setValue( "right" )
 		views["views"][0]["value"].setInput( constantSource["out"] )
 		views["views"][1]["value"].setInput( reader["out"] )
 

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -132,8 +132,9 @@ class ImageSamplerTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( self.imagesPath() / "blueWithDataWindow.100x100.exr" )
 
 		views = GafferImage.CreateViews()
-		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )
-		views["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True ) )
+		views["views"].resize( 2 )
+		views["views"][0]["name"].setValue( "left" )
+		views["views"][1]["name"].setValue( "right" )
 		views["views"][0]["value"].setInput( constantSource["out"] )
 		views["views"][1]["value"].setInput( reader["out"] )
 

--- a/python/GafferImageTest/ImageStatsTest.py
+++ b/python/GafferImageTest/ImageStatsTest.py
@@ -310,8 +310,9 @@ class ImageStatsTest( GafferImageTest.ImageTestCase ) :
 		reader["fileName"].setValue( self.__rgbFilePath )
 
 		views = GafferImage.CreateViews()
-		views["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True ) )
-		views["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True ) )
+		views["views"].resize( 2 )
+		views["views"][0]["name"].setValue( "left" )
+		views["views"][1]["name"].setValue( "right" )
 		views["views"][0]["value"].setInput( constantSource["out"] )
 		views["views"][1]["value"].setInput( reader["out"] )
 

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -240,8 +240,9 @@ parent["color"] = imath.Color4f( 0.5, 0.6, 0.7, 0.8 ) if context.get( "collect:l
 	def channelTestImageMultiView( self ) :
 
 		channelTestImageMultiView = GafferImage.CreateViews()
-		channelTestImageMultiView["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		channelTestImageMultiView["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		channelTestImageMultiView["views"].resize( 2 )
+		channelTestImageMultiView["views"][0]["name"].setValue( "left" )
+		channelTestImageMultiView["views"][1]["name"].setValue( "right" )
 
 		channelTestImageMultiView["TestImage"] = self.channelTestImage()
 

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -859,14 +859,16 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		c4["format"]["displayWindow"].setValue( imath.Box2i( imath.V2i( 0 ), imath.V2i( 64 ) ) )
 
 		createViews1 = GafferImage.CreateViews()
-		createViews1["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews1["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews1["views"].resize( 2 )
+		createViews1["views"][0]["name"].setValue( "left" )
+		createViews1["views"][1]["name"].setValue( "right" )
 		createViews1["views"][0]["value"].setInput( c1["out"] )
 		createViews1["views"][1]["value"].setInput( c2["out"] )
 
 		createViews2 = GafferImage.CreateViews()
-		createViews2["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews2["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews2["views"].resize( 2 )
+		createViews2["views"][0]["name"].setValue( "left" )
+		createViews2["views"][1]["name"].setValue( "right" )
 		createViews2["views"][0]["value"].setInput( c3["out"] )
 		createViews2["views"][1]["value"].setInput( c4["out"] )
 

--- a/python/GafferImageTest/SelectViewTest.py
+++ b/python/GafferImageTest/SelectViewTest.py
@@ -63,9 +63,10 @@ class SelectViewTest( GafferImageTest.ImageTestCase ) :
 
 		createViews = GafferImage.CreateViews()
 
-		createViews["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-		createViews["views"].addChild( Gaffer.NameValuePlug( "default", GafferImage.ImagePlug(), True, "view2", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+		createViews["views"].resize( 3 )
+		createViews["views"][0]["name"].setValue( "left" )
+		createViews["views"][1]["name"].setValue( "right" )
+		createViews["views"][2]["name"].setValue( "default" )
 
 		createViews["views"]["view0"]["value"].setInput( reader["out"] )
 		createViews["views"]["view1"]["value"].setInput( constant1["out"] )

--- a/python/GafferImageTest/scripts/createViews-1.4.10.0.gfr
+++ b/python/GafferImageTest/scripts/createViews-1.4.10.0.gfr
@@ -1,0 +1,51 @@
+import Gaffer
+import GafferImage
+import imath
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 4, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 10, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+parent["variables"].addChild( Gaffer.NameValuePlug( "image:catalogue:port", Gaffer.IntPlug( "value", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "imageCataloguePort", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:name", Gaffer.StringPlug( "value", defaultValue = 'default', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectName", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+parent["variables"].addChild( Gaffer.NameValuePlug( "project:rootDirectory", Gaffer.StringPlug( "value", defaultValue = '$HOME/gaffer/projects/${project:name}', flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "projectRootDirectory", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["openColorIO"] = GafferImage.OpenColorIOConfigPlug( "openColorIO", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["openColorIO"] )
+__children["defaultFormat"] = GafferImage.FormatPlug( "defaultFormat", defaultValue = GafferImage.Format( 1920, 1080, 1.000 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, )
+parent.addChild( __children["defaultFormat"] )
+__children["CheckerboardLeft"] = GafferImage.Checkerboard( "CheckerboardLeft" )
+parent.addChild( __children["CheckerboardLeft"] )
+__children["CheckerboardLeft"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CreateViews"] = GafferImage.CreateViews( "CreateViews" )
+parent.addChild( __children["CreateViews"] )
+__children["CreateViews"]["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug( "value", ), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["CreateViews"]["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug( "value", ), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+__children["CreateViews"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["CheckerboardRight"] = GafferImage.Checkerboard( "CheckerboardRight" )
+parent.addChild( __children["CheckerboardRight"] )
+__children["CheckerboardRight"].addChild( Gaffer.V2fPlug( "__uiPosition", defaultValue = imath.V2f( 0, 0 ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+parent["variables"]["imageCataloguePort"]["value"].setValue( 37035 )
+Gaffer.Metadata.registerValue( parent["variables"]["imageCataloguePort"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectName"]["name"], 'readOnly', True )
+Gaffer.Metadata.registerValue( parent["variables"]["projectRootDirectory"]["name"], 'readOnly', True )
+__children["CheckerboardLeft"]["size"]["y"].setInput( __children["CheckerboardLeft"]["size"]["x"] )
+__children["CheckerboardLeft"]["__uiPosition"].setValue( imath.V2f( -7.31522799, 2.82158232 ) )
+__children["CreateViews"]["out"]["format"].setInput( __children["CreateViews"]["__switch"]["out"]["format"] )
+__children["CreateViews"]["out"]["dataWindow"].setInput( __children["CreateViews"]["__switch"]["out"]["dataWindow"] )
+__children["CreateViews"]["out"]["metadata"].setInput( __children["CreateViews"]["__switch"]["out"]["metadata"] )
+__children["CreateViews"]["out"]["deep"].setInput( __children["CreateViews"]["__switch"]["out"]["deep"] )
+__children["CreateViews"]["out"]["sampleOffsets"].setInput( __children["CreateViews"]["__switch"]["out"]["sampleOffsets"] )
+__children["CreateViews"]["out"]["channelNames"].setInput( __children["CreateViews"]["__switch"]["out"]["channelNames"] )
+__children["CreateViews"]["out"]["channelData"].setInput( __children["CreateViews"]["__switch"]["out"]["channelData"] )
+__children["CreateViews"]["views"][0]["value"].setInput( __children["CheckerboardLeft"]["out"] )
+__children["CreateViews"]["views"][1]["value"].setInput( __children["CheckerboardRight"]["out"] )
+__children["CreateViews"]["__uiPosition"].setValue( imath.V2f( 0.366687864, -5.34316444 ) )
+__children["CheckerboardRight"]["size"]["y"].setInput( __children["CheckerboardRight"]["size"]["x"] )
+__children["CheckerboardRight"]["__uiPosition"].setValue( imath.V2f( 8.04854202, 2.82158256 ) )
+
+
+del __children
+

--- a/python/GafferImageUI/CreateViewsUI.py
+++ b/python/GafferImageUI/CreateViewsUI.py
@@ -43,9 +43,9 @@ import imath
 # sets up the default "left" and "right" views
 def postCreate( node, menu ) :
 
-	node["views"].addChild( Gaffer.NameValuePlug( "left", GafferImage.ImagePlug(), True, "view0", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-	node["views"].addChild( Gaffer.NameValuePlug( "right", GafferImage.ImagePlug(), True, "view1", Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
-
+	node["views"].resize( 2 )
+	node["views"][0]["name"].setValue( "left" )
+	node["views"][1]["name"].setValue( "right" )
 
 Gaffer.Metadata.registerNode(
 

--- a/python/GafferSceneUI/SceneEditor.py
+++ b/python/GafferSceneUI/SceneEditor.py
@@ -55,7 +55,7 @@ class SceneEditor( GafferUI.NodeSetEditor ) :
 			if numInputs == 1 :
 				self["in"] = GafferScene.ScenePlug()
 			else :
-				self["in"] = Gaffer.ArrayPlug( element = GafferScene.ScenePlug(), minSize = numInputs, maxSize = numInputs )
+				self["in"] = Gaffer.ArrayPlug( elementPrototype = GafferScene.ScenePlug(), minSize = numInputs, maxSize = numInputs )
 
 	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::SceneEditor::Settings" )
 

--- a/python/GafferTest/ArrayPlugNode.py
+++ b/python/GafferTest/ArrayPlugNode.py
@@ -47,7 +47,7 @@ class ArrayPlugNode( Gaffer.Node ) :
 		self.addChild(
 			Gaffer.ArrayPlug(
 				"in",
-				element = Gaffer.IntPlug( "e1", minValue=0, maxValue=10 ),
+				elementPrototype = Gaffer.IntPlug( "e1", minValue=0, maxValue=10 ),
 				maxSize = 6
 			)
 		)

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -494,6 +494,22 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		with self.assertRaises( RuntimeError ) :
 			p.resize( p.maxSize() + 1 )
 
+	def testRemoveInputDuringResize( self ) :
+
+		node = Gaffer.Node()
+		node["user"]["p"] = Gaffer.IntPlug()
+		node["user"]["array"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), resizeWhenInputsChange = True )
+		node["user"]["array"].resize( 4 )
+		node["user"]["array"][2].setInput( node["user"]["p"] )
+
+		node["user"]["array"].resize( 1 )
+		self.assertEqual( len( node["user"]["array"] ), 1 )
+
+	def testResizeOutputPlug( self ) :
+
+		array = Gaffer.ArrayPlug( element = Gaffer.IntPlug( direction = Gaffer.Plug.Direction.Out ), direction = Gaffer.Plug.Direction.Out )
+		array.resize( 2 )
+
 	def testSerialisationUsesIndices( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferTest/ArrayPlugTest.py
+++ b/python/GafferTest/ArrayPlugTest.py
@@ -187,7 +187,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		a = GafferTest.AddNode()
 		n = Gaffer.Node()
-		n["in"] = Gaffer.ArrayPlug( "in", element = Gaffer.IntPlug( "e1" ), minSize=3 )
+		n["in"] = Gaffer.ArrayPlug( "in", elementPrototype = Gaffer.IntPlug( "e1" ), minSize=3 )
 
 		self.assertEqual( len( n["in"] ), 3 )
 
@@ -291,7 +291,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		s["a"] = GafferTest.AddNode()
 		s["n"] = Gaffer.Node()
-		s["n"]["a"] = Gaffer.ArrayPlug( "a", element = Gaffer.IntPlug(), minSize = 4, maxSize = 4, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["a"] = Gaffer.ArrayPlug( "a", elementPrototype = Gaffer.IntPlug(), minSize = 4, maxSize = 4, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["n"]["a"][1].setInput( s["a"]["sum"] )
 		s["n"]["a"][2].setInput( s["a"]["sum"] )
 
@@ -327,7 +327,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 				return PythonElement( name, direction, self.getFlags() )
 
 		n = Gaffer.Node()
-		n["a"] = Gaffer.ArrayPlug( element = PythonElement() )
+		n["a"] = Gaffer.ArrayPlug( elementPrototype = PythonElement() )
 
 		self.assertEqual( len( n["a"] ), 1 )
 		self.assertTrue( isinstance( n["a"][0], PythonElement ) )
@@ -342,8 +342,8 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		n = Gaffer.Node()
 
-		n["a"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
-		n["b"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n["a"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
+		n["b"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
 		n["b"].setInput( n["a"] )
 
 		def assertInput( plug, input ) :
@@ -383,7 +383,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerValue( element, "connectionGadget:color", connectionColor )
 		Gaffer.Metadata.registerValue( element, "nodule:color", noodleColor )
 
-		n["a"] = Gaffer.ArrayPlug( element = element )
+		n["a"] = Gaffer.ArrayPlug( elementPrototype = element )
 		n["a"][0].setInput(n2["test"])
 
 		self.assertEqual( Gaffer.Metadata.value( n["a"][1], "connectionGadget:color" ), connectionColor )
@@ -391,20 +391,20 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 	def testOnlyOneChildType( self ) :
 
-		p = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		p = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
 		self.assertTrue( p.acceptsChild( Gaffer.IntPlug() ) )
 		self.assertFalse( p.acceptsChild( Gaffer.FloatPlug() ) )
 
 	def testDenyInputFromNonArrayPlugs( self ) :
 
-		a = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		a = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
 		p = Gaffer.V2iPlug()
 		self.assertFalse( a.acceptsInput( p ) )
 
 	def testPartialConnections( self ) :
 
 		n = Gaffer.Node()
-		n["p"] = Gaffer.ArrayPlug( element = Gaffer.V3fPlug( "e" ) )
+		n["p"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.V3fPlug( "e" ) )
 		self.assertEqual( len( n["p"] ), 1 )
 
 		p = Gaffer.FloatPlug()
@@ -432,7 +432,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		s["a"] = GafferTest.AddNode()
 		s["n"] = Gaffer.Node()
-		s["n"]["user"]["p"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, resizeWhenInputsChange = False )
+		s["n"]["user"]["p"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, resizeWhenInputsChange = False )
 		self.assertEqual( s["n"]["user"]["p"].resizeWhenInputsChange(), False )
 
 		self.assertEqual( len( s["n"]["user"]["p"] ), 1 )
@@ -449,8 +449,8 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 		a = GafferTest.AddNode()
 
 		n = Gaffer.Node()
-		n["a1"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
-		n["a2"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), maxSize = 3, resizeWhenInputsChange = False )
+		n["a1"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
+		n["a2"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug(), maxSize = 3, resizeWhenInputsChange = False )
 
 		self.assertEqual( len( n["a1"] ), 1 )
 		self.assertEqual( len( n["a2"] ), 1 )
@@ -485,7 +485,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 	def testResize( self ) :
 
-		p = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), minSize = 1, maxSize = 3, resizeWhenInputsChange = False )
+		p = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug(), minSize = 1, maxSize = 3, resizeWhenInputsChange = False )
 		self.assertEqual( len( p ), p.minSize() )
 
 		p.resize( 2 )
@@ -506,7 +506,7 @@ class ArrayPlugTest( GafferTest.TestCase ) :
 
 		node = Gaffer.Node()
 		node["user"]["p"] = Gaffer.IntPlug()
-		node["user"]["array"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), resizeWhenInputsChange = True )
+		node["user"]["array"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug(), resizeWhenInputsChange = True )
 		node["user"]["array"].resize( 4 )
 		node["user"]["array"][2].setInput( node["user"]["p"] )
 

--- a/python/GafferTest/DotTest.py
+++ b/python/GafferTest/DotTest.py
@@ -143,10 +143,10 @@ class DotTest( GafferTest.TestCase ) :
 	def testArrayPlug( self ) :
 
 		n1 = Gaffer.Node()
-		n1["a"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n1["a"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
 
 		n2 = Gaffer.Node()
-		n2["a"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug() )
+		n2["a"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug() )
 
 		d = Gaffer.Dot()
 		d.setup( n1["a"] )

--- a/python/GafferTest/ReferenceTest.py
+++ b/python/GafferTest/ReferenceTest.py
@@ -971,7 +971,7 @@ class ReferenceTest( GafferTest.TestCase ) :
 		s = Gaffer.ScriptNode()
 
 		s["b"] = Gaffer.Box()
-		s["b"]["array"] = Gaffer.ArrayPlug( element = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["array"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.IntPlug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"]["color"] = Gaffer.Color3fPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		s["b"].exportForReference( self.temporaryDirectory() / "test.grf" )
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -262,7 +262,7 @@ class SwitchTest( GafferTest.TestCase ) :
 	def testPassThroughWhenIndexConstant( self ) :
 
 		n = Gaffer.Switch()
-		n["in"] = Gaffer.ArrayPlug( element = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["in"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic  )
 
 		self.assertTrue( n["out"].source().isSame( n["in"][0] ) )
@@ -309,7 +309,7 @@ class SwitchTest( GafferTest.TestCase ) :
 	def testConnectedIndex( self ) :
 
 		n = Gaffer.Switch()
-		n["in"] = Gaffer.ArrayPlug( element = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["in"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic  )
 
 		input0 = Gaffer.Plug()
@@ -344,7 +344,7 @@ class SwitchTest( GafferTest.TestCase ) :
 	def testIndirectInputsToIndex( self ) :
 
 		n = Gaffer.Switch()
-		n["in"] = Gaffer.ArrayPlug( element = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		n["in"] = Gaffer.ArrayPlug( elementPrototype = Gaffer.Plug(), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 		n["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic  )
 
 		input0 = Gaffer.Plug()

--- a/python/GafferTest/scripts/arrayPlug-1.4.10.0.gfr
+++ b/python/GafferTest/scripts/arrayPlug-1.4.10.0.gfr
@@ -1,0 +1,26 @@
+import Gaffer
+import GafferTest
+
+Gaffer.Metadata.registerValue( parent, "serialiser:milestoneVersion", 1, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:majorVersion", 4, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:minorVersion", 10, persistent=False )
+Gaffer.Metadata.registerValue( parent, "serialiser:patchVersion", 0, persistent=False )
+
+__children = {}
+
+__children["n"] = Gaffer.Node( "n" )
+parent.addChild( __children["n"] )
+__children["n"]["user"].addChild( Gaffer.ArrayPlug( "p", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["n"]["user"]["p"].addChild( Gaffer.IntPlug( "e0", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["n"]["user"]["p"].addChild( Gaffer.IntPlug( "e1", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["n"]["user"]["p"].addChild( Gaffer.IntPlug( "e2", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["n"]["user"]["p"].addChild( Gaffer.IntPlug( "e3", defaultValue = 0, flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+__children["a"] = GafferTest.AddNode( "a" )
+parent.addChild( __children["a"] )
+__children["n"]["user"]["p"][1].setValue( 1 )
+__children["n"]["user"]["p"][2].setInput( __children["a"]["sum"] )
+__children["n"]["user"]["p"][3].setValue( 3 )
+
+
+del __children
+

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -153,12 +153,13 @@ void ArrayPlug::resize( size_t size )
 
 	while( size > children().size() )
 	{
-		PlugPtr p = getChild<Plug>( 0 )->createCounterpart( getChild<Plug>( 0 )->getName(), Plug::In );
+		PlugPtr p = getChild<Plug>( 0 )->createCounterpart( getChild<Plug>( 0 )->getName(), direction() );
 		p->setFlags( Gaffer::Plug::Dynamic, true );
 		addChild( p );
 		MetadataAlgo::copyColors( getChild<Plug>( 0 ) , p.get() , /* overwrite = */ false );
 	}
 
+	Gaffer::Signals::BlockedConnection blockedInputChange( m_inputChangedConnection );
 	while( children().size() > size )
 	{
 		removeChild( children().back() );

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -69,27 +69,19 @@ bool hasInput( const Plug *p )
 
 GAFFER_PLUG_DEFINE_TYPE( ArrayPlug )
 
-ArrayPlug::ArrayPlug( const std::string &name, Direction direction, PlugPtr element, size_t minSize, size_t maxSize, unsigned flags, bool resizeWhenInputsChange )
-	:	Plug( name, direction, flags ), m_minSize( std::max( minSize, size_t( 1 ) ) ), m_maxSize( std::max( maxSize, m_minSize ) ), m_resizeWhenInputsChange( resizeWhenInputsChange )
+ArrayPlug::ArrayPlug( const std::string &name, Direction direction, ConstPlugPtr elementPrototype, size_t minSize, size_t maxSize, unsigned flags, bool resizeWhenInputsChange )
+	:	Plug( name, direction, flags ), m_elementPrototype( elementPrototype ), m_minSize( minSize ), m_maxSize( std::max( maxSize, m_minSize ) ), m_resizeWhenInputsChange( resizeWhenInputsChange )
 {
-	if( element )
+	if( !m_elementPrototype )
 	{
-		// If we're dynamic ourselves, then serialisations will include a constructor
-		// for us, but it will have element==None. In this case we make sure the first
-		// element is dynamic, so that it too will have a constructor written out. But
-		// if we're not dynamic, we expect to be passed the element again upon reconstruction,
-		// so we don't need a constructor to be serialised for the element, and therefore
-		// we must set it to be non-dynamic.
-		element->setFlags( Gaffer::Plug::Dynamic, getFlags( Gaffer::Plug::Dynamic ) );
-		addChild( element );
-
-		for( size_t i = 1; i < m_minSize; ++i )
-		{
-			PlugPtr p = element->createCounterpart( element->getName(), Plug::In );
-			addChild( p );
-			MetadataAlgo::copyColors( element.get() , p.get() , /* overwrite = */ false  );
-		}
+		// We're being constructed during execution of a legacy serialisation
+		// (nobody else is allowed to pass a null `elementPrototype`). Arrange
+		// to recover our protoype when the first element is added.
+		childAddedSignal().connect( boost::bind( &ArrayPlug::childAdded, this ) );
+		return;
 	}
+
+	resize( m_minSize );
 }
 
 ArrayPlug::~ArrayPlug()
@@ -103,7 +95,16 @@ bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 		return false;
 	}
 
-	return children().size() == 0 || potentialChild->typeId() == children()[0]->typeId();
+	if( !m_elementPrototype )
+	{
+		// Special case to support loading of legacy serialisations. We accept
+		// the first child we are given and then in `childAdded()` we initialise
+		// `m_elementPrototype` from it.
+		assert( children().size() == 0 );
+		return true;
+	}
+
+	return potentialChild->typeId() == m_elementPrototype->typeId();
 }
 
 bool ArrayPlug::acceptsInput( const Plug *input ) const
@@ -126,12 +127,17 @@ void ArrayPlug::setInput( PlugPtr input )
 
 PlugPtr ArrayPlug::createCounterpart( const std::string &name, Direction direction ) const
 {
-	ArrayPlugPtr result = new ArrayPlug( name, direction, nullptr, m_minSize, m_maxSize, getFlags(), resizeWhenInputsChange() );
-	for( Plug::Iterator it( this ); !it.done(); ++it )
+	ArrayPlugPtr result = new ArrayPlug( name, direction, m_elementPrototype, m_minSize, m_maxSize, getFlags(), resizeWhenInputsChange() );
+	if( m_elementPrototype )
 	{
-		result->addChild( (*it)->createCounterpart( (*it)->getName(), direction ) );
+		result->resize( children().size() );
 	}
 	return result;
+}
+
+const Plug *ArrayPlug::elementPrototype() const
+{
+	return m_elementPrototype.get();
 }
 
 size_t ArrayPlug::minSize() const
@@ -156,12 +162,21 @@ void ArrayPlug::resize( size_t size )
 		);
 	}
 
+	if( !m_elementPrototype )
+	{
+		throw IECore::Exception(
+			fmt::format(
+				"ArrayPlug `{}` was constructed without the required `elementPrototype`",
+				fullName()
+			)
+		);
+	}
+
 	while( size > children().size() )
 	{
-		PlugPtr p = getChild<Plug>( 0 )->createCounterpart( getChild<Plug>( 0 )->getName(), direction() );
-		p->setFlags( Gaffer::Plug::Dynamic, true );
+		PlugPtr p = m_elementPrototype->createCounterpart( m_elementPrototype->getName(), direction() );
 		addChild( p );
-		MetadataAlgo::copyColors( getChild<Plug>( 0 ) , p.get() , /* overwrite = */ false );
+		MetadataAlgo::copyColors( m_elementPrototype.get(), p.get() , /* overwrite = */ false );
 	}
 
 	Gaffer::Signals::BlockedConnection blockedInputChange( m_inputChangedConnection );
@@ -178,10 +193,13 @@ bool ArrayPlug::resizeWhenInputsChange() const
 
 Gaffer::Plug *ArrayPlug::next()
 {
-	Plug *last = static_cast<Plug *>( children().back().get() );
-	if( !hasInput( last ) )
+	if( children().size() )
 	{
-		return last;
+		Plug *last = static_cast<Plug *>( children().back().get() );
+		if( !hasInput( last ) )
+		{
+			return last;
+		}
 	}
 
 	if( children().size() >= m_maxSize )
@@ -189,11 +207,8 @@ Gaffer::Plug *ArrayPlug::next()
 		return nullptr;
 	}
 
-	PlugPtr p = getChild<Plug>( 0 )->createCounterpart( getChild<Plug>( 0 )->getName(), Plug::In );
-	p->setFlags( Gaffer::Plug::Dynamic, true );
-	addChild( p );
-	MetadataAlgo::copyColors( getChild<Plug>( 0 ) , p.get() , /* overwrite = */ false );
-	return p.get();
+	resize( children().size() + 1 );
+	return static_cast<Plug *>( children().back().get() );
 }
 
 void ArrayPlug::parentChanged( GraphComponent *oldParent )
@@ -263,5 +278,15 @@ void ArrayPlug::inputChanged( Gaffer::Plug *plug )
 				break;
 			}
 		}
+	}
+}
+
+void ArrayPlug::childAdded()
+{
+	if( !m_elementPrototype )
+	{
+		// First child being added from a legacy serialisation. Initialise prototype.
+		const Plug *firstElement = getChild<Plug>( 0 );
+		m_elementPrototype = firstElement->createCounterpart( firstElement->getName(), firstElement->direction() );
 	}
 }

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -104,6 +104,10 @@ bool ArrayPlug::acceptsChild( const GraphComponent *potentialChild ) const
 		return true;
 	}
 
+	/// \todo We could beef up these checks to check any descendants of
+	/// `potentialChild` and to check the default value etc. We can't do that
+	/// until we fix a few violators of our constraint that all children are
+	/// identical - see `ShaderQuery::ShaderQuery`.
 	return potentialChild->typeId() == m_elementPrototype->typeId();
 }
 

--- a/src/Gaffer/ArrayPlug.cpp
+++ b/src/Gaffer/ArrayPlug.cpp
@@ -148,7 +148,12 @@ void ArrayPlug::resize( size_t size )
 {
 	if( size > m_maxSize || size < m_minSize )
 	{
-		throw IECore::Exception( "Invalid size" );
+		throw IECore::Exception(
+			fmt::format(
+				"Invalid size {} requested for `{}` (minSize={}, maxSize={})",
+				size, fullName(), m_minSize, m_maxSize
+			)
+		);
 	}
 
 	while( size > children().size() )

--- a/src/Gaffer/BoxIO.cpp
+++ b/src/Gaffer/BoxIO.cpp
@@ -125,7 +125,7 @@ void applyDynamicFlag( Plug *plug )
 {
 	plug->setFlags( Plug::Dynamic, true );
 
-	auto compoundTypes = { PlugTypeId, ValuePlugTypeId, ArrayPlugTypeId };
+	auto compoundTypes = { PlugTypeId, ValuePlugTypeId };
 	if( find( begin( compoundTypes ), end( compoundTypes ), (Gaffer::TypeId)plug->typeId() ) != end( compoundTypes ) )
 	{
 		for( Plug::RecursiveIterator it( plug ); !it.done(); ++it )

--- a/src/Gaffer/ContextQuery.cpp
+++ b/src/Gaffer/ContextQuery.cpp
@@ -125,6 +125,7 @@ ContextQuery::ContextQuery( const std::string &name ) : Gaffer::ComputeNode( nam
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 
+	/// \todo See notes in `ShaderQuery::ShaderQuery`.
 	addChild( new ArrayPlug( "queries", Plug::Direction::In, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 	addChild( new ArrayPlug( "out", Plug::Direction::Out, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 }

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -1436,7 +1436,7 @@ void applyDynamicFlag( Plug *plug )
 	// for types like CompoundNumericPlug that create children in their constructors.
 	// Or, even better, abolish the Dynamic flag entirely and deal with everything
 	// via serialisers.
-	std::array<Gaffer::TypeId, 4> compoundTypes = { PlugTypeId, ValuePlugTypeId, ArrayPlugTypeId, CompoundDataPlugTypeId };
+	std::array<Gaffer::TypeId, 4> compoundTypes = { PlugTypeId, ValuePlugTypeId, CompoundDataPlugTypeId };
 	if( find( compoundTypes.begin(), compoundTypes.end(), (Gaffer::TypeId)plug->typeId() ) != compoundTypes.end() )
 	{
 		for( Plug::RecursiveIterator it( plug ); !it.done(); ++it )

--- a/src/Gaffer/Switch.cpp
+++ b/src/Gaffer/Switch.cpp
@@ -150,7 +150,7 @@ void Switch::setup( const Plug *plug )
 		g_inPlugsName,
 		Plug::In,
 		inElement,
-		0,
+		1,
 		std::numeric_limits<size_t>::max()
 	);
 	addChild( in );

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -82,7 +82,7 @@ namespace
 // and more readable, and opens the possibility of omitting the
 // overhead of the names entirely one day.
 /// \todo Consider an official way for GraphComponents to opt in
-/// to this behaviour.
+/// to this behaviour. Perhaps this could just be driven by metadata?
 bool keyedByIndex( const GraphComponent *parent )
 {
 	return

--- a/src/GafferImage/CreateViews.cpp
+++ b/src/GafferImage/CreateViews.cpp
@@ -68,7 +68,12 @@ CreateViews::CreateViews( const std::string &name )
 	ArrayPlugPtr views = new ArrayPlug(
 		"views",
 		Plug::In,
-		nullptr,
+		new NameValuePlug(
+			/* nameDefault = */ "",
+			/* valuePlug = */ new ImagePlug(),
+			/* defaultEnabled = */ true,
+			/* name = */ "view0"
+		),
 		0,
 		std::numeric_limits<size_t>::max(),
 		Plug::Default,

--- a/src/GafferImage/CreateViews.cpp
+++ b/src/GafferImage/CreateViews.cpp
@@ -86,6 +86,7 @@ CreateViews::CreateViews( const std::string &name )
 	s->indexPlug()->setInput( indexPlug() );
 
 	ImagePlug *switchOut = runTimeCast< ImagePlug >( s->outPlug() );
+	outPlug()->setFlags( Plug::Serialisable, false );
 	outPlug()->formatPlug()->setInput( switchOut->formatPlug() );
 	outPlug()->dataWindowPlug()->setInput( switchOut->dataWindowPlug() );
 	outPlug()->metadataPlug()->setInput( switchOut->metadataPlug() );

--- a/src/GafferScene/OptionQuery.cpp
+++ b/src/GafferScene/OptionQuery.cpp
@@ -135,6 +135,7 @@ OptionQuery::OptionQuery( const std::string &name ) : Gaffer::ComputeNode( name 
 	storeIndexOfNextChild( g_firstPlugIndex );
 
 	addChild( new ScenePlug( "scene" ) );
+	/// \todo See notes in `ShaderQuery::ShaderQuery`.
 	addChild( new ArrayPlug( "queries", Plug::Direction::In, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 
 	addChild( new ArrayPlug( "out", Plug::Direction::Out, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );

--- a/src/GafferScene/PrimitiveVariableQuery.cpp
+++ b/src/GafferScene/PrimitiveVariableQuery.cpp
@@ -134,6 +134,7 @@ PrimitiveVariableQuery::PrimitiveVariableQuery( const std::string& name )
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new ScenePlug( "scene" ) );
 	addChild( new Gaffer::StringPlug( "location" ) );
+	/// \todo See notes in `ShaderQuery::ShaderQuery`.
 	addChild( new Gaffer::ArrayPlug( "queries", Gaffer::Plug::Direction::In,
 		nullptr, 1, std::numeric_limits< size_t >::max(), Gaffer::Plug::Flags::Default, false ) );
 	addChild( new Gaffer::ArrayPlug( "out", Gaffer::Plug::Direction::Out,

--- a/src/GafferScene/ShaderQuery.cpp
+++ b/src/GafferScene/ShaderQuery.cpp
@@ -141,8 +141,16 @@ ShaderQuery::ShaderQuery( const std::string &name ) : Gaffer::ComputeNode( name 
 	addChild( new StringPlug( "location" ) );
 	addChild( new StringPlug( "shader" ) );
 	addChild( new BoolPlug( "inherit", Plug::In, false ) );
+	/// \todo This is violating the ArrayPlug requirements by not providing an `elementPrototype`
+	/// at construction. And we later violate it further by creating non-homogeneous elements in
+	/// `addQuery()`. We're only using an ArrayPlug because we want the serialisation to use numeric
+	/// indexing for the children of `queries` and `out` - since the serialisation uses `addQuery()`
+	/// to recreate the children, and that doesn't maintain names. So perhaps we can just use a
+	/// ValuePlug instead of an ArrayPlug, and add a separate mechanism for requesting that children use
+	/// numeric indices separately (see `keyedByIndex()` in `Serialisation.cpp`).
+	///
+	/// The same applies to OptionQuery, PrimitiveVariableQuery and ContextQuery.
 	addChild( new ArrayPlug( "queries", Plug::Direction::In, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
-
 	addChild( new ArrayPlug( "out", Plug::Direction::Out, nullptr, 1, std::numeric_limits<size_t>::max(), Plug::Flags::Default, false ) );
 
 	AttributeQueryPtr attributeQuery = new AttributeQuery( "__attributeQuery" );

--- a/startup/Gaffer/arrayPlugCompatibility.py
+++ b/startup/Gaffer/arrayPlugCompatibility.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+def __initWrapper( originalInit ) :
+
+	def init( self, *args, **kw ) :
+
+		if "element" in kw :
+
+			# We renamed `element` to `elementPrototype` in Gaffer 1.5.
+			kw["elementPrototype"] = kw["element"]
+			del kw["element"]
+
+		originalInit( self, *args, **kw )
+
+	return init
+
+Gaffer.ArrayPlug.__init__ = __initWrapper( Gaffer.ArrayPlug.__init__ )

--- a/startup/GafferImage/createViewsCompatibility.py
+++ b/startup/GafferImage/createViewsCompatibility.py
@@ -1,0 +1,62 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferImage
+
+def __viewsChildAdded( parent, child ) :
+
+	if child["name"].defaultValue() :
+		# Legacy code and files create children with non-empty default values
+		# in the `name`` plug. This violates the uniformity of the array, and
+		# can no longer be serialised. Reset the default value while preserving
+		# the current value.
+		value = child["name"].getValue()
+		child["name"].setValue( "" )
+		child["name"].resetDefault()
+		child["name"].setValue( value )
+
+def __initWrapper( originalInit ) :
+
+	def init( self, *args, **kw ) :
+
+		originalInit( self, *args, **kw )
+		self["views"].childAddedSignal().connect(
+			__viewsChildAdded, scoped = False
+		)
+
+	return init
+
+GafferImage.CreateViews.__init__ = __initWrapper( GafferImage.CreateViews.__init__ )


### PR DESCRIPTION
This improves the ArrayPlug API so that we can create zero-length arrays which are still aware of the type of their elements, and can automatically resize to create new such elements. It is motivated by https://github.com/GafferHQ/gaffer/pull/5954, which has just that need. 

This isn't without its wrinkles, since it turns out we have several ArrayPlug clients that are violating the constraint that all elements by identical. But I think it's a big step forward for the ArrayPlug itself, so I've fixed one client (CreateViews) and documented a path forwards for the others.