### PR TITLE
Miscellaneous ScriptNodeAlgo precursor work

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -50,6 +50,7 @@ API
 - PlugValueWidget :
   - A `DeprecationWarning` is now emitted for any subclasses still implementing the legacy `_updateFromPlug()` or `_updateFromPlugs()` methods. Implement `_updateFromValues()`, `_updateFromMetadata()` and `_updateFromEditable()` instead.
   - A `DeprecationWarning` is now emitted by `_plugConnections()`. Use `_blockedUpdateFromValues()` instead.
+  - Added `scriptNode()` convenience method.
 - NodeGadget, ConnectionGadget : Added `updateFromContextTracker()` virtual methods.
 - Path : Added `inspectionContext()` virtual method.
 - PathColumn :

--- a/Changes.md
+++ b/Changes.md
@@ -59,6 +59,7 @@ API
 - ArrayPlug :
   - It is now legal to construct an ArrayPlug with a minimum size of 0. Previously the minimum size was 1.
   - Added `elementPrototype()` method.
+- View : Added `scriptNode()` method.
 
 Breaking Changes
 ----------------
@@ -80,6 +81,9 @@ Breaking Changes
 - ArrayPlug :
   - Renamed `element` constructor argument to `elementPrototype`.
   - Deprecated the passing of `element = nullptr` to the constructor.
+- View :
+  - Changed constructor arguments for View and all subclasses. A ScriptNode must now be passed.
+  - Changed `ViewCreator` signature.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -84,6 +84,7 @@ Breaking Changes
 - View :
   - Changed constructor arguments for View and all subclasses. A ScriptNode must now be passed.
   - Changed `ViewCreator` signature.
+- LightTool : Removed `selection()` and `selectionChangedSignal()`.
 
 Build
 -----

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -84,7 +84,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 	public :
 
-		explicit ImageView( const std::string &name = defaultName<ImageView>() );
+		explicit ImageView( Gaffer::ScriptNodePtr scriptNode );
 		~ImageView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferImageUI::ImageView, ImageViewTypeId, GafferUI::View );

--- a/include/GafferSceneUI/LightTool.h
+++ b/include/GafferSceneUI/LightTool.h
@@ -99,7 +99,6 @@ class GAFFERSCENEUI_API LightTool : public GafferSceneUI::SelectionTool
 		SelectionChangedSignal m_selectionChangedSignal;
 
 		bool m_dragging;
-		Gaffer::ScriptNodePtr m_scriptNode;
 
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 		Gaffer::Signals::ScopedConnection m_preRenderConnection;

--- a/include/GafferSceneUI/LightTool.h
+++ b/include/GafferSceneUI/LightTool.h
@@ -65,11 +65,6 @@ class GAFFERSCENEUI_API LightTool : public GafferSceneUI::SelectionTool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::LightTool, LightToolTypeId, SelectionTool );
 
-		const IECore::PathMatcher selection() const;
-
-		using SelectionChangedSignal = Gaffer::Signals::Signal<void (LightTool &)>;
-		SelectionChangedSignal &selectionChangedSignal();
-
 	private :
 
 		GafferScene::ScenePlug *scenePlug();
@@ -95,8 +90,6 @@ class GAFFERSCENEUI_API LightTool : public GafferSceneUI::SelectionTool
 		bool m_handleTransformsDirty;
 
 		bool m_priorityPathsDirty;
-
-		SelectionChangedSignal m_selectionChangedSignal;
 
 		bool m_dragging;
 

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -71,7 +71,7 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 
 	public :
 
-		explicit SceneView( const std::string &name = defaultName<SceneView>() );
+		explicit SceneView( Gaffer::ScriptNodePtr scriptNode );
 		~SceneView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::SceneView, SceneViewTypeId, GafferUI::View );

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -56,7 +56,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 	public :
 
-		explicit ShaderView( const std::string &name = defaultName<ShaderView>() );
+		explicit ShaderView( Gaffer::ScriptNodePtr scriptNode );
 		~ShaderView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::ShaderView, ShaderViewTypeId, GafferImageUI::ImageView );

--- a/include/GafferSceneUI/UVView.h
+++ b/include/GafferSceneUI/UVView.h
@@ -61,7 +61,7 @@ class GAFFERSCENEUI_API UVView : public GafferUI::View
 
 	public :
 
-		explicit UVView( const std::string &name = defaultName<UVView>() );
+		explicit UVView( Gaffer::ScriptNodePtr scriptNode );
 		~UVView() override;
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::UVView, UVViewTypeId, View );

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -96,6 +96,10 @@ class GAFFERUI_API View : public Gaffer::Node
 		template<typename T=Gaffer::Plug>
 		const T *inPlug() const;
 
+		/// Returns the ScriptNode this view was created for.
+		Gaffer::ScriptNode *scriptNode();
+		const Gaffer::ScriptNode *scriptNode() const;
+
 		/// The current EditScope for the view is specified by connecting
 		/// an `EditScope::outPlug()` into this plug.
 		Gaffer::Plug *editScopePlug();
@@ -131,7 +135,7 @@ class GAFFERUI_API View : public Gaffer::Node
 		//@{
 		/// Creates a View for the specified plug.
 		static ViewPtr create( Gaffer::PlugPtr input );
-		using ViewCreator = std::function<ViewPtr ( Gaffer::PlugPtr )>;
+		using ViewCreator = std::function<ViewPtr ( Gaffer::ScriptNodePtr )>;
 		/// Registers a function which will return a View instance for a
 		/// plug of a specific type.
 		static void registerView( IECore::TypeId plugType, ViewCreator creator );
@@ -147,7 +151,7 @@ class GAFFERUI_API View : public Gaffer::Node
 		/// class should construct a plug of a suitable type and pass it
 		/// to the View constructor. For instance, the SceneView will pass
 		/// a ScenePlug so that only scenes may be viewed.
-		View( const std::string &name, Gaffer::PlugPtr input );
+		View( const std::string &name, Gaffer::ScriptNodePtr scriptNode, Gaffer::PlugPtr input );
 
 		/// The View may want to perform preprocessing of the input before
 		/// displaying it, for instance by applying a LUT to an image. This
@@ -185,13 +189,16 @@ class GAFFERUI_API View : public Gaffer::Node
 		{
 			ViewDescription( IECore::TypeId plugType );
 			ViewDescription( IECore::TypeId nodeType, const std::string &plugPathRegex );
-			static ViewPtr creator( Gaffer::PlugPtr input );
 		};
+
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
 
 	private :
 
 		void toolsChildAdded( Gaffer::GraphComponent *child );
 		void toolPlugSet( Gaffer::Plug *plug );
+
+		const Gaffer::ScriptNodePtr m_scriptNode;
 
 		using ToolPlugSetMap = std::unordered_map<Tool *, Gaffer::Signals::ScopedConnection>;
 		ToolPlugSetMap m_toolPlugSetConnections;

--- a/include/GafferUI/View.inl
+++ b/include/GafferUI/View.inl
@@ -85,21 +85,13 @@ T *View::preprocessedInPlug()
 template<typename T>
 View::ViewDescription<T>::ViewDescription( IECore::TypeId plugType )
 {
-	View::registerView( plugType, &creator );
+	View::registerView( plugType, []( Gaffer::ScriptNodePtr script ) { return new T( script ); } );
 }
 
 template<typename T>
 View::ViewDescription<T>::ViewDescription( const IECore::TypeId nodeType, const std::string &plugPathRegex )
 {
-	View::registerView( nodeType, plugPathRegex, &creator );
+	View::registerView( nodeType, plugPathRegex, []( Gaffer::ScriptNodePtr script ) { return new T( script ); } );
 }
-
-template<typename T>
-ViewPtr View::ViewDescription<T>::creator( Gaffer::PlugPtr input )
-{
-	ViewPtr result = new T();
-	result->inPlug<Gaffer::Plug>()->setInput( input );
-	return result;
-};
 
 } // namespace GafferUI

--- a/python/GafferImageUI/ChannelMaskPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelMaskPlugValueWidget.py
@@ -207,13 +207,13 @@ class ChannelMaskPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.setValue( value )
 
 	def __toggleCustom( self, checked ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				if not checked :
 					Gaffer.Metadata.deregisterValue( plug, self.__customMetadataName )

--- a/python/GafferImageUI/ChannelPlugValueWidget.py
+++ b/python/GafferImageUI/ChannelPlugValueWidget.py
@@ -172,14 +172,14 @@ class ChannelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.setValue( value )
 				Gaffer.Metadata.deregisterValue( plug, "channelPlugValueWidget:isCustom" )
 
 	def __applyCustom( self, unused ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				Gaffer.Metadata.registerValue( plug, "channelPlugValueWidget:isCustom", True )
 

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -171,14 +171,14 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __applyFormat( self, unused, fmt ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				Gaffer.Metadata.registerValue( plug, "formatPlugValueWidget:mode", "standard" )
 				plug.setValue( fmt )
 
 	def __applyCustomFormat( self, unused ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 
 			if self.__currentFormat == GafferImage.Format() :
 				# Format is empty. It's kindof confusing to display that

--- a/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
+++ b/python/GafferImageUI/RGBAChannelsPlugValueWidget.py
@@ -178,6 +178,6 @@ class RGBAChannelsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.setValue( value )

--- a/python/GafferImageUI/ViewPlugValueWidget.py
+++ b/python/GafferImageUI/ViewPlugValueWidget.py
@@ -125,6 +125,6 @@ class ViewPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setValue( self, unused, value ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.setValue( value )

--- a/python/GafferImageUITest/ImageViewTest.py
+++ b/python/GafferImageUITest/ImageViewTest.py
@@ -49,19 +49,20 @@ class ImageViewTest( GafferUITest.TestCase ) :
 
 	def testFactory( self ) :
 
-		image = GafferImage.Constant()
-		view = GafferUI.View.create( image["out"] )
+		script = Gaffer.ScriptNode()
+		script["image"] = GafferImage.Constant()
+		view = GafferUI.View.create( script["image"]["out"] )
 
 		self.assertTrue( isinstance( view, GafferImageUI.ImageView ) )
-		self.assertTrue( view["in"].getInput().isSame( image["out"] ) )
+		self.assertTrue( view["in"].getInput().isSame( script["image"]["out"] ) )
 
 	def testDeriving( self ) :
 
 		class MyView( GafferImageUI.ImageView ) :
 
-			def __init__( self, viewedPlug = None ) :
+			def __init__( self, scriptNode ) :
 
-				GafferImageUI.ImageView.__init__( self, "MyView" )
+				GafferImageUI.ImageView.__init__( self, scriptNode )
 
 				converter = Gaffer.Node()
 				converter["in"] = Gaffer.StringPlug()
@@ -72,22 +73,22 @@ class ImageViewTest( GafferUITest.TestCase ) :
 
 				self._insertConverter( converter )
 
-				self["in"].setInput( viewedPlug )
-
 		GafferUI.View.registerView( GafferTest.StringInOutNode, "out", MyView )
 
-		string = GafferTest.StringInOutNode()
+		script = Gaffer.ScriptNode()
+		script["string"] = GafferTest.StringInOutNode()
 
-		view = GafferUI.View.create( string["out"] )
+		view = GafferUI.View.create( script["string"]["out"] )
 		self.assertTrue( isinstance( view, MyView ) )
-		self.assertTrue( view["in"].getInput().isSame( string["out"] ) )
+		self.assertTrue( view["in"].getInput().isSame( script["string"]["out"] ) )
 		self.assertTrue( isinstance( view["in"], Gaffer.StringPlug ) )
 		view["displayTransform"]["exposure"].setValue( 1 )
 		view["displayTransform"]["gamma"].setValue( 0.5 )
 
 	def testImageGadget( self ) :
 
-		view = GafferImageUI.ImageView()
+		script = Gaffer.ScriptNode()
+		view = GafferImageUI.ImageView( script )
 		self.assertIsInstance( view.imageGadget(), GafferImageUI.ImageGadget )
 		self.assertTrue( view.viewportGadget().isAncestorOf( view.imageGadget() ) )
 

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -209,27 +209,19 @@ def __hierarchyViewKeyPress( hierarchyView, event ) :
 
 def __nodeEditorKeyPress( nodeEditor, event ) :
 
-	layout = nodeEditor.ancestor( GafferUI.CompoundEditor )
-	if layout is None :
+	focusNode = nodeEditor.scriptNode().getFocus()
+	if focusNode is None :
 		return False
 
-	## \todo In Gaffer 0.61, we should get the scene directly from the focus node.
-	scene = None
-	for hierarchyView in layout.editors( GafferSceneUI.HierarchyView ) :
-		if hierarchyView.scene() is not None :
-			scene = hierarchyView.scene()
-			break
-
-	if scene is None :
-		for viewer in layout.editors( GafferUI.Viewer ) :
-			if isinstance( viewer.view(), GafferSceneUI.SceneView ) :
-				scene = viewer.view()["in"]
-				break
+	scene = next(
+		( p for p in GafferScene.ScenePlug.RecursiveOutputRange( focusNode ) if not p.getName().startswith( "__" ) ),
+		None
+	)
 
 	if scene is None :
 		return False
 
-	context = layout.scriptNode().context()
+	context = nodeEditor.scriptNode().context()
 
 	if event == __editSourceKeyPress :
 		selectedPath = __contextSelectedPath( context )

--- a/python/GafferSceneUI/SetExpressionPlugValueWidget.py
+++ b/python/GafferSceneUI/SetExpressionPlugValueWidget.py
@@ -157,7 +157,7 @@ class SetExpressionPlugValueWidget( GafferUI.PlugValueWidget ) :
 			return
 
 		text = self.__codeWidget.getText()
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.setValue( text )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -219,7 +219,7 @@ class _ShaderNamePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __reloadButtonClicked( self, button ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.node().reloadShader()
 

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -597,7 +597,7 @@ class _IncludedPurposesPlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __togglePurpose( self, checked, purpose ) :
 
 		with self.context() :
-			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.scriptNode() ) :
 				for plug in self.getPlugs() :
 					value = plug.getValue()
 					# Conform value so that only valid purposes are present, and they are

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -49,7 +49,7 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 
 		GafferSceneUI.SceneEditor.__init__( self, column, scriptNode, **kw )
 
-		self.__uvView = GafferSceneUI.UVView()
+		self.__uvView = GafferSceneUI.UVView( scriptNode )
 		self.__uvView["in"].setInput( self.settings()["in"] )
 		Gaffer.NodeAlgo.applyUserDefaults( self.__uvView )
 		self.__uvView.setContext( self.context() )

--- a/python/GafferSceneUITest/CameraToolTest.py
+++ b/python/GafferSceneUITest/CameraToolTest.py
@@ -63,7 +63,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["camera"] = GafferScene.Camera()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["camera"]["out"] )
 
 		self.assertCameraEditable( view, True )
@@ -100,7 +100,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["camera"] = GafferScene.Camera()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["camera"]["out"] )
 
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -141,7 +141,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["camera"]["out"] )
 		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -166,7 +166,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script["camera"] = GafferScene.Camera()
 		script["camera"]["fieldOfView"].setValue( 15 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["camera"]["out"] )
 
 		# Force update, since everything is done lazily in the SceneView
@@ -211,7 +211,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["camera"] = GafferScene.Camera()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["camera"]["out"] )
 		view["camera"]["lookThroughCamera"].setValue( "/camera" )
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -267,7 +267,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script["transform"]["in"].setInput( script["camera"]["out"] )
 		script["transform"]["filter"].setInput( script["filter"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -300,7 +300,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["camera"]["out"] )
 		script["editScope"]["in"].setInput( script["camera"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -346,7 +346,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["camera"] = GafferScene.Camera()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["camera"]["out"] )
 
 		view["camera"]["lookThroughEnabled"].setValue( True )
@@ -389,7 +389,7 @@ class CameraToolTest( GafferUITest.TestCase ) :
 		script["group"] = GafferScene.Group()
 		script["group"]["in"][0].setInput( script["camera"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		view["camera"]["lookThroughEnabled"].setValue( True )
 		view["camera"]["lookThroughCamera"].setValue( "/group/camera" )

--- a/python/GafferSceneUITest/LightPositionToolTest.py
+++ b/python/GafferSceneUITest/LightPositionToolTest.py
@@ -88,7 +88,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["light"] = GafferSceneTest.TestLight()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["light"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light" ] ) )
 
@@ -142,7 +142,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 		script["group"] = GafferScene.Group()
 		script["group"]["in"][0].setInput( script["light"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/light"] ) )
 
@@ -228,7 +228,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["light"] = GafferSceneTest.TestLight()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["light"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light" ] ) )
 
@@ -284,7 +284,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["light"] = GafferSceneTest.TestLight()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["light"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light"] ) )
 
@@ -333,7 +333,7 @@ class LightPositionToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["light"] = GafferSceneTest.TestLight()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["light"]["out"] )
 
 		tool = GafferSceneUI.LightPositionTool( view )

--- a/python/GafferSceneUITest/LightToolTest.py
+++ b/python/GafferSceneUITest/LightToolTest.py
@@ -69,7 +69,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["light1"]["out"] )
 		script["group"]["in"][1].setInput( script["light2"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.LightTool( view )
@@ -105,7 +105,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][1].setInput( script["spotLight2"]["out"] )
 		script["group"]["in"][2].setInput( script["light1"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.LightTool( view )
@@ -131,7 +131,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["light"] = GafferSceneTest.TestLight()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["light"]["out"] )
 
 		tool = GafferSceneUI.LightTool( view )
@@ -155,7 +155,7 @@ class LightToolTest( GafferUITest.TestCase ) :
 		script["shaderAssignment"] = GafferScene.ShaderAssignment()
 		script["shaderAssignment"]["in"].setInput( script["spotLight"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["shaderAssignment"]["out"] )
 
 		tool = GafferSceneUI.LightTool( view )

--- a/python/GafferSceneUITest/LightToolTest.py
+++ b/python/GafferSceneUITest/LightToolTest.py
@@ -58,35 +58,6 @@ class LightToolTest( GafferUITest.TestCase ) :
 		Gaffer.Metadata.registerValue( "light:testLight", "coneAngleParameter", "coneAngle" )
 		Gaffer.Metadata.registerValue( "light:testLight", "penumbraAngleParameter", "penumbraAngle" )
 
-	def testSelection( self ) :
-
-		script = Gaffer.ScriptNode()
-
-		script["light1"] = GafferSceneTest.TestLight()
-		script["light2"] = GafferSceneTest.TestLight()
-
-		script["group"] = GafferScene.Group()
-		script["group"]["in"][0].setInput( script["light1"]["out"] )
-		script["group"]["in"][1].setInput( script["light2"]["out"] )
-
-		view = GafferSceneUI.SceneView( script )
-		view["in"].setInput( script["group"]["out"] )
-
-		tool = GafferSceneUI.LightTool( view )
-		tool["active"].setValue( True )
-
-		self.assertTrue( tool.selection().isEmpty() )
-
-		for selection in [ [ "/group/light" ], ["/group/light", "/group/light1" ], [ "/group/light"] ] :
-			with self.subTest( selection, selection = selection ) :
-				GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( selection ) )
-				s = tool.selection()
-				self.assertEqual( len( s.paths() ), len( selection ) )
-
-		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [] ) )
-		s = tool.selection()
-		self.assertTrue( s.isEmpty() )
-
 	def testSpotLightHandleVisibility( self ) :
 
 		script = Gaffer.ScriptNode()
@@ -125,22 +96,6 @@ class LightToolTest( GafferUITest.TestCase ) :
 		# \todo We should test that the handles are visible with a spotlight selection
 		# and not visible with a non-spotlight selection. Currently handles come in as
 		# `GraphComponent` which prevents testing that.
-
-	def testSelectionChangedSignal( self ) :
-
-		script = Gaffer.ScriptNode()
-		script["light"] = GafferSceneTest.TestLight()
-
-		view = GafferSceneUI.SceneView( script )
-		view["in"].setInput( script["light"]["out"] )
-
-		tool = GafferSceneUI.LightTool( view )
-		tool["active"].setValue( True )
-
-		cs = GafferTest.CapturingSlot( tool.selectionChangedSignal() )
-		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/light" ]  ) )
-		self.assertTrue( len( cs ) )
-		self.assertEqual( cs[0][0], tool )
 
 	def testDeleteNodeCrash( self ) :
 

--- a/python/GafferSceneUITest/RotateToolTest.py
+++ b/python/GafferSceneUITest/RotateToolTest.py
@@ -52,7 +52,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["cube"] = GafferScene.Cube()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["cube"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
 
@@ -74,7 +74,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		# Rotates the X axis onto the negative Z axis
 		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/cube" ] ) )
 
@@ -114,7 +114,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["cube"]["out"] )
 		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/cube" ] ) )
 
@@ -179,7 +179,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["filter"].setInput( script["transformFilter"]["out"] )
 		script["transform"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -207,7 +207,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["cube"] = GafferScene.Cube()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["cube"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
 
@@ -248,7 +248,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["in"].setInput( script["cube"]["out"] )
 		script["transform"]["filter"].setInput( script["transformFilter"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
 
@@ -306,7 +306,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["sphere"]["out"] )
 		script["editScope"]["in"].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -354,7 +354,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["constraint"]["filter"].setInput( script["sphereFilter"]["out"] )
 		script["constraint"]["target"].setValue( "/cube" )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["constraint"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
@@ -389,7 +389,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["constraint"]["filter"].setInput( script["sphereFilter"]["out"] )
 		script["constraint"]["target"].setValue( "/cube" )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["constraint"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
@@ -413,7 +413,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 		script["plane"] = GafferScene.Plane()
 		script["plane"]["transform"]["scale"]["z"].setValue( -10 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -477,7 +477,7 @@ class RotateToolTest( GafferUITest.TestCase ) :
 
 		script["group"]["transform"]["scale"]["z"].setValue( -10 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/plane" ] ) )
 

--- a/python/GafferSceneUITest/ScaleToolTest.py
+++ b/python/GafferSceneUITest/ScaleToolTest.py
@@ -51,7 +51,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 
 		tool = GafferSceneUI.ScaleTool( view )
@@ -80,7 +80,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 
 		tool = GafferSceneUI.ScaleTool( view )
@@ -120,7 +120,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["sphere"]["out"] )
 		script["editScope"]["in"].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -165,7 +165,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		script["constraint"]["filter"].setInput( script["sphereFilter"]["out"] )
 		script["constraint"]["target"].setValue( "/cube" )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["constraint"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
@@ -183,7 +183,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		script["box"]["sphere"] = GafferScene.Sphere()
 		promoted = Gaffer.PlugAlgo.promote( script["box"]["sphere"]["transform"]["scale"]["y"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["box"]["sphere"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
@@ -202,7 +202,7 @@ class ScaleToolTest( GafferUITest.TestCase ) :
 		script["sphere"] = GafferScene.Sphere()
 		script["sphere"]["transform"]["scale"].gang()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["sphere"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -53,11 +53,12 @@ class SceneViewTest( GafferUITest.TestCase ) :
 
 	def testFactory( self ) :
 
-		sphere = GafferScene.Sphere()
-		view = GafferUI.View.create( sphere["out"] )
+		script = Gaffer.ScriptNode()
+		script["sphere"] = GafferScene.Sphere()
+		view = GafferUI.View.create( script["sphere"]["out"] )
 
 		self.assertTrue( isinstance( view, GafferSceneUI.SceneView ) )
-		self.assertTrue( view["in"].getInput().isSame( sphere["out"] ) )
+		self.assertTrue( view["in"].getInput().isSame( script["sphere"]["out"] ) )
 
 	def testExpandSelection( self ) :
 
@@ -67,27 +68,29 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		#    |__D
 		#	 |__E
 
-		D = GafferScene.Sphere()
-		D["name"].setValue( "D" )
+		script = Gaffer.ScriptNode()
 
-		E = GafferScene.Sphere()
-		E["name"].setValue( "E" )
+		script["D"] = GafferScene.Sphere()
+		script["D"]["name"].setValue( "D" )
 
-		C = GafferScene.Group()
-		C["name"].setValue( "C" )
+		script["E"] = GafferScene.Sphere()
+		script["E"]["name"].setValue( "E" )
 
-		C["in"][0].setInput( D["out"] )
-		C["in"][1].setInput( E["out"] )
+		script["C"] = GafferScene.Group()
+		script["C"]["name"].setValue( "C" )
 
-		B = GafferScene.Sphere()
-		B["name"].setValue( "B" )
+		script["C"]["in"][0].setInput( script["D"]["out"] )
+		script["C"]["in"][1].setInput( script["E"]["out"] )
 
-		A = GafferScene.Group()
-		A["name"].setValue( "A" )
-		A["in"][0].setInput( B["out"] )
-		A["in"][1].setInput( C["out"] )
+		script["B"] = GafferScene.Sphere()
+		script["B"]["name"].setValue( "B" )
 
-		view = GafferUI.View.create( A["out"] )
+		script["A"] = GafferScene.Group()
+		script["A"]["name"].setValue( "A" )
+		script["A"]["in"][0].setInput( script["B"]["out"] )
+		script["A"]["in"][1].setInput( script["C"]["out"] )
+
+		view = GafferUI.View.create( script["A"]["out"] )
 
 		def setSelection( paths ) :
 			GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( paths ) )
@@ -338,8 +341,9 @@ class SceneViewTest( GafferUITest.TestCase ) :
 
 	def testInitialClippingPlanes( self ) :
 
-		sphere = GafferScene.Sphere()
-		view = GafferUI.View.create( sphere["out"] )
+		script = Gaffer.ScriptNode()
+		script["sphere"] = GafferScene.Sphere()
+		view = GafferUI.View.create( script["sphere"]["out"] )
 		view["camera"]["clippingPlanes"].setValue( imath.V2f( 1, 10 ) )
 
 		view.viewportGadget().preRenderSignal()( view.viewportGadget() ) # Force update
@@ -419,8 +423,9 @@ class SceneViewTest( GafferUITest.TestCase ) :
 
 	def testClippingPlaneConstraints( self ) :
 
-		sphere = GafferScene.Sphere()
-		view = GafferUI.View.create( sphere["out"] )
+		script = Gaffer.ScriptNode()
+		script["sphere"] = GafferScene.Sphere()
+		view = GafferUI.View.create( script["sphere"]["out"] )
 
 		# Far must be greater than near
 
@@ -452,8 +457,9 @@ class SceneViewTest( GafferUITest.TestCase ) :
 
 	def testChangingClippingPlanesUpdatesAllFreeCameras( self ) :
 
-		sphere = GafferScene.Sphere()
-		view = GafferUI.View.create( sphere["out"] )
+		script = Gaffer.ScriptNode()
+		script["sphere"] = GafferScene.Sphere()
+		view = GafferUI.View.create( script["sphere"]["out"] )
 
 		expectedClippingPlanes = view["camera"]["clippingPlanes"].getValue()
 		view.viewportGadget().preRenderSignal()( view.viewportGadget() ) # Force update

--- a/python/GafferSceneUITest/SelectionToolTest.py
+++ b/python/GafferSceneUITest/SelectionToolTest.py
@@ -64,7 +64,7 @@ class SelectionToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["cube"] = GafferScene.Cube()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["cube"]["out"] )
 
 		tool1 = GafferSceneUI.TranslateTool( view )

--- a/python/GafferSceneUITest/ShaderViewTest.py
+++ b/python/GafferSceneUITest/ShaderViewTest.py
@@ -50,11 +50,12 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 	def testFactory( self ) :
 
-		shader = GafferSceneTest.TestShader()
-		shader["type"].setValue( "test:surface" )
-		shader["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferSceneTest.TestShader()
+		script["shader"]["type"].setValue( "test:surface" )
+		script["shader"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shader["out"] )
+		view = GafferUI.View.create( script["shader"]["out"] )
 		self.assertTrue( isinstance( view, GafferSceneUI.ShaderView ) )
 
 	def testRegisterScene( self ) :
@@ -69,11 +70,12 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ShaderView.registerScene( "test", "Default", TestShaderBall )
 
-		shader = GafferSceneTest.TestShader()
-		shader["type"].setValue( "test:surface" )
-		shader["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferSceneTest.TestShader()
+		script["shader"]["type"].setValue( "test:surface" )
+		script["shader"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shader["out"] )
+		view = GafferUI.View.create( script["shader"]["out"] )
 		self.assertTrue( isinstance( view.scene(), TestShaderBall ) )
 
 	def testRegisterReferenceScene( self ) :
@@ -93,11 +95,12 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ShaderView.registerScene( "test", "Default", self.temporaryDirectory() / "test.grf" )
 
-		shader = GafferSceneTest.TestShader()
-		shader["type"].setValue( "test:surface" )
-		shader["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferSceneTest.TestShader()
+		script["shader"]["type"].setValue( "test:surface" )
+		script["shader"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shader["out"] )
+		view = GafferUI.View.create( script["shader"]["out"] )
 		self.assertTrue( isinstance( view.scene(), Gaffer.Reference ) )
 		self.assertEqual( view.scene().fileName(), self.temporaryDirectory() / "test.grf" )
 		self.assertEqual( view.scene()["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "cube" ] ) )
@@ -123,26 +126,27 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ShaderView.registerScene( "testA", "Default", TestAShaderBall )
 		GafferSceneUI.ShaderView.registerScene( "testB", "Default", TestBShaderBall )
 
-		shaderA = GafferSceneTest.TestShader()
-		shaderA["type"].setValue( "testA:surface" )
-		shaderA["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shaderA"] = GafferSceneTest.TestShader()
+		script["shaderA"]["type"].setValue( "testA:surface" )
+		script["shaderA"]["name"].setValue( "test" )
 
-		shaderB = GafferSceneTest.TestShader()
-		shaderB["type"].setValue( "testB:surface" )
-		shaderB["name"].setValue( "test" )
+		script["shaderB"] = GafferSceneTest.TestShader()
+		script["shaderB"]["type"].setValue( "testB:surface" )
+		script["shaderB"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shaderA["out"] )
+		view = GafferUI.View.create( script["shaderA"]["out"] )
 		sceneA = view.scene()
 		self.assertTrue( isinstance( sceneA, TestAShaderBall ) )
 
-		view["in"].setInput( shaderB["out"] )
+		view["in"].setInput( script["shaderB"]["out"] )
 		sceneB = view.scene()
 		self.assertTrue( isinstance( sceneB, TestBShaderBall ) )
 
-		view["in"].setInput( shaderA["out"] )
+		view["in"].setInput( script["shaderA"]["out"] )
 		self.assertTrue( view.scene().isSame( sceneA ) )
 
-		view["in"].setInput( shaderB["out"] )
+		view["in"].setInput( script["shaderB"]["out"] )
 		self.assertTrue( view.scene().isSame( sceneB ) )
 
 	def testChangeScene( self ) :
@@ -150,11 +154,12 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ShaderView.registerScene( "sceneTest", "A", GafferScene.ShaderBall )
 		GafferSceneUI.ShaderView.registerScene( "sceneTest", "B", GafferScene.ShaderBall )
 
-		shader = GafferSceneTest.TestShader()
-		shader["type"].setValue( "sceneTest:surface" )
-		shader["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferSceneTest.TestShader()
+		script["shader"]["type"].setValue( "sceneTest:surface" )
+		script["shader"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shader["out"] )
+		view = GafferUI.View.create( script["shader"]["out"] )
 		view["scene"].setValue( "A" )
 
 		sceneA = view.scene()
@@ -176,11 +181,12 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ShaderView.registerScene( "test", "Default", functools.partial( shaderBallCreator, 16 ) )
 
-		shader = GafferSceneTest.TestShader()
-		shader["type"].setValue( "test:surface" )
-		shader["name"].setValue( "test" )
+		script = Gaffer.ScriptNode()
+		script["shader"] = GafferSceneTest.TestShader()
+		script["shader"]["type"].setValue( "test:surface" )
+		script["shader"]["name"].setValue( "test" )
 
-		view = GafferUI.View.create( shader["out"] )
+		view = GafferUI.View.create( script["shader"]["out"] )
 		scene1 = view.scene()
 		self.assertEqual( view.scene()["resolution"].getValue(), 16 )
 
@@ -197,20 +203,23 @@ class ShaderViewTest( GafferUITest.TestCase ) :
 
 	def testCannotViewCatalogue( self ) :
 
-		view = GafferSceneUI.ShaderView()
-		catalogue = GafferImage.Catalogue()
-		self.assertFalse( view["in"].acceptsInput( catalogue["out"] ) )
+		script = Gaffer.ScriptNode()
+		script["catalogue"] = GafferImage.Catalogue()
+
+		view = GafferSceneUI.ShaderView( script )
+		self.assertFalse( view["in"].acceptsInput( script["catalogue"]["out"] ) )
 
 	def testCannotViewSceneSwitch( self ) :
 
-		view = GafferSceneUI.ShaderView()
+		script = Gaffer.ScriptNode()
+		script["sphere"] = GafferScene.Sphere()
+		script["switch"] = Gaffer.Switch()
+		script["switch"].setup( script["sphere"]["out"] )
 
-		sphere = GafferScene.Sphere()
-		switch = Gaffer.Switch()
-		switch.setup( sphere["out"] )
+		view = GafferSceneUI.ShaderView( script )
 
-		self.assertFalse( view["in"].acceptsInput( sphere["out"] ) )
-		self.assertFalse( view["in"].acceptsInput( switch["out"] ) )
+		self.assertFalse( view["in"].acceptsInput( script["sphere"]["out"] ) )
+		self.assertFalse( view["in"].acceptsInput( script["switch"]["out"] ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -73,7 +73,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["in"].setInput( script["group"]["out"] )
 		script["transform"]["filter"].setInput( script["transformFilter"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -127,7 +127,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -147,7 +147,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -188,7 +188,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/plane" ] ) )
 
@@ -213,7 +213,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/plane" ] ) )
 
@@ -238,7 +238,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group/plane" ] ) )
 
@@ -296,7 +296,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["plane"] = GafferScene.Plane()
 		script["plane"]["transform"]["scale"].setValue( imath.V3f( 10 ) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -334,7 +334,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["plane"] = GafferScene.Plane()
 		script["plane"]["transform"]["scale"]["x"].setValue( -10 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -370,7 +370,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["group"] = GafferScene.Group()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/group" ] ) )
 
@@ -398,7 +398,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["in"].setInput( script["plane"]["out"] )
 		script["transform"]["filter"].setInput( script["transformFilter"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -429,7 +429,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["filter"].setInput( script["transformFilter"]["out"] )
 		script["transform"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -453,7 +453,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["plane"] = GafferScene.Plane()
 		script["plane"]["transform"]["rotate"]["y"].setValue( 90 )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/plane" ] ) )
 
@@ -494,7 +494,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			"""
 		) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 		view.setContext( script.context() )
 
@@ -524,7 +524,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["variables"]["in"].setInput( script["plane"]["out"] )
 		script["variables"]["variables"].addChild( Gaffer.NameValuePlug( "x", 1.0 ) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["variables"]["out"] )
 		view.setContext( script.context() )
 
@@ -548,7 +548,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["in"][1].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -581,7 +581,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["in"][1].setInput( script["plane"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -610,7 +610,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["plane"]["out"] )
 		script["group"]["in"][1].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -634,7 +634,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		Gaffer.PlugAlgo.promote( script["box"]["sphere"]["transform"] )
 		Gaffer.PlugAlgo.promote( script["box"]["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["box"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -649,7 +649,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["plane"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -666,7 +666,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["sceneReader"] = GafferScene.SceneReader()
 		script["sceneReader"]["fileName"].setValue( "${GAFFER_ROOT}/python/GafferSceneTest/alembicFiles/groupedPlane.abc" )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["sceneReader"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -684,7 +684,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["plane"] = GafferScene.Plane()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -727,7 +727,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["subTree"]["out"] )
 		script["group"]["in"][1].setInput( script["plane"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
@@ -751,7 +751,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["group"]["in"][0].setInput( script["sphere"]["out"] )
 		script["group"]["in"][1].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["group"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -808,7 +808,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		# Set up a TransformTool and tell it to transform each of the spheres.
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["reader"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -835,7 +835,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["transform"]["in"].setInput( script["sphere"]["out"] )
 		script["transform"]["filter"].setInput( script["setFilter"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["transform"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -863,7 +863,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( script["collect"]["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "sphere1", "sphere2" ] ) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["collect"]["out"] )
 
 		tool = GafferSceneUI.TranslateTool( view )
@@ -893,7 +893,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["sphere"]["out"] )
 		script["editScope"]["in"].setInput( script["sphere"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -929,7 +929,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["group"]["out"] )
 		script["editScope"]["in"].setInput( script["group"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -971,7 +971,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["cube"] = GafferScene.Cube()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["cube"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
@@ -996,7 +996,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["cube"]["out"] )
 		script["editScope"]["in"].setInput( script["cube"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -1040,7 +1040,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		transformEdit = GafferScene.EditScopeAlgo.acquireTransformEdit( script["editScope"], "/sphere" )
 		transformEdit.translate.setValue( imath.V3f( 1, 0, 0 ) )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/sphere" ] ) )
@@ -1070,7 +1070,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script = Gaffer.ScriptNode()
 		script["sphere"] = GafferScene.Sphere()
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["sphere"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube", "/plane" ] ) )
 
@@ -1121,7 +1121,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 			imath.V3f( 0, 10, 0 )
 		)
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["aim"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
 
@@ -1196,7 +1196,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		# View and Tool
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["constraint"]["out"] )
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )
 
@@ -1243,7 +1243,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		script["editScope"].setup( script["parent"]["out"] )
 		script["editScope"]["in"].setInput( script["parent"]["out"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["editScope"]["out"] )
 		view["editScope"].setInput( script["editScope"]["out"] )
 
@@ -1271,7 +1271,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		promotedY = Gaffer.PlugAlgo.promote( script["box"]["cube"]["transform"]["translate"]["y"] )
 		promotedZ = Gaffer.PlugAlgo.promote( script["box"]["cube"]["transform"]["translate"]["z"] )
 
-		view = GafferSceneUI.SceneView()
+		view = GafferSceneUI.SceneView( script )
 		view["in"].setInput( script["box"]["cube"]["out"] )
 
 		GafferSceneUI.ContextAlgo.setSelectedPaths( view.getContext(), IECore.PathMatcher( [ "/cube" ] ) )

--- a/python/GafferUI/BoolPlugValueWidget.py
+++ b/python/GafferUI/BoolPlugValueWidget.py
@@ -115,7 +115,7 @@ class BoolPlugValueWidget( GafferUI.PlugValueWidget ) :
 		value = self.__boolWidget.getState()
 		assert( value != self.__boolWidget.State.Indeterminate ) # Should be set by us, not by user action
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 
 				if Gaffer.Animation.isAnimated( plug ) :

--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -81,7 +81,7 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__lastChangedReason = reason
 
 		with Gaffer.UndoScope(
-			next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ),
+			self.scriptNode(),
 			mergeGroup = "ColorPlugValueWidget%d%d" % ( id( self, ), self.__mergeGroupId )
 		) :
 

--- a/python/GafferUI/CompoundNumericPlugValueWidget.py
+++ b/python/GafferUI/CompoundNumericPlugValueWidget.py
@@ -130,13 +130,13 @@ class CompoundNumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __gang( self ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.gang()
 
 	def __ungang( self ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				plug.ungang()
 

--- a/python/GafferUI/NameValuePlugValueWidget.py
+++ b/python/GafferUI/NameValuePlugValueWidget.py
@@ -149,7 +149,7 @@ class NameValuePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# child plugs _except_ `name`.
 
 		widget.setHighlighted( False )
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).node().scriptNode() ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for p in self.getPlugs() :
 				for c in p.children() :
 					if c.getName() != "name" :

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -173,7 +173,7 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setPlugValues( self, mergeGroup="" ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ), mergeGroup=mergeGroup ) :
+		with Gaffer.UndoScope( self.scriptNode(), mergeGroup=mergeGroup ) :
 
 			with self._blockedUpdateFromValues() :
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -140,6 +140,15 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		return self.__context
 
+	## Returns the ScriptNode ancestor for the plugs, or `None` if
+	# no such ancestor exists.
+	def scriptNode( self ) :
+
+		if not len( self.__plugs ) :
+			return None
+		else :
+			return next( iter( self.__plugs ) ).ancestor( Gaffer.ScriptNode )
+
 	## Should be reimplemented to return True if this widget includes
 	# some sort of labelling for the plug. This is used to prevent
 	# extra labels being created in the NodeUI when they're not necessary.
@@ -779,7 +788,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 		if not isinstance( values, list ) :
 			values = itertools.repeat( values, len( self.getPlugs() ) )
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug, value in zip( self.getPlugs(), values ) :
 				plug.setValue( value )
 
@@ -807,13 +816,13 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __removeInputs( self ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for p in self.getPlugs() :
 				p.setInput( None )
 
 	def __applyUserDefaults( self ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for p in self.getPlugs() :
 				Gaffer.NodeAlgo.applyUserDefault( p )
 
@@ -851,13 +860,13 @@ class PlugValueWidget( GafferUI.Widget ) :
 	def __applyPreset( self, presetName, *unused ) :
 
 		with self.context() :
-			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.scriptNode() ) :
 				for p in self.getPlugs() :
 					Gaffer.NodeAlgo.applyPreset( p, presetName )
 
 	def __applyReadOnly( self, readOnly ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for p in self.getPlugs() :
 				Gaffer.MetadataAlgo.setReadOnly( p, readOnly )
 
@@ -897,7 +906,7 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		self.setHighlighted( False )
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).node().scriptNode() ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			if isinstance( event.data, Gaffer.Plug ) :
 				for p in self.getPlugs() :
 					p.setInput( event.data )

--- a/python/GafferUI/PresetsPlugValueWidget.py
+++ b/python/GafferUI/PresetsPlugValueWidget.py
@@ -180,14 +180,14 @@ class PresetsPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# Required for context-sensitive dynamic presets
 		with self.context() :
-			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.scriptNode() ) :
 				for plug in self.getPlugs() :
 					Gaffer.Metadata.deregisterValue( plug, "presetsPlugValueWidget:isCustom" )
 					Gaffer.NodeAlgo.applyPreset( plug, preset )
 
 	def __applyCustomPreset( self, unused ) :
 
-		with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
 				# When we first switch to custom mode, the current value will
 				# actually be one of the registered presets. So we use this

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -176,7 +176,7 @@ class StringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self._editable() :
 			text = self.__textWidget.getText()
-			with Gaffer.UndoScope( next( iter( self.getPlugs() ) ).ancestor( Gaffer.ScriptNode ) ) :
+			with Gaffer.UndoScope( self.scriptNode() ) :
 				for plug in self.getPlugs() :
 					plug.setValue( text )
 

--- a/python/GafferUITest/StandardNodeToolbarTest.py
+++ b/python/GafferUITest/StandardNodeToolbarTest.py
@@ -54,7 +54,8 @@ class StandardNodeToolbarTest( GafferUITest.TestCase ) :
 		)
 		Gaffer.Metadata.registerValue( script["node"]["op1"], "toolbarLayout:section", "Top" )
 
-		view = GafferUITest.ViewTest.MyView( script["node"]["op1"] )
+		view = GafferUITest.ViewTest.MyView( script )
+		view["in"].setInput( script["node"]["op1"] )
 		view.setContext( script.context() )
 		view["testPlug"] = Gaffer.IntPlug()
 		Gaffer.Metadata.registerValue(

--- a/python/GafferUITest/ToolTest.py
+++ b/python/GafferUITest/ToolTest.py
@@ -59,7 +59,8 @@ class ToolTest( GafferUITest.TestCase ) :
 
 		self.assertIn( "TestTool", GafferUI.Tool.registeredTools( GafferUITest.ViewTest.MyView ) )
 
-		view = GafferUITest.ViewTest.MyView()
+		script = Gaffer.ScriptNode()
+		view = GafferUITest.ViewTest.MyView( script )
 		tool = GafferUI.Tool.create( "TestTool", view )
 		self.assertIsInstance( tool, self.TestTool )
 		self.assertIsInstance( tool, GafferUI.Tool )
@@ -72,7 +73,8 @@ class ToolTest( GafferUITest.TestCase ) :
 
 		# When a tool is created, it is automatically parented to the View's
 		# tool container.
-		view1 = GafferUITest.ViewTest.MyView()
+		script = Gaffer.ScriptNode()
+		view1 = GafferUITest.ViewTest.MyView( script )
 		tool = GafferUI.Tool.create( "TestTool", view1 )
 		self.assertTrue( tool.parent().isSame( view1["tools"] ) )
 		self.assertTrue( tool.view().isSame( view1 ) )
@@ -80,7 +82,7 @@ class ToolTest( GafferUITest.TestCase ) :
 
 		# After that, it can't be reparented to another view. This simplifies
 		# tool implementation substantially.
-		view2 = GafferUITest.ViewTest.MyView()
+		view2 = GafferUITest.ViewTest.MyView( script )
 		self.assertFalse( tool.acceptsParent( view2["tools"] ) )
 
 		# Tool containers don't accept any other children.
@@ -88,7 +90,8 @@ class ToolTest( GafferUITest.TestCase ) :
 
 	def testToolOutlivingView( self ) :
 
-		view = GafferUITest.ViewTest.MyView()
+		script = Gaffer.ScriptNode()
+		view = GafferUITest.ViewTest.MyView( script )
 		tool = GafferUI.Tool.create( "TestTool", view )
 		del view
 		while gc.collect() :

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -60,6 +60,7 @@
 #include "Gaffer/BoxPlug.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/NameSwitch.h"
+#include "Gaffer/ScriptNode.h"
 
 #include "IECoreGL/IECoreGL.h"
 #include "IECoreGL/Shader.h"
@@ -1439,8 +1440,8 @@ GAFFER_NODE_DEFINE_TYPE( ImageView );
 
 GAFFERIMAGEUI_API ImageView::ViewDescription<ImageView> ImageView::g_viewDescription( GafferImage::ImagePlug::staticTypeId() );
 
-ImageView::ImageView( const std::string &name )
-	:	View( name, new GafferImage::ImagePlug() ),
+ImageView::ImageView( Gaffer::ScriptNodePtr scriptNode )
+	:	View( defaultName<ImageView>(), scriptNode, new GafferImage::ImagePlug() ),
 		m_imageGadgets{ new ImageGadget(), new ImageGadget() },
 		m_framed( false )
 {

--- a/src/GafferImageUIModule/ImageViewBinding.cpp
+++ b/src/GafferImageUIModule/ImageViewBinding.cpp
@@ -46,6 +46,8 @@
 #include "GafferBindings/NodeBinding.h"
 #include "GafferBindings/PlugBinding.h"
 
+#include "Gaffer/ScriptNode.h"
+
 using namespace std;
 using namespace boost::python;
 using namespace Gaffer;
@@ -61,8 +63,8 @@ class ImageViewWrapper : public NodeWrapper<ImageView>
 
 	public :
 
-		ImageViewWrapper( PyObject *self, const std::string &name )
-			:	NodeWrapper<ImageView>( self, name )
+		ImageViewWrapper( PyObject *self, ScriptNodePtr scriptNode )
+			:	NodeWrapper<ImageView>( self, scriptNode )
 		{
 		}
 
@@ -77,8 +79,8 @@ class ImageViewWrapper : public NodeWrapper<ImageView>
 
 void GafferImageUIModule::bindImageView()
 {
-	scope s = GafferBindings::NodeClass<ImageView, ImageViewWrapper>()
-		.def( init<const std::string &>() )
+	scope s = GafferBindings::NodeClass<ImageView, ImageViewWrapper>( nullptr, no_init )
+		.def( init<ScriptNodePtr>() )
 		.def( "imageGadget", (ImageGadget *(ImageView::*)())&ImageView::imageGadget, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "_insertConverter", &ImageViewWrapper::insertConverter )
 	;

--- a/src/GafferSceneUI/CameraTool.cpp
+++ b/src/GafferSceneUI/CameraTool.cpp
@@ -391,7 +391,7 @@ void CameraTool::viewportCameraChanged()
 	// Now apply this offset to the current value on the transform plug.
 
 	Gaffer::Private::ScopedAssignment<bool> editingScope( g_editingTransform, true );
-	UndoScope undoScope( selection.editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, m_undoGroup );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, m_undoGroup );
 	auto edit = selection.acquireTransformEdit();
 
 	M44f plugTransform;

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -739,7 +739,7 @@ void CropWindowTool::overlayRectangleChanged( unsigned reason )
 		flipNDCOrigin( b );
 	}
 
-	UndoScope undoScope( m_cropWindowPlug->ancestor<ScriptNode>() );
+	UndoScope undoScope( view()->scriptNode() );
 
 	if( m_cropWindowEnabledPlug && !m_cropWindowEnabledPlug->getValue() )
 	{
@@ -1032,7 +1032,7 @@ bool CropWindowTool::keyPress( const KeyEvent &event )
 			activePlug()->setValue( newState );
 			if( m_cropWindowEnabledPlug )
 			{
-				UndoScope undoScope( m_cropWindowPlug->ancestor<ScriptNode>() );
+				UndoScope undoScope( view()->scriptNode() );
 				m_cropWindowEnabledPlug->setValue( newState );
 			}
 		}

--- a/src/GafferSceneUI/LightPositionTool.cpp
+++ b/src/GafferSceneUI/LightPositionTool.cpp
@@ -789,7 +789,7 @@ IECore::RunTimeTypedPtr LightPositionTool::handleDragBegin( Gadget *gadget )
 
 bool LightPositionTool::handleDragMove( Gadget *gadget, const DragDropEvent &event )
 {
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 
 	if( gadget == m_distanceHandle.get() )
 	{
@@ -868,7 +868,7 @@ bool LightPositionTool::sceneGadgetDragMove( const DragDropEvent &event )
 		return true;
 	}
 
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 
 	placeTarget( event.line );
 	return true;
@@ -973,7 +973,7 @@ bool LightPositionTool::buttonPress( const ButtonEvent &event )
 		return true;
 	}
 
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 
 	placeTarget( event.line );
 	return true;

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -2965,7 +2965,6 @@ LightTool::LightTool( SceneView *view, const std::string &name ) :
 	m_handleTransformsDirty( true ),
 	m_priorityPathsDirty( true ),
 	m_dragging( false ),
-	m_scriptNode( nullptr ),
 	m_mergeGroupId( 0 )
 {
 	view->viewportGadget()->addChild( m_handles );
@@ -3323,8 +3322,6 @@ void LightTool::dirtyHandleTransforms()
 RunTimeTypedPtr LightTool::dragBegin( Gadget *gadget )
 {
 	m_dragging = true;
-	m_scriptNode = view()->inPlug()->source()->ancestor<ScriptNode>();
-
 	return nullptr;
 }
 
@@ -3333,7 +3330,7 @@ bool LightTool::dragMove( Gadget *gadget, const DragDropEvent &event )
 	auto handle = runTimeCast<LightToolHandle>( gadget );
 	assert( handle );
 
-	UndoScope undoScope( m_scriptNode.get(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 
 	handle->handleDragMove( event );
 

--- a/src/GafferSceneUI/LightTool.cpp
+++ b/src/GafferSceneUI/LightTool.cpp
@@ -3037,16 +3037,6 @@ LightTool::~LightTool()
 
 }
 
-const PathMatcher LightTool::selection() const
-{
-	return ContextAlgo::getSelectedPaths( view()->getContext() );
-}
-
-LightTool::SelectionChangedSignal &LightTool::selectionChangedSignal()
-{
-	return m_selectionChangedSignal;
-}
-
 ScenePlug *LightTool::scenePlug()
 {
 	return getChild<ScenePlug>( g_firstPlugIndex );
@@ -3075,7 +3065,6 @@ void LightTool::contextChanged( const InternedString &name )
 		m_handleInspectionsDirty = true;
 		m_handleTransformsDirty = true;
 		m_priorityPathsDirty = true;
-		selectionChangedSignal()( *this );
 	}
 }
 
@@ -3102,7 +3091,7 @@ void LightTool::updateHandleInspections()
 
 	m_inspectorsDirtiedConnection.clear();
 
-	const PathMatcher selection = this->selection();
+	const PathMatcher selection = ContextAlgo::getSelectedPaths( view()->getContext() );
 	if( selection.isEmpty() )
 	{
 		for( auto &c : m_handles->children() )
@@ -3176,7 +3165,7 @@ void LightTool::updateHandleTransforms( float rasterScale )
 		return;
 	}
 
-	const PathMatcher selection = this->selection();
+	const PathMatcher selection = ContextAlgo::getSelectedPaths( view()->getContext() );
 	if( selection.isEmpty() )
 	{
 		return;
@@ -3225,10 +3214,6 @@ void LightTool::plugDirtied( const Plug *plug )
 		( plug->ancestor<View>() && plug == view()->editScopePlug() )
 	)
 	{
-		if( !m_dragging )
-		{
-			selectionChangedSignal()( *this );
-		}
 		m_handleInspectionsDirty = true;
 		m_priorityPathsDirty = true;
 	}
@@ -3280,14 +3265,7 @@ void LightTool::preRender()
 		{
 			m_priorityPathsDirty = false;
 			auto sceneGadget = static_cast<SceneGadget *>( view()->viewportGadget()->getPrimaryChild() );
-			if( !selection().isEmpty() )
-			{
-				sceneGadget->setPriorityPaths( ContextAlgo::getSelectedPaths( view()->getContext() ) );
-			}
-			else
-			{
-				sceneGadget->setPriorityPaths( IECore::PathMatcher() );
-			}
+			sceneGadget->setPriorityPaths( ContextAlgo::getSelectedPaths( view()->getContext() ) );
 		}
 	}
 
@@ -3341,8 +3319,6 @@ bool LightTool::dragEnd( Gadget *gadget )
 {
 	m_dragging = false;
 	m_mergeGroupId++;
-	selectionChangedSignal()( *this );
-
 	auto handle = runTimeCast<LightToolHandle>( gadget );
 	handle->handleDragEnd();
 

--- a/src/GafferSceneUI/RotateTool.cpp
+++ b/src/GafferSceneUI/RotateTool.cpp
@@ -247,7 +247,7 @@ IECore::RunTimeTypedPtr RotateTool::handleDragBegin()
 
 bool RotateTool::handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 	const V3f rotation = static_cast<RotateHandle *>( gadget )->rotation( event );
 	for( auto &r : m_drag )
 	{
@@ -289,7 +289,7 @@ bool RotateTool::buttonPress( const GafferUI::ButtonEvent &event )
 		return true;
 	}
 
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>() );
+	UndoScope undoScope( view()->scriptNode() );
 
 	for( const auto &s : selection() )
 	{

--- a/src/GafferSceneUI/ScaleTool.cpp
+++ b/src/GafferSceneUI/ScaleTool.cpp
@@ -140,7 +140,7 @@ IECore::RunTimeTypedPtr ScaleTool::dragBegin( GafferUI::Style::Axes axes )
 
 bool ScaleTool::dragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 	ScaleHandle *scaleHandle = static_cast<ScaleHandle *>( gadget );
 	const V3f &scaling = scaleHandle->scaling( event );
 	for( auto &s : m_drag )

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -58,6 +58,7 @@
 #include "Gaffer/MetadataAlgo.h"
 #include "Gaffer/NameSwitch.h"
 #include "Gaffer/PlugAlgo.h"
+#include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 
 #include "IECoreGL/Camera.h"
@@ -1935,8 +1936,8 @@ GAFFER_NODE_DEFINE_TYPE( SceneView );
 size_t SceneView::g_firstPlugIndex = 0;
 SceneView::ViewDescription<SceneView> SceneView::g_viewDescription( GafferScene::ScenePlug::staticTypeId() );
 
-SceneView::SceneView( const std::string &name )
-	:	View( name, new GafferScene::ScenePlug() ),
+SceneView::SceneView( ScriptNodePtr scriptNode )
+	:	View( defaultName<SceneView>(), scriptNode, new GafferScene::ScenePlug() ),
 		m_sceneGadget( new SceneGadget )
 {
 

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -49,6 +49,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Reference.h"
+#include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 
 #include "IECoreImage/DisplayDriverServer.h"
@@ -131,8 +132,8 @@ GAFFER_NODE_DEFINE_TYPE( ShaderView );
 /// but that would be a breaking change (albeit a small one).
 ShaderView::ViewDescription<ShaderView> ShaderView::g_viewDescription( GafferScene::Shader::staticTypeId(), "out" );
 
-ShaderView::ShaderView( const std::string &name )
-	:	ImageView( name ), m_framed( false )
+ShaderView::ShaderView( Gaffer::ScriptNodePtr scriptNode )
+	:	ImageView( scriptNode ), m_framed( false )
 {
 	// Create a converter to generate an image
 	// from the input shader.

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -1253,7 +1253,7 @@ bool TransformTool::keyPress( const GafferUI::KeyEvent &event )
 			return false;
 		}
 
-		UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>() );
+		UndoScope undoScope( view()->scriptNode() );
 		for( const auto &s : selection() )
 		{
 			Context::Scope contextScope( s.context() );

--- a/src/GafferSceneUI/TranslateTool.cpp
+++ b/src/GafferSceneUI/TranslateTool.cpp
@@ -246,7 +246,7 @@ IECore::RunTimeTypedPtr TranslateTool::handleDragBegin()
 
 bool TranslateTool::handleDragMove( GafferUI::Gadget *gadget, const GafferUI::DragDropEvent &event )
 {
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>(), UndoScope::Enabled, undoMergeGroup() );
+	UndoScope undoScope( view()->scriptNode(), UndoScope::Enabled, undoMergeGroup() );
 	const V3f translation = static_cast<TranslateHandle *>( gadget )->translation( event );
 	for( auto &t : m_drag )
 	{
@@ -301,7 +301,7 @@ bool TranslateTool::buttonPress( const GafferUI::ButtonEvent &event )
 		selectionCentroids.extendBy( s.scene()->bound( s.path() ).center() * worldTransform );
 	}
 
-	UndoScope undoScope( selection().back().editTarget()->ancestor<ScriptNode>() );
+	UndoScope undoScope( view()->scriptNode() );
 
 	const V3f offset = targetPos - selectionCentroids.center();
 	for( const auto &s : selection() )

--- a/src/GafferSceneUI/UVView.cpp
+++ b/src/GafferSceneUI/UVView.cpp
@@ -56,6 +56,7 @@
 #include "GafferUI/Style.h"
 #include "GafferUI/ViewportGadget.h"
 
+#include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 
 #include "IECore/Math.h"
@@ -574,8 +575,8 @@ static InternedString g_gridGadgetName( "gridGadget" );
 
 GAFFER_NODE_DEFINE_TYPE( UVView )
 
-UVView::UVView( const std::string &name )
-	:	View( name, new ScenePlug ), m_textureGadgetsDirty( true ), m_framed( false )
+UVView::UVView( Gaffer::ScriptNodePtr scriptNode )
+	:	View( defaultName<UVView>(), scriptNode, new ScenePlug ), m_textureGadgetsDirty( true ), m_framed( false )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -109,12 +109,6 @@ boost::python::list selection( const TransformTool &tool )
 	return result;
 }
 
-IECore::PathMatcher lightToolSelection( const LightTool &tool )
-{
-	IECorePython::ScopedGILRelease gilRelease;
-	return tool.selection();
-}
-
 bool selectionEditable( const TransformTool &tool )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -302,15 +296,9 @@ void GafferSceneUIModule::bindTools()
 		.def( init<SceneView *>() )
 	;
 
-	{
-		scope s = GafferBindings::NodeClass<LightTool>( nullptr, no_init )
-			.def( init<SceneView *>() )
-			.def( "selection", &lightToolSelection )
-			.def( "selectionChangedSignal", &LightTool::selectionChangedSignal, return_internal_reference<1>() )
-		;
-
-		GafferBindings::SignalClass<LightTool::SelectionChangedSignal, GafferBindings::DefaultSignalCaller<LightTool::SelectionChangedSignal>, SelectionChangedSlotCaller<LightTool>>( "SelectionChangedSignal" );
-	}
+	GafferBindings::NodeClass<LightTool>( nullptr, no_init )
+		.def( init<SceneView *>() )
+	;
 
 	{
 		scope s = GafferBindings::NodeClass<LightPositionTool>( nullptr, no_init )

--- a/src/GafferSceneUIModule/ViewBinding.cpp
+++ b/src/GafferSceneUIModule/ViewBinding.cpp
@@ -315,7 +315,8 @@ struct UVViewSlotCaller
 void GafferSceneUIModule::bindViews()
 {
 
-	GafferBindings::NodeClass<SceneView>()
+	GafferBindings::NodeClass<SceneView>( nullptr, no_init )
+		.def( init<ScriptNodePtr>() )
 		.def( "frame", &frame, ( boost::python::arg_( "filter" ), boost::python::arg_( "direction" ) = Imath::V3f( -0.64, -0.422, -0.64 ) ) )
 		.def( "resolutionGate", &resolutionGateWrapper )
 		.def( "expandSelection", &expandSelection, ( boost::python::arg_( "depth" ) = 1 ) )
@@ -330,7 +331,8 @@ void GafferSceneUIModule::bindViews()
 		.staticmethod( "registeredShadingModes" )
 	;
 
-	GafferBindings::NodeClass<ShaderView>()
+	GafferBindings::NodeClass<ShaderView>( nullptr, no_init )
+		.def( init<ScriptNodePtr>() )
 		.def( "shaderPrefix", &ShaderView::shaderPrefix )
 		.def( "scene", (Gaffer::Node *(ShaderView::*)())&ShaderView::scene, return_value_policy<CastToIntrusivePtr>() )
 		.def( "sceneChangedSignal", &ShaderView::sceneChangedSignal, return_internal_reference<1>() )
@@ -348,7 +350,8 @@ void GafferSceneUIModule::bindViews()
 	SignalClass<ShaderView::SceneChangedSignal, DefaultSignalCaller<ShaderView::SceneChangedSignal>, SceneChangedSlotCaller>( "SceneChangedSignal" );
 
 	{
-		scope s = GafferBindings::NodeClass<UVView>()
+		scope s = GafferBindings::NodeClass<UVView>( nullptr, no_init )
+			.def( init<ScriptNodePtr>() )
 			.def( "setPaused", &setPaused )
 			.def( "getPaused", &UVView::getPaused )
 			.def( "state", &UVView::state )

--- a/src/GafferUIModule/ViewBinding.cpp
+++ b/src/GafferUIModule/ViewBinding.cpp
@@ -45,6 +45,7 @@
 #include "Gaffer/Context.h"
 #include "Gaffer/EditScope.h"
 #include "Gaffer/Plug.h"
+#include "Gaffer/ScriptNode.h"
 
 #include "IECorePython/ExceptionAlgo.h"
 #include "IECorePython/ScopedGILRelease.h"
@@ -63,8 +64,8 @@ class ViewWrapper : public GafferBindings::NodeWrapper<View>
 
 	public :
 
-		ViewWrapper( PyObject *self, const std::string &name, PlugPtr input )
-			:	GafferBindings::NodeWrapper<View>( self, name, input )
+		ViewWrapper( PyObject *self, const std::string &name, ScriptNodePtr scriptNode, PlugPtr input )
+			:	GafferBindings::NodeWrapper<View>( self, name, scriptNode, input )
 		{
 		}
 
@@ -77,10 +78,10 @@ struct ViewCreator
 	{
 	}
 
-	ViewPtr operator()( Gaffer::PlugPtr plug )
+	ViewPtr operator()( Gaffer::ScriptNodePtr scriptNode )
 	{
 		IECorePython::ScopedGILLock gilLock;
-		ViewPtr result = extract<ViewPtr>( m_fn( plug ) );
+		ViewPtr result = extract<ViewPtr>( m_fn( scriptNode ) );
 		return result;
 	}
 
@@ -149,7 +150,8 @@ Gaffer::NodePtr getPreprocessor( View &v )
 void bindView()
 {
 	scope s = GafferBindings::NodeClass<View, ViewWrapper>( nullptr, no_init )
-		.def( init<const std::string &, PlugPtr>() )
+		.def( init<const std::string &, ScriptNodePtr, PlugPtr>() )
+		.def( "scriptNode", (ScriptNode *(View::*)())&View::scriptNode, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "editScope", (EditScope *(View::*)())&View::editScope, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "getContext", (Context *(View::*)())&View::getContext, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "setContext", &View::setContext )

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -59,10 +59,9 @@ Gaffer.Metadata.registerValue( preferences["viewer"], "layout:section", "Viewer"
 
 # register a customised view for viewing scenes
 
-def __sceneView( plug ) :
+def __sceneView( scriptNode ) :
 
-	view = GafferSceneUI.SceneView()
-	view["in"].setInput( plug )
+	view = GafferSceneUI.SceneView( scriptNode )
 	view["grid"]["dimensions"].setInput( preferences["viewer"]["gridDimensions"] )
 
 	return view


### PR DESCRIPTION
The main additions here are `PlugValueWidget.scriptNode()` and `View.scriptNode()` accessors. These simplify common operations in the UI, and will be especially useful in a future PR where I replace the ContextAlgo API with a ScriptNodeAlgo API which takes `ScriptNode *` rather than `Context *`. I've also included a few other miscellaneous commits for things I noticed while refactoring various components to use that new API (that refactoring will also appear in a future PR).