### PR TITLE
IECoreArnold : Add location names to warning messages

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,9 @@ Improvements
 - FreezeTransform :
   - Improved performance for large meshes by using multithreading.
   - Improved UI responsiveness by supporting cancellation of long computes.
+- Arnold :
+  - Added location names to warning messages.
+  - A missing "P" primitive variable no longer aborts the render, but outputs a warning message instead.
 
 Fixes
 -----
@@ -123,6 +126,7 @@ Breaking Changes
 - ImageGadget : Remove non-const variant of `getContext()`.
 - LazyMethod : `deferUntilPlaybackStops` now requires that the Widget has a `scriptNode()` method rather than a `context()` method.
 - Python : Gaffer now disables the user site-packages directory by setting `PYTHONNOUSERSITE=1`. To revert to the previous behaviour, set `PYTHONNOUSERSITE=0` before launching Gaffer.
+- IECoreArnold : Added `messageContext` argument to `NodeAlgo::Converter` and `NodeAlgo::MotionConverter`.
 
 Build
 -----

--- a/include/IECoreArnold/CameraAlgo.h
+++ b/include/IECoreArnold/CameraAlgo.h
@@ -46,8 +46,8 @@ namespace IECoreArnold
 namespace CameraAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "CameraAlgo::convert" );
 
 } // namespace CameraAlgo
 

--- a/include/IECoreArnold/NodeAlgo.h
+++ b/include/IECoreArnold/NodeAlgo.h
@@ -49,19 +49,19 @@ namespace NodeAlgo
 /// Converts the specified IECore::Object into an equivalent
 /// Arnold object, returning nullptr if no conversion is
 /// available.
-IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
 /// Converts the specified IECore::Object samples into an
 /// equivalent moving Arnold object. If no motion converter
 /// is available, then returns a standard conversion of the
 /// first sample.
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr, const std::string &messageContext = "NodeAlgo::convert" );
 
 /// Signature of a function which can convert an IECore::Object
 /// into an Arnold object.
-using Converter = AtNode *(*)( const IECore::Object *, AtUniverse *, const std::string &, const AtNode * );
+using Converter = AtNode *(*)( const IECore::Object *sample, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Arnold object.
-using MotionConverter = AtNode *(*)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent );
+using MotionConverter = AtNode *(*)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parent, const std::string &messageContext );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -77,8 +77,8 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		using Converter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode * );
-		using MotionConverter = AtNode *(*)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string &, const AtNode * );
+		using Converter = AtNode *(*)( const T *, AtUniverse *, const std::string &, const AtNode *, const std::string & );
+		using MotionConverter = AtNode *(*)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string &, const AtNode *, const std::string & );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/include/IECoreArnold/ParameterAlgo.h
+++ b/include/IECoreArnold/ParameterAlgo.h
@@ -46,10 +46,10 @@ namespace IECoreArnold
 namespace ParameterAlgo
 {
 
-IECOREARNOLD_API void setParameter( AtNode *node, const AtParamEntry *parameter, const IECore::Data *value );
-IECOREARNOLD_API void setParameter( AtNode *node, AtString name, const IECore::Data *value );
-IECOREARNOLD_API void setParameter( AtNode *node, const char *name, const IECore::Data *value );
-IECOREARNOLD_API void setParameters( AtNode *node, const IECore::CompoundDataMap &values );
+IECOREARNOLD_API void setParameter( AtNode *node, const AtParamEntry *parameter, const IECore::Data *value, const std::string &messageContext = "ParameterAlgo::setParameter" );
+IECOREARNOLD_API void setParameter( AtNode *node, AtString name, const IECore::Data *value, const std::string &messageContext = "ParameterAlgo::setParameter" );
+IECOREARNOLD_API void setParameter( AtNode *node, const char *name, const IECore::Data *value, const std::string &messageContext = "ParameterAlgo::setParameter" );
+IECOREARNOLD_API void setParameters( AtNode *node, const IECore::CompoundDataMap &values, const std::string &messageContext = "ParameterAlgo::setParameter" );
 
 IECOREARNOLD_API IECore::DataPtr getParameter( AtNode *node, const AtParamEntry *parameter );
 IECOREARNOLD_API IECore::DataPtr getParameter( AtNode *node, const AtUserParamEntry *parameter );

--- a/include/IECoreArnold/ProceduralAlgo.h
+++ b/include/IECoreArnold/ProceduralAlgo.h
@@ -46,7 +46,7 @@ namespace IECoreArnold
 namespace ProceduralAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext = "ProceduralAlgo::convert" );
 
 } // namespace ProceduralAlgo
 

--- a/include/IECoreArnold/ShapeAlgo.h
+++ b/include/IECoreArnold/ShapeAlgo.h
@@ -46,16 +46,16 @@ namespace IECoreArnold
 namespace ShapeAlgo
 {
 
-IECOREARNOLD_API void convertP( const IECoreScene::Primitive *primitive, AtNode *shape, const AtString name );
-IECOREARNOLD_API void convertP( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name );
+IECOREARNOLD_API void convertP( const IECoreScene::Primitive *primitive, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
+IECOREARNOLD_API void convertP( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
 
-IECOREARNOLD_API void convertRadius( const IECoreScene::Primitive *primitive, AtNode *shape );
-IECOREARNOLD_API void convertRadius( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape );
+IECOREARNOLD_API void convertRadius( const IECoreScene::Primitive *primitive, AtNode *shape, const std::string &messageContext = "ShapeAlgo::convertRadius" );
+IECOREARNOLD_API void convertRadius( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const std::string &messageContext = "ShapeAlgo::convertRadius" );
 
-IECOREARNOLD_API void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const IECoreScene::PrimitiveVariable &primitiveVariable, AtNode *shape, const AtString name );
+IECOREARNOLD_API void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const IECoreScene::PrimitiveVariable &primitiveVariable, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertPrimitiveVariable" );
 /// Converts primitive variables from primitive into user parameters on shape, ignoring any variables
 /// whose names are present in the ignore array.
-IECOREARNOLD_API void convertPrimitiveVariables( const IECoreScene::Primitive *primitive, AtNode *shape, const char **namesToIgnore=nullptr );
+IECOREARNOLD_API void convertPrimitiveVariables( const IECoreScene::Primitive *primitive, AtNode *shape, const char **namesToIgnore=nullptr, const std::string &messageContext = "ShapeAlgo::convertPrimitiveVariables" );
 
 } // namespace ShapeAlgo
 

--- a/src/IECoreArnold/CameraAlgo.cpp
+++ b/src/IECoreArnold/CameraAlgo.cpp
@@ -86,12 +86,12 @@ AtVector2 curvePoint( const Splineff::Point &point )
 	);
 }
 
-void setShutterCurveParameter( AtNode *camera, const IECore::Data *value )
+void setShutterCurveParameter( AtNode *camera, const IECore::Data *value, const std::string &messageContext )
 {
 	auto *splineData = runTimeCast<const SplineffData>( value );
 	if( !splineData )
 	{
-		msg( Msg::Warning, "setShutterCurveParameter", fmt::format( "Unsupported value type \"{}\" (expected SplineffData).", value->typeName() ) );
+		msg( Msg::Warning, messageContext, fmt::format( "Unsupported value type \"{}\" (expected SplineffData).", value->typeName() ) );
 		return;
 	}
 
@@ -127,7 +127,7 @@ void setShutterCurveParameter( AtNode *camera, const IECore::Data *value )
 }
 
 // Performs the part of the conversion that is shared by both animated and non-animated cameras.
-AtNode *convertCommon( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convertCommon( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	// Use projection to decide what sort of camera node to create
 	const std::string projection = camera->getProjection();
@@ -171,11 +171,11 @@ AtNode *convertCommon( const IECoreScene::Camera *camera, AtUniverse *universe, 
 		{
 			if( paramNameArnold == g_shutterCurveArnoldString )
 			{
-				setShutterCurveParameter( result, it->second.get() );
+				setShutterCurveParameter( result, it->second.get(), messageContext );
 			}
 			else
 			{
-				ParameterAlgo::setParameter( result, paramNameArnold, it->second.get() );
+				ParameterAlgo::setParameter( result, paramNameArnold, it->second.get(), messageContext );
 			}
 		}
 	}
@@ -260,9 +260,9 @@ void setAnimatedFloat( AtNode *node, AtString name, const std::vector<const IECo
 
 } // namespace
 
-AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( camera, universe, nodeName, parentNode );
+	AtNode *result = convertCommon( camera, universe, nodeName, parentNode, messageContext );
 	if( camera->getProjection()=="perspective" )
 	{
 		AiNodeSetFlt( result, g_fovArnoldString, fieldOfView( camera ) );
@@ -277,9 +277,9 @@ AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *univ
 	return result;
 }
 
-AtNode *CameraAlgo::convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *CameraAlgo::convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( samples[0], universe, nodeName, parentNode );
+	AtNode *result = convertCommon( samples[0], universe, nodeName, parentNode, messageContext );
 	if( samples[0]->getProjection()=="perspective" )
 	{
 		setAnimatedFloat( result, g_fovArnoldString, samples, fieldOfView );

--- a/src/IECoreArnold/NodeAlgo.cpp
+++ b/src/IECoreArnold/NodeAlgo.cpp
@@ -34,6 +34,8 @@
 
 #include "IECoreArnold/NodeAlgo.h"
 
+#include "IECore/MessageHandler.h"
+
 #include "boost/unordered_map.hpp"
 
 //////////////////////////////////////////////////////////////////////////
@@ -78,7 +80,7 @@ namespace IECoreArnold
 namespace NodeAlgo
 {
 
-AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	const Registry &r = registry();
 	Registry::const_iterator it = r.find( object->typeId() );
@@ -86,10 +88,10 @@ AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::
 	{
 		return nullptr;
 	}
-	return it->second.converter( object, universe, nodeName, parentNode );
+	return it->second.converter( object, universe, nodeName, parentNode, messageContext );
 }
 
-AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	if( samples.empty() )
 	{
@@ -102,7 +104,8 @@ AtNode *convert( const std::vector<const IECore::Object *> &samples, float motio
 	{
 		if( (*it)->typeId() != firstSampleTypeId )
 		{
-			throw IECore::Exception( "Inconsistent object types." );
+			IECore::msg( IECore::Msg::Error, messageContext, "Inconsistent object types." );
+			return nullptr;
 		}
 	}
 
@@ -115,11 +118,11 @@ AtNode *convert( const std::vector<const IECore::Object *> &samples, float motio
 
 	if( it->second.motionConverter )
 	{
-		return it->second.motionConverter( samples, motionStart, motionEnd, universe, nodeName, parentNode );
+		return it->second.motionConverter( samples, motionStart, motionEnd, universe, nodeName, parentNode, messageContext );
 	}
 	else
 	{
-		return it->second.converter( firstSample, universe, nodeName, parentNode );
+		return it->second.converter( firstSample, universe, nodeName, parentNode, messageContext );
 	}
 }
 

--- a/src/IECoreArnold/PointsAlgo.cpp
+++ b/src/IECoreArnold/PointsAlgo.cpp
@@ -57,7 +57,7 @@ const AtString g_pointsArnoldString( "points" );
 const AtString g_quadArnoldString( "quad" );
 const AtString g_sphereArnoldString( "sphere" );
 
-AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr )
+AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 
 	AtNode *result = AiNode( universe, g_pointsArnoldString, AtString( nodeName.c_str() ), parentNode );
@@ -81,38 +81,38 @@ AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *u
 		}
 		else
 		{
-			IECore::msg( IECore::Msg::Warning, "ToArnoldPointsConverter::doConversion", fmt::format( "Unknown type \"{}\" - reverting to disk mode.", t->readable() ) );
+			IECore::msg( IECore::Msg::Warning, messageContext, fmt::format( "Unknown type \"{}\" - reverting to disk mode.", t->readable() ) );
 		}
 	}
 
 	// arbitrary user parameters
 
 	const char *ignore[] = { "P", "width", "radius", nullptr };
-	ShapeAlgo::convertPrimitiveVariables( points, result, ignore );
+	ShapeAlgo::convertPrimitiveVariables( points, result, ignore, messageContext );
 
 	return result;
 
 }
 
-AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( points, universe, nodeName, parentNode );
+	AtNode *result = convertCommon( points, universe, nodeName, parentNode, messageContext );
 
-	ShapeAlgo::convertP( points, result, g_pointsArnoldString );
-	ShapeAlgo::convertRadius( points, result );
+	ShapeAlgo::convertP( points, result, g_pointsArnoldString, messageContext );
+	ShapeAlgo::convertRadius( points, result, messageContext );
 
 	/// \todo Aspect, rotation
 
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
-	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode );
+	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
 
 	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
-	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString );
-	ShapeAlgo::convertRadius( primitiveSamples, result );
+	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString, messageContext );
+	ShapeAlgo::convertRadius( primitiveSamples, result, messageContext );
 
 
 	AiNodeSetFlt( result, g_motionStartArnoldString, motionStart );

--- a/src/IECoreArnold/ProceduralAlgo.cpp
+++ b/src/IECoreArnold/ProceduralAlgo.cpp
@@ -67,10 +67,10 @@ namespace IECoreArnold
 namespace ProceduralAlgo
 {
 
-AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode  )
+AtNode *convert( const IECoreScene::ExternalProcedural *procedural, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *node = AiNode( universe, AtString( procedural->getFileName().c_str() ), AtString( nodeName.c_str() ), parentNode );
-	ParameterAlgo::setParameters( node, procedural->parameters()->readable() );
+	ParameterAlgo::setParameters( node, procedural->parameters()->readable(), messageContext );
 
 	return node;
 }

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -535,12 +535,12 @@ class ArnoldOutput : public IECore::RefCounted
 					}
 				}
 
-				ParameterAlgo::setParameter( m_driver.get(), it->first.c_str(), it->second.get() );
+				ParameterAlgo::setParameter( m_driver.get(), it->first.c_str(), it->second.get(), /* messageContext = */ m_name.string() );
 			}
 
 			if( AiNodeEntryLookUpParameter( AiNodeGetNodeEntry( m_driver.get() ), g_customAttributesArnoldString ) )
 			{
-				ParameterAlgo::setParameter( m_driver.get(), "custom_attributes", customAttributesData.get() );
+				ParameterAlgo::setParameter( m_driver.get(), "custom_attributes", customAttributesData.get(), /* messageContext = */ m_name.string() );
 			}
 
 			// Create a filter node, or reuse an existing one if we can.
@@ -595,7 +595,7 @@ class ArnoldOutput : public IECore::RefCounted
 					}
 				}
 
-				ParameterAlgo::setParameter( m_filter.get(), it->first.c_str() + 6, it->second.get() );
+				ParameterAlgo::setParameter( m_filter.get(), it->first.c_str() + 6, it->second.get(), /* messageContext = */ m_name.string() );
 			}
 
 			// Convert the data specification to the form
@@ -1343,7 +1343,7 @@ class ArnoldAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 					continue;
 				}
 
-				ParameterAlgo::setParameter( node, attr.first, attr.second.get() );
+				ParameterAlgo::setParameter( node, attr.first, attr.second.get(), "IECoreArnold::Renderer::attributes" );
 			}
 
 			// Early out for IECoreScene::Procedurals. Arnold's inheritance rules for procedurals are back
@@ -2184,7 +2184,7 @@ class InstanceCache : public IECore::RefCounted
 
 			if( !arnoldAttributes || !arnoldAttributes->canInstanceGeometry( object ) )
 			{
-				return Instance( convert( object, arnoldAttributes, nodeName ) );
+				return Instance( convert( object, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
 			}
 
 			IECore::MurmurHash h = object->hash();
@@ -2204,7 +2204,7 @@ class InstanceCache : public IECore::RefCounted
 				{
 					try
 					{
-						writeAccessor->second = convert( object, arnoldAttributes, "instance:" + h.toString() );
+						writeAccessor->second = convert( object, arnoldAttributes, "instance:" + h.toString(), /* messageContext = */ nodeName );
 					}
 					catch( const IECore::Cancelled & )
 					{
@@ -2228,7 +2228,7 @@ class InstanceCache : public IECore::RefCounted
 
 			if( !arnoldAttributes->canInstanceGeometry( samples.front() ) )
 			{
-				return Instance( convert( samples, times, arnoldAttributes, nodeName ) );
+				return Instance( convert( samples, times, arnoldAttributes, nodeName, /* messageContext = */ nodeName ) );
 			}
 
 			IECore::MurmurHash h;
@@ -2256,7 +2256,7 @@ class InstanceCache : public IECore::RefCounted
 				{
 					try
 					{
-						writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString() );
+						writeAccessor->second = convert( samples, times, arnoldAttributes, "instance:" + h.toString(), /* messageContext = */ nodeName );
 					}
 					catch( const IECore::Cancelled & )
 					{
@@ -2303,7 +2303,7 @@ class InstanceCache : public IECore::RefCounted
 
 	private :
 
-		SharedAtNodePtr convert( const IECore::Object *object, const ArnoldAttributes *attributes, const std::string &nodeName )
+		SharedAtNodePtr convert( const IECore::Object *object, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
 		{
 			if( !object )
 			{
@@ -2317,7 +2317,7 @@ class InstanceCache : public IECore::RefCounted
 			}
 			else
 			{
-				node = NodeAlgo::convert( object, m_universe, nodeName, m_parentNode );
+				node = NodeAlgo::convert( object, m_universe, nodeName, m_parentNode, messageContext );
 			}
 
 			if( !node )
@@ -2333,7 +2333,7 @@ class InstanceCache : public IECore::RefCounted
 			return SharedAtNodePtr( node, m_nodeDeleter );
 		}
 
-		SharedAtNodePtr convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const ArnoldAttributes *attributes, const std::string &nodeName )
+		SharedAtNodePtr convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const ArnoldAttributes *attributes, const std::string &nodeName, const std::string &messageContext )
 		{
 			ensureUniformTimeSamples( times );
 			AtNode *node = nullptr;
@@ -2343,7 +2343,7 @@ class InstanceCache : public IECore::RefCounted
 			}
 			else
 			{
-				node = NodeAlgo::convert( samples, times[0], times[times.size() - 1], m_universe, nodeName, m_parentNode );
+				node = NodeAlgo::convert( samples, times[0], times[times.size() - 1], m_universe, nodeName, m_parentNode, messageContext );
 			}
 
 			if( !node )
@@ -3645,7 +3645,7 @@ class ArnoldGlobals
 					const IECore::Data *dataValue = IECore::runTimeCast<const IECore::Data>( value );
 					if( dataValue )
 					{
-						ParameterAlgo::setParameter( options, arnoldName, dataValue );
+						ParameterAlgo::setParameter( options, arnoldName, dataValue, "IECoreArnold::Renderer::option" );
 					}
 				}
 				return;
@@ -3677,7 +3677,7 @@ class ArnoldGlobals
 
 					if( dataValue )
 					{
-						ParameterAlgo::setParameter( options, arnoldName, dataValue );
+						ParameterAlgo::setParameter( options, arnoldName, dataValue, "IECoreArnold::Renderer::option" );
 					}
 					else
 					{
@@ -3692,7 +3692,7 @@ class ArnoldGlobals
 				const IECore::Data *dataValue = IECore::runTimeCast<const IECore::Data>( value );
 				if( dataValue )
 				{
-					ParameterAlgo::setParameter( options, arnoldName, dataValue );
+					ParameterAlgo::setParameter( options, arnoldName, dataValue, "IECoreArnold::Renderer::option" );
 				}
 				else
 				{
@@ -4006,8 +4006,8 @@ class ArnoldGlobals
 
 			AiRenderRemoveAllInteractiveOutputs( m_renderSession.get() );
 
-			IECoreArnold::ParameterAlgo::setParameter( options, "outputs", outputs.get() );
-			IECoreArnold::ParameterAlgo::setParameter( options, "light_path_expressions", lpes.get() );
+			IECoreArnold::ParameterAlgo::setParameter( options, "outputs", outputs.get(), "IECoreArnold::Renderer" );
+			IECoreArnold::ParameterAlgo::setParameter( options, "light_path_expressions", lpes.get(), "IECoreArnold::Renderer" );
 
 			for( auto i : interactiveIndices )
 			{
@@ -4028,7 +4028,7 @@ class ArnoldGlobals
 					IECoreScene::ConstCameraPtr defaultCortexCamera = new IECoreScene::Camera();
 					m_cameras["ieCoreArnold:defaultCamera"] = defaultCortexCamera;
 					m_defaultCamera = SharedAtNodePtr(
-						NodeAlgo::convert( defaultCortexCamera.get(), m_universeBlock->universe(), "ieCoreArnold:defaultCamera", nullptr ),
+						NodeAlgo::convert( defaultCortexCamera.get(), m_universeBlock->universe(), "ieCoreArnold:defaultCamera", nullptr, "ieCoreArnold:defaultCamera" ),
 						nodeDeleter( m_renderType )
 					);
 				}

--- a/src/IECoreArnold/SphereAlgo.cpp
+++ b/src/IECoreArnold/SphereAlgo.cpp
@@ -68,22 +68,22 @@ void warnIfUnsupported( const IECoreScene::SpherePrimitive *sphere )
 	}
 }
 
-AtNode *convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	warnIfUnsupported( sphere );
 
 	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
-	ShapeAlgo::convertPrimitiveVariables( sphere, result );
+	ShapeAlgo::convertPrimitiveVariables( sphere, result, nullptr, messageContext );
 
 	AiNodeSetFlt( result, g_radiusArnoldString, sphere->radius() );
 
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode, const std::string &messageContext )
 {
 	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
-	ShapeAlgo::convertPrimitiveVariables( samples.front(), result );
+	ShapeAlgo::convertPrimitiveVariables( samples.front(), result, nullptr, messageContext );
 
 	AtArray *radiusSamples = AiArrayAllocate( 1, samples.size(), AI_TYPE_FLOAT );
 

--- a/src/IECoreArnold/VDBAlgo.cpp
+++ b/src/IECoreArnold/VDBAlgo.cpp
@@ -123,12 +123,12 @@ CompoundDataPtr createParameters(const IECoreVDB::VDBObject* vdbObject)
 	return parameters;
 }
 
-AtNode *convert( const IECoreVDB::VDBObject *vdbObject, AtUniverse *universe, const std::string &name, const AtNode* parent )
+AtNode *convert( const IECoreVDB::VDBObject *vdbObject, AtUniverse *universe, const std::string &name, const AtNode* parent, const std::string &messageContext )
 {
 	AtNode *node = AiNode( universe, g_volume, AtString( name.c_str() ), parent );
 
 	CompoundDataPtr parameters = createParameters( vdbObject );
-	ParameterAlgo::setParameters( node, parameters->readable() );
+	ParameterAlgo::setParameters( node, parameters->readable(), messageContext );
 
 	return node;
 }

--- a/src/IECoreArnoldModule/IECoreArnoldModule.cpp
+++ b/src/IECoreArnoldModule/IECoreArnoldModule.cpp
@@ -137,10 +137,10 @@ object convertWrapper2( object pythonSamples, float motionStart, float motionEnd
 	return atNodeToPythonObject( NodeAlgo::convert( samples, motionStart, motionEnd, pythonObjectToAtUniverse( universe ), nodeName, nullptr ) );
 }
 
-void setParameter( object &pythonNode, const char *name, const IECore::Data *data )
+void setParameter( object &pythonNode, const char *name, const IECore::Data *data, const std::string &messageContext )
 {
 	AtNode *node = atNodeFromPythonObject( pythonNode );
-	ParameterAlgo::setParameter( node, name, data );
+	ParameterAlgo::setParameter( node, name, data, messageContext );
 }
 
 IECore::DataPtr getParameter( object &pythonNode, const char *name )
@@ -204,7 +204,7 @@ BOOST_PYTHON_MODULE( _IECoreArnold )
 		scope().attr( "ParameterAlgo" ) = parameterAlgoModule;
 		scope parameterAlgoModuleScope( parameterAlgoModule );
 
-		def( "setParameter", &setParameter );
+		def( "setParameter", &setParameter, ( arg( "node" ), arg( "name" ), arg( "data" ), arg( "messageContext" ) = "ParameterAlgo::setParameter" ) );
 		def( "getParameter", &getParameter );
 	}
 


### PR DESCRIPTION
To avoid the needle-in-a-haystack search triggered by the previous non-specific warnings.

Most of this is all straightforward, but there are a couple of things worth noting :

- `ShapeAlgo::convertP()` no longer throws if it doesn't find "P". Instead it just outputs a warning and the render continues. This is more in keeping with our general "Renderers don't throw" approach.
- `ShapeAlgo::convertRadius()` gained the `messageContext` argument but doesn't currently use it. Since this is our chance to make the ABI break needed to improve the messaging, it seemed worth adding for potential future use.
