### PR TITLE
Widget Editor

### DIFF
--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -173,6 +173,8 @@ class PythonEditor( GafferUI.Editor ) :
 			return repr( dragData )
 		elif isinstance( dragData, IECore.Data ) and hasattr( dragData, "value" ) :
 			return repr( dragData.value )
+		elif isinstance( dragData, GafferUI.WidgetPath ) :
+			return repr( dragData )
 
 		return None
 

--- a/python/GafferUI/WidgetEditor.py
+++ b/python/GafferUI/WidgetEditor.py
@@ -336,4 +336,5 @@ class WidgetEditor( GafferUI.Editor ) :
 		QtWidgets.QApplication.instance().removeEventFilter( self.__buttonPressFilter )
 
 
+IECore.registerRunTimeTyped( WidgetPath, typeName = "GafferUI::WidgetPath" )
 GafferUI.Editor.registerType( "WidgetEditor", WidgetEditor )

--- a/python/GafferUI/WidgetEditor.py
+++ b/python/GafferUI/WidgetEditor.py
@@ -101,7 +101,8 @@ class WidgetPath( Gaffer.Path ) :
 
 		return Gaffer.Path.propertyNames() + [
 			"widgetEditor:name",
-			"widgetEditor:widget"
+			"widgetEditor:widget",
+			"widgetEditor:widgetType",
 		]
 
 	def property( self, name, canceller = None ) :
@@ -119,6 +120,8 @@ class WidgetPath( Gaffer.Path ) :
 			return self[-1]
 		elif name == "widgetEditor:widget" :
 			return widget
+		elif name == "widgetEditor:widgetType" :
+			return type( widget ).__name__
 
 	def widget( self ) :
 		# Returns the `GafferUI.Widget` for this path.
@@ -213,12 +216,13 @@ class WidgetEditor( GafferUI.Editor ) :
 
 				self.__timerWidget = GafferUI.BusyWidget( size = 25, busy = False )
 
-			self.__widgetNameColumn = GafferUI.PathListingWidget.StandardColumn( "Name", "widgetEditor:name", sizeMode = GafferUI.PathColumn.SizeMode.Stretch )
+			self.__widgetNameColumn = GafferUI.PathListingWidget.StandardColumn( "Name", "widgetEditor:name" )
 
 			self.__widgetListingWidget = GafferUI.PathListingWidget(
 				WidgetPath( None ),  # temp until we make a WidgetPath
 				columns = (
 					self.__widgetNameColumn,
+					GafferUI.PathListingWidget.StandardColumn( "Type", "widgetEditor:widgetType" ),
 				),
 				selectionMode = GafferUI.PathListingWidget.SelectionMode.Row,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree

--- a/python/GafferUI/WidgetEditor.py
+++ b/python/GafferUI/WidgetEditor.py
@@ -103,6 +103,8 @@ class WidgetPath( Gaffer.Path ) :
 			"widgetEditor:name",
 			"widgetEditor:widget",
 			"widgetEditor:widgetType",
+			"widgetEditor:width",
+			"widgetEditor:height",
 		]
 
 	def property( self, name, canceller = None ) :
@@ -122,6 +124,10 @@ class WidgetPath( Gaffer.Path ) :
 			return widget
 		elif name == "widgetEditor:widgetType" :
 			return type( widget ).__name__
+		elif name == "widgetEditor:width" :
+			return widget.size().x
+		elif name == "widgetEditor:height" :
+			return widget.size().y
 
 	def widget( self ) :
 		# Returns the `GafferUI.Widget` for this path.
@@ -223,6 +229,8 @@ class WidgetEditor( GafferUI.Editor ) :
 				columns = (
 					self.__widgetNameColumn,
 					GafferUI.PathListingWidget.StandardColumn( "Type", "widgetEditor:widgetType" ),
+					GafferUI.PathListingWidget.StandardColumn( "Width", "widgetEditor:width" ),
+					GafferUI.PathListingWidget.StandardColumn( "Height", "widgetEditor:height" ),
 				),
 				selectionMode = GafferUI.PathListingWidget.SelectionMode.Row,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree

--- a/python/GafferUI/WidgetEditor.py
+++ b/python/GafferUI/WidgetEditor.py
@@ -1,0 +1,207 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import imath
+
+import IECore
+
+import Gaffer
+import GafferUI
+
+
+class WidgetPath( Gaffer.Path ) :
+	# A `Gaffer.Path` to a `GafferUI.Widget` rooted at `rootWidget`. Path
+	# entries are string representations of the integer index into the parent
+	# widget's children for the widget, or the name of the parent's member variable
+	# for the widget.
+
+	def __init__( self, scriptNode, path = None, root = "/", filter = None ) :
+
+		Gaffer.Path.__init__( self, path = path, root = root, filter = filter )
+
+		self.__scriptNode = scriptNode
+
+	def copy( self ) :
+
+		return self.__class__( self.__scriptNode, self[:], self.root(), self.getFilter() )
+
+	def isValid( self, canceller = None ) :
+
+		return self.widget() is not None
+
+	def isLeaf( self, canceller = None ) :
+
+		return self.isValid() and len( self.__childWidgets( self.widget() ) ) == 0
+
+	def propertyNames( self ) :
+
+		return Gaffer.Path.propertyNames() + [
+			"widgetEditor:name",
+			"widgetEditor:widget"
+		]
+
+	def property( self, name, canceller = None ) :
+
+		result = Gaffer.Path.property( self, name )
+
+		if result is not None :
+			return result
+
+		widget = self.widget()
+		if widget is None :
+			return None
+
+		if name == "widgetEditor:name" :
+			return self[-1]
+		elif name == "widgetEditor:widget" :
+			return widget
+
+	def widget( self ) :
+		# Returns the `GafferUI.Widget` for this path.
+
+		if self.__scriptNode is None :
+			return None
+
+		widget = GafferUI.ScriptWindow.acquire( self.__scriptNode )
+		assert( widget is not None )
+		# A path with a single element is the top level `ScriptWindow`, start looking below that.
+		for i in self[1:] :
+			childWidgets = self.__childWidgets( widget )
+			if i.isnumeric():
+				widget = widget[ int( i ) ]
+			else :
+				widget = childWidgets[i]
+
+		return widget
+
+	def scriptNode( self ) :
+
+		return self.__scriptNode
+
+	def _children( self, canceller ) :
+
+		if not self.isValid() or self.isLeaf() :
+			return []
+
+		if len( self ) == 0 :
+			return [ WidgetPath( self.__scriptNode, self[:] + ["scriptWindow"], self.root(), self.getFilter() ) ]
+
+		childWidgets = self.__childWidgets( self.widget() )
+		return [
+			WidgetPath( self.__scriptNode, self[:] + [ k ], self.root(), self.getFilter() )
+			for k in childWidgets.keys()
+		]
+
+	def __repr__( self ) :
+
+		result = "GafferUI.ScriptWindow.acquire(root)"
+		for p in self[1:] :
+			if p.isnumeric() :
+				result += f"[{p}]"
+			else :
+				result += "." + p
+
+		return result
+
+	def __isAggregate( self, widget ) :
+
+		return hasattr( widget, "__getitem__" ) and hasattr( widget, "__len__" )
+
+	def __childWidgets( self, widget ) :
+
+		result = {}
+
+		visited = set()
+
+		if self.__isAggregate( widget ) :
+			for i in range( 0, len( widget ) ) :
+				if isinstance( widget[i], GafferUI.Widget ) and widget[i] not in visited :
+					result[str( i )] = widget[i]
+					visited.add( widget[i] )
+
+		for a in dir( widget ) :
+			if isinstance( getattr( widget, a ), GafferUI.Widget ) and getattr( widget, a ) not in visited :
+				result[a] = getattr( widget, a )
+				visited.add( getattr( widget, a ) )
+
+		return result
+
+class WidgetEditor( GafferUI.Editor ) :
+
+	def __init__( self, scriptNode, **kw ) :
+
+		column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 4, spacing = 4 )
+		GafferUI.Editor.__init__( self, column, scriptNode, **kw )
+
+		self.__scriptNode = scriptNode
+
+		with column :
+
+			self.__widgetNameColumn = GafferUI.PathListingWidget.StandardColumn( "Name", "widgetEditor:name", sizeMode = GafferUI.PathColumn.SizeMode.Stretch )
+
+			self.__widgetListingWidget = GafferUI.PathListingWidget(
+				WidgetPath( None ),  # temp until we make a WidgetPath
+				columns = (
+					self.__widgetNameColumn,
+				),
+				selectionMode = GafferUI.PathListingWidget.SelectionMode.Row,
+				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+			)
+
+			self.__widgetListingWidget.dragBeginSignal().connectFront( Gaffer.WeakMethod( self.__dragBegin ) )
+
+		self.visibilityChangedSignal().connect( Gaffer.WeakMethod( self.__visibilityChanged ) )
+
+	def __repr__( self ) :
+
+		return "GafferUI.WidgetEditor( scriptNode )"
+
+	def __dragBegin( self, widget, event ) :
+
+		path = self.__widgetListingWidget.pathAt( imath.V2f( event.line.p0.x, event.line.p0.y ) )
+
+		column = self.__widgetListingWidget.columnAt( imath.V2f( event.line.p0.x, event.line.p0.y ) )
+
+		if column == self.__widgetNameColumn :
+			GafferUI.Pointer.setCurrent( "nodes" )
+			return path
+
+	def __visibilityChanged( self, widget ) :
+
+		if widget.visible() and self.__widgetListingWidget.getPath().scriptNode() is None :
+			self.__widgetListingWidget.setPath( WidgetPath( self.__scriptNode ) )
+
+GafferUI.Editor.registerType( "WidgetEditor", WidgetEditor )

--- a/python/GafferUI/WidgetEditor.py
+++ b/python/GafferUI/WidgetEditor.py
@@ -105,6 +105,10 @@ class WidgetPath( Gaffer.Path ) :
 			"widgetEditor:widgetType",
 			"widgetEditor:width",
 			"widgetEditor:height",
+			"widgetEditor:minimumWidth",
+			"widgetEditor:minimumHeight",
+			"widgetEditor:maximumWidth",
+			"widgetEditor:maximumHeight",
 		]
 
 	def property( self, name, canceller = None ) :
@@ -128,6 +132,14 @@ class WidgetPath( Gaffer.Path ) :
 			return widget.size().x
 		elif name == "widgetEditor:height" :
 			return widget.size().y
+		elif name == "widgetEditor:minimumWidth" :
+			return widget._qtWidget().minimumwidth()
+		elif name == "widgetEditor:minimumHeight" :
+			return widget._qtWidget().minimumheight()
+		elif name == "widgetEditor:maximumWidth" :
+			return widget._qtWidget().maximumWidth()
+		elif name == "widgetEditor:maximumHeight" :
+			return widget._qtWidget().maximumHeight()
 
 	def widget( self ) :
 		# Returns the `GafferUI.Widget` for this path.
@@ -231,6 +243,10 @@ class WidgetEditor( GafferUI.Editor ) :
 					GafferUI.PathListingWidget.StandardColumn( "Type", "widgetEditor:widgetType" ),
 					GafferUI.PathListingWidget.StandardColumn( "Width", "widgetEditor:width" ),
 					GafferUI.PathListingWidget.StandardColumn( "Height", "widgetEditor:height" ),
+					GafferUI.PathListingWidget.StandardColumn( "Minimum Width", "widgetEditor:minumumWidth" ),
+					GafferUI.PathListingWidget.StandardColumn( "Minimum Height", "widgetEditor:minumumHeight" ),
+					GafferUI.PathListingWidget.StandardColumn( "Maximum Width", "widgetEditor:maximumWidth" ),
+					GafferUI.PathListingWidget.StandardColumn( "Maximum Height", "widgetEditor:maximumHeight" ),
 				),
 				selectionMode = GafferUI.PathListingWidget.SelectionMode.Row,
 				displayMode = GafferUI.PathListingWidget.DisplayMode.Tree

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -275,6 +275,9 @@ from . import AnnotationsUI
 from .TweakPlugValueWidget import TweakPlugValueWidget
 from .PlugPopup import PlugPopup
 from .OptionalValuePlugValueWidget import OptionalValuePlugValueWidget
+from .WidgetEditor import WidgetEditor
+from .WidgetEditor import WidgetPath
+
 
 # and then specific node uis
 

--- a/startup/gui/layouts.py
+++ b/startup/gui/layouts.py
@@ -58,6 +58,7 @@ layouts.registerEditor( "LocalJobs" )
 layouts.registerEditor( "ImageInspector")
 layouts.registerEditor( "RenderPassEditor" )
 layouts.registerEditor( "AttributeEditor" )
+layouts.registerEditor( "WidgetEditor" )
 
 # Register some predefined layouts
 #


### PR DESCRIPTION
This adds a new editor for inspecting (and someday, actually editing) widget properties in the UI. I've been working on it on Friday afternoons for a bit now - it's not done by any means, but I think it's worth having a look at the current state to see what we think about the direction it's going in and how the basics are working out.

Currently it can :
- Browse the hierarchy of widgets starting with the script window children.
- Let the user pick a widget with the mouse and focus on that widget in the hierarchy.
- A variation on picking widgets where the picker waits 3 seconds to activate in case you need to open a menu or similar.
- Highlight the selected widget in the UI with a blue overlay.
- Drag and drop into the Python editor to get code for identifying that widget.

Here are a few items I have on mind for discussion :
- How to expose the editor. Currently I have it as a registered editor you can add to a layout (but not part of any default layout). Is even that giving it too much exposure to users who will likely never need it and may be confused by it?
- How to allow editing since the values are not plugs. I'm thinking custom columns as needed that respond to double clicks by popping up a `NumericWidget`, but haven't started to implement this, maybe there's a better solution.
- Add other properties.
- Allow changing the root window to something other than the script window so you can inspect widgets in a dialog box.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
