### PR TITLE
Instancer : Support inactive ids

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- Instancer : Added support for 64 bit ints for ids ( matching what is loaded from USD ).
+- Instancer :
+  - Added `inactiveIds` plug for selecting primitive variables to disable some instances.
+  - Added support for 64 bit integer ids (matching what is loaded from USD).
 
 Fixes
 -----

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -138,6 +138,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::StringPlug *scalePlug();
 		const Gaffer::StringPlug *scalePlug() const;
 
+		Gaffer::StringPlug *inactiveIdsPlug();
+		const Gaffer::StringPlug *inactiveIdsPlug() const;
+
 		Gaffer::StringPlug *attributesPlug();
 		const Gaffer::StringPlug *attributesPlug() const;
 

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -284,6 +284,7 @@ Gaffer.Metadata.registerNode(
 
 	"layout:section:Settings.General:collapsed", False,
 	"layout:section:Settings.Transforms:collapsed", False,
+	"layout:section:Settings.Inactive Ids:collapsed", False,
 	"layout:section:Settings.Attributes:collapsed", False,
 
 	"layout:activator:modeIsIndexedRootsList", lambda node : node["prototypeMode"].getValue() == GafferScene.Instancer.PrototypeMode.IndexedRootsList,
@@ -543,6 +544,25 @@ Gaffer.Metadata.registerNode(
 
 			"userDefault", "scale",
 			"layout:section", "Settings.Transforms",
+
+		],
+
+		"inactiveIds" : [
+
+			"description",
+			"""
+			A space separated list of names of primitive variables specifying instances to make inactive.
+			Inactive instances are not output from the instancer or rendered.
+
+			Each primitive variable either must be a constant vector of type Int or Int64 with a list of
+			matching ids to deactivate, or it  must be a vertex bool primitive variable, in which case it
+			will deactivate the instance for the corresponding vertex if the value is true.
+			""",
+
+			# This user default will pick up any of the standard USD ways of controlling this.
+			"userDefault", "inactiveIds invisibleIds",
+
+			"layout:section", "Settings.Inactive Ids",
 
 		],
 


### PR DESCRIPTION
This isn't ready for review yet - there's one TODO, and it needs testing, but it seems to be fundamentally working.

I thought it might make sense to upload the current state in case it's a useful reference in considering the next question: how are we going to handle int64 primvars?

This seems to already be a problem with the existing code - the USD loader translates USD's USDGeomPointInstancer::GetIdsAttr() to "instanceIds", and the Gaffer Instancer looks for a var named "instanceIds", so it looks like these are supposed to work together. But it appears that currently this doesn't actually work, because the USD attribute is int64, and is translate to Int64VectorData, and Instancer is explicitly looking for IntVectorData.

So it seems like we need some sort of convention for adding something to everywhere in Instancer where we look for ids, to support both IntVector and Int64Vector ( and maybe uint types as well? ), either with an accessor that can handle either type, or by allocating memory and converting to the standard type if you get the non-standard type ( should the standard be int or int64? )

Currently, the new code is written to work solely with int64, so I can test with USD files, but I'm pretty sure we should support the same types for ids and invalidIds.