### PR TITLE
EditScopeUI : Fix bug handling read-only ScriptNodes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - Widget : Fixed `event.sourceWidget` for DragDropEvents generated from a Qt native drag within the same Gaffer process. This will now reference the `GafferUI.Widget` that the Qt source widget belongs to, if any.
 - Catalogue : Fixed bug which "stole" drags that crossed the image listing but which were destined elsewhere, for instance a drag from the HierarchyView to a PathFilter in the GraphEditor.
 - GadgetWidget : Fixed signal handling bug in `setViewportGadget()`. This could cause the widget to attempt to redraw unnecessarily when the _old_ viewport requested a redraw.
+- EditScope : Fixed error updating the Global Edit Target in read-only files.
 
 API
 ---

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -600,9 +600,11 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	def __readOnlyReason( self, editScope ) :
 
-		if Gaffer.MetadataAlgo.readOnly( editScope ) :
+		readOnlyReason = Gaffer.MetadataAlgo.readOnlyReason( editScope )
+		if readOnlyReason is not None :
 			return "{} is locked.".format(
-				Gaffer.MetadataAlgo.readOnlyReason( editScope ).relativeName( editScope.scriptNode() )
+				"File" if isinstance( readOnlyReason, Gaffer.ScriptNode )
+				else readOnlyReason.relativeName( readOnlyReason.scriptNode() )
 			)
 
 		return None


### PR DESCRIPTION
In this case `relativeName()` was throwing due to the ScriptNode not being a child of itself. I wasn't really sure what name to use here - the node name itself isn't really meaningful, and `ScriptNode` might not mean much to a user. In practice ScriptNodes are only read-only when the file on the filesystem is read-only, so I went with "File" as hopefully being the most self-explanatory.
