### PR TITLE
IECoreArnold, IECoreDelight : Load configs from `GAFFER_STARTUP_PATHS`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ API
 ---
 
 - TweakPlug : Added `applyElementwiseTweak()` method, for tweaking elements of a `*VectorData`.
+- IECoreArnold, IECoreDelight : Added support for config files installed on `GAFFER_STARTUP_PATHS`.
 
 1.5.2.0 (relative to 1.5.1.0)
 =======

--- a/python/IECoreArnold/__init__.py
+++ b/python/IECoreArnold/__init__.py
@@ -44,3 +44,5 @@ del os, pathlib # Don't pollute the namespace
 from ._IECoreArnold import *
 
 from .UniverseBlock import UniverseBlock
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "IECoreArnold" )

--- a/python/IECoreDelight/__init__.py
+++ b/python/IECoreDelight/__init__.py
@@ -42,3 +42,5 @@ if hasattr( os, "add_dll_directory" ) and "DELIGHT" in os.environ :
 del os, pathlib # Don't pollute the namespace
 
 from ._IECoreDelight import *
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "IECoreDelight" )


### PR DESCRIPTION
In the case of IECoreArnold, this is particularly useful for registering substitutions with ShaderNetworkAlgo.
