### PR TITLE
OpDialogue enum fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Fixes
   - Fixed error when trying to visualise data unsupported data.
 - TweakPlug : Fixed preservation of geometric interpretation when tweaking V3f values.
 - ApplicationTest : Extended grace period when testing process name on slower hosts.
+- OpDialogue : Fixed `DefaultButton` handling.
 
 API
 ---

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -464,8 +464,13 @@ class OpDialogue( GafferUI.Dialogue ) :
 			with IECore.IgnoredExceptions( KeyError ) :
 				d = self.__node.getParameterised()[0].userData()["UI"]["defaultButton"]
 			if d is not None :
-				for v in self.DefaultButton.values() :
+				for v in self.DefaultButton :
 					if str( v ).lower() == d.value.lower() :
+						defaultButton = v
+						break
+
+					# backwards compatibility for IECore.Enum()
+					if str( v ).lower() == f"DefaultButton.{d.value}".lower() :
 						defaultButton = v
 						break
 


### PR DESCRIPTION
This is the same type of fix as the one performed by #6131, which is necessary since the transition to native python enums.

I believe this is the last one of this type (at least for anything in `GafferCortex`).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
