### PR TITLE
Inspector : Add support for disabling edits

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Improvements
 - Spreadsheet : Added yellow underlining to the currently active row.
 - PlugLayout : Summaries and activators are now evaluated in a context determined relative to the focus node.
 - Editor : The node graph is now evaluated in a context determined relative to the focus node.
+- LightEditor, RenderPassEditor : The "Disable Edit" right-click menu item and <kdb>D</kdb> shortcut now act as a toggle, where edits disabled in the current session via these actions can be reenabled with <kbd>D</kbd> or by selecting "Reenable Edit" from the right-click menu.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -56,6 +56,7 @@ Fixes
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed.
 - usdview : Added Windows support (#5599).
 - ContextTracker : Removed unnecessary reference increment/decrement from `isTracked()`, `context()` and `isEnabled()`.
+- Menu : Fixed bug causing a menu item's tooltip to not hide when moving the cursor to another menu item without a tooltip.
 
 API
 ---

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -65,9 +65,9 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 
 		GafferScene::SceneAlgo::History::ConstPtr history() const override;
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history) const override;
-		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 
 		bool attributeExists() const;
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -183,6 +183,14 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		/// > that edits the processor itself.
 		virtual EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const;
 
+		using DisableEditFunction = std::function<void ()>;
+		using DisableEditFunctionOrFailure = boost::variant<DisableEditFunction, std::string>;
+		/// Can be implemented to return a function that will disable an edit
+		/// at the specified plug. If this is not possible, should return an
+		/// error explaining why (this is typically due to `readOnly` metadata).
+		/// Called with `history->context` as the current context.
+		virtual DisableEditFunctionOrFailure disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const;
+
 	protected :
 
 		Gaffer::EditScope *targetEditScope() const;
@@ -343,6 +351,16 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		/// by `acquireEdit()`. This should be displayed to the user.
 		std::string editWarning() const;
 
+		/// Returns `true` if `disableEdit()` will disable the edit
+		/// at `source()`, and `false` otherwise.
+		bool canDisableEdit() const;
+		/// If `canDisableEdit()` returns false, returns the reason why.
+		/// This should be displayed to the user.
+		std::string nonDisableableReason() const;
+		/// Disables the edit at `source()`. Throws if
+		/// `!canDisableEdit()`
+		void disableEdit() const;
+
 	private :
 
 		Result( const IECore::ConstObjectPtr &value, const Gaffer::EditScopePtr &editScope );
@@ -358,6 +376,8 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 
 		EditFunctionOrFailure m_editFunction;
 		std::string m_editWarning;
+
+		DisableEditFunctionOrFailure m_disableEditFunction;
 
 };
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -170,7 +170,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		/// history class?
 		virtual Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const;
 
-		using EditFunction = std::function<Gaffer::ValuePlugPtr ()>;
+		using EditFunction = std::function<Gaffer::ValuePlugPtr ( bool createIfNecessary )>;
 		using EditFunctionOrFailure = boost::variant<EditFunction, std::string>;
 		/// Should be implemented to return a function that will acquire
 		/// an edit from the EditScope at the specified point in the history.
@@ -338,7 +338,7 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		/// Returns a plug that can be used to edit the property
 		/// represented by this inspector, creating it if necessary.
 		/// Throws if `!editable()`.
-		Gaffer::ValuePlugPtr acquireEdit() const;
+		Gaffer::ValuePlugPtr acquireEdit( bool createIfNecessary = true ) const;
 		/// Returns a warning associated with the plug returned
 		/// by `acquireEdit()`. This should be displayed to the user.
 		std::string editWarning() const;

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -63,9 +63,9 @@ class GAFFERSCENEUI_API OptionInspector : public Inspector
 
 		GafferScene::SceneAlgo::History::ConstPtr history() const override;
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
-		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -67,9 +67,9 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 	private :
 
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
-		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 
 		const IECoreScene::ShaderNetwork::Parameter m_parameter;
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -75,13 +75,13 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 
 		GafferScene::SceneAlgo::History::ConstPtr history() const override;
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
+		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		/// For the given `history`, returns either the "sets" `StringPlug` of an `ObjectSource`
 		/// node, the "name" `StringPlug` of a `Set` node, the `Spreadsheet::RowPlug` for the
 		/// appropriate row of a set membership processor spreadsheet or `nullptr` if none of
 		/// those are found.
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
-		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -82,6 +82,7 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 		/// those are found.
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+		DisableEditFunctionOrFailure disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :
 

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -219,7 +219,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			source = s["light"]["visualiserAttributes"]["scale"],
 			sourceType = SourceType.Other,
 			editable=False,
-			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+			nonEditableReason = "The target edit scope editScope1 is not in the scene history."
 		)
 
 		# If it is in the history though, and we're told to use it, then we will.
@@ -369,7 +369,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			source = independentAttributeTweakPlug,
 			sourceType = SourceType.Downstream,
 			editable = False,
-			nonEditableReason = "The target EditScope (editScope2) is disabled."
+			nonEditableReason = "The target edit scope editScope2 is disabled."
 		)
 
 		s["editScope2"]["enabled"].setValue( True )
@@ -455,7 +455,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			source = light["visualiserAttributes"]["scale"],
 			sourceType = SourceType.Other,
 			editable = False,
-			nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+			nonEditableReason = "The target edit scope EditScope is not in the scene history."
 		)
 
 		self.__assertExpectedResult(
@@ -471,7 +471,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			source = attributeTweaks["tweaks"][0],
 			sourceType = SourceType.Other,
 			editable = False,
-			nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+			nonEditableReason = "The target edit scope EditScope is not in the scene history."
 		)
 
 	def testDisabledTweaks( self ) :
@@ -893,7 +893,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "The target EditScope (editScope2) is not in the scene history." )
+		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -821,6 +821,30 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			edit = edit
 		)
 
+	def testAcquireEditCreateIfNecessary( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["light"] = GafferSceneTest.TestLight()
+		s["light"]["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+
+		s["group"] = GafferScene.Group()
+		s["editScope"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["light"]["out"] )
+
+		s["editScope"].setup( s["group"]["out"] )
+		s["editScope"]["in"].setInput( s["group"]["out"] )
+
+		inspection = self.__inspect( s["group"]["out"], "/group/light", "gl:visualiser:scale", None )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), s["light"]["visualiserAttributes"]["scale"] )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/group/light", "gl:visualiser:scale", s["editScope"] )
+		self.assertIsNone( inspection.acquireEdit( createIfNecessary = False ) )
+
+		edit = inspection.acquireEdit( createIfNecessary = True )
+		self.assertIsNotNone( edit )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), edit )
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -892,5 +892,31 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 			edit = edit
 		)
 
+	def testAcquireEditCreateIfNecessary( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		s["group"] = GafferScene.Group()
+		s["editScope"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["standardOptions"]["out"] )
+
+		s["editScope"].setup( s["group"]["out"] )
+		s["editScope"]["in"].setInput( s["group"]["out"] )
+
+		inspection = self.__inspect( s["group"]["out"], "render:camera", None )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), s["standardOptions"]["options"]["renderCamera"] )
+
+		inspection = self.__inspect( s["editScope"]["out"], "render:camera", s["editScope"] )
+		self.assertIsNone( inspection.acquireEdit( createIfNecessary = False ) )
+
+		edit = inspection.acquireEdit( createIfNecessary = True )
+		self.assertIsNotNone( edit )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), edit )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -162,7 +162,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 			source = s["standardOptions"]["options"]["renderCamera"],
 			sourceType = SourceType.Other,
 			editable = False,
-			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+			nonEditableReason = "The target edit scope editScope1 is not in the scene history."
 		)
 
 		# If it is in the history though, and we're told to use it, then we will.
@@ -285,7 +285,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 			source = s["independentOptions"]["options"]["renderCamera"],
 			sourceType = SourceType.Downstream,
 			editable = False,
-			nonEditableReason = "The target EditScope (editScope2) is disabled."
+			nonEditableReason = "The target edit scope editScope2 is disabled."
 		)
 
 		s["editScope2"]["enabled"].setValue( True )
@@ -561,7 +561,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 				source = s["standardOptions"]["options"]["renderCamera"],
 				sourceType = SourceType.Other,
 				editable = False,
-				nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+				nonEditableReason = "The target edit scope editScope1 is not in the scene history."
 			)
 
 			# If it is in the history though, and we're told to use it, then we will.
@@ -684,7 +684,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 				source = s["independentOptions"]["options"]["renderCamera"],
 				sourceType = SourceType.Downstream,
 				editable = False,
-				nonEditableReason = "The target EditScope (editScope2) is disabled."
+				nonEditableReason = "The target edit scope editScope2 is disabled."
 			)
 
 			s["editScope2"]["enabled"].setValue( True )
@@ -967,7 +967,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "The target EditScope (editScope2) is not in the scene history." )
+		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -393,6 +393,29 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 			editable = False, nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
 		)
 
+	def testAcquireEditCreateIfNecessary( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["light"] = GafferSceneTest.TestLight()
+		s["group"] = GafferScene.Group()
+		s["editScope"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["light"]["out"] )
+
+		s["editScope"].setup( s["group"]["out"] )
+		s["editScope"]["in"].setInput( s["group"]["out"] )
+
+		inspection = self.__inspect( s["group"]["out"], "/group/light", "exposure", None )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), s["light"]["parameters"]["exposure"] )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/group/light", "exposure", s["editScope"] )
+		self.assertIsNone( inspection.acquireEdit( createIfNecessary = False ) )
+
+		edit = inspection.acquireEdit( createIfNecessary = True )
+		self.assertIsNotNone( edit )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), edit )
+
 	def testDisabledTweaks( self ) :
 
 		light = GafferSceneTest.TestLight()

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -156,7 +156,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			self.__inspect( s["group"]["out"], "/group/light", "intensity", s["editScope1"] ),
 			source = s["light"]["parameters"]["intensity"], sourceType = SourceType.Other,
-			editable = False, nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+			editable = False, nonEditableReason = "The target edit scope editScope1 is not in the scene history."
 		)
 
 		# If it is in the history though, and we're told to use it, then we will.
@@ -302,7 +302,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			self.__inspect( s["independentLightTweak"]["out"], "/group/light", "intensity", s["editScope2"] ),
 			source = independentLightTweakPlug, sourceType = SourceType.Downstream,
-			editable = False, nonEditableReason = "The target EditScope (editScope2) is disabled."
+			editable = False, nonEditableReason = "The target edit scope editScope2 is disabled."
 		)
 
 		s["editScope2"]["enabled"].setValue( True )
@@ -378,7 +378,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			self.__inspect( light["out"], "/light", "exposure", editScope ),
 			source = light["parameters"]["exposure"], sourceType = SourceType.Other,
-			editable = False, nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+			editable = False, nonEditableReason = "The target edit scope EditScope is not in the scene history."
 		)
 
 		self.__assertExpectedResult(
@@ -390,7 +390,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			self.__inspect( shaderTweaks["out"], "/light", "exposure", editScope ),
 			source = shaderTweaks["tweaks"][0], sourceType = SourceType.Other,
-			editable = False, nonEditableReason = "The target EditScope (EditScope) is not in the scene history."
+			editable = False, nonEditableReason = "The target edit scope EditScope is not in the scene history."
 		)
 
 	def testAcquireEditCreateIfNecessary( self ) :
@@ -467,7 +467,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "The target EditScope (editScope2) is not in the scene history." )
+		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/light", "exposure", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -594,6 +594,29 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 		self.assertFalse( inspector.editSetMembership( inspection, "/plane", GafferScene.EditScopeAlgo.SetMembership.Removed ) )
 
+	def testAcquireEditCreateIfNecessary( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["plane"] = GafferScene.Plane()
+		s["plane"]["sets"].setValue( "planeSetA planeSetB" )
+
+		s["group"] = GafferScene.Group()
+		s["editScope"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["plane"]["out"] )
+		s["editScope"].setup( s["group"]["out"] )
+		s["editScope"]["in"].setInput( s["group"]["out"] )
+
+		inspection = self.__inspect( s["group"]["out"], "/group/plane", "planeSetA", None )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), s["plane"]["sets"] )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/group/plane", "planeSetA", s["editScope"] )
+		self.assertIsNone( inspection.acquireEdit( createIfNecessary = False ) )
+
+		edit = inspection.acquireEdit( createIfNecessary = True )
+		self.assertIsNotNone( edit )
+		self.assertEqual( inspection.acquireEdit( createIfNecessary = False ), edit )
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -192,7 +192,7 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 			source = s["plane"]["sets"],
 			sourceType = SourceType.Other,
 			editable = False,
-			nonEditableReason = "The target EditScope (editScope1) is not in the scene history."
+			nonEditableReason = "The target edit scope editScope1 is not in the scene history."
 		)
 
 		# If it is in the history though, and we're told to use it, then we will.
@@ -329,7 +329,7 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 			source = s["independentSet"]["name"],
 			sourceType = SourceType.Downstream,
 			editable = False,
-			nonEditableReason = "The target EditScope (editScope2) is disabled."
+			nonEditableReason = "The target edit scope editScope2 is disabled."
 		)
 
 		s["editScope2"]["enabled"].setValue( True )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -728,6 +728,9 @@ class _Menu( QtWidgets.QMenu ) :
 			if action and action.statusTip() :
 				QtWidgets.QToolTip.showText( qEvent.globalPos(), action.statusTip(), self )
 				return True
+			elif QtWidgets.QToolTip.isVisible() :
+				QtWidgets.QToolTip.hideText()
+				return True
 
 		return QtWidgets.QMenu.event( self, qEvent )
 

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -394,12 +394,13 @@ Inspector::EditFunctionOrFailure AttributeInspector::editFunction( Gaffer::EditS
 			editScope = EditScopePtr( editScope ),
 			attributeName,
 			context = history->context
-		] () {
+		] ( bool createIfNecessary ) {
 			Context::Scope scope( context.get() );
 			return EditScopeAlgo::acquireAttributeEdit(
 				editScope.get(),
 				context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ),
-				attributeName
+				attributeName,
+				createIfNecessary
 			);
 		};
 	}

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -213,7 +213,7 @@ Inspector::ResultPtr Inspector::inspect() const
 	if( result->editScope() && !result->m_editScopeInHistory )
 	{
 		const std::string nonEditableReason = fmt::format(
-			"The target EditScope ({}) is not in the scene history.",
+			"The target edit scope {} is not in the scene history.",
 			result->editScope()->relativeName( result->editScope()->scriptNode() )
 		);
 		result->m_editFunction = nonEditableReason;
@@ -357,7 +357,7 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 			else
 			{
 				result->m_editFunction = fmt::format(
-					"The target EditScope ({}) is disabled.",
+					"The target edit scope {} is disabled.",
 					editScope->relativeName( editScope->scriptNode() )
 				);
 			}

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -38,6 +38,7 @@
 
 #include "Gaffer/Animation.h"
 #include "Gaffer/MetadataAlgo.h"
+#include "Gaffer/OptionalValuePlug.h"
 #include "Gaffer/PathFilter.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/Spreadsheet.h"
@@ -211,18 +212,23 @@ Inspector::ResultPtr Inspector::inspect() const
 
 	if( result->editScope() && !result->m_editScopeInHistory )
 	{
-		result->m_editFunction = fmt::format(
+		const std::string nonEditableReason = fmt::format(
 			"The target EditScope ({}) is not in the scene history.",
 			result->editScope()->relativeName( result->editScope()->scriptNode() )
 		);
+		result->m_editFunction = nonEditableReason;
+		result->m_disableEditFunction = nonEditableReason;
 		result->m_sourceType = Result::SourceType::Other;
 	}
-
-	else if( !result->m_source && !result->editable() )
+	else if( !result->m_source )
 	{
-		// There's no source plug and no way of making
-		// the property.
-		result->m_editFunction = "No editable source found in history.";
+		if( !result->editable() )
+		{
+			// There's no source plug and no way of making
+			// the property.
+			result->m_editFunction = "No editable source found in history.";
+		}
+		result->m_disableEditFunction = "No editable source found in history.";
 	}
 
 	if( fallbackValue )
@@ -290,12 +296,25 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 						if( nonEditableReason.empty() )
 						{
 							result->m_editFunction = [source = result->m_source] ( bool unused ) { return source; };
+							result->m_disableEditFunction = disableEditFunction( result->m_source.get(), history );
 							result->m_editWarning = editWarning;
 						}
 						else
 						{
 							result->m_editFunction = nonEditableReason;
+							result->m_disableEditFunction = nonEditableReason;
 						}
+					}
+					else if( node->ancestor<EditScope>() && node->ancestor<EditScope>() != result->m_editScope )
+					{
+						result->m_disableEditFunction = fmt::format(
+							"Edit is not in the current edit scope. Change scope to {} to disable.",
+							node->ancestor<EditScope>()->relativeName( node->ancestor<EditScope>()->scriptNode() )
+						);
+					}
+					else if( !node->ancestor<EditScope>() && result->m_editScope )
+					{
+						result->m_disableEditFunction = "Edit is not in the current edit scope. Change scope to None to disable.";
 					}
 				}
 			}
@@ -366,6 +385,47 @@ Gaffer::ValuePlugPtr Inspector::source( const GafferScene::SceneAlgo::History *h
 Inspector::EditFunctionOrFailure Inspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	return "Editing not supported";
+}
+
+Inspector::DisableEditFunctionOrFailure Inspector::disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const
+{
+	Gaffer::BoolPlugPtr enabledPlug;
+	if( auto tweakPlug = runTimeCast<TweakPlug>( plug ) )
+	{
+		enabledPlug = tweakPlug->enabledPlug();
+	}
+	else if( auto nameValuePlug = runTimeCast<NameValuePlug>( plug ) )
+	{
+		enabledPlug = nameValuePlug->enabledPlug();
+	}
+	else if( auto optionalValuePlug = runTimeCast<OptionalValuePlug>( plug ) )
+	{
+		enabledPlug = optionalValuePlug->enabledPlug();
+	}
+
+	if( enabledPlug )
+	{
+		if( const GraphComponent *readOnlyReason = MetadataAlgo::readOnlyReason( enabledPlug.get() ) )
+		{
+			return fmt::format( "{} is locked.", readOnlyReason->relativeName( readOnlyReason->ancestor<ScriptNode>() ) );
+		}
+		else if( !enabledPlug->settable() )
+		{
+			return fmt::format( "{} is not settable.", enabledPlug->relativeName( enabledPlug->ancestor<ScriptNode>() ) );
+		}
+		else if( !enabledPlug->getValue() )
+		{
+			return fmt::format( "{} is not enabled.", enabledPlug->relativeName( enabledPlug->ancestor<ScriptNode>() ) );
+		}
+		else
+		{
+			return [ enabledPlug ] () { enabledPlug->setValue( false ); };
+		}
+	}
+	else
+	{
+		return "Disabling edits not supported for this plug.";
+	}
 }
 
 IECore::ConstObjectPtr Inspector::fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const
@@ -674,6 +734,31 @@ Gaffer::ValuePlugPtr Inspector::Result::acquireEdit( bool createIfNecessary ) co
 	}
 
 	throw IECore::Exception( "Not editable : " + boost::get<std::string>( m_editFunction ) );
+}
+
+bool Inspector::Result::canDisableEdit() const
+{
+	return m_disableEditFunction.which() == 0 && boost::get<DisableEditFunction>( m_disableEditFunction ) != nullptr;
+}
+
+std::string Inspector::Result::nonDisableableReason() const
+{
+	if( m_disableEditFunction.which() == 1 )
+	{
+		return boost::get<std::string>( m_disableEditFunction );
+	}
+
+	return "";
+}
+
+void Inspector::Result::disableEdit() const
+{
+	if( m_disableEditFunction.which() == 0 )
+	{
+		return boost::get<DisableEditFunction>( m_disableEditFunction )();
+	}
+
+	throw IECore::Exception( "Cannot disable edit : " + boost::get<std::string>( m_disableEditFunction ) );
 }
 
 std::string Inspector::Result::editWarning() const

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -289,7 +289,7 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 
 						if( nonEditableReason.empty() )
 						{
-							result->m_editFunction = [source = result->m_source] () { return source; };
+							result->m_editFunction = [source = result->m_source] ( bool unused ) { return source; };
 							result->m_editWarning = editWarning;
 						}
 						else
@@ -666,11 +666,11 @@ std::string Inspector::Result::nonEditableReason() const
 	return "";
 }
 
-Gaffer::ValuePlugPtr Inspector::Result::acquireEdit() const
+Gaffer::ValuePlugPtr Inspector::Result::acquireEdit( bool createIfNecessary ) const
 {
 	if( m_editFunction.which() == 0 )
 	{
-		return boost::get<EditFunction>( m_editFunction )();
+		return boost::get<EditFunction>( m_editFunction )( createIfNecessary );
 	}
 
 	throw IECore::Exception( "Not editable : " + boost::get<std::string>( m_editFunction ) );

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -293,12 +293,13 @@ Inspector::EditFunctionOrFailure OptionInspector::editFunction( Gaffer::EditScop
 				renderPass,
 				option = m_option,
 				context = history->context
-			] () {
+			] ( bool createIfNecessary ) {
 				Context::Scope scope( context.get() );
 				return EditScopeAlgo::acquireRenderPassOptionEdit(
 					editScope.get(),
 					renderPass,
-					option
+					option,
+					createIfNecessary
 				);
 			};
 		}
@@ -326,11 +327,12 @@ Inspector::EditFunctionOrFailure OptionInspector::editFunction( Gaffer::EditScop
 				editScope = EditScopePtr( editScope ),
 				option = m_option,
 				context = history->context
-			] () {
+			] ( bool createIfNecessary ) {
 				Context::Scope scope( context.get() );
 				return EditScopeAlgo::acquireOptionEdit(
 					editScope.get(),
-					option
+					option,
+					createIfNecessary
 				);
 			};
 		}

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -215,13 +215,14 @@ Inspector::EditFunctionOrFailure ParameterInspector::editFunction( Gaffer::EditS
 			attributeName = attributeHistory->attributeName,
 			context = attributeHistory->context,
 			parameter = m_parameter
-		] () {
+		] ( bool createIfNecessary ) {
 				Context::Scope scope( context.get() );
 				return EditScopeAlgo::acquireParameterEdit(
 					editScope.get(),
 					context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName ),
 					attributeName,
-					parameter
+					parameter,
+					createIfNecessary
 				);
 		};
 	}

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -312,9 +312,9 @@ Inspector::EditFunctionOrFailure SetMembershipInspector::editFunction( Gaffer::E
 			editScope = editScope,
 			setName,
 			context = history->context
-		] () {
+		] ( bool createIfNecessary ) {
 			Context::Scope scope( context.get() );
-			return EditScopeAlgo::acquireSetEdits( editScope, setName );
+			return EditScopeAlgo::acquireSetEdits( editScope, setName, createIfNecessary );
 		};
 	}
 }

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -127,6 +127,71 @@ HistoryCache g_historyCache(
 
 );
 
+bool editSetMembership( Gaffer::Plug *plug, const std::string &setName, const ScenePlug::ScenePath &path, EditScopeAlgo::SetMembership setMembership )
+{
+	if( auto objectNode = runTimeCast<ObjectSource>( plug->node() ) )
+	{
+		std::vector<std::string> sets;
+		IECore::StringAlgo::tokenize( objectNode->setsPlug()->getValue(), ' ', sets );
+
+		if( setMembership == EditScopeAlgo::SetMembership::Added )
+		{
+			if( std::find( sets.begin(), sets.end(), setName ) == sets.end() )
+			{
+				sets.push_back( setName );
+			}
+		}
+		else
+		{
+			sets.erase( std::remove( sets.begin(), sets.end(), setName ), sets.end() );
+		}
+
+		objectNode->setsPlug()->setValue( boost::algorithm::join( sets, " " ) );
+
+		return true;
+	}
+
+	if( auto cells = runTimeCast<Gaffer::ValuePlug>( plug ) )
+	{
+		auto row = cells->parent<Spreadsheet::RowPlug>();
+		auto editScope = cells->ancestor<EditScope>();
+		if( row && editScope )
+		{
+			PathMatcher m;
+			m.addPath( path );
+			EditScopeAlgo::setSetMembership(
+				editScope,
+				m,
+				setName,
+				setMembership
+			);
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+std::string nonDisableableReason( const Gaffer::Plug *plug, const std::string &setName )
+{
+	if( const GraphComponent *readOnlyReason = MetadataAlgo::readOnlyReason( plug ) )
+	{
+		return fmt::format( "{} is locked.", readOnlyReason->relativeName( readOnlyReason->ancestor<ScriptNode>() ) );
+	}
+	else if( auto objectNode = runTimeCast<const ObjectSource>( plug->node() ) )
+	{
+		std::vector<std::string> sets;
+		IECore::StringAlgo::tokenize( objectNode->setsPlug()->getValue(), ' ', sets );
+		if( std::find( sets.begin(), sets.end(), setName ) == sets.end() )
+		{
+			return fmt::format( "{} has no edit to disable.", plug->relativeName( plug->ancestor<ScriptNode>() ) );
+		}
+	}
+
+	return "";
+}
+
 }  // namespace
 
 SetMembershipInspector::SetMembershipInspector(
@@ -148,50 +213,7 @@ m_setName( setName )
 
 bool SetMembershipInspector::editSetMembership( const Result *inspection, const ScenePlug::ScenePath &path, EditScopeAlgo::SetMembership setMembership ) const
 {
-	PlugPtr plug = inspection->acquireEdit();
-
-	if( auto objectNode = runTimeCast<ObjectSource>( plug->node() ) )
-	{
-		std::vector<std::string> sets;
-		IECore::StringAlgo::tokenize( objectNode->setsPlug()->getValue(), ' ', sets );
-
-		if( setMembership == EditScopeAlgo::SetMembership::Added )
-		{
-			if( std::find( sets.begin(), sets.end(), m_setName.string() ) == sets.end() )
-			{
-				sets.push_back( m_setName.string() );
-			}
-		}
-		else
-		{
-			sets.erase( std::remove( sets.begin(), sets.end(), m_setName.string() ), sets.end() );
-		}
-
-		objectNode->setsPlug()->setValue( boost::algorithm::join( sets, " " ) );
-
-		return true;
-	}
-
-	if( auto cells = runTimeCast<Gaffer::ValuePlug>( plug ) )
-	{
-		auto row = cells->parent<Spreadsheet::RowPlug>();
-		auto editScope = cells->ancestor<EditScope>();
-		if( row && editScope )
-		{
-			PathMatcher m;
-			m.addPath( path );
-			EditScopeAlgo::setSetMembership(
-				editScope,
-				m,
-				m_setName.string(),
-				setMembership
-			);
-
-			return true;
-		}
-	}
-
-	return false;
+	return ::editSetMembership( inspection->acquireEdit().get(), m_setName.string(), path, setMembership );
 }
 
 GafferScene::SceneAlgo::History::ConstPtr SetMembershipInspector::history() const
@@ -315,6 +337,26 @@ Inspector::EditFunctionOrFailure SetMembershipInspector::editFunction( Gaffer::E
 		] ( bool createIfNecessary ) {
 			Context::Scope scope( context.get() );
 			return EditScopeAlgo::acquireSetEdits( editScope, setName, createIfNecessary );
+		};
+	}
+}
+
+Inspector::DisableEditFunctionOrFailure SetMembershipInspector::disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const
+{
+	const std::string nonDisableableReason = ::nonDisableableReason( plug, m_setName );
+
+	if( !nonDisableableReason.empty() )
+	{
+		return nonDisableableReason;
+	}
+	else
+	{
+		return [
+			plug = PlugPtr( plug ),
+			setName = m_setName,
+			path = history->context->get<ScenePlug::ScenePath>( ScenePlug::scenePathContextName )
+		] () {
+			return ::editSetMembership( plug.get(), setName.string(), path, EditScopeAlgo::SetMembership::Unchanged );
 		};
 	}
 }

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -72,10 +72,16 @@ IECore::ObjectPtr valueWrapper( const GafferSceneUI::Private::Inspector::Result 
 	return result.value() ? result.value()->copy() : nullptr;
 }
 
-Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Result &result, bool createIfNecessary = true )
+Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Result &result, bool createIfNecessary )
 {
 	ScopedGILRelease gilRelease;
 	return result.acquireEdit( createIfNecessary );
+}
+
+void disableEditWrapper( GafferSceneUI::Private::Inspector::Result &result )
+{
+	ScopedGILRelease gilRelease;
+	return result.disableEdit();
 }
 
 bool editSetMembershipWrapper(
@@ -135,6 +141,9 @@ void GafferSceneUIModule::bindInspector()
 			.def( "nonEditableReason", &Inspector::Result::nonEditableReason )
 			.def( "acquireEdit", &acquireEditWrapper, ( arg( "createIfNecessary" ) = true ) )
 			.def( "editWarning", &Inspector::Result::editWarning )
+			.def( "canDisableEdit", &Inspector::Result::canDisableEdit )
+			.def( "nonDisableableReason", &Inspector::Result::nonDisableableReason )
+			.def( "disableEdit", &disableEditWrapper )
 		;
 
 		enum_<Inspector::Result::SourceType>( "SourceType" )

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -72,10 +72,10 @@ IECore::ObjectPtr valueWrapper( const GafferSceneUI::Private::Inspector::Result 
 	return result.value() ? result.value()->copy() : nullptr;
 }
 
-Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Result &result )
+Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Result &result, bool createIfNecessary = true )
 {
 	ScopedGILRelease gilRelease;
-	return result.acquireEdit();
+	return result.acquireEdit( createIfNecessary );
 }
 
 bool editSetMembershipWrapper(
@@ -133,7 +133,7 @@ void GafferSceneUIModule::bindInspector()
 			.def( "fallbackDescription", &Inspector::Result::fallbackDescription, return_value_policy<copy_const_reference>() )
 			.def( "editable", &Inspector::Result::editable )
 			.def( "nonEditableReason", &Inspector::Result::nonEditableReason )
-			.def( "acquireEdit", &acquireEditWrapper )
+			.def( "acquireEdit", &acquireEditWrapper, ( arg( "createIfNecessary" ) = true ) )
 			.def( "editWarning", &Inspector::Result::editWarning )
 		;
 


### PR DESCRIPTION
This moves the potentially Inspector-specific "Disable Edit" functionality from InspectorColumn to the Inspectors themselves via the new `Inspector::Result::disableEdit()`. Inspectors with custom disabling logic, such as the SetMembershipInspector, can provide their own by implementing `disableEditFunction()`.

On the user-facing side, this PR allows toggling of edits disabled via the "Disable Edit" actions in the Light Editor and Render Pass Editor. The approach taken is to only allow edits disabled in the current session to be re-enabled to allow for investigative "how would my scene be affected by disabling this edit?" toggling, while attempting to avoid enabling edits the user may not expect to exist, such as previously unmodified Spreadsheet cells in EditScope processors.