### PR TITLE
Graphics : Reinstate "context yellow" current render pass indicator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Improvements
   - Added a "No EditScopes Available" menu item that is displayed when no upstream EditScopes are available.
   - Increased menu item icon sizes.
   - A lock icon is now displayed next to read-only nodes.
+- RenderPassEditor : Changed the current render pass indicator to yellow to match other context-related UI elements.
 
 Fixes
 -----

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -10150,7 +10150,7 @@
            cy="2784.9451"
            cx="54.179211"
            id="circle6245-3"
-           style="display:inline;vector-effect:none;fill:#54ad5e;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+           style="display:inline;vector-effect:none;fill:#f0dc28;fill-opacity:1;fill-rule:nonzero;stroke:#3c3c3c;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
       </g>
       <g
          transform="translate(61.820791,-0.81469727)"
@@ -10162,7 +10162,7 @@
            cy="2784.9451"
            cx="56.179211"
            id="circle6253-6"
-           style="display:inline;vector-effect:none;fill:#54ad5e;fill-opacity:0.4;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+           style="display:inline;vector-effect:none;fill:#f0dc28;fill-opacity:0.38041458;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
       </g>
     </g>
     <path


### PR DESCRIPTION
This was originally added in dced4d402f9456daccac9a5676d3ead718547b5b but was lost in some merge shenanigans along the way.