### PR TITLE
GafferOSL : Update for OSL 1.13

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a3/gafferDependencies-9.0.0a3-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a4/gafferDependencies-9.0.0a4-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Features
   - Added a menu item to the color chooser settings to save the UI configuration for the inline color chooser and the dialogue color chooser as a startup script to persist the configuration across Gaffer restarts.
 - MeshToLevelSet : Added `destination` plug, allowing multiple input meshes to be merged into a single level set at an arbitrary location.
 - LevelSetToMesh : Added `destination` plug, allowing multiple input level sets to be merged into a single mesh at an arbitrary location.
+- Cycles : Added support for OSL shading with Optix devices.
 
 Improvements
 ------------
@@ -30,6 +31,7 @@ Fixes
 
 - Viewer : Fixed hangs when focussing a node for the first time (bug introduced in 1.5.0.0a2). [^1]
 - Cycles : Fixed issue where scaling unnormalized quad and disk lights would not affect their brightness.
+- SceneReader : Fixed crash reading facevarying normals skinned with UsdSkel. [^1]
 - ShaderView : Fixed crash caused by a SceneCreator returning `None`. [^1]
 
 Breaking Changes
@@ -41,6 +43,14 @@ Breaking Changes
   - Objects which are not level sets are now converted to an empty mesh, instead of being left unchanged.
   - Removed the `adjustBounds` plug. In the rare case where it is important to recompute slightly tighter bounds, one workaround is to use ShufflePrimitiveVariables to shuffle from "P" to "P" with `adjustBounds` checked.
   - Removed support for grid types other than `FloatGrid`. If other types are required, please request them.
+
+Build
+-----
+
+- Cortex : Updated to version 10.5.9.5.
+- OpenShadingLanguage :
+  - Updated to version 1.13.11.0.
+  - Enabled Optix support.
 
 1.5.0.0a2 (relative to 1.5.0.0a1)
 =========

--- a/python/GafferOSLTest/shaders/debugClosure.osl
+++ b/python/GafferOSLTest/shaders/debugClosure.osl
@@ -43,6 +43,6 @@ surface debugClosure
 	Ci = 0;
 	if( name != "" )
 	{
-		Ci += weight * debug( name );
+		Ci += weight * debug( name, "value", color( 1 ) );
 	}
 }

--- a/python/GafferOSLTest/shaders/extractTranslate.osl
+++ b/python/GafferOSLTest/shaders/extractTranslate.osl
@@ -39,5 +39,5 @@ surface extractTranslate
 	matrix m = 1
 )
 {
-	Ci = color( m[3][0], m[3][1], m[3][2] ) * debug( "translate", "type", "vector" );
+	Ci = color( m[3][0], m[3][1], m[3][2] ) * debug( "translate", "type", "vector", "value", color( 1 ) );
 }

--- a/python/GafferOSLTest/shaders/multipleDebugClosures.osl
+++ b/python/GafferOSLTest/shaders/multipleDebugClosures.osl
@@ -36,5 +36,5 @@
 
 surface multipleDebugClosures()
 {
-	Ci = u * debug( "u" ) + v * debug( "v" ) + color( P ) * debug( "P" );
+	Ci = u * debug( "u", "value", color( 1 ) ) + v * debug( "v", "value", color( 1 ) ) + color( P ) * debug( "P", "value", color( 1 ) );
 }

--- a/python/GafferOSLTest/shaders/typedDebugClosure.osl
+++ b/python/GafferOSLTest/shaders/typedDebugClosure.osl
@@ -36,14 +36,14 @@
 
 surface typedDebugClosure()
 {
-	Ci = u * debug( "f", "type", "float" ) +
-	     color( P ) * debug( "p", "type", "point" ) +
-	     color( P ) * debug( "v", "type", "vector" ) +
-	     color( P ) * debug( "n", "type", "normal" ) +
-	     color( P ) * debug( "c", "type", "color" ) +
-	     color( P ) * debug( "p2", "type", "point2" ) +
-	     color( P ) * debug( "v2", "type", "vector2" ) +
-	     color( P ) * debug( "n2", "type", "normal2" ) +
-	     color( P ) * debug( "uv", "type", "uv" )
+	Ci = u * debug( "f", "type", "float", "value", color( 1 ) ) +
+	     color( P ) * debug( "p", "type", "point", "value", color( 1 ) ) +
+	     color( P ) * debug( "v", "type", "vector", "value", color( 1 ) ) +
+	     color( P ) * debug( "n", "type", "normal", "value", color( 1 ) ) +
+	     color( P ) * debug( "c", "type", "color", "value", color( 1 ) ) +
+	     color( P ) * debug( "p2", "type", "point2", "value", color( 1 ) ) +
+	     color( P ) * debug( "v2", "type", "vector2", "value", color( 1 ) ) +
+	     color( P ) * debug( "n2", "type", "normal2", "value", color( 1 ) ) +
+	     color( P ) * debug( "uv", "type", "uv", "value", color( 1 ) )
 	;
 }

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -105,7 +105,7 @@ struct RenderState
 //////////////////////////////////////////////////////////////////////////
 
 
-bool getAttributeInternal( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, std::optional<int> index, void *value )
+bool getAttributeInternal( OSL::ShaderGlobals *sg, bool derivatives, ustringhash object, TypeDesc type, ustringhash name, std::optional<int> index, void *value )
 {
 	const RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 	if( !renderState )
@@ -184,29 +184,29 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time ) override
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustringhash from, float time ) override
 		{
 			return false;
 		}
 
-		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from ) override
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustringhash from ) override
 		{
 			return false;
 		}
 
-		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value ) override
+		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustringhash object, TypeDesc type, ustringhash name, void *value ) override
 		{
 			return getAttributeInternal( sg, derivatives, object, type, name, std::nullopt, value );
 		}
 
-		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value ) override
+		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustringhash object, TypeDesc type, ustringhash name, int index, void *value ) override
 		{
 			return getAttributeInternal( sg, derivatives, object, type, name, index, value );
 		}
 
 		// OSL tries to populate shader parameter values per-object by calling this method.
 		// So we implement it to search for an appropriate input plug and get its value.
-		bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
+		bool get_userdata( bool derivatives, ustringhash name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
 		{
 			RenderState *renderState = sg ? static_cast<RenderState *>( sg->renderstate ) : nullptr;
 			if( !renderState )
@@ -691,7 +691,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 		static void findPlugPaths( const string &expression, vector<string> &inPaths, vector<string> &outPaths )
 		{
-			set<string> visited;
+			std::set<string> visited;
 			const regex plugPathRegex( "(parent\\.[A-Za-z_0-9\\.]+)[ \t]*(=*)" );
 			for( sregex_iterator it = make_regex_iterator( expression, plugPathRegex ); it != sregex_iterator(); ++it )
 			{

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -286,8 +286,9 @@ bool convertValue( void *dst, TypeDesc dstType, const void *src, TypeDesc srcTyp
 namespace
 {
 
-OIIO::ustring gIndex( "shading:index" );
+ustringhash g_index( "shading:index" );
 ustring g_contextVariableAttributeScope( "gaffer:context" );
+ustringhash g_contextVariableAttributeScopeHash( g_contextVariableAttributeScope );
 
 #if OSL_USE_BATCHED
 template< int WidthT >
@@ -334,13 +335,13 @@ class RenderState
 						// convertValue() in get_userdata().
 						userData.dataView.type.unarray();
 					}
-					m_userData.insert( make_pair( ustring( it->first.c_str() ), userData ) );
+					m_userData.insert( make_pair( ustringhash( it->first.c_str() ), userData ) );
 				}
 			}
 
 			for( ShadingEngine::Transforms::const_iterator it = transforms.begin(); it != transforms.end(); it++ )
 			{
-				m_transforms[ OIIO::ustring( it->first.string() ) ] = it->second;
+				m_transforms[ OIIO::ustringhash( it->first.string() ) ] = it->second;
 			}
 
 			for( const auto &name : contextVariablesNeeded )
@@ -358,7 +359,7 @@ class RenderState
 			}
 		}
 
-		bool contextVariable( ustring name, TypeDesc type, void *value ) const
+		bool contextVariable( ustringhash name, TypeDesc type, void *value ) const
 		{
 			auto it = m_contextVariables.find( name );
 			if( it == m_contextVariables.end() )
@@ -369,9 +370,9 @@ class RenderState
 			return ShadingSystem::convert_value( value, type, it->second.dataView.data, it->second.dataView.type );
 		}
 
-		bool userData( size_t pointIndex, ustring name, TypeDesc type, void *value ) const
+		bool userData( size_t pointIndex, ustringhash name, TypeDesc type, void *value ) const
 		{
-			if( name == gIndex )
+			if( name == g_index )
 			{
 				// if a 4 byte type has been requested then ensure we fit and cast to narrower type
 				// this way f32 reads of shading:index will succeed.
@@ -401,9 +402,9 @@ class RenderState
 
 #if OSL_USE_BATCHED
 		template< int WidthT >
-		Mask<WidthT> userDataWide( size_t pointIndex, ustring name, MaskedData<WidthT> &wval ) const
+		Mask<WidthT> userDataWide( size_t pointIndex, ustringhash name, MaskedData<WidthT> &wval ) const
 		{
-			if( name == gIndex )
+			if( name == g_index )
 			{
 				if( wval.type() == OIIO::TypeDesc( OIIO::TypeDesc::INT32 ) )
 				{
@@ -423,7 +424,7 @@ class RenderState
 				}
 				else
 				{
-					throw IECore::Exception( gIndex.string() + " must be accessed as float or int. " + wval.type().c_str() + " not supported." );
+					throw IECore::Exception( g_index.string() + " must be accessed as float or int. " + wval.type().c_str() + " not supported." );
 				}
 
 				return wval.mask();
@@ -480,7 +481,7 @@ class RenderState
 		}
 #endif
 
-		bool matrixToObject( OIIO::ustring name, Imath::M44f &result ) const
+		bool matrixToObject( OIIO::ustringhash name, Imath::M44f &result ) const
 		{
 			RenderStateTransforms::const_iterator i = m_transforms.find( name );
 			if( i != m_transforms.end() )
@@ -491,7 +492,7 @@ class RenderState
 			return false;
 		}
 
-		bool matrixFromObject( OIIO::ustring name, Imath::M44f &result ) const
+		bool matrixFromObject( OIIO::ustringhash name, Imath::M44f &result ) const
 		{
 			RenderStateTransforms::const_iterator i = m_transforms.find( name );
 			if( i != m_transforms.end() )
@@ -504,7 +505,7 @@ class RenderState
 
 	private :
 
-		using RenderStateTransforms = boost::unordered_map< OIIO::ustring, ShadingEngine::Transform, OIIO::ustringHash>;
+		using RenderStateTransforms = boost::unordered_map< OIIO::ustringhash, ShadingEngine::Transform, std::hash<ustringhash> >;
 		RenderStateTransforms m_transforms;
 
 		struct UserData
@@ -519,8 +520,8 @@ class RenderState
 			ConstDataPtr dataStorage;
 		};
 
-		container::flat_map<ustring, UserData, OIIO::ustringPtrIsLess> m_userData;
-		container::flat_map<ustring, ContextData, OIIO::ustringPtrIsLess> m_contextVariables;
+		container::flat_map<ustringhash, UserData> m_userData;
+		container::flat_map<ustringhash, ContextData> m_contextVariables;
 
 };
 
@@ -608,7 +609,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 			return false;
 		}
 
-		Mask get_matrix( BatchedShaderGlobals *sg, Masked<OSL::Matrix44> result, ustring from, Wide<const float> time ) override
+		Mask get_matrix( BatchedShaderGlobals *sg, Masked<OSL::Matrix44> result, ustringhash from, Wide<const float> time ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->uniform.renderstate ) : nullptr;
 			if( threadRenderState )
@@ -624,7 +625,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 			return Mask( false );
 		}
 
-		Mask get_inverse_matrix( BatchedShaderGlobals *sg, Masked<OSL::Matrix44> result, ustring to, Wide<const float> time ) override
+		Mask get_inverse_matrix( BatchedShaderGlobals *sg, Masked<OSL::Matrix44> result, ustringhash to, Wide<const float> time ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->uniform.renderstate ) : nullptr;
 			if( threadRenderState )
@@ -640,7 +641,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 			return Mask( false );
 		}
 
-		Mask get_attribute( BatchedShaderGlobals *sg, ustring object, ustring name, MaskedData wval ) override
+		Mask get_attribute( BatchedShaderGlobals *sg, ustringhash object, ustringhash name, MaskedData wval ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->uniform.renderstate ) : nullptr;
 			if( !threadRenderState )
@@ -648,7 +649,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 				return Mask( false );
 			}
 
-			if( object == g_contextVariableAttributeScope )
+			if( object == g_contextVariableAttributeScopeHash )
 			{
 				int neededSize = wval.type().size();
 				const int maximumAttributeSize = 4096;
@@ -675,7 +676,7 @@ class GafferBatchedRendererServices : public OSL::BatchedRendererServices<WidthT
 			return get_userdata( name, sg, wval );
 		}
 
-		Mask get_userdata( ustring name, BatchedShaderGlobals *sg, MaskedData wval ) override
+		Mask get_userdata( ustringhash name, BatchedShaderGlobals *sg, MaskedData wval ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->uniform.renderstate ) : nullptr;
 			if( !threadRenderState )
@@ -712,7 +713,7 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from, float time ) override
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustringhash from, float time ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->renderstate ) : nullptr;
 			if( threadRenderState )
@@ -723,7 +724,7 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		bool get_inverse_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring to, float time ) override
+		bool get_inverse_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustringhash to, float time ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->renderstate ) : nullptr;
 			if( threadRenderState )
@@ -734,12 +735,12 @@ class RendererServices : public OSL::RendererServices
 			return false;
 		}
 
-		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustring from ) override
+		bool get_matrix( OSL::ShaderGlobals *sg, OSL::Matrix44 &result, ustringhash from ) override
 		{
 			return false;
 		}
 
-		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, void *value ) override
+		bool get_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustringhash object, TypeDesc type, ustringhash name, void *value ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->renderstate ) : nullptr;
 			if( !threadRenderState )
@@ -747,7 +748,7 @@ class RendererServices : public OSL::RendererServices
 				return false;
 			}
 
-			if( object == g_contextVariableAttributeScope )
+			if( object == g_contextVariableAttributeScopeHash )
 			{
 				if( derivatives )
 				{
@@ -762,12 +763,12 @@ class RendererServices : public OSL::RendererServices
 			return get_userdata( derivatives, name, type, sg, value );
 		}
 
-		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustring object, TypeDesc type, ustring name, int index, void *value ) override
+		bool get_array_attribute( OSL::ShaderGlobals *sg, bool derivatives, ustringhash object, TypeDesc type, ustringhash name, int index, void *value ) override
 		{
 			return false;
 		}
 
-		bool get_userdata( bool derivatives, ustring name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
+		bool get_userdata( bool derivatives, ustringhash name, TypeDesc type, OSL::ShaderGlobals *sg, void *value ) override
 		{
 			const ThreadRenderState *threadRenderState = sg ? static_cast<ThreadRenderState *>( sg->renderstate ) : nullptr;
 			if( !threadRenderState )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -829,16 +829,6 @@ struct DebugParameters
 	M44f matrixValue;
 	ustring stringValue;
 
-	static void prepare( OSL::RendererServices *rendererServices, int id, void *data )
-	{
-		DebugParameters *debugParameters = static_cast<DebugParameters *>( data );
-		debugParameters->name = ustring();
-		debugParameters->type = ustring();
-		debugParameters->value = Color3f( 1.0f );
-		debugParameters->matrixValue = M44f();
-		debugParameters->stringValue = ustring();
-	}
-
 };
 
 // Must be held in order to modify the shading system.
@@ -900,7 +890,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 		/* name */ "debug",
 		/* id */ DebugClosureId,
 		/* params */ debugParams,
-		/* prepare */ DebugParameters::prepare,
+		/* prepare */ nullptr,
 		/* setup */ nullptr
 	);
 
@@ -908,7 +898,7 @@ OSL::ShadingSystem *shadingSystem( int *batchSize = nullptr )
 		/* name */ "deformation",
 		/* id */ DeformationClosureId,
 		/* params */ debugParams,
-		/* prepare */ DebugParameters::prepare,
+		/* prepare */ nullptr,
 		/* setup */ nullptr
 	);
 


### PR DESCRIPTION
This updates us to `gafferDependencies-9.0.0a4` which includes OSL 1.13.11.0 built with Optix. To support OSL 1.13 this PR includes the RendererServices changes necessary for the beginning of OSL's great ustring to ustringhash migration.

Windows CI is currently going to fail until the Windows build of gafferDependencies-9.0.0a4 is uploaded.

Given that Cycles _should_ now support OSL shading on Optix devices (I'm currently without an Optix device so I'll leave that to others to confirm!), at some point we'll likely want to revisit the "revert to SVM shading mode" logic in `CyclesOptionsUI.ViewerDevicePlugValueWidget` so we maintain the OSL shading mode for devices that support it (or address the todo for the CyclesRenderer fallaback)...