### PR TITLE
Visual Studio 2022 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,6 @@ jobs:
             testArguments: -excludedCategories performance GafferTest GafferVDBTest GafferUSDTest GafferSceneTest GafferDispatchTest GafferOSLTest GafferImageTest GafferUITest GafferImageUITest GafferSceneUITest GafferDispatchUITest GafferOSLUITest GafferUSDUITest GafferVDBUITest GafferDelightUITest GafferTractorTest GafferTractorUITest
             sconsCacheMegabytes: 800
             jobs: 4
-            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.9.2/cortex-10.5.9.2-windows.zip
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
             jobs: 4
 
           - name: windows
-            os: windows-2019
+            os: windows-2022
             buildType: RELEASE
             publish: true
             containerImage:
@@ -86,7 +86,7 @@ jobs:
 
     - uses: ilammy/msvc-dev-cmd@v1.13.0
       with:
-        sdk: 10.0.17763.0
+        sdk: 10.0.19041.0
 
     - name: Install toolchain (Windows)
       run: |

--- a/Changes.md
+++ b/Changes.md
@@ -117,6 +117,7 @@ Build
 - Qt : Updated to version 5.15.14.
 - USD : Updated to version 24.08.
 - Zstandard : Added version 1.5.0.
+- Windows : Update compiler to Visual Studio 2022 / MSVC 17.8 / Runtime library 14.3.
 
 1.4.x.x (relative to 1.4.12.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -46,6 +46,7 @@ Fixes
   - Fixed thread-safety bug.
 - HierarchyView, SetEditor : Fixed thread-safety bugs.
 - FreezeTransform : Constant primitive variables with point/vector interpretations are now also transformed.
+- usdview : Added Windows support (#5599).
 
 API
 ---

--- a/SConstruct
+++ b/SConstruct
@@ -377,7 +377,7 @@ options.Add( "GAFFER_VERSION_SUFFIX", "Version suffix", str( gafferVersionSuffix
 
 env = Environment(
 
-	MSVC_VERSION = "14.2",
+	MSVC_VERSION = "14.3",
 
 	options = options,
 
@@ -588,6 +588,8 @@ else:
 				"/wd4003",  # suppress warning "not enough arguments for function-like macro invocation 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'". Needed for USD.
 				"/wd4702",  # suppress warning "unreachable code". Need for OpenVDB.
 				"/wd4180",  # suppress warning "qualifier applied to function type has no meaning; ignored". Needed for OpenVDB
+				"/wd4146",  # suppress warning "unary minus operator applied to unsigned type, result still unsigned" (from Cryptomatte::MurmurHash3_x86_32())
+				"/D_CRT_NONSTDC_NO_WARNINGS",  # suppress warnings about deprecated POSIX names. The names are deprecated, not the functions, so this is safe.
 			],
 		)
 

--- a/SConstruct
+++ b/SConstruct
@@ -1289,7 +1289,7 @@ libraries = {
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferOSL"
 			] + cyclesLibraries + [
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "oslquery$OSL_LIB_SUFFIX",
-				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
+				"openvdb$VDB_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl", "zstd",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : cyclesDefines,
@@ -1301,7 +1301,7 @@ libraries = {
 				"Gaffer", "GafferScene", "GafferDispatch", "GafferBindings", "GafferCycles", "IECoreScene",
 			] + ( cyclesLibraries if includeCyclesLibrariesInPythonModule else [] ) + [
 				"OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", "oslexec$OSL_LIB_SUFFIX", "openvdb$VDB_LIB_SUFFIX",
-				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl",
+				"oslquery$OSL_LIB_SUFFIX", "Alembic", "osdCPU", "OpenColorIO$OCIO_LIB_SUFFIX", "embree4", "Iex", "openpgl", "zstd",
 			],
 			"CXXFLAGS" : [ systemIncludeArgument, "$CYCLES_ROOT/include" ],
 			"CPPDEFINES" : cyclesDefines,
@@ -1454,7 +1454,7 @@ if env["PLATFORM"] == "win32" :
 
 else :
 
-	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl", "zstd" ] )
+	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl" ] )
 
 # Optionally add vTune requirements
 

--- a/src/Gaffer/MonitorAlgo.cpp
+++ b/src/Gaffer/MonitorAlgo.cpp
@@ -206,7 +206,7 @@ struct HashesPerComputeMetric
 
 // Utility for invoking a templated functor with a particular metric.
 template<typename F>
-std::result_of_t<F(const HashCountMetric &)> dispatchMetric( const F &f, MonitorAlgo::PerformanceMetric performanceMetric )
+std::invoke_result_t<F, const HashCountMetric &> dispatchMetric( const F &f, MonitorAlgo::PerformanceMetric performanceMetric )
 {
 	switch( performanceMetric )
 	{

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1571,7 +1571,7 @@ class InstanceCache : public IECore::RefCounted
 
 			for( Geometry::iterator it = m_geometry.begin(), eIt = m_geometry.end(); it != eIt; ++it )
 			{
-				if( it->second.unique() )
+				if( it->second.use_count() == 1 )
 				{
 					// Only one reference - this is ours, so
 					// nothing outside of the cache is using the
@@ -1846,7 +1846,7 @@ class CameraCache : public IECore::RefCounted
 			vector<IECore::MurmurHash> toErase;
 			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
 			{
-				if( it->second.unique() )
+				if( it->second.use_count() == 1 )
 				{
 					// Only one reference - this is ours, so
 					// nothing outside of the cache is using the

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2276,7 +2276,7 @@ class InstanceCache : public IECore::RefCounted
 			vector<IECore::MurmurHash> toErase;
 			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
 			{
-				if( it->second.unique() )
+				if( it->second.use_count() == 1 )
 				{
 					// Only one reference - this is ours, so
 					// nothing outside of the cache is using the

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -970,7 +970,7 @@ class InstanceCache : public IECore::RefCounted
 			vector<IECore::MurmurHash> toErase;
 			for( Cache::iterator it = m_cache.begin(), eIt = m_cache.end(); it != eIt; ++it )
 			{
-				if( it->second.unique() )
+				if( it->second.use_count() == 1 )
 				{
 					// Only one reference - this is ours, so
 					// nothing outside of the cache is using the


### PR DESCRIPTION
This updates the Windows build to use Visual Studio 2022 / MSVC 17.8 / Runtime 14.3. In doing so, it uses the Gaffer dependencies 9.0.0a2 build, which is also built on MSVC 17.8.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
