### PR TITLE
Recursive Instancer Experiment

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -245,6 +245,12 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::PathMatcherDataPlug *setCollaboratePlug();
 		const Gaffer::PathMatcherDataPlug *setCollaboratePlug() const;
 
+		Gaffer::BoolPlug *recursiveModePlug();
+		const Gaffer::BoolPlug *recursiveModePlug() const;
+
+		const ScenePlug *effectivePrototypesPlug() const;
+
+
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3123,6 +3123,109 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 			else:
 				rootsByHash[ co.hash() ] = co.root()
 
+	def testRecursive( self ):
+
+		# Create a test scene with the following structure
+		# /plane/prototypes/cube/prototypes/sphere
+		# ... where both the plane and the cube are treated as instancers, resulting in 32 leaf instance spheres
+		# ( each of the 4 vertices of the plane gets a cube of 8 spheres ).
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+
+		testSet = GafferScene.Set()
+		testSet["in"].setInput( sphere["out"] )
+		testSet["filter"].setInput( sphereFilter["out"] )
+		testSet["name"].setValue( 'testSet' )
+
+		cubePrototypes = GafferScene.Group()
+		cubePrototypes["in"][0].setInput( testSet["out"] )
+		cubePrototypes["name"].setValue( 'prototypes' )
+
+		cube = GafferScene.Cube()
+
+		cubeFilter = GafferScene.PathFilter()
+		cubeFilter["paths"].setValue( IECore.StringVectorData( [ '/cube' ] ) )
+
+		cubePrototypeVars = GafferScene.PrimitiveVariableTweaks()
+		cubePrototypeVars["tweaks"].addChild( Gaffer.TweakPlug( Gaffer.StringVectorDataPlug( "value", defaultValue = IECore.StringVectorData( [  ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "tweak1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+		cubePrototypeVars["in"].setInput( cube["out"] )
+		cubePrototypeVars["filter"].setInput( cubeFilter["out"] )
+		cubePrototypeVars["interpolation"].setValue( 1 )
+		cubePrototypeVars["tweaks"]["tweak1"]["name"].setValue( 'prototypeRoots' )
+		cubePrototypeVars["tweaks"]["tweak1"]["mode"].setValue( 5 )
+		cubePrototypeVars["tweaks"]["tweak1"]["value"].setValue( IECore.StringVectorData( [ '/plane/prototypes/cube/prototypes/sphere' ] ) )
+
+		mergeCubePrototypes = GafferScene.Parent()
+		mergeCubePrototypes["in"].setInput( cubePrototypeVars["out"] )
+		mergeCubePrototypes["parent"].setValue( '/cube' )
+		mergeCubePrototypes["children"][0].setInput( cubePrototypes["out"] )
+
+		plane = GafferScene.Plane()
+		plane["dimensions"].setValue( imath.V2f( 10, 10 ) )
+
+		planeFilter = GafferScene.PathFilter()
+		planeFilter["paths"].setValue( IECore.StringVectorData( [ '/plane' ] ) )
+
+		planePrototypeVars = GafferScene.PrimitiveVariableTweaks()
+		planePrototypeVars["tweaks"].addChild( Gaffer.TweakPlug( Gaffer.StringVectorDataPlug( "value", defaultValue = IECore.StringVectorData( [  ] ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ), "tweak1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic, ) )
+		planePrototypeVars["in"].setInput( plane["out"] )
+		planePrototypeVars["filter"].setInput( planeFilter["out"] )
+		planePrototypeVars["interpolation"].setValue( 1 )
+		planePrototypeVars["tweaks"]["tweak1"]["name"].setValue( 'prototypeRoots' )
+		planePrototypeVars["tweaks"]["tweak1"]["mode"].setValue( 5 )
+		planePrototypeVars["tweaks"]["tweak1"]["value"].setValue( IECore.StringVectorData( [ '/plane/prototypes/cube' ] ) )
+
+		planePrototypes = GafferScene.Group()
+		planePrototypes["in"][0].setInput( mergeCubePrototypes["out"] )
+		planePrototypes["name"].setValue( 'prototypes' )
+
+		mergePlanePrototypes = GafferScene.Parent()
+		mergePlanePrototypes["in"].setInput( planePrototypeVars["out"] )
+		mergePlanePrototypes["parent"].setValue( '/plane' )
+		mergePlanePrototypes["children"][0].setInput( planePrototypes["out"] )
+
+		instancersFilter = GafferScene.PathFilter()
+		instancersFilter["paths"].setValue( IECore.StringVectorData( [ '/plane', '/plane/prototypes/cube' ] ) )
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( mergePlanePrototypes["out"] )
+		instancer["filter"].setInput( instancersFilter["out"] )
+		instancer['prototypeMode'].setValue( GafferScene.Instancer.PrototypeMode.IndexedRootsVariable )
+		instancer["prototypeIndex"].setValue( 'prototypeIndex' )
+		instancer["__recursiveMode"].setValue( True )
+
+		sphereGeo = sphere["out"].object( "sphere" )
+
+		# Test that all the instances are getting created
+		topLevelInstanceNames = IECore.InternedStringVectorData( [ "0", "1", "2", "3" ] )
+		subLevelInstanceNames = IECore.InternedStringVectorData( [ "0", "1", "2", "3", "4", "5", "6", "7" ] )
+
+		self.assertEqual( instancer["out"].childNames( '/plane/instances/cube' ), topLevelInstanceNames )
+		self.assertEqual( instancer["out"].childNames( '/plane/instances/cube/0/instances/sphere' ), subLevelInstanceNames )
+		self.assertEqual( instancer["out"].childNames( '/plane/instances/cube/1/instances/sphere' ), subLevelInstanceNames )
+		self.assertEqual( instancer["out"].childNames( '/plane/instances/cube/2/instances/sphere' ), subLevelInstanceNames )
+		self.assertEqual( instancer["out"].childNames( '/plane/instances/cube/3/instances/sphere' ), subLevelInstanceNames )
+
+		# Check some random instances to see that there are objects there
+		self.assertEqual( instancer["out"].object( '/plane/instances/cube/0/instances/sphere/7' ), sphereGeo )
+		self.assertEqual( instancer["out"].object( '/plane/instances/cube/2/instances/sphere/4' ), sphereGeo )
+		self.assertEqual( instancer["out"].object( '/plane/instances/cube/3/instances/sphere/0' ), sphereGeo )
+
+		# Make sure encapsulation works
+		self.assertEncapsulatedRendersSame( instancer )
+
+		# Documenting the current behaviour with sets : we don't expand the sets at all ( even though this set
+		# actually should now be echoed throughout many instances ). This is fine in our currently intended use,
+		# as an adaptor that runs right before rendering. If we were officially exposing __recursiveMode, we
+		# would need to do something a lot smarter.
+		self.assertEqual(
+			instancer["out"].set( 'testSet' ),
+			IECore.PathMatcherData( IECore.PathMatcher( ['/plane/prototypes/cube/prototypes/sphere'] ) )
+		)
+
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 10 )
 	def testBoundPerformance( self ) :
 


### PR DESCRIPTION
I mentioned that I had discovered that it was possible to handle instancing of instancers coming from USD files by plugging the out plug of an Instancer back into its prototypes plug, along with a bit of hacking of Instancer.

When I started thinking about how to clean this up, it started feeling like just adding a special plug to Instancer would kind of be the easier approach.

For the previous hacky approach, I needed to `setFlags( Plug::AcceptsDependencyCycles, true );` on prototypesPlug(), and then put a special case in computeBranchSetNames that detected that specific loop having been set up.

I think you liked that approach because it involved minimal modifications to Instancer, and it could be a hidden thing that we just use where needed ... but the approach I've presented here also involves fairly minimal modifications, and seems less tricky to me?

Importantly, it's easy to just make the plug to control it hidden, and that ensures pretty well that a user won't accidentally engage with it. Whereas if we set the flag on prototypesPlug() to accept dependency cycles, then it would be possible for a user to wire into it by accident.

If this code seems reasonable to you, I think it could be a pretty reasonable way of supporting USD instancers in an adapter. The biggest remaining issue is that there's no protection against creating two instancers that include each other as prototypes, resulting in an infinitely deep scene, and a crash. But you suggested that maybe we want a generic mechanism for detecting that kind of issue.