### PR TITLE
CyclesShaderUI : Fix presets menus

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.5.x.x (relative to 1.5.0.0)
+=======
+
+Fixes
+-----
+
+- CyclesShader : Fixed broken presets menus.
+
 1.5.0.0 (relative to 1.4.15.0)
 =======
 

--- a/python/GafferCyclesUI/CyclesShaderUI.py
+++ b/python/GafferCyclesUI/CyclesShaderUI.py
@@ -72,15 +72,13 @@ __metadata = collections.defaultdict( dict )
 
 def __translateParamMetadata( nodeTypeName, socketName, value ) :
 	paramPath = nodeTypeName + ".parameters." + socketName
-	socketType = value["type"]
-	label = value["ui_name"]
-	flags = value["flags"]
+	socketType = value["type"].value
 	if socketType == "enum" :
 		presetNames = IECore.StringVectorData()
 		presetValues = IECore.StringVectorData()
 		for enumName, enumValues in value["enum_values"].items() :
 			presetNames.append(enumName)
-			presetValues.append(enumValues)
+			presetValues.append( enumValues.value )
 		__metadata[paramPath]["presetNames"] = presetNames
 		__metadata[paramPath]["presetValues"] = presetValues
 		__metadata[paramPath]["plugValueWidget:type"] = "GafferUI.PresetsPlugValueWidget"
@@ -94,10 +92,11 @@ def __translateParamMetadata( nodeTypeName, socketName, value ) :
 		__metadata[paramPath]["fileSystemPath:extensionsLabel"] = "Show only image files"
 
 	__metadata[paramPath]["noduleLayout:visible"] = True
+	label = value["ui_name"].value
 	__metadata[paramPath]["label"] = label
 	__metadata[paramPath]["noduleLayout:label"] = label
 	# Linkable
-	linkable = bool( flags.value & ( 1 << 0 ) )
+	linkable = bool( value["flags"].value & ( 1 << 0 ) )
 	__metadata[paramPath]["nodule:type"] = "" if not linkable else None # "" disables the nodule, and None falls through to the default
 
 	if "category" in value :


### PR DESCRIPTION
This was broken in #6082, where we switched the storage from Python dicts to CompoundData.

Also moved the `label` variable closer to the point of usage and omitted the `flags` variable since it wasn't really helpful. The `label` variable actually worked without the `.value` part, but I added it to avoid any future surprises.
