### PR TITLE
StandardNodule : Remove deprecated `setCompatibleLabelsVisible()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.x.x.x (relative to 1.5.x.x)
 =======
 
+Breaking Changes
+----------------
+
+- StandardNodule : Removed deprecated `setCompatibleLabelsVisible()`.
+
 
 
 1.5.x.x (relative to 1.5.1.0)

--- a/include/GafferUI/StandardNodule.h
+++ b/include/GafferUI/StandardNodule.h
@@ -89,10 +89,6 @@ class GAFFERUI_API StandardNodule : public Nodule
 		bool dragEnd( GadgetPtr gadget, const DragDropEvent &event );
 		bool drop( GadgetPtr gadget, const DragDropEvent &event );
 
-		/// \deprecated Use overloaded method without `visible` when setting `visible = true`
-		/// or `StandardNodeGadget::applyNoduleLabelVisibilityMetadata()` to restore
-		/// metadata-aware visibility.
-		void setCompatibleLabelsVisible( const DragDropEvent &event, bool visible );
 		void setCompatibleLabelsVisible( const DragDropEvent &event );
 
 	private :

--- a/src/GafferUI/StandardNodule.cpp
+++ b/src/GafferUI/StandardNodule.cpp
@@ -401,10 +401,6 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 				{
 					nodeGadget->applyNoduleLabelVisibilityMetadata();
 				}
-				else
-				{
-					setCompatibleLabelsVisible( event, false );
-				}
 			}
 		}
 		else if( NodeGadget *newDestination = IECore::runTimeCast<NodeGadget>( event.destinationGadget.get() ) )
@@ -415,10 +411,6 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 				{
 					nodeGadget->applyNoduleLabelVisibilityMetadata();
 				}
-				else
-				{
-					setCompatibleLabelsVisible( event, false );
-				}
 			}
 		}
 		else
@@ -426,10 +418,6 @@ bool StandardNodule::dragLeave( GadgetPtr gadget, const DragDropEvent &event )
 			if( auto nodeGadget = ancestor<StandardNodeGadget>() )
 			{
 				nodeGadget->applyNoduleLabelVisibilityMetadata();
-			}
-			else
-			{
-				setCompatibleLabelsVisible( event, false );
 			}
 		}
 		dirty( DirtyType::Render );
@@ -459,10 +447,6 @@ bool StandardNodule::drop( GadgetPtr gadget, const DragDropEvent &event )
 	{
 		nodeGadget->applyNoduleLabelVisibilityMetadata();
 	}
-	else
-	{
-		setCompatibleLabelsVisible( event, false );
-	}
 
 	if( ConnectionCreator *creator = IECore::runTimeCast<ConnectionCreator>( event.sourceGadget.get() ) )
 	{
@@ -477,29 +461,6 @@ bool StandardNodule::drop( GadgetPtr gadget, const DragDropEvent &event )
 	}
 
 	return false;
-}
-
-void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event, bool visible )
-{
-	NodeGadget *nodeGadget = ancestor<NodeGadget>();
-	if( !nodeGadget )
-	{
-		return;
-	}
-
-	ConnectionCreator *creator = IECore::runTimeCast<ConnectionCreator>( event.sourceGadget.get() );
-	if( !creator )
-	{
-		return;
-	}
-
-	for( StandardNodule::RecursiveIterator it( nodeGadget ); !it.done(); ++it )
-	{
-		if( creator->canCreateConnection( it->get()->plug() ) )
-		{
-			(*it)->setLabelVisible( visible );
-		}
-	}
 }
 
 void StandardNodule::setCompatibleLabelsVisible( const DragDropEvent &event )


### PR DESCRIPTION
This was deprecated in #6135. We don't expect there to be any other uses of it, and the fix to avoid the deprecated method is pretty simple, so it should be safe to remove.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
