### PR TITLE
Render Pass Menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
   - The shading mode menu icon now updates to indicate when a non-default shading mode is in use.
   - Added the ability to toggle between default shading and the last selected shading mode by <kbd>Ctrl</kbd> + clicking the shading mode menu button.
 - PythonEditor : Added workaround for slow code completion caused by poorly performing Python property getters.
+- PlugLayout : A warning widget is now displayed when an invalid custom widget is registered.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ API
   - Backward compatibility is not trivial to maintain in this case.
 - PlugAlgo : Added `contextSensitiveSource()` method.
 - ShaderPlug : Added Python binding for `parameterSource()` method.
+- ScriptNodeAlgo : Added `setCurrentRenderPass()`, `getCurrentRenderPass()`, and `acquireRenderPassPlug()` methods.
 
 1.5.2.0 (relative to 1.5.1.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,7 @@ Improvements
 - PlugLayout :
   - A warning widget is now displayed when an invalid custom widget is registered.
   - `layout:customWidget:<name>:width` and `layout:customWidget:<name>:minimumWidth` metadata registrations are now supported for custom widgets.
-- RenderPassEditor : Render passes disabled by render adaptors registered to `client = "RenderPassWedge"` are now shown as disabled. To differentiate these from user disabled render passes, an orange dot is shown in the corner of the disabled icon and the tooltip describes them as automatically disabled.
+- RenderPassEditor : Render passes deleted or disabled by render adaptors registered to `client = "RenderPassWedge"` are now shown as disabled. To differentiate these from user disabled render passes, an orange dot is shown in the corner of the disabled icon and the tooltip describes them as automatically disabled.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -17,7 +17,9 @@ Improvements
   - The shading mode menu icon now updates to indicate when a non-default shading mode is in use.
   - Added the ability to toggle between default shading and the last selected shading mode by <kbd>Ctrl</kbd> + clicking the shading mode menu button.
 - PythonEditor : Added workaround for slow code completion caused by poorly performing Python property getters.
-- PlugLayout : A warning widget is now displayed when an invalid custom widget is registered.
+- PlugLayout :
+  - A warning widget is now displayed when an invalid custom widget is registered.
+  - `layout:customWidget:<name>:width` and `layout:customWidget:<name>:minimumWidth` metadata registrations are now supported for custom widgets.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - PrimitiveVariableTweaks : Added node for tweaking primitive variables. Can affect just part of a primitive based on ids or a mask.
+- Menu Bar : Added a "Render Pass" menu to the Menu Bar that can be used to choose the current render pass from those provided by the focus node.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
 - PlugLayout :
   - A warning widget is now displayed when an invalid custom widget is registered.
   - `layout:customWidget:<name>:width` and `layout:customWidget:<name>:minimumWidth` metadata registrations are now supported for custom widgets.
+- RenderPassEditor : Render passes disabled by render adaptors registered to `client = "RenderPassWedge"` are now shown as disabled. To differentiate these from user disabled render passes, an orange dot is shown in the corner of the disabled icon and the tooltip describes them as automatically disabled.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,9 @@ Improvements
 - PlugLayout :
   - A warning widget is now displayed when an invalid custom widget is registered.
   - `layout:customWidget:<name>:width` and `layout:customWidget:<name>:minimumWidth` metadata registrations are now supported for custom widgets.
-- RenderPassEditor : Render passes deleted or disabled by render adaptors registered to `client = "RenderPassWedge"` are now shown as disabled. To differentiate these from user disabled render passes, an orange dot is shown in the corner of the disabled icon and the tooltip describes them as automatically disabled.
+- RenderPassEditor :
+  - Render passes deleted or disabled by render adaptors registered to `client = "RenderPassWedge"` are now shown as disabled. To differentiate these from user disabled render passes, an orange dot is shown in the corner of the disabled icon and the tooltip describes them as automatically disabled.
+  - Changing the current render pass is now undoable.
 
 Fixes
 -----

--- a/include/GafferSceneUI/ScriptNodeAlgo.h
+++ b/include/GafferSceneUI/ScriptNodeAlgo.h
@@ -40,6 +40,7 @@
 
 #include "GafferScene/VisibleSet.h"
 
+#include "Gaffer/NameValuePlug.h"
 #include "Gaffer/Signals.h"
 
 #include "IECore/PathMatcher.h"
@@ -111,6 +112,16 @@ GAFFERSCENEUI_API std::vector<IECore::InternedString> getLastSelectedPath( const
 
 /// Returns a signal emitted when either the selected paths or last selected path change for `script`.
 GAFFERSCENEUI_API ChangedSignal &selectedPathsChangedSignal( Gaffer::ScriptNode *script );
+
+/// Render Passes
+/// =============
+
+/// Acquires a plug used to specify the current render pass for the script.
+GAFFERSCENEUI_API Gaffer::NameValuePlug *acquireRenderPassPlug( Gaffer::ScriptNode *script, bool createIfMissing = true );
+/// Sets the current render pass for the script.
+GAFFERSCENEUI_API void setCurrentRenderPass( Gaffer::ScriptNode *script, std::string renderPass );
+/// Returns the current render pass for the script.
+GAFFERSCENEUI_API std::string getCurrentRenderPass( const Gaffer::ScriptNode *script );
 
 } // namespace ScriptNodeAlgo
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -244,15 +244,15 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		adaptors["__adaptorSwitch"] = Gaffer.Switch()
 		adaptors["__adaptorSwitch"].setup( GafferScene.ScenePlug() )
-		adaptors["__adaptorSwitch"]["in"]["in0"].setInput( adaptors["__renderAdaptors"]["out"] )
-		adaptors["__adaptorSwitch"]["in"]["in1"].setInput( adaptors["in"] )
+		adaptors["__adaptorSwitch"]["in"]["in0"].setInput( adaptors["in"] )
+		adaptors["__adaptorSwitch"]["in"]["in1"].setInput( adaptors["__renderAdaptors"]["out"] )
 
 		adaptors["__contextQuery"] = Gaffer.ContextQuery()
-		adaptors["__contextQuery"].addQuery( Gaffer.BoolPlug( "disableAdaptors", defaultValue = False ) )
-		adaptors["__contextQuery"]["queries"][0]["name"].setValue( "renderPassEditor:disableAdaptors" )
+		adaptors["__contextQuery"].addQuery( Gaffer.BoolPlug( "enableAdaptors", defaultValue = False ) )
+		adaptors["__contextQuery"]["queries"][0]["name"].setValue( "renderPassEditor:enableAdaptors" )
 
 		adaptors["__adaptorSwitch"]["index"].setInput( adaptors["__contextQuery"]["out"][0]["value"] )
-		adaptors["__adaptorSwitch"]["deleteContextVariables"].setValue( "renderPassEditor:disableAdaptors" )
+		adaptors["__adaptorSwitch"]["deleteContextVariables"].setValue( "renderPassEditor:enableAdaptors" )
 
 		adaptors["out"].setInput( adaptors["__adaptorSwitch"]["out"] )
 
@@ -1030,19 +1030,20 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 			renderPasses = {}
 
 			with Gaffer.Context( Gaffer.Context.current() ) as context :
+				context["renderPassEditor:enableAdaptors"] = True
 				adaptedRenderPassNames = globalsPlug.getValue().get( "option:renderPass:names", IECore.StringVectorData() )
-				context["renderPassEditor:disableAdaptors"] = True
+				context["renderPassEditor:enableAdaptors"] = False
 				for renderPass in globalsPlug.getValue().get( "option:renderPass:names", IECore.StringVectorData() ) :
 					renderPasses.setdefault( "all", [] ).append( renderPass )
 					context["renderPass"] = renderPass
-					context["renderPassEditor:disableAdaptors"] = False
+					context["renderPassEditor:enableAdaptors"] = True
 					if renderPass not in adaptedRenderPassNames :
 						# The render pass has been deleted by a render adaptor so present it as disabled
 						renderPasses.setdefault( "adaptorDisabled", [] ).append( renderPass )
 					elif globalsPlug.getValue().get( "option:renderPass:enabled", IECore.BoolData( True ) ).value :
 						renderPasses.setdefault( "enabled", [] ).append( renderPass )
 					else :
-						context["renderPassEditor:disableAdaptors"] = True
+						context["renderPassEditor:enableAdaptors"] = False
 						if globalsPlug.getValue().get( "option:renderPass:enabled", IECore.BoolData( True ) ).value :
 							renderPasses.setdefault( "adaptorDisabled", [] ).append( renderPass )
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1030,11 +1030,16 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 			renderPasses = {}
 
 			with Gaffer.Context( Gaffer.Context.current() ) as context :
+				adaptedRenderPassNames = globalsPlug.getValue().get( "option:renderPass:names", IECore.StringVectorData() )
+				context["renderPassEditor:disableAdaptors"] = True
 				for renderPass in globalsPlug.getValue().get( "option:renderPass:names", IECore.StringVectorData() ) :
 					renderPasses.setdefault( "all", [] ).append( renderPass )
 					context["renderPass"] = renderPass
 					context["renderPassEditor:disableAdaptors"] = False
-					if globalsPlug.getValue().get( "option:renderPass:enabled", IECore.BoolData( True ) ).value :
+					if renderPass not in adaptedRenderPassNames :
+						# The render pass has been deleted by a render adaptor so present it as disabled
+						renderPasses.setdefault( "adaptorDisabled", [] ).append( renderPass )
+					elif globalsPlug.getValue().get( "option:renderPass:enabled", IECore.BoolData( True ) ).value :
 						renderPasses.setdefault( "enabled", [] ).append( renderPass )
 					else :
 						context["renderPassEditor:disableAdaptors"] = True

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -360,17 +360,10 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			self.__popup.popup( parent = self )
 			return
 
-		## \todo Perhaps we should add `ScriptNodeAlgo.set/getCurrentRenderPass()`
-		# to wrap this up for general consumption?
-		if "renderPass" not in script["variables"] :
-			renderPassPlug = Gaffer.NameValuePlug( "renderPass", "", "renderPass", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
-			script["variables"].addChild( renderPassPlug )
-			Gaffer.MetadataAlgo.setReadOnly( renderPassPlug["name"], True )
-		else :
-			renderPassPlug = script["variables"]["renderPass"]
-
-		currentRenderPass = renderPassPlug["value"].getValue()
-		renderPassPlug["value"].setValue( selectedPassNames[0] if selectedPassNames[0] != currentRenderPass else "" )
+		GafferSceneUI.ScriptNodeAlgo.setCurrentRenderPass(
+			script,
+			selectedPassNames[0] if selectedPassNames[0] != GafferSceneUI.ScriptNodeAlgo.getCurrentRenderPass( script ) else ""
+		)
 
 	def __columnContextMenuSignal( self, column, pathListing, menuDefinition ) :
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -399,10 +399,11 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			self.__popup.popup( parent = self )
 			return
 
-		GafferSceneUI.ScriptNodeAlgo.setCurrentRenderPass(
-			script,
-			selectedPassNames[0] if selectedPassNames[0] != GafferSceneUI.ScriptNodeAlgo.getCurrentRenderPass( script ) else ""
-		)
+		with Gaffer.UndoScope( script ) :
+			GafferSceneUI.ScriptNodeAlgo.setCurrentRenderPass(
+				script,
+				selectedPassNames[0] if selectedPassNames[0] != GafferSceneUI.ScriptNodeAlgo.getCurrentRenderPass( script ) else ""
+			)
 
 	def __columnContextMenuSignal( self, column, pathListing, menuDefinition ) :
 
@@ -1150,8 +1151,9 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __setCurrentRenderPass( self, renderPass, *unused ) :
 
-		for plug in self.getPlugs() :
-			plug.setValue( renderPass )
+		with Gaffer.UndoScope( self.scriptNode() ) :
+			for plug in self.getPlugs() :
+				plug.setValue( renderPass )
 
 	def __renderPassDescription( self, renderPass ) :
 

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -208,6 +208,35 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 			self.assertEqual( pathCopy.property( "renderPassPath:enabled" ), p in ( "/A", "/D" ) )
 			self.assertTrue( pathCopy.property( "renderPassPath:enabledWithoutAdaptors" ) )
 
+	def testRenderPassPathAdaptorDeletingPasses( self ) :
+
+		def createAdaptor() :
+
+			node = GafferScene.DeleteRenderPasses()
+			node["names"].setValue( "B C" )
+			return node
+
+		GafferScene.SceneAlgo.registerRenderAdaptor( "RenderPassEditorTest", createAdaptor, client = "RenderPassWedge" )
+		self.addCleanup( GafferScene.SceneAlgo.deregisterRenderAdaptor, "RenderPassEditorTest" )
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( [ "A", "B", "C", "D" ] ) )
+
+		adaptors = GafferSceneUI.RenderPassEditor._createRenderAdaptors()
+		adaptors["in"].setInput( renderPasses["out"] )
+
+		context = Gaffer.Context()
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( adaptors["out"], context, "/" )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
+
+		pathCopy = path.copy()
+
+		for p in [ "/A", "/B", "/C", "/D" ] :
+			pathCopy.setFromString( p )
+			self.assertEqual( pathCopy.property( "renderPassPath:enabled" ), p in ( "/A", "/D" ) )
+			self.assertTrue( pathCopy.property( "renderPassPath:enabledWithoutAdaptors" ) )
+
 	def testSearchFilter( self ) :
 
 		renderPasses = GafferScene.RenderPasses()

--- a/python/GafferSceneUITest/RenderPassEditorTest.py
+++ b/python/GafferSceneUITest/RenderPassEditorTest.py
@@ -202,11 +202,17 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
 
 		pathCopy = path.copy()
+		c = _GafferSceneUI._RenderPassEditor.RenderPassNameColumn()
 
 		for p in [ "/A", "/B", "/C", "/D" ] :
 			pathCopy.setFromString( p )
-			self.assertEqual( pathCopy.property( "renderPassPath:enabled" ), p in ( "/A", "/D" ) )
-			self.assertTrue( pathCopy.property( "renderPassPath:enabledWithoutAdaptors" ) )
+			cellData = c.cellData( pathCopy, None )
+			if p in ( "/A", "/D" ) :
+				self.assertEqual( cellData.icon, "renderPass.png" )
+				self.assertEqual( cellData.toolTip, None )
+			else :
+				self.assertEqual( cellData.icon, "adaptorDisabledRenderPass.png" )
+				self.assertEqual( cellData.toolTip, "Automatically disabled by a render adaptor." )
 
 	def testRenderPassPathAdaptorDeletingPasses( self ) :
 
@@ -231,11 +237,17 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
 
 		pathCopy = path.copy()
+		c = _GafferSceneUI._RenderPassEditor.RenderPassNameColumn()
 
 		for p in [ "/A", "/B", "/C", "/D" ] :
 			pathCopy.setFromString( p )
-			self.assertEqual( pathCopy.property( "renderPassPath:enabled" ), p in ( "/A", "/D" ) )
-			self.assertTrue( pathCopy.property( "renderPassPath:enabledWithoutAdaptors" ) )
+			cellData = c.cellData( pathCopy, None )
+			if p in ( "/A", "/D" ) :
+				self.assertEqual( cellData.icon, "renderPass.png" )
+				self.assertEqual( cellData.toolTip, None )
+			else :
+				self.assertEqual( cellData.icon, "adaptorDisabledRenderPass.png" )
+				self.assertEqual( cellData.toolTip, "Automatically disabled by a render adaptor." )
 
 	def testSearchFilter( self ) :
 
@@ -289,6 +301,52 @@ class RenderPassEditorTest( GafferUITest.TestCase ) :
 		path.setFilter( disabledRenderPassFilter )
 
 		self.assertEqual( [ str( c ) for c in path.children() ], [ "/B", "/C" ] )
+
+		disabledRenderPassFilter.setEnabled( False )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
+
+	def testDisabledRenderPassFilterWithAdaptor( self ) :
+
+		def createAdaptor() :
+
+			node = GafferScene.SceneProcessor()
+			node["options"] = GafferScene.CustomOptions()
+			node["options"]["in"].setInput( node["in"] )
+			node["options"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:enabled", False ) )
+
+			node["switch"] = Gaffer.NameSwitch()
+			node["switch"].setup( node["options"]["out"] )
+			node["switch"]["in"][0]["value"].setInput( node["in"] )
+			node["switch"]["in"][1]["value"].setInput( node["options"]["out"] )
+			node["switch"]["in"][1]["name"].setValue( "B" )
+			node["switch"]["selector"].setValue( "${renderPass}" )
+
+			node["delete"] = GafferScene.DeleteRenderPasses()
+			node["delete"]["names"].setValue( "C" )
+			node["delete"]["in"].setInput( node["switch"]["out"]["value"] )
+
+			node["out"].setInput( node["delete"]["out"] )
+
+			return node
+
+		GafferScene.SceneAlgo.registerRenderAdaptor( "RenderPassEditorTest", createAdaptor, client = "RenderPassWedge" )
+		self.addCleanup( GafferScene.SceneAlgo.deregisterRenderAdaptor, "RenderPassEditorTest" )
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( ["A", "B", "C", "D"] ) )
+
+		adaptors = GafferSceneUI.RenderPassEditor._createRenderAdaptors()
+		adaptors["in"].setInput( renderPasses["out"] )
+
+		context = Gaffer.Context()
+		path = _GafferSceneUI._RenderPassEditor.RenderPassPath( adaptors["out"], context, "/" )
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/B", "/C", "/D" ] )
+
+		disabledRenderPassFilter = _GafferSceneUI._RenderPassEditor.DisabledRenderPassFilter()
+		path.setFilter( disabledRenderPassFilter )
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/A", "/D" ] )
 
 		disabledRenderPassFilter.setEnabled( False )
 

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -426,9 +426,14 @@ class PlugLayout( GafferUI.Widget ) :
 	def __createCustomWidget( self, name ) :
 
 		widgetType = self.__itemMetadataValue( name, "widgetType" )
-		widgetClass = self.__import( widgetType )
+		try :
+			widgetClass = self.__import( widgetType )
+			result = widgetClass( self.__parent )
+		except Exception as e :
+			message = "Could not create custom widget \"{}\" : {}".format( name, str( e ) )
+			IECore.msg( IECore.Msg.Level.Error, "GafferUI.PlugLayout", message )
 
-		result = widgetClass( self.__parent )
+			result = _MissingCustomWidget( self.__parent, message )
 
 		return result
 
@@ -753,3 +758,16 @@ class _CollapsibleLayout( _Layout ) :
 	def __collapsibleStateChanged( self, collapsible, subsection ) :
 
 		subsection.saveState( "collapsed", collapsible.getCollapsed() )
+
+class _MissingCustomWidget( GafferUI.Widget ) :
+
+	def __init__( self, parent, warning, **kw ) :
+
+		self.__image = GafferUI.Image( "warningSmall.png" )
+		self.__warning = warning
+
+		GafferUI.Widget.__init__( self, self.__image, **kw )
+
+	def getToolTip( self ) :
+
+		return self.__warning

--- a/python/GafferUI/PlugLayout.py
+++ b/python/GafferUI/PlugLayout.py
@@ -390,22 +390,26 @@ class PlugLayout( GafferUI.Widget ) :
 
 		return result
 
+	def __setWidthFromMetadata( self, widget, item ) :
+
+		width = self.__itemMetadataValue( item, "width" )
+		if width is not None :
+			widget._qtWidget().setFixedWidth( width )
+
+		minimumWidth = self.__itemMetadataValue( item, "minimumWidth" )
+		if minimumWidth is not None :
+			widget._qtWidget().setMinimumWidth( minimumWidth )
+
+		if widget._qtWidget().layout() is not None and ( width is not None or minimumWidth is not None ) :
+			widget._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
+
 	def __createPlugWidget( self, plug ) :
 
 		result = GafferUI.PlugValueWidget.create( plug )
 		if result is None :
 			return result
 
-		width = self.__itemMetadataValue( plug, "width" )
-		if width is not None :
-			result._qtWidget().setFixedWidth( width )
-
-		minimumWidth = self.__itemMetadataValue( plug, "minimumWidth" )
-		if minimumWidth is not None :
-			result._qtWidget().setMinimumWidth( minimumWidth )
-
-		if result._qtWidget().layout() is not None and ( width is not None or minimumWidth is not None ) :
-			result._qtWidget().layout().setSizeConstraint( QtWidgets.QLayout.SetDefaultConstraint )
+		self.__setWidthFromMetadata( result, plug )
 
 		if isinstance( result, GafferUI.PlugValueWidget ) and not result.hasLabel() and self.__itemMetadataValue( plug, "label" ) != "" :
 			result = GafferUI.PlugWidget( result )
@@ -429,6 +433,7 @@ class PlugLayout( GafferUI.Widget ) :
 		try :
 			widgetClass = self.__import( widgetType )
 			result = widgetClass( self.__parent )
+			self.__setWidthFromMetadata( result, name )
 		except Exception as e :
 			message = "Could not create custom widget \"{}\" : {}".format( name, str( e ) )
 			IECore.msg( IECore.Msg.Level.Error, "GafferUI.PlugLayout", message )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1307,6 +1307,12 @@ _styleSheet = string.Template(
 		padding-bottom: 0px;
 	}
 
+	*[gafferClass="GafferSceneUI.RenderPassEditor"] QTreeView::item {
+		min-height: 22px;
+		padding-top: 0px;
+		padding-bottom: 0px;
+	}
+
 	*[gafferClass="GafferSceneUI._HistoryWindow"] QTreeView::item {
 		height: 18px;
 		padding-top: 0px;

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1538,7 +1538,18 @@ _styleSheet = string.Template(
 		padding: 2px;
 	}
 
-	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
+	#gafferMenuBarWidgetContainer QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
+	{
+		border: 1px solid rgb( 70, 70, 70 );
+		border-top-color: rgb( 108, 108, 108 );
+		border-left-color: rgb( 108, 108, 108 );
+		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb( 108, 108, 108 ), stop: 0.1 rgb( 91, 91, 91 ), stop: 0.90 rgb( 81, 81, 81 ));
+		margin-top: 2px;
+		margin-bottom: 2px;
+	}
+
+	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"],
+	#gafferMenuBarWidgetContainer *[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
 	{
 		border: 1px solid rgb( 46, 75, 107 );
 		border-top-color: rgb( 75, 113, 155 );

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1538,6 +1538,11 @@ _styleSheet = string.Template(
 		padding: 2px;
 	}
 
+	*[gafferClass="GafferSceneUI.RenderPassEditor._RenderPassPlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
+	{
+		min-height: 14px;
+	}
+
 	#gafferMenuBarWidgetContainer QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"]
 	{
 		border: 1px solid rgb( 70, 70, 70 );
@@ -1546,6 +1551,7 @@ _styleSheet = string.Template(
 		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb( 108, 108, 108 ), stop: 0.1 rgb( 91, 91, 91 ), stop: 0.90 rgb( 81, 81, 81 ));
 		margin-top: 2px;
 		margin-bottom: 2px;
+		min-height: 14px;
 	}
 
 	*[gafferClass="GafferUI.EditScopeUI.EditScopePlugValueWidget"] QPushButton[gafferWithFrame="true"][gafferMenuIndicator="true"],
@@ -1557,6 +1563,7 @@ _styleSheet = string.Template(
 		background-color : qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 rgb( 69, 113, 161 ), stop: 0.1 rgb( 48, 99, 153 ), stop: 0.90 rgb( 54, 88, 125 ));
 		margin-top: 2px;
 		margin-bottom: 2px;
+		min-height: 14px;
 	}
 
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] QPushButton[gafferWithFrame="true"] {

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -463,8 +463,8 @@
 		"renderPassEditor" : {
 
 			"options" : {
-				"requiredWidth" : 16,
-				"requiredHeight" : 16,
+				"requiredWidth" : 14,
+				"requiredHeight" : 14,
 				"validatePixelAlignment" : True
 			},
 

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -471,6 +471,7 @@
 			"ids" : [
 				"renderPass",
 				"disabledRenderPass",
+				"adaptorDisabledRenderPass",
 				"renderPassFolder",
 				"activeRenderPass",
 				"activeRenderPassFadedHighlighted",

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3555,41 +3555,41 @@
       <rect
          inkscape:label="renderPassIcon"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-         width="16"
-         height="16"
-         x="30"
-         y="2776"
+         width="14"
+         height="14"
+         x="31"
+         y="2777"
          id="renderPass" />
       <rect
          id="disabledRenderPass"
-         y="2776"
-         x="50"
-         height="16"
-         width="16"
+         y="2777"
+         x="51"
+         height="14"
+         width="14"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="disabledRenderPassIcon" />
       <rect
          id="renderPassFolder"
-         y="2776"
-         x="70"
-         height="16"
-         width="16"
+         y="2777"
+         x="71"
+         height="14"
+         width="14"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="renderPassFolderIcon" />
       <rect
          id="activeRenderPass"
-         y="2776"
-         x="90"
-         height="16"
-         width="16"
+         y="2777"
+         x="91"
+         height="14"
+         width="14"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="activeRenderPassIcon" />
       <rect
          id="activeRenderPassFadedHighlighted"
-         y="2776"
-         x="110"
-         height="16"
-         width="16"
+         y="2777"
+         x="111"
+         height="14"
+         width="14"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="activeRenderPassFadedHighlightedIcon" />
     </g>
@@ -10189,10 +10189,10 @@
        transform="translate(0,159.23177)">
       <rect
          id="rect8"
-         y="2776.1304"
+         y="2777.1304"
          x="9.9351273"
-         height="16"
-         width="16"
+         height="14"
+         width="14"
          style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="sizeGuide" />
       <g

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -3592,6 +3592,14 @@
          width="14"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="activeRenderPassFadedHighlightedIcon" />
+      <rect
+         id="adaptorDisabledRenderPass"
+         y="2777"
+         x="131"
+         height="14"
+         width="14"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="adaptorDisabledRenderPassIcon" />
     </g>
     <rect
        style="display:inline;fill:none;fill-opacity:1;stroke:none;stroke-opacity:1"
@@ -10277,6 +10285,32 @@
            cx="56.179211"
            id="circle6253-6"
            style="display:inline;vector-effect:none;fill:#f0dc28;fill-opacity:0.38041458;fill-rule:nonzero;stroke:#779cbd;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal" />
+      </g>
+      <g
+         style="fill:url(#backgroundLight);fill-opacity:1"
+         inkscape:label="adaptorDisabledRenderPass"
+         id="g3"
+         transform="translate(79.963757,0.12970317)">
+        <rect
+           style="display:inline;fill:url(#backgroundLight);stroke:#3d3d3d;stroke-width:1;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect1"
+           width="11"
+           height="7"
+           x="52.537006"
+           y="2782.4839" />
+        <rect
+           style="display:inline;fill:url(#backgroundLight);stroke:#3d3d3d;stroke-width:1;stroke-linejoin:miter;stroke-dasharray:none"
+           id="rect2"
+           width="11"
+           height="2.5"
+           x="52.536243"
+           y="2779.0571" />
+        <circle
+           style="display:inline;fill:#d66800;fill-opacity:1;stroke:none;stroke-width:8.001;stroke-dasharray:none;stroke-opacity:1"
+           id="path3"
+           cx="53.036243"
+           cy="2779.0007"
+           r="2" />
       </g>
     </g>
     <path

--- a/src/GafferSceneUIModule/ScriptNodeAlgoBinding.cpp
+++ b/src/GafferSceneUIModule/ScriptNodeAlgoBinding.cpp
@@ -98,6 +98,23 @@ std::string getLastSelectedPathWrapper( const ScriptNode &script )
 	return result;
 }
 
+NameValuePlugPtr acquireRenderPassPlugWrapper( Gaffer::ScriptNode &script, bool createIfMissing )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return acquireRenderPassPlug( &script, createIfMissing );
+}
+
+void setCurrentRenderPassWrapper( ScriptNode &script, const std::string &renderPass )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	setCurrentRenderPass( &script, renderPass );
+}
+
+std::string getCurrentRenderPassWrapper( ScriptNode &script )
+{
+	return getCurrentRenderPass( &script );
+}
+
 } // namespace
 
 void GafferSceneUIModule::bindScriptNodeAlgo()
@@ -117,4 +134,7 @@ void GafferSceneUIModule::bindScriptNodeAlgo()
 	def( "setLastSelectedPath", &setLastSelectedPathWrapper );
 	def( "getLastSelectedPath", &getLastSelectedPathWrapper );
 	def( "selectedPathsChangedSignal", &selectedPathsChangedSignal, return_value_policy<reference_existing_object>() );
+	def( "acquireRenderPassPlug", &acquireRenderPassPlugWrapper, ( arg( "script" ), arg( "createIfMissing" ) = true ) );
+	def( "setCurrentRenderPass", &setCurrentRenderPassWrapper );
+	def( "getCurrentRenderPass", &getCurrentRenderPassWrapper );
 }

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -45,6 +45,8 @@ import GafferImage
 import GafferDispatch
 import GafferTractor
 
+import GafferSceneUI
+
 ##########################################################################
 # Note this file is shared with the `dispatch` app. We need to ensure any
 # changes here have the desired behaviour in both applications.
@@ -66,6 +68,9 @@ def __scriptAdded( container, script ) :
 	Gaffer.MetadataAlgo.setReadOnly( variables["projectRootDirectory"]["name"], True )
 
 	GafferImage.FormatPlug.acquireDefaultFormatPlug( script )
+
+	renderPassPlug = GafferSceneUI.ScriptNodeAlgo.acquireRenderPassPlug( script )
+	Gaffer.Metadata.registerValue( renderPassPlug["value"], "plugValueWidget:type", "GafferSceneUI.RenderPassEditor._RenderPassPlugValueWidget" )
 
 application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
 

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -38,6 +38,7 @@ import os
 
 import IECore
 import Gaffer
+import GafferUI
 import GafferSceneUI
 
 GafferSceneUI.RenderPassEditor.registerOption( "*", "renderPass:enabled" )
@@ -130,3 +131,14 @@ def __defaultPathGroupingFunction( renderPassName ) :
 	return renderPassName.split( "_" )[0] if "_" in renderPassName else ""
 
 GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( __defaultPathGroupingFunction )
+
+def __compoundEditorCreated( editor ) :
+
+	if editor.scriptNode().ancestor( Gaffer.ApplicationRoot ).getName() == "gui" :
+
+		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:widgetType", "GafferSceneUI.RenderPassEditor.RenderPassChooserWidget" )
+		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:section", "Settings" )
+		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:index", 0 )
+		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:width", 185 )
+
+GafferUI.CompoundEditor.instanceCreatedSignal().connect( __compoundEditorCreated )


### PR DESCRIPTION
This adds a widget for selecting the current render pass to the Menu Bar. This is added as a customWidget registration that hosts a PlugValueWidget for the `script.variables.renderPass` plug. Of the few approaches that we've tried, this does seem the best, though the interplay between the widgets and their respective plugs on the ScriptNode and CompoundEditor still irks me a little, so suggestions are very welcome.

Given the introduction of #6030, it felt necessary to preview to users that the render passes they are interacting with in the menu may in fact be later disabled or deleted by a render adaptor. We present these to the user by overlaying an orange dot on the regular "disabled" render pass icon, and introducing some tooltips to disambiguate render passes automatically disabled by a render adaptor from those manually disabled in the scene. It made sense to adjust the RenderPassEditor's display of disabled render passes at the same time to keep the presentation in sync.

![renderPassMenu](https://github.com/user-attachments/assets/a7ee952e-881d-4e01-89a4-4ca00233d82d)
