### PR TITLE
CompoundEditor : Fix maximizing detached windows

### DIFF
--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -1429,7 +1429,14 @@ def _restoreWindowState( gafferWindow, boundData ) :
 		screens = QtWidgets.QApplication.screens()
 		if boundData["screen"] < len(screens) :
 			targetScreen = screens[ boundData["screen"] ]
-			window.setScreen( targetScreen )
+			# \todo In Qt6, `setScreen()` is added to `QWidget` which we should
+			# be able to use to set the screen including for detached windows.
+
+			window.setWindowState( QtCore.Qt.WindowNoState )
+
+			screenGeom = targetScreen.availableGeometry()
+			geometry = window.geometry()
+			window.setGeometry( screenGeom.x(), screenGeom.y(), geometry.width(), geometry.height() )
 
 	if boundData["fullScreen"] :
 		window.setWindowState( QtCore.Qt.WindowFullScreen )


### PR DESCRIPTION
Qt can only `setScreen()` on the top-level Window (https://doc.qt.io/qt-5/qwindow.html#setScreen), which means that layouts with detached windows that set to maximized would not be moved to a non-primary screen. By setting the window geometry based on the desired screen, before maximizing, the detached windows get maximized on the right screen.

There's a bit of an assumption here when doing `window.setGeometry()` that the target screen will have at least enough resolution to hold the originally created window. From what I've seen so far, if the screen can't hold the dimensions requested, at worst you get a warning on the terminal that the window is being resized.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
