### PR TITLE
Pause render hotkey

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - PythonEditor, PythonCommand, Expression, UIEditor, OSLCode : Added line numbers to code editors (#6091).
 - CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 - AttributeTweaks : Added tooltips and presets for all attribute values.
+- InteractiveRenderer : Added <kbd>Esc</kbd> hotkey handling to pause an interactive render. This is in addition to the existing behavior of pausing the image viewer.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
 - InteractiveRenderer :
   - Added <kbd>Esc</kbd> hotkey handling to pause an interactive render. This is in addition to the existing behavior of pausing the image viewer.
   - Added <kbd>Ctrl</kbd> + <kbd>\</kbd> hotkey handling to toggle the interactive renderer between paused and running. If the new state is `Running`, the image viewer will also be unpaused.
+  - Starting or unpausing the render using the viewer control play button will also unpause the image viewer.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,9 @@ Improvements
 - PythonEditor, PythonCommand, Expression, UIEditor, OSLCode : Added line numbers to code editors (#6091).
 - CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 - AttributeTweaks : Added tooltips and presets for all attribute values.
-- InteractiveRenderer : Added <kbd>Esc</kbd> hotkey handling to pause an interactive render. This is in addition to the existing behavior of pausing the image viewer.
+- InteractiveRenderer :
+  - Added <kbd>Esc</kbd> hotkey handling to pause an interactive render. This is in addition to the existing behavior of pausing the image viewer.
+  - Added <kbd>Ctrl</kbd> + <kbd>\</kbd> hotkey handling to toggle the interactive renderer between paused and running. If the new state is `Running`, the image viewer will also be unpaused.
 
 Fixes
 -----

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -310,6 +310,15 @@ Duplicate current Catalogue image    | {kbd}`Ctrl` + {kbd}`D`
 Toggle image comparison              | {kbd}`Q`
 Toggle wipes                         | {kbd}`W`
 
+### Interactive Render Viewer ###
+
+> Note :
+> For the following controls and shortcuts, the cursor must hover over the Viewer.
+
+Action                               | Control or shortcut
+-------------------------------------|--------------------
+Pause active render                  | {kdb}`Escape`
+
 ### Crop window tool ###
 
 Action                               | Control or shortcut

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -318,6 +318,7 @@ Toggle wipes                         | {kbd}`W`
 Action                               | Control or shortcut
 -------------------------------------|--------------------
 Pause active render                  | {kdb}`Escape`
+Toggle render running / paused       | {kdb}`Ctrl` + {kbd}`\`
 
 ### Crop window tool ###
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -96,7 +96,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
 				GafferUI.Spacer( imath.V2i( 1, 1 ), imath.V2i( 1, 1 ) )
 				self.__label = GafferUI.Label( "Render" )
-				self.__stateWidget = _StatePlugValueWidget( None )
+				self.__stateWidget = _StatePlugValueWidget( None, view )
 				self.__messagesWidget = _MessageSummaryPlugValueWidget( None )
 
 		self.__view = view
@@ -207,7 +207,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 
 class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 
-	def __init__( self, plug, *args, **kwargs) :
+	def __init__( self, plug, view = None, *args, **kwargs) :
 
 		row = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal )
 		GafferUI.PlugValueWidget.__init__( self, row, plug )
@@ -236,6 +236,7 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 		}
 
 		self.__state = None
+		self.__view = view
 
 	def _updateFromValues( self, values, exception ) :
 
@@ -257,6 +258,8 @@ class _StatePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# Not enabling undo here is done so that users won't accidentally restart/stop their renderings.
 		if state != GafferScene.InteractiveRender.State.Running:
 			self.getPlug().setValue( GafferScene.InteractiveRender.State.Running )
+			if isinstance( self.__view, GafferImageUI.ImageView ) :
+				self.__view.imageGadget().setPaused( False )
 		else:
 			self.getPlug().setValue( GafferScene.InteractiveRender.State.Paused )
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -104,6 +104,9 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 		if isinstance( self.__view["in"], GafferImage.ImagePlug ) :
 			view.plugDirtiedSignal().connect( Gaffer.WeakMethod( self.__viewPlugDirtied ) )
 
+		if isinstance( self.__view, GafferUI.View ) :
+			self.__view.viewportGadget().keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
+
 		self.__update()
 
 	def __update( self ) :
@@ -178,6 +181,14 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 
 		if plug.getName() == "state" :
 			self.__updateLazily();
+
+	def __keyPress( self, widget, event ) :
+
+		if event.key == "Escape" :
+			renderNode = self._interactiveRenderNode( self.__view )
+			if renderNode is not None :
+				statePlug = renderNode["state"].source()
+				statePlug.setValue( GafferScene.InteractiveRender.State.Paused )
 
 ##########################################################################
 # UI for the state plug that allows setting the state through buttons

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -180,7 +180,7 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 	def __renderNodePlugDirtied( self, plug ) :
 
 		if plug.getName() == "state" :
-			self.__updateLazily();
+			self.__updateLazily()
 
 	def __keyPress( self, widget, event ) :
 

--- a/python/GafferSceneUI/InteractiveRenderUI.py
+++ b/python/GafferSceneUI/InteractiveRenderUI.py
@@ -189,6 +189,17 @@ class _ViewRenderControlUI( GafferUI.Widget ) :
 			if renderNode is not None :
 				statePlug = renderNode["state"].source()
 				statePlug.setValue( GafferScene.InteractiveRender.State.Paused )
+		elif event.key == "Backslash" and event.modifiers == event.modifiers.Control :
+			renderNode = self._interactiveRenderNode( self.__view )
+			if renderNode is not None :
+				statePlug = renderNode["state"].source()
+				state = statePlug.getValue()
+				if state == GafferScene.InteractiveRender.State.Running :
+					statePlug.setValue( GafferScene.InteractiveRender.State.Paused )
+				else :
+					statePlug.setValue( GafferScene.InteractiveRender.State.Running )
+					if isinstance( self.__view, GafferImageUI.ImageView ) :
+						self.__view.imageGadget().setPaused( False )
 
 ##########################################################################
 # UI for the state plug that allows setting the state through buttons


### PR DESCRIPTION
This adds `Escape` as a hotkey to pause the render, as well as pausing the viewport updates (which was already the behavior). It also adds a hotkey, `Control` + `\`, to pause and start the render. Both need to have the viewer as the focus widget.

Finally, aiming to match the hotkey behavior, I added a commit to unpause the viewer when the play button is pushed.

I tested this with Arnold, adding a high number of subdivisions to the Gafferbot meshes. Pausing worked fairly well - it still takes a few seconds on my machine to get it to pause. We're already using Arnold's `AiRenderInterrupt()` which from their documentation sounds like the most appropriate method for what we want to do.

It seems like that needs to wait for the current batch of meshes to finish subdividing, then it pauses. Adding more subdivisions increases the time it takes for Arnold to pause.

There's also the issue of pausing the render before the renderer actually begins. Talking yesterday about this, that would require shifting some scene processing to a background thread so the UI thread is unlocked. We discussed that being a follow-up to this PR rather than including it now.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
