### PR TITLE
CyclesOptions : Add `denoiseDevice` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
   - Changed the color field widget to a color wheel when hue is one of the varying components. [^1]
   - Changed the indicator for the color field and color sliders to an unfilled circle so the chosen color is visible in the center.
 - PythonEditor, PythonCommand, Expression, UIEditor, OSLCode : Added line numbers to code editors (#6091).
+- CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 
 Fixes
 -----

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -40,19 +40,24 @@ import Gaffer
 import GafferUI
 import GafferCycles
 
+def __deviceSummary( plug ) :
+
+	# We don't have enough space to display the full device string, but the
+	# `:00` device indices are kindof confusing. Just strip off the
+	# indices so we're showing a list of device types.
+	devices = set(
+		d.partition( ":" )[0]
+		for d in plug.getValue().split()
+	)
+
+	return " + ".join( devices )
+
 def __sessionSummary( plug ) :
 
 	info = []
 
 	if plug["device"]["enabled"].getValue() :
-		# We don't have enough space to display the full device string, but the
-		# `:00` device indices are kindof confusing. Just strip off the
-		# indices so we're showing a list of device types.
-		devices = set(
-			d.partition( ":" )[0]
-			for d in plug["device"]["value"].getValue().split()
-		)
-		info.append( " + ".join( devices ) )
+		info.append( __deviceSummary( plug["device"]["value"] ) )
 
 	if plug["shadingSystem"]["enabled"].getValue() :
 		info.append( "Shading System {}".format( plug["shadingSystem"]["value"].getValue() ) )
@@ -264,6 +269,9 @@ def __denoisingSummary( plug ) :
 	if plug["denoiserType"]["enabled"].getValue() :
 		info.append( "Denoise Type {}".format( plug["denoiserType"]["value"].getValue() ) )
 
+	if plug["denoiseDevice"]["enabled"].getValue() :
+		info.append( "Device {}".format( __deviceSummary( plug["denoiseDevice"]["value"] ) ) )
+
 	if plug["denoiseStartSample"]["enabled"].getValue() :
 		info.append( "Denoise Start Sample {}".format( plug["denoiseStartSample"]["value"].getValue() ) )
 
@@ -359,6 +367,44 @@ def __registerDevicePresets() :
 			"options.device.value",
 			"preset:{}/All + CPU".format( deviceType ),
 			"CPU {}:*".format( deviceType )
+		)
+
+def __registerDenoiseDevicePresets() :
+
+	cpuRegistered = False
+	typeIndices = {}
+	for device in GafferCycles.devices.values() :
+
+		# Ignore devices that don't support any denoisers
+		if device["denoisers"].value == 0 :
+			continue
+
+		if device["type"] == "CPU" :
+			if not cpuRegistered :
+				Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options.denoiseDevice.value", "preset:CPU", "CPU" )
+				cpuRegistered = True
+			continue
+
+		typeIndex = typeIndices.setdefault( device["type"], 0 )
+		typeIndices[device["type"]] += 1
+
+		Gaffer.Metadata.registerValue(
+			GafferCycles.CyclesOptions,
+			"options.denoiseDevice.value",
+			"preset:{}/{}".format( device["type"], device["description"] ),
+			"{}:{:02}".format( device["type"], typeIndex )
+		)
+
+	for deviceType, count in typeIndices.items() :
+
+		if count <= 1 :
+			continue
+
+		Gaffer.Metadata.registerValue(
+			GafferCycles.CyclesOptions,
+			"options.denoiseDevice.value",
+			"preset:{}/All".format( deviceType ),
+			"{}:*".format( deviceType )
 		)
 
 Gaffer.Metadata.registerNode(
@@ -1384,6 +1430,29 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"options.denoiseDevice" : [
+
+			"description",
+			"""
+			The device to denoise with. If multiple devices are specified, Cycles will denoise with
+			the first suitable device from the list.
+
+			`Automatic` mode allows Cycles to choose from all available devices that support the current
+			denoiser.
+			""",
+
+			"layout:section", "Denoising",
+
+		],
+
+		"options.denoiseDevice.value" : [
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"preset:Automatic", "*",
+			"presetsPlugValueWidget:allowCustom", True,
+
+		],
+
 		"options.denoiseStartSample" : [
 
 			"description",
@@ -1470,6 +1539,7 @@ Gaffer.Metadata.registerNode(
 )
 
 __registerDevicePresets()
+__registerDenoiseDevicePresets()
 
 if GafferCycles.hasOptixDenoise :
 

--- a/python/GafferCyclesUI/CyclesOptionsUI.py
+++ b/python/GafferCyclesUI/CyclesOptionsUI.py
@@ -1415,8 +1415,12 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			Denoise the image with the selected denoiser.
-			OptiX - Use the OptiX AI denoiser with GPU acceleration, only available on NVIDIA GPUs
-			OpenImageDenoise - Use Intel OpenImageDenoise AI denoiser running on the CPU
+
+			- OptiX : Use the OptiX AI denoiser with GPU acceleration, only available on NVIDIA GPUs
+			- OpenImageDenoise : Use the Intel OpenImageDenoise AI denoiser running on the CPU
+
+			> Tip : Only outputs that include a `denoise` parameter set to `true` will be denoised.
+			> Denoised outputs are renamed to include a "denoised" suffix.
 			""",
 
 			"layout:section", "Denoising",

--- a/src/GafferCycles/CyclesOptions.cpp
+++ b/src/GafferCycles/CyclesOptions.cpp
@@ -114,6 +114,7 @@ CyclesOptions::CyclesOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:adaptive_threshold", new IECore::FloatData( 0.0f ), false, "adaptiveThreshold" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:adaptive_min_samples", new IECore::IntData( 0 ), false, "adaptiveMinSamples" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:denoiser_type", new IECore::StringData( "openimagedenoise" ), false, "denoiserType" ) );
+	options->addChild( new Gaffer::NameValuePlug( "cycles:denoise_device", new IECore::StringData( "*" ), false, "denoiseDevice" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:denoise_start_sample", new IECore::IntData( 0 ), false, "denoiseStartSample" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_denoise_pass_albedo", new IECore::BoolData( true ), false, "useDenoisePassAlbedo" ) );
 	options->addChild( new Gaffer::NameValuePlug( "cycles:integrator:use_denoise_pass_normal", new IECore::BoolData( true ), false, "useDenoisePassNormal" ) );


### PR DESCRIPTION
Cycles now requires a denoise device to be specified when denoising, this device needs to support the configured denoiser otherwise Cycles will fall back to only denoising with OIDN on the CPU, erroring if OIDN is not available. To make this a little easier on the user, we include an `Automatic` preset which provides all devices to Cycles, where it will attempt to choose a [suitable device](https://projects.blender.org/blender/cycles/src/commit/2d4573dbae53f4850f7e35b679556d5d64ad1f3b/src/integrator/denoiser.cpp#L41-L73) for the current denoiser type (favouring GPU devices where available).

I have quite limited access to optix devices at present, so this would benefit from a little more render testing...