### PR TITLE
GadgetWidget : Fix signal handling bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - GraphEditor : Fixed errors when dragging an unknown file type into the GraphEditor.
 - Widget : Fixed `event.sourceWidget` for DragDropEvents generated from a Qt native drag within the same Gaffer process. This will now reference the `GafferUI.Widget` that the Qt source widget belongs to, if any.
 - Catalogue : Fixed bug which "stole" drags that crossed the image listing but which were destined elsewhere, for instance a drag from the HierarchyView to a PathFilter in the GraphEditor.
+- GadgetWidget : Fixed signal handling bug in `setViewportGadget()`. This could cause the widget to attempt to redraw unnecessarily when the _old_ viewport requested a redraw.
 
 1.4.15.2 (relative to 1.4.15.1)
 ========

--- a/python/GafferUI/GadgetWidget.py
+++ b/python/GafferUI/GadgetWidget.py
@@ -106,7 +106,7 @@ class GadgetWidget( GafferUI.GLWidget ) :
 			self.__viewportGadget.setVisible( False )
 
 		self.__viewportGadget = viewportGadget
-		self.__viewportGadget.renderRequestSignal().connect( Gaffer.WeakMethod( self.__renderRequest ), scoped = False )
+		self.__renderRequestConnection = self.__viewportGadget.renderRequestSignal().connect( Gaffer.WeakMethod( self.__renderRequest ), scoped = True )
 		size = self.size()
 		if size.x and size.y :
 			self.__viewportGadget.setViewport( size )

--- a/python/GafferUITest/GadgetWidgetTest.py
+++ b/python/GafferUITest/GadgetWidgetTest.py
@@ -66,5 +66,18 @@ class GadgetWidgetTest( GafferUITest.TestCase ) :
 		self.assertFalse( vg1.visible() )
 		self.assertFalse( vg2.visible() )
 
+	def testConnectionLifetime( self ) :
+
+		gadgetWidget = GafferUI.GadgetWidget()
+		viewportGadget1 = gadgetWidget.getViewportGadget()
+		self.assertEqual( viewportGadget1.renderRequestSignal().numSlots(), 1 )
+
+		viewportGadget2 = GafferUI.ViewportGadget()
+		self.assertEqual( viewportGadget2.renderRequestSignal().numSlots(), 0 )
+
+		gadgetWidget.setViewportGadget( viewportGadget2 )
+		self.assertEqual( viewportGadget1.renderRequestSignal().numSlots(), 0 )
+		self.assertEqual( viewportGadget2.renderRequestSignal().numSlots(), 1 )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This was broken in 9e052380bc2c272067827d6d0144b00cb3d41fbb, which switched from using a scoped to an unscoped connection. We need a scoped connection so that we automatically remove the connection to the previous viewport when making the connection to the new one.
