### PR TITLE
Recursive Instancer Other Approach

### DIFF
--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -1396,6 +1396,12 @@ Instancer::Instancer( const std::string &name )
 	capsuleScenePlug()->attributesPlug()->setInput( outPlug()->attributesPlug() );
 	capsuleScenePlug()->setNamesPlug()->setInput( outPlug()->setNamesPlug() );
 	capsuleScenePlug()->globalsPlug()->setInput( outPlug()->globalsPlug() );
+
+	prototypesPlug()->setFlags( Plug::AcceptsDependencyCycles, true );
+	for( Gaffer::Plug::RecursiveIterator it( prototypesPlug() ); !it.done(); ++it )
+	{
+		(*it)->setFlags( Plug::AcceptsDependencyCycles, true );
+	}
 }
 
 Instancer::~Instancer()
@@ -2665,12 +2671,25 @@ bool Instancer::affectsBranchSetNames( const Gaffer::Plug *input ) const
 void Instancer::hashBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+
+	if( prototypesPlug()->getInput() == outPlug() )
+	{
+		h = inPlug()->setNamesPlug()->hash();
+		return;
+	}
+
 	h = prototypesPlug()->setNamesPlug()->hash();
 }
 
 IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchSetNames( const ScenePath &sourcePath, const Gaffer::Context *context ) const
 {
 	assert( sourcePath.size() == 0 ); // Expectation driven by `constantBranchSetNames() == true`
+
+	if( prototypesPlug()->getInput() == outPlug() )
+	{
+		return inPlug()->setNamesPlug()->getValue();
+	}
+
 	return prototypesPlug()->setNamesPlug()->getValue();
 }
 


### PR DESCRIPTION
As requested on #6194, here is an absolutely minimal set of changes to allow recursive instancing. This does allow using a single node to adapt a USD scene with instancing of instancers ( by plugging the output of an Instancer back into it's prototypes ), but I don't yet see a path to actually deploying it. Currently there is nothing to prevent a casual user from accidentally connecting a cycle into `prototypes`, and if that connection goes through even a dot, then the special case for a direct loop in hashBranchSetNames won't trigger, resulting in an immediate crash.