### PR TITLE
Wrapper : Set `PYTHONNOUSERSITE=1`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -57,6 +57,7 @@ Fixes
 - usdview : Added Windows support (#5599).
 - ContextTracker : Removed unnecessary reference increment/decrement from `isTracked()`, `context()` and `isEnabled()`.
 - Menu : Fixed bug causing a menu item's tooltip to not hide when moving the cursor to another menu item without a tooltip.
+- Python : Fixed startup failures caused by conflicting Python modules in the user `site-packages` directory.
 
 API
 ---
@@ -117,6 +118,7 @@ Breaking Changes
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed (this is more correct, but it is a change in behaviour).
 - ImageGadget : Remove non-const variant of `getContext()`.
 - LazyMethod : `deferUntilPlaybackStops` now requires that the Widget has a `scriptNode()` method rather than a `context()` method.
+- Python : Gaffer now disables the user site-packages directory by setting `PYTHONNOUSERSITE=1`. To revert to the previous behaviour, set `PYTHONNOUSERSITE=0` before launching Gaffer.
 
 Build
 -----

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -170,6 +170,15 @@ fi
 
 prependToPath "$GAFFER_ROOT/python" PYTHONPATH
 
+if [[ -z $PYTHONNOUSERSITE ]] ; then
+	# Prevent Python automatically adding a user-level `site-packages`
+	# directory to the `sys.path`. These frequently contain modules which
+	# conflict with our own. Users who know what they are doing can set
+	# `PYTHONNOUSERSITE=0` before running Gaffer if they want to use
+	# the user directory.
+	export PYTHONNOUSERSITE=1
+fi
+
 # Stop Cortex from making all Python modules load with RTLD_GLOBAL.
 export IECORE_RTLD_GLOBAL=0
 

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -48,6 +48,15 @@ set PYTHONHOME=%GAFFER_ROOT%
 
 call :prependToPath "%GAFFER_ROOT%\python" PYTHONPATH
 
+if "%PYTHONNOUSERSITE%" EQU "" (
+	REM Prevent Python automatically adding a user-level `site-packages`
+	REM directory to the `sys.path`. These frequently contain modules which
+	REM conflict with our own. Users who know what they are doing can set
+	REM `PYTHONNOUSERSITE=0` before running Gaffer if they want to use
+	REM the user directory.
+	set PYTHONNOUSERSITE=1
+)
+
 call :prependToPath "%GAFFER_ROOT%\lib" PATH
 
 set QT_OPENGL=desktop


### PR DESCRIPTION
This removes a common cause of conflicts between Gaffer and Python modules the user has installed using the system Python. Users who know what they are doing and want to use those modules in Gaffer can set `PYTHONNOUSERSITE=0` before running Gaffer to get the prior behaviour.

Confession : I have not tested the `gaffer.cmd` changes - I am relying on Windows CI and review to do that.
