### PR TITLE
VisualiserTool : Vertex Labels

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 1.5.x.x (relative to 1.5.4.0)
 =======
 
+Improvements
+------------
+
+- VisualiserTool : Added `mode` plug. The available modes are :
+  - Auto : Chooses the most appropriate mode based on the data and primitive type.
+  - Color (Auto Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
+  - Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,10 +4,12 @@
 Improvements
 ------------
 
-- VisualiserTool : Added `mode` plug. The available modes are :
-  - Auto : Chooses the most appropriate mode based on the data and primitive type.
-  - Color (Auto Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
-  - Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
+- VisualiserTool :
+  - Changed naming requirements for visualising primitive variables. Values in `dataName` now prefix the primitive variable name with `primitiveVariable:`. Setting `dataName` to `vertex:index` will display vertex indices.
+  - Added `mode` plug. The available modes are :
+    - Auto : Chooses the most appropriate mode based on the data and primitive type.
+    - Color (Auto Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
+    - Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
     - Auto : Chooses the most appropriate mode based on the data and primitive type.
     - Color (Auto Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
     - Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
+    - Vertex Label : Values are displayed as a label next to each vertex.
   - When visualising data as vertex labels, the value for the vertex nearest the mouse cursor gets visual emphasis. This value is also used for drag and drop.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
     - Auto : Chooses the most appropriate mode based on the data and primitive type.
     - Color (Auto Range) : Float, integer, V2f and color data is displayed without modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
     - Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
+  - When visualising data as vertex labels, the value for the vertex nearest the mouse cursor gets visual emphasis. This value is also used for drag and drop.
 
 Fixes
 -----
@@ -51,20 +52,6 @@ API
 - ScriptNodeAlgo : Added functions for managing VisibleSet bookmarks.
 
 1.5.3.0 (relative to 1.5.2.0)
-=======
-
-Features
---------
-
-- PrimitiveVariableTweaks : Added node for tweaking primitive variables. Can affect just part of a primitive based on ids or a mask.
-- Menu Bar : Added a "Render Pass" menu to the Menu Bar that can be used to choose the current render pass from those provided by the focus node.
-
-Improvements
-------------
-
-- Shader, ShaderPlug : Added support for ContextProcessor, Loop and Spreadsheet nodes to be used inline between shader nodes and as the terminal node connected to
-  ShaderAssignment and other shader-consuming nodes.
-- VisualiserTool : Changed `dataName` input widget for choosing the primitive variable to visualise to a list of available variable names for the current selection.
 - Tweaks nodes : Moved list of tweaks to a collapsible "Tweaks" section in the NodeEditor.
 - Viewer :
   - The shading mode menu icon now updates to indicate when a non-default shading mode is in use.

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -68,11 +68,24 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::VisualiserTool, VisualiserToolTypeId, SelectionTool );
 
+		enum class Mode
+		{
+			Auto,
+			ColorAutoRange,
+			Color,
+
+			First = Auto,
+			Last = Color
+		};
+
 		Gaffer::StringPlug *dataNamePlug();
 		const Gaffer::StringPlug *dataNamePlug() const;
 
 		Gaffer::FloatPlug *opacityPlug();
 		const Gaffer::FloatPlug *opacityPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
 
 		Gaffer::V3fPlug *valueMinPlug();
 		const Gaffer::V3fPlug *valueMinPlug() const;

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -122,7 +122,8 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 
 		const std::vector<Selection> &selection() const;
 
-		Imath::V2f cursorPos() const;
+		using CursorPosition = std::optional<Imath::V2f>;
+		CursorPosition cursorPos() const;
 
 		const IECore::Data *cursorValue() const;
 
@@ -159,8 +160,7 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 
 		GafferUI::GadgetPtr m_gadget;
 		mutable std::vector<Selection> m_selection;
-		Imath::V2i m_cursorPos;
-		bool m_cursorPosValid;
+		CursorPosition m_cursorPos;
 		IECore::DataPtr m_cursorValue;
 		bool m_gadgetDirty;
 		mutable bool m_selectionDirty;

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -73,9 +73,10 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 			Auto,
 			ColorAutoRange,
 			Color,
+			VertexLabel,
 
 			First = Auto,
-			Last = Color
+			Last = VertexLabel
 		};
 
 		Gaffer::StringPlug *dataNamePlug();

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -50,6 +50,8 @@
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/StringPlug.h"
 
+#include <variant>
+
 namespace
 {
 
@@ -126,7 +128,8 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		using CursorPosition = std::optional<Imath::V2f>;
 		CursorPosition cursorPos() const;
 
-		const IECore::Data *cursorValue() const;
+		using CursorValue = std::variant<std::monostate, int, float, Imath::V2f, Imath::V3f, Imath::Color3f>;
+		const CursorValue cursorValue() const;
 
 		GafferScene::ScenePlug *internalScenePlug();
 		const GafferScene::ScenePlug *internalScenePlug() const;
@@ -162,11 +165,11 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		GafferUI::GadgetPtr m_gadget;
 		mutable std::vector<Selection> m_selection;
 		CursorPosition m_cursorPos;
-		IECore::DataPtr m_cursorValue;
+		CursorValue m_cursorValue;
 		bool m_gadgetDirty;
 		mutable bool m_selectionDirty;
 		bool m_priorityPathsDirty;
-		IECore::DataPtr m_valueAtButtonPress;
+		CursorValue m_valueAtButtonPress;
 		bool m_initiatedDrag;
 
 		static ToolDescription<VisualiserTool, SceneView> m_toolDescription;

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -108,6 +108,7 @@ Gaffer.Metadata.registerNode(
 			"preset:Auto", GafferSceneUI.VisualiserTool.Mode.Auto,
 			"preset:Color", GafferSceneUI.VisualiserTool.Mode.Color,
 			"preset:Color (Auto Range)", GafferSceneUI.VisualiserTool.Mode.ColorAutoRange,
+			"preset:Vertex Label", GafferSceneUI.VisualiserTool.Mode.VertexLabel,
 
 			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
 

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -59,6 +59,8 @@ Gaffer.Metadata.registerNode(
 	"order", 8,
 	"tool:exclusive", False,
 
+	"toolbarLayout:activator:modeIsColor", lambda node : node["mode"].getValue() == GafferSceneUI.VisualiserTool.Mode.Color,
+
 	plugs = {
 
 		"dataName" : [
@@ -86,6 +88,28 @@ Gaffer.Metadata.registerNode(
 			"toolbarLayout:width", 100,
 
 		],
+		"mode" : [
+
+			"description",
+			"""
+			The method for displaying the data.
+
+			- Auto : Chooses the most appropriate mode based on the data and primitive type.
+			- Color : Values are remapped from the range `[valueMin, valueMax]` to `[0, 1]`.
+			- Color (Auto Range) : Float, integer, V2f and color data is displayed without
+			modification. Vector data is remapped from `[-1, 1]` to `[0, 1]`.
+			""",
+
+			"preset:Auto", GafferSceneUI.VisualiserTool.Mode.Auto,
+			"preset:Color", GafferSceneUI.VisualiserTool.Mode.Color,
+			"preset:Color (Auto Range)", GafferSceneUI.VisualiserTool.Mode.ColorAutoRange,
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 150,
+
+		],
 		"valueMin" : [
 
 			"description",
@@ -98,6 +122,8 @@ Gaffer.Metadata.registerNode(
 
 			"toolbarLayout:section", "Bottom",
 			"toolbarLayout:width", 175,
+
+			"toolbarLayout:visibilityActivator", "modeIsColor",
 
 		],
 		"valueMax" : [
@@ -112,6 +138,8 @@ Gaffer.Metadata.registerNode(
 
 			"toolbarLayout:section", "Bottom",
 			"toolbarLayout:width", 175,
+
+			"toolbarLayout:visibilityActivator", "modeIsColor",
 
 		],
 		"size": [

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -51,7 +51,7 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Tool for displaying named primitive variables of type float, V2f or V3f as a colored overlay.
+	Tool for displaying object data.
 	""",
 
 	"viewer:shortCut", "O",
@@ -71,6 +71,9 @@ Gaffer.Metadata.registerNode(
 			prefixed by `primitiveVariable:`. For example, `primitiveVariable:uv`
 			would display the `uv` primitive variable. Primitive variables of
 			type int, float, V2f, Color3f or V3f can be visualised.
+
+			To visualise vertex indices instead of a primitive variable, use the
+			value `vertex:index`.
 			""",
 
 			"toolbarLayout:section", "Bottom",
@@ -162,6 +165,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 
 	__primitiveVariablePrefix = "primitiveVariable:"
 	__primitiveVariablePrefixSize = len( __primitiveVariablePrefix )
+	__vertexIndexDataName = "vertex:index"
 
 	def __init__( self, plug, **kw ) :
 
@@ -173,7 +177,12 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 
 	def _updateFromValues( self, values, exception ) :
 
-		self.__menuButton.setText( sole( [ self.__primitiveVariableFromDataName( v ) for v in values ] ) or "None" )
+		singleValue = sole( values )
+		text = "None"
+		if singleValue is not None :
+			text = "Vertex Index" if singleValue == self.__vertexIndexDataName else self.__primitiveVariableFromDataName( singleValue )
+
+		self.__menuButton.setText( text )
 
 	def __menuDefinition( self ) :
 
@@ -236,6 +245,15 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 				)
 
 		menuDefinition.prepend( "/PrimitiveVariableDivider", { "divider" : True, "label" : "Primitive Variables" } )
+
+		menuDefinition.append( "/Other", { "divider" : True, "label" : "Other" } )
+		menuDefinition.append(
+			"/Vertex Index",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setDataName ), self.__vertexIndexDataName ),
+				"checkBox" : self.getPlug().getValue() == self.__vertexIndexDataName,
+			}
+		)
 
 		return menuDefinition
 

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -207,7 +207,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 					continue
 
 				primitive = scenePlug.object( path )
-				if not isinstance( primitive, IECoreScene.MeshPrimitive ) :
+				if not isinstance( primitive, IECoreScene.Primitive ) :
 					continue
 
 				for v in primitive.keys() :

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -489,7 +489,6 @@ class VisualiserGadget : public Gadget
 				return;
 			}
 
-			// Bootleg shader
 			buildShader( m_colorShader, g_colorShaderVertSource, g_colorShaderFragSource );
 
 			if( !m_colorShader )
@@ -501,7 +500,6 @@ class VisualiserGadget : public Gadget
 			// variable data to opengl buffers which will be shared with the IECoreGL renderer
 			IECoreGL::CachedConverter *converter = IECoreGL::CachedConverter::defaultCachedConverter();
 
-			// Bootleg uniform buffer
 			GLint uniformBinding;
 			glGetIntegerv( GL_UNIFORM_BUFFER_BINDING, &uniformBinding );
 

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -76,10 +76,11 @@ IECORE_POP_DEFAULT_VISIBILITY
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/preprocessor/stringize.hpp"
 
+#include "fmt/format.h"
+
 #include <algorithm>
 #include <cassert>
 #include <limits>
-#include <sstream>
 #include <string>
 
 using namespace Imath;
@@ -829,29 +830,37 @@ class VisualiserGadget : public Gadget
 
 			if( value )
 			{
-				std::ostringstream oss;
+				std::string text;
 				switch( value->typeId() )
 				{
 					case IntDataTypeId:
-						oss << ( assertedStaticCast<const IntData>( value )->readable() );
+						text = fmt::format( "{}", assertedStaticCast<const IntData>( value )->readable() );
 						break;
 					case FloatDataTypeId:
-						oss << ( assertedStaticCast<const FloatData>( value )->readable() );
+						text = fmt::format( "{:.3f}", assertedStaticCast<const FloatData>( value )->readable() );
 						break;
 					case V2fDataTypeId:
-						oss << ( assertedStaticCast<const V2fData>( value )->readable() );
+						{
+							auto v = assertedStaticCast<const V2fData>( value )->readable();
+							text = fmt::format( "{:.3f}, {:.3f}", v.x, v.y );
+						}
 						break;
 					case V3fDataTypeId:
-						oss << ( assertedStaticCast<const V3fData>( value )->readable() );
+						{
+							auto v = assertedStaticCast<const V3fData>( value )->readable();
+							text = fmt::format( "{:.3f}, {:.3f}, {:.3f}", v.x, v.y, v.z);
+						}
 						break;
 					case Color3fDataTypeId:
-						oss << ( assertedStaticCast<const Color3fData>( value )->readable() );
+						{
+							auto v = assertedStaticCast<const Color3fData>( value )->readable();
+							text = fmt::format( "{:.3f}, {:.3f}, {:.3f}", v.x, v.y, v.z );
+						}
 						break;
 					default:
 						break;
 				}
 
-				const std::string text = oss.str();
 				if( !text.empty() )
 				{
 					// Draw in raster space
@@ -981,7 +990,6 @@ class VisualiserGadget : public Gadget
 
 			// Loop through current selection
 
-			std::stringstream oss;
 			for( const auto &location : m_tool->selection() )
 			{
 				GafferScene::ScenePlug::PathScope scope( &location.context() , &location.path() );
@@ -1242,10 +1250,7 @@ class VisualiserGadget : public Gadget
 
 								if( vertexId != -1 )
 								{
-									oss.str( "" );
-									oss.clear();
-									oss << vertexId;
-									const std::string text = oss.str();
+									const std::string text = fmt::format( "{}", vertexId );
 
 									drawStrokedText(
 										viewportGadget,
@@ -1279,10 +1284,7 @@ class VisualiserGadget : public Gadget
 			{
 				GafferUI::ViewportGadget::RasterScope raster( viewportGadget );
 
-				oss.str( "" );
-				oss.clear();
-				oss << cursorVertexId;
-				std::string const text = oss.str();
+				std::string const text = fmt::format( "{}", cursorVertexId );
 
 				drawStrokedText(
 					viewportGadget,

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -821,7 +821,7 @@ class VisualiserGadget : public Gadget
 			// Display value at cursor as text
 
 			std::optional<V2f> cursorPos = m_tool->cursorPos();
-			if( !cursorPos )
+			if( !cursorPos || !std::holds_alternative<std::monostate>( cursorVertexValue() ) )
 			{
 				return;
 			}
@@ -1013,7 +1013,11 @@ class VisualiserGadget : public Gadget
 						continue;
 					}
 
-					if( mode == VisualiserTool::Mode::Auto && vData->typeId() != IntVectorDataTypeId )
+					if(
+						mode == VisualiserTool::Mode::Auto &&
+						primitive->typeId() == MeshPrimitive::staticTypeId() &&
+						vData->typeId() != IntVectorDataTypeId
+					)
 					{
 						// Will be handled by `renderColorVisualiser()` instead.
 						continue;

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -1944,7 +1944,7 @@ void VisualiserTool::updateCursorValue()
 		return;
 	}
 
-	const std::string &dataName = dataNamePlug()->getValue();
+	const std::string dataName = dataNamePlug()->getValue();
 
 	// We draw all visualisation types each time, and the vertex label visualisation
 	// resets the `cursorVertexData()` each time before potentially setting it to

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -113,7 +113,7 @@ const Color4f g_textShadowColor( 0.2f, 0.2f, 0.2f, 1.f );
 const float g_textShadowOffset = 0.1f;
 
 // Uniform block structure (std140 layout)
-struct UniformBlock
+struct UniformBlockColorShader
 {
 	alignas( 16 ) M44f o2c;
 	alignas( 16 ) V3f valueMin;
@@ -123,7 +123,7 @@ struct UniformBlock
 
 const GLuint g_uniformBlockBindingIndex = 0;
 
-#define UNIFORM_BLOCK_GLSL_SOURCE \
+#define UNIFORM_BLOCK_COLOR_SHADER_GLSL_SOURCE \
 	"layout( std140, row_major ) uniform UniformBlock\n" \
 	"{\n" \
 	"   mat4 o2c;\n" \
@@ -137,13 +137,13 @@ const GLuint g_uniformBlockBindingIndex = 0;
 #define ATTRIB_GLSL_LOCATION_VSY 2
 #define ATTRIB_GLSL_LOCATION_VSZ 3
 
-#define ATTRIB_GLSL_SOURCE \
+#define ATTRIB_COLOR_SHADER_GLSL_SOURCE \
 	"layout( location = " BOOST_PP_STRINGIZE( ATTRIB_GLSL_LOCATION_PS ) " ) in vec3 ps;\n" \
 	"layout( location = " BOOST_PP_STRINGIZE( ATTRIB_GLSL_LOCATION_VSX ) " ) in float vsx;\n" \
 	"layout( location = " BOOST_PP_STRINGIZE( ATTRIB_GLSL_LOCATION_VSY ) " ) in float vsy;\n" \
 	"layout( location = " BOOST_PP_STRINGIZE( ATTRIB_GLSL_LOCATION_VSZ ) " ) in float vsz;\n" \
 
-#define INTERFACE_BLOCK_GLSL_SOURCE( STORAGE, NAME ) \
+#define INTERFACE_BLOCK_COLOR_SHADER_GLSL_SOURCE( STORAGE, NAME ) \
 	BOOST_PP_STRINGIZE( STORAGE ) " InterfaceBlock\n" \
 	"{\n" \
 	"   smooth vec3 value;\n" \
@@ -151,14 +151,14 @@ const GLuint g_uniformBlockBindingIndex = 0;
 
 // Opengl vertex shader code
 
-const std::string g_vertSource(
+const std::string g_colorShaderVertSource(
 	"#version 330\n"
 
-	UNIFORM_BLOCK_GLSL_SOURCE
+	UNIFORM_BLOCK_COLOR_SHADER_GLSL_SOURCE
 
-	ATTRIB_GLSL_SOURCE
+	ATTRIB_COLOR_SHADER_GLSL_SOURCE
 
-	INTERFACE_BLOCK_GLSL_SOURCE( out, outputs )
+	INTERFACE_BLOCK_COLOR_SHADER_GLSL_SOURCE( out, outputs )
 
 	"void main()\n"
 	"{\n"
@@ -170,13 +170,13 @@ const std::string g_vertSource(
 
 // Opengl fragment shader code
 
-const std::string g_fragSource
+const std::string g_colorShaderFragSource
 (
 	"#version 330\n"
 
-	UNIFORM_BLOCK_GLSL_SOURCE
+	UNIFORM_BLOCK_COLOR_SHADER_GLSL_SOURCE
 
-	INTERFACE_BLOCK_GLSL_SOURCE( in, inputs )
+	INTERFACE_BLOCK_COLOR_SHADER_GLSL_SOURCE( in, inputs )
 
 	"layout( location = 0 ) out vec4 cs;\n"
 
@@ -225,399 +225,12 @@ class VisualiserGadget : public Gadget
 
 			if( layer == Gadget::Layer::MidFront )
 			{
-
-				// Bootleg shader
-				buildShader();
-
-				if( !m_shader )
-				{
-					return;
-				}
-
-				// Get the cached converter from IECoreGL, this is used to convert primitive
-				// variable data to opengl buffers which will be shared with the IECoreGL renderer
-				IECoreGL::CachedConverter *converter = IECoreGL::CachedConverter::defaultCachedConverter();
-
-				// Bootleg uniform buffer
-				GLint uniformBinding;
-				glGetIntegerv( GL_UNIFORM_BUFFER_BINDING, &uniformBinding );
-
-				if( !m_uniformBuffer )
-				{
-					GLuint buffer = 0u;
-					glGenBuffers( 1, &buffer );
-					glBindBuffer( GL_UNIFORM_BUFFER, buffer );
-					glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlock ), 0, GL_DYNAMIC_DRAW );
-					m_uniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
-				}
-
-				glBindBufferBase( GL_UNIFORM_BUFFER, g_uniformBlockBindingIndex, m_uniformBuffer->buffer() );
-
-				// Get the name of the primitive variable to visualise
-				const std::string &name = m_tool->dataNamePlug()->getValue();
-
-				// Get min/max values and colors and opacity
-				UniformBlock uniforms;
-				const VisualiserTool::Mode mode = (VisualiserTool::Mode)m_tool->modePlug()->getValue();
-				const V3f valueMin = m_tool->valueMinPlug()->getValue();
-				const V3f valueMax = m_tool->valueMaxPlug()->getValue();
-				uniforms.opacity = m_tool->opacityPlug()->getValue();
-
-				// Compute value range reciprocal
-				//
-				// NOTE : when range is <= 0 set the reciprocal to 0 so that value becomes 0 (minimum)
-				std::optional<V3f> valueRange;
-				if( mode == VisualiserTool::Mode::Color )
-				{
-					valueRange = ( valueMax - valueMin );
-					for( int i = 0; i < 3; ++i )
-					{
-						valueRange.value()[i] = ( valueRange.value()[i] > 0.f ) ? ( 1.f / valueRange.value()[i] ) : 0.f;
-					}
-				}
-
-				// Get the world to clip space matrix
-				M44f v2c;
-				glGetFloatv( GL_PROJECTION_MATRIX, v2c.getValue() );
-				const M44f w2c = viewportGadget->getCameraTransform().gjInverse() * v2c;
-
-				// Set opengl polygon and blend state
-				//
-				// NOTE : use polygon offset to ensure that any discrepancies between the transform
-				//        from object to clip space do not cause z-fighting. This is necessary as
-				//        the shader uses an object to clip matrix which may give slighly different
-				//        depth results to the transformation used in the IECoreGL renderer.
-				GLint blendEqRgb;
-				GLint blendEqAlpha;
-				glGetIntegerv( GL_BLEND_EQUATION_RGB, &blendEqRgb );
-				glGetIntegerv( GL_BLEND_EQUATION_ALPHA, &blendEqAlpha );
-				glBlendEquation( GL_FUNC_ADD );
-
-				GLint blendSrcRgb;
-				GLint blendSrcAlpha;
-				GLint blendDstRgb;
-				GLint blendDstAlpha;
-				glGetIntegerv( GL_BLEND_SRC_RGB, &blendSrcRgb );
-				glGetIntegerv( GL_BLEND_SRC_ALPHA, &blendSrcAlpha );
-				glGetIntegerv( GL_BLEND_DST_RGB, &blendDstRgb );
-				glGetIntegerv( GL_BLEND_DST_ALPHA, &blendDstAlpha );
-				glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
-
-				const GLboolean depthEnabled = glIsEnabled( GL_DEPTH_TEST );
-				if( !depthEnabled )
-				{
-					glEnable( GL_DEPTH_TEST );
-				}
-
-				GLint depthFunc;
-				glGetIntegerv( GL_DEPTH_FUNC, &depthFunc );
-				glDepthFunc( GL_LEQUAL );
-
-				GLboolean depthWriteEnabled;
-				glGetBooleanv( GL_DEPTH_WRITEMASK, &depthWriteEnabled );
-				if( depthWriteEnabled )
-				{
-					glDepthMask( GL_FALSE );
-				}
-
-				const GLboolean blendEnabled = glIsEnabled( GL_BLEND );
-				if( !blendEnabled )
-				{
-					glEnable( GL_BLEND );
-				}
-
-				// MSVC appears to be doing an optimization that causes the call to
-				// `glPolygonMode( GL_FRONT_AND_BACK, polygonMode )` to fail with an
-				// "invalid enum" error. Initializing the value even when we are going
-				// to immediately set it via `glGetIntegerv()` prevents that optimization
-				// and allows us to successfully reset the value.
-				GLint polygonMode = GL_FILL;
-				glGetIntegerv( GL_POLYGON_MODE, &polygonMode );
-				glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );
-
-				const GLboolean cullFaceEnabled = glIsEnabled( GL_CULL_FACE );
-				if( cullFaceEnabled )
-				{
-					glDisable( GL_CULL_FACE );
-				}
-
-				const GLboolean polgonOffsetFillEnabled = glIsEnabled( GL_POLYGON_OFFSET_FILL );
-				if( !polgonOffsetFillEnabled )
-				{
-					glEnable( GL_POLYGON_OFFSET_FILL );
-				}
-
-				GLfloat polygonOffsetFactor, polygonOffsetUnits;
-				glGetFloatv( GL_POLYGON_OFFSET_FACTOR, &polygonOffsetFactor );
-				glGetFloatv( GL_POLYGON_OFFSET_UNITS, &polygonOffsetUnits );
-				glPolygonOffset( -1, -1 );
-
-				// Enable shader program
-
-				GLint shaderProgram;
-				glGetIntegerv( GL_CURRENT_PROGRAM, &shaderProgram );
-				glUseProgram( m_shader->program() );
-
-				// Set opengl vertex attribute array state
-
-				GLint arrayBinding;
-				glGetIntegerv( GL_ARRAY_BUFFER_BINDING, &arrayBinding );
-
-				glPushClientAttrib( GL_CLIENT_VERTEX_ARRAY_BIT );
-
-				glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_PS, 0 );
-				glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_PS );
-				glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSX, 0 );
-				glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSX );
-				glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSY, 0 );
-				glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSY );
-				glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSZ, 0 );
-
-				// Loop through current selection
-
-				for( const auto &location : m_tool->selection() )
-				{
-					ScenePlug::PathScope scope( &location.context(), &location.path() );
-
-					// Check path exists
-					if( !location.scene().existsPlug()->getValue() )
-					{
-						continue;
-					}
-
-					// Extract mesh primitive
-					auto mesh = runTimeCast<const MeshPrimitive>( location.scene().objectPlug()->getValue() );
-					if( !mesh )
-					{
-						continue;
-					}
-
-					// Retrieve cached IECoreGL mesh primitive
-					auto meshGL = runTimeCast<const IECoreGL::MeshPrimitive>( converter->convert( mesh.get() ) );
-					if( !meshGL )
-					{
-						continue;
-					}
-
-					// Find opengl "P" buffer data
-
-					IECoreGL::ConstBufferPtr pBuffer = meshGL->getVertexBuffer( g_pName );
-					if( !pBuffer )
-					{
-						continue;
-					}
-
-					// Find opengl named buffer data
-					//
-					// NOTE : conversion to IECoreGL mesh may generate vertex attributes (eg. "N")
-					//        so check named primitive variable exists on IECore mesh primitive.
-
-					const auto vIt = mesh->variables.find( name );
-					if( vIt == mesh->variables.end() )
-					{
-						continue;
-					}
-
-					ConstDataPtr vData = vIt->second.data;
-					GLsizei stride = 0;
-					GLenum type = GL_FLOAT;
-					bool offset = false;
-					bool enableVSZ = false;
-					switch( vData->typeId() )
-					{
-						case IntVectorDataTypeId:
-							type = GL_INT;
-							[[fallthrough]];
-						case FloatVectorDataTypeId:
-							enableVSZ = true;
-							uniforms.valueMin = valueRange ? V3f( valueMin.x ) : V3f( 0.f );
-							uniforms.valueRange = valueRange ? V3f( valueRange.value().x ) : V3f( 1.f );
-							break;
-						case V2fVectorDataTypeId:
-							stride = 2;
-							offset = true;
-							uniforms.valueMin = valueRange ? V3f( valueMin.x, valueMin.y, 0.f ) : V3f( 0.f );
-							uniforms.valueRange = valueRange ? V3f( valueRange.value().x, valueRange.value().y, 0.f ) : V3f( 1.f, 1.f, 0.f );
-							break;
-						case Color3fVectorDataTypeId:
-							stride = 3;
-							offset = true;
-							enableVSZ = true;
-							uniforms.valueMin = valueRange ? valueMin : V3f( 0.f );
-							uniforms.valueRange = valueRange ? valueRange.value() : V3f( 1.f );
-							break;
-						case V3fVectorDataTypeId:
-							stride = 3;
-							offset = true;
-							enableVSZ = true;
-							uniforms.valueMin = valueRange ? valueMin : V3f( -1.f );
-							// Use 0.5 instead of 2.0 to account for reciprocal in `valueRange` above
-							uniforms.valueRange = valueRange ? valueRange.value() : V3f( 0.5f );
-							break;
-						default:
-							continue;
-					}
-
-					IECoreGL::ConstBufferPtr vBuffer = meshGL->getVertexBuffer( name );
-					if( !vBuffer )
-					{
-						continue;
-					}
-
-					// Get the object to world transform
-
-					M44f o2w;
-					ScenePlug::ScenePath path( location.path() );
-					while( !path.empty() )
-					{
-						scope.setPath( &path );
-						o2w = o2w * location.scene().transformPlug()->getValue();
-						path.pop_back();
-					}
-
-					// Compute object to clip matrix
-					uniforms.o2c = o2w * w2c;
-
-					// Upload opengl uniform block data
-
-					glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlock ), &uniforms, GL_DYNAMIC_DRAW );
-
-					// Draw primitive
-					glBindBuffer( GL_ARRAY_BUFFER, pBuffer->buffer() );
-					glVertexAttribPointer( ATTRIB_GLSL_LOCATION_PS, 3, GL_FLOAT, GL_FALSE, 0, nullptr );
-					glBindBuffer( GL_ARRAY_BUFFER, vBuffer->buffer() );
-					glVertexAttribPointer( ATTRIB_GLSL_LOCATION_VSX, 1, type, GL_FALSE, stride * sizeof( GLfloat ), nullptr );
-					glVertexAttribPointer(
-						ATTRIB_GLSL_LOCATION_VSY,
-						1,
-						type,
-						GL_FALSE,
-						stride * sizeof( GLfloat ),
-						( void const *)( ( offset ? 1 : 0 ) * sizeof( GLfloat ) )
-					);
-					if( enableVSZ )
-					{
-						glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSZ );
-						glVertexAttribPointer(
-							ATTRIB_GLSL_LOCATION_VSZ,
-							1,
-							type,
-							GL_FALSE,
-							stride * sizeof( GLfloat ),
-							( void const *)( ( offset ? 2 : 0 ) * sizeof( GLfloat ) )
-						);
-					}
-					else
-					{
-						glDisableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSZ );
-						glVertexAttrib1f( ATTRIB_GLSL_LOCATION_VSZ, 0.f );
-					}
-
-					meshGL->renderInstances( 1 );
-				}
-
-				// Restore opengl state
-
-				glPopClientAttrib();
-				glBindBuffer( GL_ARRAY_BUFFER, arrayBinding );
-				glBindBuffer( GL_UNIFORM_BUFFER, uniformBinding );
-
-				glDepthFunc( depthFunc );
-				glBlendEquationSeparate( blendEqRgb, blendEqAlpha );
-				glBlendFuncSeparate( blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha );
-				glPolygonMode( GL_FRONT_AND_BACK, polygonMode );
-				if( cullFaceEnabled )
-				{
-					glEnable( GL_CULL_FACE );
-				}
-				if( !polgonOffsetFillEnabled )
-				{
-					glDisable( GL_POLYGON_OFFSET_FILL );
-				}
-				glPolygonOffset( polygonOffsetFactor, polygonOffsetUnits );
-
-				if( !blendEnabled )
-				{
-					glDisable( GL_BLEND );
-				}
-				if( !depthEnabled )
-				{
-					glDisable( GL_DEPTH_TEST );
-				}
-				if( depthWriteEnabled )
-				{
-					glDepthMask( GL_TRUE );
-				}
-				glUseProgram( shaderProgram );
+				renderColorVisualiser( viewportGadget );
 			}
 
 			else if( layer == Gadget::Layer::Front )
 			{
-				// Display value at cursor as text
-
-				const Data *value = m_tool->cursorValue();
-				if( value )
-				{
-					std::ostringstream oss;
-					switch( value->typeId() )
-					{
-						case IntDataTypeId:
-							oss << ( assertedStaticCast<const IntData>( value )->readable() );
-							break;
-						case FloatDataTypeId:
-							oss << ( assertedStaticCast<const FloatData>( value )->readable() );
-							break;
-						case V2fDataTypeId:
-							oss << ( assertedStaticCast<const V2fData>( value )->readable() );
-							break;
-						case V3fDataTypeId:
-							oss << ( assertedStaticCast<const V3fData>( value )->readable() );
-							break;
-						case Color3fDataTypeId:
-							oss << ( assertedStaticCast<const Color3fData>( value )->readable() );
-							break;
-						default:
-							break;
-					}
-
-					const std::string text = oss.str();
-					if( !text.empty() )
-					{
-						// Draw in raster space
-						//
-						// NOTE : It seems that Gaffer defines the origin of raster space as the top left corner
-						//        of the viewport, however the style text drawing functions assume that y increases
-						//        "up" the screen rather than "down", so invert y to ensure text is not upside down.
-
-						ViewportGadget::RasterScope raster( viewportGadget );
-						const float size = m_tool->sizePlug()->getValue();
-						const V3f scale( size, -size, 1.f );
-						const V2f &rp = m_tool->cursorPos();
-
-						glPushMatrix();
-						glTranslatef( rp.x, rp.y, 0.f );
-						glScalef( scale.x, scale.y, scale.z );
-
-						/// Shadow text
-						glTranslatef( g_textShadowOffset, 0.f, 0.f );
-						style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
-
-						glTranslatef( -g_textShadowOffset * 2.f, 0.f, 0.f );
-						style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
-
-						glTranslatef( g_textShadowOffset, g_textShadowOffset, 0.f );
-						style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
-
-						glTranslatef( 0.f, -g_textShadowOffset * 2.f, 0.f );
-						style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
-
-						/// Primary text
-						glTranslatef( 0.f, g_textShadowOffset, 0.f );
-						style->renderText( Style::LabelText, text );
-
-						glPopMatrix();
-					}
-				}
+				renderColorValue( viewportGadget, style );
 			}
 		}
 
@@ -642,7 +255,7 @@ class VisualiserGadget : public Gadget
 			if( !m_shader )
 			{
 				m_shader = IECoreGL::ShaderLoader::defaultShaderLoader()->create(
-					g_vertSource, std::string(), g_fragSource
+					g_colorShaderVertSource, std::string(), g_colorShaderFragSource
 				);
 				if( m_shader )
 				{
@@ -652,6 +265,402 @@ class VisualiserGadget : public Gadget
 					{
 						glUniformBlockBinding( program, blockIndex, g_uniformBlockBindingIndex );
 					}
+				}
+			}
+		}
+
+		void renderColorVisualiser( const ViewportGadget *viewportGadget ) const
+		{
+			// Bootleg shader
+			buildShader();
+
+			if( !m_shader )
+			{
+				return;
+			}
+
+			// Get the cached converter from IECoreGL, this is used to convert primitive
+			// variable data to opengl buffers which will be shared with the IECoreGL renderer
+			IECoreGL::CachedConverter *converter = IECoreGL::CachedConverter::defaultCachedConverter();
+
+			// Bootleg uniform buffer
+			GLint uniformBinding;
+			glGetIntegerv( GL_UNIFORM_BUFFER_BINDING, &uniformBinding );
+
+			if( !m_uniformBuffer )
+			{
+				GLuint buffer = 0u;
+				glGenBuffers( 1, &buffer );
+				glBindBuffer( GL_UNIFORM_BUFFER, buffer );
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockColorShader ), 0, GL_DYNAMIC_DRAW );
+				m_uniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
+			}
+
+			glBindBufferBase( GL_UNIFORM_BUFFER, g_uniformBlockBindingIndex, m_uniformBuffer->buffer() );
+
+			// Get the name of the primitive variable to visualise
+			const std::string &name = m_tool->dataNamePlug()->getValue();
+
+			// Get min/max values and colors and opacity
+			UniformBlockColorShader uniforms;
+			const VisualiserTool::Mode mode = (VisualiserTool::Mode)m_tool->modePlug()->getValue();
+			const V3f valueMin = m_tool->valueMinPlug()->getValue();
+			const V3f valueMax = m_tool->valueMaxPlug()->getValue();
+			uniforms.opacity = m_tool->opacityPlug()->getValue();
+
+			// Compute value range reciprocal
+			//
+			// NOTE : when range is <= 0 set the reciprocal to 0 so that value becomes 0 (minimum)
+			std::optional<V3f> valueRange;
+			if( mode == VisualiserTool::Mode::Color )
+			{
+				valueRange = ( valueMax - valueMin );
+				for( int i = 0; i < 3; ++i )
+				{
+					valueRange.value()[i] = ( valueRange.value()[i] > 0.f ) ? ( 1.f / valueRange.value()[i] ) : 0.f;
+				}
+			}
+
+			// Get the world to clip space matrix
+			M44f v2c;
+			glGetFloatv( GL_PROJECTION_MATRIX, v2c.getValue() );
+			const M44f w2c = viewportGadget->getCameraTransform().gjInverse() * v2c;
+
+			// Set opengl polygon and blend state
+			//
+			// NOTE : use polygon offset to ensure that any discrepancies between the transform
+			//        from object to clip space do not cause z-fighting. This is necessary as
+			//        the shader uses an object to clip matrix which may give slighly different
+			//        depth results to the transformation used in the IECoreGL renderer.
+			GLint blendEqRgb;
+			GLint blendEqAlpha;
+			glGetIntegerv( GL_BLEND_EQUATION_RGB, &blendEqRgb );
+			glGetIntegerv( GL_BLEND_EQUATION_ALPHA, &blendEqAlpha );
+			glBlendEquation( GL_FUNC_ADD );
+
+			GLint blendSrcRgb;
+			GLint blendSrcAlpha;
+			GLint blendDstRgb;
+			GLint blendDstAlpha;
+			glGetIntegerv( GL_BLEND_SRC_RGB, &blendSrcRgb );
+			glGetIntegerv( GL_BLEND_SRC_ALPHA, &blendSrcAlpha );
+			glGetIntegerv( GL_BLEND_DST_RGB, &blendDstRgb );
+			glGetIntegerv( GL_BLEND_DST_ALPHA, &blendDstAlpha );
+			glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
+
+			const GLboolean depthEnabled = glIsEnabled( GL_DEPTH_TEST );
+			if( !depthEnabled )
+			{
+				glEnable( GL_DEPTH_TEST );
+			}
+
+			GLint depthFunc;
+			glGetIntegerv( GL_DEPTH_FUNC, &depthFunc );
+			glDepthFunc( GL_LEQUAL );
+
+			GLboolean depthWriteEnabled;
+			glGetBooleanv( GL_DEPTH_WRITEMASK, &depthWriteEnabled );
+			if( depthWriteEnabled )
+			{
+				glDepthMask( GL_FALSE );
+			}
+
+			const GLboolean blendEnabled = glIsEnabled( GL_BLEND );
+			if( !blendEnabled )
+			{
+				glEnable( GL_BLEND );
+			}
+
+			// MSVC appears to be doing an optimization that causes the call to
+			// `glPolygonMode( GL_FRONT_AND_BACK, polygonMode )` to fail with an
+			// "invalid enum" error. Initializing the value even when we are going
+			// to immediately set it via `glGetIntegerv()` prevents that optimization
+			// and allows us to successfully reset the value.
+			GLint polygonMode = GL_FILL;
+			glGetIntegerv( GL_POLYGON_MODE, &polygonMode );
+			glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );
+
+			const GLboolean cullFaceEnabled = glIsEnabled( GL_CULL_FACE );
+			if( cullFaceEnabled )
+			{
+				glDisable( GL_CULL_FACE );
+			}
+
+			const GLboolean polgonOffsetFillEnabled = glIsEnabled( GL_POLYGON_OFFSET_FILL );
+			if( !polgonOffsetFillEnabled )
+			{
+				glEnable( GL_POLYGON_OFFSET_FILL );
+			}
+
+			GLfloat polygonOffsetFactor, polygonOffsetUnits;
+			glGetFloatv( GL_POLYGON_OFFSET_FACTOR, &polygonOffsetFactor );
+			glGetFloatv( GL_POLYGON_OFFSET_UNITS, &polygonOffsetUnits );
+			glPolygonOffset( -1, -1 );
+
+			// Enable shader program
+
+			GLint shaderProgram;
+			glGetIntegerv( GL_CURRENT_PROGRAM, &shaderProgram );
+			glUseProgram( m_shader->program() );
+
+			// Set opengl vertex attribute array state
+
+			GLint arrayBinding;
+			glGetIntegerv( GL_ARRAY_BUFFER_BINDING, &arrayBinding );
+
+			glPushClientAttrib( GL_CLIENT_VERTEX_ARRAY_BIT );
+
+			glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_PS, 0 );
+			glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_PS );
+			glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSX, 0 );
+			glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSX );
+			glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSY, 0 );
+			glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSY );
+			glVertexAttribDivisor( ATTRIB_GLSL_LOCATION_VSZ, 0 );
+
+			// Loop through current selection
+
+			for( const auto &location : m_tool->selection() )
+			{
+				ScenePlug::PathScope scope( &location.context(), &location.path() );
+
+				// Check path exists
+				if( !location.scene().existsPlug()->getValue() )
+				{
+					continue;
+				}
+
+				// Extract mesh primitive
+				auto mesh = runTimeCast<const MeshPrimitive>( location.scene().objectPlug()->getValue() );
+				if( !mesh )
+				{
+					continue;
+				}
+
+				// Retrieve cached IECoreGL mesh primitive
+				auto meshGL = runTimeCast<const IECoreGL::MeshPrimitive>( converter->convert( mesh.get() ) );
+				if( !meshGL )
+				{
+					continue;
+				}
+
+				// Find opengl "P" buffer data
+
+				IECoreGL::ConstBufferPtr pBuffer = meshGL->getVertexBuffer( g_pName );
+				if( !pBuffer )
+				{
+					continue;
+				}
+
+				// Find opengl named buffer data
+				//
+				// NOTE : conversion to IECoreGL mesh may generate vertex attributes (eg. "N")
+				//        so check named primitive variable exists on IECore mesh primitive.
+
+				const auto vIt = mesh->variables.find( name );
+				if( vIt == mesh->variables.end() )
+				{
+					continue;
+				}
+
+				ConstDataPtr vData = vIt->second.data;
+				GLsizei stride = 0;
+				GLenum type = GL_FLOAT;
+				bool offset = false;
+				bool enableVSZ = false;
+				switch( vData->typeId() )
+				{
+					case IntVectorDataTypeId:
+						type = GL_INT;
+						[[fallthrough]];
+					case FloatVectorDataTypeId:
+						enableVSZ = true;
+						uniforms.valueMin = valueRange ? V3f( valueMin.x ) : V3f( 0.f );
+						uniforms.valueRange = valueRange ? V3f( valueRange.value().x ) : V3f( 1.f );
+						break;
+					case V2fVectorDataTypeId:
+						stride = 2;
+						offset = true;
+						uniforms.valueMin = valueRange ? V3f( valueMin.x, valueMin.y, 0.f ) : V3f( 0.f );
+						uniforms.valueRange = valueRange ? V3f( valueRange.value().x, valueRange.value().y, 0.f ) : V3f( 1.f, 1.f, 0.f );
+						break;
+					case Color3fVectorDataTypeId:
+						stride = 3;
+						offset = true;
+						enableVSZ = true;
+						uniforms.valueMin = valueRange ? valueMin : V3f( 0.f );
+						uniforms.valueRange = valueRange ? valueRange.value() : V3f( 1.f );
+						break;
+					case V3fVectorDataTypeId:
+						stride = 3;
+						offset = true;
+						enableVSZ = true;
+						uniforms.valueMin = valueRange ? valueMin : V3f( -1.f );
+						// Use 0.5 instead of 2.0 to account for reciprocal in `valueRange` above
+						uniforms.valueRange = valueRange ? valueRange.value() : V3f( 0.5f );
+						break;
+					default:
+						continue;
+				}
+
+				IECoreGL::ConstBufferPtr vBuffer = meshGL->getVertexBuffer( name );
+				if( !vBuffer )
+				{
+					continue;
+				}
+
+				// Get the object to world transform
+
+				M44f o2w;
+				ScenePlug::ScenePath path( location.path() );
+				while( !path.empty() )
+				{
+					scope.setPath( &path );
+					o2w = o2w * location.scene().transformPlug()->getValue();
+					path.pop_back();
+				}
+
+				// Compute object to clip matrix
+				uniforms.o2c = o2w * w2c;
+
+				// Upload opengl uniform block data
+
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockColorShader ), &uniforms, GL_DYNAMIC_DRAW );
+
+				// Draw primitive
+				glBindBuffer( GL_ARRAY_BUFFER, pBuffer->buffer() );
+				glVertexAttribPointer( ATTRIB_GLSL_LOCATION_PS, 3, GL_FLOAT, GL_FALSE, 0, nullptr );
+				glBindBuffer( GL_ARRAY_BUFFER, vBuffer->buffer() );
+				glVertexAttribPointer( ATTRIB_GLSL_LOCATION_VSX, 1, type, GL_FALSE, stride * sizeof( GLfloat ), nullptr );
+				glVertexAttribPointer(
+					ATTRIB_GLSL_LOCATION_VSY,
+					1,
+					type,
+					GL_FALSE,
+					stride * sizeof( GLfloat ),
+					( void const *)( ( offset ? 1 : 0 ) * sizeof( GLfloat ) )
+				);
+				if( enableVSZ )
+				{
+					glEnableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSZ );
+					glVertexAttribPointer(
+						ATTRIB_GLSL_LOCATION_VSZ,
+						1,
+						type,
+						GL_FALSE,
+						stride * sizeof( GLfloat ),
+						( void const *)( ( offset ? 2 : 0 ) * sizeof( GLfloat ) )
+					);
+				}
+				else
+				{
+					glDisableVertexAttribArray( ATTRIB_GLSL_LOCATION_VSZ );
+					glVertexAttrib1f( ATTRIB_GLSL_LOCATION_VSZ, 0.f );
+				}
+
+				meshGL->renderInstances( 1 );
+			}
+
+			// Restore opengl state
+
+			glPopClientAttrib();
+			glBindBuffer( GL_ARRAY_BUFFER, arrayBinding );
+			glBindBuffer( GL_UNIFORM_BUFFER, uniformBinding );
+
+			glDepthFunc( depthFunc );
+			glBlendEquationSeparate( blendEqRgb, blendEqAlpha );
+			glBlendFuncSeparate( blendSrcRgb, blendDstRgb, blendSrcAlpha, blendDstAlpha );
+			glPolygonMode( GL_FRONT_AND_BACK, polygonMode );
+			if( cullFaceEnabled )
+			{
+				glEnable( GL_CULL_FACE );
+			}
+			if( !polgonOffsetFillEnabled )
+			{
+				glDisable( GL_POLYGON_OFFSET_FILL );
+			}
+			glPolygonOffset( polygonOffsetFactor, polygonOffsetUnits );
+
+			if( !blendEnabled )
+			{
+				glDisable( GL_BLEND );
+			}
+			if( !depthEnabled )
+			{
+				glDisable( GL_DEPTH_TEST );
+			}
+			if( depthWriteEnabled )
+			{
+				glDepthMask( GL_TRUE );
+			}
+			glUseProgram( shaderProgram );
+		}
+
+		void renderColorValue( const ViewportGadget *viewportGadget, const Style *style ) const
+		{
+			// Display value at cursor as text
+
+			const Data *value = m_tool->cursorValue();
+			if( value )
+			{
+				std::ostringstream oss;
+				switch( value->typeId() )
+				{
+					case IntDataTypeId:
+						oss << ( assertedStaticCast<const IntData>( value )->readable() );
+						break;
+					case FloatDataTypeId:
+						oss << ( assertedStaticCast<const FloatData>( value )->readable() );
+						break;
+					case V2fDataTypeId:
+						oss << ( assertedStaticCast<const V2fData>( value )->readable() );
+						break;
+					case V3fDataTypeId:
+						oss << ( assertedStaticCast<const V3fData>( value )->readable() );
+						break;
+					case Color3fDataTypeId:
+						oss << ( assertedStaticCast<const Color3fData>( value )->readable() );
+						break;
+					default:
+						break;
+				}
+
+				const std::string text = oss.str();
+				if( !text.empty() )
+				{
+					// Draw in raster space
+					//
+					// NOTE : It seems that Gaffer defines the origin of raster space as the top left corner
+					//        of the viewport, however the style text drawing functions assume that y increases
+					//        "up" the screen rather than "down", so invert y to ensure text is not upside down.
+
+					ViewportGadget::RasterScope raster( viewportGadget );
+					const float size = m_tool->sizePlug()->getValue();
+					const V3f scale( size, -size, 1.f );
+					const V2f &rp = m_tool->cursorPos();
+
+					glPushMatrix();
+					glTranslatef( rp.x, rp.y, 0.f );
+					glScalef( scale.x, scale.y, scale.z );
+
+					/// Shadow text
+					glTranslatef( g_textShadowOffset, 0.f, 0.f );
+					style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
+
+					glTranslatef( -g_textShadowOffset * 2.f, 0.f, 0.f );
+					style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
+
+					glTranslatef( g_textShadowOffset, g_textShadowOffset, 0.f );
+					style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
+
+					glTranslatef( 0.f, -g_textShadowOffset * 2.f, 0.f );
+					style->renderText( Style::LabelText, text, GafferUI::Style::State::NormalState, &g_textShadowColor );
+
+					/// Primary text
+					glTranslatef( 0.f, g_textShadowOffset, 0.f );
+					style->renderText( Style::LabelText, text );
+
+					glPopMatrix();
 				}
 			}
 		}

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -317,8 +317,16 @@ void GafferSceneUIModule::bindTools()
 		;
 	}
 
-	GafferBindings::NodeClass<VisualiserTool>( nullptr, no_init )
-		.def( init<SceneView *>() )
-	;
+	{
+		scope s = GafferBindings::NodeClass<VisualiserTool>( nullptr, no_init )
+			.def( init<SceneView *>() )
+		;
+
+		enum_<VisualiserTool::Mode>( "Mode" )
+			.value( "Auto", VisualiserTool::Mode::Auto )
+			.value( "ColorAutoRange", VisualiserTool::Mode::ColorAutoRange )
+			.value( "Color", VisualiserTool::Mode::Color )
+		;
+	}
 
 }

--- a/src/GafferSceneUIModule/ToolBinding.cpp
+++ b/src/GafferSceneUIModule/ToolBinding.cpp
@@ -326,6 +326,7 @@ void GafferSceneUIModule::bindTools()
 			.value( "Auto", VisualiserTool::Mode::Auto )
 			.value( "ColorAutoRange", VisualiserTool::Mode::ColorAutoRange )
 			.value( "Color", VisualiserTool::Mode::Color )
+			.value( "VertexLabel", VisualiserTool::Mode::VertexLabel )
 		;
 	}
 


### PR DESCRIPTION
This adds a new method for visualising object data, a vertex label per-vertex.

It uses this new method for vertex indices and integer primitive variables when in `Auto` mode, leaving the other data types to be displayed as colors. And there's a dedicated `Vertex Label` mode to see other data types as a label as well. There are some additions that could be made, such as visualising string variables, but I've drawn the line for the PR at the types we support.

This also includes the change from #6190, which I'll close.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
