### PR TITLE
Shader : Handle ContextProcessors within the shader network

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
   - Fixed bug where the value dragged from the visualiser would be slightly different from the initial value on button press. (#6191)
   - Fixed error when trying to visualise data unsupported data.
 - TweakPlug : Fixed preservation of geometric interpretation when tweaking V3f values.
+- Shader : Fixed handling of multiple consecutive Switch nodes in a shader network.
 - ApplicationTest : Extended grace period when testing process name on slower hosts.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ API
 ---
 
 - TweakPlug : Added `applyElementwiseTweak()` method, for tweaking elements of a `*VectorData`.
+- ShaderPlug : Added Python binding for `parameterSource()` method.
 
 1.5.2.0 (relative to 1.5.1.0)
 =======

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -48,6 +48,7 @@
 namespace Gaffer
 {
 
+IE_CORE_FORWARDDECLARE( Context )
 IE_CORE_FORWARDDECLARE( GraphComponent )
 IE_CORE_FORWARDDECLARE( ValuePlug )
 
@@ -65,6 +66,20 @@ GAFFER_API void replacePlug( GraphComponent *parent, PlugPtr plug );
 /// Returns `true` if the plug's value is provided by the output
 /// of a ComputeNode, and `false` otherwise.
 GAFFER_API bool dependsOnCompute( const ValuePlug *plug );
+
+/// WHAT SEMANTICS?
+///
+/// - INSPECTOR DOESN'T WANT OUTPUT PLUGS
+/// - EVERYTHING ELSE WANTS THE ACTUAL SOURCE, BUT THEN AGAIN IT'S EASY
+///   TO GET THAT
+///		- AND MAYBE THEY DON'T ACTUALLY CARE? BECAUSE THEY'LL CALL GETVALUE?
+///			- NOT SURE THAT'S TRUE
+///
+/// EITHER WE HAVE A BOOL FOR INSPECTOR TO USE, OR WE NEED GOOD DOCS. GOOD DOCS I THINK.
+///
+/// `computedSource( plug, preferInputs )`
+/// `
+std::tuple<const Plug *, ConstContextPtr> computedSource( const Plug *plug );
 
 /// Visits the plug and its downstream outputs, returning the first `predicate( plug )`
 /// result which evaluates to `true`. Traverses across Spreadsheets to visit the output

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -279,6 +279,42 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 					[ network.Connection( network.Parameter( "n{0}".format( effectiveIndex + 1 ), "out", ), network.Parameter( "n3", "c" ) ) ]
 				)
 
+	def testSecondSwitchWithContextSensitiveIndex( self ) :
+
+		contextQuery = Gaffer.ContextQuery()
+		contextQuery.addQuery( Gaffer.IntPlug(), "index" )
+
+		n1 = GafferSceneTest.TestShader( "n1" )
+		n2 = GafferSceneTest.TestShader( "n2" )
+		n3 = GafferSceneTest.TestShader( "n3" )
+		n3["type"].setValue( "test:surface" )
+
+		switch1 = Gaffer.Switch( "switch1" )
+		switch1.setup( n3["parameters"]["c"] )
+		switch2 = Gaffer.Switch( "switch2" )
+		switch2.setup( n3["parameters"]["c"] )
+
+		switch1["index"].setInput( contextQuery["out"][0]["value"] )
+		switch1["in"][0].setInput( n1["out"] )
+		switch1["in"][1].setInput( n2["out"] )
+
+		switch2["index"].setInput( contextQuery["out"][0]["value"] )
+		switch2["in"][0].setInput( n1["out"] )
+		switch2["in"][1].setInput( switch1["out"] )
+
+		n3["parameters"]["c"].setInput( switch2["out"] )
+
+		with Gaffer.Context() as context :
+
+			context["index"] = 1
+
+			network = n3.attributes()["test:surface"]
+			self.assertEqual( len( network ), 2 )
+			self.assertEqual(
+				network.inputConnections( "n3" ),
+				[ network.Connection( network.Parameter( "n2", "out", ), network.Parameter( "n3", "c" ) ) ]
+			)
+
 	def testSwitchWithComponentConnections( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -360,6 +396,16 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 				network.inputConnections( "n3" ),
 				[ network.Connection( network.Parameter( n, "out", ), network.Parameter( "n3", "c" ) ) ]
 			)
+
+	def testConnectionFromSwitchIndex( self ) :
+
+		switch = Gaffer.Switch()
+		shader = GafferSceneTest.TestShader()
+		shader["type"].setValue( "test:surface" )
+		shader["parameters"]["i"].setInput( switch["index"] )
+
+		network = shader.attributes()["test:surface"]
+		self.assertEqual( network.outputShader().parameters["i"], IECore.IntData( 0 ) )
 
 	def testSpline( self ) :
 

--- a/python/GafferSceneTest/ShaderTest.py
+++ b/python/GafferSceneTest/ShaderTest.py
@@ -588,7 +588,6 @@ class ShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertEqual( input, IECoreScene.ShaderNetwork.Parameter( "baseTexture", "out" ) )
 
-	@unittest.expectedFailure
 	def testContextProcessorsWithoutContextSensitiveShaders( self ) :
 
 		texture = GafferSceneTest.TestShader( "texture" )

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -146,12 +146,12 @@ struct CycleDetector // TODO : DOES THIS NEED TO BE CONTEXT-AWARE? AND COULD/SHO
 	{
 		if( !m_downstreamShaders.insert( m_shader ).second )
 		{
-			throw IECore::Exception(
-				fmt::format(
-					"Shader \"{}\" is involved in a dependency cycle.",
-					m_shader->relativeName( m_shader->ancestor<ScriptNode>() )
-				)
-			);
+			// throw IECore::Exception(
+			// 	fmt::format(
+			// 		"Shader \"{}\" is involved in a dependency cycle.",
+			// 		m_shader->relativeName( m_shader->ancestor<ScriptNode>() )
+			// 	)
+			// );
 		}
 	}
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -40,6 +40,7 @@
 #include "GafferScene/ShaderTweakProxy.h"
 
 #include "Gaffer/ContextProcessor.h"
+#include "Gaffer/Loop.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/OptionalValuePlug.h"

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -40,10 +40,10 @@
 #include "GafferScene/ShaderTweakProxy.h"
 
 #include "Gaffer/ContextProcessor.h"
-#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Metadata.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/OptionalValuePlug.h"
+#include "Gaffer/PlugAlgo.h"
 #include "Gaffer/ScriptNode.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/SplinePlug.h"

--- a/src/GafferSceneModule/ShaderBinding.cpp
+++ b/src/GafferSceneModule/ShaderBinding.cpp
@@ -140,6 +140,12 @@ IECore::CompoundObjectPtr shaderPlugAttributes( const ShaderPlug &p, bool copy=t
 	}
 }
 
+Gaffer::ValuePlugPtr shaderPlugParameterSource( ShaderPlug &p, const IECoreScene::ShaderNetwork::Parameter &parameter )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return p.parameterSource( parameter );
+}
+
 } // namespace
 
 void GafferSceneModule::bindShader()
@@ -167,6 +173,7 @@ void GafferSceneModule::bindShader()
 		// value accessors
 		.def( "attributesHash", &shaderPlugAttributesHash  )
 		.def( "attributes", &shaderPlugAttributes, ( boost::python::arg_( "_copy" ) = true ) )
+		.def( "parameterSource", &shaderPlugParameterSource )
 	;
 
 	GafferBindings::NodeClass<OpenGLShader>();

--- a/src/GafferSceneTest/TestShader.cpp
+++ b/src/GafferSceneTest/TestShader.cpp
@@ -143,4 +143,10 @@ void TestShader::loadShader( const std::string &shaderName, bool keepExistingVal
 		setupTypedPlug<SplinefColor3fPlug>( "spline", parametersPlug, SplineDefinitionfColor3f() );
 		setupOptionalValuePlug<StringPlug>( "optionalString", parametersPlug, new StringPlug() );
 	}
+	else if( shaderName == "mix" )
+	{
+		setupTypedPlug<Color3fPlug>( "a", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<Color3fPlug>( "b", parametersPlug, Imath::Color3f( 0.f ) );
+		setupTypedPlug<FloatPlug>( "mix", parametersPlug, 0.5 );
+	}
 }


### PR DESCRIPTION
Draft PR so we can get a build deployed for initial testing and internal development at Cinesite. This initial implementation works, but duplicates shaders unnecessarily if they are seen in different contexts but don't actually vary in those contexts. We won't merge until we have that sorted. Don't review just yet - let me get my ducks in a row first.