### PR TITLE
renderCompatibility : Add default node name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Instancer : Added support for 64 bit ints for ids ( matching what is loaded from USD ).
 
+Fixes
+-----
+
+- Render, InteractiveRender : Added default node name arguments to the compatibility shims for removed subclasses such as ArnoldRender.
+
 1.5.0.1 (relative to 1.5.0.0)
 =======
 

--- a/startup/GafferArnold/renderCompatibility.py
+++ b/startup/GafferArnold/renderCompatibility.py
@@ -37,7 +37,7 @@
 import GafferScene
 import GafferArnold
 
-def __arnoldRender( name ) :
+def __arnoldRender( name = "ArnoldRender" ) :
 
 	node = GafferScene.Render( name )
 	node["renderer"].setValue( "Arnold" )
@@ -45,7 +45,7 @@ def __arnoldRender( name ) :
 
 GafferArnold.ArnoldRender = __arnoldRender
 
-def __interactiveArnoldRender( name ) :
+def __interactiveArnoldRender( name = "InteractiveArnoldRender" ) :
 
 	node = GafferScene.InteractiveRender( name )
 	node["renderer"].setValue( "Arnold" )

--- a/startup/GafferCycles/renderCompatibility.py
+++ b/startup/GafferCycles/renderCompatibility.py
@@ -37,7 +37,7 @@
 import GafferScene
 import GafferCycles
 
-def __cyclesRender( name ) :
+def __cyclesRender( name = "CyclesRender" ) :
 
 	node = GafferScene.Render( name )
 	node["renderer"].setValue( "Cycles" )
@@ -45,7 +45,7 @@ def __cyclesRender( name ) :
 
 GafferCycles.CyclesRender = __cyclesRender
 
-def __interactiveCyclesRender( name ) :
+def __interactiveCyclesRender( name = "InteractiveCyclesRender" ) :
 
 	node = GafferScene.InteractiveRender( name )
 	node["renderer"].setValue( "Cycles" )

--- a/startup/GafferDelight/renderCompatibility.py
+++ b/startup/GafferDelight/renderCompatibility.py
@@ -37,7 +37,7 @@
 import GafferScene
 import GafferDelight
 
-def __delightRender( name ) :
+def __delightRender( name = "DelightRender" ) :
 
 	node = GafferScene.Render( name )
 	node["renderer"].setValue( "3Delight" )
@@ -45,7 +45,7 @@ def __delightRender( name ) :
 
 GafferDelight.DelightRender = __delightRender
 
-def __interactiveDelightRender( name ) :
+def __interactiveDelightRender( name = "InteractiveDelightRender" ) :
 
 	node = GafferScene.InteractiveRender( name )
 	node["renderer"].setValue( "3Delight" )

--- a/startup/GafferScene/renderCompatibility.py
+++ b/startup/GafferScene/renderCompatibility.py
@@ -36,7 +36,7 @@
 
 import GafferScene
 
-def __openGLRender( name ) :
+def __openGLRender( name = "OpenGLRender" ) :
 
 	node = GafferScene.Render( name )
 	node["renderer"].setValue( "OpenGL" )


### PR DESCRIPTION
Provides compatibility with previously supported notation to create render nodes, like `GafferArnold.ArnoldRender()`.

### Related issues ###

- Creating render nodes in the format  `GafferArnold.ArnoldRender()`.

### Dependencies ###
None

### Breaking changes ###
None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
