### PR TITLE
Shader : Handle ContextProcessors within the shader network

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
   - Fixed bug where the value dragged from the visualiser would be slightly different from the initial value on button press. (#6191)
   - Fixed error when trying to visualise data unsupported data.
 - TweakPlug : Fixed preservation of geometric interpretation when tweaking V3f values.
+- Shader : Fixed handling of multiple consecutive Switch nodes in a shader network.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ API
 ---
 
 - TweakPlug : Added `applyElementwiseTweak()` method, for tweaking elements of a `*VectorData`.
+- ShaderPlug : Added Python binding for `parameterSource()` method.
 
 1.5.2.0 (relative to 1.5.1.0)
 =======

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -397,6 +397,118 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 				[ network.Connection( network.Parameter( n, "out", ), network.Parameter( "n3", "c" ) ) ]
 			)
 
+	def testContextProcessors( self ) :
+
+		contextQuery = Gaffer.ContextQuery()
+		contextQuery.addQuery( Gaffer.Color3fPlug(), "c" )
+
+		texture = GafferSceneTest.TestShader( "texture" )
+		texture["parameters"]["c"].setInput( contextQuery["out"][0]["value"] )
+
+		redContext = Gaffer.ContextVariables()
+		redContext.setup( texture["out"] )
+		redContext["variables"].addChild( Gaffer.NameValuePlug( "c", imath.Color3f( 1, 0, 0 ) ) )
+		redContext["in"].setInput( texture["out"] )
+
+		greenContext = Gaffer.ContextVariables()
+		greenContext.setup( texture["out"] )
+		greenContext["variables"].addChild( Gaffer.NameValuePlug( "c", imath.Color3f( 0, 1, 0 ) ) )
+		greenContext["in"].setInput( texture["out"] )
+
+		mix = GafferSceneTest.TestShader( "mix" )
+		mix.loadShader( "mix" )
+		mix["type"].setValue( "test:surface" )
+		mix["parameters"]["a"].setInput( redContext["out"] )
+		mix["parameters"]["b"].setInput( greenContext["out"] )
+
+		shaderPlug = GafferScene.ShaderPlug()
+		shaderPlug.setInput( mix["out"] )
+
+		network = shaderPlug.attributes()["test:surface"]
+		self.assertEqual( len( network.shaders() ), 3 )
+		self.assertEqual( network.getOutput(), ( "mix", "out" ) )
+
+		aInput = network.input( ( "mix", "a" ) )
+		bInput = network.input( ( "mix", "b" ) )
+
+		self.assertEqual( network.getShader( aInput.shader ).parameters["c"], IECore.Color3fData( imath.Color3f( 1, 0, 0 ) ) )
+		self.assertEqual( network.getShader( bInput.shader ).parameters["c"], IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ) )
+
+		self.assertEqual( shaderPlug.parameterSource( ( "texture", "c" ) ), texture["parameters"]["c"] )
+		self.assertEqual( shaderPlug.parameterSource( ( "texture1", "c" ) ), texture["parameters"]["c"] )
+
+	def testContextProcessorsWithSpreadsheets( self ) :
+
+		spreadsheet = Gaffer.Spreadsheet()
+		spreadsheet["selector"].setValue( "${color}" )
+		spreadsheet["rows"].addColumn( Gaffer.Color3fPlug( "c" ) )
+		spreadsheet["rows"].addRows( 2 )
+		spreadsheet["rows"][1]["name"].setValue( "red" )
+		spreadsheet["rows"][1]["cells"]["c"]["value"].setValue( imath.Color3f( 1, 0, 0 ) )
+		spreadsheet["rows"][2]["name"].setValue( "green" )
+		spreadsheet["rows"][2]["cells"]["c"]["value"].setValue( imath.Color3f( 0, 1, 0 ) )
+
+		texture = GafferSceneTest.TestShader( "texture" )
+		texture["parameters"]["c"].setInput( spreadsheet["out"]["c"] )
+
+		redContext = Gaffer.ContextVariables()
+		redContext.setup( texture["out"] )
+		redContext["variables"].addChild( Gaffer.NameValuePlug( "color", "red" ) )
+		redContext["in"].setInput( texture["out"] )
+
+		greenContext = Gaffer.ContextVariables()
+		greenContext.setup( texture["out"] )
+		greenContext["variables"].addChild( Gaffer.NameValuePlug( "color", "green" ) )
+		greenContext["in"].setInput( texture["out"] )
+
+		mix = GafferSceneTest.TestShader( "mix" )
+		mix.loadShader( "mix" )
+		mix["type"].setValue( "test:surface" )
+		mix["parameters"]["a"].setInput( redContext["out"] )
+		mix["parameters"]["b"].setInput( greenContext["out"] )
+
+		shaderPlug = GafferScene.ShaderPlug()
+		shaderPlug.setInput( mix["out"] )
+
+		network = shaderPlug.attributes()["test:surface"]
+		self.assertEqual( len( network.shaders() ), 3 )
+		self.assertEqual( network.getOutput(), ( "mix", "out" ) )
+
+		aInput = network.input( ( "mix", "a" ) )
+		bInput = network.input( ( "mix", "b" ) )
+
+		self.assertEqual( network.getShader( aInput.shader ).parameters["c"], IECore.Color3fData( imath.Color3f( 1, 0, 0 ) ) )
+		self.assertEqual( network.getShader( bInput.shader ).parameters["c"], IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ) )
+
+	@unittest.expectedFailure
+	def testContextProcessorsWithoutContextSensitiveShaders( self ) :
+
+		texture = GafferSceneTest.TestShader( "texture" )
+
+		contextA = Gaffer.ContextVariables()
+		contextA.setup( texture["out"] )
+		contextA["variables"].addChild( Gaffer.NameValuePlug( "c", "A" ) )
+		contextA["in"].setInput( texture["out"] )
+
+		contextB = Gaffer.ContextVariables()
+		contextB.setup( texture["out"] )
+		contextB["variables"].addChild( Gaffer.NameValuePlug( "c", "B" ) )
+		contextB["in"].setInput( texture["out"] )
+
+		mix = GafferSceneTest.TestShader( "mix" )
+		mix.loadShader( "mix" )
+		mix["type"].setValue( "test:surface" )
+		mix["parameters"]["a"].setInput( contextA["out"] )
+		mix["parameters"]["b"].setInput( contextB["out"] )
+
+		# The `texture` shader is the same in both contexts, so there should only
+		# be a single instance of it in the result.
+
+		network = mix.attributes()["test:surface"]
+		self.assertEqual( len( network.shaders() ), 2 )
+		self.assertEqual( network.getOutput(), ( "mix", "out" ) )
+		self.assertEqual( network.input( ( "mix", "a" ) ), network.input( ( "mix", "a" ) ) )
+
 	def testSpline( self ) :
 
 		n1 = GafferSceneTest.TestShader( "n1" )

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -266,19 +266,30 @@ class Shader::NetworkBuilder
 				{
 					assert( isInputParameter( parameterPlug ) );
 					const Gaffer::Plug *source = parameterPlug->source<Gaffer::Plug>();
-
-					if( auto switchNode = IECore::runTimeCast<const Switch>( source->node() ) )
+					if( source == parameterPlug )
 					{
-						// Special case for switches with context-varying index values.
-						// Query the active input for this context, and manually traverse
-						// out the other side.
-						if( const Plug *activeInPlug = switchNode->activeInPlug( source ) )
+						return parameterPlug;
+					}
+
+					while( true )
+					{
+						if( auto switchNode = IECore::runTimeCast<const Switch>( source->node() ) )
 						{
-							source = activeInPlug->source();
+							// Special case for switches with context-varying index values.
+							// Query the active input for this context, and manually traverse
+							// out the other side.
+							if( const Plug *activeInPlug = switchNode->activeInPlug( source ) )
+							{
+								source = activeInPlug->source();
+							}
+						}
+						else
+						{
+							break;
 						}
 					}
 
-					if( source == parameterPlug || !isParameter( source ) )
+					if( !isParameter( source ) )
 					{
 						return parameterPlug;
 					}

--- a/src/GafferSceneModule/ShaderBinding.cpp
+++ b/src/GafferSceneModule/ShaderBinding.cpp
@@ -140,6 +140,12 @@ IECore::CompoundObjectPtr shaderPlugAttributes( const ShaderPlug &p, bool copy=t
 	}
 }
 
+Gaffer::ValuePlugPtr shaderPlugParameterSource( ShaderPlug &p, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return p.parameterSource( parameter );
+}
+
 } // namespace
 
 void GafferSceneModule::bindShader()
@@ -167,6 +173,7 @@ void GafferSceneModule::bindShader()
 		// value accessors
 		.def( "attributesHash", &shaderPlugAttributesHash  )
 		.def( "attributes", &shaderPlugAttributes, ( boost::python::arg_( "_copy" ) = true ) )
+		.def( "parameterSource", &shaderPlugParameterSource )
 	;
 
 	GafferBindings::NodeClass<OpenGLShader>();

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -143,4 +143,10 @@ void TestShader::loadShader( const std::string &shaderName, bool keepExistingVal
 		setupTypedPlug<SplinefColor3fPlug>( "spline", parametersPlug, SplineDefinitionfColor3f() );
 		setupOptionalValuePlug<StringPlug>( "optionalString", parametersPlug, new StringPlug() );
 	}
+	else if( shaderName == "mix" )
+	{
+		setupTypedPlug<Color3fPlug>( "a", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<Color3fPlug>( "b", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<FloatPlug>( "mix", parametersPlug, 0.5 );
+	}
 }


### PR DESCRIPTION
Draft PR so we can get a build deployed for initial testing and internal development at Cinesite. This initial implementation works, but duplicates shaders unnecessarily if they are seen in different contexts but don't actually vary in those contexts. We won't merge until we have that sorted.