### PR TITLE
ShadingEngine : Support 64 bit ints in `RendererServices::get_userdata()`

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.0.0/gafferDependencies-9.0.0-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/9.1.0/gafferDependencies-9.1.0-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 

--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ Fixes
 - `gaffer view` : Fixed default OpenColorIO display transform.
 - AnimationEditor : Fixed changing of the current frame by dragging the frame indicator or clicking on the time axis.
 - ImageWriter : Matched view metadata to Nuke when using the Nuke options for `layout`. This should address an issue where EXRs written from Gaffer using Nuke layouts sometimes did not load correctly in Nuke (#6120). In the unlikely situation that you were relying on the old behaviour, you can set the env var `GAFFERIMAGE_IMAGEWRITER_OMIT_DEFAULT_NUKE_VIEW = 1` in order to keep the old behaviour.
+- OSLObject : Fixed `getattribute()` to support 64 bit integer data, such as an `instanceId` primitive variable loaded from USD. Since OSL doesn't provide a 64 bit integer type, values are truncated to 32 bits.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -44,6 +44,7 @@ Fixes
 - AnimationEditor : Fixed changing of the current frame by dragging the frame indicator or clicking on the time axis.
 - ImageWriter : Matched view metadata to Nuke when using the Nuke options for `layout`. This should address an issue where EXRs written from Gaffer using Nuke layouts sometimes did not load correctly in Nuke (#6120). In the unlikely situation that you were relying on the old behaviour, you can set the env var `GAFFERIMAGE_IMAGEWRITER_OMIT_DEFAULT_NUKE_VIEW = 1` in order to keep the old behaviour.
 - OSLObject : Fixed `getattribute()` to support 64 bit integer data, such as an `instanceId` primitive variable loaded from USD. Since OSL doesn't provide a 64 bit integer type, values are truncated to 32 bits.
+- MeshSplit : Vertex order is now preserved.
 
 API
 ---
@@ -54,6 +55,11 @@ API
   - Deprecated `connect()` function. Use `connectToApplication()` instead.
 - SceneEditor : Added `editScope()` method.
 - Image : Added optional `image` argument to `createSwatch()` static method.
+
+Build
+-----
+
+- Cortex : Updated to version 10.5.11.0.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/python/GafferOSLTest/ShadingEngineTest.py
+++ b/python/GafferOSLTest/ShadingEngineTest.py
@@ -160,6 +160,33 @@ class ShadingEngineTest( GafferOSLTest.OSLTestCase ) :
 		for i, c in enumerate( p["Ci"] ) :
 			self.assertEqual( c[0], float(i) )
 
+	def testInt64GetAttribute( self ) :
+
+		shader = self.compileShader( pathlib.Path( __file__ ).parent / "shaders" / "intAttribute.osl" )
+
+		for dataType in ( IECore.Int64VectorData, IECore.UInt64VectorData ) :
+
+			with self.subTest( dataType = dataType ) :
+
+				points = IECore.CompoundData( {
+					"P" : IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 10 ) ] ),
+					"int64Data" : dataType( range( 0, 10 ) )
+				} )
+
+				engine = GafferOSL.ShadingEngine( IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( shader, "osl:surface", { "name" : "int64Data" } ),
+					},
+					output = "output"
+				) )
+
+				self.assertTrue( engine.needsAttribute( "int64Data" ) )
+
+				points = engine.shade( points )
+
+				for i, c in enumerate( points["Ci"] ) :
+					self.assertEqual( c[0], float( i ) )
+
 	def testUserDataViaGetAttribute( self ) :
 
 		shader = self.compileShader( pathlib.Path( __file__ ).parent / "shaders" / "attribute.osl" )

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -215,6 +215,29 @@ DataPtr dataFromTypeDesc( TypeDesc type, void *&basePointer )
 	return nullptr;
 }
 
+template<typename SourceType>
+bool convertScalar( void *dst, TypeDesc dstType, const void *src )
+{
+	const SourceType *typedSrc = reinterpret_cast<const SourceType *>( src );
+	if( dstType == TypeDesc::FLOAT )
+	{
+		if( typedSrc && dst )
+		{
+			*((float*)dst) = static_cast<float>( *typedSrc );
+		}
+		return true;
+	}
+	else if( dstType == TypeDesc::INT )
+	{
+		if( typedSrc && dst )
+		{
+			*((int*)dst) = static_cast<int>( *typedSrc );
+		}
+		return true;
+	}
+	return false;
+}
+
 // Equivalent to `OSL::ShadingSystem:convert_value()`, but with support for
 // additional conversions.
 bool convertValue( void *dst, TypeDesc dstType, const void *src, TypeDesc srcType )
@@ -254,24 +277,15 @@ bool convertValue( void *dst, TypeDesc dstType, const void *src, TypeDesc srcTyp
 	}
 	else if( srcType.basetype == TypeDesc::DOUBLE && srcType.aggregate == TypeDesc::SCALAR )
 	{
-		const double *doubleCast = reinterpret_cast<const double *>( src );
-		if( dstType == TypeDesc::FLOAT )
-		{
-			if( doubleCast && dst )
-			{
-				*((float*)dst) = static_cast<float>( *doubleCast );
-			}
-			return true;
-		}
-		else if( dstType == TypeDesc::INT )
-		{
-			if( doubleCast && dst )
-			{
-				*((int*)dst) = static_cast<int>( *doubleCast );
-			}
-			return true;
-		}
-		return false;
+		return convertScalar<double>( dst, dstType, src );
+	}
+	else if( srcType.basetype == TypeDesc::INT64 && srcType.aggregate == TypeDesc::SCALAR )
+	{
+		return convertScalar<int64_t>( dst, dstType, src );
+	}
+	else if( srcType.basetype == TypeDesc::UINT64 && srcType.aggregate == TypeDesc::SCALAR )
+	{
+		return convertScalar<uint64_t>( dst, dstType, src );
 	}
 
 	return false;


### PR DESCRIPTION
This requires https://github.com/ImageEngine/cortex/pull/1439 to work.
