### PR TITLE
CI : Update to GafferHQ/dependencies 9.0.0a1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,38 +28,12 @@ jobs:
         # and then use `include` to define their settings.
 
         name: [
-          linux-gcc9,
-          linux-debug-gcc9,
           linux-gcc11,
+          linux-debug-gcc11,
           windows,
         ]
 
         include:
-
-          - name: linux-gcc9
-            os: ubuntu-20.04
-            buildType: RELEASE
-            publish: true
-            containerImage: ghcr.io/gafferhq/build/build:2.1.2
-            # GitHub container builds run as root. This causes failures for tests that
-            # assert that filesystem permissions are respected, because root doesn't
-            # respect permissions. So we run the final test suite as a dedicated
-            # test user rather than as root.
-            testRunner: su testUser -c
-            sconsCacheMegabytes: 400
-            jobs: 4
-
-          - name: linux-debug-gcc9
-            os: ubuntu-20.04
-            buildType: DEBUG
-            publish: false
-            containerImage: ghcr.io/gafferhq/build/build:2.1.2
-            testRunner: su testUser -c
-            testArguments: -excludedCategories performance
-            # Debug builds are ludicrously big, so we must use a larger cache
-            # limit. In practice this compresses down to 4-500Mb.
-            sconsCacheMegabytes: 2500
-            jobs: 4
 
           - name: linux-gcc11
             os: ubuntu-20.04
@@ -72,6 +46,18 @@ jobs:
             # test user rather than as root.
             testRunner: su testUser -c
             sconsCacheMegabytes: 400
+            jobs: 4
+
+          - name: linux-debug-gcc11
+            os: ubuntu-20.04
+            buildType: DEBUG
+            publish: false
+            containerImage: ghcr.io/gafferhq/build/build:3.0.0
+            testRunner: su testUser -c
+            testArguments: -excludedCategories performance
+            # Debug builds are ludicrously big, so we must use a larger cache
+            # limit. In practice this compresses down to 4-500Mb.
+            sconsCacheMegabytes: 2500
             jobs: 4
 
           - name: windows

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -245,6 +245,9 @@ jobs:
       with:
         name: ${{ env.GAFFER_BUILD_NAME }}
         path: ${{ env.GAFFER_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}
+        # Using compression-level 0 avoids compressing our already compressed
+        # package and results in a significantly faster upload.
+        compression-level: 0
       if: matrix.publish
 
     - name: Publish Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 800
             jobs: 4
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.9.1/cortex-10.5.9.1-windows.zip
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,16 +79,12 @@ jobs:
       ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL: 0 # And don't abort because the license isn't found
       GAFFER_BUILD_DIR: "./build"
       GAFFER_CACHE_DIR: "./sconsCache"
-      # GitHub have moved to running actions on Node20, which prevents them from
-      # running on CentOS 7. The below allows actions to continue running on Node16
-      # until October.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: ilammy/msvc-dev-cmd@v1.12.1
+    - uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
         sdk: 10.0.17763.0
 
@@ -158,7 +154,7 @@ jobs:
       if: runner.os == 'Windows'
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.GAFFER_CACHE_DIR }}
         key: ${{ runner.os }}-${{ matrix.containerImage }}-${{env.GAFFER_DEPENDENCIES_HASH}}-${{ matrix.buildType }}-${{ github.sha }}
@@ -245,7 +241,7 @@ jobs:
         echo "::remove-matcher owner=validateRelease::"
       if: matrix.publish
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ env.GAFFER_BUILD_NAME }}
         path: ${{ env.GAFFER_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -64,8 +64,8 @@ parser.add_argument(
 parser.add_argument(
 	"--buildEnvironment",
 	help = "The build environment of the dependencies archive to download.",
-	choices = [ "gcc9", "gcc11" ],
-	default = os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "gcc9" if sys.platform == "linux" else "" ),
+	choices = [ "gcc11" ],
+	default = os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "gcc11" if sys.platform == "linux" else "" ),
 )
 
 parser.add_argument(

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.5.9.1/cortex-10.5.9.1-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a1/gafferDependencies-9.0.0a1-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -80,6 +80,23 @@ Breaking Changes
   - Renamed `element` constructor argument to `elementPrototype`.
   - Deprecated the passing of `element = nullptr` to the constructor.
 
+Build
+-----
+
+- Cycles :
+  - Updated to version 4.2.0.
+  - Disabled CUDA binary generation for Kepler and Maxwell architecture GPUs.
+- Embree : Updated to version 4.3.2.
+- Imath : Updated to version 3.1.11.
+- LibJPEG-Turbo : Updated to version 3.0.3.
+- MaterialX : Updated to version 1.38.10.
+- OpenImageIO : Updated to version 2.5.10.1.
+- OpenPGL : Updated to version 0.6.0.
+- PySide : Updated to version 5.15.14.
+- Qt : Updated to version 5.15.14.
+- USD : Updated to version 24.08.
+- Zstandard : Added version 1.5.0.
+
 1.4.x.x (relative to 1.4.11.0)
 =======
 

--- a/SConstruct
+++ b/SConstruct
@@ -1452,7 +1452,7 @@ if env["PLATFORM"] == "win32" :
 
 else :
 
-	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl" ] )
+	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl", "zstd" ] )
 
 # Optionally add vTune requirements
 

--- a/startup/GafferCyclesUI/metadata.py
+++ b/startup/GafferCyclesUI/metadata.py
@@ -945,7 +945,7 @@ def metadata( plug, name ) :
 	parameterDict = shaderDict.get( plug.getName() )
 	if parameterDict is None :
 		return None
-	
+
 	value = parameterDict.get( name )
 	if callable( value ) :
 		return value( plug )
@@ -961,9 +961,9 @@ for name in ( "label", "layout:section", "layout:index", "userDefault", "layout:
 
 ### tex_mapping section, indexes and labels ###
 
-mapping = [ "parameters.tex_mapping__translation", "parameters.tex_mapping__rotation", "parameters.tex_mapping__scale", "parameters.tex_mapping__use_minmax", 
-			"parameters.tex_mapping__min", "parameters.tex_mapping__max", "parameters.tex_mapping__x_mapping", "parameters.tex_mapping__y_mapping", 
-			"parameters.tex_mapping__z_mapping", "parameters.tex_mapping__type", "parameters.tex_mapping__projection" 
+mapping = [ "parameters.tex_mapping__translation", "parameters.tex_mapping__rotation", "parameters.tex_mapping__scale", "parameters.tex_mapping__use_minmax",
+			"parameters.tex_mapping__min", "parameters.tex_mapping__max", "parameters.tex_mapping__x_mapping", "parameters.tex_mapping__y_mapping",
+			"parameters.tex_mapping__z_mapping", "parameters.tex_mapping__type", "parameters.tex_mapping__projection"
 ]
 mapping_labels = [ "Translation", "Rotation", "Scale", "Use Min Max", "Min", "Max", "X Mapping", "Y Mapping", "Z Mapping", "Type", "Projection" ]
 mapping_index = 89

--- a/startup/GafferCyclesUI/metadata.py
+++ b/startup/GafferCyclesUI/metadata.py
@@ -178,6 +178,16 @@ parameterMetadata = {
 			"label" : "Strength",
 			"layout:index" : 29,
 		},
+		"thin_film_thickness" : {
+			"layout:section" : "Thin Film",
+			"label" : "Thickness",
+			"layout:index" : 30,
+		},
+		"thin_film_ior" : {
+			"layout:section" : "Thin Film",
+			"label" : "IOR",
+			"layout:index" : 31,
+		},
 	},
 	"principled_hair_bsdf" : {
 		"model" : {
@@ -800,12 +810,16 @@ parameterMetadata = {
 			"label" : "IOR",
 			"layout:index" : 5,
 		},
-		"subsurface_anisotropy" : {
-			"label" : "Anisotropy",
+		"subsurface_roughness" : {
+			"label" : "Roughness",
 			"layout:index" : 6,
 		},
-		"normal" : {
+		"subsurface_anisotropy" : {
+			"label" : "Anisotropy",
 			"layout:index" : 7,
+		},
+		"normal" : {
+			"layout:index" : 8,
 		},
 	},
 	"math" : {


### PR DESCRIPTION
This updates `main` to use the new `9.0.0a1` dependencies package. 

Given CentOS 7's end of life and GitHub's intended removal of support for Actions that can run on CentOS 7 in October, this takes the opportunity to remove use of our CentoOS 7 GCC9 build container and only publish GCC11 builds from `main`, which allows us to remove the node16 workaround and update to the supported node20 versions of Actions necessary for CI.

Windows builds remain using `cortex-10.5.9.1` for the time being, as we don't yet have a `gafferDependencies-9.0.0a1-windows` release. There are a few Cycles 4.2 specific changes that will need to be made once we have that Windows dependencies release.