### PR TITLE
ImageWriter : Match Nuke view metadata when using Nuke layouts.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - LocalDispatcher : Fixed job status update when a job was killed _immediately_ after being launched.
 - `gaffer view` : Fixed default OpenColorIO display transform.
 - AnimationEditor : Fixed changing of the current frame by dragging the frame indicator or clicking on the time axis.
+- ImageWriter : Matched view metadata to Nuke when using the Nuke options for `layout`. This should address an issue where EXRs written from Gaffer using Nuke layouts sometimes did not load correctly in Nuke (#6120). In the unlikely situation that you were relying on the old behaviour, you can set the env var `GAFFERIMAGE_IMAGEWRITER_OMIT_DEFAULT_NUKE_VIEW = 1` in order to keep the old behaviour.
 
 API
 ---

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -1636,9 +1636,6 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			header = self.usefulHeader( writePath )
 			refHeader = self.usefulHeader( self.imagesPath() / ( "channelTest" + referenceFile + ".exr" ) )
 
-			if layout == "Nuke/Interleave Channels":
-				# We don't match the view metadata which Nuke sticks on files without specific views
-				refHeader = list( filter( lambda i : i != 'view (type string): "main"', refHeader ) )
 			self.assertEqual( header, refHeader )
 
 	def testWithMultiViewChannelTestImage( self ):


### PR DESCRIPTION
This should address an issue where EXRs written from Gaffer using Nuke layouts sometimes did not load correctly in Nuke.

We've already had some discussion about the pros/cons of this method of detecting when the nukeViewName is used by the partName - this approach seems to work.

The name of the env var is perhaps a bit verbose, but I wasn't sure what to call it ( and it's probably fine, because I'm really not expecting anyone to use it ). Totally open to naming suggestions on the context tokens as well.

Would be good to get Jed to confirm that this actually fixes his issue in Nuke, but I'm confident enough in this based on my testing that it might be fine to merge it first, and then get him to test.