### PR TITLE
VisualiserTool : Fix OpenGL buffer creation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,8 +9,9 @@ Improvements
 Fixes
 -----
 
-- VisualiserTool : Fixed bug where the value dragged from the visualiser would be slightly different from the initial value on button press. (#6191)
-
+- VisualiserTool :
+  - Fixed bug where the value dragged from the visualiser would be slightly different from the initial value on button press. (#6191)
+  - Fixed error when trying to visualise data unsupported data.
 
 1.5.2.0 (relative to 1.5.1.0)
 =======

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -413,12 +413,6 @@ class VisualiserGadget : public Gadget
 						continue;
 					}
 
-					IECoreGL::ConstBufferPtr vBuffer = meshGL->getVertexBuffer( name );
-					if( !vBuffer )
-					{
-						continue;
-					}
-
 					ConstDataPtr vData = vIt->second.data;
 					GLsizei stride = 0;
 					GLenum type = GL_FLOAT;
@@ -450,6 +444,12 @@ class VisualiserGadget : public Gadget
 							break;
 						default:
 							continue;
+					}
+
+					IECoreGL::ConstBufferPtr vBuffer = meshGL->getVertexBuffer( name );
+					if( !vBuffer )
+					{
+						continue;
 					}
 
 					// Get the object to world transform


### PR DESCRIPTION
When conforming the `VisualiserTool` code in 3537f4e7a0b02b73db7ce9ffb9fc5b7e3ea1fa30, we moved to using Cortex's OpenGL buffer creation. This was done before checking the data type of the primitive variable being visualised. This meant that we could ask OpenGL to convert incompatible data to a buffer, such as string data.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
