### PR TITLE
RandomChoiceUI : Fix handling of non-ValuePlugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
 - Widget : Fixed `event.sourceWidget` for DragDropEvents generated from a Qt native drag within the same Gaffer process. This will now reference the `GafferUI.Widget` that the Qt source widget belongs to, if any.
 - Catalogue : Fixed bug which "stole" drags that crossed the image listing but which were destined elsewhere, for instance a drag from the HierarchyView to a PathFilter in the GraphEditor.
 - GadgetWidget : Fixed signal handling bug in `setViewportGadget()`. This could cause the widget to attempt to redraw unnecessarily when the _old_ viewport requested a redraw.
+- RandomChoice : Fixed errors right-clicking on non-value plugs in the NodeEditor.
 
 1.4.15.2 (relative to 1.4.15.1)
 ========

--- a/python/GafferUI/RandomChoiceUI.py
+++ b/python/GafferUI/RandomChoiceUI.py
@@ -240,6 +240,8 @@ def __popupMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	for plug in plugValueWidget.getPlugs() :
+		if not isinstance( plug, Gaffer.ValuePlug ) :
+			return
 		if plug.getInput() is not None or Gaffer.MetadataAlgo.readOnly( plug ) :
 			return
 		if not Gaffer.RandomChoice.canSetup( plug ) :


### PR DESCRIPTION
Right-clicking on (for example) a `ShaderAssignment.shader` plug in the NodeEditor was leading to the following warning :

```
ERROR : Plug menu : Traceback (most recent call last):
ERROR :   File "/home/john/dev/build/gaffer-1.4/python/GafferUI/PlugValueWidget.py", line 994, in __combiner
ERROR :     next( results )
ERROR : IECore.Exception: Traceback (most recent call last):
ERROR :   File "/home/john/dev/build/gaffer-1.4/python/GafferUI/RandomChoiceUI.py", line 245, in __popupMenu
ERROR :     if not Gaffer.RandomChoice.canSetup( plug ) :
ERROR : Boost.Python.ArgumentError: Python argument types in
ERROR :     RandomChoice.canSetup(ShaderPlug)
ERROR : did not match C++ signature:
ERROR :     canSetup(Gaffer::ValuePlug const*)
```