### PR TITLE
Various Cycles 4.2 improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,9 @@ Features
 Improvements
 ------------
 
-- Cycles : Added `is_sphere` plug to spot and point lights. Disabling `is_sphere` is equivalent to enabling "Soft Falloff" in Blender, which reverts the light to the behaviour of Cycles 3.6 and earlier.
+- Cycles :
+  - Added `is_sphere` plug to spot and point lights. Disabling `is_sphere` is equivalent to enabling "Soft Falloff" in Blender, which reverts the light to the behaviour of Cycles 3.6 and earlier.
+  - Changed sampling pattern to blue noise dithered sampling.
 
 1.5.0.0a2 (relative to 1.5.0.0a1)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,10 @@ Features
     - `colorFieldVisible` : A boolean indicating if the color field should be visible or not.
   - Added a menu item to the color chooser settings to save the UI configuration for the inline color chooser and the dialogue color chooser as a startup script to persist the configuration across Gaffer restarts.
 
+Improvements
+------------
+
+- Cycles : Added `is_sphere` plug to spot and point lights. Disabling `is_sphere` is equivalent to enabling "Soft Falloff" in Blender, which reverts the light to the behaviour of Cycles 3.6 and earlier.
 
 1.5.0.0a2 (relative to 1.5.0.0a1)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,16 @@ Improvements
   - Added `is_sphere` plug to spot and point lights. Disabling `is_sphere` is equivalent to enabling "Soft Falloff" in Blender, which reverts the light to the behaviour of Cycles 3.6 and earlier.
   - Changed sampling pattern to blue noise dithered sampling.
 
+Fixes
+-----
+
+- Cycles : Fixed issue where scaling unnormalized quad and disk lights would not affect their brightness.
+
+Breaking Changes
+----------------
+
+- Cycles : Removed custom handling of unnormalized lights. We now rely on Cycles' inbuilt behaviour which results in a brightness difference for unnormalized point, spot and disk lights.
+
 1.5.0.0a2 (relative to 1.5.0.0a1)
 =========
 

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
 - Cycles :
   - Added `is_sphere` plug to spot and point lights. Disabling `is_sphere` is equivalent to enabling "Soft Falloff" in Blender, which reverts the light to the behaviour of Cycles 3.6 and earlier.
   - Changed sampling pattern to blue noise dithered sampling.
+  - Spot, disk, quad and point light strength now better match Blender, Arnold and hdCycles. As a result these lights are now `pi` times brighter at the same intensity when compared with previous versions. If necessary, this adjustment can be disabled by setting the `GAFFERCYCLES_USE_LEGACY_LIGHTS` environment variable with a value of `1`.
 
 Fixes
 -----

--- a/python/GafferCyclesTest/RenderPassAdaptorTest.py
+++ b/python/GafferCyclesTest/RenderPassAdaptorTest.py
@@ -81,7 +81,7 @@ class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
 
 		options = GafferCycles.CyclesOptions()
 		options["options"]["samples"]["enabled"].setValue( True )
-		options["options"]["samples"]["value"].setValue( 16 )
+		options["options"]["samples"]["value"].setValue( 20 )
 		return options
 
 if __name__ == "__main__":

--- a/python/GafferCyclesUI/CyclesLightUI.py
+++ b/python/GafferCyclesUI/CyclesLightUI.py
@@ -96,6 +96,22 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"parameters.is_sphere" : [
+
+			"description",
+			"""
+			Treat the light as a sphere. Disable to avoid
+			sharp boundaries when the light intersects with
+			other geometry.
+
+			> Tip: Disabling this is equivalent to
+			> enabling "Soft Falloff" in Blender and
+			> matches the behaviour of Cycles 3.6 and
+			> earlier.
+			""",
+
+		],
+
 	}
 
 )

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2946,6 +2946,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 			ccl::Integrator *integrator = m_scene->integrator;
 			integrator->set_seed( optionValue<int>( g_seedOptionName, frame() ) );
 			integrator->set_motion_blur( optionValue<bool>( g_sampleMotionOptionName, true ) );
+			integrator->set_sampling_pattern( m_session->params.background ? ccl::SAMPLING_PATTERN_BLUE_NOISE_PURE : ccl::SAMPLING_PATTERN_BLUE_NOISE_FIRST );
 
 			if( integrator->is_modified() )
 			{

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -356,15 +356,13 @@ T parameterValue( const IECore::CompoundDataMap &parameters, const IECore::Inter
 
 // Cycles lights just have a single `strength` parameter which
 // we want to present as separate "virtual" parameters for
-// intensity, color, exposure and normalize. We calculate un-normalized
-// lights by multiplying the surface area of the light source.
+// intensity, color, exposure.
 bool contributesToLightStrength( InternedString parameterName )
 {
 	return
 		parameterName == "intensity" ||
 		parameterName == "color" ||
-		parameterName == "exposure" ||
-		parameterName == "normalize"
+		parameterName == "exposure"
 	;
 }
 
@@ -386,48 +384,6 @@ Imath::Color3f constantLightStrength( const IECoreScene::ShaderNetwork *light )
 	// We don't support input connections to exposure - it seems unlikely that
 	// you'd want to texture that.
 	strength *= powf( 2.0f, parameterValue<float>( lightShader->parameters(), "exposure", 0.0f ) );
-
-	// Cycles has normalized lights as a default, we can emulate un-normalized lights
-	// with a bit of surface area size calculation onto the strength parameter.
-	/// \todo I think we should move normalization into Cycles itself -
-	/// https://developer.blender.org/D16838
-	if( !parameterValue<bool>( lightShader->parameters(), "normalize", true ) )
-	{
-		if( lightShader->getName() == "distant_light" )
-		{
-			const float angle = IECore::degreesToRadians( parameterValue<float>( lightShader->parameters(), "angle", 0.0f ) ) / 2.0f;
-			const float radius = tanf( angle );
-			const float area = M_PI_F * radius * radius;
-			if( area > 0.0f )
-			{
-				strength *= area;
-			}
-		}
-		else if( lightShader->getName() == "background_light" )
-		{
-			// Do nothing.
-		}
-		else if(
-			lightShader->getName() == "quad_light" ||
-			lightShader->getName() == "portal"
-		)
-		{
-			const float width = parameterValue( lightShader->parameters(), "width", 1.0f );
-			const float height = parameterValue( lightShader->parameters(), "height", 1.0f );
-			strength *= width * height;
-		}
-		else if( lightShader->getName() == "disk_light" )
-		{
-			const float width = parameterValue( lightShader->parameters(), "width", 2.0f ) * 0.5f;
-			const float height = parameterValue( lightShader->parameters(), "height", 2.0f ) * 0.5f;
-			strength *= M_PI * width * height;
-		}
-		else // Point or spot light.
-		{
-			const float size = parameterValue( lightShader->parameters(), "size", 1.0f ) * 0.5f;
-			strength *= M_PI * size * size * 4.0f;
-		}
-	}
 
 	return strength;;
 }

--- a/src/GafferCycles/SocketHandler.cpp
+++ b/src/GafferCycles/SocketHandler.cpp
@@ -564,10 +564,12 @@ void setupLightPlugs( const std::string &shaderName, const ccl::NodeType *nodeTy
 			)
 		);
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "spot_smooth" ) )), plugsParent, Gaffer::Plug::In ) );
+		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "is_sphere" ) )), plugsParent, Gaffer::Plug::In ) );
 	}
 	else if( shaderName == "point_light" )
 	{
 		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "size" ) )), plugsParent, Gaffer::Plug::In ) );
+		validPlugs.insert( setupPlug( nodeType, *(nodeType->find_input( ccl::ustring( "is_sphere" ) )), plugsParent, Gaffer::Plug::In ) );
 	}
 	else if( shaderName == "disk_light" )
 	{

--- a/src/GafferCyclesModule/GafferCyclesModule.cpp
+++ b/src/GafferCyclesModule/GafferCyclesModule.cpp
@@ -397,6 +397,14 @@ py::dict getLights()
 			{
 				in["spot_angle"] = _in["spot_angle"];
 				in["spot_smooth"] = _in["spot_smooth"];
+				in["is_sphere"] = _in["is_sphere"];
+				d["in"] = in;
+				d["enum"] = it->second;
+				result[type] = d;
+			}
+			else if( type == "point_light" )
+			{
+				in["is_sphere"] = _in["is_sphere"];
 				d["in"] = in;
 				d["enum"] = it->second;
 				result[type] = d;

--- a/startup/GafferCyclesUI/metadata.py
+++ b/startup/GafferCyclesUI/metadata.py
@@ -1033,11 +1033,12 @@ Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.max_bounces
 Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.cast_shadow", "layout:index", 13 )
 Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_mis", "layout:index", 14 )
 Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_caustics", "layout:index", 15 )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_camera", "layout:index", 16 )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_diffuse", "layout:index", 17 )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_glossy", "layout:index", 18 )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_transmission", "layout:index", 19 )
-Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_scatter", "layout:index", 20 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.is_sphere", "layout:index", 16 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_camera", "layout:index", 17 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_diffuse", "layout:index", 18 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_glossy", "layout:index", 19 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_transmission", "layout:index", 20 )
+Gaffer.Metadata.registerValue( GafferCycles.CyclesLight, "parameters.use_scatter", "layout:index", 21 )
 
 ### universal sections ###
 

--- a/startup/GafferCyclesUI/metadata.py
+++ b/startup/GafferCyclesUI/metadata.py
@@ -34,10 +34,11 @@
 #
 ##########################################################################
 
+import functools
+import imath
+
 import Gaffer
 import GafferCycles
-import imath
-import functools
 
 parameterMetadata = {
 	"principled_bsdf" : {


### PR DESCRIPTION
This brings a few changes related to the recent Cycles update:

- Exposing the `is_sphere` socket on point and spot lights to allow reverting them back to the non-physically based behaviour from Cycles 3.6.0 and earlier. This is equivalent to Blender's [Soft Falloff](https://developer.blender.org/docs/release_notes/4.1/rendering/#lights) option, though the logic in Blender is reversed for presentation.
- Changing over to Cycles' new [blue noise](https://developer.blender.org/docs/release_notes/4.2/cycles/#sampling) based sampling pattern. Blender provides the ability to revert back to the "Classic" sampling pattern as an advanced option. We could add this option back to CyclesOptions if necessary later, but it seems worthwhile to at least introduce this change of the default in advance of Gaffer 1.5.
- Removing our custom handing of unnormalized lights now that this is handled by Cycles. This fixes an issue where scaling wasn't being taken into account for unnormalized quad and disk lights with our code, but does introduce a breaking look change as the strength of unnormalized point, spot and disk lights differ with the Cycles code. Unnormalized disk lights get closer to Arnold as a result, but point and spot lights diverge as the Cycles code is based on a sphere with a surface area of 1, while Arnold and our code is/was based on a surface area of 4.

These changes are grouped in a single PR in order to more easily facilitate user testing with a single build artifact.