### PR TITLE
ApplicationTest : Increase pause before checking process name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.1.0)
 =======
 
+Fixes
+-----
 
+- ApplicationTest : Slightly increased pause before checking process name to ensure it has had time to change it.
 
 1.5.1.0 (relative to 1.5.0.1)
 =======

--- a/python/GafferTest/ApplicationTest.py
+++ b/python/GafferTest/ApplicationTest.py
@@ -64,7 +64,7 @@ class ApplicationTest( GafferTest.TestCase ) :
 	def testProcessName( self ) :
 
 		process = subprocess.Popen( [ str( Gaffer.executablePath() ), "env", "sleep", "100" ] )
-		time.sleep( 1 )
+		time.sleep( 3 )
 		command = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "command=" ], universal_newlines = True ).strip()
 		name = subprocess.check_output( [ "ps", "-p", str( process.pid ), "-o", "comm=" ], universal_newlines = True ).strip()
 		process.kill()


### PR DESCRIPTION
This ensures the process has had time to change its own name.

This is part of the effort to get the gaffer tests to pass inside IE's environment.
1s wasn't enough of a pause to guarantee that the gaffer process had had time to startup, import the `Gaffer` module, and then rename the process, before the test would check for the name. That's likely related to the use of non-local storage and loading extra startups.

2s does seem to be enough, but I added an extra second for safety.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
