### PR TITLE
SetEditor : Use `PathListingWidget.columnContextMenuSignal()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ Fixes
   - Fixed error when `resize()` was used on an output plug.
 - CreateViews : Fixed redundant serialisation of internal connections.
 - LightEditor, RenderPassEditor : Removed ambiguous `The selected cells cannot be edited in the current Edit Scope` message when attempting to edit non-editable columns, such as the `Name` column.
+- SetEditor : Fixed right-click to ensure the item under the cursor is selected before the menu is shown.
 
 API
 ---

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -92,7 +92,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 			)
 
 			self.__pathListing.dragBeginSignal().connectFront( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
-			self.__pathListing.contextMenuSignal().connect( Gaffer.WeakMethod( self.__contextMenuSignal ), scoped = False )
+			self.__pathListing.columnContextMenuSignal().connect( Gaffer.WeakMethod( self.__columnContextMenuSignal ), scoped = False )
 			self.__pathListing.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPressSignal ), scoped = False )
 
 		self._updateFromSet()
@@ -179,9 +179,7 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 
 		return False
 
-	def __contextMenuSignal( self, widget ) :
-
-		menuDefinition = IECore.MenuDefinition()
+	def __columnContextMenuSignal( self, column, pathListingWidget, menuDefinition ) :
 
 		selection = self.__pathListing.getSelection()
 		selectedSetNames = self.__selectedSetNames()
@@ -211,11 +209,6 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 				"active" : len( selectedSetNames ) > 0,
 			}
 		)
-
-		self.__contextMenu = GafferUI.Menu( menuDefinition )
-		self.__contextMenu.popup( widget )
-
-		return True
 
 	def __copySelectedSetNames( self, *unused ) :
 


### PR DESCRIPTION
This means that the row under the cursor is selected automatically before the menu is shown, matching the behaviour in other similar UIs. This also means we could more easily expose a signal to allow extensions to customise the menu in future.

