### PR TITLE
Inspector, TransformTool : Do not edit EditScopes when target is "None"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Improvements
 - PlugLayout : Summaries and activators are now evaluated in a context determined relative to the focus node.
 - Editor : The node graph is now evaluated in a context determined relative to the focus node.
 - LightEditor, RenderPassEditor : The "Disable Edit" right-click menu item and <kdb>D</kdb> shortcut now act as a toggle, where edits disabled in the current session via these actions can be reenabled with <kbd>D</kbd> or by selecting "Reenable Edit" from the right-click menu.
+- EditScope : Setting a Viewer or Editor's target edit scope to "None" will now prevent edits from being made within any upstream edit scope. To make edits in an edit scope, it must be set as the target.
 
 Fixes
 -----

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -318,6 +318,16 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 			edit = editScopeAttributeTweak
 		)
 
+		# When using no scope, make sure that we don't inadvertently edit the contents of an EditScope.
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/light2", "gl:visualiser:scale", None ),
+			source = editScopeAttributeTweak,
+			sourceType = SourceType.Other,
+			editable = False,
+			nonEditableReason = "Source is in an EditScope. Change scope to editScope1 to edit."
+		)
+
 		# If there is a manual tweak outside of an edit scope, make sure we use that with no scope
 		s["independentAttributeTweak"] = GafferScene.AttributeTweaks()
 		s["independentAttributeTweak"]["in"].setInput( s["editScope2"]["out"] )
@@ -894,6 +904,11 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		inspection = self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
 		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", None )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "Source is in an EditScope. Change scope to editScope1 to disable." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Source is in an EditScope. Change scope to editScope1 to disable.", inspection.disableEdit )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -651,6 +651,16 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 				edit = s["editScope1"]["standardOptions3"]["options"]["renderCamera"]
 			)
 
+			# When using no scope, make sure that we don't inadvertently edit the contents of an EditScope.
+
+			self.__assertExpectedResult(
+				self.__inspect( s["editScope2"]["out"], "render:camera", None, context ),
+				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
+				sourceType = SourceType.Other,
+				editable = False,
+				nonEditableReason = "Source is in an EditScope. Change scope to editScope1 to edit."
+			)
+
 			# If there is a StandardOptions node outside of an edit scope, make sure we use that with no scope
 
 			s["independentOptions"] = GafferScene.StandardOptions()
@@ -968,6 +978,11 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
 		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
+
+		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", None )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "Source is in an EditScope. Change scope to editScope1 to disable." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Source is in an EditScope. Change scope to editScope1 to disable.", inspection.disableEdit )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -247,6 +247,14 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 			editable = True, edit = editScopeShaderTweak
 		)
 
+		# When using no scope, make sure that we don't inadvertently edit the contents of an EditScope.
+
+		self.__assertExpectedResult(
+			self.__inspect( s["editScope2"]["out"], "/light2", "intensity", None ),
+			source = editScopeShaderTweak, sourceType = SourceType.Other,
+			editable = False, nonEditableReason = "Source is in an EditScope. Change scope to editScope1 to edit."
+		)
+
 		# If there is a manual tweak outside of an edit scope make sure we use that with no scope
 
 		s["independentLightTweak"] = GafferScene.ShaderTweaks()
@@ -468,6 +476,11 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
 		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
+
+		inspection = self.__inspect( s["editScope2"]["out"], "/light", "exposure", None )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "Source is in an EditScope. Change scope to editScope to disable." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Source is in an EditScope. Change scope to editScope to disable.", inspection.disableEdit )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/light", "exposure", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/TransformToolTest.py
+++ b/python/GafferSceneUITest/TransformToolTest.py
@@ -333,5 +333,27 @@ class TransformToolTest( GafferUITest.TestCase ) :
 		self.assertEqual( selection.warning(), "Transform is locked as it is inside \"reference\" which disallows edits to its children" )
 		self.assertFalse( selection.editable() )
 
+	def testDisallowEditingWithEditScopeNone( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["plane"] = GafferScene.Plane()
+
+		script["editScope"] = Gaffer.EditScope()
+		script["editScope"].setup( script["plane"]["out"] )
+		script["editScope"]["in"].setInput( script["plane"]["out"] )
+
+		selection = GafferSceneUI.TransformTool.Selection( script["editScope"]["out"], "/plane", script.context(), script["editScope"] )
+		edit = selection.acquireTransformEdit()
+		self.assertTrue( script["editScope"].isAncestorOf( edit.translate ) )
+
+		selection = GafferSceneUI.TransformTool.Selection( script["editScope"]["out"], "/plane", script.context(), None )
+		self.assertFalse( selection.editable() )
+		self.assertEqual( selection.warning(), "Source is in an EditScope. Change scope to editScope to edit" )
+
+		selection = GafferSceneUI.TransformTool.Selection( script["editScope"]["out"], "/plane", script.context(), script["editScope"] )
+		self.assertTrue( selection.editable() )
+		self.assertEqual( selection.warning(), "" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/TranslateToolTest.py
+++ b/python/GafferSceneUITest/TranslateToolTest.py
@@ -1043,25 +1043,19 @@ class TranslateToolTest( GafferUITest.TestCase ) :
 
 		GafferSceneUI.ScriptNodeAlgo.setSelectedPaths( script, IECore.PathMatcher( [ "/sphere" ] ) )
 
-		# We want the TranslateTool to pick up and use that edit
-		# even if we haven't told it to use that EditScope.
+		# We don't want the TranslateTool to pick up and use that edit
+		# as we haven't told it to use that EditScope.
 
 		tool = GafferSceneUI.TranslateTool( view )
 		tool["active"].setValue( True )
 
-		self.assertEqual( tool.handlesTransform(), imath.M44f().translate( imath.V3f( 1, 0, 0 ) ) )
 		self.assertEqual( len( tool.selection() ), 1 )
-		self.assertTrue( tool.selectionEditable() )
-		self.assertTrue( tool.selection()[0].editable() )
-		self.assertEqual( tool.selection()[0].acquireTransformEdit( createIfNecessary = False ), transformEdit )
+		self.assertFalse( tool.selectionEditable() )
+		self.assertFalse( tool.selection()[0].editable() )
 		self.assertEqual(
-			tool.selection()[0].editTarget(),
-			transformEdit.translate.ancestor( Gaffer.Spreadsheet.RowPlug )
+			tool.selection()[0].warning(),
+			"Source is in an EditScope. Change scope to editScope to edit"
 		)
-
-		tool.translate( imath.V3f( 0, 1, 0 ) )
-		self.assertEqual( tool.handlesTransform(), imath.M44f().translate( imath.V3f( 1, 1, 0 ) ) )
-		self.assertEqual( transformEdit.translate.getValue(), imath.V3f( 1, 1, 0 ) )
 
 	def testNonEditableSelections( self ) :
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -169,7 +169,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		editScope = self.__editScope()
 		if editScope is None :
-			return "Edits will be made using the last relevant node, including nodes not in any EditScope."
+			return "Edits will be made using the last relevant node found outside of an edit scope.\n\nTo make an edit in an edit scope, choose it from the menu."
 
 		unusableReason = self.__unusableReason( editScope )
 		if unusableReason :

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -289,7 +289,21 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 
 					// See if we can use it for editing
 
-					if( !result->m_editScope || node->ancestor<EditScope>() == result->m_editScope )
+					if( !result->m_editScope && node->ancestor<EditScope>() )
+					{
+						// We don't allow editing if the user hasn't requested a specific scope
+						// (they have selected "None" from the Menu) and the upstream edit is
+						// inside _any_ EditScope.
+						result->m_editFunction = fmt::format(
+							"Source is in an EditScope. Change scope to {} to edit.",
+							node->ancestor<EditScope>()->relativeName( node->ancestor<EditScope>()->scriptNode() )
+						);
+						result->m_disableEditFunction = fmt::format(
+							"Source is in an EditScope. Change scope to {} to disable.",
+							node->ancestor<EditScope>()->relativeName( node->ancestor<EditScope>()->scriptNode() )
+						);
+					}
+					else if( !result->m_editScope || node->ancestor<EditScope>() == result->m_editScope )
 					{
 						const std::string nonEditableReason = ::nonEditableReason( result->m_source.get() );
 

--- a/src/GafferSceneUI/TransformTool.cpp
+++ b/src/GafferSceneUI/TransformTool.cpp
@@ -471,11 +471,22 @@ void TransformTool::Selection::initWalk( const GafferScene::SceneAlgo::History *
 		// First, check for a supported node in this history entry
 		initFromSceneNode( history );
 
-		// If we found a node to edit here and the user has requested a
-		// specific scope, check if the edit is in it.
-		if( m_upstreamScene && m_editScope )
+		if( m_upstreamScene )
 		{
-			editScopeFound = m_upstreamScene->ancestor<EditScope>() == m_editScope;
+			const auto upstreamEditScope = m_upstreamScene->ancestor<EditScope>();
+			if( m_editScope )
+			{
+				// If we found a node to edit here and the user has requested a
+				// specific scope, check if the edit is in it.
+				editScopeFound = upstreamEditScope == m_editScope;
+			}
+			else if( upstreamEditScope )
+			{
+				// We don't allow editing if the user hasn't requested a specific scope
+				// and the upstream edit is inside an EditScope.
+				m_warning = "Source is in an EditScope. Change scope to " + displayName( upstreamEditScope ) + " to edit";
+				m_editable = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adjusts the meaning of the "None" menu item in the EditScope UI. Previously, choosing "None" would edit the first upstream plug, wherever it was found. This could result in edits being made inside of any edit scope if it already contained a plug that could receive that edit. This resulted in users potentially inadvertently scattering their edits across multiple edit scopes while the target edit scope was set to "None".

With this change, "None" still allows editing the first upstream plug as long as it is not inside an edit scope, but now prevents editing if the first upstream plug is inside an edit scope and directs the user to change their scope, which we feel is clearer behaviour than the previous scatter-shot approach.