### PR TITLE
GafferUITest : Fix `assertNodeUIsHaveExpectedLifetime()` test

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Render, InteractiveRender : Added default node name arguments to the compatibility shims for removed subclasses such as ArnoldRender.
+- GafferUITest : Fixed `assertNodeUIsHaveExpectedLifetime()` test for invisible nodes.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/python/GafferUITest/TestCase.py
+++ b/python/GafferUITest/TestCase.py
@@ -169,11 +169,13 @@ class TestCase( GafferTest.TestCase ) :
 			weakScript = weakref.ref( script )
 
 			nodeGadget = GafferUI.NodeGadget.create( script["node"] )
-			weakNodeGadget = weakref.ref( nodeGadget )
+			if nodeGadget :
+				weakNodeGadget = weakref.ref( nodeGadget )
+				del nodeGadget
+				self.assertIsNone( weakNodeGadget() )
 
-			del window, nodeUI, nodeGadget
+			del window, nodeUI
 			self.assertIsNone( weakNodeUI() )
-			self.assertIsNone( weakNodeGadget() )
 
 			del script
 			self.assertIsNone( weakScript() )


### PR DESCRIPTION
This test was raising an exception for nodes that are supposed to be "invisible", and therefore had no `NodeGadget`.

### Related issues ###

- Allows the use of `assertNodeUIsHaveExpectedLifetime()` test on modules that include invisible nodes.

### Dependencies ###
None

### Breaking changes ###
None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
