### PR TITLE
CatalogueUI : Don't "steal" irrelevant drags

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Fixes
 
 - GraphEditor : Fixed errors when dragging an unknown file type into the GraphEditor.
 - Widget : Fixed `event.sourceWidget` for DragDropEvents generated from a Qt native drag within the same Gaffer process. This will now reference the `GafferUI.Widget` that the Qt source widget belongs to, if any.
+- Catalogue : Fixed bug which "stole" drags that crossed the image listing but which were destined elsewhere, for instance a drag from the HierarchyView to a PathFilter in the GraphEditor.
 
 1.4.15.2 (relative to 1.4.15.1)
 ========

--- a/python/GafferImageUI/CatalogueUI.py
+++ b/python/GafferImageUI/CatalogueUI.py
@@ -1079,7 +1079,7 @@ class ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __pathListingDragEnter( self, widget, event ) :
 
-		if isinstance( event.data, IECore.StringVectorData ) :
+		if event.sourceWidget is widget and isinstance( event.data, IECore.StringVectorData ) and event.data :
 			# Allow reordering of images
 			self.__moveToPath = None
 			self.__mergeGroupId += 1
@@ -1101,7 +1101,7 @@ class ImageListing( GafferUI.PlugValueWidget ) :
 
 	def __pathListingDragMove( self, listing, event ) :
 
-		if not event.data or not isinstance( event.data, IECore.StringVectorData ) :
+		if not ( event.sourceWidget is listing and isinstance( event.data, IECore.StringVectorData ) and event.data ) :
 			return
 
 		targetPath = self.__pathListing.pathAt( event.line.p0 )


### PR DESCRIPTION
We were accepting any drag which provided StringVectorData, when we should only have been accepting those which originated in the image listing (because we are using the drag to reorder images). This meant we were accepting drags of paths from the HierarchyView, and then clobbering the custom pointer in `__pathListingDragLeave`. This gave people the impression that the drag was broken, when in fact you could still continue and drop elsewhere (despite the pointer indicating otherwise).

Also tweaked the drag move logic so we use exactly the same checks in both enter and move.
