### PR TITLE
EditScopePlugValueWidget : Display lock icon next to read-only nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -51,6 +51,7 @@ API
   - Added `connectToApplication()` function.
   - Deprecated `connect()` function. Use `connectToApplication()` instead.
 - SceneEditor : Added `editScope()` method.
+- Image : Added optional `image` argument to `createSwatch()` static method.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ Improvements
   - The "Source" menu item now displays a checkbox when chosen.
   - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.
   - Increased menu item icon sizes.
+  - A lock icon is now displayed next to read-only nodes.
 
 Fixes
 -----

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -72,9 +72,10 @@ class Image( GafferUI.Widget ) :
 		self.__pixmapDisabled = None
 
 	## Creates an Image containing a color swatch useful for
-	# button and menu icons.
+	# button and menu icons. An `image` can be overlaid on
+	# top of the swatch, this will be scaled to fit.
 	@staticmethod
-	def createSwatch( color ) :
+	def createSwatch( color, image = None ) :
 
 		pixmap = QtGui.QPixmap( 14, 14 )
 		pixmap.fill( QtGui.QColor( 0, 0, 0, 0 ) )
@@ -84,6 +85,32 @@ class Image( GafferUI.Widget ) :
 		painter.setPen( GafferUI._StyleSheet.styleColor( "backgroundDarkHighlight" ) )
 		painter.setBrush( QtGui.QColor.fromRgbF( color[0], color[1], color[2] ) )
 		painter.drawRoundedRect( QtCore.QRectF( 0.5, 0.5, 13, 13 ), 2, 2 )
+
+		if image is not None :
+
+			try :
+				iconImage = GafferUI.Image( image )
+			except Exception as e:
+				IECore.msg( IECore.Msg.Level.Error, "GafferUI.Image",
+					"Could not read image for swatch icon : " + str( e )
+				)
+				iconImage = GafferUI.Image( "warningSmall.png" )
+
+			iconSize = pixmap.size() - QtCore.QSize( 2, 2 )
+			iconPixmap = iconImage._qtPixmap()
+			if iconPixmap.width() > iconSize.width() or iconPixmap.height() > iconSize.height() :
+				iconPixmap = iconPixmap.scaled(
+					iconSize,
+					QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+					QtCore.Qt.TransformationMode.SmoothTransformation
+				)
+
+			painter.drawPixmap(
+				( pixmap.width() - iconPixmap.width() ) // 2,
+				( pixmap.height() - iconPixmap.height() ) // 2,
+				iconPixmap
+			)
+
 		del painter
 
 		swatch = GafferUI.Image( None )

--- a/python/GafferUITest/ImageTest.py
+++ b/python/GafferUITest/ImageTest.py
@@ -39,6 +39,8 @@ import unittest
 
 import imath
 
+import IECore
+
 import GafferUI
 import GafferUITest
 
@@ -72,6 +74,25 @@ class ImageTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( s._qtPixmap().width(), 14 )
 		self.assertEqual( s._qtPixmap().height(), 14 )
+
+	def testCreateSwatchWithImage( self ) :
+
+		s = GafferUI.Image.createSwatch( imath.Color3f( 1, 0, 0 ), image = "arrowRight10.png" )
+
+		self.assertEqual( s._qtPixmap().width(), 14 )
+		self.assertEqual( s._qtPixmap().height(), 14 )
+
+		# Create a swatch with a large image. The swatch size should not increase.
+		s2 = GafferUI.Image.createSwatch( imath.Color3f( 1, 0, 0 ), image = "warningNotification.png" )
+
+		self.assertEqual( s2._qtPixmap().width(), 14 )
+		self.assertEqual( s2._qtPixmap().height(), 14 )
+
+		with IECore.CapturingMessageHandler() as mh :
+			GafferUI.Image.createSwatch( imath.Color3f( 1, 0, 0 ), image = "iAmNotAFile" )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertIn( 'Unable to find file "iAmNotAFile"', mh.messages[0].message )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -414,6 +414,7 @@
 				"menuIndicator",
 				"menuIndicatorDisabled",
 				"menuSource",
+				"menuLock",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3466,6 +3466,15 @@
          y="95"
          transform="matrix(0,1,1,0,0,0)"
          inkscape:label="menuSource" />
+      <rect
+         inkscape:label="menuLock"
+         transform="matrix(0,1,1,0,0,0)"
+         y="113"
+         x="2672"
+         height="12"
+         width="12"
+         id="menuLock"
+         style="fill:none;fill-opacity:1;stroke:none;stroke-width:1" />
     </g>
     <path
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -9204,6 +9213,12 @@
            id="path2103-95" />
       </g>
     </g>
+    <path
+       id="menuItemLock"
+       style="display:inline;fill:url(#foreground);stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       d="m 119,2726.3622 c -0.64455,0 -1.96974,0.1251 -2,2 -0.002,0.131 0.004,1.3744 0,2 -0.0392,0 0.0359,-0.01 0,0 -0.79927,0.015 -0.9991,0.3788 -1,0.7745 -0.006,1.2744 -0.007,1.9514 0,3.2258 0,0 5.56167,-0.013 5.99999,0 l 1e-5,-3.2258 c 0,-0.4319 -0.15861,-0.7533 -1,-0.7745 v 0 c -0.005,-0.6246 -2.7e-4,-1.833 0,-2 0.0106,-1.8456 -1.35545,-1.9976 -2,-2 z m 1,2 c 0.001,0.083 -0.003,1.3973 0,2 -0.72747,0.01 -1.29923,-0.01 -2,0 0.002,-0.6036 -7e-5,-1.9355 0,-2 8e-4,-0.7281 0.28642,-0.9994 1,-1 0.7133,-6e-4 0.98739,0.2748 1,1 z"
+       sodipodi:nodetypes="cscccccsccccsccsss"
+       inkscape:label="menuItemLock" />
     <circle
        id="menuBreadCrumbShape"
        style="display:inline;fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"


### PR DESCRIPTION
This adds a little padlock icon next to read-only nodes in the EditScope menu as a hint that the edit scope you are about to select is locked and not editable. As this icon replaces the node colour swatch, I've tinted it based on the node colour so we don't lose that information on read-only edit scopes. The end result may be a little subtle given the limited real-estate available for a menu icon, but see what you think. I'm also not too beholden to the `Image._tint()` method for tinting the icon, so if there are better ideas, I'm all ears...

![image](https://github.com/user-attachments/assets/50894026-1bd8-434b-a1aa-e43c3122eb81)
