### PR TITLE
VectorDataWidget : Disable word wrap

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.3.16.x (relative to 1.3.16.7)
 ========
 
+Fixes
+-----
 
+- VectorDataWidget : Fixed bug causing paths to display as "..." after the last visible "/" when the widget wasn't wide enough to show the entire path.
 
 1.3.16.7 (relative to 1.3.16.6)
 ========

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -111,6 +111,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 		self.__tableView.customContextMenuRequested.connect( Gaffer.WeakMethod( self.__contextMenu ) )
 
 		self.__tableView.verticalHeader().setDefaultSectionSize( 20 )
+		self.__tableView.setWordWrap( False )
 
 		self.__tableViewHolder = GafferUI.Widget( self.__tableView )
 		self.__column.append( self.__tableViewHolder )


### PR DESCRIPTION
Back in the mists of time a Qt update caused paths displayed in VectorDataWidgets to be more aggressively elided when the path was longer than the widget could fit. A path of `/a/longpath` would be elided to `/a/...` rather than `/a/long...`. We suspected some change in behaviour as to how Qt was handling elided text, but early investigations proved to be not so fruitful, and the alternative of implementing `_StringDelegate.paint()` in Python didn't feel ideal for performance.

It turns out that we were barking up the wrong tree there and the real issue was word wrapping. The path text was being wrapped before the text was elided. The wrapping considered '/' characters to be appropriate places to introduce line breaks, which are indicated with the same ellipses as elided text when the widget cannot display the additional line(s). Disabling word wrap on the VectorDataWidget's TableView allows the full path to be elided and we return to displaying `/a/long...` rather than `/a/...`.