### PR TITLE
Color Chooser Constrain Drag

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,9 @@ Improvements
 - DeletePoints : Added modes for deleting points based on a list of ids.
 - Light Editor, Attribute Editor, Spreadsheet : Add original and current color swatches to color popups.
 - SceneView : Added fallback framing extents to create a reasonable view when `SceneGadget` is empty, for example if the grid is hidden.
-- ColorChooser : Added an option to toggle the dynamic update of colors displayed in the slider and color field backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
+- ColorChooser :
+  - Added an option to toggle the dynamic update of colors displayed in the slider and color field backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
+  - Holding the <kbd>Control</kbd> key now constrains dragging in the color field to a single axis.
 
 Fixes
 -----

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -438,3 +438,9 @@ Toggle cell selection                                | {kbd}`Ctrl` + {{leftClick
 Edit selected cells                                  | {kbd}`Return`<br>or<br>{kbd}`Enter`
 Disable edit                                         | {kbd}`D`
 Toggle a render pass as active                       | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the {{activeRenderPass}} column
+
+## Color Chooser Color Field ##
+
+Action                                               | Control or shortcut
+-----------------------------------------------------|--------------------
+Constrain drag to single axis                        | {kbd}`Ctrl`

--- a/python/GafferUI/ColorChooser.py
+++ b/python/GafferUI/ColorChooser.py
@@ -691,6 +691,42 @@ class _ColorField( GafferUI.Widget ) :
 
 		painter.drawImage( self._qtWidget().contentsRect(), self.__colorFieldToDraw )
 
+		if self.__constraintPath is None and self.__dragConstraints is not None and self.__constraintPosition is not None :
+			path = QtGui.QPainterPath()
+
+			if self.__useWheel() :
+				center = imath.V2f( self.bound().size() ) * 0.5
+
+				if self.__DragConstraints.X in self.__dragConstraints :
+					radius = ( self.__constraintPosition - center ).length()
+					path.addEllipse( QtCore.QPoint( center.x, center.y ), radius, radius )
+
+				if self.__DragConstraints.Y in self.__dragConstraints :
+					radiusEnd = center + ( self.__constraintPosition - center ).normalized() * center.x
+
+					path.moveTo( center.x, center.y )
+					path.lineTo( radiusEnd.x, radiusEnd.y )
+			else :
+				if self.__dragConstraints.X in self.__dragConstraints :
+					path.moveTo( 0, self.__constraintPosition.y )
+					path.lineTo( self.bound().max().x, self.__constraintPosition.y )
+				if self.__DragConstraints.Y in self.__dragConstraints :
+					path.moveTo( self.__constraintPosition.x, 0 )
+					path.lineTo( self.__constraintPosition.x, self.bound().max().y )
+
+			strokedPath = QtGui.QPainterPathStroker()
+			strokedPath.setWidth( 2 )
+
+			self.__constraintPath = strokedPath.createStroke( path )
+
+		if self.__constraintPath is not None :
+			pen = QtGui.QPen( QtGui.QColor( 0, 0, 0, 60 ) )
+			pen.setWidth( 1 )
+			painter.setPen( pen )
+			painter.setBrush( QtGui.QBrush( QtGui.QColor( 255, 255, 255, 60 ) ) )
+
+			painter.drawPath( self.__constraintPath )
+
 	def __drawValue( self, painter ) :
 
 		position = self.__colorToPosition( self.__color )


### PR DESCRIPTION
This lets users constrain dragging in the color field to a single axis (or circle if the wheel is the current widget) by holding the `Control` key.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
