### PR TITLE
Visualiser `mode` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,12 @@ Features
 Improvements
 ------------
 
-- VisualiserTool : Changed `dataName` input widget for choosing the primitive variable to visualise to a list of available variable names for the current selection.
+- VisualiserTool :
+  - Changed `dataName` input widget for choosing the primitive variable to visualise to a list of available variable names for the current selection.
+  - Added `mode` plug. There are currently three modes :
+    - Auto : Currently the same as `Color (Type Range)`.
+    - Color (Type Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
+    - Color (Manual Range) : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
 - Tweaks nodes : Moved list of tweaks to a collapsible "Tweaks" section in the NodeEditor.
 - Viewer :
   - The shading mode menu icon now updates to indicate when a non-default shading mode is in use.

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -68,11 +68,24 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::VisualiserTool, VisualiserToolTypeId, SelectionTool );
 
+		enum class Mode
+		{
+			Auto,
+			ColorTypeRange,
+			ColorManualRange,
+
+			First = Auto,
+			Last = ColorManualRange
+		};
+
 		Gaffer::StringPlug *dataNamePlug();
 		const Gaffer::StringPlug *dataNamePlug() const;
 
 		Gaffer::FloatPlug *opacityPlug();
 		const Gaffer::FloatPlug *opacityPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
 
 		Gaffer::V3fPlug *valueMinPlug();
 		const Gaffer::V3fPlug *valueMinPlug() const;

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -59,6 +59,8 @@ Gaffer.Metadata.registerNode(
 	"order", 8,
 	"tool:exclusive", False,
 
+	"toolbarLayout:activator:modeIsColorManualRange", lambda node : node["mode"].getValue() == GafferSceneUI.VisualiserTool.Mode.ColorManualRange,
+
 	plugs = {
 
 		"dataName" : [
@@ -86,6 +88,34 @@ Gaffer.Metadata.registerNode(
 			"toolbarLayout:width", 100,
 
 		],
+		"mode" : [
+
+			"description",
+			"""
+			The method for displaying the data.
+
+			Float and integer data are displayed as grayscale. V2f data is displayed with
+			the `x` value for red, `y` value for green and `0` for blue. Vector data is
+			displayed with the `x` value for red, `y` value for green and `z` value for blue.
+			Color data is displayed directly.
+
+			- Auto : Same as `Color (Type Range)`.
+			- Color (Type Range) : Float, integer, V2f and color data is displayed without
+			modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
+			- Color (Manual Range) : Values are remapped from the range `[valueMin, valueMax]` to
+			`[0, 1]`.
+			""",
+
+			"preset:Auto", GafferSceneUI.VisualiserTool.Mode.Auto,
+			"preset:Color (Type Range)", GafferSceneUI.VisualiserTool.Mode.ColorTypeRange,
+			"preset:Color (Manual Range)", GafferSceneUI.VisualiserTool.Mode.ColorManualRange,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 150,
+
+		],
 		"valueMin" : [
 
 			"description",
@@ -98,6 +128,8 @@ Gaffer.Metadata.registerNode(
 
 			"toolbarLayout:section", "Bottom",
 			"toolbarLayout:width", 175,
+
+			"toolbarLayout:visibilityActivator", "modeIsColorManualRange",
 
 		],
 		"valueMax" : [
@@ -112,6 +144,8 @@ Gaffer.Metadata.registerNode(
 
 			"toolbarLayout:section", "Bottom",
 			"toolbarLayout:width", 175,
+
+			"toolbarLayout:visibilityActivator", "modeIsColorManualRange",
 
 		],
 		"size": [

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -258,6 +258,7 @@ class VisualiserGadget : public Gadget
 
 				// Get min/max values and colors and opacity
 				UniformBlock uniforms;
+				const VisualiserTool::Mode mode = (VisualiserTool::Mode)m_tool->modePlug()->getValue();
 				const V3f valueMin = m_tool->valueMinPlug()->getValue();
 				const V3f valueMax = m_tool->valueMaxPlug()->getValue();
 				uniforms.opacity = m_tool->opacityPlug()->getValue();
@@ -265,10 +266,14 @@ class VisualiserGadget : public Gadget
 				// Compute value range reciprocal
 				//
 				// NOTE : when range is <= 0 set the reciprocal to 0 so that value becomes 0 (minimum)
-				V3f valueRange = ( valueMax - valueMin );
-				for( int i = 0; i < 3; ++i )
+				std::optional<V3f> valueRange;
+				if( mode == VisualiserTool::Mode::ColorManualRange )
 				{
-					valueRange[i] = ( valueRange[i] > 0.f ) ? ( 1.f / valueRange[i] ) : 0.f;
+					valueRange = ( valueMax - valueMin );
+					for( int i = 0; i < 3; ++i )
+					{
+						valueRange.value()[i] = ( valueRange.value()[i] > 0.f ) ? ( 1.f / valueRange.value()[i] ) : 0.f;
+					}
 				}
 
 				// Get the world to clip space matrix
@@ -425,22 +430,29 @@ class VisualiserGadget : public Gadget
 							[[fallthrough]];
 						case FloatVectorDataTypeId:
 							enableVSZ = true;
-							uniforms.valueMin = V3f( valueMin.x );
-							uniforms.valueRange = V3f( valueRange.x );
+							uniforms.valueMin = valueRange ? V3f( valueMin.x ) : V3f( 0.f );
+							uniforms.valueRange = valueRange ? V3f( valueRange.value().x ) : V3f( 1.f );
 							break;
 						case V2fVectorDataTypeId:
 							stride = 2;
 							offset = true;
-							uniforms.valueMin = V3f( valueMin.x, valueMin.y, 0.f );
-							uniforms.valueRange = V3f( valueRange.x, valueRange.y, 0.f );
+							uniforms.valueMin = valueRange ? V3f( valueMin.x, valueMin.y, 0.f ) : V3f( 0.f );
+							uniforms.valueRange = valueRange ? V3f( valueRange.value().x, valueRange.value().y, 0.f ) : V3f( 1.f, 1.f, 0.f );
 							break;
 						case Color3fVectorDataTypeId:
+							stride = 3;
+							offset = true;
+							enableVSZ = true;
+							uniforms.valueMin = valueRange ? valueMin : V3f( 0.f );
+							uniforms.valueRange = valueRange ? valueRange.value() : V3f( 1.f );
+							break;
 						case V3fVectorDataTypeId:
 							stride = 3;
 							offset = true;
 							enableVSZ = true;
-							uniforms.valueMin = valueMin;
-							uniforms.valueRange = valueRange;
+							uniforms.valueMin = valueRange ? valueMin : V3f( -1.f );
+							// Use 0.5 instead of 2.0 to account for reciprocal in `valueRange` above
+							uniforms.valueRange = valueRange ? valueRange.value() : V3f( 0.5f );
 							break;
 						default:
 							continue;
@@ -702,6 +714,7 @@ VisualiserTool::VisualiserTool( SceneView *view, const std::string &name ) : Sel
 
 	addChild( new StringPlug( "dataName", Plug::In, "uv" ) );
 	addChild( new FloatPlug( "opacity", Plug::In, g_opacityDefault, g_opacityMin, g_opacityMax ) );
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::Auto, (int)Mode::First, (int)Mode::Last ) );
 	addChild( new V3fPlug( "valueMin", Plug::In, g_valueMinDefault ) );
 	addChild( new V3fPlug( "valueMax", Plug::In, g_valueMaxDefault ) );
 	addChild( new FloatPlug( "size", Plug::In, g_textSizeDefault, g_textSizeMin ) );
@@ -790,44 +803,54 @@ const FloatPlug *VisualiserTool::opacityPlug() const
 	return getChild<FloatPlug>( g_firstPlugIndex + 1 );
 }
 
+IntPlug *VisualiserTool::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
+const IntPlug *VisualiserTool::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 2 );
+}
+
 V3fPlug *VisualiserTool::valueMinPlug()
 {
-	return getChild<V3fPlug>( g_firstPlugIndex + 2 );
+	return getChild<V3fPlug>( g_firstPlugIndex + 3 );
 }
 
 const V3fPlug *VisualiserTool::valueMinPlug() const
 {
-	return getChild<V3fPlug>( g_firstPlugIndex + 2 );
+	return getChild<V3fPlug>( g_firstPlugIndex + 3 );
 }
 
 V3fPlug *VisualiserTool::valueMaxPlug()
 {
-	return getChild<V3fPlug>( g_firstPlugIndex + 3 );
+	return getChild<V3fPlug>( g_firstPlugIndex + 4 );
 }
 
 const V3fPlug *VisualiserTool::valueMaxPlug() const
 {
-	return getChild<V3fPlug>( g_firstPlugIndex + 3 );
+	return getChild<V3fPlug>( g_firstPlugIndex + 4 );
 }
 
 FloatPlug *VisualiserTool::sizePlug()
 {
-	return getChild<FloatPlug>( g_firstPlugIndex + 4 );
+	return getChild<FloatPlug>( g_firstPlugIndex + 5 );
 }
 
 const FloatPlug *VisualiserTool::sizePlug() const
 {
-	return getChild<FloatPlug>( g_firstPlugIndex + 4 );
+	return getChild<FloatPlug>( g_firstPlugIndex + 5 );
 }
 
 ScenePlug *VisualiserTool::internalScenePlug()
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 5 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 6 );
 }
 
 const ScenePlug *VisualiserTool::internalScenePlug() const
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 5 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 6 );
 }
 
 const std::vector<VisualiserTool::Selection> &VisualiserTool::selection() const
@@ -1031,7 +1054,8 @@ void VisualiserTool::plugDirtied( const Plug *plug )
 		plug == opacityPlug() ||
 		plug == valueMinPlug() ||
 		plug == valueMaxPlug() ||
-		plug == sizePlug()
+		plug == sizePlug() ||
+		plug == modePlug()
 	)
 	{
 		m_gadgetDirty = true;

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -317,8 +317,16 @@ void GafferSceneUIModule::bindTools()
 		;
 	}
 
-	GafferBindings::NodeClass<VisualiserTool>( nullptr, no_init )
-		.def( init<SceneView *>() )
-	;
+	{
+		scope s = GafferBindings::NodeClass<VisualiserTool>( nullptr, no_init )
+			.def( init<SceneView *>() )
+		;
+
+		enum_<VisualiserTool::Mode>( "Mode" )
+			.value( "Auto", VisualiserTool::Mode::Auto )
+			.value( "ColorTypeRange", VisualiserTool::Mode::ColorTypeRange )
+			.value( "ColorManualRange", VisualiserTool::Mode::ColorManualRange )
+		;
+	}
 
 }


### PR DESCRIPTION
This adds a new plug to the `VisualiserTool` for the mode of visualisation. Right now we're still only displaying color visualisation, but other types will be coming shortly. The current modes are :
- Auto : For now the same as `Color (Type Range)`. In the future this will change the way various data such as vectors and integers are displayed. I'm including it now as I expect it to be the default in the future and including it now prevents a change in default behavior when `Auto` becomes more meaningful.
- Color (Type Range) : Displays like the existing color visualisation, but the range changes based on the type of data. Data is unmodified except vectors, which are remapped from `[-1, 1]` to `[0, 1]`.
- Color (Manual Range) : This is the existing mode where you get `valueMin` and `valueMax` plugs and values are remapped from `[valueMin, valueMax]` to `[0, 1]`.

I considered naming "Color (Type Range)" as "Color (Auto Range)", but went with "Type" because we briefly talked about a mode where we look at the min and max value of the data and use that for the range. That seems more "Auto"-like to me so I figured I'd try not to preclude that future use.

Depends on https://github.com/GafferHQ/gaffer/pull/6181.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
