### PR TITLE
Use ContextTracker in all the things

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -100,6 +100,7 @@ Breaking Changes
 - View :
   - Changed constructor arguments for View and all subclasses. A ScriptNode must now be passed.
   - Changed `ViewCreator` signature.
+  - Removed `contextChanged()` and `contextChangedConnection()` methods.
 - LightTool : Removed `selection()` and `selectionChangedSignal()`.
 - ArnoldRender, CyclesRender, DelightRender, OpenGLRender : Removed. Use the generic Render node instead.
 - Render : Removed protected constructor for creating renderer-specific derived classes.

--- a/Changes.md
+++ b/Changes.md
@@ -101,6 +101,8 @@ Breaking Changes
   - Changed constructor arguments for View and all subclasses. A ScriptNode must now be passed.
   - Changed `ViewCreator` signature.
   - Removed `contextChanged()` and `contextChangedConnection()` methods.
+  - Removed `setContext()` and `getContext()` methods. Use `context()` instead of `getContext()`.
+  - The `contextChangedSignal()` is now emitted for all changes to the context, whereas previously it was only emitted by `setContext()`. This simplifies context handling in Tools, which no longer need to connect to `Context::changedSignal()` as well.
 - LightTool : Removed `selection()` and `selectionChangedSignal()`.
 - ArnoldRender, CyclesRender, DelightRender, OpenGLRender : Removed. Use the generic Render node instead.
 - Render : Removed protected constructor for creating renderer-specific derived classes.

--- a/Changes.md
+++ b/Changes.md
@@ -72,6 +72,7 @@ API
 - VisibleSet : Added Python constructor with keyword arguments for `expansions`, `inclusions` and `exclusions`.
 - ScriptNodeAlgo : Added new namespace with functions for managing shared UI state for GafferSceneUI.
 - ContextAlgo : Deprecated. Use ScriptNodeAlgo instead.
+- ContextTracker : Added support for plugs in Views and `Editor.Settings` nodes, which should use the tracked context for the node being viewed.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Improvements
   - The "Double-click to toggle" tooltip is no longer displayed while hovering over non-editable cells, and a "Double-click to edit" tooltip is now displayed while hovering over other non-toggleable but editable cells.
 - Spreadsheet : Added yellow underlining to the currently active row.
 - PlugLayout : Summaries and activators are now evaluated in a context determined relative to the focus node.
+- Editor : The node graph is now evaluated in a context determined relative to the focus node.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
   - Improved formatting of column headers containing whitespace.
   - The "Double-click to toggle" tooltip is no longer displayed while hovering over non-editable cells, and a "Double-click to edit" tooltip is now displayed while hovering over other non-toggleable but editable cells.
 - Spreadsheet : Added yellow underlining to the currently active row.
+- PlugLayout : Summaries and activators are now evaluated in a context determined relative to the focus node.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -47,6 +47,7 @@ Fixes
 - HierarchyView, SetEditor : Fixed thread-safety bugs.
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed.
 - usdview : Added Windows support (#5599).
+- ContextTracker : Removed unnecessary reference increment/decrement from `isTracked()`, `context()` and `isEnabled()`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -106,6 +106,7 @@ Breaking Changes
 - Render : Removed protected constructor for creating renderer-specific derived classes.
 - Signal : The `connect()` and `connectFront()` methods now default to `scoped = False`. If a scoped connection is required, pass `scoped = True`.
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed (this is more correct, but it is a change in behaviour).
+- ImageGadget : Remove non-const variant of `getContext()`.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -109,6 +109,7 @@ Breaking Changes
 - Signal : The `connect()` and `connectFront()` methods now default to `scoped = False`. If a scoped connection is required, pass `scoped = True`.
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed (this is more correct, but it is a change in behaviour).
 - ImageGadget : Remove non-const variant of `getContext()`.
+- LazyMethod : `deferUntilPlaybackStops` now requires that the Widget has a `scriptNode()` method rather than a `context()` method.
 
 Build
 -----

--- a/include/GafferImageUI/ImageGadget.h
+++ b/include/GafferImageUI/ImageGadget.h
@@ -106,8 +106,7 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		void setImage( GafferImage::ImagePlugPtr image );
 		const GafferImage::ImagePlug *getImage() const;
 
-		void setContext( Gaffer::ContextPtr context );
-		Gaffer::Context *getContext();
+		void setContext( Gaffer::ConstContextPtr context );
 		const Gaffer::Context *getContext() const;
 
 		using Channels = std::array<IECore::InternedString, 4>;
@@ -184,7 +183,7 @@ class GAFFERIMAGEUI_API ImageGadget : public GafferUI::Gadget
 		void contextChanged( const IECore::InternedString &name );
 
 		GafferImage::ImagePlugPtr m_image;
-		Gaffer::ContextPtr m_context;
+		Gaffer::ConstContextPtr m_context;
 
 		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;
 		Gaffer::Signals::ScopedConnection m_contextChangedConnection;

--- a/include/GafferImageUI/ImageView.h
+++ b/include/GafferImageUI/ImageView.h
@@ -109,8 +109,6 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 		ImageGadget *imageGadget();
 		const ImageGadget *imageGadget() const;
 
-		void setContext( Gaffer::ContextPtr context ) override;
-
 		class GAFFERIMAGEUI_API ColorInspectorPlug : public Gaffer::ValuePlug
 		{
 			public :
@@ -152,6 +150,7 @@ class GAFFERIMAGEUI_API ImageView : public GafferUI::View
 
 	private :
 
+		void contextChanged();
 		void plugSet( Gaffer::Plug *plug );
 		bool keyPress( const GafferUI::KeyEvent &event );
 		void preRender();

--- a/include/GafferSceneUI/CameraTool.h
+++ b/include/GafferSceneUI/CameraTool.h
@@ -66,11 +66,7 @@ class GAFFERSCENEUI_API CameraTool : public GafferSceneUI::SelectionTool
 		const Gaffer::BoolPlug *lookThroughEnabledPlug() const;
 		const Gaffer::StringPlug *lookThroughCameraPlug() const;
 
-		void connectToViewContext();
-		void contextChanged( const IECore::InternedString &name );
-
-		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
-
+		void contextChanged();
 		void plugDirtied( const Gaffer::Plug *plug );
 		GafferScene::ScenePlug::ScenePath cameraPath() const;
 		const TransformTool::Selection &cameraSelection();

--- a/include/GafferSceneUI/LightTool.h
+++ b/include/GafferSceneUI/LightTool.h
@@ -70,8 +70,7 @@ class GAFFERSCENEUI_API LightTool : public GafferSceneUI::SelectionTool
 		GafferScene::ScenePlug *scenePlug();
 		const GafferScene::ScenePlug *scenePlug() const;
 
-		void connectToViewContext();
-		void contextChanged( const IECore::InternedString &name );
+		void contextChanged();
 		void selectedPathsChanged();
 		void metadataChanged( IECore::InternedString key );
 		void updateHandleInspections();
@@ -94,7 +93,6 @@ class GAFFERSCENEUI_API LightTool : public GafferSceneUI::SelectionTool
 
 		bool m_dragging;
 
-		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 		Gaffer::Signals::ScopedConnection m_preRenderConnection;
 
 		std::vector<Gaffer::Signals::ScopedConnection> m_inspectorsDirtiedConnection;

--- a/include/GafferSceneUI/SceneView.h
+++ b/include/GafferSceneUI/SceneView.h
@@ -89,8 +89,6 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 		void expandSelection( size_t depth = 1 );
 		void collapseSelection();
 
-		void setContext( Gaffer::ContextPtr context ) override;
-
 		/// If the view is locked to a particular camera,
 		/// this returns the bound of the resolution gate
 		/// in raster space - this can be useful when
@@ -116,6 +114,7 @@ class GAFFERSCENEUI_API SceneView : public GafferUI::View
 
 		Imath::Box3f framingBound() const;
 
+		void contextChanged();
 		void selectedPathsChanged();
 		void visibleSetChanged();
 		bool keyPress( GafferUI::GadgetPtr gadget, const GafferUI::KeyEvent &event );

--- a/include/GafferSceneUI/ShaderView.h
+++ b/include/GafferSceneUI/ShaderView.h
@@ -74,8 +74,6 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 		using SceneChangedSignal = Gaffer::Signals::Signal<void ( ShaderView * )>;
 		SceneChangedSignal &sceneChangedSignal();
 
-		void setContext( Gaffer::ContextPtr context ) override;
-
 		using RendererCreator = std::function<GafferScene::InteractiveRenderPtr ()>;
 		static void registerRenderer( const std::string &shaderPrefix, RendererCreator rendererCreator );
 		static void deregisterRenderer( const std::string &shaderPrefix );
@@ -95,6 +93,7 @@ class GAFFERSCENEUI_API ShaderView : public GafferImageUI::ImageView
 
 		void viewportVisibilityChanged();
 
+		void contextChanged();
 		void plugSet( Gaffer::Plug *plug );
 		void plugDirtied( Gaffer::Plug *plug );
 		void sceneRegistrationChanged( const PrefixAndName &prefixAndName );

--- a/include/GafferSceneUI/TransformTool.h
+++ b/include/GafferSceneUI/TransformTool.h
@@ -254,8 +254,7 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 
 	private :
 
-		void connectToViewContext();
-		void contextChanged( const IECore::InternedString &name );
+		void contextChanged();
 		void selectedPathsChanged();
 		void plugDirtied( const Gaffer::Plug *plug );
 		void metadataChanged( IECore::InternedString key );
@@ -263,7 +262,6 @@ class GAFFERSCENEUI_API TransformTool : public GafferSceneUI::SelectionTool
 		void preRender();
 		bool keyPress( const GafferUI::KeyEvent &event );
 
-		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 		Gaffer::Signals::ScopedConnection m_preRenderConnection;
 
 		GafferUI::GadgetPtr m_handles;

--- a/include/GafferSceneUI/UVView.h
+++ b/include/GafferSceneUI/UVView.h
@@ -66,8 +66,6 @@ class GAFFERSCENEUI_API UVView : public GafferUI::View
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::UVView, UVViewTypeId, View );
 
-		void setContext( Gaffer::ContextPtr context ) override;
-
 		Gaffer::StringPlug *uvSetPlug();
 		const Gaffer::StringPlug *uvSetPlug() const;
 
@@ -107,6 +105,7 @@ class GAFFERSCENEUI_API UVView : public GafferUI::View
 		GafferUI::Gadget *textureGadgets();
 		const GafferUI::Gadget *textureGadgets() const;
 
+		void contextChanged();
 		void plugDirtied( const Gaffer::Plug *plug );
 		void preRender();
 		void visibilityChanged();

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -144,7 +144,11 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		///    it was tracked in is chosen.
 		/// 2. If the node or plug is part of a `View` or `Editor`, then
 		///    the context for the node being viewed is chosen.
-		/// 3. Otherwise, `targetContext()` is chosen.
+		/// 3. Otherwise, a copy of `targetContext()` is chosen.
+		///
+		/// > Note : The returned context is immutable, so it is not necessary
+		/// > to monitor it for changes via `Context::changedSignal()`. It is
+		/// > only necessary to monitor `ContextTracker::changedSignal()`.
 		Gaffer::ConstContextPtr context( const Gaffer::Plug *plug ) const;
 		Gaffer::ConstContextPtr context( const Gaffer::Node *node ) const;
 
@@ -164,7 +168,7 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		const Gaffer::Context *findPlugContext( const Gaffer::Plug *plug ) const;
 
 		Gaffer::ConstNodePtr m_node;
-		Gaffer::ConstContextPtr m_context;
+		Gaffer::ConstContextPtr m_targetContext;
 		Gaffer::Signals::ScopedConnection m_plugDirtiedConnection;
 
 		Gaffer::Signals::ScopedConnection m_idleConnection;
@@ -212,6 +216,9 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 			std::deque<std::pair<const Gaffer::Plug *, Gaffer::ConstContextPtr>> &toVisit,
 			NodeContexts &nodeContexts, PlugContexts &plugContexts, const IECore::Canceller *canceller
 		);
+
+		// The context returned for plugs and nodes that we haven't tracked.
+		Gaffer::ConstContextPtr m_defaultContext;
 
 };
 

--- a/include/GafferUI/ContextTracker.h
+++ b/include/GafferUI/ContextTracker.h
@@ -94,9 +94,9 @@ class GAFFERUI_API ContextTracker final : public IECore::RefCounted, public Gaff
 		/// belong to a ScriptNode, so that `ScriptNode::context()` can be used
 		/// to provide the target context.
 		static Ptr acquire( const Gaffer::NodePtr &node );
-		/// Returns an shared instance that will automatically track the focus
-		/// node in the specified `script`.
-		static Ptr acquireForFocus( Gaffer::ScriptNode *script );
+		/// Returns a shared instance that will automatically track the focus
+		/// node in the ScriptNode associated with `graphComponent`.
+		static Ptr acquireForFocus( Gaffer::GraphComponent *graphComponent );
 
 		/// Target
 		/// ======

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -176,14 +176,6 @@ class GAFFERUI_API View : public Gaffer::Node
 		template<typename T=Gaffer::Plug>
 		T *preprocessedInPlug();
 
-		/// Called when the context changes. Derived classes should call the
-		/// base class implementation if they override this method.
-		virtual void contextChanged( const IECore::InternedString &name );
-		/// Returns the connection used to trigger the call to contextChanged(). Derived
-		/// classes may block this temporarily if they want to prevent the triggering -
-		/// this can be useful when modifying the context.
-		Gaffer::Signals::Connection &contextChangedConnection();
-
 		template<class T>
 		struct ViewDescription
 		{
@@ -206,7 +198,6 @@ class GAFFERUI_API View : public Gaffer::Node
 		ViewportGadgetPtr m_viewportGadget;
 		Gaffer::ContextPtr m_context;
 		UnarySignal m_contextChangedSignal;
-		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
 
 		using CreatorMap = std::map<IECore::TypeId, ViewCreator>;
 		static CreatorMap &creators();

--- a/include/GafferUI/View.h
+++ b/include/GafferUI/View.h
@@ -60,6 +60,7 @@ IE_CORE_FORWARDDECLARE( EditScope )
 namespace GafferUI
 {
 
+IE_CORE_FORWARDDECLARE( ContextTracker )
 IE_CORE_FORWARDDECLARE( View )
 
 } // namespace GafferUI
@@ -110,13 +111,8 @@ class GAFFERUI_API View : public Gaffer::Node
 		const Gaffer::EditScope *editScope() const;
 
 		/// The Context in which the View should operate.
-		Gaffer::Context *getContext();
-		const Gaffer::Context *getContext() const;
-		/// May be overridden by derived classes to perform
-		/// additional work, but they _must_ call the base
-		/// class implementation.
-		virtual void setContext( Gaffer::ContextPtr context );
-		/// Signal emitted by setContext().
+		const Gaffer::Context *context() const;
+		/// Signal emitted when the result of `context()` has changed.
 		UnarySignal &contextChangedSignal();
 
 		/// Subclasses are responsible for presenting their content in this viewport.
@@ -187,6 +183,7 @@ class GAFFERUI_API View : public Gaffer::Node
 
 	private :
 
+		void contextTrackerChanged();
 		void toolsChildAdded( Gaffer::GraphComponent *child );
 		void toolPlugSet( Gaffer::Plug *plug );
 
@@ -196,7 +193,8 @@ class GAFFERUI_API View : public Gaffer::Node
 		ToolPlugSetMap m_toolPlugSetConnections;
 
 		ViewportGadgetPtr m_viewportGadget;
-		Gaffer::ContextPtr m_context;
+		ContextTrackerPtr m_contextTracker;
+		Gaffer::ConstContextPtr m_context;
 		UnarySignal m_contextChangedSignal;
 
 		using CreatorMap = std::map<IECore::TypeId, ViewCreator>;
@@ -253,16 +251,14 @@ class GAFFERUI_API View::DisplayTransform : public Gaffer::Node
 		Gaffer::FloatPlug *gammaPlug();
 		Gaffer::BoolPlug *absolutePlug();
 
-		void connectToViewContext();
-		void contextChanged( const IECore::InternedString &name );
+		void contextChanged();
 		void registrationChanged( const std::string &name );
 		void plugDirtied( const Gaffer::Plug *plug );
 		void preRender();
 		bool keyPress( const KeyEvent &event );
 
-		Gaffer::Signals::ScopedConnection m_contextChangedConnection;
-
 		IECoreGL::Shader::SetupPtr m_shader;
+		IECore::MurmurHash m_shaderContextHash;
 		bool m_shaderDirty;
 		bool m_parametersDirty;
 

--- a/python/GafferImageUI/FormatPlugValueWidget.py
+++ b/python/GafferImageUI/FormatPlugValueWidget.py
@@ -72,12 +72,6 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__pixelAspectWidget = GafferUI.NumericPlugValueWidget( plugs = [] )
 		grid[1,3] = self.__pixelAspectWidget
 
-		# If the plug hasn't got an input, the PlugValueWidget base class assumes we're not
-		# sensitive to context changes and omits calls to `_updateFromValues()`. But the default
-		# format mechanism uses the context, so we must arrange to do updates ourselves when
-		# necessary.
-		self.context().changedSignal().connect( Gaffer.WeakMethod( self.__contextChanged ) )
-
 		self._addPopupMenu( self.__menuButton )
 
 		self.__currentFormat = None
@@ -120,6 +114,12 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__maxLabel.setText( "Max" if nonZeroOrigin else "Size" )
 
 		self.__menuButton.setErrored( exception is not None )
+
+	def _valuesDependOnContext( self ) :
+
+		# We use the context in `_updateFromValues()`, so must return True
+		# here so that it is called when the context changes.
+		return True
 
 	def _updateFromMetadata( self ) :
 
@@ -196,11 +196,6 @@ class FormatPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# state automatically.
 			for p in self.getPlugs() :
 				Gaffer.Metadata.registerValue( p, "formatPlugValueWidget:mode", "custom" )
-
-	def __contextChanged( self, context, key ) :
-
-		if key == "image:defaultFormat" :
-			self._requestUpdateFromValues()
 
 GafferUI.PlugValueWidget.registerType( GafferImage.FormatPlug, FormatPlugValueWidget )
 

--- a/python/GafferImageUI/ImageViewUI.py
+++ b/python/GafferImageUI/ImageViewUI.py
@@ -387,7 +387,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		plug.node()["colorInspector"]["evaluator"]["pixelColor"].getInput().node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__updateFromImageNode ) )
 
 		plug.node().plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__plugDirtied ) )
-		plug.node()["in"].getInput().node().scriptNode().context().changedSignal().connect( Gaffer.WeakMethod( self.__updateFromContext ) )
+		plug.node().contextChangedSignal().connect( Gaffer.WeakMethod( self.__updateFromContext ) )
 		Gaffer.Metadata.plugValueChangedSignal( self.getPlug().node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ) )
 
 		self.__updateLabels( [ imath.V2i( 0 ) ] * 2 , [ imath.Color4f( 0, 0, 0, 1 ) ] * 2 )
@@ -450,7 +450,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			# we stored the last evaluated color so we could directly call _updateLabels
 			self.__updateLazily()
 
-	def __updateFromContext( self, context, name ) :
+	def __updateFromContext( self, unused ) :
 
 		self.__updateLazily()
 
@@ -535,7 +535,7 @@ class _ColorInspectorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.__updateLabels( sources, [ imath.Color4f( 0 ) ] * 2 )
 			return
 
-		with inputImagePlug.node().scriptNode().context() :
+		with self.getPlug().node().context() :
 			self.__updateInBackground( sources )
 
 	def __evaluateColors( self, sources ):

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -113,9 +113,9 @@ class _StatusWidget( GafferUI.Frame ) :
 
 		self.__update()
 
-	def context( self ) :
+	def scriptNode( self ) : # For LazyMethod's `deferUntilPlaybackStops`
 
-		return self.ancestor( GafferUI.NodeToolbar ).context()
+		return self.__tool.ancestor( GafferUI.View ).scriptNode()
 
 	def getToolTip( self ) :
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -119,7 +119,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 				self.__renderNodePlugDirtiedConnection = renderNode.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__renderNodePlugDirtied ), scoped = True )
 
 			# We disable the controls if a render is in progress, but not being viewed
-			with self.__view.getContext() :
+			with self.__view.context() :
 				renderNodeStopped = statePlug.getValue() == GafferScene.InteractiveRender.State.Stopped
 				viewedImageIsRendering = self.__imageIsRendering( self.__view["in"] )
 				controlsEnabled  = ( viewedImageIsRendering and not renderNodeStopped ) or renderNodeStopped
@@ -141,7 +141,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 		if not isinstance( view["in"], GafferImage.ImagePlug ) :
 			return None
 
-		with view.getContext() :
+		with view.context() :
 			try :
 				renderScene = GafferScene.SceneAlgo.sourceScene( view["in"] )
 			except :

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -256,7 +256,7 @@ def __lightLinksSubMenu( view ) :
 
 	selectedObjects = view.viewportGadget().getPrimaryChild().getSelection()
 	if not selectedObjects.isEmpty() :
-		with view.getContext() :
+		with view.context() :
 			selectedLights = view["in"].set( "__lights" ).value.intersection( selectedObjects )
 		selectedObjects.removePaths( selectedLights )
 	else :
@@ -266,7 +266,7 @@ def __lightLinksSubMenu( view ) :
 		"Select Linked Objects",
 		{
 			"command" : functools.partial(
-				__selectLinked, context = view.getContext(), title = "Selecting Linked Objects",
+				__selectLinked, context = view.context(), title = "Selecting Linked Objects",
 				linkingQuery = functools.partial( GafferScene.SceneAlgo.linkedObjects, view["in"], selectedLights )
 			),
 			"active" : not selectedLights.isEmpty(),
@@ -277,7 +277,7 @@ def __lightLinksSubMenu( view ) :
 		"Select Linked Lights",
 		{
 			"command" : functools.partial(
-				__selectLinked, context = view.getContext(), title = "Selecting Linked Lights",
+				__selectLinked, context = view.context(), title = "Selecting Linked Lights",
 				linkingQuery = functools.partial( GafferScene.SceneAlgo.linkedLights, view["in"], selectedObjects )
 			),
 			"active" : not selectedObjects.isEmpty(),

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -360,6 +360,8 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			self.__popup.popup( parent = self )
 			return
 
+		## \todo Perhaps we should add `ScriptNodeAlgo.set/getCurrentRenderPass()`
+		# to wrap this up for general consumption?
 		if "renderPass" not in script["variables"] :
 			renderPassPlug = Gaffer.NameValuePlug( "renderPass", "", "renderPass", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
 			script["variables"].addChild( renderPassPlug )
@@ -367,9 +369,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		else :
 			renderPassPlug = script["variables"]["renderPass"]
 
-		with Gaffer.Context( self.getContext() ) :
-			currentRenderPass = renderPassPlug["value"].getValue()
-
+		currentRenderPass = renderPassPlug["value"].getValue()
 		renderPassPlug["value"].setValue( selectedPassNames[0] if selectedPassNames[0] != currentRenderPass else "" )
 
 	def __columnContextMenuSignal( self, column, pathListing, menuDefinition ) :

--- a/python/GafferSceneUI/SceneHistoryUI.py
+++ b/python/GafferSceneUI/SceneHistoryUI.py
@@ -54,7 +54,7 @@ def appendViewContextMenuItems( viewer, view, menuDefinition ) :
 		{
 			"subMenu" : functools.partial(
 				__historySubMenu,
-				context = view.getContext(),
+				context = view.context(),
 				scene = view["in"],
 				selectedPath = __sceneViewSelectedPath( view )
 			)
@@ -186,12 +186,12 @@ def __viewerKeyPress( viewer, event ) :
 	if event == __editSourceKeyPress :
 		selectedPath = __sceneViewSelectedPath( view )
 		if selectedPath is not None :
-			__editSourceNode( view.getContext(), view["in"], selectedPath )
+			__editSourceNode( view.context(), view["in"], selectedPath )
 		return True
 	elif event == __editTweaksKeyPress :
 		selectedPath = __sceneViewSelectedPath( view )
 		if selectedPath is not None :
-			__editTweaksNode( view.getContext(), view["in"], selectedPath )
+			__editTweaksNode( view.context(), view["in"], selectedPath )
 		return True
 
 def __hierarchyViewKeyPress( hierarchyView, event ) :

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -842,7 +842,7 @@ class _CameraPlugValueWidget( GafferUI.PlugValueWidget ) :
 			self.getPlug()["lookThroughCamera"],
 			path = GafferScene.ScenePath(
 				self.getPlug().node()["in"],
-				self.getPlug().node().getContext(),
+				self.getPlug().node().context(),
 				"/",
 				filter = self.__pathFilter()
 			),
@@ -1112,7 +1112,7 @@ def __snapshotToCatalogue( catalogue, view ) :
 	metadata = IECore.CompoundData(
 		{
 			"gaffer:sourceScene" : view["in"].getInput().relativeName( scriptRoot ),
-			"gaffer:context:frame" : view["in"].node().getContext().getFrame()
+			"gaffer:context:frame" : view.context().getFrame()
 		}
 	)
 

--- a/python/GafferSceneUI/TransformToolUI.py
+++ b/python/GafferSceneUI/TransformToolUI.py
@@ -138,9 +138,9 @@ class _SelectionWidget( GafferUI.Frame ) :
 
 		self.__update()
 
-	def context( self ) :
+	def scriptNode( self ) : # For LazyMethod's `deferUntilPlaybackStops`
 
-		return self.ancestor( GafferUI.NodeToolbar ).context()
+		return self.__tool.ancestor( GafferUI.View ).scriptNode()
 
 	def getToolTip( self ) :
 

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -76,11 +76,6 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 
 		self._updateFromSet()
 
-	def _updateFromContext( self, modifiedItems ) :
-
-		if any( not k.startswith( "ui:" ) for k in modifiedItems ) :
-			self.__uvView.setContext( self.context() )
-
 	def __repr__( self ) :
 
 		return "GafferSceneUI.UVInspector( scriptNode )"

--- a/python/GafferSceneUI/UVInspector.py
+++ b/python/GafferSceneUI/UVInspector.py
@@ -52,7 +52,6 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 		self.__uvView = GafferSceneUI.UVView( scriptNode )
 		self.__uvView["in"].setInput( self.settings()["in"] )
 		Gaffer.NodeAlgo.applyUserDefaults( self.__uvView )
-		self.__uvView.setContext( self.context() )
 
 		with column :
 
@@ -76,6 +75,11 @@ class UVInspector( GafferSceneUI.SceneEditor ) :
 		)
 
 		self._updateFromSet()
+
+	def _updateFromContext( self, modifiedItems ) :
+
+		if any( not k.startswith( "ui:" ) for k in modifiedItems ) :
+			self.__uvView.setContext( self.context() )
 
 	def __repr__( self ) :
 

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -273,7 +273,7 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		self.assertEqual( getViewCameraTransform(), imath.M44f().translate( imath.V3f( 200, 0, 0 ) ) )
 
 		# Change the viewer context - since look-through is disabled the user camera should not move.
-		viewer.getContext().setFrame( 10 )
+		script.context().setFrame( 10 )
 		self.waitForIdle( 100 )
 		self.assertEqual( getViewCameraTransform(), imath.M44f().translate( imath.V3f( 200, 0, 0 ) ) )
 

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -84,7 +84,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( script, IECore.PathMatcher( [ "/group/plane" ] ) )
 		self.assertEqual( len( tool.selection() ), 1 )
 		self.assertEqual( tool.selection()[0].path(), "/group/plane" )
-		self.assertEqual( tool.selection()[0].context(), view.getContext() )
+		self.assertEqual( tool.selection()[0].context(), view.context() )
 		self.assertTrue( tool.selection()[0].upstreamScene().isSame( script["plane"]["out"] ) )
 		self.assertEqual( tool.selection()[0].upstreamPath(), "/plane" )
 		self.assertTrue( tool.selection()[0].editTarget().isSame( script["plane"]["transform"] ) )
@@ -93,7 +93,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( script, IECore.PathMatcher( [ "/group" ] ) )
 		self.assertEqual( tool.selection()[0].path(), "/group" )
-		self.assertEqual( tool.selection()[0].context(), view.getContext() )
+		self.assertEqual( tool.selection()[0].context(), view.context() )
 		self.assertTrue( tool.selection()[0].upstreamScene().isSame( script["group"]["out"] ) )
 		self.assertEqual( tool.selection()[0].upstreamPath(), "/group" )
 		self.assertTrue( tool.selection()[0].editTarget().isSame( script["group"]["transform"] ) )
@@ -110,7 +110,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		script["transformFilter"]["enabled"].setValue( True )
 		self.assertEqual( tool.selection()[0].path(), "/group" )
-		self.assertEqual( tool.selection()[0].context(), view.getContext() )
+		self.assertEqual( tool.selection()[0].context(), view.context() )
 		self.assertTrue( tool.selection()[0].upstreamScene().isSame( script["transform"]["out"] ) )
 		self.assertEqual( tool.selection()[0].upstreamPath(), "/group" )
 		self.assertTrue( tool.selection()[0].editTarget().isSame( script["transform"]["transform"] ) )
@@ -1254,7 +1254,7 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 		with Gaffer.UndoScope( script ) :
 			tool.translate( imath.V3f( 10, 0, 0 ) )
 
-		with view.getContext() :
+		with view.context() :
 			self.assertEqual( script["editScope"]["out"].transform( "/cube" ).translation(), imath.V3f( 10, 0, 0 ) )
 			self.assertEqual( script["editScope"]["out"].transform( "/cube1" ).translation(), imath.V3f( 10, 0, 0 ) )
 			self.assertEqual( script["editScope"]["out"].transform( "/cube2" ).translation(), imath.V3f( 10, 0, 0 ) )

--- a/python/GafferUI/LazyMethod.py
+++ b/python/GafferUI/LazyMethod.py
@@ -46,6 +46,9 @@ class LazyMethod( object ) :
 
 	__PendingCall = collections.namedtuple( "__PendingCall", [ "args", "kw" ] )
 
+	# Using `deferUntilPlaybackStops` requires that the widget has a
+	# `scriptNode()` method that returns the appropriate ScriptNode from which
+	# to acquire a Playback object.
 	def __init__( self, deferUntilVisible = True, deferUntilIdle = True, deferUntilPlaybackStops = False, replacePendingCalls = True ) :
 
 		self.__deferUntilVisible = deferUntilVisible
@@ -124,14 +127,9 @@ class LazyMethod( object ) :
 	@classmethod
 	def __playback( cls, widget ) :
 
-		context = None
-		with IECore.IgnoredExceptions( AttributeError ) :
-			context = widget.context()
-		if context is None :
-			with IECore.IgnoredExceptions( AttributeError ) :
-				context = widget.getContext()
-
-		return GafferUI.Playback.acquire( context )
+		return GafferUI.Playback.acquire(
+			widget.scriptNode().context()
+		)
 
 	@classmethod
 	def __visibilityChanged( cls, widget, method ) :

--- a/python/GafferUI/NodeToolbar.py
+++ b/python/GafferUI/NodeToolbar.py
@@ -50,9 +50,7 @@ class NodeToolbar( GafferUI.Widget ) :
 		GafferUI.Widget.__init__( self, topLevelWidget, **kw )
 
 		self.__node = node
-
-		scriptNode = self.__node.scriptNode()
-		self.__context = GafferUI.PlugValueWidget._PlugValueWidget__defaultContext( node )
+		self.__contextTracker = GafferUI.ContextTracker.acquireForFocus( self.__node )
 
 	## Returns the node the toolbar represents.
 	def node( self ) :
@@ -62,7 +60,7 @@ class NodeToolbar( GafferUI.Widget ) :
 	## Returns the context in which the toolbar shows its plugs.
 	def context( self ) :
 
-		return self.__context
+		return self.__contextTracker.context( self.__node )
 
 	## Creates a NodeToolbar instance for the specified node and edge.
 	# Note that not all nodes have toolbars, so None may be returned.

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -137,17 +137,15 @@ class PlugLayout( GafferUI.Widget ) :
 		self.__rootSection = _Section( self.__parent )
 
 		# Set up an appropriate context in which to view the plugs.
-		self.__context = GafferUI.PlugValueWidget._PlugValueWidget__defaultContext( self.__parent )
-		self.__contextChangedConnection = self.__context.changedSignal().connect(
-			Gaffer.WeakMethod( self.__contextChanged ), scoped = True
-		)
+		self.__contextTracker = GafferUI.ContextTracker.acquireForFocus( parent )
+		self.__contextTracker.changedSignal( parent ).connect( Gaffer.WeakMethod( self.__contextChanged ) )
 
 		# Build the layout
 		self.__update()
 
 	def context( self ) :
 
-		return self.__context
+		return self.__contextTracker.context( self.__parent )
 
 	## Returns a PlugValueWidget representing the specified child plug.
 	def plugValueWidget( self, childPlug ) :
@@ -526,7 +524,7 @@ class PlugLayout( GafferUI.Widget ) :
 		self.__summariesDirty = True
 		self.__updateLazily()
 
-	def __contextChanged( self, context, name ) :
+	def __contextChanged( self, contextTracker ) :
 
 		self.__activationsDirty = True
 		self.__summariesDirty = True

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -611,8 +611,10 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 	def __plugInputChanged( self, plug ) :
 
-		if plug in self.__plugs :
+		if plug in self.__plugs or any( plug in plugs for plugs in self.__auxiliaryPlugs ) :
 			self.__updateContextConnection()
+
+		if plug in self.__plugs :
 			self._updateFromEditable()
 
 	def __plugMetadataChanged( self, plug, key, reason ) :
@@ -696,6 +698,10 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		self.__auxiliaryPlugDirtiedConnections = [
 			node.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__auxiliaryPlugDirtied ), scoped = True )
+			for node in auxiliaryNodes
+		]
+		self.__auxiliaryPlugInputChangedConnections = [
+			node.plugInputChangedSignal().connect( Gaffer.WeakMethod( self.__plugInputChanged ), scoped = True )
 			for node in auxiliaryNodes
 		]
 

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -725,34 +725,6 @@ class PlugValueWidget( GafferUI.Widget ) :
 		else :
 			self.__contextChangedConnection = None
 
-	__fallbackContext = Gaffer.Context()
-
-	# Note : Despite being private (because we don't want to include it in the official API),
-	# This method is accessed by NodeToolbar and PlugLayout (because we do want to share the
-	# logic internally).
-	@classmethod
-	def __defaultContext( cls, graphComponent ) :
-
-		scriptNode = graphComponent if isinstance( graphComponent, Gaffer.ScriptNode ) else graphComponent.ancestor( Gaffer.ScriptNode )
-		if scriptNode is not None :
-			return scriptNode.context()
-
-		# Special case for plugs that form the settings for a view.
-
-		view = graphComponent if isinstance( graphComponent, GafferUI.View ) else graphComponent.ancestor( GafferUI.View )
-		if view is not None :
-			return view.getContext()
-
-		# Special case for plugs that form the settings for an Editor.
-
-		settings = graphComponent if isinstance( graphComponent, GafferUI.Editor.Settings ) else graphComponent.ancestor( GafferUI.Editor.Settings )
-		if settings is not None :
-			scriptNode = settings["__scriptNode"].source().ancestor( Gaffer.ScriptNode )
-			if scriptNode is not None :
-				return scriptNode.context()
-
-		return cls.__fallbackContext
-
 	def __buttonPress( self, widget, event, buttonMask ) :
 
 		if event.buttons & buttonMask :

--- a/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableModel.py
@@ -68,7 +68,7 @@ class _PlugTableModel( QtCore.QAbstractTableModel ) :
 		self.__columnRemovedConnection = rowsPlug.defaultRow()["cells"].childRemovedSignal().connect( Gaffer.WeakMethod( self.__columnRemoved ), scoped = True )
 		self.__plugMetadataChangedConnection = Gaffer.Metadata.plugValueChangedSignal( rowsPlug.node() ).connect( Gaffer.WeakMethod( self.__plugMetadataChanged ), scoped = True )
 
-		self.__contextTracker = GafferUI.ContextTracker.acquireForFocus( rowsPlug.node().scriptNode() )
+		self.__contextTracker = GafferUI.ContextTracker.acquireForFocus( rowsPlug )
 		self.__contextTrackerChangedConnection = self.__contextTracker.changedSignal().connect( Gaffer.WeakMethod( self.__contextTrackerChanged ), scoped = True )
 		self.__context = None
 		self.__contextTrackerChanged( self.__contextTracker )

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -202,7 +202,6 @@ class Viewer( GafferUI.NodeSetEditor ) :
 						self.__currentView = GafferUI.View.create( plug )
 						if self.__currentView is not None:
 							Gaffer.NodeAlgo.applyUserDefaults( self.__currentView )
-							self.__currentView.setContext( self.context() )
 							self.__views.append( self.__currentView )
 					# if we succeeded in getting a suitable view, then
 					# don't bother checking the other plugs
@@ -227,14 +226,6 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			self.__updateViewportMessage()
 
 		self.__primaryToolChanged()
-
-	def _updateFromContext( self, modifiedItems ) :
-
-		if all( k.startswith( "ui:" ) for k in modifiedItems ) :
-			return
-
-		for view in self.__views :
-			view.setContext( self.context() )
 
 	def _titleFormat( self ) :
 

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -60,6 +60,21 @@ import IECoreGL
 # without modifying the Views themselves.
 class Viewer( GafferUI.NodeSetEditor ) :
 
+	class Settings( GafferUI.Editor.Settings ) :
+
+		def __init__( self ) :
+
+			GafferUI.Editor.Settings.__init__( self )
+
+			# Receives input from the node being viewed, allowing
+			# `Editor.context()` to get the right context from the
+			# ContextTracker.
+			## \todo Can we centralise this and the behaviour of
+			# SceneEditor in NodeSetEditor?
+			self["in"] = Gaffer.Plug()
+
+	IECore.registerRunTimeTyped( Settings, typeName = "GafferUI::Viewer::Settings" )
+
 	def __init__( self, scriptNode, **kw ) :
 
 		self.__gadgetWidget = GafferUI.GadgetWidget()
@@ -194,6 +209,10 @@ class Viewer( GafferUI.NodeSetEditor ) :
 					if self.__currentView is not None :
 						break
 
+		self.settings()["in"].setInput(
+			self.__currentView["in"].getInput() if self.__currentView is not None else None
+		)
+
 		for toolbar in self.__nodeToolbars :
 			toolbar.setNode( node )
 
@@ -208,6 +227,14 @@ class Viewer( GafferUI.NodeSetEditor ) :
 			self.__updateViewportMessage()
 
 		self.__primaryToolChanged()
+
+	def _updateFromContext( self, modifiedItems ) :
+
+		if all( k.startswith( "ui:" ) for k in modifiedItems ) :
+			return
+
+		for view in self.__views :
+			view.setContext( self.context() )
 
 	def _titleFormat( self ) :
 

--- a/python/GafferUITest/ContextTrackerTest.py
+++ b/python/GafferUITest/ContextTrackerTest.py
@@ -734,6 +734,30 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 			tracker = GafferUI.ContextTracker.acquireForFocus( script )
 		self.assertTrue( tracker.isTracked( script["node"] ) )
 
+	def testAcquireForFocusFromViewAndEditor( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["add"] = GafferTest.AddNode()
+		contextTracker = GafferUI.ContextTracker.acquireForFocus( script )
+
+		editor = GafferUI.Editor( GafferUI.Label( "TestEditor" ), script )
+		editor.settings()["testPlug"] = Gaffer.StringPlug()
+		self.assertTrue(
+			GafferUI.ContextTracker.acquireForFocus( editor.settings() ).isSame( contextTracker )
+		)
+		self.assertTrue(
+			GafferUI.ContextTracker.acquireForFocus( editor.settings()["testPlug"] ).isSame( contextTracker )
+		)
+
+		view = GafferUITest.ViewTest.MyView( script )
+		view["testPlug"] = Gaffer.StringPlug()
+		self.assertTrue(
+			GafferUI.ContextTracker.acquireForFocus( view ).isSame( contextTracker )
+		)
+		self.assertTrue(
+			GafferUI.ContextTracker.acquireForFocus( view["testPlug"] ).isSame( contextTracker )
+		)
+
 	def testAcquireNone( self ) :
 
 		tracker1 = GafferUI.ContextTracker.acquire( None )

--- a/python/GafferUITest/ContextTrackerTest.py
+++ b/python/GafferUITest/ContextTrackerTest.py
@@ -991,5 +991,114 @@ class ContextTrackerTest( GafferUITest.TestCase ) :
 		self.assertTrue( tracker.isEnabled( script["tracked" ] ) )
 		self.assertFalse( tracker.isEnabled( script["untracked" ] ) )
 
+	def testContextForEditorSettings( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["node"] = GafferTest.AddNode()
+
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["node"]["sum"] )
+		script["contextVariables"]["in"].setInput( script["node"]["sum"] )
+		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "testVariable", True ) )
+
+		script.setFocus( script["contextVariables"] )
+
+		editor = GafferUI.Editor( GafferUI.Label( "TestEditor" ), script )
+		editor.settings()["in"] = Gaffer.IntPlug()
+		editor.settings()["testPlug"] = Gaffer.StringPlug()
+
+		with self.UpdateHandler() :
+			tracker = GafferUI.ContextTracker.acquireForFocus( script )
+
+		self.assertIn( "testVariable", tracker.context( script["node"] ) )
+		self.assertNotIn( "testVariable", tracker.context( script["contextVariables"] ) )
+
+		# No node being viewed.
+
+		for plug in ( editor.settings()["in"], editor.settings()["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), script.context() )
+
+		# Node being viewed. We want to take the context from that.
+
+		genericChangedSlot = GafferTest.CapturingSlot( tracker.changedSignal() )
+		specificChangedSlot = GafferTest.CapturingSlot( tracker.changedSignal( editor.settings()["testPlug" ] ) )
+
+		editor.settings()["in"].setInput( script["node"]["sum"] )
+
+		self.assertEqual( len( genericChangedSlot ), 0 )
+		self.assertEqual( len( specificChangedSlot ), 1 )
+
+		for plug in ( editor.settings()["in"], editor.settings()["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), tracker.context( script["node"] ) )
+
+		# Edit the context. This should also emit the editor-specific signal.
+
+		with self.UpdateHandler() :
+			script["contextVariables"]["variables"][0]["value"].setValue( False )
+
+		self.assertEqual( len( genericChangedSlot ), 1 )
+		self.assertEqual( len( specificChangedSlot ), 2 )
+
+		for plug in ( editor.settings()["in"], editor.settings()["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), tracker.context( script["node"] ) )
+
+	def testContextForView( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["node"] = GafferTest.AddNode()
+
+		script["contextVariables"] = Gaffer.ContextVariables()
+		script["contextVariables"].setup( script["node"]["sum"] )
+		script["contextVariables"]["in"].setInput( script["node"]["sum"] )
+		script["contextVariables"]["variables"].addChild( Gaffer.NameValuePlug( "testVariable", True ) )
+
+		script.setFocus( script["contextVariables"] )
+
+		view = GafferUITest.ViewTest.MyView( script )
+		view["testPlug"] = Gaffer.StringPlug()
+
+		with self.UpdateHandler() :
+			tracker = GafferUI.ContextTracker.acquireForFocus( script )
+
+		self.assertIn( "testVariable", tracker.context( script["node"] ) )
+		self.assertNotIn( "testVariable", tracker.context( script["contextVariables"] ) )
+
+		# No node being viewed.
+
+		for plug in ( view["in"], view["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), script.context() )
+
+		# Node being viewed. We want to take the context from that.
+
+		genericChangedSlot = GafferTest.CapturingSlot( tracker.changedSignal() )
+		specificChangedSlot = GafferTest.CapturingSlot( tracker.changedSignal( view["testPlug" ] ) )
+
+		view["in"].setInput( script["node"]["sum"] )
+
+		self.assertEqual( len( genericChangedSlot ), 0 )
+		self.assertEqual( len( specificChangedSlot ), 1 )
+
+		for plug in ( view["in"], view["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), tracker.context( script["node"] ) )
+
+		# Edit the context. This should also emit the view-specific signal.
+
+		with self.UpdateHandler() :
+			script["contextVariables"]["variables"][0]["value"].setValue( False )
+
+		self.assertEqual( len( genericChangedSlot ), 1 )
+		self.assertEqual( len( specificChangedSlot ), 2 )
+
+		for plug in ( view["in"], view["testPlug"] ) :
+			self.assertFalse( tracker.isTracked( plug ) )
+			self.assertEqual( tracker.context( plug ), tracker.context( script["node"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/EditorTest.py
+++ b/python/GafferUITest/EditorTest.py
@@ -70,7 +70,8 @@ class EditorTest( GafferUITest.TestCase ) :
 		editor = GafferUI.Viewer( s )
 
 		self.assertTrue( editor.scriptNode().isSame( s ) )
-		self.assertTrue( editor.context().isSame( s.context() ) )
+		self.assertEqual( editor.context(), s.context() )
+		self.assertFalse( editor.context().isSame( s.context() ) )
 
 	def testSerialisation( self ) :
 

--- a/python/GafferUITest/LazyMethodTest.py
+++ b/python/GafferUITest/LazyMethodTest.py
@@ -47,14 +47,14 @@ class LazyMethodTest( GafferUITest.TestCase ) :
 
 			GafferUI.TextWidget.__init__( self, **kw )
 
-			self.__context = Gaffer.Context()
+			self.__scriptNode = Gaffer.ScriptNode()
 
 		## To use deferUntilPlaybackStops, the widget must
-		# have a context() or getContext() method which
-		# provides the context in which it works.
-		def context( self ) :
+		# have a `scriptNode()` method from which a Playback
+		# object can be acquired.
+		def scriptNode( self ) :
 
-			return self.__context
+			return self.__scriptNode
 
 		@GafferUI.LazyMethod()
 		def setTextLazily( self, text ) :
@@ -141,7 +141,7 @@ class LazyMethodTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 1 )
 		self.assertEqual( w.getText(), "t" )
 
-		p = GafferUI.Playback.acquire( w.context() )
+		p = GafferUI.Playback.acquire( w.scriptNode().context() )
 
 		p.setState( p.State.PlayingForwards )
 

--- a/python/GafferUITest/StandardNodeToolbarTest.py
+++ b/python/GafferUITest/StandardNodeToolbarTest.py
@@ -72,7 +72,7 @@ class StandardNodeToolbarTest( GafferUITest.TestCase ) :
 			widget = toolbar._StandardNodeToolbar__layout.plugValueWidget( plug )
 			GafferUITest.PlugValueWidgetTest.waitForUpdate( widget )
 			self.assertEqual( widget.updateCount, 1 )
-			self.assertTrue( widget.updateContexts[0].isSame( script.context() ) )
+			self.assertEqual( widget.updateContexts[0], script.context() )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferUITest/StandardNodeToolbarTest.py
+++ b/python/GafferUITest/StandardNodeToolbarTest.py
@@ -56,7 +56,6 @@ class StandardNodeToolbarTest( GafferUITest.TestCase ) :
 
 		view = GafferUITest.ViewTest.MyView( script )
 		view["in"].setInput( script["node"]["op1"] )
-		view.setContext( script.context() )
 		view["testPlug"] = Gaffer.IntPlug()
 		Gaffer.Metadata.registerValue(
 			view["testPlug"], "plugValueWidget:type",

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -363,7 +363,7 @@ const GafferImage::ImagePlug *ImageGadget::getImage() const
 	return m_image.get();
 }
 
-void ImageGadget::setContext( Gaffer::ContextPtr context )
+void ImageGadget::setContext( Gaffer::ConstContextPtr context )
 {
 	if( context == m_context )
 	{
@@ -371,14 +371,11 @@ void ImageGadget::setContext( Gaffer::ContextPtr context )
 	}
 
 	m_context = context;
-	m_contextChangedConnection = m_context->changedSignal().connect( boost::bind( &ImageGadget::contextChanged, this, ::_2 ) );
+	m_contextChangedConnection = const_cast<Context *>( m_context.get() )->changedSignal().connect(
+		boost::bind( &ImageGadget::contextChanged, this, ::_2 )
+	);
 
 	dirty( AllDirty );
-}
-
-Gaffer::Context *ImageGadget::getContext()
-{
-	return m_context.get();
 }
 
 const Gaffer::Context *ImageGadget::getContext() const

--- a/src/GafferImageUI/ImageView.cpp
+++ b/src/GafferImageUI/ImageView.cpp
@@ -1508,6 +1508,7 @@ ImageView::ImageView( Gaffer::ScriptNodePtr scriptNode )
 
 	// connect up to some signals
 
+	contextChangedSignal().connect( boost::bind( &ImageView::contextChanged, this ) );
 	plugSetSignal().connect( boost::bind( &ImageView::plugSet, this, ::_1 ) );
 	viewportGadget()->keyPressSignal().connect( boost::bind( &ImageView::keyPress, this, ::_2 ) );
 	viewportGadget()->preRenderSignal().connect( boost::bind( &ImageView::preRender, this ) );
@@ -1516,7 +1517,7 @@ ImageView::ImageView( Gaffer::ScriptNodePtr scriptNode )
 	// hard work of actually displaying the image.
 
 	m_imageGadgets[0]->setImage( preprocessedInPlug<ImagePlug>() );
-	m_imageGadgets[0]->setContext( getContext() );
+	m_imageGadgets[0]->setContext( context() );
 
 	m_comparisonSelect = new Gaffer::ContextVariables( "__comparisonSelect" );
 	addChild( m_comparisonSelect );
@@ -1527,7 +1528,7 @@ ImageView::ImageView( Gaffer::ScriptNodePtr scriptNode )
 	m_comparisonSelect->variablesPlug()->addChild( new NameValuePlug( "imageView:__useComparisonImage",  new StringData( "True" ), true ) );
 
 	m_imageGadgets[1]->setImage( IECore::runTimeCast<GafferImage::ImagePlug>( m_comparisonSelect->outPlug() ) );
-	m_imageGadgets[1]->setContext( getContext() );
+	m_imageGadgets[1]->setContext( context() );
 	m_imageGadgets[1]->setLabelsVisible( false );
 	m_imageGadgets[1]->setVisible( false );
 	viewportGadget()->addChild( m_imageGadgets[1] );
@@ -1684,11 +1685,10 @@ const ImageGadget *ImageView::imageGadget() const
 	return m_imageGadgets[0].get();
 }
 
-void ImageView::setContext( Gaffer::ContextPtr context )
+void ImageView::contextChanged()
 {
-	View::setContext( context );
-	m_imageGadgets[0]->setContext( context );
-	m_imageGadgets[1]->setContext( context );
+	m_imageGadgets[0]->setContext( context() );
+	m_imageGadgets[1]->setContext( context() );
 }
 
 void ImageView::plugSet( Gaffer::Plug *plug )

--- a/src/GafferSceneUI/CropWindowTool.cpp
+++ b/src/GafferSceneUI/CropWindowTool.cpp
@@ -843,7 +843,7 @@ void CropWindowTool::findScenePlug()
 
 		try
 		{
-			Context::Scope scopedContext( view()->getContext() );
+			Context::Scope scopedContext( view()->context() );
 			scene = findSceneForImage( imagePlug(), msg );
 		}
 		catch( const std::exception &e )
@@ -872,7 +872,7 @@ void CropWindowTool::findCropWindowPlug()
 
 	m_cropWindowPlug = nullptr;
 
-	Context::Scope scopedContext( view()->getContext() );
+	Context::Scope scopedContext( view()->context() );
 
 	findScenePlug();
 
@@ -1012,7 +1012,7 @@ Box2f CropWindowTool::resolutionGate() const
 	{
 		if( const ImagePlug *in = imageView->inPlug<ImagePlug>() )
 		{
-			Context::Scope contextScope( imageView->getContext() );
+			Context::Scope contextScope( imageView->context() );
 			const std::string view = imageView->viewPlug()->getValue();
 			const Format format = in->format( &view );
 			resolutionGate = Box2f( V2f( 0 ), V2f( format.width() * format.getPixelAspect(), format.height() ) );

--- a/src/GafferSceneUI/ShaderView.cpp
+++ b/src/GafferSceneUI/ShaderView.cpp
@@ -174,6 +174,7 @@ ShaderView::ShaderView( Gaffer::ScriptNodePtr scriptNode )
 
 	viewportGadget()->visibilityChangedSignal().connect( boost::bind( &ShaderView::viewportVisibilityChanged, this ) );
 	viewportGadget()->preRenderSignal().connect( boost::bind( &ShaderView::preRender, this ) );
+	contextChangedSignal().connect( boost::bind( &ShaderView::contextChanged, this ) );
 	plugSetSignal().connect( boost::bind( &ShaderView::plugSet, this, ::_1 ) );
 	plugDirtiedSignal().connect( boost::bind( &ShaderView::plugDirtied, this, ::_1 ) );
 	sceneRegistrationChangedSignal().connect( boost::bind( &ShaderView::sceneRegistrationChanged, this, ::_1 ) );
@@ -210,7 +211,7 @@ std::string ShaderView::shaderPrefix() const
 {
 	IECore::ConstCompoundObjectPtr attributes;
 	{
-		Context::Scope scope( getContext() );
+		Context::Scope scope( context() );
 		attributes = inPlug<ShaderPlug>()->attributes();
 	}
 	const char *shaders[] = { "surface", "displacement", "shader", nullptr };
@@ -249,15 +250,14 @@ ShaderView::SceneChangedSignal &ShaderView::sceneChangedSignal()
 	return m_sceneChangedSignal;
 }
 
-void ShaderView::setContext( Gaffer::ContextPtr context )
-{
-	ImageView::setContext( context );
-	updateRendererContext();
-}
-
 void ShaderView::viewportVisibilityChanged()
 {
 	updateRendererState();
+}
+
+void ShaderView::contextChanged()
+{
+	updateRendererContext();
 }
 
 void ShaderView::plugSet( Gaffer::Plug *plug )
@@ -352,7 +352,7 @@ void ShaderView::updateRendererContext()
 {
 	if( m_renderer )
 	{
-		m_renderer->setContext( getContext() );
+		m_renderer->setContext( new Context( *context() ) );
 	}
 }
 
@@ -439,7 +439,7 @@ void ShaderView::preRender()
 	// we get the resolution of the upcoming render from the render
 	// globals and frame ready for that.
 
-	Context::Scope scopedContext( getContext() );
+	Context::Scope scopedContext( context() );
 	/// \todo Maybe we should wrap this up into a `SceneAlgo::resolution()`
 	/// method that also takes care of overscan, multiplier etc?
 	IECore::ConstCompoundObjectPtr globals = m_scene->getChild<ScenePlug>( "out" )->globalsPlug()->getValue();

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -854,9 +854,7 @@ TransformTool::TransformTool( SceneView *view, const std::string &name )
 	view->viewportGadget()->keyPressSignal().connect( boost::bind( &TransformTool::keyPress, this, ::_2 ) );
 	plugDirtiedSignal().connect( boost::bind( &TransformTool::plugDirtied, this, ::_1 ) );
 	view->plugDirtiedSignal().connect( boost::bind( &TransformTool::plugDirtied, this, ::_1 ) );
-
-	connectToViewContext();
-	view->contextChangedSignal().connect( boost::bind( &TransformTool::connectToViewContext, this ) );
+	view->contextChangedSignal().connect( boost::bind( &TransformTool::contextChanged, this ) );
 
 	ScriptNodeAlgo::selectedPathsChangedSignal( view->scriptNode() ).connect( boost::bind( &TransformTool::selectedPathsChanged, this ) );
 
@@ -948,19 +946,11 @@ bool TransformTool::affectsHandles( const Gaffer::Plug *input ) const
 	return input == sizePlug();
 }
 
-void TransformTool::connectToViewContext()
+void TransformTool::contextChanged()
 {
-	m_contextChangedConnection = view()->getContext()->changedSignal().connect( boost::bind( &TransformTool::contextChanged, this, ::_2 ) );
-}
-
-void TransformTool::contextChanged( const IECore::InternedString &name )
-{
-	if( !boost::starts_with( name.string(), "ui:" ) )
-	{
-		// Context changes may change the scene hierarchy or transform,
-		// which impacts on the selection and handles.
-		selectedPathsChanged();
-	}
+	// Context changes may change the scene hierarchy or transform,
+	// which impacts on the selection and handles.
+	selectedPathsChanged();
 }
 
 void TransformTool::selectedPathsChanged()
@@ -1113,7 +1103,7 @@ void TransformTool::updateSelection() const
 
 	for( PathMatcher::Iterator it = selectedPaths.begin(), eIt = selectedPaths.end(); it != eIt; ++it )
 	{
-		Selection selection( scene, *it, view()->getContext(), const_cast<EditScope *>( view()->editScope() ) );
+		Selection selection( scene, *it, view()->context(), const_cast<EditScope *>( view()->editScope() ) );
 		m_selection.push_back( selection );
 		if( *it == lastSelectedPath )
 		{

--- a/src/GafferUI/ContextTracker.cpp
+++ b/src/GafferUI/ContextTracker.cpp
@@ -309,8 +309,10 @@ void ContextTracker::scheduleUpdate()
 	// multiple times in quick succession.
 
 	m_idleConnection = Gadget::idleSignal().connect(
-		[thisRef = Ptr( this )] () {
-			thisRef->updateInBackground();
+		// OK to capture `this` without owning a reference, because
+		// `~ContextTracker` will remove the connection.
+		[this] () {
+			this->updateInBackground();
 		}
 	);
 }

--- a/src/GafferUI/ContextTracker.cpp
+++ b/src/GafferUI/ContextTracker.cpp
@@ -474,13 +474,13 @@ bool ContextTracker::isTracked( const Gaffer::Plug *plug ) const
 		return false;
 	}
 
-	auto it = m_nodeContexts.find( plug->node() );
+	auto it = m_nodeContexts.find( plug->node(), TransparentPtrHash<const Node>(), std::equal_to<>() );
 	return it != m_nodeContexts.end() && it->second.allInputsActive;
 }
 
 bool ContextTracker::isTracked( const Gaffer::Node *node ) const
 {
-	return m_nodeContexts.find( node ) != m_nodeContexts.end();
+	return m_nodeContexts.find( node, TransparentPtrHash<const Node>(), std::equal_to<>() ) != m_nodeContexts.end();
 }
 
 Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Plug *plug ) const
@@ -495,7 +495,7 @@ Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Plug *plug ) cons
 
 Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Node *node ) const
 {
-	auto it = m_nodeContexts.find( node );
+	auto it = m_nodeContexts.find( node, TransparentPtrHash<const Node>(), std::equal_to<>() );
 	if( it != m_nodeContexts.end() )
 	{
 		return it->second.context;
@@ -530,7 +530,7 @@ Gaffer::ConstContextPtr ContextTracker::context( const Gaffer::Node *node ) cons
 
 bool ContextTracker::isEnabled( const Gaffer::DependencyNode *node ) const
 {
-	auto it = m_nodeContexts.find( node );
+	auto it = m_nodeContexts.find( node, TransparentPtrHash<const Node>(), std::equal_to<>() );
 	if( it != m_nodeContexts.end() )
 	{
 		return it->second.dependencyNodeEnabled;
@@ -764,7 +764,7 @@ const Gaffer::Context *ContextTracker::findPlugContext( const Gaffer::Plug *plug
 {
 	while( plug )
 	{
-		auto it = m_plugContexts.find( plug );
+		auto it = m_plugContexts.find( plug, TransparentPtrHash<const Plug>(), std::equal_to<>() );
 		if( it != m_plugContexts.end() )
 		{
 			return it->second.get();

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -169,7 +169,6 @@ void View::setContext( Gaffer::ContextPtr context )
 		return;
 	}
 	m_context = context;
-	m_contextChangedConnection = m_context->changedSignal().connect( boost::bind( &View::contextChanged, this, ::_2 ) );
 	contextChangedSignal()( this );
 }
 
@@ -192,15 +191,6 @@ void View::setPreprocessor( Gaffer::NodePtr preprocessor )
 {
 	setChild( "__preprocessor", preprocessor );
 	preprocessor->getChild<Plug>( "in" )->setInput( inPlug() );
-}
-
-void View::contextChanged( const IECore::InternedString &name )
-{
-}
-
-Signals::Connection &View::contextChangedConnection()
-{
-	return m_contextChangedConnection;
 }
 
 View::CreatorMap &View::creators()

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -37,6 +37,8 @@
 
 #include "GafferUI/View.h"
 
+#include "GafferUI/ContextTracker.h"
+
 #include "Gaffer/Context.h"
 #include "Gaffer/EditScope.h"
 #include "Gaffer/Metadata.h"
@@ -87,14 +89,16 @@ size_t View::g_firstPlugIndex = 0;
 
 View::View( const std::string &name, Gaffer::ScriptNodePtr scriptNode, Gaffer::PlugPtr inPlug )
 	:	Node( name ),
-		m_scriptNode( scriptNode ), m_viewportGadget( new ViewportGadget )
+		m_scriptNode( scriptNode ), m_viewportGadget( new ViewportGadget ),
+		m_contextTracker( ContextTracker::acquireForFocus( scriptNode.get() ) )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	setChild( "in", inPlug );
 	addChild( new Plug( g_editScopeName ) );
 	addChild( new ToolContainer( g_toolsName ) );
-	setContext( new Context() );
 
+	m_context = m_contextTracker->context( this );
+	m_contextTracker->changedSignal( this ).connect( boost::bind( &View::contextTrackerChanged, this ) );
 	tools()->childAddedSignal().connect( boost::bind( &View::toolsChildAdded, this, ::_2 ) );
 }
 
@@ -152,24 +156,9 @@ const Gaffer::EditScope *View::editScope() const
 	return p ? p->parent<EditScope>() : nullptr;
 }
 
-Gaffer::Context *View::getContext()
+const Gaffer::Context *View::context() const
 {
 	return m_context.get();
-}
-
-const Gaffer::Context *View::getContext() const
-{
-	return m_context.get();
-}
-
-void View::setContext( Gaffer::ContextPtr context )
-{
-	if( context == m_context )
-	{
-		return;
-	}
-	m_context = context;
-	contextChangedSignal()( this );
 }
 
 View::UnarySignal &View::contextChangedSignal()
@@ -290,6 +279,16 @@ bool View::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug
 	return !script || script == scriptNode();
 }
 
+void View::contextTrackerChanged()
+{
+	ConstContextPtr context = m_contextTracker->context( this );
+	if( *m_context != *context )
+	{
+		m_context = context;
+		contextChangedSignal()( this );
+	}
+}
+
 void View::toolsChildAdded( Gaffer::GraphComponent *child )
 {
 	auto tool = static_cast<Tool *>( child ); // Type guaranteed by `ToolContainer::acceptsChild()`
@@ -374,6 +373,26 @@ RegistrationChangedSignal &registrationChangedSignal()
 
 const IECore::InternedString g_frame( "frame" );
 
+MurmurHash hashWithoutFrame( const Context *context )
+{
+	// This "sum of variable hashes" approach mirrors what `Context::hash()`
+	// does itself, and means that `ui:` prefixed variables have no effect.
+	std::vector<InternedString> names;
+	context->names( names );
+	uint64_t sumH1 = 0, sumH2 = 0;
+	for( const auto &name : names )
+	{
+		if( name == g_frame )
+		{
+			continue;
+		}
+		const MurmurHash vh = context->variableHash( name );
+		sumH1 += vh.h1();
+		sumH2 += vh.h2();
+	}
+	return MurmurHash( sumH1, sumH2 );
+}
+
 } // namespace
 
 size_t View::DisplayTransform::g_firstPlugIndex = 0;
@@ -431,9 +450,8 @@ View::DisplayTransform::DisplayTransform( View *view )
 	);
 
 	view->contextChangedSignal().connect(
-		boost::bind( &DisplayTransform::connectToViewContext, this )
+		boost::bind( &DisplayTransform::contextChanged, this )
 	);
-	connectToViewContext();
 
 }
 
@@ -476,17 +494,12 @@ Gaffer::BoolPlug *View::DisplayTransform::absolutePlug()
 	return getChild<Gaffer::BoolPlug>( g_firstPlugIndex + 5 );
 }
 
-void View::DisplayTransform::connectToViewContext()
-{
-	m_contextChangedConnection = view()->getContext()->changedSignal().connect( boost::bind( &View::DisplayTransform::contextChanged, this, ::_2 ) );
-}
-
-void View::DisplayTransform::contextChanged( const IECore::InternedString &name )
+void View::DisplayTransform::contextChanged()
 {
 	// DisplayTransformCreators may be context-sensitive, so we need to
 	// call them again. But we can at least avoid the overhead for common
 	// changes which shouldn't affect them.
-	if( name != g_frame && !boost::starts_with( name.string(), "ui:" ) )
+	if( hashWithoutFrame( view()->context() ) != m_shaderContextHash )
 	{
 		m_shaderDirty = true;
 		view()->viewportGadget()->renderRequestSignal()( view()->viewportGadget() );
@@ -533,8 +546,9 @@ void View::DisplayTransform::preRender()
 			auto it = displayTransformCreators().find( name );
 			if( it != displayTransformCreators().end() )
 			{
-				Context::Scope scope( view()->getContext() );
+				Context::Scope scope( view()->context() );
 				m_shader = it->second();
+				m_shaderContextHash = hashWithoutFrame( view()->context() );
 			}
 			else
 			{

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -250,13 +250,13 @@ struct ContextTrackerSlotCaller
 	}
 };
 
-ContextPtr contextWrapper1( const ContextTracker &contextTracker, const Node &node, bool copy = false )
+ContextPtr contextWrapper1( const ContextTracker &contextTracker, const Node &node, bool copy )
 {
 	ConstContextPtr c = contextTracker.context( &node );
 	return copy ? new Context( *c ) : boost::const_pointer_cast<Context>( c );
 }
 
-ContextPtr contextWrapper2( const ContextTracker &contextTracker, const Plug &plug, bool copy = false )
+ContextPtr contextWrapper2( const ContextTracker &contextTracker, const Plug &plug, bool copy )
 {
 	ConstContextPtr c = contextTracker.context( &plug );
 	return copy ? new Context( *c ) : boost::const_pointer_cast<Context>( c );

--- a/src/GafferUIModule/GraphGadgetBinding.cpp
+++ b/src/GafferUIModule/GraphGadgetBinding.cpp
@@ -341,7 +341,8 @@ void GafferUIModule::bindGraphGadget()
 			.def( "context", &contextWrapper2, ( arg( "plug" ), arg( "_copy" ) = true ) )
 			.def( "isEnabled", &ContextTracker::isEnabled )
 			.def( "updatePending", &ContextTracker::updatePending )
-			.def( "changedSignal", &ContextTracker::changedSignal, return_internal_reference<1>() )
+			.def( "changedSignal", (ContextTracker::Signal &(ContextTracker::*)())&ContextTracker::changedSignal, return_internal_reference<1>() )
+			.def( "changedSignal", (ContextTracker::Signal &(ContextTracker::*)( GraphComponent * ))&ContextTracker::changedSignal, return_internal_reference<1>() )
 		;
 
 		SignalClass<ContextTracker::Signal, DefaultSignalCaller<ContextTracker::Signal>, ContextTrackerSlotCaller>( "Signal" );

--- a/src/GafferUIModule/ViewBinding.cpp
+++ b/src/GafferUIModule/ViewBinding.cpp
@@ -59,6 +59,12 @@ using namespace GafferUI;
 namespace
 {
 
+ContextPtr contextWrapper( const View &view, bool copy )
+{
+	ConstContextPtr c = view.context();
+	return copy ? new Context( *c ) : boost::const_pointer_cast<Context>( c );
+}
+
 class ViewWrapper : public GafferBindings::NodeWrapper<View>
 {
 
@@ -153,8 +159,7 @@ void bindView()
 		.def( init<const std::string &, ScriptNodePtr, PlugPtr>() )
 		.def( "scriptNode", (ScriptNode *(View::*)())&View::scriptNode, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "editScope", (EditScope *(View::*)())&View::editScope, return_value_policy<IECorePython::CastToIntrusivePtr>() )
-		.def( "getContext", (Context *(View::*)())&View::getContext, return_value_policy<IECorePython::CastToIntrusivePtr>() )
-		.def( "setContext", &View::setContext )
+		.def( "context", &contextWrapper, ( arg( "_copy" ) = true ) )
 		.def( "contextChangedSignal", &View::contextChangedSignal, return_internal_reference<1>() )
 		.def( "viewportGadget", (ViewportGadget *(View::*)())&View::viewportGadget, return_value_policy<IECorePython::CastToIntrusivePtr>() )
 		.def( "_setPreprocessor", &View::setPreprocessor )

--- a/startup/GafferUI/getContextCompatibility.py
+++ b/startup/GafferUI/getContextCompatibility.py
@@ -47,3 +47,4 @@ GafferUI.PlugValueWidget.getContext = getContext
 GafferUI.PlugLayout.getContext = getContext
 GafferUI.Editor.getContext = getContext
 GafferUI.NodeToolbar.getContext = getContext
+GafferUI.View.getContext = getContext


### PR DESCRIPTION
This updates PlugLayout, NodeToolbar, PlugValueWidget, Editor and View to use contexts provided by ContextTracker, making the vast majority of the UI "focus aware". Inevitably this requires quite a lot of code changes, but I've tried to break them up into manageable chunks for review. I find it reasonably reassuring that, if anything, Views and Tools have slightly simpler context handling implementations now, despite the result being more advanced conceptually.

This won't be the last PR on this topic, but it does represent the lion's share of the remaining work. I've still got various UI niceties I want to add, and I think there are also at least two knock-on effects I need to deal with from this PR :

- _HistoryWindow is connecting to `Context.changedSignal()`, which is now a bit of a "code smell". I think it will also need updating to use a ContextTracker.
- DisplayTransformPlugValueWidget is also connecting to `Context.changedSignal()`, and will need rejigging to ensure a valid value using a different approach.

Rather than wait for those and make this PR even bigger, I felt it was worth getting some :eyes: on it sooner and then deal with the stragglers separately.