### PR TITLE
Improved support for conditional enabling of nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,8 @@ Fixes
 - Viewer : Fixed drawing of custom mesh light texture visualisers (#6002). [^1]
 - GraphEditor :
   - Fixed lingering error badges (#3820).
+  - Fixed <kbd>D</kbd> shortcut to respect read-only metadata on `enabled` plugs. Previously only metadata on the node itself was respected.
+  - Fixed <kbd>D</kbd> shortcut to handle multiple selection with some nodes enabled and some disabled. This will now consistently disabled all nodes if at least one is enabled, rather than toggling each individually.
 - RenderPassEditor :
   - Fixed history window to update on context changes, for example, when the current frame is changed.
   - Fixed invalid `scene:path` context variables created by the history window. [^1]
@@ -41,6 +43,7 @@ Breaking Changes
 
 - IECoreArnold : Added `messageContext` argument to `NodeAlgo::Converter` and `NodeAlgo::MotionConverter`.
 - Instancer : Renamed `encapsulateInstanceGroups` plug to `encapsulate`. Encapsulation now produces a single capsule at the `.../instances` location, instead of capsules at each `.../instances/<prototypeName>` location.
+- GraphGadget : Moved <kbd>D</kbd> shortcut handling to GraphEditor.
 
 [^1]: To be omitted from 1.5.0.0 release notes.
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - LightEditor, RenderPassEditor : History windows now use a context determined relative to the current focus node.
 - NumericWidget : Added the ability to use <kbd>Ctrl</kbd> + scroll wheel to adjust values in the same manner as <kbd>Up</kbd> and <kbd>Down</kbd> (#6009). [^1]
 - NodeEditor : Improved performance when showing a node with many colour plugs. Showing the Arnold `standard_surface` shader is now almost 2x faster. [^1]
+- GraphEditor : Added colour coding to the strike-throughs drawn for disabled nodes. Black indicates that the node is always disabled, and yellow indicates that its `enabled` plug has an input connection, and therefore might be context-sensitive.
 - ListContainer : Adding a child widget with non-default alignment no longer causes the container to take up all available space.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.x.x.x (relative to 1.5.0.0a1)
 =======
 
+Features
+--------
+
+- PatternMatch : Added a new node for matching strings against wildcard patterns.
+
 Improvements
 ------------
 

--- a/include/Gaffer/PatternMatch.h
+++ b/include/Gaffer/PatternMatch.h
@@ -1,0 +1,80 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Gaffer/ComputeNode.h"
+#include "Gaffer/Export.h"
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/TypeIds.h"
+
+namespace Gaffer
+{
+
+class GAFFER_API PatternMatch : public ComputeNode
+{
+
+	public :
+
+		PatternMatch( const std::string &name = defaultName<PatternMatch>() );
+		~PatternMatch() override;
+
+		GAFFER_NODE_DECLARE_TYPE( Gaffer::PatternMatch, PatternMatchTypeId, ComputeNode );
+
+		StringPlug *stringPlug();
+		const StringPlug *stringPlug() const;
+
+		StringPlug *patternPlug();
+		const StringPlug *patternPlug() const;
+
+		BoolPlug *enabledPlug() override;
+		const BoolPlug *enabledPlug() const override;
+
+		BoolPlug *matchPlug();
+		const BoolPlug *matchPlug() const;
+
+		void affects( const Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const override;
+		void compute( ValuePlug *output, const Context *context) const override;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+}  // namespace Gaffer

--- a/include/Gaffer/TypeIds.h
+++ b/include/Gaffer/TypeIds.h
@@ -153,6 +153,7 @@ enum TypeId
 	OptionalValuePlugTypeId = 110107,
 	CollectTypeId = 110108,
 	Box2fVectorDataPlugTypeId = 110109,
+	PatternMatchTypeId = 110110,
 
 	LastTypeId = 110159,
 

--- a/include/GafferUI/GraphGadget.h
+++ b/include/GafferUI/GraphGadget.h
@@ -217,8 +217,6 @@ class GAFFERUI_API GraphGadget : public ContainerGadget
 		void noduleRemoved( Nodule *nodule );
 		void nodeMetadataChanged( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node );
 
-		bool keyPressed( GadgetPtr gadget, const KeyEvent &event );
-
 		bool buttonPress( GadgetPtr gadget, const ButtonEvent &event );
 		bool buttonRelease( GadgetPtr gadget, const ButtonEvent &event );
 

--- a/include/GafferUI/StandardNodeGadget.h
+++ b/include/GafferUI/StandardNodeGadget.h
@@ -158,7 +158,7 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		bool updateUserColor();
 		void updateMinWidth();
 		void updatePadding();
-		void updateStrikeThroughVisibility( const Gaffer::Plug *dirtiedPlug = nullptr );
+		void updateStrikeThroughState( const Gaffer::Plug *dirtiedPlug = nullptr );
 		void updateIcon();
 		bool updateShape();
 		void updateFocusGadgetVisibility();
@@ -170,7 +170,8 @@ class GAFFERUI_API StandardNodeGadget : public NodeGadget
 		void displayError( Gaffer::ConstPlugPtr plug, const std::string &message );
 
 		std::optional<bool> m_nodeEnabledInContextTracker;
-		bool m_strikeThroughVisible;
+		enum class StrikeThroughState : char { Invisible, Static, Dynamic };
+		StrikeThroughState m_strikeThroughState;
 		bool m_labelsVisibleOnHover;
 		// We accept drags onto the NodeGadget itself and
 		// use them to create a connection to the

--- a/python/GafferTest/PatternMatchTest.py
+++ b/python/GafferTest/PatternMatchTest.py
@@ -1,0 +1,70 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferTest
+
+class PatternMatchTest( GafferTest.TestCase ) :
+
+	def test( self ) :
+
+		node = Gaffer.PatternMatch()
+
+		for string, pattern, expectedResult in [
+			( "a", "a", True ),
+			( "a", "b", False ),
+			( "b", "b", True ),
+			( "a", "b a", True ),
+			( "a1", "a[0-9]", True ),
+			( "ab", "a[0-9]", False ),
+			( "a", "*", True ),
+		] :
+			with self.subTest( string = string, pattern = pattern ) :
+				node["string"].setValue( string )
+				node["pattern"].setValue( pattern )
+				self.assertEqual( node["match"].getValue(), expectedResult )
+
+	def testDisabling( self ) :
+
+		node = Gaffer.PatternMatch()
+		self.assertTrue( node["match"].getValue() )
+		node["enabled"].setValue( False )
+		self.assertFalse( node["match"].getValue() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferTest/__init__.py
+++ b/python/GafferTest/__init__.py
@@ -162,6 +162,7 @@ from .OptionalValuePlugTest import OptionalValuePlugTest
 from .ThreadMonitorTest import ThreadMonitorTest
 from .CollectTest import CollectTest
 from .ProcessTest import ProcessTest
+from .PatternMatchTest import PatternMatchTest
 
 from .IECorePreviewTest import *
 

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -238,13 +238,13 @@ class GraphEditor( GafferUI.Editor ) :
 	@classmethod
 	def appendEnabledPlugMenuDefinitions( cls, graphEditor, node, menuDefinition ) :
 
-		enabledPlug = node.enabledPlug() if isinstance( node, Gaffer.DependencyNode ) else None
+		enabledPlug = cls.__enabledPlugForEditing( node )
 		if enabledPlug is not None :
 			menuDefinition.append( "/EnabledDivider", { "divider" : True } )
 			menuDefinition.append(
 				"/Enabled",
 				{
-					"command" : functools.partial( cls.__setEnabled, node ),
+					"command" : functools.partial( cls.__setValue, enabledPlug ),
 					"checkBox" : enabledPlug.getValue(),
 					"active" : enabledPlug.settable() and not Gaffer.MetadataAlgo.readOnly( enabledPlug )
 				}
@@ -430,7 +430,7 @@ class GraphEditor( GafferUI.Editor ) :
 					continue
 				if self.graphGadget().nodeGadget( node ) is None :
 					continue
-				enabledPlug = node.enabledPlug()
+				enabledPlug = self.__enabledPlugForEditing( node )
 				if enabledPlug is None or not enabledPlug.settable() or Gaffer.MetadataAlgo.readOnly( enabledPlug ) :
 					continue
 				enabledPlugs.add( enabledPlug )
@@ -741,10 +741,10 @@ class GraphEditor( GafferUI.Editor ) :
 			graphGadget.setNodeOutputConnectionsMinimised( node, not value )
 
 	@classmethod
-	def __setEnabled( cls, node, value ) :
+	def __setValue( cls, plug, value ) :
 
-		with Gaffer.UndoScope( node.ancestor( Gaffer.ScriptNode ) ) :
-			node.enabledPlug().setValue( value )
+		with Gaffer.UndoScope( plug.ancestor( Gaffer.ScriptNode ) ) :
+			plug.setValue( value )
 
 	@staticmethod
 	def __childrenViewable( node ) :
@@ -761,5 +761,41 @@ class GraphEditor( GafferUI.Editor ) :
 
 		node.scriptNode().selection().clear()
 		node.scriptNode().selection().add( node )
+
+	@staticmethod
+	def __enabledPlugForEditing( node ) :
+
+		if not isinstance( node, Gaffer.DependencyNode ) :
+			return None
+
+		enabledPlug = node.enabledPlug()
+		if enabledPlug is None :
+			return None
+
+		if enabledPlug.getInput() is None :
+			return enabledPlug
+
+		# Plug has an input, but maybe we can edit that instead.
+
+		source = enabledPlug.source()
+		if not Gaffer.PlugAlgo.dependsOnCompute( source ) :
+			return source
+
+		# Plug depends on a compute, but maybe we can enable/disable
+		# that node instead? This only works if the node outputs False
+		# when disabled - things like PatternMatch.
+
+		if source.defaultValue() != False :
+			return enabledPlug
+
+		sourceNode = source.node()
+		if not isinstance( sourceNode, Gaffer.DependencyNode ) :
+			return enabledPlug
+
+		sourceEnabledPlug = sourceNode.enabledPlug()
+		if sourceEnabledPlug is not None and sourceNode.correspondingInput( source ) is None :
+			return sourceEnabledPlug
+
+		return enabledPlug
 
 GafferUI.Editor.registerType( "GraphEditor", GraphEditor )

--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -423,6 +423,24 @@ class GraphEditor( GafferUI.Editor ) :
 		elif event.key == "Tab" :
 			self.__popupNodeMenu()
 			return True
+		elif event.key == "D" and not event.modifiers :
+			enabledPlugs = set()
+			for node in self.scriptNode().selection() :
+				if not isinstance( node, Gaffer.DependencyNode ) :
+					continue
+				if self.graphGadget().nodeGadget( node ) is None :
+					continue
+				enabledPlug = node.enabledPlug()
+				if enabledPlug is None or not enabledPlug.settable() or Gaffer.MetadataAlgo.readOnly( enabledPlug ) :
+					continue
+				enabledPlugs.add( enabledPlug )
+
+			enabled = any( enabledPlug.getValue() for enabledPlug in enabledPlugs )
+			with Gaffer.UndoScope( self.scriptNode() ) :
+				for enabledPlug in enabledPlugs :
+					enabledPlug.setValue( not enabled )
+
+			return True
 
 		return False
 

--- a/python/GafferUI/PatternMatchUI.py
+++ b/python/GafferUI/PatternMatchUI.py
@@ -50,6 +50,7 @@ Gaffer.Metadata.registerNode(
 
 	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
 	"auxiliaryNodeGadget:label", "*",
+	"nodeGadget:shape", "oval",
 	"nodeGadget:focusGadgetVisible", False,
 	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
 
@@ -61,6 +62,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			The string to be tested.
 			""",
+
+			"nodule:type", "",
 
 		],
 
@@ -82,6 +85,8 @@ Gaffer.Metadata.registerNode(
 			| \\        | Escapes the next character                   |
 			""",
 
+			"nodule:type", "",
+
 		],
 
 		"enabled" : [
@@ -99,6 +104,8 @@ Gaffer.Metadata.registerNode(
 			"""
 			Outputs `true` if the string matches the pattern, and `false` otherwise.
 			""",
+
+			"nodule:type", "",
 
 		],
 

--- a/python/GafferUI/PatternMatchUI.py
+++ b/python/GafferUI/PatternMatchUI.py
@@ -1,0 +1,107 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+
+import Gaffer
+
+Gaffer.Metadata.registerNode(
+
+	Gaffer.PatternMatch,
+
+	"description",
+	"""
+	Tests an input string against a pattern, outputting true if the string
+	matches.
+	""",
+
+	"nodeGadget:type", "GafferUI::AuxiliaryNodeGadget",
+	"auxiliaryNodeGadget:label", "*",
+	"nodeGadget:focusGadgetVisible", False,
+	"uiEditor:nodeGadgetTypes", IECore.StringVectorData( [ "GafferUI::AuxiliaryNodeGadget", "GafferUI::StandardNodeGadget" ] ),
+
+	plugs = {
+
+		"string" : [
+
+			"description",
+			"""
+			The string to be tested.
+			""",
+
+		],
+
+		"pattern" : [
+
+			"description",
+			"""
+			The pattern to match the string against. This can use any of
+			Gaffer's standard wildcards :
+
+			| Pattern   | Usage                                        |
+			|:----------|:---------------------------------------------|
+			| *         | Matches any string                           |
+			| ?         | Matches any single character                 |
+			| [ABC]     | Matches any single character from a list     |
+			| [!ABC]    | Matches any single character not from a list |
+			| [a-z]     | Matches any single character in a range      |
+			| [!a-z]    | Matches any single character not in a range  |
+			| \\        | Escapes the next character                   |
+			""",
+
+		],
+
+		"enabled" : [
+
+			"description",
+			"""
+			Turns the node on and off. When off, `match` always outputs `false`.
+			""",
+
+		],
+
+		"match" : [
+
+			"description",
+			"""
+			Outputs `true` if the string matches the pattern, and `false` otherwise.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -304,6 +304,7 @@ from . import NameSwitchUI
 from . import EditScopeUI
 from . import ContextVariableTweaksUI
 from . import CollectUI
+from . import PatternMatchUI
 
 # backwards compatibility
 ## \todo Remove me

--- a/src/Gaffer/PatternMatch.cpp
+++ b/src/Gaffer/PatternMatch.cpp
@@ -1,0 +1,147 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Gaffer/PatternMatch.h"
+
+#include "IECore/StringAlgo.h"
+
+using namespace Gaffer;
+
+GAFFER_NODE_DEFINE_TYPE( PatternMatch );
+
+size_t PatternMatch::g_firstPlugIndex = 0;
+
+PatternMatch::PatternMatch( const std::string &name )
+	:	ComputeNode( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new StringPlug( "string" ) );
+	addChild( new StringPlug( "pattern" ) );
+	addChild( new BoolPlug( "enabled", Plug::In, true ) );
+	addChild( new BoolPlug( "match", Plug::Out ) );
+}
+
+PatternMatch::~PatternMatch()
+{
+}
+
+StringPlug *PatternMatch::stringPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+const StringPlug *PatternMatch::stringPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex );
+}
+
+StringPlug *PatternMatch::patternPlug()
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const StringPlug *PatternMatch::patternPlug() const
+{
+	return getChild<StringPlug>( g_firstPlugIndex + 1 );
+}
+
+BoolPlug *PatternMatch::enabledPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+const BoolPlug *PatternMatch::enabledPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 2 );
+}
+
+BoolPlug *PatternMatch::matchPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+const BoolPlug *PatternMatch::matchPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 3 );
+}
+
+void PatternMatch::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ComputeNode::affects( input, outputs );
+
+	if(
+		input == stringPlug() ||
+		input == patternPlug() ||
+		input == enabledPlug()
+	)
+	{
+		outputs.push_back( matchPlug() );
+	}
+}
+
+void PatternMatch::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == matchPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		stringPlug()->hash( h );
+		patternPlug()->hash( h );
+		enabledPlug()->hash( h );
+	}
+	else
+	{
+		ComputeNode::hash( output, context, h );
+	}
+}
+
+void PatternMatch::compute( ValuePlug *output, const Context *context) const
+{
+	ComputeNode::compute( output, context );
+
+	if( output == matchPlug() )
+	{
+		static_cast<BoolPlug *>( output )->setValue(
+			enabledPlug()->getValue() ?
+			IECore::StringAlgo::matchMultiple( stringPlug()->getValue(), patternPlug()->getValue() ) :
+			false
+		);
+	}
+	else
+	{
+		ComputeNode::compute( output, context );
+	}
+}

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -87,6 +87,7 @@
 #include "GafferBindings/DependencyNodeBinding.h"
 
 #include "Gaffer/Backdrop.h"
+#include "Gaffer/PatternMatch.h"
 
 #ifdef __linux__
 #include <sys/prctl.h>
@@ -251,6 +252,7 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	bindCollect();
 
 	NodeClass<Backdrop>();
+	DependencyNodeClass<PatternMatch>();
 
 	def( "isDebug", &isDebug );
 

--- a/src/GafferUI/GraphGadget.cpp
+++ b/src/GafferUI/GraphGadget.cpp
@@ -241,7 +241,6 @@ GAFFER_GRAPHCOMPONENT_DEFINE_TYPE( GraphGadget );
 GraphGadget::GraphGadget( Gaffer::NodePtr root, Gaffer::SetPtr filter )
 	:	m_dragStartPosition( 0 ), m_lastDragPosition( 0 ), m_dragMode( None ), m_dragReconnectCandidate( nullptr ), m_dragReconnectSrcNodule( nullptr ), m_dragReconnectDstNodule( nullptr ), m_dragMergeGroupId( 0 )
 {
-	keyPressSignal().connect( boost::bind( &GraphGadget::keyPressed, this, ::_1,  ::_2 ) );
 	buttonPressSignal().connect( boost::bind( &GraphGadget::buttonPress, this, ::_1,  ::_2 ) );
 	buttonReleaseSignal().connect( boost::bind( &GraphGadget::buttonRelease, this, ::_1,  ::_2 ) );
 	dragBeginSignal().connect( boost::bind( &GraphGadget::dragBegin, this, ::_1, ::_2 ) );
@@ -833,33 +832,6 @@ Box3f GraphGadget::renderBound() const
 	Box3f b;
 	b.makeInfinite();
 	return b;
-}
-
-bool GraphGadget::keyPressed( GadgetPtr gadget, const KeyEvent &event )
-{
-	if( event.key == "D" && !event.modifiers )
-	{
-		/// \todo This functionality would be better provided by a config file,
-		/// rather than being hardcoded in here. For that to be done easily we
-		/// need a static keyPressSignal() in Widget, which needs figuring out
-		/// some more before we commit to it. In the meantime, this will do.
-		Gaffer::UndoScope undoScope( m_scriptNode );
-		Gaffer::Set *selection = m_scriptNode->selection();
-		for( size_t i = 0, s = selection->size(); i != s; i++ )
-		{
-			Gaffer::DependencyNode *node = IECore::runTimeCast<Gaffer::DependencyNode>( selection->member( i ) );
-			if( node && findNodeGadget( node ) && !Gaffer::MetadataAlgo::readOnly( node ) )
-			{
-				Gaffer::BoolPlug *enabledPlug = node->enabledPlug();
-				if( enabledPlug && enabledPlug->settable() )
-				{
-					enabledPlug->setValue( !enabledPlug->getValue() );
-				}
-			}
-		}
-		return true;
-	}
-	return false;
 }
 
 void GraphGadget::rootChildAdded( Gaffer::GraphComponent *root, Gaffer::GraphComponent *child )

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -576,6 +576,7 @@ nodeMenu.append( "/Utility/Time Warp", Gaffer.TimeWarp, searchText = "TimeWarp" 
 nodeMenu.append( "/Utility/Spreadsheet", Gaffer.Spreadsheet )
 nodeMenu.append( "/Utility/Context Query", Gaffer.ContextQuery, searchText = "ContextQuery" )
 nodeMenu.append( "/Utility/Collect", Gaffer.Collect )
+nodeMenu.append( "/Utility/Pattern Match", Gaffer.PatternMatch, searchText = "PatternMatch" )
 
 ## Miscellaneous UI
 ###########################################################################


### PR DESCRIPTION
This adds a PatternMatch node which is useful as an enabler of other nodes, particularly by matching against the current context. It also customises the GraphEditor logic to provide improved feedback on such setups using color-coded strike-throughs, and to improve interaction with them in the <kbd>D</kbd> shortcut by "disabling the enabler". More thorough details in the final commit message.