### PR TITLE
Instancer : Fix issue with wrong prototypes in encapsulated render

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Fixes
   - Fixed handling of shader colour component to float connections in Cycles.
   - Added `CORTEX_STARTUP_PATHS` to match the Linux wrapper.
 - PlugPopup : Fixed error when displaying a popup with no PlugValueWidget.
+- Instancer : Fixed issue where wrong prototypes were sometimes used in encapsulated renders.
 
 1.5.0.0 (relative to 1.4.15.0)
 =======

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -2711,6 +2711,7 @@ struct Prototype : public IECore::RefCounted
 
 		IECore::MurmurHash h = hash;
 		h.append( prototypeContext->hash() );
+		h.append( *prototypeRoot );
 
 		// We find the capsules using the engine at shutter open, but the time used to construct the capsules
 		// must be the on-frame time, since the capsules will add their own shutter


### PR DESCRIPTION
This was a very simple and understandable fix ( now that we're putting capsules from different prototype roots in the same cache, the hash we use must include the prototype root ).

What I didn't find a good solution for was how to test this in a good and thorough way. It seems like a somewhat fundamental issue that when using GafferSceneTest.assertScenesRenderSame, the hashes aren't used at all, so it's not going to pick up any issues caused by incorrect hashes. I thought it would be straightforward to add a most that tests all hashes used ... this resulted in this branch: https://github.com/danieldresser-ie/gaffer/tree/instancerRegressTest ... which technically does show the issue, but is quite messy, and I don't think entirely correct. Maybe you'll have an obvious idea for how I should be testing this ... my current thought is that maybe it would make sense to have an option on CapturingRenderer to enable an InstanceCache that works identically to the Arnold Renderer ... then any bad hashes that cause bugs in the Arnold renderer should cause the same bugs during testing.

In the meantime, if you want to hurry out this fix, I'm pretty confident in the actual fix - I've tested both on my simplified scene, and the original test case you sent me, and it reliably fixes the issue. So it would probably be OK to release this as is, and then I can backfill some sort of unit test tomorrow.