### PR TITLE
ColorPlugValueWidget : Lazy `ColorShooser` create

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - NumericWidget : Added the ability to use <kbd>Ctrl</kbd> + scroll wheel to adjust values in the same manner as <kbd>Up</kbd> and <kbd>Down</kbd> (#6009).
+- ColorPlugValueWidget : Improved performance when creating the widget with the color chooser hidden.
 
 Fixes
 -----

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -64,7 +64,7 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 				self.__chooserButton = GafferUI.Button( image = "colorPlugValueWidgetSlidersOff.png", hasFrame = False )
 				self.__chooserButton.clickedSignal().connect( Gaffer.WeakMethod( self.__chooserButtonClicked ), scoped = False )
 
-			self.__colorChooser = GafferUI.ColorChooserPlugValueWidget( plugs )
+		self.__colorChooser = None
 
 		self.setColorChooserVisible(
 			sole( Gaffer.Metadata.value( plug, "colorPlugValueWidget:colorChooserVisible" ) for plug in self.getPlugs() )
@@ -78,10 +78,15 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__colorChooserVisible = visible
 
-		self.__colorChooser.setVisible(
-			self.__colorChooserVisible and
-			not any( p.direction() == Gaffer.Plug.Direction.Out for p in self.getPlugs() )
-		)
+		if visible and self.__colorChooser is None :
+			self.__colorChooser = GafferUI.ColorChooserPlugValueWidget( self.getPlugs() )
+			self.__column.append( self.__colorChooser )
+
+		if self.__colorChooser is not None :
+			self.__colorChooser.setVisible(
+				self.__colorChooserVisible and
+				not any( p.direction() == Gaffer.Plug.Direction.Out for p in self.getPlugs() )
+			)
 
 		self.__chooserButton.setImage(
 			"colorPlugValueWidgetSliders{}.png".format( "On" if visible else "Off" )
@@ -89,14 +94,15 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def getColorChooserVisible( self ) :
 
-		return self.__colorChooser.getVisible()
+		return self.__colorChooser.getVisible() if self.__colorChooser is not None else False
 
 	def setPlugs( self, plugs ) :
 
 		GafferUI.PlugValueWidget.setPlugs( self, plugs )
 
 		self.__compoundNumericWidget.setPlugs( plugs )
-		self.__colorChooser.setPlugs( plugs )
+		if self.__colorChooser is not None :
+			self.__colorChooser.setPlugs( plugs )
 		self.__swatch.setPlugs( plugs )
 
 		# Update widget visibility if the plug directions changed


### PR DESCRIPTION
This improves the performance of creating a `ColorPlugValueWidget` by deferring the creation of the internal color chooser to when it is first made visible.

For a single `ColorPlugValueWidget`, the difference is not all that noticeable, but for a node such as `aiStandardSurface`, the improved creation time of all the widgets in the node editor is subtly faster.

It's also noticeably faster when testing on top of https://github.com/GafferHQ/gaffer/pull/6003 where we are adding a number of additional widgets and increasing the amount of time needed to populate the node editor when not deferring color chooser creation.

For me, some timings when selecting an `aiStandardSurface` node :
- Current code : 0.60 seconds
- Deferred creation : 0.35 seconds (41% shorter)
- New `ColorChooser` without deferred creation : 0.75 seconds (26% longer than current)
- New `ColorChooser` with deferred creation : 0.35 seconds (53% shorter than without deferred)

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
