### PR TITLE
CI : Update to GafferHQ/dependencies 9.0.0a2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 800
             jobs: 4
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.9.1/cortex-10.5.9.1-windows.zip
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.9.2/cortex-10.5.9.2-windows.zip
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a1/gafferDependencies-9.0.0a1-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a2/gafferDependencies-9.0.0a2-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 


### PR DESCRIPTION
With Windows dependenciesURL override to `cortex-10.5.9.2` in place of a `gafferDependencies-9.0.0a2-windows` release.
