### PR TITLE
SceneNode : Don't append hash to itself

### DIFF
--- a/src/GafferScene/SceneNode.cpp
+++ b/src/GafferScene/SceneNode.cpp
@@ -596,7 +596,7 @@ void SceneNode::hashChildBounds( const Gaffer::Context *context, const ScenePlug
 
 	const IECore::MurmurHash reduction = parallel_deterministic_reduce(
 		SizeRange( 0, childNames.size() ),
-		h,
+		IECore::MurmurHash(),
 		[&] ( const SizeRange &range, const MurmurHash &hash ) {
 
 			ScenePlug::PathScope pathScope( threadState );


### PR DESCRIPTION
Not really a problem, but it was weird that we used h as the initial value of the reduce, and then also appended the result to h.

The reasonable option would be either to use h as an initial value, and then finish with h = reduction, or use a default hash as the initial value, and then append to the reduction. I've done the latter.

I haven't actually tested whether appending h to itself degrades the quality of the hash ... some hash functions do suffer from an issue where the possible outputs of `h.append( h )` don't cover the entire possible hash space, so you lose about 1 bit of randomness when you do this.

Probably makes sense to do this anyway though just to reduce confusion.