### PR TITLE
PythonCompleter : Don't evaluate properties

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - Viewer :
   - The shading mode menu icon now updates to indicate when a non-default shading mode is in use.
   - Added the ability to toggle between default shading and the last selected shading mode by <kbd>Ctrl</kbd> + clicking the shading mode menu button.
+- PythonEditor : Added workaround for slow code completion caused by poorly performing Python property getters.
 
 Fixes
 -----


### PR DESCRIPTION
In at least one Gaffer pipeline, common classes have properties that are slow to access, causing considerable code completion slowdowns in the PythonEditor. I'm told that optimising the properties isn't really an option, and I don't think we're losing too much by assuming that such properties won't return callables, so this seems like a reasonably pragmatic compromise.
