### PR TITLE
mergePrimitives core function

### DIFF
--- a/include/GafferScene/Private/IECoreScenePreview/PrimitiveAlgo.h
+++ b/include/GafferScene/Private/IECoreScenePreview/PrimitiveAlgo.h
@@ -1,0 +1,66 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Export.h"
+
+#include "IECoreScene/MeshPrimitive.h"
+#include "IECore/Canceller.h"
+#include "IECore/Object.h"
+
+namespace IECoreScenePreview
+{
+
+namespace PrimitiveAlgo
+{
+
+// Transform a primitive by a given matrix. Applies an appropriate transform to any primitive
+// variables that have an interpretation of point, vector or normal.
+GAFFERSCENE_API void transformPrimitive(
+	IECoreScene::Primitive &primitive, Imath::M44f matrix,
+	const IECore::Canceller *canceller = nullptr
+);
+
+// Merge a list of primitives with matching transforms into a single combined primitive.
+// Supports meshes, curves and points ( all primitives in the list must be of a matching
+// type ).
+GAFFERSCENE_API IECoreScene::PrimitivePtr mergePrimitives(
+	const std::vector< std::pair< const IECoreScene::Primitive*, Imath::M44f > > &primitives,
+	const IECore::Canceller *canceller = nullptr
+);
+
+} // namespace MeshAlgo
+
+} // namespace IECoreScenePreview

--- a/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
@@ -130,6 +130,16 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 			self.betterAssertAlmostEqual( a.b, b.b, tolerance, msg )
 			self.betterAssertAlmostEqual( a.a, b.a, tolerance, msg )
 			return
+		elif type( a ) == IECoreScene.PrimitiveVariable:
+			self.assertEqual( a.interpolation, b.interpolation )
+			self.assertEqual( a.indices, b.indices )
+			self.betterAssertAlmostEqual( a.data, b.data, tolerance, msg )
+			return
+		elif type( a ) == list or ( isinstance( a, IECore.Data ) and a.typeName().endswith( "VectorData" ) ):
+			self.assertEqual( len( a ), len( b ) )
+			for i in range( len( a ) ):
+				self.betterAssertAlmostEqual( a[i], b[i], tolerance, msg )
+			return
 
 		if type( a ) == str:
 			match = a == b

--- a/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/MeshAlgoTessellateTest.py
@@ -74,6 +74,8 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 			reverseSort[ sortIndices[i] ] = i
 
 		result = IECoreScene.MeshPrimitive( m.verticesPerFace, IECore.IntVectorData( [ reverseSort[i] for i in m.vertexIds ] ), m.interpolation )
+		result.setCorners( IECore.IntVectorData( [ reverseSort[i] for i in m.cornerIds() ] ), m.cornerSharpnesses() )
+		result.setCreases( m.creaseLengths(), IECore.IntVectorData( [ reverseSort[i] for i in m.creaseIds() ] ), m.creaseSharpnesses() )
 
 		for k in m.keys():
 			if m[k].interpolation == IECoreScene.PrimitiveVariable.Interpolation.Vertex:
@@ -97,6 +99,9 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		faceVertexReorder = sum( [ vertices[i] for i in faceReorder ], [] )
 
 		result = IECoreScene.MeshPrimitive( IECore.IntVectorData( m.verticesPerFace[i] for i in faceReorder ), IECore.IntVectorData( [ m.vertexIds[i] for i in faceVertexReorder ] ), m.interpolation )
+
+		result.setCorners( m.cornerIds(), m.cornerSharpnesses() )
+		result.setCreases( m.creaseLengths(), m.creaseIds(), m.creaseSharpnesses() )
 
 		for k in m.keys():
 			if m[k].interpolation == IECoreScene.PrimitiveVariable.Interpolation.FaceVarying:
@@ -137,7 +142,7 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 			raise AssertionError( ( msg + " : " if msg else "" ) + "%s != %s" % ( repr( a ), repr( b ) ) )
 
 	def assertPrimvarsPracticallyEqual( self, a, b, name, tolerance = 0 ):
-		self.assertEqual( a.interpolation, b.interpolation )
+		self.assertEqual( a.interpolation, b.interpolation, "Primvar %s" % name )
 		expandedVarA = a.expandedData()
 		expandedVarB = b.expandedData()
 
@@ -161,6 +166,16 @@ class MeshAlgoTessellateTest( GafferTest.TestCase ) :
 		self.assertEqual( compareA.verticesPerFace, compareB.verticesPerFace )
 		self.assertEqual( compareA.vertexIds, compareB.vertexIds )
 		self.assertEqual( compareA.interpolation, compareB.interpolation )
+
+		# \todo These crease/corner tests are stricter than necessary - two meshes are effectively
+		# equal even if their corners are specified in a different order. But we're only really putting
+		# this function together as needed, and none of my use cases yet have required support for
+		# corners / creases in differing orders.
+		self.assertEqual( compareA.cornerIds(), compareB.cornerIds() )
+		self.assertEqual( compareA.cornerSharpnesses(), compareB.cornerSharpnesses() )
+		self.assertEqual( compareA.creaseLengths(), compareB.creaseLengths() )
+		self.assertEqual( compareA.creaseIds(), compareB.creaseIds() )
+		self.assertEqual( compareA.creaseSharpnesses(), compareB.creaseSharpnesses() )
 
 		self.assertEqual( compareA.keys(), compareB.keys() )
 

--- a/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
@@ -1,0 +1,537 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+import itertools
+import math
+import pathlib
+import random
+import time
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferTest
+
+# Because we haven't yet figured out where else assertMeshesPraticallyEqual should live
+import GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest
+
+import GafferScene.Private.IECoreScenePreview.PrimitiveAlgo as PrimitiveAlgo
+Interpolation = IECoreScene.PrimitiveVariable.Interpolation
+
+class PrimitiveAlgoTest( GafferTest.TestCase ) :
+	usdFileDir = pathlib.Path( __file__ ).parent.parent / "usdFiles"
+
+	def resamplePrimVars( self, prim, primVars, interp ):
+		for pv in primVars:
+			resampled = prim[pv]
+			if type( prim ) == IECoreScene.MeshPrimitive:
+				IECoreScene.MeshAlgo.resamplePrimitiveVariable( prim, resampled, interp )
+			elif type( prim ) == IECoreScene.CurvesPrimitive:
+				IECoreScene.CurvesAlgo.resamplePrimitiveVariable( prim, resampled, interp )
+				self.assertTrue( prim.isPrimitiveVariableValid( resampled ) )
+			elif type( prim ) == IECoreScene.PointsPrimitive:
+				IECoreScene.PointsAlgo.resamplePrimitiveVariable( prim, resampled, interp )
+			prim[pv] = resampled
+
+	def interpolationMatches( self, prim, a, b ):
+		if a == b:
+			return True
+
+		# Some interpolations are effectively the same, depending on the primitive type
+		if type( prim ) == IECoreScene.MeshPrimitive:
+			isVertex = { Interpolation.Vertex, Interpolation.Varying }
+			return a in isVertex and b in isVertex
+		elif type( prim ) == IECoreScene.CurvesPrimitive:
+			isVarying = { Interpolation.Varying, Interpolation.FaceVarying }
+			return a in isVarying and b in isVarying
+		elif type( prim ) == IECoreScene.PointsPrimitive:
+			isVertex = { Interpolation.Vertex, Interpolation.Varying, Interpolation.FaceVarying }
+			return a in isVertex and b in isVertex
+
+	def testTransformPrimitive( self ):
+		prim = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		vectorData = prim["P"].data.copy()
+		vectorData.setInterpretation( IECore.GeometricData.Interpretation.Vector )
+		prim["vectorTest"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex, vectorData )
+		numericData = prim["P"].data.copy()
+		numericData.setInterpretation( IECore.GeometricData.Interpretation.Numeric )
+		prim["numericTest"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex, numericData )
+		prim["constantVectorTest"] = IECoreScene.PrimitiveVariable(
+			Interpolation.Constant, IECore.V3fData( imath.V3f( 1, 0, 0 ), IECore.GeometricData.Interpretation.Point )
+		)
+
+		m = imath.M44f()
+		m.translate( imath.V3f( 10, 1, 0 ) )
+		m.scale( imath.V3f( 0.5, 1, 1 ) )
+		m.rotate( imath.V3f( 0, math.radians( 45 ), 0 ) )
+
+		result = prim.copy()
+		PrimitiveAlgo.transformPrimitive( result, m )
+
+		sq = math.sqrt( 2.0 )
+		rotated = [ imath.V3f( *i ) for i in [ ( -sq, -1, 0 ), ( 0, -1, -sq ), ( 0, 1, -sq ), ( -sq, 1, 0 ), ( sq, -1, 0 ), ( sq, 1, 0 ), ( 0, -1, sq ), ( 0, 1, sq ) ] ]
+		squashed = [ imath.V3f( 0.5, 1, 1 ) * i for i in rotated ]
+		self.assertEqual(
+			result["P"],
+			IECoreScene.PrimitiveVariable(
+				Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( 10,1,0 ) + i for i in squashed ], IECore.GeometricData.Interpretation.Point )
+			)
+		)
+		self.assertEqual(
+			result["vectorTest"],
+			IECoreScene.PrimitiveVariable(
+				Interpolation.Vertex,
+				IECore.V3fVectorData( squashed, IECore.GeometricData.Interpretation.Vector )
+			)
+		)
+		normals = [ imath.V3f( *i ) for i in [ ( sq, 0, sq/2 ), ( -sq, 0, -sq/2 ), ( 0, 1, 0 ), ( 0, -1, 0 ), ( sq, 0, -sq/2 ), ( -sq, 0, sq/2 ) ] ]
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().betterAssertAlmostEqual(
+			result["N"],
+			IECoreScene.PrimitiveVariable(
+				Interpolation.FaceVarying,
+				IECore.V3fVectorData( normals, IECore.GeometricData.Interpretation.Normal ),
+				IECore.IntVectorData( sum( [[i,i,i,i] for i in [1, 4, 0, 5, 2, 3]], [] ) )
+			),
+			tolerance = 0.0000002
+		)
+		self.assertEqual( result["numericTest"], prim["numericTest"] )
+
+		self.assertEqual(
+			result["constantVectorTest"],
+			IECoreScene.PrimitiveVariable(
+				Interpolation.Constant,
+				IECore.V3fData( imath.V3f( 10 + sq/4, 1, -sq/2 ), IECore.GeometricData.Interpretation.Point )
+			)
+		)
+
+		# Test cancellation
+		# ( This function is so fast that we actually need some pretty enormous data to show cancellation doing
+		# something )
+		bigPlane = IECoreScene.MeshPrimitive.createPlane(
+			imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ),
+			divisions = imath.V2i( 2000, 2000 )
+		)
+
+		def slowTransform():
+			PrimitiveAlgo.transformPrimitive( bigPlane, m, Gaffer.Context.current().canceller() )
+
+		t = time.time()
+		backgroundTask = Gaffer.ParallelAlgo.callOnBackgroundThread( None, slowTransform )
+
+		# Delay so that the computation actually starts, rather
+		# than being avoided entirely.
+		time.sleep( 0.01 )
+
+		acceptableCancellationDelay = 0.01 if GafferTest.inCI() else 0.001
+		backgroundTask.cancelAndWait()
+		self.assertLess( time.time() - t, 0.01 + acceptableCancellationDelay )
+
+
+	def testMergePrimitivesSimple( self ) :
+		mesh1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ) )
+
+		self.assertEqual( PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() )] ), mesh1 )
+
+
+		with self.assertRaisesRegex( RuntimeError, "Cannot merge null Primitive" ) :
+			PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( None, imath.M44f() )] )
+
+		mesh2 = IECoreScene.MeshPrimitive(
+			IECore.IntVectorData( [ 3 ] ), IECore.IntVectorData( range( 3 ) ),
+			"linear", IECore.V3fVectorData( [ imath.V3f( i ) for i in [ (1,0,0),(0,1,0),(0,0,1) ] ] )
+		)
+		mesh2["constV3fPrimVar"] = IECoreScene.PrimitiveVariable( Interpolation.Constant,
+			IECore.V3fData( imath.V3f( 0.1, 0.2, 0.3 ), IECore.GeometricData.Interpretation.Point )
+		)
+
+		merged = PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( mesh2, imath.M44f() ) ] )
+		self.assertTrue( merged.arePrimitiveVariablesValid() )
+		self.assertEqual( merged.interpolation, "linear" )
+		self.assertEqual( merged.verticesPerFace, IECore.IntVectorData( [ 4, 3 ] ) )
+		self.assertEqual( merged.vertexIds, IECore.IntVectorData( [ 0, 1, 3, 2,   4, 5, 6 ] ) )
+		self.assertEqual( merged["P"], IECoreScene.PrimitiveVariable( Interpolation.Vertex, IECore.V3fVectorData( [ imath.V3f( i ) for i in [
+			(-2, -2, 0), (2, -2, 0), (-2, 2, 0), (2, 2, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1) ]
+		], IECore.GeometricData.Interpretation.Point ) ) )
+
+		m = imath.M44f()
+		m.translate( imath.V3f( 30, 0, 0 ) )
+		mergedTranslated = PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( mesh2, m ) ] )
+		self.assertEqual( mergedTranslated["P"].data, IECore.V3fVectorData( [ imath.V3f( i ) for i in [
+			(-2, -2, 0), (2, -2, 0), (-2, 2, 0), (2, 2, 0), (31, 0, 0), (30, 1, 0), (30, 0, 1) ]
+		], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual(
+			mergedTranslated["constV3fPrimVar"].data,
+			IECore.V3fVectorData( [ imath.V3f( 0 ), imath.V3f( 30.1, 0.2, 0.3 ) ],
+				IECore.GeometricData.Interpretation.Point )
+		)
+
+		mesh1.setInterpolation( "catmullClark" )
+
+		with IECore.CapturingMessageHandler() as mh:
+			mergedNew = PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( mesh2, imath.M44f() ) ] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, 'Ignoring mismatch between mesh interpolations catmullClark and linear and defaulting to linear' )
+
+		mesh2.setInterpolation( "catmullClark" )
+		mergedNew = PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( mesh2, imath.M44f() ) ] )
+		merged.setInterpolation( "catmullClark" )
+		self.assertEqual( mergedNew, merged )
+
+		curveVerts1 = [ imath.V3f( i ) for i in [ (0,0,0),(0,1,0),(1,1,0),(1,0,0) ] ]
+		curves1 = IECoreScene.CurvesPrimitive( IECore.IntVectorData( [ 4 ] ), IECore.CubicBasisf.linear(), False,
+			IECore.V3fVectorData( curveVerts1 )
+		)
+
+		with self.assertRaisesRegex( RuntimeError, "Primitive type mismatch: CurvesPrimitive != MeshPrimitive" ) :
+			PrimitiveAlgo.mergePrimitives( [( mesh1, imath.M44f() ), ( curves1, imath.M44f() ) ] )
+
+		curveVerts2	= [ imath.V3f( i, 2, 0 ) for i in range( 7 ) ]
+		curves2 = IECoreScene.CurvesPrimitive( IECore.IntVectorData( [ 7 ] ), IECore.CubicBasisf.linear(), False,
+			IECore.V3fVectorData( curveVerts2 )
+		)
+
+		merged = PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( curves2, imath.M44f() ) ] )
+		self.assertTrue( merged.arePrimitiveVariablesValid() )
+		self.assertEqual( merged.verticesPerCurve(), IECore.IntVectorData( [ 4, 7 ] ) )
+		self.assertEqual( merged["P"], IECoreScene.PrimitiveVariable( Interpolation.Vertex, IECore.V3fVectorData( curveVerts1 + curveVerts2, IECore.GeometricData.Interpretation.Point ) ) )
+
+		curves1.setTopology( curves1.verticesPerCurve(), curves1.basis(), True )
+		with self.assertRaisesRegex( RuntimeError, "Cannot merge periodic and non-periodic curves" ) :
+			PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( curves2, imath.M44f() ) ] )
+
+		curves2.setTopology( curves2.verticesPerCurve(), curves2.basis(), True )
+		mergedNew = PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( curves2, imath.M44f() ) ] )
+		merged.setTopology( merged.verticesPerCurve(), merged.basis(), True )
+		self.assertEqual( mergedNew, merged )
+
+		curves1.setTopology( curves1.verticesPerCurve(), IECore.CubicBasisf.bezier(), True )
+		with IECore.CapturingMessageHandler() as mh:
+			mergedNew = PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( curves2, imath.M44f() ) ] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].message, 'Ignoring mismatch in curve basis and defaulting to linear' )
+
+		self.assertEqual( mergedNew, merged )
+
+		curves2.setTopology( curves2.verticesPerCurve(), IECore.CubicBasisf.bezier(), True )
+		mergedNew = PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( curves2, imath.M44f() ) ] )
+		merged.setTopology( merged.verticesPerCurve(), IECore.CubicBasisf.bezier(), True )
+
+		self.assertEqual( mergedNew, merged )
+
+		pointVerts1 = [ imath.V3f( i ) for i in range( 9 ) ]
+		points1 = IECoreScene.PointsPrimitive( IECore.V3fVectorData( pointVerts1 ) )
+
+		with self.assertRaisesRegex( RuntimeError, "Primitive type mismatch: PointsPrimitive != CurvesPrimitive" ) :
+			PrimitiveAlgo.mergePrimitives( [( curves1, imath.M44f() ), ( points1, imath.M44f() ) ] )
+
+		pointVerts2 = [ imath.V3f( i, 0, 0 ) for i in range( 11 ) ]
+		points2 = IECoreScene.PointsPrimitive( IECore.V3fVectorData( pointVerts2 ) )
+
+		merged = PrimitiveAlgo.mergePrimitives( [( points1, imath.M44f() ), ( points2, imath.M44f() ) ] )
+		self.assertTrue( merged.arePrimitiveVariablesValid() )
+		self.assertEqual( merged["P"], IECoreScene.PrimitiveVariable( Interpolation.Vertex, IECore.V3fVectorData( pointVerts1 + pointVerts2, IECore.GeometricData.Interpretation.Point ) ) )
+
+	def testMismatchedInterpolation( self ) :
+
+		# A lot of the complexity comes from handling every possible combination for mismatched interpolations,
+		# so make sure we test it thoroughly
+
+		file = IECoreScene.SceneInterface.create(
+			str( self.usdFileDir / "generalTestMesh.usd" ), IECore.IndexedIO.OpenMode.Read
+		)
+		meshSource = file.child( "object" ).readObject( 0.0 )
+		for k in meshSource.keys():
+			if k == "P":
+				continue
+			del meshSource[k]
+
+		random.seed( 42 )
+
+		def randomC():
+			return imath.Color3f( random.random(), random.random(), random.random() )
+
+		curvesSource = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4, 5, 6, 5, 4] ), IECore.CubicBasisf.linear(), False
+		)
+		curvesSourceCubic = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4, 5, 6, 5, 4] ), IECore.CubicBasisf.bSpline(), False
+		)
+		curvesSourcePeriodic = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4, 5, 6, 5, 4] ), IECore.CubicBasisf.linear(), True
+		)
+		curvesSourcePeriodicCubic = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4, 5, 6, 5, 4] ), IECore.CubicBasisf.bSpline(), True
+		)
+
+		for c in [ curvesSource, curvesSourceCubic, curvesSourcePeriodic, curvesSourcePeriodicCubic ]:
+			c["P"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex,
+				IECore.V3fVectorData( [ imath.V3f( randomC() ) for i in range( c.variableSize( Interpolation.Vertex ) ) ] )
+			)
+
+		pointsSource = IECoreScene.PointsPrimitive( 20 )
+		pointsSource["P"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex,
+			IECore.V3fVectorData( [ imath.V3f( randomC() ) for i in range( 20 ) ] )
+		)
+
+		for source in [ meshSource, curvesSource, curvesSourceCubic, curvesSourcePeriodic, curvesSourcePeriodicCubic, pointsSource ]:
+			isMesh = type( source ) == IECoreScene.MeshPrimitive
+			isCurves = type( source ) == IECoreScene.CurvesPrimitive
+			isPoints = not isMesh and not isCurves
+
+			# Create a source with one primvar of each interpolation
+			allInterps = source.copy()
+			allInterps["A"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.Color3fData( randomC() ) )
+			for name, interp in [
+				( "B", Interpolation.Vertex ), ( "C", Interpolation.Uniform ),
+				( "D", Interpolation.Varying ), ( "E", Interpolation.FaceVarying )
+			]:
+				allInterps[name] = IECoreScene.PrimitiveVariable(
+					interp, IECore.Color3fVectorData( [ randomC() for i in range( source.variableSize( interp ) ) ] )
+				)
+			allInterps["labelSource"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 0 ) )
+
+			for interp, indexed in itertools.product( [
+					Interpolation.Constant, Interpolation.Vertex, Interpolation.Uniform,
+					Interpolation.Varying, Interpolation.FaceVarying
+				], [ False, True ] ):
+
+				# Create a source with all primvars set to the current interpolation, optionally indexed
+				oneInterp = source.copy()
+				for name in [ "A", "B", "C", "D", "E" ]:
+					varSize = source.variableSize( interp )
+
+					if interp == Interpolation.Constant:
+						oneInterp[name] = IECoreScene.PrimitiveVariable( interp, IECore.Color3fData( randomC() ) )
+					elif indexed:
+						oneInterp[name] = IECoreScene.PrimitiveVariable(
+							interp,
+							IECore.Color3fVectorData( [ randomC() for i in range( 10 ) ] ),
+							IECore.IntVectorData( [ random.randint( 0, 9 ) for i in range( varSize ) ] )
+						)
+					else:
+						oneInterp[name] = IECoreScene.PrimitiveVariable(
+							interp,
+							IECore.Color3fVectorData( [ randomC() for i in range( varSize ) ] )
+						)
+				oneInterp["labelSource"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) )
+
+				with IECore.CapturingMessageHandler() as mh:
+					merged = PrimitiveAlgo.mergePrimitives( [( allInterps, imath.M44f() ), ( oneInterp, imath.M44f() )] )
+				self.assertTrue( merged.arePrimitiveVariablesValid() )
+
+				allInterpsRef = allInterps.copy()
+				oneInterpRef = oneInterp.copy()
+
+				numDiscarded = 0
+				if isCurves:
+					# We don't support merging varying/vertex on curves ( the resampling required is more complicated,
+					# and can't be done losslessly )
+					messageTexts = [ i.message for i in mh.messages ]
+					for k in allInterps.keys():
+						mixedInterps = set( [ allInterpsRef[k].interpolation, oneInterpRef[k].interpolation ] )
+						if Interpolation.Vertex in mixedInterps and (
+								Interpolation.Varying in mixedInterps or Interpolation.FaceVarying in mixedInterps ):
+							del allInterpsRef[k]
+							del oneInterpRef[k]
+							numDiscarded += 1
+							self.assertIn(
+								'Discarding variable "%s" - Cannot mix Vertex and Varying curve variables.' % k,
+								messageTexts
+							)
+				self.assertEqual( len( mh.messages ), numDiscarded )
+
+				for k in allInterpsRef.keys():
+					if k == "P":
+						continue
+
+					kInterp = allInterps[k].interpolation
+
+					if isPoints:
+						expectedInterp = Interpolation.Vertex
+					elif k == "P":
+						expectedInterp = Interpolation.Vertex
+					elif k == "labelSource":
+						expectedInterp = Interpolation.Uniform
+					elif self.interpolationMatches( source, kInterp, interp ):
+						expectedInterp = interp
+					elif kInterp == Interpolation.Constant or ( not isMesh and kInterp == Interpolation.Uniform ):
+						expectedInterp = interp
+					elif interp == Interpolation.Constant or ( not isMesh and interp == Interpolation.Uniform ):
+						expectedInterp = kInterp
+					elif isMesh:
+						expectedInterp = Interpolation.FaceVarying
+					else:
+						raise IECore.Exception( "%s %s" % ( kInterp, interp ) )
+						expectedInterp = None
+
+					if expectedInterp == Interpolation.Constant:
+						expectedInterp = Interpolation.Uniform
+
+					if isMesh:
+						if expectedInterp == Interpolation.Varying:
+							expectedInterp = Interpolation.Vertex
+					elif isCurves:
+						if expectedInterp == Interpolation.FaceVarying:
+							expectedInterp = Interpolation.Varying
+					else:
+						if expectedInterp == Interpolation.FaceVarying or expectedInterp == Interpolation.Varying:
+							expectedInterp = Interpolation.Vertex
+
+					self.assertTrue( allInterpsRef.arePrimitiveVariablesValid() )
+					self.assertTrue( oneInterpRef.arePrimitiveVariablesValid() )
+
+					self.resamplePrimVars( allInterpsRef, [ k ], expectedInterp )
+					self.resamplePrimVars( oneInterpRef, [ k ], expectedInterp )
+
+					self.assertTrue( allInterpsRef.arePrimitiveVariablesValid() )
+					self.assertTrue( oneInterpRef.arePrimitiveVariablesValid() )
+
+					needIndices = indexed or not self.interpolationMatches( source, kInterp, expectedInterp ) or not self.interpolationMatches( source, interp, expectedInterp )
+					self.assertEqual( merged[k].indices != None, needIndices )
+					self.assertEqual( merged[k].interpolation, expectedInterp )
+
+				if type( merged ) == IECoreScene.MeshPrimitive:
+					splitter = IECoreScene.MeshAlgo.MeshSplitter( merged, merged["labelSource"] )
+
+					GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 0 ), allInterpsRef )
+					GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 1 ), oneInterpRef )
+
+				for k in allInterpsRef.keys():
+					self.assertEqual(
+						list( merged[k].expandedData() ),
+						list( allInterpsRef[k].expandedData() ) + list( oneInterpRef[k].expandedData() )
+					)
+
+	def testMergeMeshes( self ) :
+
+		# Test with a more complex mesh that has creases
+
+		file = IECoreScene.SceneInterface.create(
+			str( self.usdFileDir / "generalTestMesh.usd" ), IECore.IndexedIO.OpenMode.Read
+		)
+		source = file.child( "object" ).readObject( 0.0 )
+
+		with IECore.CapturingMessageHandler() as mh:
+			bogusIndexed = PrimitiveAlgo.mergePrimitives( [( source, imath.M44f() ), ( source, imath.M44f() )] )
+		self.assertEqual( bogusIndexed.keys(), [ 'P', 'altUv', 'indexedUniform', 'indexedVertex', 'stringConstant', 'unindexedFaceVarying', 'unindexedUniform', 'uv' ] )
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].context, "mergePrimitives" )
+		self.assertEqual( mh.messages[0].message, 'Discarding variable "indexedConstant" - Cannot promote Constant primitive variable of type "Color3fVectorData".' )
+
+		del source["indexedConstant"]
+
+
+		m = imath.M44f()
+		m.translate( imath.V3f( 30, 0, 0 ) )
+		sourceShifted = source.copy()
+		PrimitiveAlgo.transformPrimitive( sourceShifted, m )
+
+		self.assertEqual(
+			PrimitiveAlgo.mergePrimitives( [( source, imath.M44f() ), ( source, m )] ),
+			PrimitiveAlgo.mergePrimitives( [( source, imath.M44f() ), ( sourceShifted, imath.M44f() )] )
+		)
+
+		sourceShifted["labelSource"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 1 ) )
+
+		referenceSource = source.copy()
+		referenceSource["labelSource"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 0 ) )
+		self.resamplePrimVars( referenceSource, [ "labelSource", "stringConstant" ], Interpolation.Uniform )
+
+		referenceShifted = sourceShifted.copy()
+		self.resamplePrimVars( referenceShifted, [ "labelSource", "stringConstant" ], Interpolation.Uniform )
+
+
+		# Try merging two complex meshes, and then splitting them back apart to make sure they match.
+		# We need to use assertMeshesPracticallyEqual here instead of assertEqual because MeshSplitter
+		# does not preserve vertex order.
+		merged = PrimitiveAlgo.mergePrimitives( [( source, imath.M44f() ), ( sourceShifted, imath.M44f() )] )
+
+		splitter = IECoreScene.MeshAlgo.MeshSplitter( merged, merged["labelSource"] )
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 0 ), referenceSource )
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 1 ), referenceShifted )
+
+		# assertMeshesPracticallyEqual ignores whether variables are indexed. We want to make sure that any
+		# variables that aren't already indexed, and having match interpolations between the meshes, and
+		# don't need to be promoted from Constant to Uniform, don't need to be indexed.
+		self.assertEqual(
+			{ i for i in merged.keys() if merged[i].indices },
+			{'labelSource', 'uv', 'indexedVertex', 'stringConstant', 'altUv', 'indexedUniform'}
+		)
+
+		# Now try merging a plane that has different primvars
+		sourcePlane = IECoreScene.MeshPrimitive.createPlane(
+			imath.Box2f( imath.V2f( -2 ), imath.V2f( 2 ) ),
+			divisions = imath.V2i( 4, 4 )
+		)
+		sourcePlane["labelSource"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 2 ) )
+		sourcePlane.setInterpolation( "catmullClark" )
+
+		referencePlane = sourcePlane.copy()
+		referencePlane["altUv"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.V2fData( imath.V2f( 0 ) ) )
+		referencePlane["indexedUniform"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 0 ) )
+		referencePlane["indexedVertex"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.V3fData( imath.V3f(0) ) )
+		referencePlane["stringConstant"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.StringData( "" ) )
+		referencePlane["unindexedFaceVarying"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.V3fData( imath.V3f( 0 ) ) )
+		referencePlane["unindexedUniform"] = IECoreScene.PrimitiveVariable( Interpolation.Constant, IECore.IntData( 0 ) )
+		self.resamplePrimVars( referencePlane, [ "labelSource", "stringConstant", "indexedUniform", "unindexedUniform" ], Interpolation.Uniform )
+		self.resamplePrimVars( referencePlane, [ "indexedVertex" ], Interpolation.Vertex )
+		self.resamplePrimVars( referencePlane, [ "altUv", "unindexedFaceVarying" ], Interpolation.FaceVarying )
+
+		# Merge 3 meshes - complex mesh, shifted complex mesh, and a plane
+		merged = PrimitiveAlgo.mergePrimitives( [( source, imath.M44f() ), ( sourcePlane, imath.M44f() ), ( sourceShifted, imath.M44f() )] )
+
+		referenceSource["N"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex, IECore.V3fVectorData( [imath.V3f( 0 ) ] * referenceSource.variableSize( Interpolation.Vertex ) ) )
+		referenceShifted["N"] = IECoreScene.PrimitiveVariable( Interpolation.Vertex, IECore.V3fVectorData( [imath.V3f( 0 ) ] * referenceSource.variableSize( Interpolation.Vertex ) ) )
+
+		splitter = IECoreScene.MeshAlgo.MeshSplitter( merged, merged["labelSource"] )
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 0 ), referenceSource )
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 1 ), referenceShifted )
+		GafferSceneTest.IECoreScenePreviewTest.MeshAlgoTessellateTest().assertMeshesPracticallyEqual( splitter.mesh( 2 ), referencePlane )
+
+		# Just about everything needs to be indexed now, since the variables that are missing from one prim get
+		# indexed
+		self.assertEqual(
+			{ i for i in merged.keys() if merged[i].indices },
+			{'labelSource', 'uv', 'indexedVertex', 'stringConstant', 'altUv', 'indexedUniform', 'N', 'unindexedUniform', 'unindexedFaceVarying'}
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/src/GafferScene/IECoreScenePreview/PrimitiveAlgo.cpp
+++ b/src/GafferScene/IECoreScenePreview/PrimitiveAlgo.cpp
@@ -1,0 +1,1188 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/Private/IECoreScenePreview/PrimitiveAlgo.h"
+
+#include "IECoreScene/PrimitiveVariable.h"
+#include "IECoreScene/MeshPrimitive.h"
+#include "IECoreScene/CurvesPrimitive.h"
+#include "IECoreScene/PointsPrimitive.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/TypeTraits.h"
+
+#include <unordered_map>
+#include <numeric>
+
+#include "fmt/format.h"
+
+#include "tbb/parallel_for.h"
+
+using namespace IECoreScene;
+using namespace IECore;
+using namespace IECoreScenePreview;
+
+
+namespace {
+
+// Copied from Context.inl because it isn't public
+template<typename T>
+struct DataTraits
+{
+	using DataType = IECore::TypedData<T>;
+};
+
+template<typename T>
+struct DataTraits<Imath::Vec2<T> >
+{
+	using DataType = IECore::GeometricTypedData<Imath::Vec2<T>>;
+};
+
+template<typename T>
+struct DataTraits<Imath::Vec3<T> >
+{
+	using DataType = IECore::GeometricTypedData<Imath::Vec3<T>>;
+};
+
+template<typename T>
+struct DataTraits<std::vector<Imath::Vec2<T> > >
+{
+	using DataType = IECore::GeometricTypedData<std::vector<Imath::Vec2<T>>>;
+};
+
+template<typename T>
+struct DataTraits<std::vector<Imath::Vec3<T> > >
+{
+	using DataType = IECore::GeometricTypedData<std::vector<Imath::Vec3<T>>>;
+};
+
+
+// Return if we have TypedData holder for a vector of T
+template< typename T>
+constexpr bool supportsVectorTypedData()
+{
+	// This should probably be a whitelist, not a blacklist. But also it should be defined somewhere
+	// central, not here.
+	return !(
+		std::is_same_v< T, IECore::TransformationMatrixd > ||
+		std::is_same_v< T, IECore::TransformationMatrixf > ||
+		std::is_same_v< T, IECore::Splineff > ||
+		std::is_same_v< T, IECore::SplinefColor3f > ||
+		std::is_same_v< T, IECore::SplinefColor4f > ||
+		std::is_same_v< T, IECore::Splinedd > ||
+		std::is_same_v< T, IECore::PathMatcher > ||
+		std::is_same_v< T, boost::posix_time::ptime>
+	);
+}
+
+Imath::M44f normalTransform( const Imath::M44f &m )
+{
+	Imath::M44f result = m.inverse();
+	result.transpose();
+	return result;
+}
+
+// \todo : Perhaps belongs in DataAlgo with IECore::size? ( Also, stuff like DataAlgo::size should be
+// refactored to use `if constexpr` )
+void dataResize( Data *data, size_t size )
+{
+	IECore::dispatch( data,
+		[size] ( auto *typedData ) {
+			using DataType = std::remove_pointer_t< decltype( typedData ) >;
+			if constexpr( TypeTraits::IsVectorTypedData< DataType >::value )
+			{
+				// Ideally, we wouldn't initialize anything here, and we would only zero out the memory
+				// if needed. ( ie. while we're in the final multithreaded loop of mergePrimitives, and find
+				// that one primvar has no data for this primvar, then we could zero out just that segment ...
+				// that would be a potentially significant performance win ).
+				//
+				// However, we currently can't suppress zero-initialization for most types, so it's most
+				// consistent if for now we just force everything to to zero-initialize, rather than taking
+				// advantage of the extra performance for the types where we could.
+				//
+				// So we've got a hardcoded list here of imath types where the default constructor doesn't
+				// initialize. Note that if there is any type covered by dispatch which doesn't initialize,
+				// and isn't listed in this hardcoded list, you will get weird, uninitialized behaviour.
+				if constexpr(
+					std::is_same_v< DataType, V2iVectorData > || std::is_same_v< DataType, V3iVectorData > ||
+					std::is_same_v< DataType, V2fVectorData > || std::is_same_v< DataType, V3fVectorData > ||
+					std::is_same_v< DataType, V2dVectorData > || std::is_same_v< DataType, V3dVectorData > ||
+					std::is_same_v< DataType, Color3fVectorData > || std::is_same_v< DataType, Color4fVectorData >
+				)
+				{
+					using SingleElementType = typename DataType::ValueType::value_type;
+					typedData->writable().resize( size, SingleElementType( 0 ) );
+				}
+				else
+				{
+					typedData->writable().resize( size );
+				}
+			}
+			else if( size != 1 )
+			{
+				throw IECore::Exception( fmt::format(
+					"Can't resize, not a vector data type: {}", typedData->typeName()
+				) );
+			}
+		}
+	);
+}
+
+inline void transformPrimVarValue(
+	const Imath::V3f &source, Imath::V3f &dest,
+	const Imath::M44f &matrix, const Imath::M44f &normalMatrix, GeometricData::Interpretation interpretation
+)
+{
+	if( interpretation == GeometricData::Point )
+	{
+		dest = source * matrix;
+	}
+	else if( interpretation == GeometricData::Vector )
+	{
+		matrix.multDirMatrix( source, dest );
+	}
+	else if( interpretation == GeometricData::Normal )
+	{
+		normalMatrix.multDirMatrix( source, dest );
+	}
+	else
+	{
+		dest = source;
+	}
+
+}
+
+
+inline void copyElements( const Data *sourceData, size_t sourceIndex, Data *destData, size_t destIndex, size_t num, const Imath::M44f &matrix, const Imath::M44f &normalMatrix )
+{
+	IECore::dispatch( destData,
+		[&] ( auto *typedDestData ) {
+			using DataType = std::remove_pointer_t< decltype( typedDestData ) >;
+			if constexpr( TypeTraits::IsVectorTypedData< DataType >::value )
+			{
+				auto &typedDest = typedDestData->writable();
+				auto *typedSourceData = IECore::runTimeCast< const DataType >( sourceData );
+				if( !typedSourceData )
+				{
+					// Failed to cast to destination type ... maybe this is a Constant variable being promoted,
+					// and the Data stores a single element instead of a vector?
+
+					using SingleElementDataType = typename DataTraits< typename DataType::ValueType::value_type >::DataType;
+
+					auto *singleElementTypedSourceData = IECore::runTimeCast< const SingleElementDataType >( sourceData );
+					if( singleElementTypedSourceData )
+					{
+						if constexpr( std::is_same_v< SingleElementDataType, V3fData > )
+						{
+							// Fairly weird corner case, but technically Constant primvars could need transforming too
+							GeometricData::Interpretation interp = singleElementTypedSourceData->getInterpretation();
+							transformPrimVarValue(
+								singleElementTypedSourceData->readable(), typedDest[ destIndex ], matrix, normalMatrix, interp
+							);
+						}
+						else
+						{
+							typedDest[ destIndex ] = singleElementTypedSourceData->readable();
+						}
+						return;
+					}
+					else
+					{
+						throw IECore::Exception( fmt::format(
+							"Can't copy element of type {} to destination of type: {}",
+							sourceData->typeName(), destData->typeName()
+						) );
+					}
+				}
+				const auto &typedSource = typedSourceData->readable();
+
+				if constexpr( std::is_same_v< DataType, V3fVectorData > )
+				{
+					GeometricData::Interpretation interp = typedSourceData->getInterpretation();
+					for( size_t i = 0; i < num; i++ )
+					{
+						transformPrimVarValue(
+							typedSource[ sourceIndex + i ], typedDest[ destIndex + i ], matrix, normalMatrix, interp
+						);
+					}
+				}
+				else
+				{
+					for( size_t i = 0; i < num; i++ )
+					{
+						typedDest[ destIndex + i ] = typedSource[ sourceIndex + i ];
+					}
+				}
+			}
+			else
+			{
+				throw IECore::Exception( fmt::format(
+					"Can't copy elements, not a vector data type: {}", typedDestData->typeName()
+				) );
+			}
+		}
+	);
+}
+
+IECore::TypeId vectorDataTypeFromDataType( const Data *data )
+{
+	return IECore::dispatch( data,
+		[] ( auto *typedData ) {
+			using DataType = std::remove_pointer_t< decltype( typedData ) >;
+			if constexpr( TypeTraits::HasValueType< DataType >::value )
+			{
+				using ValueType = typename DataType::ValueType;
+				if constexpr(
+					!TypeTraits::IsVectorTypedData< DataType >::value &&
+					supportsVectorTypedData<ValueType>()
+				)
+				{
+					return DataTraits< std::vector<ValueType> >::DataType::staticTypeId();
+				}
+			}
+			return IECore::InvalidTypeId;
+		}
+	);
+}
+
+bool interpolationMatches(
+	IECoreScene::TypeId primType, PrimitiveVariable::Interpolation a, PrimitiveVariable::Interpolation b
+)
+{
+	if( a == b )
+	{
+		return true;
+	}
+
+	if( primType == IECoreScene::MeshPrimitiveTypeId )
+	{
+		auto isVertex = []( PrimitiveVariable::Interpolation x) {
+			return x == PrimitiveVariable::Vertex || x == PrimitiveVariable::Varying;
+		};
+		return isVertex( a ) && isVertex( b );
+	}
+	else if( primType == IECoreScene::MeshPrimitiveTypeId )
+	{
+		auto isVarying = []( PrimitiveVariable::Interpolation x) {
+			return x == PrimitiveVariable::Varying || x == PrimitiveVariable::FaceVarying;
+		};
+		return isVarying( a ) && isVarying( b );
+	}
+	else
+	{
+		auto isVertex = []( PrimitiveVariable::Interpolation x) {
+			return x == PrimitiveVariable::Vertex || x == PrimitiveVariable::Varying || x == PrimitiveVariable::FaceVarying;
+		};
+		return isVertex( a ) && isVertex( b );
+	}
+}
+
+// Set up indices on the destination matching the source indices ( includes handling converting interpolations ).
+// Note that this only handles interpolations used by mergePrimitives ( ie. only promotion to more specific
+// interpolations, like Vertex -> FaceVarying, but it cann't do averaging ).
+void copyIndices(
+	const std::vector<int> *sourceIndices, int *destIndices,
+	IECoreScene::TypeId primTypeId,
+	PrimitiveVariable::Interpolation sourceInterp, PrimitiveVariable::Interpolation destInterp,
+	size_t numIndices, size_t dataStart,
+	const Primitive *sourcePrim
+)
+{
+	// Helper function that translates from an index in the source data to an index in the destination
+	// data, based on the data offset, and the source indices ( if present )
+	auto translateIndex = [sourceIndices, dataStart]( int j ){
+		return sourceIndices ? dataStart + (*sourceIndices)[j] : dataStart + j;
+	};
+
+	if( interpolationMatches( primTypeId, sourceInterp, destInterp ) )
+	{
+		// If the interpolation hasn't changed, we don't need to anything special, just translate
+		// each index.
+		for( size_t j = 0; j < numIndices; j++ )
+		{
+			*(destIndices++) = translateIndex( j );
+		}
+	}
+	else if( sourceInterp == PrimitiveVariable::Constant )
+	{
+		// Constant variables aren't stored as vectors, so they can't have been indexed to start,
+		// just set all the output indices to the one element of output data.
+		for( size_t j = 0; j < numIndices; j++ )
+		{
+			*(destIndices++) = dataStart;
+		}
+	}
+	else if( sourceInterp == PrimitiveVariable::Uniform )
+	{
+		if( primTypeId == IECoreScene::MeshPrimitiveTypeId )
+		{
+			// On a mesh, if you combine a Uniform with anything it doesn't match, then it gets
+			// promoted to FaceVarying.
+			assert( destInterp == PrimitiveVariable::FaceVarying );
+
+			const MeshPrimitive *sourceMesh = IECore::runTimeCast< const MeshPrimitive >( sourcePrim );
+			const std::vector<int> &sourceVerticesPerFace = sourceMesh->verticesPerFace()->readable();
+
+			int sourceI = 0;
+			for( int numVerts : sourceVerticesPerFace )
+			{
+				for( int k = 0; k < numVerts; k++ )
+				{
+					*(destIndices++) = translateIndex( sourceI );
+				}
+				sourceI++;
+			}
+		}
+		else if( primTypeId == IECoreScene::CurvesPrimitiveTypeId )
+		{
+			const CurvesPrimitive *sourceCurves = IECore::runTimeCast< const CurvesPrimitive >( sourcePrim );
+
+			if( destInterp == PrimitiveVariable::Vertex )
+			{
+				const std::vector<int> &sourceVerticesPerCurve = sourceCurves->verticesPerCurve()->readable();
+				int sourceI = 0;
+				for( int numVerts : sourceVerticesPerCurve )
+				{
+					for( int k = 0; k < numVerts; k++ )
+					{
+						*(destIndices++) = translateIndex( sourceI );
+					}
+					sourceI++;
+				}
+			}
+			else
+			{
+				assert( destInterp == PrimitiveVariable::Varying );
+				int sourceI = 0;
+				size_t sourceNumCurves = sourceCurves->numCurves();
+				for( size_t i = 0; i < sourceNumCurves; i++ )
+				{
+					int numVarying = sourceCurves->variableSize( PrimitiveVariable::Varying, i );
+					for( int k = 0; k < numVarying; k++ )
+					{
+						*(destIndices++) = translateIndex( sourceI );
+					}
+					sourceI++;
+				}
+			}
+		}
+		else
+		{
+			int constantIndex = translateIndex( 0 );
+			for( size_t j = 0; j < numIndices; j++ )
+			{
+				*(destIndices++) = constantIndex;
+			}
+		}
+	}
+	else
+	{
+		// The only time we convert to a non-matching interpolation from something that isn't uniform,
+		// is when promototing Vertex primvars on meshes.
+		assert( destInterp == PrimitiveVariable::FaceVarying );
+		assert( primTypeId == IECoreScene::MeshPrimitiveTypeId );
+		assert( sourceInterp == PrimitiveVariable::Vertex || sourceInterp == PrimitiveVariable::Varying );
+
+		const MeshPrimitive *sourceMesh = IECore::runTimeCast< const MeshPrimitive >( sourcePrim );
+		const std::vector<int> &sourceVertexIds = sourceMesh->vertexIds()->readable();
+
+		for( size_t j = 0; j < numIndices; j++ )
+		{
+			*(destIndices++) = translateIndex( sourceVertexIds[ j ] );
+		}
+	}
+}
+
+} // namespace
+
+
+void PrimitiveAlgo::transformPrimitive(
+	IECoreScene::Primitive &primitive, Imath::M44f matrix,
+	const IECore::Canceller *canceller
+)
+{
+	if( matrix == Imath::M44f() )
+	{
+		// Early out for identity matrix
+		return;
+	}
+
+	Imath::M44f normalMatrix = normalTransform( matrix );
+
+	for( const auto &[name, var] : primitive.variables )
+	{
+		Canceller::check( canceller );
+		V3fVectorData *vecVar = IECore::runTimeCast<V3fVectorData>( var.data.get() );
+		V3fData *vecConstVar = IECore::runTimeCast<V3fData>( var.data.get() );
+		if( !vecVar && !vecConstVar )
+		{
+			continue;
+		}
+
+		GeometricData::Interpretation interp = vecVar ? vecVar->getInterpretation() : vecConstVar->getInterpretation();
+		if( !(
+			interp == GeometricData::Interpretation::Point ||
+			interp == GeometricData::Interpretation::Vector ||
+			interp == GeometricData::Interpretation::Normal
+		) )
+		{
+			continue;
+		}
+
+		if( vecVar )
+		{
+			for( Imath::V3f &i : vecVar->writable() )
+			{
+				Canceller::check( canceller );
+				transformPrimVarValue( i, i, matrix, normalMatrix, interp );
+			}
+		}
+		else
+		{
+			// Fairly weird corner case, but technically Constant primvars could need transforming too
+			transformPrimVarValue( vecConstVar->writable(), vecConstVar->writable(), matrix, normalMatrix, interp );
+		}
+	}
+}
+
+IECoreScene::PrimitivePtr PrimitiveAlgo::mergePrimitives(
+	const std::vector< std::pair< const IECoreScene::Primitive*, Imath::M44f > > &primitives,
+	const IECore::Canceller *canceller
+)
+{
+	IECoreScene::TypeId resultTypeId = (IECoreScene::TypeId)IECore::InvalidTypeId;
+
+	// Mesh specific globals
+	std::string resultMeshInterpolation;
+
+	// Curve specific globals
+	const CubicBasisf invalidBasis( Imath::M44f( 0.0f ), 0 );
+	CubicBasisf resultCurvesBasis( invalidBasis );
+	bool resultCurvesPeriodic( false );
+
+	// Data we need to store for each primvar we output
+	struct PrimVarInfo
+	{
+		PrimVarInfo( IECore::TypeId t, GeometricData::Interpretation interpretation, int numMeshes )
+			: invalid( false ), needsVerts( false ), needsFaces( false ), needsCurveKnots( false ),
+			typeId( t ), interpret( interpretation ), interpretInvalid( false ), indexed( false ),
+			numData( numMeshes, 0 )
+		{
+		}
+		// Primitive variables that are invalid should be reported once when we first realize it's invalid,
+		// and subsequently ignored.
+		bool invalid;
+
+		// These flags determine what interpolation is necessary for the result
+		bool needsVerts;
+		bool needsFaces;
+		bool needsCurveKnots;
+
+		// Computed from the flags above.
+		PrimitiveVariable::Interpolation interpolation;
+
+		// Need to track typeId so we can make sure everything matches
+		IECore::TypeId typeId;
+
+		GeometricData::Interpretation interpret;
+		bool interpretInvalid;
+
+		// The only case where we don't index the output is if all the input interpolations match, and none
+		// of the inputs are indexed - hopefully this is the common case though.
+		bool indexed;
+
+		// We need to collect the data size before we can allocate the output primvars
+		std::vector<unsigned int> numData;
+		std::vector<unsigned int> accumDataSizes;
+	};
+
+	std::unordered_map< IECore::InternedString, PrimVarInfo > varInfos;
+
+	//
+	// Before we can even start counting the sizes of things, we need to gather information about what
+	// kinds of primitives and primvars we're dealing with.
+	//
+
+	for( unsigned int i = 0; i < primitives.size(); i++ )
+	{
+		if( !primitives[i].first )
+		{
+			throw IECore::Exception( "Cannot merge null Primitive" );
+		}
+
+		IECoreScene::TypeId primTypeId = (IECoreScene::TypeId)primitives[i].first->typeId();
+		if( resultTypeId == (IECoreScene::TypeId)IECore::InvalidTypeId )
+		{
+			// Initializing for first primitive
+			if( !(
+				primTypeId == IECoreScene::PointsPrimitiveTypeId ||
+				primTypeId == IECoreScene::MeshPrimitiveTypeId ||
+				primTypeId == IECoreScene::CurvesPrimitiveTypeId
+			) )
+			{
+				throw IECore::Exception( fmt::format(
+					"Unsupported Primitive type for merging: {}", primitives[i].first->typeName()
+				) );
+			}
+
+			resultTypeId = primTypeId;
+
+			if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+			{
+				resultMeshInterpolation = static_cast< const MeshPrimitive *>( primitives[i].first )->interpolation();
+			}
+			else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+			{
+				const CurvesPrimitive *sourceCurves = static_cast< const CurvesPrimitive *>( primitives[i].first );
+				resultCurvesBasis = sourceCurves->basis();
+				resultCurvesPeriodic = sourceCurves->periodic();
+			}
+		}
+		else
+		{
+			// We already have a primitive, so the types must match
+			if( primTypeId != resultTypeId )
+			{
+				throw IECore::Exception( fmt::format(
+					"Primitive type mismatch: {} != {}",
+					primitives[i].first->typeName(), RunTimeTyped::typeNameFromTypeId( (IECore::TypeId) resultTypeId )
+				) );
+			}
+
+			// Check that the primitive type specific globals match. These globals all have a reasonable default
+			// value, so we don't throw an exception if they don't match, we just emit a warning, and use the
+			// default value.
+			if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+			{
+				const MeshPrimitive *sourceMesh = static_cast< const MeshPrimitive *>( primitives[i].first );
+				const std::string interp = sourceMesh->interpolation();
+				if(
+					resultMeshInterpolation != "" &&
+					interp != resultMeshInterpolation
+				)
+				{
+					msg( Msg::Warning, "mergePrimitives",
+						fmt::format(
+							"Ignoring mismatch between mesh interpolations {} and {} and defaulting to linear",
+							resultMeshInterpolation, interp
+						)
+					);
+					resultMeshInterpolation = "";
+				}
+			}
+			else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+			{
+				const CurvesPrimitive *sourceCurves = static_cast< const CurvesPrimitive *>( primitives[i].first );
+				CubicBasisf basis = sourceCurves->basis();
+				bool periodic = sourceCurves->periodic();
+				if( periodic != resultCurvesPeriodic )
+				{
+					throw IECore::Exception( "Cannot merge periodic and non-periodic curves" );
+				}
+
+				if(
+					resultCurvesBasis != invalidBasis &&
+					basis != resultCurvesBasis
+				)
+				{
+					msg( Msg::Warning, "mergePrimitives",
+						"Ignoring mismatch in curve basis and defaulting to linear"
+					);
+					resultCurvesBasis = invalidBasis;
+				}
+			}
+		}
+
+		// Process all the primvars for this primitive, adding new entries to the varInfo list, or
+		// checking that existing entries match correctly
+		for( const auto &[name, var] : primitives[i].first->variables )
+		{
+			GeometricData::Interpretation interpret = IECore::getGeometricInterpretation( var.data.get() );
+
+			IECore::TypeId varTypeId = var.data->typeId();
+
+			if( var.interpolation == PrimitiveVariable::Constant )
+			{
+				varTypeId = vectorDataTypeFromDataType( var.data.get() );
+			}
+
+			PrimVarInfo &varInfo = varInfos.try_emplace( name, varTypeId, interpret, primitives.size() ).first->second;
+
+			if( varInfo.invalid )
+			{
+				continue;
+			}
+
+			if( varTypeId == IECore::InvalidTypeId )
+			{
+				msg( Msg::Warning, "mergePrimitives",
+					fmt::format(
+						"Discarding variable \"{}\" - Cannot promote Constant primitive variable of type \"{}\".",
+						std::string( name ), var.data->typeName()
+					)
+				);
+				varInfo.invalid = true;
+				continue;
+			}
+
+			if( varInfo.typeId != varTypeId )
+			{
+				msg( Msg::Warning, "mergePrimitives",
+					fmt::format(
+						"Discarding variable \"{}\" - types don't match: \"{}\" and \"{}\"",
+						name,
+						IECore::RunTimeTyped::typeNameFromTypeId( varInfo.typeId ),
+						IECore::RunTimeTyped::typeNameFromTypeId( var.data->typeId() )
+					)
+				);
+				varInfo.invalid = true;
+				continue;
+			}
+
+			if( !varInfo.interpretInvalid )
+			{
+				if( interpret != varInfo.interpret )
+				{
+					varInfo.interpret = GeometricData::Interpretation::Numeric;
+					varInfo.interpretInvalid = true;
+					msg( Msg::Warning, "mergePrimitives",
+						fmt::format(
+							"Interpretation mismatch for primitive variable \"{}\", defaulting to \"Numeric\"", name
+						)
+					);
+				}
+			}
+
+			// For meshes and curves, the interpolation we need depends on the interpolations of all the variables
+			// being combined.
+			if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+			{
+				switch( var.interpolation )
+				{
+					case PrimitiveVariable::Vertex:
+					case PrimitiveVariable::Varying:
+						varInfo.needsVerts = true;
+						break;
+					case PrimitiveVariable::Uniform:
+						varInfo.needsFaces = true;
+						break;
+					case PrimitiveVariable::FaceVarying:
+						varInfo.needsVerts = true;
+						varInfo.needsFaces = true;
+						break;
+					default:
+						break;
+				}
+			}
+			else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+			{
+				switch( var.interpolation )
+				{
+					case PrimitiveVariable::Vertex:
+						varInfo.needsVerts = true;
+						break;
+					case PrimitiveVariable::Varying:
+					case PrimitiveVariable::FaceVarying:
+						varInfo.needsCurveKnots = true;
+						break;
+					default:
+						break;
+				}
+			}
+		}
+	}
+
+	//
+	// Now loop over variables collecting the information we'll need to allocate them.
+	//
+
+	for( auto &[name, varInfo] : varInfos )
+	{
+		if( varInfo.invalid )
+		{
+			continue;
+		}
+
+		// Now that we've scanned all the primitives, we can decide which interpolation each variable needs.
+
+		if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+		{
+			if( varInfo.needsFaces && varInfo.needsVerts )
+			{
+				varInfo.interpolation = PrimitiveVariable::FaceVarying;
+			}
+			else if( varInfo.needsVerts )
+			{
+				varInfo.interpolation = PrimitiveVariable::Vertex;
+			}
+			else
+			{
+				// We promote constant primvars to uniform so we can preserve values that differ
+				// between source primitives.
+				varInfo.interpolation = PrimitiveVariable::Uniform;
+			}
+		}
+		else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+		{
+			if( varInfo.needsCurveKnots && varInfo.needsVerts )
+			{
+				msg( Msg::Warning, "mergePrimitives",
+					fmt::format(
+						"Discarding variable \"{}\" - Cannot mix Vertex and Varying curve variables.",
+						std::string( name )
+					)
+				);
+				varInfo.invalid = true;
+				continue;
+			}
+			else if( varInfo.needsCurveKnots )
+			{
+				varInfo.interpolation = PrimitiveVariable::Varying;
+			}
+			else if( varInfo.needsVerts )
+			{
+				varInfo.interpolation = PrimitiveVariable::Vertex;
+			}
+			else
+			{
+				// We promote constant primvars to uniform so we can preserve values that differ
+				// between source primitives.
+				varInfo.interpolation = PrimitiveVariable::Uniform;
+			}
+		}
+		else
+		{
+			// Even for constants, we want to preserve values that differ between source primitives,
+			// so for PointsPrimitive, everything must be promoted to Vertex.
+			varInfo.interpolation = PrimitiveVariable::Vertex;
+		}
+
+		// We also need to count the amount of data for this primvar contributed by each primitive.
+
+		for( unsigned int i = 0; i < primitives.size(); i++ )
+		{
+
+			auto it = primitives[i].first->variables.find( name );
+
+			if( it == primitives[i].first->variables.end() )
+			{
+				// This primitive doesn't have this primvar, we'll just write one data element
+				// that will be left uninitialized.
+				// Note : It's probably arguable what is most correct here ... is it unexpected that a var that
+				// usually isn't indexed would become indexed because one prim is missing it? But there is an
+				// efficiency gain in not storing the zero value repeatedly ( in any case where the data type is
+				// more than 4 bytes ). I've currently gone with indexing it because it feels simplest to
+				// implement - we need to make this work for the indexed case, so it's easy to just always use
+				// the indexed case.
+				varInfo.numData[i] = 1;
+				varInfo.indexed = true;
+				continue;
+			}
+
+			varInfo.numData[i] = IECore::size( it->second.data.get() );
+
+			// Only if everything is simple and matches can we skip outputting indices ( though this
+			// is hopefully the most common case )
+			if( it->second.indices || !interpolationMatches( resultTypeId, it->second.interpolation, varInfo.interpolation ) )
+			{
+				varInfo.indexed = true;
+			}
+		}
+	}
+
+	//
+	// Prepare count and offset lists for every interpolation type ( simpler than doing an extra query over
+	// all variables to collect which interpolations are used ).
+	//
+
+	// There isn't a MaxInterpolation enum, but we don't expect this list to change, and can double check
+	// the current maximum
+	const int numInterpolations = 6;
+	assert( PrimitiveVariable::Constant < numInterpolations );
+	assert( PrimitiveVariable::Uniform < numInterpolations );
+	assert( PrimitiveVariable::Vertex < numInterpolations );
+	assert( PrimitiveVariable::Varying < numInterpolations );
+	assert( PrimitiveVariable::FaceVarying < numInterpolations );
+
+	std::vector< std::vector<int> > countInterpolation( numInterpolations );
+	std::vector< int > totalInterpolation( numInterpolations );
+	std::vector< std::vector<int> > accumInterpolation( numInterpolations );
+
+	for( int interpolation = 0; interpolation < numInterpolations; interpolation++ )
+	{
+		int accum = 0;
+		countInterpolation[interpolation].reserve( primitives.size() );
+		accumInterpolation[interpolation].reserve( primitives.size() );
+		for( unsigned int i = 0; i < primitives.size(); i++ )
+		{
+			countInterpolation[interpolation].push_back( primitives[i].first->variableSize( ((PrimitiveVariable::Interpolation)interpolation) ) );
+			accumInterpolation[interpolation][i] = accum;
+			accum += countInterpolation[interpolation].back();
+		}
+		totalInterpolation[interpolation] = accum;
+	}
+
+	//
+	// Allocate the result, together with any topology information needed ( and optionally crease data in the case of
+	// meshes.
+	//
+
+	IECoreScene::PrimitivePtr result;
+
+	IECoreScene::MeshPrimitivePtr resultMesh;
+	IntVectorDataPtr resultVerticesPerFaceData;
+	IntVectorDataPtr resultVertexIdsData;
+
+	std::vector<int> countCorners;
+	std::vector<int> countCreases;
+	std::vector<int> countCreaseIds;
+	std::vector< int > accumCorners;
+	std::vector< int > accumCreases;
+	std::vector< int > accumCreaseIds;
+
+	IntVectorDataPtr resultCornerIdsData;
+	FloatVectorDataPtr resultCornerSharpnessesData;
+	IntVectorDataPtr resultCreaseLengthsData;
+	IntVectorDataPtr resultCreaseIdsData;
+	FloatVectorDataPtr resultCreaseSharpnessesData;
+
+	IECoreScene::CurvesPrimitivePtr resultCurves;
+	IntVectorDataPtr resultVerticesPerCurveData;
+
+	if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+	{
+		resultMesh = new IECoreScene::MeshPrimitive();
+
+		resultVerticesPerFaceData = new IntVectorData;
+		resultVertexIdsData = new IntVectorData;
+
+		resultVerticesPerFaceData->writable().resize( totalInterpolation[ PrimitiveVariable::Uniform ] );
+		resultVertexIdsData->writable().resize( totalInterpolation[ PrimitiveVariable::FaceVarying ] );
+
+		int totalAccumCorners = 0;
+		int totalAccumCreases = 0;
+		int totalAccumCreaseIds = 0;
+
+		countCorners.reserve( primitives.size() );
+		countCreases.reserve( primitives.size() );
+		countCreaseIds.reserve( primitives.size() );
+		accumCorners.reserve( primitives.size() );
+		accumCreases.reserve( primitives.size() );
+		accumCreaseIds.reserve( primitives.size() );
+
+		for( unsigned int i = 0; i < primitives.size(); i++ )
+		{
+			const MeshPrimitive *p = static_cast< const MeshPrimitive *>( primitives[i].first );
+
+			countCorners.push_back( p->cornerIds()->readable().size() );
+			accumCorners.push_back( totalAccumCorners );
+			totalAccumCorners += countCorners.back();
+
+			countCreases.push_back( p->creaseLengths()->readable().size() );
+			accumCreases.push_back( totalAccumCreases );
+			totalAccumCreases += countCreases.back();
+
+			countCreaseIds.push_back( p->creaseIds()->readable().size() );
+			accumCreaseIds.push_back( totalAccumCreaseIds );
+			totalAccumCreaseIds += countCreaseIds.back();
+		}
+
+		if( totalAccumCorners )
+		{
+			resultCornerIdsData = new IntVectorData;
+			resultCornerIdsData->writable().resize( totalAccumCorners );
+			resultCornerSharpnessesData = new FloatVectorData;
+			resultCornerSharpnessesData->writable().resize( totalAccumCorners );
+		}
+
+		if( totalAccumCreases )
+		{
+			resultCreaseLengthsData = new IntVectorData;
+			resultCreaseLengthsData->writable().resize( totalAccumCreases );
+			resultCreaseSharpnessesData = new FloatVectorData;
+			resultCreaseSharpnessesData->writable().resize( totalAccumCreases );
+			resultCreaseIdsData = new IntVectorData;
+			resultCreaseIdsData->writable().resize( totalAccumCreaseIds );
+		}
+
+		result = resultMesh;
+	}
+	else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+	{
+		resultCurves = new IECoreScene::CurvesPrimitive();
+		result = resultCurves;
+
+		resultVerticesPerCurveData = new IntVectorData;
+		resultVerticesPerCurveData->writable().resize( totalInterpolation[ PrimitiveVariable::Uniform ] );
+	}
+	else
+	{
+		result = new IECoreScene::PointsPrimitive( totalInterpolation[ PrimitiveVariable::Vertex ] );
+	}
+
+	//
+	// Allocate storage for the primitives variables
+	//
+
+	for( auto &[name, varInfo] : varInfos )
+	{
+		if( varInfo.invalid )
+		{
+			continue;
+		}
+
+		varInfo.accumDataSizes.reserve( varInfo.numData.size() );
+		size_t accumDataSize = 0;
+		for( unsigned int i : varInfo.numData )
+		{
+			varInfo.accumDataSizes.push_back( accumDataSize );
+			accumDataSize += i;
+		}
+
+		PrimitiveVariable &p = result->variables.emplace(name, PrimitiveVariable() ).first->second;
+
+		p.data = IECore::runTimeCast<Data>( IECore::Object::create( varInfo.typeId ) );
+
+		IECore::setGeometricInterpretation( p.data.get(), varInfo.interpret );
+		p.interpolation = varInfo.interpolation;
+		Canceller::check( canceller );
+		dataResize( p.data.get(), accumDataSize );
+
+		if( varInfo.indexed )
+		{
+			p.indices = new IntVectorData();
+			Canceller::check( canceller );
+			p.indices->writable().resize( totalInterpolation[ varInfo.interpolation ] );
+		}
+	}
+
+	//
+	// Now a big parallel loop where we do the majority of actual work - copying all the primvar and topology
+	// data to the destination.
+	//
+
+	tbb::task_group_context taskGroupContext( tbb::task_group_context::isolated );
+
+	tbb::parallel_for(
+		tbb::blocked_range<size_t>( 0, primitives.size() ),
+		[&]( tbb::blocked_range<size_t> &range )
+		{
+			for( size_t i = range.begin(); i != range.end(); i++ )
+			{
+				const Primitive &sourcePrim = *primitives[i].first;
+
+				const Imath::M44f &matrix = primitives[i].second;
+				const Imath::M44f normalMatrix = normalTransform( matrix );
+
+				// Copy the data ( and indices ) for each prim var for this primitive into
+				// the destination primvar.
+				for( auto &[name, varInfo] : varInfos )
+				{
+					if( varInfo.invalid )
+					{
+						continue;
+					}
+
+					PrimitiveVariable &destVar = result->variables.find( name )->second;
+
+					const size_t numIndices = countInterpolation[ varInfo.interpolation ][i];
+					const size_t startIndex = accumInterpolation[ varInfo.interpolation ][i];
+					const size_t dataStart = varInfo.accumDataSizes[i];
+
+
+					auto it = sourcePrim.variables.find( name );
+					if( it == sourcePrim.variables.end() || it->second.interpolation == PrimitiveVariable::Invalid )
+					{
+						// No matching data found in this primitive for this primvar
+
+						// We don't currently have a way to suppress zero-initialization of the data, so
+						// we don't need to initialize that here
+
+						if( varInfo.indexed )
+						{
+							Canceller::check( canceller );
+
+							// We always leave one data element for primitives that don't have the relevant
+							// primvar, so just write out all indices pointing to that element.
+							int *destIndices = &destVar.indices->writable()[ startIndex ];
+							for( size_t j = 0; j < numIndices; j++ )
+							{
+								*(destIndices++) = dataStart;
+							}
+						}
+					}
+					else
+					{
+						const PrimitiveVariable &sourceVar = it->second;
+
+						Canceller::check( canceller );
+						copyElements( sourceVar.data.get(), 0, destVar.data.get(), dataStart, varInfo.numData[i], matrix, normalMatrix );
+
+						if( varInfo.indexed )
+						{
+							Canceller::check( canceller );
+							int *destIndices = &destVar.indices->writable()[ startIndex ];
+
+							copyIndices(
+								sourceVar.indices ? &sourceVar.indices->readable() : nullptr, destIndices,
+								resultTypeId, sourceVar.interpolation, varInfo.interpolation,
+								numIndices, dataStart,
+								&sourcePrim
+							);
+						}
+					}
+				}
+
+				// Copy the topology information for this primitive into the result topology information
+
+				if( resultTypeId == IECoreScene::MeshPrimitiveTypeId )
+				{
+					const MeshPrimitive *sourceMesh = IECore::runTimeCast< const MeshPrimitive >( &sourcePrim );
+
+					int startUniform = accumInterpolation[ PrimitiveVariable::Uniform ][i];
+					int numUniform = countInterpolation[ PrimitiveVariable::Uniform ][i];
+					int startVertex = accumInterpolation[ PrimitiveVariable::Vertex ][i];
+					int startFaceVarying = accumInterpolation[ PrimitiveVariable::FaceVarying ][i];
+					int numFaceVarying = countInterpolation[ PrimitiveVariable::FaceVarying ][i];
+
+					const int *sourceVerticesPerFace = &sourceMesh->verticesPerFace()->readable()[0];
+					int *resultVerticesPerFace = &resultVerticesPerFaceData->writable()[ startUniform ];
+					Canceller::check( canceller );
+					for( int j = 0; j < numUniform; j++ )
+					{
+						*(resultVerticesPerFace++) = *(sourceVerticesPerFace++);
+					}
+
+					const int* sourceVertexIds = &sourceMesh->vertexIds()->readable()[0];
+					int *resultVertexIds = &resultVertexIdsData->writable()[startFaceVarying];
+					Canceller::check( canceller );
+					for( int j = 0; j < numFaceVarying; j++ )
+					{
+						*(resultVertexIds++) = *(sourceVertexIds++) + startVertex;
+					}
+
+					if( resultCornerIdsData )
+					{
+						const int *sourceCornerIds = &sourceMesh->cornerIds()->readable()[0];
+						const float *sourceCornerSharpnesses = &sourceMesh->cornerSharpnesses()->readable()[0];
+						int *resultCornerIds = &resultCornerIdsData->writable()[ accumCorners[i] ];
+						float *resultCornerSharpnesses = &resultCornerSharpnessesData->writable()[ accumCorners[i] ];
+						Canceller::check( canceller );
+						for( int j = 0; j < countCorners[i]; j++ )
+						{
+							*(resultCornerIds++) = *(sourceCornerIds++) + startVertex;
+							*(resultCornerSharpnesses++) = *(sourceCornerSharpnesses++);
+						}
+					}
+
+					if( resultCreaseLengthsData )
+					{
+						const int *sourceCreaseLengths = &sourceMesh->creaseLengths()->readable()[0];
+						const float *sourceCreaseSharpnesses = &sourceMesh->creaseSharpnesses()->readable()[0];
+						int *resultCreaseLengths = &resultCreaseLengthsData->writable()[accumCreases[i]];
+						float *resultCreaseSharpnesses = &resultCreaseSharpnessesData->writable()[accumCreases[i]];
+						Canceller::check( canceller );
+						for( int j = 0; j < countCreases[i]; j++ )
+						{
+							*(resultCreaseLengths++) = *(sourceCreaseLengths++);
+							*(resultCreaseSharpnesses++) = *(sourceCreaseSharpnesses++);
+						}
+
+						const int *sourceCreaseIds = &sourceMesh->creaseIds()->readable()[0];
+						int *resultCreaseIds = &resultCreaseIdsData->writable()[accumCreaseIds[i]];
+						Canceller::check( canceller );
+						for( int j = 0; j < countCreaseIds[i]; j++ )
+						{
+							*(resultCreaseIds++) = *(sourceCreaseIds++) + startVertex;
+						}
+					}
+				}
+				else if( resultTypeId == IECoreScene::CurvesPrimitiveTypeId )
+				{
+					const CurvesPrimitive *sourceCurves = IECore::runTimeCast< const CurvesPrimitive >( &sourcePrim );
+
+					int startUniform = accumInterpolation[ PrimitiveVariable::Uniform ][i];
+					int numUniform = countInterpolation[ PrimitiveVariable::Uniform ][i];
+
+					int *resultVerticesPerCurve = &resultVerticesPerCurveData->writable()[ startUniform ];
+					const int *sourceVerticesPerCurve = &sourceCurves->verticesPerCurve()->readable()[0];
+					Canceller::check( canceller );
+					for( int j = 0; j < numUniform; j++ )
+					{
+						*(resultVerticesPerCurve++) = *(sourceVerticesPerCurve++);
+					}
+				}
+			}
+		},
+		tbb::auto_partitioner(),
+		taskGroupContext
+	);
+
+	// Set topology and other primitive type specific globals
+
+	if( resultMesh )
+	{
+		if( resultMeshInterpolation == "" )
+		{
+			resultMeshInterpolation = "linear";
+		}
+
+		resultMesh->setTopologyUnchecked( resultVerticesPerFaceData, resultVertexIdsData, totalInterpolation[ PrimitiveVariable::Vertex ], resultMeshInterpolation );
+
+		if( resultCornerIdsData )
+		{
+			resultMesh->setCorners( resultCornerIdsData.get(), resultCornerSharpnessesData.get() );
+		}
+
+		if( resultCreaseLengthsData )
+		{
+			resultMesh->setCreases(
+				resultCreaseLengthsData.get(), resultCreaseIdsData.get(), resultCreaseSharpnessesData.get()
+			);
+		}
+	}
+	else if( resultCurves )
+	{
+		if( resultCurvesBasis == invalidBasis )
+		{
+			resultCurvesBasis = CubicBasisf::linear();
+		}
+
+		resultCurves->setTopology( resultVerticesPerCurveData, resultCurvesBasis, resultCurvesPeriodic );
+	}
+
+	return result;
+}


### PR DESCRIPTION
Found a few other weird odds-n-ends while doing a last clean up pass today, so didn't end up getting to transferring the mesh boundary interpolation properties, but I wanted to get this up for review, and everything else in a pretty good state to be reviewed. I might consider dividing some things up into more functions - it is a big chunk of code ... but at this point, where to draw those boundaries would be pretty arbitrary, so I might as well see how you feel about it.

Oh - something I just realized - I'm now handling interpretations of Constant primvars correctly ... but I guess that's a behaviour change when I use this same behaviour for FreezeTransform. I guess if we're putting this in 1.5, then the compatibility break is OK? I'd also be OK with just not transforming Constant primvars, but the behaviour should match between MergeMeshes and FreezeTransform.