### PR TITLE
GafferModule : Windows `verifyAllocator()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - Light Editor : Added `is_sphere` column for Cycles lights.
-
+- Windows : Gaffer now uses the TBB memory allocator for significantly better performance.
 
 
 1.5.0.0a3 (relative to 1.5.0.0a2)

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -56,6 +56,9 @@ Gaffer._Gaffer._nameProcess()
 
 import IECore
 
+if os.name == "nt" :
+	Gaffer._Gaffer._verifyAllocator()
+
 # Increase the soft limit for file handles as high as we can - we need everything we can get for
 # opening models, textures etc.
 if os.name != "nt" :

--- a/src/GafferModule/GafferModule.cpp
+++ b/src/GafferModule/GafferModule.cpp
@@ -93,6 +93,12 @@
 #include <sys/prctl.h>
 #endif
 
+#ifdef _MSC_VER
+#include "IECore/MessageHandler.h"
+
+#include "tbb/tbbmalloc_proxy.h"
+#endif
+
 using namespace boost::python;
 using namespace Gaffer;
 using namespace GafferModule;
@@ -187,6 +193,25 @@ void nameProcess()
 #endif
 }
 
+#ifdef _MSC_VER
+void verifyAllocator()
+{
+
+	char **replacementLog;
+	int replacementStatus = TBB_malloc_replacement_log( &replacementLog );
+
+	if( replacementStatus != 0 )
+	{
+		IECore::msg( IECore::Msg::Warning, "Gaffer", "Failed to install TBB memory allocator. Performance may be degraded." );
+		for( char **logEntry = replacementLog; *logEntry != 0; logEntry++ )
+		{
+			IECore::msg( IECore::Msg::Warning, "Gaffer", *logEntry );
+		}
+	}
+
+}
+#endif
+
 } // namespace
 
 // Arrange for `storeArgcArgv()` to be called when our module loads,
@@ -257,5 +282,8 @@ BOOST_PYTHON_MODULE( _Gaffer )
 	def( "isDebug", &isDebug );
 
 	def( "_nameProcess", &nameProcess );
+#ifdef _MSC_VER
+	def( "_verifyAllocator", &verifyAllocator );
+#endif
 
 }


### PR DESCRIPTION
This adds a check on Windows when starting Gaffer to verify that the TBB allocator has been installed correctly. Other platforms don't perform the check and the check method is not present.

I don't actually know what circumstances the allocator would fail to install itself. If I just remove the `tbbmalloc_proxy.dll` file from the installation, Gaffer immediately and silently fails to open at all.

But I _think_ this is still worthwhile as an easy box to check off when debugging performance problems.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
