### PR TITLE
NameWidget : Improve validator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.x.x (relative to 1.4.12.0)
 =======
 
+Improvements
+------------
+
+- NodeEditor, NameWidget : Invalid characters are automatically converted to `_` when renaming a node or plug, and `:` is no longer treated as invalid.
+
 Fixes
 -----
 

--- a/python/GafferUI/NameWidget.py
+++ b/python/GafferUI/NameWidget.py
@@ -125,18 +125,17 @@ class NameWidget( GafferUI.TextWidget ) :
 
 class _Validator( QtGui.QValidator ) :
 
+	__invalidCharacters = re.compile( "[^A-Za-z_:0-9]" )
+
 	def __init__( self, parent ) :
 
 		QtGui.QValidator.__init__( self, parent )
 
 	def validate( self, input, pos ) :
 
-		input = input.replace( " ", "_" )
+		input = self.__invalidCharacters.sub( "_", input )
 		if len( input ) :
-			if re.match( "^(?!__)[A-Za-z_]+[A-Za-z_0-9]*$", input ) :
-				result = QtGui.QValidator.Acceptable
-			else :
-				result = QtGui.QValidator.Invalid
+			result = QtGui.QValidator.Acceptable
 		else :
 			result = QtGui.QValidator.Intermediate
 

--- a/src/Gaffer/GraphComponent.cpp
+++ b/src/Gaffer/GraphComponent.cpp
@@ -69,6 +69,7 @@ namespace
 /// \todo Relax restrictions to only disallow '.' and `/'? We originally had
 /// these strict requirements because we accessed GraphComponent children
 /// as attributes in Python, but that approach has long since gone.
+/// When doing this, also update the validator in NameWidget.
 bool validName( const std::string &name )
 {
 	if( name.empty() )


### PR DESCRIPTION
- Allow ':', since that has been allowed at the API level since 1.3.0.0.
- Automatically convert all invalid characters to `_`. This allows anything to be copy-pasted into the field, whereas before anything with an invalid character was rejected.
