### PR TITLE
Global Edit Target

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,8 @@ Improvements
     - Removed the dark background.
     - Changed the menu button color to be always blue.
     - Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
-  - The "None" menu item now displays a checkbox when chosen.
+  - Renamed "None" mode to "Source" and added icon.
+  - The "Source" menu item now displays a checkbox when chosen.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Features
 - EditScope : Introduced the Global Edit Target, providing script-level control over the target used by editors. The Global Edit Target can be set from a new "Edit Target" menu in the menu bar, which displays all available edit targets upstream of the focus node.
   - Editors now follow the Global Edit Target by default, allowing for a simpler experience when switching multiple editors to a common target.
   - Individual editors can be overridden to use a specific edit target where necessary. An overridden editor can return to following the Global Edit Target via the new "Follow Global Edit Target" menu item.
+  - While following the Global Edit Target, an editor's Edit Scope menu will shrink to only display an icon. When an Editor is overridden to a specific edit target, the menu grows to display the name of the target.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
     - Removed the dark background.
     - Changed the menu button color to be always blue.
     - Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
+  - The "None" menu item now displays a checkbox when chosen.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - EditScope : Introduced the Global Edit Target, providing script-level control over the target used by editors. The Global Edit Target can be set from a new "Edit Target" menu in the menu bar, which displays all available edit targets upstream of the focus node.
+  - Individual editors can be overridden to use a specific edit target where necessary. An overridden editor can return to following the Global Edit Target via the new "Follow Global Edit Target" menu item.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Improvements
     - Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
   - Renamed "None" mode to "Source" and added icon.
   - The "Source" menu item now displays a checkbox when chosen.
+  - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -30,6 +30,7 @@ Improvements
   - Renamed "None" mode to "Source" and added icon.
   - The "Source" menu item now displays a checkbox when chosen.
   - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.
+  - Increased menu item swatch size.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -30,7 +30,7 @@ Improvements
   - Renamed "None" mode to "Source" and added icon.
   - The "Source" menu item now displays a checkbox when chosen.
   - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.
-  - Increased menu item swatch size.
+  - Increased menu item icon sizes.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Improvements
     - Removed the dark background.
     - Changed the menu button color to be always blue.
     - Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
+    - Hid the label. It can be made visible for a specific plug by registering `editScopePlugValueWidget:showLabel` metadata with a value of `True`.
   - Renamed "None" mode to "Source" and added icon.
   - The "Source" menu item now displays a checkbox when chosen.
   - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.

--- a/Changes.md
+++ b/Changes.md
@@ -40,6 +40,7 @@ API
 - OpenColorIOConfigPlugUI :
   - Added `connectToApplication()` function.
   - Deprecated `connect()` function. Use `connectToApplication()` instead.
+- SceneEditor : Added `editScope()` method.
 
 1.5.0.1 (relative to 1.5.0.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - EditScope : Introduced the Global Edit Target, providing script-level control over the target used by editors. The Global Edit Target can be set from a new "Edit Target" menu in the menu bar, which displays all available edit targets upstream of the focus node.
+  - Editors now follow the Global Edit Target by default, allowing for a simpler experience when switching multiple editors to a common target.
   - Individual editors can be overridden to use a specific edit target where necessary. An overridden editor can return to following the Global Edit Target via the new "Follow Global Edit Target" menu item.
 
 Improvements

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.0.1)
 =======
 
+Features
+--------
+
+- EditScope : Introduced the Global Edit Target, providing script-level control over the target used by editors. The Global Edit Target can be set from a new "Edit Target" menu in the menu bar, which displays all available edit targets upstream of the focus node.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - ColorChooser :
   - Added an option to toggle the dynamic update of colors displayed in the slider and color field backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
   - Holding the <kbd>Control</kbd> key now constrains dragging in the color field to a single axis.
+- EditScope : Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,11 @@ Improvements
 - ColorChooser :
   - Added an option to toggle the dynamic update of colors displayed in the slider and color field backgrounds. When enabled, the widget backgrounds update to show the color that will result from moving the indicator to a given position. When disabled, a static range of values is displayed instead.
   - Holding the <kbd>Control</kbd> key now constrains dragging in the color field to a single axis.
-- EditScope : Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
+- EditScope :
+  - Simplified the Edit Scope menu UI :
+    - Removed the dark background.
+    - Changed the menu button color to be always blue.
+    - Removed the "Navigation Arrow" button from the right side of the Edit Scope menu. Its actions have been relocated to a "Show Edits" submenu of the Edit Scope menu.
 
 Fixes
 -----

--- a/python/GafferImageUI/OpenColorIOConfigPlugUI.py
+++ b/python/GafferImageUI/OpenColorIOConfigPlugUI.py
@@ -261,7 +261,7 @@ class DisplayTransformPlugValueWidget( GafferUI.PlugValueWidget ) :
 		result.append( "/__OptionsDivider__", { "divider" : True, "label" : "Options" } )
 
 		result.append(
-			f"/Use Default Display And View", {
+			f"/Follow Default Display And View", {
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setToDefault ) ),
 				"checkBox" : self.__currentValue == "__default__",
 				"description" : "Always uses the default display and view for the current config. Useful when changing configs often, or using context-sensitive configs."

--- a/python/GafferSceneUI/AttributeEditor.py
+++ b/python/GafferSceneUI/AttributeEditor.py
@@ -322,7 +322,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 185,
+			"layout:width", 130,
 
 		],
 

--- a/python/GafferSceneUI/AttributeEditor.py
+++ b/python/GafferSceneUI/AttributeEditor.py
@@ -322,7 +322,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 225,
+			"layout:width", 185,
 
 		],
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -413,7 +413,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 185,
+			"layout:width", 130,
 
 		],
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -311,9 +311,8 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 			# or unintuitive
 			deleteEnabled = True
 			inputNode = self.settings()["in"].getInput().node()
-			editScopeInput = self.settings()["editScope"].getInput()
-			if editScopeInput is not None :
-				editScopeNode = editScopeInput.node()
+			editScopeNode = self.editScope()
+			if editScopeNode is not None :
 				if inputNode != editScopeNode and editScopeNode not in Gaffer.NodeAlgo.upstreamNodes( inputNode ) :
 					# Edit scope is downstream of input
 					deleteEnabled = False
@@ -368,7 +367,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		# There may be multiple columns with a selection, but we only operate on the name column.
 		selection = self.__pathListing.getSelection()[0]
 
-		editScope = self.settings()["editScope"].getInput().node()
+		editScope = self.editScope()
 
 		with Gaffer.UndoScope( editScope.ancestor( Gaffer.ScriptNode ) ) :
 			GafferScene.EditScopeAlgo.setPruned( editScope, selection, True )

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -414,7 +414,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 225,
+			"layout:width", 185,
 
 		],
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -634,7 +634,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 185,
+			"layout:width", 130,
 
 		],
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -402,12 +402,10 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		if editScope is None :
 			# No edit scope provided so use the current selected
-			editScopeInput = self.settings()["editScope"].getInput()
-			if editScopeInput is None :
+			editScope = self.editScope()
+			if editScope is None :
 				# No edit scope selected
 				return False
-
-			editScope = editScopeInput.node()
 
 		if inputNode != editScope and editScope not in Gaffer.NodeAlgo.upstreamNodes( inputNode ) :
 			# Edit scope is downstream of input
@@ -456,11 +454,10 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		if len( selectedRenderPasses ) == 0 :
 			return
 
-		editScopeInput = self.settings()["editScope"].getInput()
-		if editScopeInput is None :
+		editScope = self.editScope()
+		if editScope is None :
 			return
 
-		editScope = editScopeInput.node()
 		localRenderPasses = []
 		renderPassesProcessor = editScope.acquireProcessor( "RenderPasses", createIfNecessary = False )
 		if renderPassesProcessor is not None :
@@ -528,10 +525,9 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 	def __renderPassCreationDialogue( self ) :
 
-		editScopeInput = self.settings()["editScope"].getInput()
-		assert( editScopeInput is not None )
+		editScope = self.editScope()
+		assert( editScope is not None )
 
-		editScope = editScopeInput.node()
 		dialogue = _RenderPassCreationDialogue( self.__renderPassNames( self.settings()["in"] ), editScope )
 		renderPassName = dialogue.waitForRenderPassName( parentWindow = self.ancestor( GafferUI.Window ) )
 		if renderPassName :
@@ -564,14 +560,14 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 	def __metadataChanged( self, nodeTypeId, key, node ) :
 
-		editScopeInput = self.settings()["editScope"].getInput()
-		if editScopeInput is None :
+		editScope = self.editScope()
+		if editScope is None :
 			return
 
-		renderPassesProcessor = editScopeInput.node().acquireProcessor( "RenderPasses", createIfNecessary = False )
+		renderPassesProcessor = editScope.acquireProcessor( "RenderPasses", createIfNecessary = False )
 
 		if (
-			Gaffer.MetadataAlgo.readOnlyAffectedByChange( editScopeInput, nodeTypeId, key, node ) or
+			Gaffer.MetadataAlgo.readOnlyAffectedByChange( editScope, nodeTypeId, key, node ) or
 			( renderPassesProcessor and Gaffer.MetadataAlgo.readOnlyAffectedByChange( renderPassesProcessor, nodeTypeId, key, node ) )
 		) :
 			self.__updateButtonStatus()

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -638,7 +638,7 @@ Gaffer.Metadata.registerNode(
 		"editScope" : [
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
-			"layout:width", 225,
+			"layout:width", 185,
 
 		],
 

--- a/python/GafferSceneUI/SceneEditor.py
+++ b/python/GafferSceneUI/SceneEditor.py
@@ -65,6 +65,16 @@ class SceneEditor( GafferUI.NodeSetEditor ) :
 
 		self.__parentingConnections = {}
 
+	def editScope( self ) :
+
+		if not "editScope" in self.settings() :
+			return None
+
+		return Gaffer.PlugAlgo.findSource(
+			self.settings()["editScope"],
+			lambda plug : plug.node() if isinstance( plug.node(), Gaffer.EditScope ) else None
+		)
+
 	def _updateFromSet( self ) :
 
 		# Find ScenePlugs and connect them to `settings()["in"]`.

--- a/python/GafferSceneUI/SceneEditor.py
+++ b/python/GafferSceneUI/SceneEditor.py
@@ -65,6 +65,9 @@ class SceneEditor( GafferUI.NodeSetEditor ) :
 
 		self.__parentingConnections = {}
 
+		self.__globalEditTargetLinked = False
+		self.parentChangedSignal().connect( Gaffer.WeakMethod( self.__parentChanged ) )
+
 	def editScope( self ) :
 
 		if not "editScope" in self.settings() :
@@ -133,6 +136,16 @@ class SceneEditor( GafferUI.NodeSetEditor ) :
 			_reverseNodes = True,
 			_ellipsis = False
 		)
+
+	def __parentChanged( self, widget ) :
+
+		if self.__globalEditTargetLinked or not "editScope" in self.settings() :
+			return
+
+		compoundEditor = self.ancestor( GafferUI.CompoundEditor )
+		if compoundEditor :
+			self.settings()["editScope"].setInput( compoundEditor.settings()["editScope"] )
+			self.__globalEditTargetLinked = True
 
 	def __scenePlugParentChanged( self, plug, newParent ) :
 

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -66,6 +66,11 @@ def __rendererPlugActivator( plug ) :
 
 	return plug.parent()["name"].getValue().lower() == plug.getName().lower()
 
+def __condensedEditScopeSpacerActivator( node ) :
+
+	input = node["editScope"].getInput()
+	return input is not None and input.getName() == "editScope" and isinstance( input.node(), GafferUI.Editor.Settings )
+
 Gaffer.Metadata.registerNode(
 
 	GafferSceneUI.SceneView,
@@ -92,6 +97,12 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:widgetType", "GafferSceneUI.SceneViewUI._RightEditScopeBalancingSpacer",
 	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:section", "Top",
 	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:index", -2,
+
+	"toolbarLayout:activator:condensedEditScopeMenu", __condensedEditScopeSpacerActivator,
+	"toolbarLayout:customWidget:CondensedEditScopeBalancingSpacer:widgetType", "GafferSceneUI.SceneViewUI._CondensedEditScopeBalancingSpacer",
+	"toolbarLayout:customWidget:CondensedEditScopeBalancingSpacer:section", "Top",
+	"toolbarLayout:customWidget:CondensedEditScopeBalancingSpacer:index", -2,
+	"toolbarLayout:customWidget:CondensedEditScopeBalancingSpacer:visibilityActivator", "condensedEditScopeMenu",
 
 	"nodeToolbar:right:type", "GafferUI.StandardNodeToolbar.right",
 
@@ -1259,6 +1270,17 @@ class _RightEditScopeBalancingSpacer( GafferUI.Spacer ) :
 			preferredSize = imath.V2i( width, 1 ),
 			maximumSize = imath.V2i( width, 1 )
 		)
+
+# This Spacer balance the right side of the toolbar by
+# preserving the width lost when the EditScope menu is
+# displayed in condensed form.
+class _CondensedEditScopeBalancingSpacer( GafferUI.Spacer ) :
+
+	def __init__( self, sceneView, **kw ) :
+
+		editScopeWidth = Gaffer.Metadata.value( sceneView["editScope"], "toolbarLayout:width" ) or 130
+		# EditScope width - spacer - condensed EditScope width
+		width = max( editScopeWidth - 4 - 50, 0 )
 		GafferUI.Spacer.__init__(
 			self,
 			imath.V2i( 0 ), # Minimum

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -105,7 +105,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
 			"toolbarLayout:index", -1,
-			"toolbarLayout:width", 185,
+			"toolbarLayout:width", 130,
 
 		],
 
@@ -1226,7 +1226,7 @@ class _EditScopeBalancingSpacer( GafferUI.Spacer ) :
 	def __init__( self, sceneView, **kw ) :
 
 		# EditScope width - pause button - spacer - spinner - renderer
-		width = 185 - 25 - 4 - 20 - 100
+		width = 130 - 25 - 4 - 20 - 100
 
 		GafferUI.Spacer.__init__(
 			self,

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -105,7 +105,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
 			"toolbarLayout:index", -1,
-			"toolbarLayout:width", 225,
+			"toolbarLayout:width", 185,
 
 		],
 
@@ -1226,7 +1226,7 @@ class _EditScopeBalancingSpacer( GafferUI.Spacer ) :
 	def __init__( self, sceneView, **kw ) :
 
 		# EditScope width - pause button - spacer - spinner - renderer
-		width = 200 - 25 - 4 - 20 - 100
+		width = 185 - 25 - 4 - 20 - 100
 
 		GafferUI.Spacer.__init__(
 			self,

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -74,6 +74,9 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:StateWidget:section", "Top",
 	"toolbarLayout:customWidget:StateWidget:index", 0,
 
+	## \todo These balancing spacers are horrendous. We should be able to improve PlugLayout
+	# to support arranging plugs horizontally in sections with alignment as well as other
+	# niceties such as collapsible sections, etc.
 	"toolbarLayout:customWidget:EditScopeBalancingSpacer:widgetType", "GafferSceneUI.SceneViewUI._EditScopeBalancingSpacer",
 	"toolbarLayout:customWidget:EditScopeBalancingSpacer:section", "Top",
 	"toolbarLayout:customWidget:EditScopeBalancingSpacer:index", 1,
@@ -85,6 +88,10 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:CenterRightSpacer:widgetType", "GafferSceneUI.SceneViewUI._Spacer",
 	"toolbarLayout:customWidget:CenterRightSpacer:section", "Top",
 	"toolbarLayout:customWidget:CenterRightSpacer:index", -2,
+
+	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:widgetType", "GafferSceneUI.SceneViewUI._RightEditScopeBalancingSpacer",
+	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:section", "Top",
+	"toolbarLayout:customWidget:RightEditScopeBalancingSpacer:index", -2,
 
 	"nodeToolbar:right:type", "GafferUI.StandardNodeToolbar.right",
 
@@ -1221,13 +1228,37 @@ GafferUI.PlugValueWidget.popupMenuSignal().connect( __plugValueWidgetContextMenu
 # _Spacers
 ##########################################################################
 
+# This Spacer balances the left side of the toolbar when
+# the EditScope menu is wider than the tools on the left
 class _EditScopeBalancingSpacer( GafferUI.Spacer ) :
 
 	def __init__( self, sceneView, **kw ) :
 
-		# EditScope width - pause button - spacer - spinner - renderer
-		width = 130 - 25 - 4 - 20 - 100
+		editScopeWidth = Gaffer.Metadata.value( sceneView["editScope"], "toolbarLayout:width" ) or 130
+		# EditScope width + spacer - pause button - spacer - spinner - renderer
+		width = max( editScopeWidth + 4 - 25 - 4 - 20 - 100, 0 )
+		GafferUI.Spacer.__init__(
+			self,
+			imath.V2i( 0 ), # Minimum
+			preferredSize = imath.V2i( width, 1 ),
+			maximumSize = imath.V2i( width, 1 )
+		)
 
+# This Spacer balances the right side of the toolbar when
+# the EditScope menu is narrower than the tools on the left
+class _RightEditScopeBalancingSpacer( GafferUI.Spacer ) :
+
+	def __init__( self, sceneView, **kw ) :
+
+		editScopeWidth = Gaffer.Metadata.value( sceneView["editScope"], "toolbarLayout:width" ) or 130
+		# pause button + spacer + spinner + renderer - spacer - EditScope width
+		width = max( 25 + 4 + 20 + 100 - 4 - editScopeWidth, 0 )
+		GafferUI.Spacer.__init__(
+			self,
+			imath.V2i( 0 ), # Minimum
+			preferredSize = imath.V2i( width, 1 ),
+			maximumSize = imath.V2i( width, 1 )
+		)
 		GafferUI.Spacer.__init__(
 			self,
 			imath.V2i( 0 ), # Minimum

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -53,6 +53,16 @@ from Qt import QtWidgets
 
 class CompoundEditor( GafferUI.Editor ) :
 
+	class Settings( GafferUI.Editor.Settings ) :
+
+		def __init__( self ) :
+
+			GafferUI.Editor.Settings.__init__( self )
+
+			self["editScope"] = Gaffer.Plug()
+
+	IECore.registerRunTimeTyped( Settings, typeName = "GafferUI::CompoundEditor::Settings" )
+
 	# The CompoundEditor constructor args are considered 'private', used only
 	# by the persistent layout system.
 	def __init__( self, scriptNode, _state={}, **kw ) :
@@ -1660,3 +1670,26 @@ class _PinningWidget( _Frame ) :
 			return nodeSet
 
 		return None
+
+Gaffer.Metadata.registerNode(
+
+	CompoundEditor.Settings,
+
+	plugs = {
+
+		"*" : [
+
+			"label", "",
+
+		],
+
+		"editScope" : [
+
+			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
+			"layout:width", 185,
+
+		],
+
+	}
+
+)

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -1687,6 +1687,7 @@ Gaffer.Metadata.registerNode(
 
 			"plugValueWidget:type", "GafferUI.EditScopeUI.EditScopePlugValueWidget",
 			"layout:width", 185,
+			"editScopePlugValueWidget:showLabel", True,
 
 		],
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -203,6 +203,10 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		if plug.getName() == "in" and plug.parent() == self.getPlug().node() :
 			# The result of `__inputNode()` will have changed.
 			self.__acquireContextTracker()
+		elif plug == self.getPlug() :
+			# Update menu button width immediately to prevent layout flicker
+			# caused by a deferred update from _updateFromValues.
+			self.__updateMenuButtonWidth()
 
 	def __acquireContextTracker( self ) :
 
@@ -242,10 +246,24 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		return compoundEditor.settings()["editScope"]
 
+	def __updateMenuButtonWidth( self ) :
+
+		if self.__followingGlobalEditTarget() :
+			Gaffer.Metadata.registerValue( self.getPlug(), "layout:width", 50, persistent = False )
+			Gaffer.Metadata.registerValue( self.getPlug(), "toolbarLayout:width", 50, persistent = False )
+		else :
+			Gaffer.Metadata.deregisterValue( self.getPlug(), "layout:width" )
+			Gaffer.Metadata.deregisterValue( self.getPlug(), "toolbarLayout:width" )
+
 	def __updateMenuButton( self ) :
 
 		editScope = self.__editScope()
-		self.__menuButton.setText( editScope.getName() if editScope is not None else "Source" )
+		self.__updateMenuButtonWidth()
+
+		if self.__followingGlobalEditTarget() :
+			self.__menuButton.setText( " " )
+		else :
+			self.__menuButton.setText( editScope.getName() if editScope is not None else "Source" )
 
 		if editScope is not None :
 			self.__menuButton.setImage(

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -124,7 +124,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__listContainer, plug, **kw )
 
 		with self.__listContainer :
-			GafferUI.Label( "Edit Target" )
+			self.__label = GafferUI.Label( "Edit Target" )
 			self.__busyWidget = GafferUI.BusyWidget( size = 18 )
 			self.__busyWidget.setVisible( False )
 			self.__menuButton = GafferUI.MenuButton(
@@ -144,6 +144,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		# run the default dropSignal handler from PlugValueWidget.
 		self.dropSignal().connectFront( Gaffer.WeakMethod( self.__drop ) )
 
+		self.__updateLabelVisibility()
 		self.__updatePlugInputChangedConnection()
 		self.__acquireContextTracker()
 
@@ -168,6 +169,10 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			return unusableReason
 		else :
 			return "Edits will be made in {}.".format( editScope.getName() )
+
+	def _updateFromMetadata( self ) :
+
+		self.__updateLabelVisibility()
 
 	# We don't actually display values, but this is also called whenever the
 	# input changes, which is when we need to update.
@@ -215,6 +220,10 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		else :
 			# We'll update later in `__contextTrackerChanged()`.
 			pass
+
+	def __updateLabelVisibility( self ) :
+
+		self.__label.setVisible( Gaffer.Metadata.value( self.getPlug(), "editScopePlugValueWidget:showLabel" ) or False )
 
 	def __updateMenuButton( self ) :
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -120,23 +120,20 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __init__( self, plug, **kw ) :
 
-		self.__frame = GafferUI.Frame( borderWidth = 0 )
-		GafferUI.PlugValueWidget.__init__( self, self.__frame, plug, **kw )
+		self.__listContainer = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
+		GafferUI.PlugValueWidget.__init__( self, self.__listContainer, plug, **kw )
 
-		with self.__frame :
-			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
-				GafferUI.Spacer( imath.V2i( 4, 1 ), imath.V2i( 4, 1 ) )
-				GafferUI.Label( "Edit Scope" )
-				self.__busyWidget = GafferUI.BusyWidget( size = 18 )
-				self.__busyWidget.setVisible( False )
-				self.__menuButton = GafferUI.MenuButton(
-					"",
-					menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
-					highlightOnOver = False
-				)
-				# Ignore the width in X so MenuButton width is limited by the overall width of the widget
-				self.__menuButton._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
-				GafferUI.Spacer( imath.V2i( 4, 1 ), imath.V2i( 4, 1 ) )
+		with self.__listContainer :
+			GafferUI.Label( "Edit Scope" )
+			self.__busyWidget = GafferUI.BusyWidget( size = 18 )
+			self.__busyWidget.setVisible( False )
+			self.__menuButton = GafferUI.MenuButton(
+				"",
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
+				highlightOnOver = False
+			)
+			# Ignore the width in X so MenuButton width is limited by the overall width of the widget
+			self.__menuButton._qtWidget().setSizePolicy( QtWidgets.QSizePolicy.Ignored, QtWidgets.QSizePolicy.Fixed )
 
 		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ) )
 		self.dragBeginSignal().connect( Gaffer.WeakMethod( self.__dragBegin ) )
@@ -189,10 +186,6 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		else :
 			self.__editScopeNameChangedConnection = None
 			self.__editScopeMetadataChangedConnection = None
-
-		if self._qtWidget().property( "editScopeActive" ) != editScopeActive :
-			self._qtWidget().setProperty( "editScopeActive", GafferUI._Variant.toVariant( editScopeActive ) )
-			self._repolish()
 
 	def __updatePlugInputChangedConnection( self ) :
 
@@ -469,13 +462,13 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			return False
 
 		if self.__dropNode( event ) :
-			self.__frame.setHighlighted( True )
+			self.__menuButton.setHighlighted( True )
 
 		return True
 
 	def __dragLeave( self, widget, event ) :
 
-		self.__frame.setHighlighted( False )
+		self.__menuButton.setHighlighted( False )
 
 		return True
 
@@ -494,7 +487,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 						GafferUI.Label( f"<h4>{reason}</h4>" )
 				self.__popup.popup( parent = self )
 
-		self.__frame.setHighlighted( False )
+		self.__menuButton.setHighlighted( False )
 
 		return True
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -257,6 +257,10 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.getPlug().setInput( editScope["out"] )
 
+	def __connectPlug( self, plug, *ignored ) :
+
+		self.getPlug().setInput( plug )
+
 	def __inputNode( self ) :
 
 		node = self.getPlug().node()
@@ -378,7 +382,11 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result.append( "/__NoneDivider__", { "divider" : True } )
 		result.append(
-			"/None", { "command" : functools.partial( self.getPlug().setInput, None ) },
+			"/None",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__connectPlug ), None ),
+				"checkBox" : self.getPlug().getInput() == None,
+			},
 		)
 
 		if currentEditScope is not None :

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -124,7 +124,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 		GafferUI.PlugValueWidget.__init__( self, self.__listContainer, plug, **kw )
 
 		with self.__listContainer :
-			GafferUI.Label( "Edit Scope" )
+			GafferUI.Label( "Edit Target" )
 			self.__busyWidget = GafferUI.BusyWidget( size = 18 )
 			self.__busyWidget.setVisible( False )
 			self.__menuButton = GafferUI.MenuButton(
@@ -215,14 +215,14 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __updateMenuButton( self ) :
 
 		editScope = self.__editScope()
-		self.__menuButton.setText( editScope.getName() if editScope is not None else "None" )
+		self.__menuButton.setText( editScope.getName() if editScope is not None else "Source" )
 
 		if editScope is not None :
 			self.__menuButton.setImage(
 				self.__editScopeSwatch( editScope ) if not self.__unusableReason( editScope ) else "warningSmall.png"
 			)
 		else :
-			self.__menuButton.setImage( None )
+			self.__menuButton.setImage( "menuSource.png" )
 
 	def __editScopeNameChanged( self, editScope, oldName ) :
 
@@ -380,12 +380,13 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 			result.append( "/__RefreshDivider__", { "divider" : True } )
 			result.append( "/Refresh", { "command" : Gaffer.WeakMethod( self.__refreshMenu ) } )
 
-		result.append( "/__NoneDivider__", { "divider" : True } )
+		result.append( "/__SourceDivider__", { "divider" : True } )
 		result.append(
-			"/None",
+			"/Source",
 			{
 				"command" : functools.partial( Gaffer.WeakMethod( self.__connectPlug ), None ),
 				"checkBox" : self.getPlug().getInput() == None,
+				"icon" : "menuSource.png",
 			},
 		)
 

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -299,6 +299,7 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __buildMenu( self, path, currentEditScope ) :
 
 		result = IECore.MenuDefinition()
+		result.append( "/__TargetsDivider__", { "divider" : True, "label" : "Edit Targets" } )
 
 		for childPath in path.children() :
 			itemName = childPath[-1]
@@ -344,6 +345,9 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 						"icon" : icon
 					}
 				)
+
+		if result.size() == 1 :
+			result.append( "No EditScopes Available", { "active" : False } )
 
 		return result
 

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -76,14 +76,14 @@ class Image( GafferUI.Widget ) :
 	@staticmethod
 	def createSwatch( color ) :
 
-		pixmap = QtGui.QPixmap( 10, 10 )
+		pixmap = QtGui.QPixmap( 14, 14 )
 		pixmap.fill( QtGui.QColor( 0, 0, 0, 0 ) )
 
 		painter = QtGui.QPainter( pixmap )
 		painter.setRenderHint( QtGui.QPainter.Antialiasing )
 		painter.setPen( GafferUI._StyleSheet.styleColor( "backgroundDarkHighlight" ) )
 		painter.setBrush( QtGui.QColor.fromRgbF( color[0], color[1], color[2] ) )
-		painter.drawRoundedRect( QtCore.QRectF( 0.5, 0.5, 9, 9 ), 2, 2 )
+		painter.drawRoundedRect( QtCore.QRectF( 0.5, 0.5, 13, 13 ), 2, 2 )
 		del painter
 
 		swatch = GafferUI.Image( None )

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -274,6 +274,8 @@ class PlugLayout( GafferUI.Widget ) :
 				self.__widgets[item] = widget
 			else :
 				widget = self.__widgets[item]
+				if self.__itemMetadataValue( item, "width" ) :
+					widget._qtWidget().setFixedWidth( self.__itemMetadataValue( item, "width" ) )
 
 			if widget is None :
 				continue
@@ -492,6 +494,7 @@ class PlugLayout( GafferUI.Widget ) :
 				self.__layoutName + ":index",
 				self.__layoutName + ":section",
 				self.__layoutName + ":accessory",
+				self.__layoutName + ":width",
 				"plugValueWidget:type"
 			) :
 				# We often see sequences of several metadata changes, so

--- a/python/GafferUI/PlugValueWidget.py
+++ b/python/GafferUI/PlugValueWidget.py
@@ -148,8 +148,18 @@ class PlugValueWidget( GafferUI.Widget ) :
 
 		if not len( self.__plugs ) :
 			return None
-		else :
-			return next( iter( self.__plugs ) ).ancestor( Gaffer.ScriptNode )
+
+		plug = next( iter( self.__plugs ) )
+		scriptNode = plug.ancestor( Gaffer.ScriptNode )
+		if scriptNode is not None :
+			return scriptNode
+
+		# The plug may otherwise be on an `Editor.Settings` node,
+		# which receives a connection from the ScriptNode.
+		if "__scriptNode" in plug.node() and plug.node()["__scriptNode"].getInput() is not None :
+			return plug.node()["__scriptNode"].getInput().node()
+
+		return None
 
 	## Should be reimplemented to return True if this widget includes
 	# some sort of labelling for the plug. This is used to prevent

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -92,7 +92,11 @@ class ScriptWindow( GafferUI.Window ) :
 
 	def setLayout( self, compoundEditor ) :
 
+		# When changing layout we need to manually transfer the edit scope
+		# from an existing CompoundEditor to the new one.
+		currentEditScope = None
 		if len( self.__listContainer ) > 1 :
+			currentEditScope = self.getLayout().settings()["editScope"].getInput()
 			del self.__listContainer[1]
 
 		assert( compoundEditor.scriptNode().isSame( self.scriptNode() ) )
@@ -101,15 +105,16 @@ class ScriptWindow( GafferUI.Window ) :
 		if len( self.__menuContainer ) > 1 :
 			del self.__menuContainer[1:]
 
-		if hasattr( compoundEditor, "settings" ) :
-			self.__menuContainer.append(
-				GafferUI.PlugLayout(
-					compoundEditor.settings(),
-					orientation = GafferUI.ListContainer.Orientation.Horizontal,
-					rootSection = "Settings"
-				)
+		if currentEditScope is not None :
+			compoundEditor.settings()["editScope"].setInput( currentEditScope )
+		self.__menuContainer.append(
+			GafferUI.PlugLayout(
+				compoundEditor.settings(),
+				orientation = GafferUI.ListContainer.Orientation.Horizontal,
+				rootSection = "Settings"
 			)
-			self.__menuContainer.append( GafferUI.Spacer( imath.V2i( 0 ) ) )
+		)
+		self.__menuContainer.append( GafferUI.Spacer( imath.V2i( 0 ) ) )
 
 	def getLayout( self ) :
 

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1519,7 +1519,6 @@ _styleSheet = string.Template(
 	*[gafferClass="GafferSceneUI.TransformToolUI._SelectionWidget"],
 	*[gafferClass="GafferSceneUI.CropWindowToolUI._StatusWidget"],
 	*[gafferClass="GafferSceneUI.TransformToolUI._TargetTipWidget"] > QFrame,
-	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] > QFrame,
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] > QFrame,
 	*[gafferClass="GafferSceneUI._SceneViewInspector"] > QFrame
 	{
@@ -1529,7 +1528,7 @@ _styleSheet = string.Template(
 		padding: 2px;
 	}
 
-	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"][editScopeActive="true"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
+	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
 	{
 		border: 1px solid rgb( 46, 75, 107 );
 		border-top-color: rgb( 75, 113, 155 );

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1538,6 +1538,8 @@ _styleSheet = string.Template(
 		border-top-color: rgb( 75, 113, 155 );
 		border-left-color: rgb( 75, 113, 155 );
 		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb( 69, 113, 161 ), stop: 0.1 rgb( 48, 99, 153 ), stop: 0.90 rgb( 54, 88, 125 ));
+		margin-top: 2px;
+		margin-bottom: 2px;
 	}
 
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] QPushButton[gafferWithFrame="true"] {

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -283,6 +283,10 @@ _styleSheet = string.Template(
 		padding: 5px 8px 5px 8px;
 	}
 
+	#gafferMenuBarWidgetContainer {
+		background-color: $backgroundDarkest;
+	}
+
 	QMenu {
 		border: 1px solid $backgroundDark;
 		padding-bottom: 5px;

--- a/python/GafferUITest/ImageTest.py
+++ b/python/GafferUITest/ImageTest.py
@@ -70,8 +70,8 @@ class ImageTest( GafferUITest.TestCase ) :
 
 		s = GafferUI.Image.createSwatch( imath.Color3f( 1, 0, 0 ) )
 
-		self.assertEqual( s._qtPixmap().width(), 10 )
-		self.assertEqual( s._qtPixmap().height(), 10 )
+		self.assertEqual( s._qtPixmap().width(), 14 )
+		self.assertEqual( s._qtPixmap().height(), 14 )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -413,6 +413,7 @@
 				"menuChecked",
 				"menuIndicator",
 				"menuIndicatorDisabled",
+				"menuSource",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3457,6 +3457,15 @@
          y="79"
          transform="matrix(0,1,1,0,0,0)"
          inkscape:label="menuBreadCrumb" />
+      <rect
+         style="fill:none;fill-opacity:1;stroke:none;stroke-width:1.4"
+         id="menuSource"
+         width="14"
+         height="14"
+         x="2670"
+         y="95"
+         transform="matrix(0,1,1,0,0,0)"
+         inkscape:label="menuSource" />
     </g>
     <path
        style="fill:none;stroke:url(#foreground);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -10504,6 +10513,12 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cc" />
     </g>
+    <path
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:connector-curvature="0"
+       id="menuSourceShape"
+       d="m 98,2725.3622 h 4 l -2,4 2,0 0.0385,5.0769 h 0.92308 L 103,2729.3622 h 2 l -2,-4 h 4 v -1 h -9 z"
+       style="display:inline;fill:url(#foreground);fill-opacity:1;stroke:#3c3c3c;stroke-width:1.84615;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill" />
     <g
        id="g6273"
        transform="matrix(0.83291134,0,0,0.8249516,3.9491823,572.50686)"

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3451,10 +3451,10 @@
       <rect
          style="fill:none;fill-opacity:1;stroke:none;stroke-width:1"
          id="menuBreadCrumb"
-         width="10"
-         height="10"
-         x="2674"
-         y="79"
+         width="14"
+         height="14"
+         x="2670"
+         y="77"
          transform="matrix(0,1,1,0,0,0)"
          inkscape:label="menuBreadCrumb" />
       <rect
@@ -9209,8 +9209,8 @@
        style="display:inline;fill:#63ba86;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        inkscape:label="menuBreadCrumb"
        cx="84"
-       cy="2731.3623"
-       r="4.5" />
+       cy="2729.3623"
+       r="5.5" />
     <g
        inkscape:groupmode="layer"
        id="layer5"

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -454,7 +454,12 @@ Gaffer::EditScope *Inspector::targetEditScope() const
 		return nullptr;
 	}
 
-	return runTimeCast<EditScope>( m_editScope->getInput()->node() );
+	return PlugAlgo::findSource(
+		m_editScope.get(),
+		[] ( Plug *plug ) {
+			return runTimeCast<EditScope>( plug->node() );
+		}
+	);
 }
 
 void Inspector::editScopeInputChanged( const Gaffer::Plug *plug )

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -153,14 +153,23 @@ const ToolContainer *View::tools() const
 
 Gaffer::EditScope *View::editScope()
 {
-	Plug *p = editScopePlug()->getInput();
-	return p ? p->parent<EditScope>() : nullptr;
+	return PlugAlgo::findSource(
+		editScopePlug(),
+		[] ( Plug *plug ) {
+			return runTimeCast<EditScope>( plug->node() );
+		}
+	);
 }
 
 const Gaffer::EditScope *View::editScope() const
 {
-	const Plug *p = editScopePlug()->getInput();
-	return p ? p->parent<EditScope>() : nullptr;
+	// Cheeky cast to avoid a duplicate `PlugAlgo::findSource( const... )` implementation
+	return PlugAlgo::findSource(
+		const_cast<Plug *>( editScopePlug() ),
+		[] ( Plug *plug ) {
+			return runTimeCast<const EditScope>( plug->node() );
+		}
+	);
 }
 
 const Gaffer::Context *View::context() const


### PR DESCRIPTION
This adds a new script-level Global Edit Target, which provides a centralised way of specifying the Edit Scope that should be the target for interactive edits via a new "Edit Target" menu in the menu bar. This menu displays the EditScopes upstream of the focus node. Editors default to following this choice by default, but can still be overridden to a specific edit scope where necessary. An overridden editor can resume following the Global Edit Target by choosing "Follow Global Edit Target" from its Edit Scope menu.

![globalEditTargetScreenshot](https://github.com/user-attachments/assets/2dc02293-cc39-4a79-8794-138596fdd80e)

The Edit Scope menu has also received an update, simplifying its UI by removing much of the additional chrome surrounding the menu. The intent here is twofold: make better use of the available space and remove some of the visual weight of the growing number of edit scope menus displayed across all the editors that now support them. To that end, we simplify the menu further when an editor is following the Global Edit Target, it shrinks to a condensed form that only displays an icon. This further reduces its visual importance, nudging users towards interacting with the global "Edit Target" menu instead, and distinguishes editors that have been overridden to target a specific edit scope as they display the wider menu button with the target name visible.

Lastly, we rename the existing "None" mode to "Source" (and give it an icon!). We feel "Source" more clearly conveys that this mode edits the first available upstream plug outside of an Edit Scope, rather than does nothing.