### PR TITLE
Cycles : Interactive displacement edit fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.0.1)
 =======
 
+Features
+--------
+
+- Cycles : Added support for enabling and disabling automatic instancing that can be set onto locations with `StandardAttributes`. Previously automatic instancing was the only option. Partially addresses #4890 as a workaround for "leaking" shaders.
+
 Improvements
 ------------
 
@@ -15,6 +20,7 @@ Fixes
 - Render, InteractiveRender : Added default node name arguments to the compatibility shims for removed subclasses such as ArnoldRender.
 - GafferUITest : Fixed `assertNodeUIsHaveExpectedLifetime()` test for invisible nodes.
 - OpDialogue : Fixed `postExecuteBehaviour` handling.
+- Cycles : Displacement interactive edits won't double-up on displacements.
 
 API
 ---


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Cycles :
  - Fixes a double-up of displacement edits every time the shader was modified.
  - Added support for `automaticInstancing` attribute support (this is an opportunistic addition which is fairly related!)

TODO: I can't seem to trigger the unit-test as the live scene edit isn't actually being applied properly with the update to the sphere object's attributes - is there something I'm missing here?

### Related issues ###

- Partial workaround for https://github.com/GafferHQ/gaffer/issues/4890

### Dependencies ###

- N/A

### Breaking changes ###

- Scene locations with `automaticInstancing` disabled on scene locations will now not do any instancing, not sure if anyone would be setting this in a Cycles scene prior to this but they might've been and will get a different result.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
