### PR TITLE
OpDialogue : Fix postExecuteBehaviour handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 
 - Render, InteractiveRender : Added default node name arguments to the compatibility shims for removed subclasses such as ArnoldRender.
 - GafferUITest : Fixed `assertNodeUIsHaveExpectedLifetime()` test for invisible nodes.
+- OpDialogue : Fixed `postExecuteBehaviour` handling.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -130,10 +130,16 @@ class OpDialogue( GafferUI.Dialogue ) :
 			with IECore.IgnoredExceptions( KeyError ) :
 				d = opInstance.userData()["UI"]["postExecuteBehaviour"]
 			if d is not None :
-				for v in self.PostExecuteBehaviour.values() :
+				for v in self.PostExecuteBehaviour :
 					if str( v ).lower() == d.value.lower() :
 						postExecuteBehaviour = v
 						break
+
+					# backwards compatibility for IECore.Enum()
+					if str( v ).lower() == f"PostExecuteBehaviour.{d.value}".lower() :
+						postExecuteBehaviour = v
+						break
+
 			else :
 				# backwards compatibility with batata
 				with IECore.IgnoredExceptions( KeyError ) :


### PR DESCRIPTION
This was broken by the switch to native python enums from `IECore.Enum`.

This commit also preserves compatibility with the old string values provided by `IECore.Enum`.

Note that having the `Ops` refer to `GafferCortexUI.OpDialogue.PostExecuteBehaviour` instead of hard-coded strings is not practical because that would require importing `GafferCortexUI` in the `Op`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
