### PR TITLE
BackgroundTask : Fix hang when creating Views

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Improvements
 Fixes
 -----
 
+- Viewer : Fixed hangs when focussing a node for the first time (bug introduced in 1.5.0.0a2). [^1]
 - Cycles : Fixed issue where scaling unnormalized quad and disk lights would not affect their brightness.
 
 Breaking Changes

--- a/python/GafferSceneUITest/SceneViewTest.py
+++ b/python/GafferSceneUITest/SceneViewTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import time
 import unittest
 
 import imath
@@ -482,6 +483,20 @@ class SceneViewTest( GafferUITest.TestCase ) :
 		view.viewportGadget().preRenderSignal()( view.viewportGadget() ) # Force update
 		self.assertEqual( view.viewportGadget().getCamera().getClippingPlanes(), expectedClippingPlanes )
 		self.assertEqual( view["camera"]["clippingPlanes"].getValue(), expectedClippingPlanes )
+
+	def testConstructWhileBackgroundTaskRuns( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		def task( canceller ) :
+
+			while True :
+				IECore.Canceller.check( canceller )
+				time.sleep( 0.01 )
+
+		backgroundTask = Gaffer.BackgroundTask( script["fileName"], task )
+		GafferSceneUI.SceneView( script )
+		backgroundTask.cancelAndWait()
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -99,6 +99,12 @@ const ScriptNode *scriptNode( const GraphComponent *subject )
 	{
 		if( subject->isInstanceOf( "GafferUI::View" ) || subject->isInstanceOf( "GafferUI::Editor::Settings" ) )
 		{
+			if( !subject->refCount() )
+			{
+				// View or Settings still in construction, and therefore can't
+				// be accessed by any background tasks. No need to cancel anything.
+				return nullptr;
+			}
 			if( auto scriptPlug = subject->getChild<Plug>( "__scriptNode" ) )
 			{
 				return scriptNode( scriptPlug->getInput() );


### PR DESCRIPTION
This could be triggered randomly when focussing a node for the first time in a Gaffer session. It was caused by 5019e9f17c74a2834e7a21c773647fc5dbc71bc9, which meant that we could get a ScriptNode from a View that was still undergoing construction, whereas before we wouldn't get to the script until it was fully constructed.

Because we could get the ScriptNode during construction, we were also requesting cancellation during construction. And because the View constructors in Python don't release the GIL, any background tasks need the GIL in order to be cancelled will cause deadlock. We fix this by simply not triggering cancellation from a View until it has finished construction, as determined by `refCount()`. This puts us back in the same situation we were in before.

An alternative fix would have been to release the GIL in the bindings for all View constructors. This is a bit fiddly for constructors, but would have been completely doable. I went for the simpler solution because it seems worthwhile to avoid unnecessary cancellation.
