### PR TITLE
TweakPlug : Fix list append performance.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - PythonEditor, PythonCommand, Expression, UIEditor, OSLCode : Added line numbers to code editors (#6091).
 - CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 - AttributeTweaks : Added tooltips and presets for all attribute values.
+- TweakPlug : Improved performance when dealing with large lists.
 
 Fixes
 -----

--- a/python/GafferTest/TweakPlugTest.py
+++ b/python/GafferTest/TweakPlugTest.py
@@ -485,5 +485,20 @@ class TweakPlugTest( GafferTest.TestCase ) :
 		self.assertFalse( plug.applyTweak( data, Gaffer.TweakPlug.MissingMode.Ignore ) )
 		self.assertEqual( data, IECore.CompoundData() )
 
+	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 1 )
+	def testListPerformance( self ) :
+
+		parameters = IECore.CompoundData(
+			{
+				"l" : IECore.IntVectorData( range( 100000 ) ),
+			}
+		)
+
+		tweaks = Gaffer.TweaksPlug()
+		tweaks.addChild( Gaffer.TweakPlug( "l", IECore.IntVectorData( range( 100000, 200000 ) ), Gaffer.TweakPlug.Mode.ListAppend ) )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			tweaks.applyTweaks( parameters )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -50,7 +50,7 @@
 
 #include "fmt/format.h"
 
-#include <unordered_map>
+#include <unordered_set>
 
 using namespace std;
 using namespace IECore;
@@ -112,17 +112,25 @@ vector<T> tweakedList( const std::vector<T> &source, const std::vector<T> &tweak
 {
 	vector<T> result = source;
 
+	struct HashFunc
+	{
+		size_t operator()(const T& x) const
+		{
+			IECore::MurmurHash h;
+			h.append( x );
+			return h.h1();
+		}
+	};
+
+	std::unordered_set<T, HashFunc> tweakSet( tweak.begin(), tweak.end() );
+
 	result.erase(
 		std::remove_if(
 			result.begin(),
 			result.end(),
-			[&tweak]( const auto &elem )
+			[&tweakSet]( const auto &elem )
 			{
-				return std::find(
-					tweak.begin(),
-					tweak.end(),
-					elem
-				) != tweak.end();
+				return tweakSet.count( elem );
 			}
 		),
 		result.end()


### PR DESCRIPTION
Simple fix for an issue John caught with how this performance scales.

In this test for 100000 elements, runtime goes from 2s to 0.02s
