### PR TITLE
VisualiserTool Primitive Variable Menu

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.2.0)
 =======
 
+Improvements
+------------
+
+- VisualiserTool : Changed `dataName` input widget for choosing the primitive variable to visualise to a list of available variable names for the current selection.
+
 Fixes
 -----
 


### PR DESCRIPTION
This adds a handy sub-menu to the context menu for the `VisualisationTool.dataName` plug listing all the primitive variables that can be visualised by the tool for the current selection.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
