### PR TITLE
Number all the lines!

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,7 +14,7 @@ Improvements
 Fixes
 -----
 
-- Expression : Fixed line numbers reported in OSL parse errors.
+- Expression, OSLCode : Fixed line numbers reported in OSL parse errors.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,7 @@ Improvements
 - ColorChooser :
   - Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
   - Changed the indicator for the color field and color sliders to an unfilled circle so the chosen color is visible in the center.
-- Python Editor : Added line numbers (#6091).
+- PythonEditor, PythonCommand, Expression, UIEditor, OSLCode : Added line numbers to code editors (#6091).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,11 @@ Improvements
   - Changed the indicator for the color field and color sliders to an unfilled circle so the chosen color is visible in the center.
 - Python Editor : Added line numbers (#6091).
 
+Fixes
+-----
+
+- Expression : Fixed line numbers reported in OSL parse errors.
+
 API
 ---
 

--- a/python/GafferDispatchUI/PythonCommandUI.py
+++ b/python/GafferDispatchUI/PythonCommandUI.py
@@ -138,7 +138,7 @@ class _CommandPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		self.__codeWidget = GafferUI.CodeWidget()
+		self.__codeWidget = GafferUI.CodeWidget( lineNumbersVisible = True )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__codeWidget, plug, **kw )
 

--- a/python/GafferOSLTest/OSLCodeTest.py
+++ b/python/GafferOSLTest/OSLCodeTest.py
@@ -369,6 +369,15 @@ class OSLCodeTest( GafferOSLTest.OSLTestCase ) :
 		parameter.setName( "d" )
 		self.assertEqual( len( cs ), 0 )
 
+	def testParseErrorLineNumbers( self ) :
+
+		oslCode = GafferOSL.OSLCode()
+		cs = GafferTest.CapturingSlot( oslCode.errorSignal() )
+		oslCode["code"].setValue( "undefined" )
+
+		self.assertEqual( len( cs ), 1 )
+		self.assertRegex( cs[0][2], "code:1: error: 'undefined' was not declared in this scope$" )
+
 	def __osoFileName( self, oslCode ) :
 
 		# Right now we could get this information by

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -43,6 +43,7 @@ import re
 import IECore
 
 import Gaffer
+import GafferTest
 import GafferDispatch
 import GafferDispatchTest
 import GafferOSL
@@ -877,6 +878,15 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 			Gaffer.ProcessException, "ePython.__execute : test string",
 			s["n"]["user"]["f"].getValue
 		)
+
+	def testParseErrorLineNumbers( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["node"] = GafferTest.AddNode()
+
+		s["expression"] = Gaffer.Expression()
+		with self.assertRaisesRegex( RuntimeError, "expression:1: error: 'undefinedVariable' was not declared in this scope" ) :
+			s["expression"].setExpression( "parent.node.op1 = undefinedVariable;", "OSL" )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferOSLUI/OSLCodeUI.py
+++ b/python/GafferOSLUI/OSLCodeUI.py
@@ -259,7 +259,7 @@ class _CodePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		self.__codeWidget = GafferUI.CodeWidget()
+		self.__codeWidget = GafferUI.CodeWidget( lineNumbersVisible=True )
 
 		GafferUI.PlugValueWidget.__init__( self, self.__codeWidget, plug, **kw )
 

--- a/python/GafferUI/ExpressionUI.py
+++ b/python/GafferUI/ExpressionUI.py
@@ -147,7 +147,7 @@ class ExpressionWidget( GafferUI.Widget ) :
 				self.__languageMenu = GafferUI.MenuButton( "", menu = GafferUI.Menu( Gaffer.WeakMethod( self.__languageMenuDefinition ) ) )
 				self.__languageMenu.setEnabled( not Gaffer.MetadataAlgo.readOnly( node ) )
 
-			self.__textWidget = GafferUI.CodeWidget()
+			self.__textWidget = GafferUI.CodeWidget( lineNumbersVisible=True )
 			self.__textWidget.setEditable( not Gaffer.MetadataAlgo.readOnly( node ) )
 
 			self.__textWidget.editingFinishedSignal().connect( Gaffer.WeakMethod( self.__editingFinished ) )

--- a/python/GafferUI/UIEditor.py
+++ b/python/GafferUI/UIEditor.py
@@ -1743,7 +1743,7 @@ class _ButtonCodeMetadataWidget( GafferUI.MetadataWidget.MetadataWidget ) :
 
 	def __init__( self, target = None, **kw ) :
 
-		self.__codeWidget = GafferUI.CodeWidget()
+		self.__codeWidget = GafferUI.CodeWidget( lineNumbersVisible=True )
 		GafferUI.MetadataWidget.MetadataWidget.__init__( self, self.__codeWidget, "buttonPlugValueWidget:clicked", target, defaultValue = "", **kw )
 
 		self.__codeWidget.setPlaceholderText( inspect.cleandoc(

--- a/src/GafferOSL/OSLCode.cpp
+++ b/src/GafferOSL/OSLCode.cpp
@@ -49,6 +49,7 @@
 
 #include "OSL/oslcomp.h"
 
+#include "boost/algorithm/string/replace.hpp"
 #include "boost/bind/bind.hpp"
 #include "boost/filesystem.hpp"
 
@@ -144,6 +145,11 @@ string generate( const OSLCode *shader, string &shaderName )
 	}
 
 	result += ")\n";
+
+	// Reset line numbers reported by the OSL parser, so that they
+	// don't include the stuff above.
+
+	result += "#line 1\n";
 
 	// Add on body
 
@@ -300,7 +306,9 @@ std::filesystem::path compile( const std::string &shaderName, const std::string 
 	{
 		if( errorHandler.errors().size() )
 		{
-			throw IECore::Exception( errorHandler.errors() );
+			string error = errorHandler.errors();
+			boost::replace_all( error, tempOSLFileName, "code" );
+			throw IECore::Exception( error );
 		}
 		else
 		{

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -806,6 +806,11 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 
 			result += "\n)\n";
 
+			// Reset line numbers reported by the OSL parser, so that they
+			// don't include the stuff above.
+
+			result += "#line 1\n";
+
 			// Add on a shader body consisting of the expression itself.
 
 			result += "{\n" + expression;
@@ -904,7 +909,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			}
 
 			string oso;
-			if( !compiler.compile_buffer( shaderSource, oso, options ) )
+			if( !compiler.compile_buffer( shaderSource, oso, options, std::string_view(), "expression" ) )
 			{
 				if( errorHandler.errors().size() )
 				{


### PR DESCRIPTION
This takes the new line numbering feature from the PythonEditor and adds it to the ExpressionUI, OSLCodeUI, PythonCommandUI and UIEditor. It also fixes the reporting of line number from OSL parse errors in OSLCode and OSLExpressionEngine, so the line numbers actually line up as expected.