### PR TITLE
View/BackgroundTask : Improve ScriptNode discovery hack

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,7 +23,9 @@ Fixes
   - Fixed partial image updates when an unrelated InteractiveRender was running (#6043).
   - Fixed "colour tearing", where updates to some image channels became visible before updates to others.
   - Fixed unnecessary texture updates when specific image tiles don't change.
-- Viewer : Fixed drawing of custom mesh light texture visualisers (#6002). [^1]
+- Viewer :
+  - Fixed drawing of custom mesh light texture visualisers (#6002). [^1]
+  - Fixed BackgroundTask warning when deleting the node being viewed.
 - GraphEditor :
   - Fixed lingering error badges (#3820).
 - RenderPassEditor :

--- a/python/GafferSceneUITest/LightToolTest.py
+++ b/python/GafferSceneUITest/LightToolTest.py
@@ -136,13 +136,8 @@ class LightToolTest( GafferUITest.TestCase ) :
 		# we're pretty happy if it doesn't.
 
 		del preRenderSlot[:]
-		with IECore.CapturingMessageHandler() as mh :
-			while not len( preRenderSlot ) :
-				self.waitForIdle( 1000 )
-
-		# Ignore unrelated message from BackgroundTask. This needs a separate fix.
-		self.assertEqual( len( mh.messages ), 1 )
-		self.assertEqual( mh.messages[0].message, "Unable to find ScriptNode for SceneView.__preprocessor.out" )
+		while not len( preRenderSlot ) :
+			self.waitForIdle( 1000 )
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -97,14 +97,7 @@ const ScriptNode *scriptNode( const GraphComponent *subject )
 	// the ScriptNode from such classes.
 	while( subject )
 	{
-		if( subject->isInstanceOf( "GafferUI::View" ) )
-		{
-			if( auto inPlug = subject->getChild<Plug>( "in" ) )
-			{
-				return scriptNode( inPlug->getInput() );
-			}
-		}
-		else if( subject->isInstanceOf( "GafferUI::Editor::Settings" ) )
+		if( subject->isInstanceOf( "GafferUI::View" ) || subject->isInstanceOf( "GafferUI::Editor::Settings" ) )
 		{
 			if( auto scriptPlug = subject->getChild<Plug>( "__scriptNode" ) )
 			{

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -97,6 +97,13 @@ View::View( const std::string &name, Gaffer::ScriptNodePtr scriptNode, Gaffer::P
 	addChild( new Plug( g_editScopeName ) );
 	addChild( new ToolContainer( g_toolsName ) );
 
+	// Hack to allow BackgroundTask to recover ScriptNode for
+	// cancellation support - see `BackgroundTask.cpp` and
+	// `Editor.Settings`.
+	PlugPtr scriptNodePlug = new Plug( "__scriptNode" );
+	addChild( scriptNodePlug );
+	scriptNodePlug->setInput( scriptNode->fileNamePlug() );
+
 	m_context = m_contextTracker->context( this );
 	m_contextTracker->changedSignal( this ).connect( boost::bind( &View::contextTrackerChanged, this ) );
 	tools()->childAddedSignal().connect( boost::bind( &View::toolsChildAdded, this, ::_2 ) );


### PR DESCRIPTION
We now use the same method we use for recovering a ScriptNode from a `View.Settings` node (one hack is better than two, right?). This fixes the following warning when deleting the node being viewed in the Viewer :

```
WARNING : BackgroundTask : Unable to find ScriptNode for SceneView.__preprocessor.out
```

In this case, the input to the `SceneView.in` had been removed by the deletion of the node, and therefore there was no path from `SceneView.__preprocessor.out` to the ScriptNode.
