### PR TITLE
ImageInspector : Fix broken UI caused by double-clicking in Image tab

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Constraint : The `target` browser now shows locations from the `targetScene` if it has an input connection. Before it always showed locations from the main input.
+- ImageInspector : Fixed broken UI caused by double-clicking in the Image tab.
 
 API
 ---

--- a/python/GafferImageUI/ImageInspector.py
+++ b/python/GafferImageUI/ImageInspector.py
@@ -108,7 +108,7 @@ class ImageInspector( GafferUI.NodeSetEditor ) :
 						GafferUI.PathListingWidget.defaultNameColumn,
 						GafferUI.StandardPathColumn( "Value", "image:value", sizeMode = GafferUI.PathColumn.SizeMode.Stretch )
 					],
-					displayMode = GafferUI.PathListingWidget.DisplayMode.List,
+					displayMode = GafferUI.PathListingWidget.DisplayMode.Tree,
 					selectionMode = GafferUI.PathListingWidget.SelectionMode.Cell,
 					horizontalScrollMode = GafferUI.ScrollMode.Automatic,
 					sortable = False,


### PR DESCRIPTION
When in `List` mode, double-click changes the root path being viewed, making the UI appear empty.
