### PR TITLE
OpenColorIOConfigPlugUI : Fix connection to scriptless apps

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,11 +18,15 @@ Fixes
 - GafferUITest : Fixed `assertNodeUIsHaveExpectedLifetime()` test for invisible nodes.
 - OpDialogue : Fixed `postExecuteBehaviour` handling.
 - LocalDispatcher : Fixed job status update when a job was killed _immediately_ after being launched.
+- `gaffer view` : Fixed default OpenColorIO display transform.
 
 API
 ---
 
 - Int64VectorDataPlug : Added new plug type for passing vectors of int64.
+- OpenColorIOConfigPlugUI :
+  - Added `connectToApplication()` function.
+  - Deprecated `connect()` function. Use `connectToApplication()` instead.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -287,19 +287,31 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 			for plug in self.getPlugs() :
 				self.getPlug().setValue( "__default__" )
 
-# Connection between default script config and Widget and View display transforms.
-# Calling `connect()` from an application startup file is what makes the UI OpenColorIO-aware.
+# Connection between application script configs and Widget and View display
+# transforms. Calling `connectToApplication()` from an application startup file
+# is what makes the UI OpenColorIO-aware.
+def connectToApplication( application ) :
 
+	GafferUI.View.DisplayTransform.registerDisplayTransform(
+		"__default__", __defaultViewDisplayTransformCreator
+	)
+
+	application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
+
+## \deprecated. Use `connectToApplication()` instead.
 def connect( script ) :
+
+	GafferUI.View.DisplayTransform.registerDisplayTransform(
+		"__default__", __defaultViewDisplayTransformCreator
+	)
+	__scriptAdded( script.parent(), script )
+
+def __scriptAdded( container, script ) :
 
 	hadPlug = GafferImage.OpenColorIOConfigPlug.acquireDefaultConfigPlug( script, createIfNecessary = False )
 	plug = GafferImage.OpenColorIOConfigPlug.acquireDefaultConfigPlug( script )
 	if not hadPlug :
 		Gaffer.NodeAlgo.applyUserDefaults( plug )
-
-	GafferUI.View.DisplayTransform.registerDisplayTransform(
-		"__default__", __defaultViewDisplayTransformCreator
-	)
 
 	script.plugDirtiedSignal().connect( __scriptPlugDirtied )
 	__scriptPlugDirtied( plug )

--- a/startup/gui/ocio.py
+++ b/startup/gui/ocio.py
@@ -45,11 +45,7 @@ import GafferImageUI
 # Make sure every script has a config plug added to it, and that we update
 # the View and Widget display transforms appropriately when the config is changed.
 
-def __scriptAdded( container, script ) :
-
-	GafferImageUI.OpenColorIOConfigPlugUI.connect( script )
-
-application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
+GafferImageUI.OpenColorIOConfigPlugUI.connectToApplication( application )
 
 Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "plugValueWidget:type", "GafferImageUI.OpenColorIOConfigPlugUI.DisplayTransformPlugValueWidget" )
 Gaffer.Metadata.registerValue( GafferUI.View, "displayTransform.name", "layout:minimumWidth", 150 )


### PR DESCRIPTION
We were missing the `__default__` display transform registration for application that didn't have a ScriptNode. This meant that the default transform was broken in `gaffer view`.
