### PR TITLE
TestCase : Temp directory access improvements

### DIFF
--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -115,6 +115,9 @@ class TestCase( unittest.TestCase ) :
 		IECore.RefCounted.collectGarbage()
 
 		if self.__temporaryDirectory is not None :
+			if os.name == "nt" :
+				subprocess.check_call( [ "icacls", self.__temporaryDirectory, "/grant", "Users:(OI)(CI)(W)" ] )
+
 			for root, dirs, files in os.walk( self.__temporaryDirectory ) :
 				for fileName in [ p for p in files + dirs if not ( pathlib.Path( root ) / p ).is_symlink() ] :
 					( pathlib.Path( root ) / fileName ).chmod( stat.S_IRWXU )

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -114,11 +114,11 @@ class TestCase( unittest.TestCase ) :
 		## \todo Fix Cortex so that wrapped classes don't require garbage collection.
 		IECore.RefCounted.collectGarbage()
 
-		for root, dirs, files in os.walk( self.temporaryDirectory() ) :
-			for fileName in [ p for p in files + dirs if not ( pathlib.Path( root ) / p ).is_symlink() ] :
-				( pathlib.Path( root ) / fileName ).chmod( stat.S_IRWXU )
-
 		if self.__temporaryDirectory is not None :
+			for root, dirs, files in os.walk( self.__temporaryDirectory ) :
+				for fileName in [ p for p in files + dirs if not ( pathlib.Path( root ) / p ).is_symlink() ] :
+					( pathlib.Path( root ) / fileName ).chmod( stat.S_IRWXU )
+
 			shutil.rmtree( self.__temporaryDirectory )
 
 		IECore.MessageHandler.setDefaultHandler( self.__defaultMessageHandler )

--- a/python/GafferUSDTest/USDLayerWriterTest.py
+++ b/python/GafferUSDTest/USDLayerWriterTest.py
@@ -265,8 +265,5 @@ class USDLayerWriterTest( GafferSceneTest.SceneTestCase ) :
 		with self.assertRaisesRegex( RuntimeError, 'Failed to export layer to "{}"'.format( layerWriter["fileName"].getValue() ) ) :
 			layerWriter["task"].execute()
 
-		if os.name == "nt" :
-			subprocess.check_call( [ "icacls", self.temporaryDirectory(), "/grant", "Users:(OI)(CI)(W)" ] )
-
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This improves a few things with `TestCase.tearDown` :
- We were always creating the temporary directory when setting descendant files to read / write / execute permissions. Now we are only setting those permissions if the directory exists.
- Windows uses a somewhat strange permissions scheme, this ensures the temporary directory is able to be deleted in `tearDown()`. I did a double check to make sure the call to `icacls` doesn't increase the overall test times too much. It does increase the time relatively, but when testing `GafferSceneTest`, it was adding up to only a bit over half a second.
- We had been skipping the `GafferImage.CatalogueTest.testNonWritableDirectory` on Windows because it was thought Windows couldn't make a directory truly read-only. Using extended permissions allows that, so this test can be adapted and enabled.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
