### PR TITLE
PlugPopup : Add original / current color swatches

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
   - Added `inactiveIds` plug for selecting primitive variables to disable some instances.
   - Added support for 64 bit integer ids (matching what is loaded from USD).
 - DeletePoints : Added modes for deleting points based on a list of ids.
+- Light Editor, Attribute Editor, Spreadsheet : Add original and current color swatches to color popups.
 
 Fixes
 -----

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -866,7 +866,7 @@ class ColorChooser( GafferUI.Widget ) :
 
 	def setSwatchesVisible( self, visible ) :
 
-		self.__swatchRow.setVisible( False )
+		self.__swatchRow.setVisible( visible )
 
 	def getSwatchesVisible( self ) :
 

--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -86,6 +86,22 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__lastChangedReason = None
 		self.__mergeGroupId = 0
 
+	def setInitialColor( self, color ) :
+
+		self.__colorChooser.setInitialColor( color )
+
+	def getInitialColor( self ) :
+
+		return self.__colorChooser.getInitialColor()
+
+	def setSwatchesVisible( self, visible ) :
+
+		self.__colorChooser.setSwatchesVisible( visible )
+
+	def getSwatchesVisible( self ) :
+
+		return self.__colorChooser.getVisible()
+
 	def _updateFromValues( self, values, exception ) :
 
 		# ColorChooser only supports one colour, and doesn't have

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -96,6 +96,22 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return self.__colorChooser.getVisible() if self.__colorChooser is not None else False
 
+	def setInitialColor( self, color ) :
+
+		self.__colorChooser.setInitialColor( color )
+
+	def getInitialColor( self ) :
+
+		return self.__colorChooser.getInitialColor()
+
+	def setSwatchesVisible( self, visible ) :
+
+		self.__colorChooser.setSwatchesVisible( visible )
+
+	def getSwatchesVisible( self ) :
+
+		return self.__colorChooser.getVisible()
+
 	def setPlugs( self, plugs ) :
 
 		GafferUI.PlugValueWidget.setPlugs( self, plugs )

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -34,6 +34,8 @@
 #
 ##########################################################################
 
+import imath
+
 import Gaffer
 import GafferUI
 
@@ -121,6 +123,30 @@ class PlugPopup( GafferUI.PopupWindow ) :
 	def popup( self, center = None, parent = None ) :
 
 		GafferUI.PopupWindow.popup( self, center, parent )
+
+		colorPlugValueWidget = self.__colorPlugValueWidget( self.__plugValueWidget )
+		if colorPlugValueWidget is not None and len( self.__plugValueWidget.getPlugs() ) > 0 :
+			colors = [
+				p.getValue() for p in self.__plugValueWidget.getPlugs() if (
+					isinstance( p, Gaffer.Color3fPlug ) or isinstance( p, Gaffer.Color4fPlug )
+				)
+			]
+			if len( colors ) == 0 :
+				for c in self.__plugValueWidget.getPlugs() :
+					colors += [ p.getValue() for p in Gaffer.Color3fPlug.RecursiveRange( c ) ]
+			if len( colors ) == 0 :
+				for c in self.__plugValueWidget.getPlugs() :
+					colors += [ p.getValue() for p in Gaffer.Color4fPlug.RecursiveRange( c ) ]
+
+			assert( len( colors ) > 0 )
+			assert(
+				all(
+					isinstance( c, imath.Color3f ) for c in colors
+				) or all( isinstance( c, imath.Color4f ) for c in colors )
+			)
+
+			colorPlugValueWidget.setInitialColor( sum( colors ) / len( colors ) )
+			colorPlugValueWidget.setSwatchesVisible( True )
 
 		# Attempt to focus the first text widget. This is done after making
 		# the window visible, as we check child widget visibility to avoid


### PR DESCRIPTION
This adds the previous / current swatches to plug popups, which are used in, at least, the spreadsheet, light editor and attribute editor.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
