### PR TITLE
Inspector : Make handling of downstream overrides consistent 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.3.0)
 =======
 
+Fixes
+-----
 
+- AttributeEditor, LightEditor, RenderPassEditor : Fixed warning message which referred to "None" rather than the "Source" scope.
 
 1.5.3.0 (relative to 1.5.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,10 @@
 Fixes
 -----
 
-- AttributeEditor, LightEditor, RenderPassEditor : Fixed warning message which referred to "None" rather than the "Source" scope.
+- AttributeEditor, LightEditor, RenderPassEditor :
+  - Fixed bugs which prevented edits being made in "Source" scope when there was a downstream edit in an EditScope (#6172).
+  - Fixed warning messages when attempting to disable a non-existent edit.
+  - Fixed warning message which referred to "None" rather than the "Source" scope.
 
 1.5.3.0 (relative to 1.5.2.0)
 =======

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -374,10 +374,15 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		Gaffer::EditScopePtr m_editScope;
 		bool m_editScopeInHistory;
 
-		EditFunctionOrFailure m_editFunction;
-		std::string m_editWarning;
+		struct Editors
+		{
+			/// \todo Rename to `acquireEditFunction`?
+			EditFunctionOrFailure editFunction;
+			std::string editWarning;
+			DisableEditFunctionOrFailure disableEditFunction;
+		};
 
-		DisableEditFunctionOrFailure m_disableEditFunction;
+		std::optional<Editors> m_editors;
 
 };
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -51,10 +51,10 @@
 #include "boost/multi_index/member.hpp"
 #include "boost/multi_index/random_access_index.hpp"
 #include "boost/multi_index_container.hpp"
-#include "boost/variant.hpp"
 
 #include <unordered_set>
 #include <unordered_map>
+#include <variant>
 
 namespace GafferSceneUIModule
 {
@@ -171,7 +171,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		virtual Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const;
 
 		using EditFunction = std::function<Gaffer::ValuePlugPtr ( bool createIfNecessary )>;
-		using EditFunctionOrFailure = boost::variant<EditFunction, std::string>;
+		using EditFunctionOrFailure = std::variant<EditFunction, std::string>;
 		/// Should be implemented to return a function that will acquire
 		/// an edit from the EditScope at the specified point in the history.
 		/// If this is not possible, should return an error explaining why
@@ -184,7 +184,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		virtual EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const;
 
 		using DisableEditFunction = std::function<void ()>;
-		using DisableEditFunctionOrFailure = boost::variant<DisableEditFunction, std::string>;
+		using DisableEditFunctionOrFailure = std::variant<DisableEditFunction, std::string>;
 		/// Can be implemented to return a function that will disable an edit
 		/// at the specified plug. If this is not possible, should return an
 		/// error explaining why (this is typically due to `readOnly` metadata).

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -912,8 +912,8 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/group/light", "gl:visualiser:scale", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to editScope1 to disable." )
-		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Edit is not in the current edit scope. Change scope to editScope1 to disable.", inspection.disableEdit )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope2." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : There is no edit in editScope2.", inspection.disableEdit )
 
 		Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], True )
 		inspection = self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] )
@@ -930,7 +930,7 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", s["editScope1"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to None to disable." )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope1." )
 
 		inspection = self.__inspect( s["editScope1"]["out"], "/group/light", "gl:visualiser:scale", None )
 		self.assertFalse( inspection.canDisableEdit() )

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -652,13 +652,15 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 			)
 
 			# When using no scope, make sure that we don't inadvertently edit the contents of an EditScope.
+			# We should be allowed to edit the source before the scope, but only with a warning about there
+			# being a downstream override.
 
 			self.__assertExpectedResult(
 				self.__inspect( s["editScope2"]["out"], "render:camera", None, context ),
 				source = s["editScope1"]["standardOptions3"]["options"]["renderCamera"],
-				sourceType = SourceType.Other,
-				editable = False,
-				nonEditableReason = "Source is in an EditScope. Change scope to editScope1 to edit."
+				sourceType = SourceType.Downstream,
+				editable = True,
+				editWarning = "Option has edits downstream in editScope1."
 			)
 
 			# If there is a StandardOptions node outside of an edit scope, make sure we use that with no scope
@@ -950,7 +952,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to None to disable." )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope2." )
 
 		Gaffer.MetadataAlgo.setReadOnly( s["standardOptions"]["options"], True )
 		inspection = self.__inspect( s["group"]["out"], "render:camera", None )
@@ -986,8 +988,8 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope2"]["out"], "render:camera", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to editScope1 to disable." )
-		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Edit is not in the current edit scope. Change scope to editScope1 to disable.", inspection.disableEdit )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope2." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : There is no edit in editScope2.", inspection.disableEdit )
 
 		Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], True )
 		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope1"] )

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -478,14 +478,15 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.assertEqual( inspection.nonDisableableReason(), "The target edit scope editScope2 is not in the scene history." )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/light", "exposure", None )
+		self.assertTrue( inspection.acquireEdit( False ).isSame( s["light"]["parameters"]["exposure"] ) )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Source is in an EditScope. Change scope to editScope to disable." )
-		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Source is in an EditScope. Change scope to editScope to disable.", inspection.disableEdit )
+		self.assertEqual( inspection.nonDisableableReason(), "Disabling edits not supported for this plug." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Disabling edits not supported for this plug.", inspection.disableEdit )
 
 		inspection = self.__inspect( s["editScope2"]["out"], "/light", "exposure", s["editScope2"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to editScope to disable." )
-		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Edit is not in the current edit scope. Change scope to editScope to disable.", inspection.disableEdit )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope2." )
+		self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : There is no edit in editScope2.", inspection.disableEdit )
 
 		Gaffer.MetadataAlgo.setReadOnly( s["editScope"], True )
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", s["editScope"] )
@@ -502,7 +503,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", s["editScope"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to Source to disable." )
+		self.assertEqual( inspection.nonDisableableReason(), "There is no edit in editScope." )
 
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", None )
 		self.assertEqual( inspection.source(), s["light"]["parameters"]["exposure"] )
@@ -1088,6 +1089,72 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 			editWarning = "Edits to box.add may affect other locations in the scene."
 		)
 
+	def testLightCreatedInEditScope( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		editScope1 = Gaffer.EditScope( "EditScope1" )
+		editScope1.setup( light["out"] )
+
+		editScope1["light"] = light
+		editScope1["parent"] = GafferScene.Parent()
+		editScope1["parent"]["parent"].setValue( "/" )
+		editScope1["parent"]["in"].setInput( editScope1["BoxIn"]["out"] )
+		editScope1["parent"]["children"][0].setInput( editScope1["light"]["out"] )
+
+		editScope1["BoxOut"]["in"].setInput( editScope1["parent"]["out"] )
+
+		editScope2 = Gaffer.EditScope( "EditScope2" )
+		editScope2.setup( editScope1["out"] )
+		editScope2["in"].setInput( editScope1["out"] )
+
+		# Make edit in EditScope2.
+
+		i = self.__inspect( editScope2["out"], "/light", "exposure", editScope2 )
+		scope2Edit = i.acquireEdit()
+		self.assertTrue( editScope2.isAncestorOf( scope2Edit ) )
+		scope2Edit["enabled"].setValue( True )
+		scope2Edit["value"].setValue( 2 )
+
+		# Check that we can still edit in EditScope1, accompanied by
+		# a suitable warning.
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope2["out"], "/light", "exposure", editScope1 ),
+			source = scope2Edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Downstream,
+			editable = True,
+			edit = light["parameters"]["exposure"],
+			editWarning = "Parameter has edits downstream in EditScope2."
+		)
+
+	def testSourceWithDownstreamOverride( self ) :
+
+		light = GafferSceneTest.TestLight()
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( light["out"] )
+		editScope["in"].setInput( light["out"] )
+
+		# Make edit in EditScope.
+
+		i = self.__inspect( editScope["out"], "/light", "exposure", editScope )
+		scopeEdit = i.acquireEdit()
+		self.assertTrue( editScope.isAncestorOf( scopeEdit ) )
+		scopeEdit["enabled"].setValue( True )
+		scopeEdit["value"].setValue( 2 )
+
+		# Check that we can still edit the source, accompanied by
+		# a suitable warning.
+
+		self.__assertExpectedResult(
+			self.__inspect( editScope["out"], "/light", "exposure", editScope = None ),
+			source = scopeEdit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Downstream,
+			editable = True,
+			edit = light["parameters"]["exposure"],
+			editWarning = "Parameter has edits downstream in EditScope."
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -502,7 +502,7 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", s["editScope"] )
 		self.assertFalse( inspection.canDisableEdit() )
-		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to None to disable." )
+		self.assertEqual( inspection.nonDisableableReason(), "Edit is not in the current edit scope. Change scope to Source to disable." )
 
 		inspection = self.__inspect( s["editScope"]["out"], "/light", "exposure", None )
 		self.assertEqual( inspection.source(), s["light"]["parameters"]["exposure"] )

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -690,9 +690,10 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 			Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], False )
 			inspection = self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSetEditScope", None )
+			self.assertTrue( inspection.acquireEdit( False ).isSame( s["plane"]["sets"] ) )
 			self.assertFalse( inspection.canDisableEdit() )
-			self.assertEqual( inspection.nonDisableableReason(), "Source is in an EditScope. Change scope to editScope1 to disable." )
-			self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : Source is in an EditScope. Change scope to editScope1 to disable.", inspection.disableEdit )
+			self.assertEqual( inspection.nonDisableableReason(), "plane.sets has no edit to disable." )
+			self.assertRaisesRegex( IECore.Exception, "Cannot disable edit : plane.sets has no edit to disable.", inspection.disableEdit )
 
 			inspection = self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSetEditScope", s["editScope1"] )
 			self.assertTrue( inspection.canDisableEdit() )

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -292,7 +292,7 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 					if( !result->m_editScope && node->ancestor<EditScope>() )
 					{
 						// We don't allow editing if the user hasn't requested a specific scope
-						// (they have selected "None" from the Menu) and the upstream edit is
+						// (they have selected "Source" from the Menu) and the upstream edit is
 						// inside _any_ EditScope.
 						result->m_editFunction = fmt::format(
 							"Source is in an EditScope. Change scope to {} to edit.",
@@ -328,7 +328,7 @@ void Inspector::inspectHistoryWalk( const GafferScene::SceneAlgo::History *histo
 					}
 					else if( !node->ancestor<EditScope>() && result->m_editScope )
 					{
-						result->m_disableEditFunction = "Edit is not in the current edit scope. Change scope to None to disable.";
+						result->m_disableEditFunction = "Edit is not in the current edit scope. Change scope to Source to disable.";
 					}
 				}
 			}

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -732,14 +732,15 @@ const std::string &Inspector::Result::fallbackDescription() const
 
 bool Inspector::Result::editable() const
 {
-	return m_editFunction.which() == 0 && boost::get<EditFunction>( m_editFunction ) != nullptr;
+	auto f = std::get_if<EditFunction>( &m_editFunction );
+	return f && *f;
 }
 
 std::string Inspector::Result::nonEditableReason() const
 {
-	if( m_editFunction.which() == 1 )
+	if( auto s = std::get_if<std::string>( &m_editFunction ) )
 	{
-		return boost::get<std::string>( m_editFunction );
+		return *s;
 	}
 
 	return "";
@@ -747,24 +748,25 @@ std::string Inspector::Result::nonEditableReason() const
 
 Gaffer::ValuePlugPtr Inspector::Result::acquireEdit( bool createIfNecessary ) const
 {
-	if( m_editFunction.which() == 0 )
+	if( auto f = std::get_if<EditFunction>( &m_editFunction ) )
 	{
-		return boost::get<EditFunction>( m_editFunction )( createIfNecessary );
+		return (*f)( createIfNecessary );
 	}
 
-	throw IECore::Exception( "Not editable : " + boost::get<std::string>( m_editFunction ) );
+	throw IECore::Exception( "Not editable : " + std::get<std::string>( m_editFunction ) );
 }
 
 bool Inspector::Result::canDisableEdit() const
 {
-	return m_disableEditFunction.which() == 0 && boost::get<DisableEditFunction>( m_disableEditFunction ) != nullptr;
+	auto f = std::get_if<DisableEditFunction>( &m_disableEditFunction );
+	return f && *f;
 }
 
 std::string Inspector::Result::nonDisableableReason() const
 {
-	if( m_disableEditFunction.which() == 1 )
+	if( auto s = std::get_if<std::string>( &m_disableEditFunction ) )
 	{
-		return boost::get<std::string>( m_disableEditFunction );
+		return *s;
 	}
 
 	return "";
@@ -772,12 +774,12 @@ std::string Inspector::Result::nonDisableableReason() const
 
 void Inspector::Result::disableEdit() const
 {
-	if( m_disableEditFunction.which() == 0 )
+	if( auto f = std::get_if<DisableEditFunction>( &m_disableEditFunction ) )
 	{
-		return boost::get<DisableEditFunction>( m_disableEditFunction )();
+		return (*f)();
 	}
 
-	throw IECore::Exception( "Cannot disable edit : " + boost::get<std::string>( m_disableEditFunction ) );
+	throw IECore::Exception( "Cannot disable edit : " + std::get<std::string>( m_disableEditFunction ) );
 }
 
 std::string Inspector::Result::editWarning() const


### PR DESCRIPTION
We were already allowing edits in a nominated EditScope even when there was a downstream override that would prevent you from seeing the result. This was communicated in the UI by an orange "overridden" background colour in the inspector cell, and a warning message in the editing popup window. But in "Source" mode we made no such allowance, meaning that you couldn't make an edit at source if it was overridden downstream, and the UI didn't even show you that it was overridden downstream. There was no background colour and a spurious message about the target not being in the history.

We now treat "Source" mode the same as EditScope mode, allowing edits at source even when overridden downstream. Along with that the UI now also shows the overridden status in the background colour and shows the appropriate warning when editing.

@tomc-cinesite, if you have any bandwidth you'd be welcome to take a look at this. Although as I explained just now, I think  changes in between the Tom-era EditScopes and the current setup mean that there's a good reason we didn't do this originally, but must do it now.