### PR TITLE
MergeScenes bugfix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,11 @@ Features
   - ImageToTensor : Converts images to tensors for use with the Inference node.
   - TensorToImage : Converts tensors back to images following inference.
 
+Improvements
+------------
+
+- MergeScenes : Removed unnecessary temporary contexts.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,11 @@ Improvements
 
 - MergeScenes : Removed unnecessary temporary contexts.
 
+Fixes
+-----
+
+- MergeScenes : Fixed bug handling input connections not originating from the output of another node. These could cause locations provided by other inputs to lose all their properties.
+
 API
 ---
 

--- a/python/GafferSceneTest/MergeScenesTest.py
+++ b/python/GafferSceneTest/MergeScenesTest.py
@@ -234,7 +234,7 @@ class MergeScenesTest( GafferSceneTest.SceneTestCase ) :
 
 	def testSingleInputPassThrough( self ) :
 
-		sphere = GafferScene.Sphere()
+		sphere = GafferSceneTest.TestLight()
 		sphere["transform"]["translate"].setValue( imath.V3f( 1, 2, 3 ) )
 		sphere["sets"].setValue( "A" )
 		cube = GafferScene.Cube()
@@ -248,6 +248,25 @@ class MergeScenesTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertScenesEqual( merge["out"], group["out"] )
 		self.assertSceneHashesEqual( merge["out"], group["out"] )
+
+		merge["in"][1].setInput( group["out"] )
+		merge["in"][0].setInput( None )
+
+		self.assertScenesEqual( merge["out"], group["out"] )
+		self.assertSceneHashesEqual( merge["out"], group["out"] )
+
+	def testFirstInputEmptyPassThrough( self ) :
+
+		merge = GafferScene.MergeScenes()
+
+		emptyScene = GafferScene.ScenePlug()
+		merge["in"][0].setInput( emptyScene )
+
+		light = GafferSceneTest.TestLight()
+		merge["in"][1].setInput( light["out"] )
+
+		self.assertScenesEqual( merge["out"], light["out"] )
+		self.assertSceneHashesEqual( merge["out"], light["out"], checks = self.allSceneChecks - { "sets" } )
 
 	def testNoInputsPassThrough( self ) :
 

--- a/src/GafferScene/MergeScenes.cpp
+++ b/src/GafferScene/MergeScenes.cpp
@@ -351,7 +351,7 @@ int MergeScenes::computeActiveInputs( const Gaffer::Context *context ) const
 			visit(
 				parentActiveInputs,
 				[&result, &scenePath] ( InputType type, size_t index, const ScenePlug *scene ) {
-					if( scene->exists( scenePath ) )
+					if( scene->existsPlug()->getValue() )
 					{
 						result[index] = true;
 					}


### PR DESCRIPTION
This fixes a fairly obscure bug in MergeScenes, and simplifies the code and removes some unnecessary contexts at the same time.