### PR TITLE
NumericWidget : Mouse wheel adjust value

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.13.0)
 =======
 
+Improvements
+------------
 
+- NumericWidget : Added the ability to use <kbd>Ctrl</kbd> + scroll wheel to adjust values in the same manner as <kbd>Up</kbd> and <kbd>Down</kbd> (#6009).
 
 1.4.13.0 (relative to 1.4.12.0)
 ========

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -77,7 +77,7 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 			if result :
 				result += "\n"
 			result += "## Actions\n"
-			result += " - Cursor up/down to increment/decrement\n"
+			result += " - Cursor up/down or <kbd>Ctrl</kbd> + scroll wheel to increment/decrement\n"
 			result += " - Use `+`, `-`, `*`, `/` and `%` to perform simple maths\n"
 
 		return result

--- a/python/GafferUI/NumericWidget.py
+++ b/python/GafferUI/NumericWidget.py
@@ -60,6 +60,7 @@ class NumericWidget( GafferUI.TextWidget ) :
 		self.__dragStart = None
 
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ), scoped = False )
+		self.wheelSignal().connect( Gaffer.WeakMethod( self.__wheel ), scoped = False )
 		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ), scoped = False )
 		self.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ), scoped = False )
 		self.dragEnterSignal().connect( Gaffer.WeakMethod( self.__dragEnter ), scoped = False )
@@ -71,6 +72,8 @@ class NumericWidget( GafferUI.TextWidget ) :
 
 		self.__numericType = None
 		self.setValue( value )
+
+		self.__scrollWheelRotation = 0
 
 	def setValue( self, value ) :
 
@@ -140,6 +143,20 @@ class NumericWidget( GafferUI.TextWidget ) :
 			return True
 
 		return False
+
+	def __wheel( self, widget, event ) :
+
+		assert( widget is self )
+
+		if not self.getEditable() or not self._qtWidget().hasFocus() or event.modifiers != GafferUI.ModifiableEvent.Modifiers.Control :
+			return False
+
+		self.__scrollWheelRotation += event.wheelRotation
+		if abs( self.__scrollWheelRotation ) >= 15.0 :
+			self.__incrementIndex( self.getCursorPosition(), int( math.copysign( 1, self.__scrollWheelRotation ) ) )
+			self.__scrollWheelRotation %= 15.0
+
+		return True
 
 	def __incrementIndex( self, index, increment ) :
 
@@ -275,6 +292,8 @@ class NumericWidget( GafferUI.TextWidget ) :
 			reason = self.ValueChangedReason.InvalidEdit
 
 		self.__emitValueChanged( reason )
+
+		self.__scrollWheelRotation = 0.0
 
 	def __setValueInternal( self, value, reason ) :
 

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -1278,7 +1278,11 @@ class _EventFilter( QtCore.QObject ) :
 				Widget._modifiers( qEvent.modifiers() ),
 			)
 
-			return widget._wheelSignal( widget, event )
+			result = widget._wheelSignal( widget, event )
+			if result :
+				qEvent.accept()
+
+			return result
 
 		return False
 


### PR DESCRIPTION
This adds the ability to change a numeric widget value with the mouse wheel in the same manner as the keyboard up and down keys currently do.

I arrived at the scale factor of `15.0` to translate the `wheelRotation` value to increment units by seeing what the `wheelRotation` value was for a single "tick" on my mouse. I don't know how universal that is, so could definitely do with some testing by others to see if it changes values in a reasonable way.

Fixes #6009.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
