### PR TITLE
Color*PlugValueWidget : Removed `scoped = False`

### DIFF
--- a/python/GafferUI/ColorChooserPlugValueWidget.py
+++ b/python/GafferUI/ColorChooserPlugValueWidget.py
@@ -86,8 +86,7 @@ class ColorChooserPlugValueWidget( GafferUI.PlugValueWidget ) :
 			functools.partial( Gaffer.WeakMethod( self.__dynamicSliderBackgroundsChanged ) )
 		)
 		self.__colorChooser.optionsMenuSignal().connect(
-			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) ),
-			scoped = False
+			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) )
 		)
 
 		self.__lastChangedReason = None

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -151,8 +151,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 			functools.partial( Gaffer.WeakMethod( self.__dynamicSliderBackgroundsChanged ) )
 		)
 		self.colorChooser().optionsMenuSignal().connect(
-			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) ),
-			scoped = False
+			functools.partial( Gaffer.WeakMethod( self.__colorChooserOptionsMenu ) )
 		)
 
 		self.confirmButton.clickedSignal().connect( Gaffer.WeakMethod( self.__buttonClicked ) )


### PR DESCRIPTION
These snuck in as a legacy from `1.4` days and should be removed.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
