### PR TITLE
LightToolUI : Generalise description metadata

### DIFF
--- a/python/GafferSceneUI/LightToolUI.py
+++ b/python/GafferSceneUI/LightToolUI.py
@@ -49,7 +49,7 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Tool for editing spot lights.
+	Tool for editing light shapes, such as spot light cones or quad light width and height.
 	""",
 
 	"viewer:shortCut", "A",


### PR DESCRIPTION
The old description dated back to a time when only spotlights were supported.
