### PR TITLE
LocalDispatcher : Fix status update in `Job.kill()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 - Render, InteractiveRender : Added default node name arguments to the compatibility shims for removed subclasses such as ArnoldRender.
 - GafferUITest : Fixed `assertNodeUIsHaveExpectedLifetime()` test for invisible nodes.
 - OpDialogue : Fixed `postExecuteBehaviour` handling.
+- LocalDispatcher : Fixed job status update when a job was killed _immediately_ after being launched.
 
 API
 ---

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -181,16 +181,17 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 
 			if self.__backgroundTask is not None :
 				self.__backgroundTask.cancel()
-				if self.__backgroundTask.status() == self.__backgroundTask.Status.Pending :
+				if self.__backgroundTask.status() == self.__backgroundTask.Status.Cancelled :
 					# Usually we'll get to update our status naturally because `__executeInternal()`
 					# will throw `IECore.Cancelled.`. But if `__executeInternal()` hasn't been called
-					# by the BackgroundTask yet, then it will _never_ be called. We work around this by
+					# by the BackgroundTask yet, then it will _never_ be called, and the BackgroundTask
+					# will have transitioned to a Cancelled status _immediately_. We work around this by
 					# updating status manually.
 					#
 					# In many ways it would be great if we used `__backgroundTask.status()` directly
 					# as _our_ status. But that can't work for foreground dispatches, so for the moment
 					# we prefer to track foreground/background status identically.
-					self.__updateState( self.Status.Killed )
+					self.__updateStatus( self.Status.Killed )
 
 		def statusChangedSignal( self ) :
 


### PR DESCRIPTION
This occurred only when `kill()` was called so quickly after dispatch that the background task hadn't even started. Because we were botching the status update, `LocalDispatcherTest.testKill()` could hang indefinitely waiting for the killed job to finish. This wasn't happening on CI, but was reproducible reliably on a local machine with more cores.

Analysis and proposal for the fix is courtesy of Ivan Imanishi - I'm just making the PR because I'm not trapped behind a firewall.
