### PR TITLE
PathFilter : Fix dropping paths onto read-only nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,11 @@
 1.4.15.x (relative to 1.4.15.1)
 ========
 
+Fixes
+-----
 
+- PathFilter : Fixed bug allowing dropping paths onto read-only `PathFilter` nodes in the graph.
+- VectorDataWidget : Fixed bug allowing dropping paths onto read-only widgets.
 
 1.4.15.1 (relative to 1.4.15.0)
 ========

--- a/python/GafferSceneUI/PathFilterUI.py
+++ b/python/GafferSceneUI/PathFilterUI.py
@@ -255,9 +255,14 @@ def __filterPlug( node ) :
 		return filterPlugs[0]
 	return None
 
+def __editable( plug ) :
+
+	return not Gaffer.MetadataAlgo.readOnly( plug ) and plug.settable()
+
 def __dropMode( nodeGadget, event ) :
 
-	if __pathsPlug( nodeGadget.node() ) is None :
+	pathsPlug = __pathsPlug( nodeGadget.node() )
+	if pathsPlug is None :
 		filter = None
 
 		filterPlug = __filterPlug( nodeGadget.node() )
@@ -267,9 +272,13 @@ def __dropMode( nodeGadget, event ) :
 		if filterPlug.getInput() is not None :
 			filter = filterPlug.source().node()
 		if filter is None :
-			return __DropMode.Replace
+			return __DropMode.Replace if __editable( filterPlug ) else __DropMode.None_
 		elif not isinstance( filter, GafferScene.PathFilter ) :
 			return __DropMode.None_
+		pathsPlug = __pathsPlug( filter )
+
+	if not __editable( pathsPlug ) :
+		return __DropMode.None_
 
 	if event.modifiers & event.Modifiers.Shift :
 		return __DropMode.Add

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -621,6 +621,9 @@ class VectorDataWidget( GafferUI.Widget ) :
 
 	def __dragEnter( self, widget, event ) :
 
+		if not self.getEditable() :
+			return False
+
 		if event.sourceWidget is self.__tableViewHolder and widget is not self.__buttonRow[1]:
 			# we don't accept drags from ourself unless the target is the remove button
 			return False


### PR DESCRIPTION
This fixes a bug that allowed dropping paths onto read-only `PathFilter` nodes in the graph editor. It also fixes dropping onto read-only `VectorDataWidget` widgets. 

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
