### PR TITLE
Arnold ShaderNetworkAlgo : Add custom substitutions API

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ API
 ---
 
 - PlugLayout : Activations may now depend on the presence of certain plugs, as they are now reevaluated when child plugs are added and removed.
+- IECoreArnold::ShaderNetworkAlgo : Added a new API to allow just-in-time substitutions to be made when translating shaders to Arnold. Use with care.
 
 1.5.1.0 (relative to 1.5.0.1)
 =======

--- a/include/IECoreArnold/ShaderNetworkAlgo.h
+++ b/include/IECoreArnold/ShaderNetworkAlgo.h
@@ -40,6 +40,8 @@
 
 #include "IECoreScene/ShaderNetwork.h"
 
+#include "IECore/CompoundObject.h"
+
 #include "ai_nodes.h"
 
 #include <vector>
@@ -90,6 +92,27 @@ IECOREARNOLD_API bool update( std::vector<AtNode *> &nodes, const IECoreScene::S
 /// is performed automatically by `convert()` and `update()` and is mainly just exposed for the unit
 /// tests.
 IECOREARNOLD_API void convertUSDShaders( IECoreScene::ShaderNetwork *shaderNetwork );
+
+/// A function that performs substitutions on a shader network, given the full
+/// inherited `attributes` for an object. Must be threadsafe.
+using SubstitutionFunction = void (*)( IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes );
+/// A function that appends to `hash` to uniquely identify the work that will be
+/// performed by a SubstitutionFunction. Particular attention must be paid to
+/// the performance of any such function, as it will be called frequently. If a
+/// substitution will be a no-op, then nothing should be appended to the hash.
+/// Must be threadsafe.
+using SubstitutionHashFunction = void (*)( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECore::MurmurHash &hash );
+
+/// Registers a just-in-time substitution to be performed on shader
+/// networks before the shader is translated to Arnold.
+IECOREARNOLD_API void registerSubstitution( const std::string &name, SubstitutionHashFunction hashFunction, SubstitutionFunction substitutionFunction );
+/// Removes a previously registered substitution with the specified name.
+IECOREARNOLD_API void deregisterSubstitution( const std::string &name );
+
+/// Hashes all the currently registered substitutions for `shaderNetwork`.
+IECOREARNOLD_API void hashSubstitutions( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECore::MurmurHash &hash );
+/// Applies all the currently registered substitutions to `shaderNetwork`.
+IECOREARNOLD_API void applySubstitutions( IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes );
 
 } // namespace ShaderNetworkAlgo
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -834,7 +834,7 @@ class ShaderCache : public IECore::RefCounted
 			IECore::MurmurHash hSubst;
 			if( attributes )
 			{
-				shader->hashSubstitutions( attributes, hSubst );
+				ShaderNetworkAlgo::hashSubstitutions( shader, attributes, hSubst );
 				h.append( hSubst );
 			}
 
@@ -851,7 +851,7 @@ class ShaderCache : public IECore::RefCounted
 				if( hSubst != IECore::MurmurHash() )
 				{
 					IECoreScene::ShaderNetworkPtr substitutedShader = shader->copy();
-					substitutedShader->applySubstitutions( attributes );
+					ShaderNetworkAlgo::applySubstitutions( substitutedShader.get(), attributes );
 					writeAccessor->second = new ArnoldShader( substitutedShader.get(), m_nodeDeleter, m_universe, namePrefix, m_parentNode );
 				}
 				else

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -1157,3 +1157,96 @@ void IECoreArnold::ShaderNetworkAlgo::convertUSDShaders( ShaderNetwork *shaderNe
 
 	IECoreScene::ShaderNetworkAlgo::removeUnusedShaders( shaderNetwork );
 }
+
+//////////////////////////////////////////////////////////////////////////
+// Substitutions
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct Substitution
+{
+	std::string name;
+	IECoreArnold::ShaderNetworkAlgo::SubstitutionHashFunction hash;
+	IECoreArnold::ShaderNetworkAlgo::SubstitutionFunction apply;
+};
+
+using Substitutions = std::vector<Substitution>;
+Substitutions &substitutions()
+{
+	static Substitutions g_substitutions;
+	return g_substitutions;
+}
+
+bool g_textureSubstitutionsRegistration = [] () {
+
+	IECoreArnold::ShaderNetworkAlgo::registerSubstitution(
+		"stringSubstitution",
+		// Hash
+		[] ( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECore::MurmurHash &hash ) {
+			shaderNetwork->hashSubstitutions( attributes, hash );
+		},
+		// Apply
+		[] ( IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes ) {
+			shaderNetwork->applySubstitutions( attributes );
+		}
+	);
+
+	return true;
+} ();
+
+} // namespace
+
+namespace IECoreArnold::ShaderNetworkAlgo
+{
+
+void registerSubstitution( const std::string &name, SubstitutionHashFunction hashFunction, SubstitutionFunction substitutionFunction )
+{
+	// Replace existing substitution if it exists.
+	Substitutions &s = substitutions();
+	for( auto &x : s )
+	{
+		if( x.name == name )
+		{
+			x.hash = hashFunction;
+			x.apply = substitutionFunction;
+			return;
+		}
+	}
+	// Otherwise add new substitution.
+	s.push_back( { name, hashFunction, substitutionFunction } );
+}
+
+void deregisterSubstitution( const std::string &name )
+{
+	Substitutions &s = substitutions();
+	s.erase(
+		std::remove_if(
+			s.begin(),
+			s.end(),
+			[&] ( const Substitution &x ) {
+				return x.name == name;
+			}
+		),
+		s.end()
+	);
+}
+
+void hashSubstitutions( const IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes, IECore::MurmurHash &hash )
+{
+	for( const auto &x : substitutions() )
+	{
+		x.hash( shaderNetwork, attributes, hash );
+	}
+}
+
+void applySubstitutions( IECoreScene::ShaderNetwork *shaderNetwork, const IECore::CompoundObject *attributes )
+{
+	for( const auto &x : substitutions() )
+	{
+		x.apply( shaderNetwork, attributes );
+	}
+}
+
+} // namespace IECoreArnold::ShaderNetworkAlgo


### PR DESCRIPTION
This is an API I promised to @tomc-cinesite and @alex-savenko-at-cinesite, to facilitate the creation of a neat system of hierarchical shader overrides. I'm really not sure that these substitutions belong in the renderer backend, and think there is a good case that they belong in the shader publishing process instead. But I have done the work in order that no one can accuse me of not wanting to do the work, and to thus strengthen my position in any future negotiations :)

