### PR TITLE
GL Renderer : Fix custom mesh light texture visualisations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
   - Fixed partial image updates when an unrelated InteractiveRender was running (#6043).
   - Fixed "colour tearing", where updates to some image channels became visible before updates to others.
   - Fixed unnecessary texture updates when specific image tiles don't change.
+- Viewer : Fixed drawing of custom mesh light texture visualisers (#6002).
 - ArrayPlug :
   - Fixed error when `resize()` removed plugs with input connections.
   - Fixed error when `resize()` was used on an output plug.

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -320,7 +320,7 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 	public :
 
 		OpenGLAttributes( const IECore::CompoundObject *attributes )
-			: m_frustumMode( FrustumMode::WhenSelected )
+			:	m_frustumMode( FrustumMode::WhenSelected ), m_visualisationStateColorSpace( Visualisation::ColorSpace::Display )
 		{
 			const FloatData *visualiserScaleData = attributes->member<FloatData>( "gl:visualiser:scale" );
 			m_visualiserScale = visualiserScaleData ? visualiserScaleData->readable() : 1.0;
@@ -388,6 +388,19 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 				}
 
 				m_visualisationState = combinedState;
+				auto solidState = m_visualisationState->get<IECoreGL::Primitive::DrawSolid>();
+				// The Visualiser API doesn't currently allow a colour space to
+				// be associated with the visualisation state. So we use a
+				// heuristic : if the state includes solid drawing then we
+				// assume Scene space. This allows custom mesh light texture
+				// visualisers to be shown with an appropriate colour transform.
+				// Otherwise we assume Display space, which gives us what we
+				// want for the coloured outline from our own mesh light
+				// visualiser.
+				if( !solidState || solidState->value() )
+				{
+					m_visualisationStateColorSpace = Visualisation::ColorSpace::Scene;
+				}
 			}
 		}
 
@@ -396,9 +409,9 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 			return m_state.get();
 		}
 
-		const State *visualisationState() const
+		const State *visualisationState( Visualisation::ColorSpace colorSpace ) const
 		{
-			return m_visualisationState.get();
+			return colorSpace == m_visualisationStateColorSpace ? m_visualisationState.get() : nullptr;
 		}
 
 		const IECoreGLPreview::Visualisations &visualisations() const
@@ -451,6 +464,7 @@ class OpenGLAttributes : public IECoreScenePreview::Renderer::AttributesInterfac
 		FrustumMode m_frustumMode;
 
 		float m_visualiserScale = 1.0f;
+		Visualisation::ColorSpace m_visualisationStateColorSpace;
 };
 
 IE_CORE_DECLAREPTR( OpenGLAttributes )
@@ -636,19 +650,12 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			// Objects are rendered into `ColorSpace::Scene`, with the caveat that selection
 			// overlays and additional visualisations are drawn into `ColorSpace::Display`.
 
-			const IECoreGL::State *visualisationState = m_attributes->visualisationState();
+			const IECoreGL::State *visualisationState = m_attributes->visualisationState( colorSpace );
 			if( m_renderable && ( colorSpace == Visualisation::ColorSpace::Scene || isSelected || visualisationState ) )
 			{
 				IECoreGL::State::ScopedBinding stateScope( *m_attributes->state(), *currentState );
-				// We assume that any additional state provided by visualisers
-				// is intended to be drawn in `ColorSpace::Display`. Currently
-				// the only such state is the yellow outline added by the mesh
-				// light visualiser, so it would be premature to extend the API
-				// to allow visualiser state to also be specified for
-				// `ColorSpace::Scene`. In fact, the potential uses for
-				// visualiser state seem very limited.
 				std::optional<IECoreGL::State::ScopedBinding> visualisationStateScope;
-				if( visualisationState && colorSpace == Visualisation::ColorSpace::Display )
+				if( visualisationState )
 				{
 					visualisationStateScope.emplace( *visualisationState, *currentState );
 				}


### PR DESCRIPTION
These were broken by cfc3857ce0da4c8f77cfc546028f5c7e64aaf585, where we assumed that such visualisations should be rendered with the Display color space. This led to them being rendered after the main Scene color space, meaning that the depth test prevented the texture visualisation from being seen. We now use a heuristic that means such visualisations are rendered first in Scene color space instead.

In theory we could extend the Visualiser API to allow two states to be specified - one for Display space and one for Scene space. But that would require an ABI break, and we want this fix to go into 1.3. We also have so few uses for the visualisation state that it seems like overkill at this point.

Fixes #6002.

> Note : I've made this PR to `1.3_maintenance` but have only been able to test on `1.4_maintenance`. My CentOS 7 distrobox setup for legacy testing was refusing to find my NVIDIA card today.