### PR TITLE
PythonEditor : Add line numbers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - ColorChooser :
   - Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
   - Changed the indicator for the color field and color sliders to an unfilled circle so the chosen color is visible in the center.
+- Python Editor : Added line numbers (#6091).
 
 API
 ---
@@ -17,6 +18,8 @@ API
   - Refactored bindings so they are no longer dependent on linking to Cycles.
   - The `devices`, `nodes`, `shaders`, `lights`, and `passes` Python attributes now contain IECore.CompoundData instead of Python dictionaries.
   - Added `majorVersion`, `minorVersion`, `patchVersion`, and `version` Python attributes containing the Cycles version.
+- MultiLineTextWidget, CodeWidget : Added the ability to show line numbers by passing `lineNumbersVisible = True` to the constructor.
+- MultiLineTextWidget : Added `setLineNumbersVisible()` and `getLineNumbersVisible()`
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -55,9 +55,9 @@ from Qt import QtGui
 
 class CodeWidget( GafferUI.MultiLineTextWidget ) :
 
-	def __init__( self, text="", editable=True, fixedLineHeight=None, **kw ) :
+	def __init__( self, text="", editable=True, fixedLineHeight=None, lineNumbersVisible = False, **kw ) :
 
-		GafferUI.MultiLineTextWidget.__init__( self, text, editable, fixedLineHeight = fixedLineHeight, wrapMode = self.WrapMode.None_, role = self.Role.Code, **kw )
+		GafferUI.MultiLineTextWidget.__init__( self, text, editable, fixedLineHeight = fixedLineHeight, wrapMode = self.WrapMode.None_, role = self.Role.Code, lineNumbersVisible = lineNumbersVisible, **kw )
 
 		self.__completer = None
 		self.__completionMenu = None

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -362,6 +362,9 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 			self.__activatedSignal( self )
 			self._emitEditingFinished()
 			return True
+		elif event.key == "Return" and event.modifiers == event.Modifiers.Shift :
+			self._qtWidget().textCursor().insertBlock()
+			return True
 
 		return False
 

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -71,7 +71,7 @@ class PythonEditor( GafferUI.Editor ) :
 			Gaffer.WeakMethod( self.__contextMenu )
 		)
 
-		self.__inputWidget = GafferUI.CodeWidget()
+		self.__inputWidget = GafferUI.CodeWidget( lineNumbersVisible = True )
 
 		self.__splittable.append( self.__outputWidget )
 		self.__splittable.append( self.__inputWidget )


### PR DESCRIPTION
Add the ability to show line numbers in a `MultiLineTextWidget` and `CodeEditor`, and makes use of that in the Python Editor's input `CodeEditor`.

Fixes #6091 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
