### PR TITLE
FPS Gadget to Front Layer

### DIFF
--- a/src/GafferUI/FPSGadget.cpp
+++ b/src/GafferUI/FPSGadget.cpp
@@ -59,7 +59,7 @@ FPSGadget::~FPSGadget()
 
 void FPSGadget::renderLayer( Gadget::Layer layer, const Style *style, Gadget::RenderReason reason ) const
 {
-	if( layer != Layer::Main )
+	if( layer != Layer::Front )
 	{
 		return;
 	}
@@ -109,7 +109,7 @@ void FPSGadget::renderLayer( Gadget::Layer layer, const Style *style, Gadget::Re
 
 unsigned FPSGadget::layerMask() const
 {
-	return (unsigned)Layer::Main;
+	return (unsigned)Layer::Front;
 }
 
 


### PR DESCRIPTION
This moves the layer we draw the FPS gadget on to be `Front`. It had been `Main` which meant that the visualiser being introduced in #6159 would draw over it.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
