### PR TITLE
AnimationEditor : Fix changing of frame by click & drag

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 - OpDialogue : Fixed `postExecuteBehaviour` handling.
 - LocalDispatcher : Fixed job status update when a job was killed _immediately_ after being launched.
 - `gaffer view` : Fixed default OpenColorIO display transform.
+- AnimationEditor : Fixed changing of the current frame by dragging the frame indicator or clicking on the time axis.
 
 API
 ---

--- a/python/GafferUI/AnimationEditor.py
+++ b/python/GafferUI/AnimationEditor.py
@@ -224,7 +224,14 @@ class AnimationEditor( GafferUI.NodeSetEditor ) :
 
 	def _updateFromContext( self, modifiedItems ) :
 
-		self.__animationGadget.setContext( self.context() )
+		# Note that we're passing `scriptNode().context()` rather than
+		# `self.context()` because we don't want to use a ContextTracker-based
+		# context in the AnimationEditor.
+		## \todo It would be better if `AnimationGadget::setContext()` connected
+		# to `Context::changedSignal()` and updated automatically after that. We
+		# could also consider removing `setContext()` entirely and connecting to
+		# the ScriptNode's context in the AnimationGadget constructor.
+		self.__animationGadget.setContext( self.scriptNode().context() )
 
 	def __updateGadgetSets( self, unused = None ) :
 


### PR DESCRIPTION
We mustn't edit the context returned by the ContextTracker - nobody is tracking it for changes, it is intended to be const, and other UI components might be using it in other threads. Instead we just use the ScriptNode context in the AnimationEditor as before.

This is the most minimal change needed to fix the bug. You could argue the case for making the AnimationEditor genuinely focus-aware by accounting for TimeWarps between the node being viewed and the node being edited. That would require a lot of work though, and it's not clear that it's worth it, or that it can be done without an ABI break.
