### PR TITLE
VisualiserTool : Drag value from `buttonPress()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.5.x.x (relative to 1.5.2.0)
 =======
 
+Fixes
+-----
+
+- VisualiserTool : Fixed bug where the value dragged from the visualiser would be slightly different from the initial value on button press. (#6191)
 
 
 1.5.2.0 (relative to 1.5.1.0)

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -152,7 +152,7 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		bool m_gadgetDirty;
 		mutable bool m_selectionDirty;
 		bool m_priorityPathsDirty;
-		bool m_acceptedButtonPress;
+		IECore::DataPtr m_valueAtButtonPress;
 		bool m_initiatedDrag;
 
 		static ToolDescription<VisualiserTool, SceneView> m_toolDescription;

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -689,7 +689,7 @@ VisualiserTool::VisualiserTool( SceneView *view, const std::string &name ) : Sel
 	m_gadgetDirty( true ),
 	m_selectionDirty( true ),
 	m_priorityPathsDirty( true ),
-	m_acceptedButtonPress( false ),
+	m_valueAtButtonPress(),
 	m_initiatedDrag( false )
 {
 	view->viewportGadget()->addChild( m_gadget );
@@ -956,7 +956,7 @@ bool VisualiserTool::keyPress( const KeyEvent &event )
 
 bool VisualiserTool::buttonPress( const ButtonEvent &event )
 {
-	m_acceptedButtonPress = false;
+	m_valueAtButtonPress.reset();
 	m_initiatedDrag = false;
 
 	if( event.button & ButtonEvent::Left && !( event.modifiers & GafferUI::ButtonEvent::Modifiers::Control ) )
@@ -964,7 +964,7 @@ bool VisualiserTool::buttonPress( const ButtonEvent &event )
 		updateCursorValue();
 		if( m_cursorValue )
 		{
-			m_acceptedButtonPress = true;
+			m_valueAtButtonPress = m_cursorValue->copy();
 			return true;
 		}
 	}
@@ -974,7 +974,7 @@ bool VisualiserTool::buttonPress( const ButtonEvent &event )
 
 bool VisualiserTool::buttonRelease( const ButtonEvent &event )
 {
-	m_acceptedButtonPress = false;
+	m_valueAtButtonPress.reset();
 	m_initiatedDrag = false;
 
 	return false;
@@ -984,27 +984,22 @@ RunTimeTypedPtr VisualiserTool::dragBegin( const DragDropEvent &event )
 {
 	m_initiatedDrag = false;
 
-	if( !m_acceptedButtonPress )
+	if( !m_valueAtButtonPress )
 	{
 		return RunTimeTypedPtr();
 	}
 
-	m_acceptedButtonPress = false;
+	// NOTE : There is a possibility that the tool has become inactive since the button
+	//        press event that triggered the drag was accepted, the cutoff point is the
+	//        button press event, so any change to the active state after that does not
+	//        affect an ongoing drag operation. We therefore always request a redraw
+	//        here so that the displayed value is cleared.
 
-	if( m_cursorValue )
-	{
-		// NOTE : There is a possibility that the tool has become inactive since the button
-		//        press event that triggered the drag was accepted, the cutoff point is the
-		//        button press event, so any change to the active state after that does not
-		//        affect an ongoing drag operation. We therefore always request a redraw
-		//        here so that the displayed value is cleared.
+	m_initiatedDrag = true;
+	view()->viewportGadget()->renderRequestSignal()( view()->viewportGadget() );
+	Pointer::setCurrent( "values" );
 
-		m_initiatedDrag = true;
-		view()->viewportGadget()->renderRequestSignal()( view()->viewportGadget() );
-		Pointer::setCurrent( "values" );
-	}
-
-	return m_cursorValue;
+	return m_valueAtButtonPress;
 }
 
 bool VisualiserTool::dragEnd( const DragDropEvent &event )


### PR DESCRIPTION
Previously, we were returning the cursor value at `dragBegin()`, which would be slightly different from what the user would expect from pressing and holding the cursor and noting the value shown on hover.

This is due to updating the cursor value during the small movement required to signal a drag. Holding the cursor value at the time of `buttonPress()`, allows us to use that as the drag value.

Fixes #6191.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
