### PR TITLE
PlugPopup : Fix error when popups have no PlugValueWidget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.x.x (relative to 1.4.15.0)
 =======
 
+Fixes
+-----
 
+- PlugPopup : Fixed error when displaying a popup with no PlugValueWidget.
 
 1.4.15.0 (relative to 1.4.14.0)
 ========

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -157,7 +157,7 @@ class PlugPopup( GafferUI.PopupWindow ) :
 
 	def __focusChanged( self, oldWidget, newWidget ) :
 
-		if self.__plugValueWidget.isAncestorOf( newWidget ) and hasattr( newWidget, "activatedSignal" ) :
+		if self.__plugValueWidget and self.__plugValueWidget.isAncestorOf( newWidget ) and hasattr( newWidget, "activatedSignal" ) :
 			self.__widgetActivatedConnection = newWidget.activatedSignal().connect(
 				Gaffer.WeakMethod( self.__activated ), scoped = True
 			)


### PR DESCRIPTION
This could occur when a popup was created from multiple plugs of differing type, where we'd display a message rather than a PlugValueWidget.