### PR TITLE
OCIO/ContextTracker fixes

### DIFF
--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -202,11 +202,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# Only show the View name, because the Display name is more of
 				# a "set once and forget" affair. The menu shows both for when
 				# you need to check.
-				self.__menuButton.setText(
-					f"Default ({self.__currentView})"
-					if self.__currentValue == "__default__"
-					else self.__currentView
-				)
+				self.__menuButton.setText( self.__currentView )
 				self.__menuButton.setErrored( not valid )
 
 	def _valuesDependOnContext( self ) :
@@ -262,12 +258,13 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		# Default section
 
-		result.append( "/__DefaultDivider__", { "divider" : True, "label" : "Default" } )
+		result.append( "/__OptionsDivider__", { "divider" : True, "label" : "Options" } )
 
 		result.append(
-			f"/Default", {
+			f"/Use Default Display And View", {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setToDefault ) ),
 				"checkBox" : self.__currentValue == "__default__",
+				"description" : "Always uses the default display and view for the current config. Useful when changing configs often, or using context-sensitive configs."
 			}
 		)
 

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -203,7 +203,9 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 				# a "set once and forget" affair. The menu shows both for when
 				# you need to check.
 				self.__menuButton.setText(
-					self.__currentView if value else f"Default ({self.__currentView})"
+					f"Default ({self.__currentView})"
+					if self.__currentValue == "__default__"
+					else self.__currentView
 				)
 				self.__menuButton.setErrored( not valid )
 
@@ -265,7 +267,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result.append(
 			f"/Default", {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setToDefault ) ),
-				"checkBox" : self.getPlug().isSetToDefault(),
+				"checkBox" : self.__currentValue == "__default__",
 			}
 		)
 
@@ -286,7 +288,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		with Gaffer.UndoScope( self.scriptNode() ) :
 			for plug in self.getPlugs() :
-				self.getPlug().setToDefault()
+				self.getPlug().setValue( "__default__" )
 
 # Connection between default script config and Widget and View display transforms.
 # Calling `connect()` from an application startup file is what makes the UI OpenColorIO-aware.

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -158,6 +158,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__menuButton = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ) )
 		GafferUI.PlugValueWidget.__init__( self, self.__menuButton, plugs, **kw )
 
+		self.__currentValue = None
 		self.__currentDisplay = None
 		self.__currentView = None
 
@@ -168,8 +169,8 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		assert( isinstance( value, str ) )
 
 		config = GafferImage.OpenColorIOAlgo.currentConfig()
-		if not value :
-			# Empty string uses the default from the config.
+		if value == "__default__" :
+			# Use the default from the config.
 			display = config.getDefaultDisplay()
 			view = config.getDefaultView( display )
 			valid = True
@@ -186,17 +187,18 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if exception is not None :
 			self.__menuButton.setText( "" )
 			self.__menuButton.setErrored( True )
+			self.__currentValue = None
 			self.__currentDisplay = None
 			self.__currentView = None
 		else :
-			value = sole( values )
-			if value is None :
+			self.__currentValue = sole( values )
+			if self.__currentValue is None :
 				self.__menuButton.setText( "---" )
 				self.__menuButton.setErrored( not all( self.parseValue( v )[2] for v in values ) )
 				self.__currentDisplay = None
 				self.__currentView = None
 			else :
-				self.__currentDisplay, self.__currentView, valid = self.parseValue( value )
+				self.__currentDisplay, self.__currentView, valid = self.parseValue( self.__currentValue )
 				# Only show the View name, because the Display name is more of
 				# a "set once and forget" affair. The menu shows both for when
 				# you need to check.
@@ -297,7 +299,7 @@ def connect( script ) :
 		Gaffer.NodeAlgo.applyUserDefaults( plug )
 
 	GafferUI.View.DisplayTransform.registerDisplayTransform(
-		"", __defaultViewDisplayTransformCreator
+		"__default__", __defaultViewDisplayTransformCreator
 	)
 
 	script.plugDirtiedSignal().connect( __scriptPlugDirtied )

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -210,6 +210,12 @@ class _ColorField( GafferUI.Widget ) :
 
 		return xAxis, yAxis
 
+	def _displayTransformChanged( self ) :
+
+		GafferUI.Widget._displayTransformChanged( self )
+		self.__colorFieldToDraw = None
+		self._qtWidget().update()
+
 	def __setColorInternal( self, color, staticComponent, reason ) :
 
 		dragBeginOrEnd = reason in ( GafferUI.Slider.ValueChangedReason.DragBegin, GafferUI.Slider.ValueChangedReason.DragEnd )

--- a/src/GafferImage/OpenColorIOConfigPlug.cpp
+++ b/src/GafferImage/OpenColorIOConfigPlug.cpp
@@ -67,7 +67,7 @@ OpenColorIOConfigPlug::OpenColorIOConfigPlug( const std::string &name, Direction
 	addChild( new StringPlug( "config", direction, "", childFlags ) );
 	addChild( new StringPlug( "workingSpace", direction, OCIO_NAMESPACE::ROLE_SCENE_LINEAR, childFlags ) );
 	addChild( new ValuePlug( "variables", direction, childFlags ) );
-	addChild( new StringPlug( "displayTransform", direction, "", childFlags ) );
+	addChild( new StringPlug( "displayTransform", direction, "__default__", childFlags ) );
 }
 
 Gaffer::StringPlug *OpenColorIOConfigPlug::configPlug()

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -549,18 +549,21 @@ void View::DisplayTransform::preRender()
 		m_shader = nullptr;
 		const std::string name = namePlug()->getValue();
 		auto it = displayTransformCreators().find( name );
-		if( it != displayTransformCreators().end() )
+		if( !name.empty() )
 		{
-			Context::Scope scope( view()->context() );
-			m_shader = it->second();
-			m_shaderContextHash = hashWithoutFrame( view()->context() );
-		}
-		else
-		{
-			IECore::msg(
-				IECore::Msg::Warning, "View::DisplayTransform",
-				fmt::format( "Transform \"{}\" not registered", name )
-			);
+			if( it != displayTransformCreators().end() )
+			{
+				Context::Scope scope( view()->context() );
+				m_shader = it->second();
+				m_shaderContextHash = hashWithoutFrame( view()->context() );
+			}
+			else
+			{
+				IECore::msg(
+					IECore::Msg::Warning, "View::DisplayTransform",
+					fmt::format( "Transform \"{}\" not registered", name )
+				);
+			}
 		}
 
 		view()->viewportGadget()->setPostProcessShader( Gadget::Layer::Main, m_shader );

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -548,22 +548,19 @@ void View::DisplayTransform::preRender()
 	{
 		m_shader = nullptr;
 		const std::string name = namePlug()->getValue();
-		if( !name.empty() )
+		auto it = displayTransformCreators().find( name );
+		if( it != displayTransformCreators().end() )
 		{
-			auto it = displayTransformCreators().find( name );
-			if( it != displayTransformCreators().end() )
-			{
-				Context::Scope scope( view()->context() );
-				m_shader = it->second();
-				m_shaderContextHash = hashWithoutFrame( view()->context() );
-			}
-			else
-			{
-				IECore::msg(
-					IECore::Msg::Warning, "View::DisplayTransform",
-					fmt::format( "Transform \"{}\" not registered", name )
-				);
-			}
+			Context::Scope scope( view()->context() );
+			m_shader = it->second();
+			m_shaderContextHash = hashWithoutFrame( view()->context() );
+		}
+		else
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "View::DisplayTransform",
+				fmt::format( "Transform \"{}\" not registered", name )
+			);
 		}
 
 		view()->viewportGadget()->setPostProcessShader( Gadget::Layer::Main, m_shader );

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -53,6 +53,7 @@ application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
 
 Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "plugValueWidget:type", "GafferImageUI.OpenColorIOConfigPlugUI.DisplayTransformPlugValueWidget" )
 Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "layout:minimumWidth", 150 )
+Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "userDefault", "__default__" )
 
 # Add "Roles" submenus to various colorspace plugs. The OCIO UX guidelines suggest we
 # shouldn't do this, but they do seem like they might be useful, and historically they


### PR DESCRIPTION
This attempts to improve the DisplayTransformPlugValueWidget for the new ContextTracker-based world, where contexts may change more frequently than before. This affects the display transform menu in the Viewer, and the OCIO section in the Settings window. I'm not sure how successful I have been - I'm definitely open to opinions on other ways of approaching it.

@jedypod, your input would be valuable here. What I've ended up doing is allowing a "Default" value for display transforms, which adapts dynamically to whatever the default is in the current OCIO config. A bit like how "Automatic" on the ImageReader adapts based on the file type. In Gaffer 1.5, the OCIO config used in the Viewer can be even more dynamic than it already is, and can theoretically change based on what you're node you have focussed. So I felt that a dynamic default had some value - better than either errors or changing things behind people's backs. I've included the dynamically resolved name in the label, so hopefully it's clear that it's not a mystery transform called "Default", but a mode which resolves to a real transform. But I know on #5215 you made a good case against having "Default", so I'd like your take on this latest iteration...

![image](https://github.com/user-attachments/assets/7aecca24-e154-4165-bdee-da4d84d89ad2)
