### PR TITLE
SceneView : Prevent empty framing bound.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Added support for 64 bit integer ids (matching what is loaded from USD).
 - DeletePoints : Added modes for deleting points based on a list of ids.
 - Light Editor, Attribute Editor, Spreadsheet : Add original and current color swatches to color popups.
+- SceneView : Added fallback framing extents to create a reasonable view when `SceneGadget` is empty, for example if the grid is hidden.
 
 Fixes
 -----

--- a/src/GafferSceneUI/SceneView.cpp
+++ b/src/GafferSceneUI/SceneView.cpp
@@ -2144,6 +2144,11 @@ Imath::Box3f SceneView::framingBound() const
 			gridGadget->waitForCompletion();
 			b.extendBy( gridGadget->bound() );
 		}
+
+		if( b.isEmpty() )
+		{
+			b.extendBy( Imath::Box3f( Imath::V3f( -5.f, 0.f, -5.f ), Imath::V3f( 5.f, 0.f, 5.f ) ) );
+		}
 	}
 
 	return b;


### PR DESCRIPTION
This is a fix / improvement that came up from a user who was hiding the grid by default via a startup script. Without this fallback, we return an empty bound from `framingBound()` which results in a view that doesn't show anything.

I'm using the default grid size as the fallback bound, happy to change it if there's a different preference.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
