### PR TITLE
Instancer : Don't output separate capsules for prototypes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Breaking Changes
 ----------------
 
 - IECoreArnold : Added `messageContext` argument to `NodeAlgo::Converter` and `NodeAlgo::MotionConverter`.
+- Instancer : `encapsulate` now produces a single Capsule at the `.../instances` location, instead of the previous `encapsulateInstanceGroups` plug which produced separate capsules at each `.../instances/<prototypeName>` location. Outputting a single capsule is slightly less flexible for users, but is much faster to render in Arnold ( Arnold is currently unable to deal effectively with large numbers of fully overlapping procedurals ). This change also allowed us to simplify the code slightly, reducing the time spent in Gaffer when rendering an encapsulated Instancer by around 20%.
 
 [^1]: To be omitted from 1.5.0.0 release notes.
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -144,8 +144,8 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *attributePrefixPlug();
 		const Gaffer::StringPlug *attributePrefixPlug() const;
 
-		Gaffer::BoolPlug *encapsulateInstanceGroupsPlug();
-		const Gaffer::BoolPlug *encapsulateInstanceGroupsPlug() const;
+		Gaffer::BoolPlug *encapsulatePlug();
+		const Gaffer::BoolPlug *encapsulatePlug() const;
 
 		Gaffer::BoolPlug *seedEnabledPlug();
 		const Gaffer::BoolPlug *seedEnabledPlug() const;
@@ -223,10 +223,15 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 	private :
 
 		IE_CORE_FORWARDDECLARE( EngineData );
+		IE_CORE_FORWARDDECLARE( EngineSplitPrototypesData );
 		IE_CORE_FORWARDDECLARE( InstancerCapsule );
 
 		Gaffer::ObjectPlug *enginePlug();
 		const Gaffer::ObjectPlug *enginePlug() const;
+
+		Gaffer::ObjectPlug *engineSplitPrototypesPlug();
+		const Gaffer::ObjectPlug *engineSplitPrototypesPlug() const;
+
 
 		GafferScene::ScenePlug *capsuleScenePlug();
 		const GafferScene::ScenePlug *capsuleScenePlug() const;
@@ -239,6 +244,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+
+		ConstEngineSplitPrototypesDataPtr engineSplitPrototypes( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
+		void engineSplitPrototypesHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 
 		struct PrototypeScope : public Gaffer::Context::EditableScope
 		{

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -70,7 +70,7 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 						continue
 					corresponding.setValue( i.getValue() )
 
-		encapInstancer["encapsulateInstanceGroups"].setValue( True )
+		encapInstancer["encapsulate"].setValue( True )
 
 		self.assertScenesRenderSame( instancer["out"], encapInstancer["out"], expandProcedurals = True, ignoreLinks = True )
 
@@ -171,14 +171,14 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		encapInstancer["prototypes"].setInput( instanceInput["out"] )
 		encapInstancer["parent"].setValue( "/seeds" )
 		encapInstancer["name"].setValue( "instances" )
-		encapInstancer["encapsulateInstanceGroups"].setValue( True )
+		encapInstancer["encapsulate"].setValue( True )
 
 		# Test an edge case, and make sure while we're at it that we're actually getting an InstancerCapsule
 		# ( Because it's private, it's bound to Python in a sorta weird way that means its typeName() will
 		# report Capsule, not InstancerCapsule, but this error is a quick test that we are actually dealing with
 		# the right thing. )
 		with self.assertRaisesRegex( RuntimeError, "Null renderer passed to InstancerCapsule" ) :
-			encapInstancer["out"].object( "/seeds/instances/sphere" ).render( None )
+			encapInstancer["out"].object( "/seeds/instances" ).render( None )
 
 		# Check that the capsule expands during rendering to render the same as the unencapsulated scene.
 		# ( Except for the light links, which aren't output by the Capsule currently )
@@ -191,8 +191,8 @@ class InstancerTest( GafferSceneTest.SceneTestCase ) :
 		unencap["in"].setInput( encapInstancer["out"] )
 		unencap["filter"].setInput( unencapFilter["out"] )
 
-		self.assertTrue( isinstance( encapInstancer["out"].object( "/seeds/instances/sphere/" ), GafferScene.Capsule ) )
-		self.assertEqual( encapInstancer["out"].childNames( "/seeds/instances/sphere/" ), IECore.InternedStringVectorData() )
+		self.assertTrue( isinstance( encapInstancer["out"].object( "/seeds/instances" ), GafferScene.Capsule ) )
+		self.assertEqual( encapInstancer["out"].childNames( "/seeds/instances" ), IECore.InternedStringVectorData() )
 		self.assertScenesEqual( unencap["out"], instancer["out"] )
 
 		# Edit seeds object
@@ -880,7 +880,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 			with self.assertRaisesRegex( RuntimeError, 'Instancer.out.transform : Instance id "2" is invalid, instancer produces only 2 children. Topology may have changed during shutter.' ):
 				self.assertScenesRenderSame( instancer["out"], instancer["out"], expandProcedurals = True, ignoreLinks = True )
 
-		instancer["encapsulateInstanceGroups"].setValue( True )
+		instancer["encapsulate"].setValue( True )
 
 		with testContext:
 			with self.assertRaisesRegex( RuntimeError, 'Instance id "2" is invalid, instancer produces only 2 children. Topology may have changed during shutter.' ):
@@ -1432,7 +1432,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		encapInstancer["prototypes"].setInput( instances["out"] )
 		encapInstancer["parent"].setValue( "/object" )
 		encapInstancer["prototypeIndex"].setValue( "index" )
-		encapInstancer["encapsulateInstanceGroups"].setValue( True )
+		encapInstancer["encapsulate"].setValue( True )
 
 		unencapFilter = GafferScene.PathFilter()
 		unencapFilter["paths"].setValue( IECore.StringVectorData( [ "/..." ] ) )
@@ -2594,7 +2594,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		# When encapsulating, we shouldn't pay any time cost for evaluating the set, even with a huge
 		# number of instances
 		plane["divisions"].setValue( imath.V2i( 1000 ) )
-		instancer["encapsulateInstanceGroups"].setValue( True )
+		instancer["encapsulate"].setValue( True )
 		t = time.time()
 		instancer["out"].set( "set" )
 		totalTime = time.time() - t
@@ -2836,7 +2836,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 			with self.subTest( encapsulate = encapsulate ) :
 
-				instancer["encapsulateInstanceGroups"].setValue( encapsulate )
+				instancer["encapsulate"].setValue( encapsulate )
 
 				# Prototype properties used by the capsule should be reflected
 				# in the object hash. For the hash to be updated successfully,
@@ -2844,25 +2844,25 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 				# hashes).
 
 				hashes = set()
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 1 )
 
 				sphere["radius"].setValue( 2 + int( encapsulate ) )
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 2 if encapsulate else 1 )
 
 				dirtiedPlugs = GafferTest.CapturingSlot( instancer.plugDirtiedSignal() )
 
 				sphere["transform"]["translate"]["x"].setValue( 2 + int( encapsulate ) )
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 3 if encapsulate else 1 )
 
 				sphereAttributes["attributes"]["test"] = Gaffer.NameValuePlug( "test", encapsulate )
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 4 if encapsulate else 1 )
 
 				sphere["sets"].setValue( "testSet{}".format( encapsulate ) )
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 5 if encapsulate else 1 )
 
 				# When not encapsulating, there should be no unnecessary
@@ -2880,7 +2880,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 				del dirtiedPlugs[:]
 
 				sphereOptions["options"]["test"] = Gaffer.NameValuePlug( "test", encapsulate )
-				hashes.add( instancer["out"].objectHash( "/plane/instances/sphere" ) )
+				hashes.add( instancer["out"].objectHash( "/plane/instances" ) )
 				self.assertEqual( len( hashes ), 5 if encapsulate else 1 )
 				self.assertNotIn(
 					instancer["out"]["object"],
@@ -3115,13 +3115,12 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testEncapsulatedRenderPerf( self ):
 		nodes = self.initSimpleInstancer( withPrototypes = True, withIds = False )
-		nodes["instancer"]["encapsulateInstanceGroups"].setValue( True )
+		nodes["instancer"]["encapsulate"].setValue( True )
 
 		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer( GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch )
 
 		with GafferTest.TestRunner.PerformanceScope() :
-			nodes["instancer"]["out"].object( "/plane/instances/sphere" ).render( renderer )
-			nodes["instancer"]["out"].object( "/plane/instances/cube" ).render( renderer )
+			nodes["instancer"]["out"].object( "/plane/instances" ).render( renderer )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3112,6 +3112,16 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 			nodes["instancer"]["out"].childNames( "/plane/instances/sphere" )
 			nodes["instancer"]["out"].childNames( "/plane/instances/cube" )
 
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testEncapsulatedRenderPerf( self ):
+		nodes = self.initSimpleInstancer( withPrototypes = True, withIds = False )
+		nodes["instancer"]["encapsulateInstanceGroups"].setValue( True )
+
+		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer( GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			nodes["instancer"]["out"].object( "/plane/instances/sphere" ).render( renderer )
+			nodes["instancer"]["out"].object( "/plane/instances/cube" ).render( renderer )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -576,11 +576,11 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"encapsulateInstanceGroups" : [
+		"encapsulate" : [
 
 			"description",
 			"""
-			Converts each group of instances into a capsule, which won't
+			Converts instances into a capsule, which won't
 			be expanded until you Unencapsulate or render. When keeping
 			these locations encapsulated, downstream nodes can't see the
 			instance locations, which prevents editing but improves
@@ -588,10 +588,11 @@ Gaffer.Metadata.registerNode(
 			Encapsulate node because it has the following benefits :
 
 			- Substantially improved performance when the prototypes
-			  define sets.
+			define sets.
 			- Fewer unnecessary updates during interactive rendering.
+			- Faster performance in renderer backends with special
+			instancer capsule support ( ie. Arnold )
 			""",
-			"label", "Instance Groups",
 
 			"layout:section", "Settings.Encapsulation",
 

--- a/startup/GafferScene/instancerCompatibility.py
+++ b/startup/GafferScene/instancerCompatibility.py
@@ -44,6 +44,8 @@ def __instancerGetItem( originalGetItem ) :
 			key = "prototypes"
 		elif key == "index" :
 			key = "prototypeIndex"
+		elif key == "encapsulateInstanceGroups" :
+			key = "encapsulate"
 
 		return originalGetItem( self, key )
 


### PR DESCRIPTION
As discussed, output one big Capsule from Instancer when `encapsulateInstanceGroups` is checked.

All seems to be working ... the Instancer code is pretty complex, but the test coverage is pretty decent.

The main goal is to avoid slowdown in Arnold because Arnold doesn't like BVH's for overlapping procedurals, but this does also result in a 20% reduction in the time spent in Gaffer while rendering an encapsulated Instancer. `testEncapsulatedRenderPerf` only shows an 8% reduction, but that's because the time spent in CapturingRender dominates that test ( in a 1.06 second test, about 0.7 seconds is in CapturingRender ). I was trying hard not to spend any time on that, so I just did a quick test to make sure I understood what's happening by ripping out all it's functionality for a temporary test. I haven't looked into why it's slow, but I suspect tbb::concurrent_hash_map might be the biggest problem.

Outputting names to the renderer including the prototype name prefix turned out not to be a performance problem at all. I'm currently keeping the property of the old code where it doesn't do any string allocations for each instance if the prototype name is the same ... I couldn't actually measure any slowdown if I did some slightly simpler code that allocated new strings for each instance, but this code is only 12 lines, so it didn't seem like a problem to keep it.

Some of the performance results look a bit unreasonable after this PR: testEngineDataPerf and testEngineDataPerfWithPrototypes show 99%/100% reductions. But it is actually true that in these cases, computing the EngineData doesn't require looping over each instance. Since the tests only evaluate childNames( ".../instances" ), now that the data necessary for splitting prototypes is stored on a separate plug, we can compute the names of the prototypes without having to process the instances, so there is actually a 99% improvement in this case. Maybe I should add more perf tests to illustrate this more clearly? But there are already a good number of performance tests that show different aspects of this, like testEngineDataPerfWithPrototypesAndIds, which is able to skip the prototype splitting calculation, but needs to process all the instances for a different reason to make sure the ids are valid, and only shows a 16% improvement, or testChildNamesPerf, which looks at the child names of one of the prototypes, so does require the prototype splitting data, and doesn't improve. 