### PR TITLE
Shader component connection improvements

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0a4/gafferDependencies-9.0.0a4-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0/gafferDependencies-9.0.0-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Improvements
 - CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 - AttributeTweaks : Added tooltips and presets for all attribute values.
 - TweakPlug : Improved performance when dealing with large lists.
+- SceneWriter : Improved emulation of component-level shader connections when exporting Cycles shaders to USD. Native adaptor shaders are now used instead of OSL shaders that may not be available in the destination DCC.
 
 Fixes
 -----
@@ -26,6 +27,7 @@ Fixes
 - Expression, OSLCode : Fixed line numbers reported in OSL parse errors.
 - PathColumn : Fixed display of swatches for cells containing `Color4fData`.
 - Arnold : Fixed "Flush Cache" menu items to work with renders being performed by an InteractiveRender node (rather than an InteractiveArnoldRender node).
+- Cycles : Fixed rendering of shaders with connections to individual `rgb` components of a colour or `xyz` components of a vector (#5553).
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
 - AttributeTweaks : Added tooltips and presets for all attribute values.
 - TweakPlug : Improved performance when dealing with large lists.
 - SceneWriter : Improved emulation of component-level shader connections when exporting Arnold and Cycles shaders to USD. Native adaptor shaders are now used instead of OSL shaders that may not be available in the destination DCC.
+- SceneReader : Added loading of `invisibleIds` and `inactiveIds` primitive variables from UsdGeomPointInstancer.
 
 Fixes
 -----
@@ -48,6 +49,11 @@ Breaking Changes
 - GafferCycles : The `devices`, `nodes`, `shaders`, `lights`, and `passes` Python attributes now contain IECore.CompoundData instead of Python dictionaries.
 - InteractiveArnoldRender, InteractiveCyclesRender, InteractiveDelightRender : Removed. Use the generic InteractiveRender node instead.
 - InteractiveRender : Removed protected constructor for creating renderer-specific derived classes.
+
+Build
+-----
+
+- Cortex : Updated to version 10.5.10.0.
 
 1.5.0.0a3 (relative to 1.5.0.0a2)
 =========

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,7 @@ Improvements
 - CyclesOptions : Added `denoiseDevice` plug for configuring the device used for denoising.
 - AttributeTweaks : Added tooltips and presets for all attribute values.
 - TweakPlug : Improved performance when dealing with large lists.
-- SceneWriter : Improved emulation of component-level shader connections when exporting Cycles shaders to USD. Native adaptor shaders are now used instead of OSL shaders that may not be available in the destination DCC.
+- SceneWriter : Improved emulation of component-level shader connections when exporting Arnold and Cycles shaders to USD. Native adaptor shaders are now used instead of OSL shaders that may not be available in the destination DCC.
 
 Fixes
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -1382,6 +1382,9 @@ libraries = {
 
 	},
 
+	# Installs `startup/IECoreScene`.
+	"IECoreScene" : {},
+
 }
 
 libraries["scripts"]["additionalFiles"].append( "bin/gaffer.cmd" if env["PLATFORM"] == "win32" else "bin/gaffer" )

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -2039,6 +2039,39 @@ class RendererTest( GafferTest.TestCase ) :
 			]
 		)
 
+	def testComponentConnections( self ) :
+
+		shader = IECoreScene.ShaderNetwork(
+			shaders = {
+				"input" : IECoreScene.Shader(
+					"convert_point_to_color", "cycles:shader",
+					{
+						"value_point" : imath.V3f( 1, 0.5, 0.25 ),
+					}
+				),
+				"output" : IECoreScene.Shader(
+					"emission", "cycles:surface",
+					{
+						"color" : imath.Color3f( 0 ),
+						"strength" : 1.0,
+					}
+				),
+			},
+			connections = [
+				( ( "input", "value_color.r" ), ( "output", "color.g" ) ),
+				( ( "input", "value_color.g" ), ( "output", "color.b" ) ),
+				( ( "input", "value_color.b" ), ( "output", "color.r" ) ),
+			],
+			output = "output",
+		)
+
+		self.__testShaderResults(
+			shader,
+			[
+				( imath.V2f( 0.5, 0.5 ), imath.Color4f( 0.25, 1, 0.5, 1 ) ),
+			]
+		)
+
 	def testInvalidShaderParameterValues( self ) :
 
 		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "Cycles" )

--- a/python/GafferCyclesUI/CyclesShaderUI.py
+++ b/python/GafferCyclesUI/CyclesShaderUI.py
@@ -98,7 +98,7 @@ def __translateParamMetadata( nodeTypeName, socketName, value ) :
 	__metadata[paramPath]["noduleLayout:label"] = label
 	# Linkable
 	linkable = bool( flags.value & ( 1 << 0 ) )
-	__metadata[paramPath]["nodule:type"] = "GafferUI::StandardNodule" if linkable else ""
+	__metadata[paramPath]["nodule:type"] = "" if not linkable else None # "" disables the nodule, and None falls through to the default
 
 	if "category" in value :
 		__metadata[paramPath]["layout:section"] = value["category"]

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -842,9 +842,9 @@ class Widget( Gaffer.Signals.Trackable, metaclass = _WidgetMetaclass ) :
 
 		color = color * 255
 		return QtGui.QColor(
-			min( 255, max( 0, color.r ) ),
-			min( 255, max( 0, color.g ) ),
-			min( 255, max( 0, color.b ) ),
+			min( 255, max( 0, color[0] ) ),
+			min( 255, max( 0, color[1] ) ),
+			min( 255, max( 0, color[2] ) ),
 		)
 
 	# We try not to install the event filter until absolutely

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -391,7 +391,7 @@ class RendererTest( GafferTest.TestCase ) :
 		s = IECoreScene.ShaderNetwork(
 			shaders = {
 				"source" : IECoreScene.Shader( "Maths/MixColor", "osl:shader" ),
-				"output" : IECoreScene.Shader( "Maths/MixColor", "osl:shader" ),
+				"output" : IECoreScene.Shader( "Maths/MixColor", "osl:shader", { "a" : imath.Color3f( 0 ) } ),
 			},
 			connections = [
 				( ( "source", "out.r" ), ( "output", "a.g" ) ),

--- a/startup/IECoreScene/componentConnectionAdaptors.py
+++ b/startup/IECoreScene/componentConnectionAdaptors.py
@@ -1,0 +1,65 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECore
+import IECoreScene
+
+# This file registers adaptors for connections between scalars and the child
+# components of vector and color parameters in shaders. These adaptors are
+# necessary for exporting to USD, where component-level connections are not
+# supported. They may also be necessary for rendering in certain renderers
+# where component-level connections are not supported.
+
+# Cycles
+# ======
+
+for c in "rgb" :
+	IECoreScene.ShaderNetworkAlgo.registerSplitAdapter(
+		"cycles", c, IECoreScene.Shader( "separate_rgb", "cycles:shader" ), "color", c
+	)
+
+for c in "xyz" :
+	IECoreScene.ShaderNetworkAlgo.registerSplitAdapter(
+		"cycles", c, IECoreScene.Shader( "separate_xyz", "cycles:shader" ), "vector", c
+	)
+
+IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
+	"cycles", IECore.Color3fData, IECoreScene.Shader( "combine_rgb", "cycles:shader" ), ( "r", "g", "b" ), "image"
+)
+
+IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
+	"cycles", IECore.V3fData, IECoreScene.Shader( "combine_xyz", "cycles:shader" ), ( "x", "y", "z" ), "vector"
+)

--- a/startup/IECoreScene/componentConnectionAdaptors.py
+++ b/startup/IECoreScene/componentConnectionAdaptors.py
@@ -63,3 +63,24 @@ IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
 IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
 	"cycles", IECore.V3fData, IECoreScene.Shader( "combine_xyz", "cycles:shader" ), ( "x", "y", "z" ), "vector"
 )
+
+# Arnold
+# ======
+
+for c, mode in zip( "rgbaxyz", "rgbargb" ) :
+
+	IECoreScene.ShaderNetworkAlgo.registerSplitAdapter(
+			"ai", c, IECoreScene.Shader( "rgba_to_float", "ai:shader", { "mode" : mode } ), "input", "out"
+		)
+
+IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
+	"ai", IECore.V3fData.staticTypeId(), IECoreScene.Shader( "float_to_rgb", "ai:shader" ), ( "r", "g", "b" ), "out"
+)
+
+IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
+	"ai", IECore.Color3fData.staticTypeId(), IECoreScene.Shader( "float_to_rgb", "ai:shader" ), ( "r", "g", "b" ), "out"
+)
+
+IECoreScene.ShaderNetworkAlgo.registerJoinAdapter(
+	"ai", IECore.Color4fData.staticTypeId(), IECoreScene.Shader( "float_to_rgba", "ai:shader" ), ( "r", "g", "b", "a" ), "out"
+)


### PR DESCRIPTION
This uses https://github.com/ImageEngine/cortex/pull/1438 to improve export of Cycles and Arnold shader networks to USD, and to fix rendering of `float->color.[rgb]` connections in Cycles.