### PR TITLE
InteractiveRenderTest : `testAddLight` tolerance

### DIFF
--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1097,7 +1097,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
 		# Tolerance is high due to sampling noise in Cycles, but is more than sufficient to
 		# be sure that the new light has been added (otherwise there would be no green at all).
-		self.assertTrue( ( c / c[0] ).equalWithAbsError( imath.Color3f( 1, 1, 0 ), 0.2 ) )
+		self.assertTrue( ( c / c[0] ).equalWithAbsError( imath.Color3f( 1, 1, 0 ), 0.25 ) )
 
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 


### PR DESCRIPTION
It seems that the change in #6061 to use Cycles' blue noise sampling pattern increased the time it takes for the render to resolve, causing intermittent test failures. Increasing the error tolerance gets the tests passing again without increasing the wait time for pixels.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
