### PR TITLE
ColorChooser : Hollow circle indicator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,7 +6,9 @@ Improvements
 
 - Light Editor : Added `is_sphere` column for Cycles lights.
 - Windows : Gaffer now uses the TBB memory allocator for significantly better performance.
-- ColorChooser : Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
+- ColorChooser :
+  - Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
+  - Changed the indicator for the color field and color sliders to an unfilled circle so the chosen color is visible in the center.
 
 API
 ---

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -100,6 +100,20 @@ _ranges = {
 	"i" : __Range( 0, 1, -sys.float_info.max, sys.float_info.max ),
 }
 
+def _drawIndicator( painter, position ) :
+
+	painter.setBrush( QtCore.Qt.transparent )
+
+	pen = QtGui.QPen( QtGui.QColor( 0, 0, 0, 255 ) )
+	pen.setWidth( 1 )
+	painter.setPen( pen )
+
+	painter.drawEllipse( position, 4.5, 4.5 )
+
+	pen.setColor( QtGui.QColor( 255, 255, 255, 255 ) )
+	painter.setPen( pen )
+	painter.drawEllipse( position, 3.5, 3.5 )
+
 # A custom slider for drawing the backgrounds.
 class _ComponentSlider( GafferUI.Slider ) :
 
@@ -157,6 +171,40 @@ class _ComponentSlider( GafferUI.Slider ) :
 
 		brush = QtGui.QBrush( grad )
 		painter.fillRect( 0, 0, size.x, size.y, brush )
+
+	def _drawValue( self, painter, value, position, state ) :
+
+		size = self.size()
+
+		if position >= 0 and position <= size.x :
+			_drawIndicator( painter, QtCore.QPoint( position, size.y / 2 ) )
+			return
+
+		pen = QtGui.QPen( QtGui.QColor( 0, 0, 0, 255 ) )
+		pen.setWidth( 1 )
+		painter.setPen( pen )
+		painter.setBrush( QtGui.QColor( 255, 255, 255, 255 ) )
+
+		if position < 0 :
+			painter.drawPolygon(
+				QtGui.QPolygonF(
+					[
+						QtCore.QPointF( 8, 4 ),
+						QtCore.QPointF( 8, size.y - 4 ),
+						QtCore.QPointF( 2, size.y / 2 ),
+					]
+				)
+			)
+		elif position > size.x :
+			painter.drawPolygon(
+				QtGui.QPolygonF(
+					[
+						QtCore.QPointF( size.x - 8, 4 ),
+						QtCore.QPointF( size.x - 8, size.y - 4 ),
+						QtCore.QPointF( size.x - 2, size.y / 2 ),
+					]
+				)
+			)
 
 	def _displayTransformChanged( self ) :
 
@@ -429,14 +477,6 @@ class _ColorField( GafferUI.Widget ) :
 
 		position = self.__colorToPosition( self.__color )
 
-		pen = QtGui.QPen( QtGui.QColor( 0, 0, 0, 255 ) )
-		pen.setWidth( 1 )
-		painter.setPen( pen )
-
-		color = QtGui.QColor( 119, 156, 255, 255 )
-
-		painter.setBrush( QtGui.QBrush( color ) )
-
 		size = self.size()
 
 		# Use a dot when both axes are a valid value.
@@ -444,11 +484,19 @@ class _ColorField( GafferUI.Widget ) :
 		delta = position - positionClamped
 
 		if abs( delta.x ) < 1e-3 and abs( delta.y ) < 1e-3 :
-			painter.drawEllipse( QtCore.QPoint( position.x, position.y ), 4.5, 4.5 )
+			_drawIndicator( painter, QtCore.QPoint( position.x, position.y ) )
 			return
 
 		triangleWidth = 5.0
 		triangleSpacing = 2.0
+
+		pen = QtGui.QPen( QtGui.QColor( 0, 0, 0, 255 ) )
+		pen.setWidth( 1 )
+		painter.setPen( pen )
+
+		color = QtGui.QColor( 255, 255, 255, 255 )
+
+		painter.setBrush( QtGui.QBrush( color ) )
 
 		offset = imath.V2f( 0 )
 


### PR DESCRIPTION
This changes the indicator for the color field and sliders to a white circle, with an inner and outer black stroke. The previous indicator was a solid blue circle, which covered the exact value. I tried a white circle with just an outer black stroke, but it felt like it read a little less clearly in some areas of grayscale, but light and dark.

I'm happy for suggestions on a better API for setting the colors and shapes of the indicator in the second commit. I tried using the hollow circle for all sliders, which currently means the spline slider. It was less visible and it felt less inviting to click and drag on than when used in the color sliders.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
