### PR TITLE
TweakPlug : Possible way to expose functionality needed by PrimitiveVariableTweaks

### DIFF
--- a/include/Gaffer/TweakPlug.h
+++ b/include/Gaffer/TweakPlug.h
@@ -123,12 +123,20 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 			MissingMode missingMode = MissingMode::Error
 		) const;
 
+		template< typename T >
+		static T applyNumericTweak(
+			const T &source,
+			const T &tweak,
+			TweakPlug::Mode mode,
+			const std::string &tweakName
+		);
+
 	private :
 
 		Gaffer::ValuePlug *valuePlugInternal();
 		const Gaffer::ValuePlug *valuePlugInternal() const;
 
-		void applyNumericTweak(
+		void applyNumericDataTweak(
 			const IECore::Data *sourceData,
 			const IECore::Data *tweakData,
 			IECore::Data *destData,
@@ -143,6 +151,12 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 			TweakPlug::Mode mode,
 			const std::string &tweakName
 		) const;
+
+		template<typename T>
+		static T vectorAwareMin( const T &v1, const T &v2 );
+
+		template<typename T>
+		static T vectorAwareMax( const T &v1, const T &v2 );
 
 		void applyReplaceTweak( const IECore::Data *sourceData, IECore::Data *tweakData ) const;
 

--- a/include/Gaffer/TweakPlug.h
+++ b/include/Gaffer/TweakPlug.h
@@ -131,6 +131,8 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 			const std::string &tweakName
 		);
 
+		static const char *modeToString( Gaffer::TweakPlug::Mode mode );
+
 	private :
 
 		Gaffer::ValuePlug *valuePlugInternal();
@@ -159,8 +161,6 @@ class GAFFER_API TweakPlug : public Gaffer::ValuePlug
 		static T vectorAwareMax( const T &v1, const T &v2 );
 
 		void applyReplaceTweak( const IECore::Data *sourceData, IECore::Data *tweakData ) const;
-
-		static const char *modeToString( Gaffer::TweakPlug::Mode mode );
 
 };
 

--- a/python/GafferTest/TweakPlugTest.py
+++ b/python/GafferTest/TweakPlugTest.py
@@ -345,6 +345,47 @@ class TweakPlugTest( GafferTest.TestCase ) :
 		self.assertTrue( result )
 		self.assertEqual( data["a"], IECore.InternedStringData( "stringValue" ) )
 
+	def testInvalidNumeric( self ) :
+
+		parameters = IECore.CompoundData(
+			{
+				"a" : "foo",
+				"b" : IECore.IntVectorData( [ 0, 1, 2 ] ),
+				"c" : IECore.StringVectorData( [ "gouda", "cheddar", "cheddar", "swiss" ] ),
+			}
+		)
+
+		tweaks = Gaffer.TweaksPlug()
+		tweaks.addChild( Gaffer.TweakPlug( "a", "foo", Gaffer.TweakPlug.Mode.Add ) )
+		#tweaks.addChild( Gaffer.TweakPlug( "b", imath.Color3f( 1.0, 2.0, 3.0 ) ) )
+		#tweaks.addChild( Gaffer.TweakPlug( "c", imath.V2f( 1.0, 2.0 ) ) )
+		#tweaks.addChild( Gaffer.TweakPlug( "d", IECore.StringVectorData( [ "brie" ] ) ) )
+		#tweaks.addChild( Gaffer.TweakPlug( "f", IECore.StringVectorData( [] ), Gaffer.TweakPlug.Mode.ListAppend ) )
+
+		with self.assertRaisesRegex( Exception,
+			'Cannot apply tweak with mode Add to "a" : Data type StringData not supported.'
+		) :
+			tweaks.applyTweaks( parameters )
+
+		del tweaks[0]
+
+		tweaks.addChild( Gaffer.TweakPlug( "b", IECore.IntVectorData( [ 0, 1, 2 ] ), Gaffer.TweakPlug.Mode.Multiply ) )
+
+		with self.assertRaisesRegex( Exception,
+			'Cannot apply tweak with mode Multiply to "b" : Data type IntVectorData not supported.'
+		) :
+			tweaks.applyTweaks( parameters )
+
+		del tweaks[0]
+
+		tweaks.addChild( Gaffer.TweakPlug( "c", IECore.StringVectorData( [ "foo" ] ), Gaffer.TweakPlug.Mode.Subtract ) )
+
+		with self.assertRaisesRegex( Exception,
+			'Cannot apply tweak with mode Subtract to "c" : Data type StringVectorData not supported.'
+		) :
+			tweaks.applyTweaks( parameters )
+
+
 	def testPathMatcherListOperations( self ) :
 
 		data = IECore.CompoundData(

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -257,6 +257,38 @@ bool TweakPlug::applyTweak( IECore::CompoundData *parameters, MissingMode missin
 	);
 }
 
+const char *TweakPlug::modeToString( Gaffer::TweakPlug::Mode mode )
+{
+	switch( mode )
+	{
+		case Gaffer::TweakPlug::Replace :
+			return "Replace";
+		case Gaffer::TweakPlug::Add :
+			return "Add";
+		case Gaffer::TweakPlug::Subtract :
+			return "Subtract";
+		case Gaffer::TweakPlug::Multiply :
+			return "Multiply";
+		case Gaffer::TweakPlug::Remove :
+			return "Remove";
+		case Gaffer::TweakPlug::Create :
+			return  "Create";
+		case Gaffer::TweakPlug::Min :
+			return "Min";
+		case Gaffer::TweakPlug::Max :
+			return "Max";
+		case Gaffer::TweakPlug::ListAppend :
+			return "ListAppend";
+		case Gaffer::TweakPlug::ListPrepend :
+			return "ListPrepend";
+		case Gaffer::TweakPlug::ListRemove :
+			return "ListRemove";
+		case Gaffer::TweakPlug::CreateIfMissing :
+			return "CreateIfMissing";
+	}
+	return  "Invalid";
+}
+
 void TweakPlug::applyNumericDataTweak(
 	const IECore::Data *sourceData,
 	const IECore::Data *tweakData,
@@ -355,38 +387,6 @@ void TweakPlug::applyReplaceTweak( const IECore::Data *sourceData, IECore::Data 
 			"{source}", static_cast<const IECore::InternedStringData *>( sourceData )->readable().string()
 		);
 	}
-}
-
-const char *TweakPlug::modeToString( Gaffer::TweakPlug::Mode mode )
-{
-	switch( mode )
-	{
-		case Gaffer::TweakPlug::Replace :
-			return "Replace";
-		case Gaffer::TweakPlug::Add :
-			return "Add";
-		case Gaffer::TweakPlug::Subtract :
-			return "Subtract";
-		case Gaffer::TweakPlug::Multiply :
-			return "Multiply";
-		case Gaffer::TweakPlug::Remove :
-			return "Remove";
-		case Gaffer::TweakPlug::Create :
-			return  "Create";
-		case Gaffer::TweakPlug::Min :
-			return "Min";
-		case Gaffer::TweakPlug::Max :
-			return "Max";
-		case Gaffer::TweakPlug::ListAppend :
-			return "ListAppend";
-		case Gaffer::TweakPlug::ListPrepend :
-			return "ListPrepend";
-		case Gaffer::TweakPlug::ListRemove :
-			return "ListRemove";
-		case Gaffer::TweakPlug::CreateIfMissing :
-			return "CreateIfMissing";
-	}
-	return  "Invalid";
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
PrimitiveVariableTweaks will need to apply tweaks to array elements, which are not `Data`. I'm exploring ways to expose this functionality in TweakPlug without duplicating code.

This appears to work somewhat decently ( all the tests are passing ). My concerns are: what should this public function be called, and would it be better not to expose vectorAwareMin/vectorAwareMax ( these functions are only called in one place, so just pasting them in is totally an option ).

Any better ideas for an interface?