### PR TITLE
Static color sliders / field

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 - DeletePoints : Added modes for deleting points based on a list of ids.
 - Light Editor, Attribute Editor, Spreadsheet : Add original and current color swatches to color popups.
 - SceneView : Added fallback framing extents to create a reasonable view when `SceneGadget` is empty, for example if the grid is hidden.
+- ColorChooser : Added an option to toggle the dynamic update of colors displayed in the slider backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,7 @@ Improvements
 - DeletePoints : Added modes for deleting points based on a list of ids.
 - Light Editor, Attribute Editor, Spreadsheet : Add original and current color swatches to color popups.
 - SceneView : Added fallback framing extents to create a reasonable view when `SceneGadget` is empty, for example if the grid is hidden.
-- ColorChooser : Added an option to toggle the dynamic update of colors displayed in the slider backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
+- ColorChooser : Added an option to toggle the dynamic update of colors displayed in the slider and color field backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
 
 Fixes
 -----

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -302,7 +302,11 @@ class _ColorField( GafferUI.Widget ) :
 			return
 
 		zIndex = self.__zIndex()
-		if color[zIndex] != self.__color[zIndex] or staticComponent != self.__staticComponent :
+		if (
+			staticComponent != self.__staticComponent or
+			( self.__dynamicBackground and color[zIndex] != self.__color[zIndex] ) or
+			( not self.__dynamicBackground and staticComponent == "h" )
+		) :
 			self.__colorFieldToDraw = None
 
 		self.__color = color

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -962,23 +962,18 @@ class ColorChooser( GafferUI.Widget ) :
 
 	## A signal emitted whenever the visible components are changed. Slots
 	# should have the signature slot( ColorChooser ).
-	# `visibleComponents` is a string representing the components currently
-	# visible.
 	def visibleComponentsChangedSignal( self ) :
 
 		return self.__visibleComponentsChangedSignal
 
 	## A signal emitted whenever the static component is changed. Slots
 	# should have the signature slot( ColorChooser ).
-	# `staticComponent` is a single character string representing the
-	# current static component.
 	def staticComponentChangedSignal( self ) :
 
 		return self.__staticComponentChangedSignal
 
 	## A signal emitted whenever the visibility of the color field changes.
 	# Slots should have the signature slot( ColorChooser ).
-	# `visible` is a boolean representing the current visibility.
 	def colorFieldVisibleChangedSignal( self ) :
 
 		return self.__colorFieldVisibleChangedSignal

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -129,11 +129,18 @@ class _ComponentSlider( GafferUI.Slider ) :
 		self.color = color
 		self.component = component
 		self.__dynamicBackground = dynamicBackground
+		self.__gradientToDraw = None
+		self.__size = self.size()
 
 	# Sets the slider color in RGB space for RGBA channels,
 	# HSV space for HSV channels and TMI space for TMI channels.
 	def setColor( self, color ) :
 
+		if (
+			( self.__dynamicBackground and color != self.color ) or
+			( not self.__dynamicBackground and self.component == "s" )
+		) :
+			self.__gradientToDraw = None
 		self.color = color
 		self._qtWidget().update()
 
@@ -144,6 +151,7 @@ class _ComponentSlider( GafferUI.Slider ) :
 	def setDynamicBackground( self, dynamicBackground ) :
 
 		self.__dynamicBackground = dynamicBackground
+		self.__gradientToDraw = None
 		self._qtWidget().update()
 
 	def getDynamicBackground( self ) :
@@ -153,43 +161,46 @@ class _ComponentSlider( GafferUI.Slider ) :
 	def _drawBackground( self, painter ) :
 
 		size = self.size()
-		grad = QtGui.QLinearGradient( 0, 0, size.x, 0 )
 
-		displayTransform = self.displayTransform()
+		if self.__gradientToDraw is None or size != self.__size :
+			self.__gradientToDraw = QtGui.QLinearGradient( 0, 0, size.x, 0 )
 
-		if self.component == "a" :
-			c1 = imath.Color3f( 0 )
-			c2 = imath.Color3f( 1 )
-		else :
-			if self.__dynamicBackground :
-				c1 = imath.Color3f( self.color[0], self.color[1], self.color[2] )
-			elif self.component in "rgbvi" :
+			displayTransform = self.displayTransform()
+
+			if self.component == "a" :
 				c1 = imath.Color3f( 0 )
-			elif self.component == "h" :
-				c1 = imath.Color3f( 0, 1, 1 )
-			elif self.component == "s" :
-				c1 = imath.Color3f( self.color[0], 0, 1 )
-			elif self.component in "tm" :
-				c1 = imath.Color3f( 0, 0, 0.5 )
-			c2 = imath.Color3f( c1 )
-			a = { "r" : 0, "g" : 1, "b" : 2, "h" : 0, "s" : 1, "v": 2, "t" : 0, "m" : 1, "i" : 2 }[self.component]
-			c1[a] = -1 if self.component in "tm" else 0
-			c2[a] = 1
+				c2 = imath.Color3f( 1 )
+			else :
+				if self.__dynamicBackground :
+					c1 = imath.Color3f( self.color[0], self.color[1], self.color[2] )
+				elif self.component in "rgbvi" :
+					c1 = imath.Color3f( 0 )
+				elif self.component == "h" :
+					c1 = imath.Color3f( 0, 1, 1 )
+				elif self.component == "s" :
+					c1 = imath.Color3f( self.color[0], 0, 1 )
+				elif self.component in "tm" :
+					c1 = imath.Color3f( 0, 0, 0.5 )
+				c2 = imath.Color3f( c1 )
+				a = { "r" : 0, "g" : 1, "b" : 2, "h" : 0, "s" : 1, "v": 2, "t" : 0, "m" : 1, "i" : 2 }[self.component]
+				c1[a] = -1 if self.component in "tm" else 0
+				c2[a] = 1
 
-		numStops = max( 2, size.x // 2 )
-		for i in range( 0, numStops ) :
+			numStops = max( 2, size.x // 2 )
+			for i in range( 0, numStops ) :
 
-			t = float( i ) / (numStops-1)
-			c = c1 + (c2-c1) * t
-			if self.component in "hsv" :
-				c = c.hsv2rgb()
-			elif self.component in "tmi" :
-				c = _tmiToRGB( c )
+				t = float( i ) / (numStops-1)
+				c = c1 + (c2-c1) * t
+				if self.component in "hsv" :
+					c = c.hsv2rgb()
+				elif self.component in "tmi" :
+					c = _tmiToRGB( c )
 
-			grad.setColorAt( t, self._qtColor( displayTransform( c ) ) )
+				self.__gradientToDraw.setColorAt( t, self._qtColor( displayTransform( c ) ) )
 
-		brush = QtGui.QBrush( grad )
+		brush = QtGui.QBrush( self.__gradientToDraw )
 		painter.fillRect( 0, 0, size.x, size.y, brush )
+		self.__size = size
 
 	def _drawValue( self, painter, value, position, state ) :
 
@@ -228,6 +239,7 @@ class _ComponentSlider( GafferUI.Slider ) :
 	def _displayTransformChanged( self ) :
 
 		GafferUI.Slider._displayTransformChanged( self )
+		self.__gradientToDraw = None
 		self._qtWidget().update()
 
 class _ColorField( GafferUI.Widget ) :

--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -65,6 +65,10 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if colorFieldVisible is not None :
 			self.__colorChooser.setColorFieldVisible( colorFieldVisible )
 
+		dynamicSliderBackgrounds = self.__colorChooserOption( "dynamicSliderBackgrounds" )
+		if dynamicSliderBackgrounds is not None :
+			self.__colorChooser.setDynamicSliderBackgrounds( dynamicSliderBackgrounds )
+
 		self.__colorChangedConnection = self.__colorChooser.colorChangedSignal().connect(
 			Gaffer.WeakMethod( self.__colorChanged )
 		)
@@ -77,6 +81,9 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 		)
 		self.__colorChooser.colorFieldVisibleChangedSignal().connect(
 			functools.partial( Gaffer.WeakMethod( self.__colorChooserColorFieldVisibleChanged ) )
+		)
+		self.__colorChooser.dynamicSliderBackgroundsChangedSignal().connect(
+			functools.partial( Gaffer.WeakMethod( self.__dynamicSliderBackgroundsChanged ) )
 		)
 		self.__colorChooser.optionsMenuSignal().connect(
 			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) ),
@@ -157,6 +164,10 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__colorChooserOptionChanged( "colorFieldVisible", colorChooser.getColorFieldVisible() )
 
+	def __dynamicSliderBackgroundsChanged( self, colorChooser ) :
+
+		self.__colorChooserOptionChanged( "dynamicSliderBackgrounds", colorChooser.getDynamicSliderBackgrounds() )
+
 	def __colorChooserOptionsMenu( self, colorChooser, menuDefinition ) :
 
 		menuDefinition.append( "/__saveDefaultOptions__", { "divider": True, "label": "Defaults" } )
@@ -193,14 +204,16 @@ def saveDefaultOptions( colorChooser, keyPrefix, scriptPath = None ) :
 	visibleComponents = colorChooser.getVisibleComponents()
 	staticComponent = colorChooser.getColorFieldStaticComponent()
 	colorFieldVisible = colorChooser.getColorFieldVisible()
+	dynamicSliderBackgrounds = colorChooser.getDynamicSliderBackgrounds()
 
 	for p in [ Gaffer.Color3fPlug, Gaffer.Color4fPlug ] :
-		for k in [ "visibleComponents", "staticComponent", "colorFieldVisible" ] :
+		for k in [ "visibleComponents", "staticComponent", "colorFieldVisible", "dynamicSliderBackgrounds" ] :
 			Gaffer.Metadata.deregisterValue( p, keyPrefix + k )
 
 		Gaffer.Metadata.registerValue( p, keyPrefix + "visibleComponents", visibleComponents )
 		Gaffer.Metadata.registerValue( p, keyPrefix + "staticComponent", staticComponent )
 		Gaffer.Metadata.registerValue( p, keyPrefix + "colorFieldVisible", colorFieldVisible )
+		Gaffer.Metadata.registerValue( p, keyPrefix + "dynamicSliderBackgrounds", dynamicSliderBackgrounds )
 
 	if scriptPath is None :
 		return
@@ -226,6 +239,7 @@ def saveDefaultOptions( colorChooser, keyPrefix, scriptPath = None ) :
 		newScript.append( f"Gaffer.Metadata.registerValue( Gaffer.Color{c}fPlug, \"{keyPrefix}visibleComponents\", \"{visibleComponents}\" )\n" )
 		newScript.append( f"Gaffer.Metadata.registerValue( Gaffer.Color{c}fPlug, \"{keyPrefix}staticComponent\", \"{staticComponent}\" )\n" )
 		newScript.append( f"Gaffer.Metadata.registerValue( Gaffer.Color{c}fPlug, \"{keyPrefix}colorFieldVisible\", {colorFieldVisible} )\n" )
+		newScript.append( f"Gaffer.Metadata.registerValue( Gaffer.Color{c}fPlug, \"{keyPrefix}dynamicSliderBackgrounds\", {dynamicSliderBackgrounds} )\n" )
 
 	with open( scriptPath, "w" ) as outFile :
 		outFile.writelines( newScript )

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -147,6 +147,9 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 		self.colorChooser().colorFieldVisibleChangedSignal().connect(
 			functools.partial( Gaffer.WeakMethod( self.__colorChooserColorFieldVisibleChanged ) )
 		)
+		self.colorChooser().dynamicSliderBackgroundsChangedSignal().connect(
+			functools.partial( Gaffer.WeakMethod( self.__dynamicSliderBackgroundsChanged ) )
+		)
 		self.colorChooser().optionsMenuSignal().connect(
 			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) ),
 			scoped = False
@@ -182,6 +185,10 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 		colorFieldVisible = self.__colorChooserOption( "colorFieldVisible" )
 		if colorFieldVisible is not None :
 			self.colorChooser().setColorFieldVisible( colorFieldVisible )
+
+		dynamicSliderBackgrounds = self.__colorChooserOption( "dynamicSliderBackgrounds" )
+		if dynamicSliderBackgrounds is not None :
+			self.colorChooser().setDynamicSliderBackgrounds( dynamicSliderBackgrounds )
 
 		parentWindow.addChildWindow( self, removeOnClose = True )
 
@@ -287,3 +294,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 	def __colorChooserColorFieldVisibleChanged( self, colorChooser ) :
 
 		self.__colorChooserOptionChanged( "colorFieldVisible", colorChooser.getColorFieldVisible() )
+
+	def __dynamicSliderBackgroundsChanged( self, colorChooser ) :
+
+		self.__colorChooserOptionChanged( "dynamicSliderBackgrounds", colorChooser.getDynamicSliderBackgrounds() )

--- a/python/GafferUITest/ColorChooserTest.py
+++ b/python/GafferUITest/ColorChooserTest.py
@@ -123,6 +123,16 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 		c = self.__colorChooserFromWidget( widget )
 		return c.getColorFieldVisible()
 
+	def __setDynamicSliderBackgrounds( self, widget, dynamic ) :
+
+		c = self.__colorChooserFromWidget( widget )
+		c.setDynamicSliderBackgrounds( dynamic )
+
+	def __getDynamicSliderBackgrounds( self, widget ) :
+
+		c = self.__colorChooserFromWidget( widget )
+		return c.getDynamicSliderBackgrounds()
+
 	def testMetadata( self ) :
 
 		script = Gaffer.ScriptNode()
@@ -145,12 +155,14 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:visibleComponents" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:staticComponent" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:colorFieldVisible" ) )
+			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:dynamicSliderBackgrounds" ) )
 
 		# Modify widget
 
 		self.__setVisibleComponents( widget, "rgbtmi" )
 		self.__setStaticComponent( widget, "t" )
 		self.__setColorFieldVisibility( widget, False )
+		self.__setDynamicSliderBackgrounds( widget, False )
 
 		for c in "rgbtmi" :
 			self.assertTrue( self.__sliderFromWidget( widget, c ).getVisible() )
@@ -158,15 +170,18 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 			self.assertFalse( self.__sliderFromWidget( widget, c ).getVisible() )
 		self.assertEqual( self.__getStaticComponent( widget ), "t" )
 		self.assertFalse( self.__getColorFieldVisibility( widget ) )
+		self.assertFalse( self.__getDynamicSliderBackgrounds( widget ) )
 
 		for p in [ "rgbPlug2" ] :
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:visibleComponents" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:staticComponent" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:colorFieldVisible" ) )
+			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:dynamicSliderBackgrounds" ) )
 
 		self.assertEqual( set( Gaffer.Metadata.value( script["node"]["rgbPlug1"], "colorChooser:inline:visibleComponents" ) ), set( "rgbtmi" ) )
 		self.assertEqual( Gaffer.Metadata.value( script["node"]["rgbPlug1"], "colorChooser:inline:staticComponent" ), "t" )
 		self.assertFalse( Gaffer.Metadata.value( script["node"]["rgbPlug1"], "colorChooser:inline:colorFieldVisible" ) )
+		self.assertFalse( Gaffer.Metadata.value( script["node"]["rgbPlug1"], "colorChooser:inline:dynamicSliderBackgrounds" ) )
 
 		# Recreate widget and should have the same state
 
@@ -180,6 +195,7 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 			self.assertFalse( self.__sliderFromWidget( widget, c ).getVisible() )
 		self.assertEqual( self.__getStaticComponent( widget ), "t" )
 		self.assertFalse( self.__getColorFieldVisibility( widget ) )
+		self.assertFalse( self.__getDynamicSliderBackgrounds( widget ) )
 
 		# We haven't saved the defaults, so a widget for a second plug
 		# gets the original defaults.
@@ -191,11 +207,13 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 			self.assertTrue( self.__sliderFromWidget( widget2, c ).getVisible() )
 		self.assertEqual( self.__getStaticComponent( widget2 ), "v" )
 		self.assertTrue( self.__getColorFieldVisibility( widget2 ) )
+		self.assertTrue( self.__getDynamicSliderBackgrounds( widget2 ) )
 
 		for p in [ "rgbPlug2" ] :
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:visibleComponents" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:staticComponent" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:colorFieldVisible" ) )
+			self.assertIsNone( Gaffer.Metadata.value( script["node"][p], "colorChooser:inline:dynamicSliderBackgrounds" ) )
 
 		# Don't serialize state
 
@@ -211,11 +229,13 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 			self.assertTrue( self.__sliderFromWidget( widget, c ).getVisible() )
 		self.assertEqual( self.__getStaticComponent( widget ), "v" )
 		self.assertTrue( self.__getColorFieldVisibility( widget ) )
+		self.assertTrue( self.__getDynamicSliderBackgrounds( widget ) )
 
 		for p in [ "rgbPlug1", "rgbPlug2" ] :
 			self.assertIsNone( Gaffer.Metadata.value( script2["node"][p], "colorChooser:inline:visibleComponents" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script2["node"][p], "colorChooser:inline:staticComponent" ) )
 			self.assertIsNone( Gaffer.Metadata.value( script2["node"][p], "colorChooser:inline:colorFieldVisible" ) )
+			self.assertIsNone( Gaffer.Metadata.value( script2["node"][p], "colorChooser:inline:dynamicSliderBackgrounds" ) )
 
 	def testSaveDefaultOptions( self ) :
 
@@ -243,12 +263,15 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 		self.assertEqual( self.__getStaticComponent( rgbaWidget ), "v" )
 		self.assertTrue( self.__getColorFieldVisibility( rgbWidget ) )
 		self.assertTrue( self.__getColorFieldVisibility( rgbaWidget ) )
+		self.assertTrue( self.__getDynamicSliderBackgrounds( rgbWidget ) )
+		self.assertTrue( self.__getDynamicSliderBackgrounds( rgbaWidget ) )
 
 		# Modify `rgbWidget`
 
 		self.__setVisibleComponents( rgbWidget, "rgbhsv" )
 		self.__setStaticComponent( rgbWidget, "g" )
 		self.__setColorFieldVisibility( rgbWidget, False )
+		self.__setDynamicSliderBackgrounds( rgbWidget, False )
 
 		# Save defaults
 		colorChooser = self.__colorChooserFromWidget( rgbWidget )
@@ -277,6 +300,8 @@ class ColorChooserTest( GafferUITest.TestCase ) :
 		self.assertEqual( self.__getStaticComponent( rgbaWidget ), "g" )
 		self.assertFalse( self.__getColorFieldVisibility( rgbWidget ) )
 		self.assertFalse( self.__getColorFieldVisibility( rgbaWidget ) )
+		self.assertFalse( self.__getDynamicSliderBackgrounds( rgbWidget ) )
+		self.assertFalse( self.__getDynamicSliderBackgrounds( rgbaWidget ) )
 
 if __name__ == "__main__" :
 	unittest.main()


### PR DESCRIPTION
This adds the option to set the color sliders and field to dynamically update. In dynamic mode, which is how they have been thus far, the sliders show the color you will get if you move the indicator to the position at that color. They update as you change other channels.

The default mode is now non-dynamic.

With dynamic mode turned off, the slider shows the pure 0-1 (-1 to 1 for temperature and magenta) range for that channel only. So the red slider will always go from black to fully red, and similar for the other colors. The only exception is the saturation slider and the color field when the static component is set to hue. These will still update because they depend on the hue to show their full range.

With dynamic mode off, we can also optimize when we calculate the gradients and field so they don' t update as often. Not updating the gradient gives about a 90% speedup which does feel a little snappier when dragging the sliders.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
