### PR TITLE
DispatchDialogue : Remove `_DispatcherCreationWidget` from shown nodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ Fixes
 - ImageWriter : Matched view metadata to Nuke when using the Nuke options for `layout`. This should address an issue where EXRs written from Gaffer using Nuke layouts sometimes did not load correctly in Nuke (#6120). In the unlikely situation that you were relying on the old behaviour, you can set the env var `GAFFERIMAGE_IMAGEWRITER_OMIT_DEFAULT_NUKE_VIEW = 1` in order to keep the old behaviour.
 - OSLObject : Fixed `getattribute()` to support 64 bit integer data, such as an `instanceId` primitive variable loaded from USD. Since OSL doesn't provide a 64 bit integer type, values are truncated to 32 bits.
 - MeshSplit : Vertex order is now preserved.
+- DispatchDialogue : Removed `_DispatcherCreationWidget` from shown nodes.
 
 API
 ---

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -95,6 +95,8 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 					nodeFrame.addChild( self.__nodeEditor( node ) )
 					# remove the per-node execute button
 					Gaffer.Metadata.registerValue( node, "layout:customWidget:dispatchButton:widgetType", "", persistent = False )
+					# remove the per-node widget to create a dispatcher
+					Gaffer.Metadata.registerValue( node, "layout:customWidget:dispatcherCreationWidget:widgetType", "", persistent = False )
 					self.__tabs.setLabel( nodeFrame, node.relativeName( self.__script ) )
 
 				with GafferUI.ListContainer() as dispatcherTab :


### PR DESCRIPTION
When dispatching a node via the `DispatchDialogue`, the `_DispatcherCreationWidget` isn't relevant.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
