### PR TITLE
Whitespace fixes

### DIFF
--- a/python/GafferImage/Anaglyph.gfr
+++ b/python/GafferImage/Anaglyph.gfr
@@ -93,4 +93,3 @@ __children["Anaglyph"]["Dot1"]["__uiPosition"].setValue( imath.V2f( 13.4827852, 
 
 
 del __children
-

--- a/python/GafferImageTest/scripts/createViews-1.4.10.0.gfr
+++ b/python/GafferImageTest/scripts/createViews-1.4.10.0.gfr
@@ -48,4 +48,3 @@ __children["CheckerboardRight"]["__uiPosition"].setValue( imath.V2f( 8.04854202,
 
 
 del __children
-

--- a/python/GafferOSLTest/scripts/networkVersion-0.23.2.1.gfr
+++ b/python/GafferOSLTest/scripts/networkVersion-0.23.2.1.gfr
@@ -117,4 +117,3 @@ __children["OutObject"].loadShader( "ObjectProcessing/OutObject", keepExistingVa
 
 
 del __children
-

--- a/python/GafferOSLTest/scripts/oslObjectVersion-0.55.0.0.gfr
+++ b/python/GafferOSLTest/scripts/oslObjectVersion-0.55.0.0.gfr
@@ -29,4 +29,3 @@ __children["OSLObject"]["__uiPosition"].setValue( imath.V2f( -5.3499999, -2.1500
 
 
 del __children
-

--- a/python/GafferOSLTest/shaders/typedDebugClosure.osl
+++ b/python/GafferOSLTest/shaders/typedDebugClosure.osl
@@ -37,13 +37,13 @@
 surface typedDebugClosure()
 {
 	Ci = u * debug( "f", "type", "float", "value", color( 1 ) ) +
-	     color( P ) * debug( "p", "type", "point", "value", color( 1 ) ) +
-	     color( P ) * debug( "v", "type", "vector", "value", color( 1 ) ) +
-	     color( P ) * debug( "n", "type", "normal", "value", color( 1 ) ) +
-	     color( P ) * debug( "c", "type", "color", "value", color( 1 ) ) +
-	     color( P ) * debug( "p2", "type", "point2", "value", color( 1 ) ) +
-	     color( P ) * debug( "v2", "type", "vector2", "value", color( 1 ) ) +
-	     color( P ) * debug( "n2", "type", "normal2", "value", color( 1 ) ) +
-	     color( P ) * debug( "uv", "type", "uv", "value", color( 1 ) )
+		color( P ) * debug( "p", "type", "point", "value", color( 1 ) ) +
+		color( P ) * debug( "v", "type", "vector", "value", color( 1 ) ) +
+		color( P ) * debug( "n", "type", "normal", "value", color( 1 ) ) +
+		color( P ) * debug( "c", "type", "color", "value", color( 1 ) ) +
+		color( P ) * debug( "p2", "type", "point2", "value", color( 1 ) ) +
+		color( P ) * debug( "v2", "type", "vector2", "value", color( 1 ) ) +
+		color( P ) * debug( "n2", "type", "normal2", "value", color( 1 ) ) +
+		color( P ) * debug( "uv", "type", "uv", "value", color( 1 ) )
 	;
 }

--- a/python/GafferSceneTest/scripts/collectScenes-0.48.0.0.gfr
+++ b/python/GafferSceneTest/scripts/collectScenes-0.48.0.0.gfr
@@ -39,4 +39,3 @@ __children["CollectScenes"]["__uiPosition"].setValue( imath.V2f( 7.04915667, 3.8
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/extraAttributes-0.58.5.2.gfr
+++ b/python/GafferSceneTest/scripts/extraAttributes-0.58.5.2.gfr
@@ -62,4 +62,3 @@ __children["Expression"]["__expression"].setValue( 'parent["__out"]["p0"] = IECo
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/extraAttributes-0.59.0.0.gfr
+++ b/python/GafferSceneTest/scripts/extraAttributes-0.59.0.0.gfr
@@ -62,4 +62,3 @@ __children["Expression"]["__expression"].setValue( 'parent["__out"]["p0"] = IECo
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/filterProcessor-0.27.0.0.gfr
+++ b/python/GafferSceneTest/scripts/filterProcessor-0.27.0.0.gfr
@@ -54,4 +54,3 @@ __children["ShaderAssignment"]["filter"].setInput( __children["UnionFilter"]["ou
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/filterProcessorBoxed-0.27.0.0.gfr
+++ b/python/GafferSceneTest/scripts/filterProcessorBoxed-0.27.0.0.gfr
@@ -45,4 +45,3 @@ __children["Box"]["__uiPosition"].setValue( imath.V2f( 1.89942265, -8.6056385 ) 
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/lightTweaks-0.52.3.1.gfr
+++ b/python/GafferSceneTest/scripts/lightTweaks-0.52.3.1.gfr
@@ -62,4 +62,3 @@ __children["LightTweaks2"]["__uiPosition"].setValue( imath.V2f( -0.399145961, -3
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/parent-0.54.1.0.gfr
+++ b/python/GafferSceneTest/scripts/parent-0.54.1.0.gfr
@@ -96,4 +96,3 @@ __children["Cube"]["__uiPosition"].setValue( imath.V2f( 11.5, 12.2999992 ) )
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr
+++ b/python/GafferSceneTest/scripts/promotedCompoundDataMemberPlug-0.53.4.0.gfr
@@ -45,4 +45,3 @@ Gaffer.Metadata.registerValue( __children["Box"]["attributes_visibility"], 'desc
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/sceneSwitch-0.49.1.0.gfr
+++ b/python/GafferSceneTest/scripts/sceneSwitch-0.49.1.0.gfr
@@ -46,4 +46,3 @@ __children["SceneSwitch"]["__uiPosition"].setValue( imath.V2f( 0.0499954224, -2.
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/shaderAssignment-0.55.0.0.gfr
+++ b/python/GafferSceneTest/scripts/shaderAssignment-0.55.0.0.gfr
@@ -28,4 +28,3 @@ __children["ShaderAssignment"]["__uiPosition"].setValue( imath.V2f( -14.8000002,
 
 
 del __children
-

--- a/python/GafferSceneTest/scripts/shaderAssignmentSwitchProblem.gfr
+++ b/python/GafferSceneTest/scripts/shaderAssignmentSwitchProblem.gfr
@@ -47,4 +47,3 @@ __children["expr"]["__expression"].setValue( 'parent["__out"]["p0"] = 0' )
 
 
 del __children
-

--- a/python/GafferTest/scripts/arrayPlug-1.4.10.0.gfr
+++ b/python/GafferTest/scripts/arrayPlug-1.4.10.0.gfr
@@ -23,4 +23,3 @@ __children["n"]["user"]["p"][3].setValue( 3 )
 
 
 del __children
-

--- a/python/GafferTest/scripts/boxIOOutsideBoxVersion-0.52.0.0.gfr
+++ b/python/GafferTest/scripts/boxIOOutsideBoxVersion-0.52.0.0.gfr
@@ -38,4 +38,3 @@ __children["BoxIn"].setup()
 
 
 del __children
-

--- a/python/GafferTest/scripts/boxPassThroughVersion-0.52.0.0.gfr
+++ b/python/GafferTest/scripts/boxPassThroughVersion-0.52.0.0.gfr
@@ -75,4 +75,3 @@ Gaffer.Metadata.registerValue( __children["AddTen"]["enabled"], 'nodule:type', '
 
 
 del __children
-

--- a/python/GafferTest/scripts/boxVersion-0.52.0.0.gfr
+++ b/python/GafferTest/scripts/boxVersion-0.52.0.0.gfr
@@ -56,4 +56,3 @@ __children["AddTen"]["sum"].setInput( __children["AddTen"]["BoxOut"]["__out"] )
 
 
 del __children
-

--- a/python/GafferTest/scripts/stringPlugSubstitutions-0.55.4.0.gfr
+++ b/python/GafferTest/scripts/stringPlugSubstitutions-0.55.4.0.gfr
@@ -15,4 +15,3 @@ __children["n"]["user"].addChild( Gaffer.StringPlug( "p", defaultValue = '', fla
 
 
 del __children
-

--- a/python/GafferTest/scripts/stringPlugSubstitutions-0.56.0.0.gfr
+++ b/python/GafferTest/scripts/stringPlugSubstitutions-0.56.0.0.gfr
@@ -15,4 +15,3 @@ __children["n"]["user"].addChild( Gaffer.StringPlug( "p", defaultValue = '', fla
 
 
 del __children
-

--- a/python/GafferUITest/scripts/auxiliaryConnectionBoxExitCrash.gfr
+++ b/python/GafferUITest/scripts/auxiliaryConnectionBoxExitCrash.gfr
@@ -48,4 +48,3 @@ __children["Box"]["__uiPosition"].setValue( imath.V2f( -9.04999924, 2.25000024 )
 
 
 del __children
-

--- a/src/GafferBindings/Serialisation.cpp
+++ b/src/GafferBindings/Serialisation.cpp
@@ -203,7 +203,7 @@ std::string Serialisation::result() const
 
 	if( m_protectParentNamespace )
 	{
-		result += "\n\ndel __children\n\n";
+		result += "\n\ndel __children\n";
 	}
 
 	return result;


### PR DESCRIPTION
This fixes a few whitespace issues. In doing so, it changes the serialisation to end with a single newline instead of two, which was causing occasional whitespace-check errors.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
