### PR TITLE
Arnold : Multiple Outputs Per Driver

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.x.x.x (relative to 1.5.x.x)
 =======
 
+Features
+--------
+
+* Arnold : Added multi-layer EXR support. All outputs with the same filename are now written to the same file via a single output driver.
+
 Improvements
 ------------
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -671,7 +671,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.output(
 			"testB",
 			IECoreScene.Output(
-				"beauty.exr",
+				"beautyWithAlpha.exr",
 				"exr",
 				"color B",
 				{
@@ -769,7 +769,7 @@ class RendererTest( GafferTest.TestCase ) :
 		r.output(
 			"testWithAlpha",
 			IECoreScene.Output(
-				"beauty.exr",
+				"beautyWithAlpha.exr",
 				"exr",
 				"lpe C.*D.*",
 				{

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -802,6 +802,123 @@ class RendererTest( GafferTest.TestCase ) :
 				"ieCoreArnold:lpe:testWithAlpha C.*D.*"
 			] ) )
 
+	def testCombinedOutputs( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.ass" )
+		)
+
+		r.output(
+			"testA",
+			IECoreScene.Output(
+				"combined.exr",
+				"exr",
+				"color A",
+				{}
+			)
+		)
+
+		r.output(
+			"testB",
+			IECoreScene.Output(
+				"combined.exr",
+				"exr",
+				"color B",
+				{ "testParm" : 2 }
+			)
+		)
+
+		with self.assertRaisesRegex( RuntimeError, 'Mismatch in combined output driver for file name "combined.exr" : missing parameter "testParm"' ):
+			r.render()
+
+		r.output(
+			"testA",
+			IECoreScene.Output(
+				"combined.exr",
+				"exr",
+				"color A",
+				{ "testParm" : 2 }
+			)
+		)
+
+		r.output(
+			"testC",
+			IECoreScene.Output(
+				"single.exr",
+				"exr",
+				"color C",
+				{ "whatever" : 3 }
+			)
+		)
+
+		r.output(
+			"testD",
+			IECoreScene.Output(
+				"combined2.exr",
+				"exr",
+				"color D",
+				{ "filter" : "catrom" }
+			)
+		)
+
+		r.output(
+			"testE",
+			IECoreScene.Output(
+				"combined2.exr",
+				"exr",
+				"color E",
+				{ "filter" : "catrom" }
+			)
+		)
+
+		r.output(
+			"testF",
+			IECoreScene.Output(
+				"combined2.exr",
+				"exr",
+				"color F",
+				{ "filter" : "catrom" }
+			)
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+
+			options = arnold.AiUniverseGetOptions( universe )
+			outputs = arnold.AiNodeGetArray( options, "outputs" )
+			outputSet = set( arnold.AiArrayGetStr( outputs, i ) for i in range( 0, arnold.AiArrayGetNumElements( outputs ) ) )
+			self.assertEqual( outputSet, set( [
+				"A RGB ieCoreArnold:filter:testA,testB ieCoreArnold:display:testA,testB",
+				"E RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF",
+				"B RGB ieCoreArnold:filter:testA,testB ieCoreArnold:display:testA,testB",
+				"C RGB ieCoreArnold:filter:testC ieCoreArnold:display:testC",
+				"D RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF",
+				"F RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF"
+			] ) )
+
+			driver1 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testA,testB" )
+			self.assertEqual( arnold.AiNodeGetStr( driver1, "filename" ), "combined.exr" )
+			self.assertEqual( arnold.AiNodeGetInt( driver1, "testParm" ), 2 )
+			filter1 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testA,testB" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter1 ) ), "gaussian_filter" )
+
+			driver2 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testC" )
+			self.assertEqual( arnold.AiNodeGetStr( driver2, "filename" ), "single.exr" )
+			self.assertEqual( arnold.AiNodeGetInt( driver2, "whatever" ), 3 )
+			filter2 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testC" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter2 ) ), "gaussian_filter" )
+
+			driver3 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testD,testE,testF" )
+			self.assertEqual( arnold.AiNodeGetStr( driver3, "filename" ), "combined2.exr" )
+			filter3 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testD,testE,testF" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter3 ) ), "catrom_filter" )
+
 	def testMultipleCameras( self ) :
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
 			"Arnold",


### PR DESCRIPTION
( Recreated from #6207 but with the branch on GafferHQ ).

This allows rendering multi-layer exrs directly from Arnold.

It took a fair bit of reorganizing to fit this into the current structure, but I'm feeling reasonably good about how it ended up - it should be in a good place for reviewing at least. It probably could use more test coverage before we merge it ( perhaps less for the new feature being added, and more for some of the existing functionality, to make sure that nothing has been broken that is currently in use ).

The only known breakage that happened in the tests were that there were some tests that used the same filename for multiple outputs - these failed with an error about these outputs not being possible to merge, until they were given distinct names, which seems to reflect the intent of the tests. Hopefully this wouldn't be an issue in production scenes, where people are actually using the files ( the only reason why the file being overwritten wasn't previously an issue is because the test in question was just testing the conversion to an Arnold scene, not an actual render ).

The one case I can think of that could affect production is that previously when using ieDisplay, you could use an identical fileName for multiple outputs with different parameters, since the fileName wasn't important to an interactive display. If users were doing that, they could an error message about the outputs not being valid to merge, and need to change the output name. But hopefully if they've been creating displays based on Gaffer's templates, this won't be an issue.