### PR TITLE
Gaffer : Support for Python 3.11 and Qt/PySide 6.5.3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -554,6 +554,7 @@ else:
 			"/experimental:external",  # Allow use of /external:I
 			"/external:W0",  # Suppress warnings for headers included with /external:I
 			"/Zc:inline", # Remove unreferenced function or data if it is COMDAT or has internal linkage only
+			"/Zc:__cplusplus", # "Qt requires a C++17 compiler, and a suitable value for __cplusplus. On MSVC, you must pass the /Zc:__cplusplus option to the compiler."
 			"/GR", # Enable RTTI
 			"/TP", # Treat all files as c++ (vs C)
 			"/FC", # Display full paths in diagnostics

--- a/include/GafferBindings/DependencyNodeBinding.inl
+++ b/include/GafferBindings/DependencyNodeBinding.inl
@@ -81,7 +81,7 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString )
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
 	// Install our custom metaclass.
-	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
+	Py_SET_TYPE( this->ptr(), Detail::dependencyNodeMetaclass() );
 }
 
 template<typename T, typename Ptr>
@@ -92,7 +92,7 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString, boost::
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
 	// Install our custom metaclass.
-	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
+	Py_SET_TYPE( this->ptr(), Detail::dependencyNodeMetaclass() );
 }
 
 } // namespace GafferBindings

--- a/python/GafferUI/CompoundEditor.py
+++ b/python/GafferUI/CompoundEditor.py
@@ -1040,15 +1040,15 @@ class _TabDragBehaviour( QtCore.QObject ) :
 		if qEventType not in self.__eventMask :
 			return False
 
-		if qEventType == qEvent.MouseButtonPress :
+		if qEventType == QtCore.QEvent.MouseButtonPress :
 
 			return self.__mousePress( qObject, qEvent )
 
-		elif qEventType == qEvent.MouseMove :
+		elif qEventType == QtCore.QEvent.MouseMove :
 
 			return self.__mouseMove( qObject, qEvent )
 
-		elif qEventType == qEvent.MouseButtonRelease :
+		elif qEventType == QtCore.QEvent.MouseButtonRelease :
 
 			return self.__mouseRelease( qObject, qEvent )
 

--- a/python/GafferUI/EventLoop.py
+++ b/python/GafferUI/EventLoop.py
@@ -50,6 +50,7 @@ import GafferUI
 
 from Qt import QtCore
 from Qt import QtWidgets
+import Qt
 
 ## This class provides the event loops used to run GafferUI based applications.
 class EventLoop( object ) :
@@ -106,7 +107,10 @@ class EventLoop( object ) :
 
 		if self.__runStyle == self.__RunStyle.Normal :
 			assert( self.__startCount == 1 )
-			self.__qtEventLoop.exec_()
+			if Qt.__binding__ == "PySide6" :
+				self.__qtEventLoop.exec()
+			else:
+				self.__qtEventLoop.exec_()
 		elif self.__runStyle == self.__RunStyle.PumpThread :
 			if self.__pumpThread is None :
 				self.__pumpThread = threading.Thread( target = self.__pumpThreadFn )
@@ -162,7 +166,9 @@ class EventLoop( object ) :
 		style = QtWidgets.QApplication.setStyle( "Fusion" )
 		# Stop icons/fonts being tiny on high-dpi monitors. Must be set before
 		# the application is created.
-		QtWidgets.QApplication.setAttribute( QtCore.Qt.AA_EnableHighDpiScaling )
+		# This attribute is deprecated in Qt6 and not needed.
+		if not Qt.__binding__ == "PySide6" :
+			QtWidgets.QApplication.setAttribute( QtCore.Qt.AA_EnableHighDpiScaling )
 		# Allow all `GafferUI.GLWidgets` to share OpenGL resources (via the underlying
 		# QOpenGLWidget).
 		QtWidgets.QApplication.setAttribute( QtCore.Qt.AA_ShareOpenGLContexts )

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -215,7 +215,7 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 
 		glWidget = self.__createGLWidget( format )
 		self.setViewport( glWidget )
-		self.setViewportUpdateMode( self.FullViewportUpdate )
+		self.setViewportUpdateMode( QtWidgets.QGraphicsView.FullViewportUpdate )
 
 	# QAbstractScrollArea (one of our base classes), implements
 	# minimumSizeHint() to include enough room for scrollbars.

--- a/python/GafferUI/GLWidget.py
+++ b/python/GafferUI/GLWidget.py
@@ -58,16 +58,19 @@ import OpenGL.GL as GL
 import Qt
 from Qt import QtCore
 
-# Importing directly rather than via Qt.py because Qt.py won't expose the
-# Qt-5-only QOpenGLWidget and QSurfaceFormat classes that we need. Their mantra
-# is to provide only what is available in Qt4/PySide1 - see
-# https://github.com/mottosso/Qt.py/issues/341.
-## \todo Now that Qt 4 is long gone, and PySide is an official
-# Qt project, Qt.py isn't much help. Remove across the board, or see
-# if we can coax the project into bridging Qt 5/6 instead of 4/5?
-from PySide2 import QtGui
-from PySide2 import QtWidgets
-from Qt import QtOpenGL
+# Looks like Qt.py as of v1.4.1 doesn't expose any OpenGL, so use
+# PySide2 or PySide6 directly and work around their differences manually.
+if Qt.__binding__ == "PySide2" :
+	from PySide2 import QtGui
+	from PySide2 import QtWidgets
+	from PySide2.QtWidgets import QOpenGLWidget
+	from PySide2 import QtOpenGL
+elif Qt.__binding__ == "PySide6" :
+	from PySide6 import QtGui
+	from PySide6 import QtWidgets
+	from PySide6.QtOpenGLWidgets import QOpenGLWidget
+else :
+	raise Exception( "GafferUI : No compatible Python binding found for Qt" )
 
 ## The GLWidget is a base class for all widgets which wish to draw using OpenGL.
 # Derived classes override the _draw() method to achieve this.
@@ -262,7 +265,7 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 		if result is not None :
 			return result
 
-		glWidget = QtWidgets.QOpenGLWidget()
+		glWidget = QOpenGLWidget()
 		# Avoid `QOpenGLFramebufferObject: Framebuffer incomplete attachment`
 		# errors caused by Qt trying to make a framebuffer with zero size.
 		glWidget.setMinimumSize( 1, 1 )
@@ -302,10 +305,14 @@ class _GLGraphicsView( QtWidgets.QGraphicsView ) :
 		# context should therefore be made current before calling this
 		# method.
 
-		qGLFormat = cls.__createQGLFormat( format )
-		result = QtOpenGL.QGLWidget()
-		_GafferUI._glWidgetSetHostedContext( GafferUI._qtAddress( result ), GafferUI._qtAddress( qGLFormat ) )
-		return result
+		try :
+			qGLFormat = cls.__createQGLFormat( format )
+			result = QtOpenGL.QGLWidget()
+			_GafferUI._glWidgetSetHostedContext( GafferUI._qtAddress( result ), GafferUI._qtAddress( qGLFormat ) )
+			return result
+		except :
+			result = QOpenGLWidget()
+			return result
 
 	@classmethod
 	def __createMayaQGLWidget( cls, format ) :

--- a/python/GafferUI/Image.py
+++ b/python/GafferUI/Image.py
@@ -136,7 +136,7 @@ class Image( GafferUI.Widget ) :
 			effect.setColor( QtGui.QColor( 119, 156, 189, 255 ) )
 			effect.setStrength( 0.85 )
 			pixmapItem.setGraphicsEffect( effect )
-			pixmapItem.setShapeMode( pixmapItem.BoundingRectShape )
+			pixmapItem.setShapeMode( QtWidgets.QGraphicsPixmapItem.BoundingRectShape )
 
 			graphicsView = QtWidgets.QGraphicsView()
 			graphicsView.setScene( graphicsScene )
@@ -183,7 +183,7 @@ class Image( GafferUI.Widget ) :
 			effect = QtWidgets.QGraphicsOpacityEffect()
 			effect.setOpacity( 0.4 )
 			pixmapItem.setGraphicsEffect( effect )
-			pixmapItem.setShapeMode( pixmapItem.BoundingRectShape )
+			pixmapItem.setShapeMode( QtWidgets.QGraphicsPixmapItem.BoundingRectShape )
 
 			graphicsView = QtWidgets.QGraphicsView()
 			graphicsView.setScene( graphicsScene )

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -43,6 +43,7 @@ import GafferUI
 from Qt import QtCore
 from Qt import QtGui
 from Qt import QtWidgets
+import Qt
 
 import weakref
 
@@ -207,7 +208,10 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 
 	def __keySequence( self, keyEvent ) :
 
-		return QtGui.QKeySequence( keyEvent.key() | int( keyEvent.modifiers() ) )
+		if Qt.__binding__ == "PySide6" :
+			return QtGui.QKeySequence( keyEvent.keyCombination() )
+		else :
+			return QtGui.QKeySequence( keyEvent.key() | int( keyEvent.modifiers() ) )
 
 	def __matchingAction( self, keySequence, menu ) :
 

--- a/python/GafferUI/MenuBar.py
+++ b/python/GafferUI/MenuBar.py
@@ -166,7 +166,7 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 		# striving to do all event handling in GafferUI with this
 		# bubble-up-until-handled methodology anyway, so doing
 		# shortcuts this way seems to make sense.
-		if qEvent.type() == qEvent.ShortcutOverride :
+		if qEvent.type() == QtCore.QEvent.ShortcutOverride :
 
 			self.__shortcutAction = None
 			keySequence = self.__keySequence( qEvent )
@@ -187,7 +187,7 @@ class _ShortcutEventFilter( QtCore.QObject ) :
 		# We handle the shortcut override event, but that just
 		# means that we then have the option of handling the
 		# associated keypress, which is what we do here.
-		elif qEvent.type() == qEvent.KeyPress :
+		elif qEvent.type() == QtCore.QEvent.KeyPress :
 
 			if self.__shortcutAction is not None and self.__keySequence( qEvent ) in self.__shortcutAction.shortcuts() :
 				self.__shortcutAction.trigger()

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -754,14 +754,14 @@ class _MessageTableView( GafferUI.Widget ) :
 
 		tableView = self._qtWidget()
 
-		tableView.setEditTriggers( tableView.NoEditTriggers )
+		tableView.setEditTriggers( QtWidgets.QAbstractItemView.NoEditTriggers )
 		tableView.setSelectionBehavior( QtWidgets.QAbstractItemView.SelectRows )
 		tableView.setSelectionMode( QtWidgets.QAbstractItemView.ContiguousSelection )
 
 		tableView.verticalHeader().setVisible( False )
 		tableView.horizontalHeader().setVisible( False )
 
-		tableView.setHorizontalScrollMode( tableView.ScrollPerPixel )
+		tableView.setHorizontalScrollMode( QtWidgets.QTableView.ScrollPerPixel )
 
 		tableView.setShowGrid( False )
 

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -557,7 +557,7 @@ class _PlainTextEdit( QtWidgets.QPlainTextEdit ) :
 
 	def event( self, event ) :
 
-		if event.type() == event.ShortcutOverride and event == QtGui.QKeySequence.Copy :
+		if event.type() == QtCore.QEvent.ShortcutOverride and event == QtGui.QKeySequence.Copy :
 			# QPlainTextEdit doesn't accept this when it's
 			# read only. so we accept it ourselves, which is
 			# enough to reenable copying from a read only

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -49,6 +49,7 @@ from ._StyleSheet import _styleColors
 from Qt import QtGui
 from Qt import QtWidgets
 from Qt import QtCore
+import Qt
 
 class MultiLineTextWidget( GafferUI.Widget ) :
 
@@ -86,7 +87,10 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 		self.dropSignal().connect( Gaffer.WeakMethod( self.__drop ) )
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
 
-		self._qtWidget().setTabStopWidth( 20 ) # pixels
+		if Qt.__binding__ == "PySide6" :
+			self._qtWidget().setTabStopDistance( 20 ) # device units
+		else :
+			self._qtWidget().setTabStopWidth( 20 ) # pixels
 
 		self.__editingFinishedSignal = GafferUI.WidgetSignal()
 		self.__activatedSignal = GafferUI.WidgetSignal()

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -989,7 +989,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 
 	def event( self, event ) :
 
-		if event.type() == event.ShortcutOverride :
+		if event.type() == QtCore.QEvent.ShortcutOverride :
 			if event.key() in ( QtCore.Qt.Key_Up, QtCore.Qt.Key_Down, QtCore.Qt.Key_Left, QtCore.Qt.Key_Right ) :
 				event.accept()
 				return True

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -535,7 +535,8 @@ class PathListingWidget( GafferUI.Widget ) :
 
 	def __selectionChanged( self ) :
 
-		self._qtWidget().update()
+		if not Qt.__binding__ == "PySide6" :
+			self._qtWidget().update()
 		self.selectionChangedSignal()( self )
 
 	def __pathChanged( self, path ) :

--- a/python/GafferUI/Slider.py
+++ b/python/GafferUI/Slider.py
@@ -607,7 +607,7 @@ class _Widget( QtWidgets.QWidget ) :
 
 	def event( self, event ) :
 
-		if event.type() == event.ShortcutOverride :
+		if event.type() == QtCore.QEvent.ShortcutOverride :
 			if event.key() in ( QtCore.Qt.Key_Delete, QtCore.Qt.Key_Backspace ) :
 				event.accept()
 				return True

--- a/python/GafferUI/SpreadsheetUI/_LinkedScrollBar.py
+++ b/python/GafferUI/SpreadsheetUI/_LinkedScrollBar.py
@@ -146,5 +146,5 @@ class _StepsChangedScrollBar( QtWidgets.QScrollBar ) :
 
 		QtWidgets.QScrollBar.sliderChange( self, change )
 
-		if change == self.SliderStepsChange :
+		if change == QtWidgets.QAbstractSlider.SliderStepsChange :
 			self.stepsChanged.emit( self.pageStep(), self.singleStep() )

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -139,9 +139,9 @@ class _PlugTableView( GafferUI.Widget ) :
 		# the QTableView itself won't edit anything, and we then implement
 		# our own editing via PlugValueWidgets in _EditWindow.
 
-		tableView.setEditTriggers( tableView.NoEditTriggers )
-		tableView.setSelectionMode( tableView.ExtendedSelection )
-		tableView.setSelectionBehavior( tableView.SelectItems )
+		tableView.setEditTriggers( QtWidgets.QTableView.NoEditTriggers )
+		tableView.setSelectionMode( QtWidgets.QTableView.ExtendedSelection )
+		tableView.setSelectionBehavior( QtWidgets.QTableView.SelectItems )
 		self.buttonPressSignal().connect( Gaffer.WeakMethod( self.__buttonPress ) )
 		self.buttonDoubleClickSignal().connect( Gaffer.WeakMethod( self.__buttonDoubleClick ) )
 		self.keyPressSignal().connect( Gaffer.WeakMethod( self.__keyPress ) )
@@ -154,7 +154,7 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		tableView.setVerticalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
 		tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAlwaysOff )
-		tableView.setHorizontalScrollMode( tableView.ScrollPerPixel )
+		tableView.setHorizontalScrollMode( QtWidgets.QTableView.ScrollPerPixel )
 
 		tableView.setSizePolicy(
 			QtWidgets.QSizePolicy.Fixed if mode == self.Mode.RowNames else QtWidgets.QSizePolicy.Maximum,

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -49,6 +49,7 @@ from GafferUI.PlugValueWidget import sole
 from Qt import QtCore
 from Qt import QtWidgets
 from Qt import QtCompat
+import Qt
 
 from . import _Algo
 from . import _ClipboardAlgo
@@ -250,7 +251,8 @@ class _PlugTableView( GafferUI.Widget ) :
 
 		GafferUI.Widget._displayTransformChanged( self )
 		# Account for _PlugTableModel's dependency on display transform.
-		self._qtWidget().update()
+		if not Qt.__binding__ == "PySide6" :
+			self._qtWidget().update()
 
 	def __applyRowFilter( self ) :
 

--- a/python/GafferUI/TabbedContainer.py
+++ b/python/GafferUI/TabbedContainer.py
@@ -347,7 +347,7 @@ class _TabWidget( QtWidgets.QTabWidget ) :
 
 		result = QtWidgets.QTabWidget.sizeHint( self )
 		if self.tabBar().isHidden() :
-			if self.tabPosition() in ( self.North, self.South ) :
+			if self.tabPosition() in ( QtWidgets.QTabWidget.North, QtWidgets.QTabWidget.South ) :
 				result.setHeight( result.height() - self.tabBar().sizeHint().height() )
 			else :
 				result.setWidth( result.width() - self.tabBar().sizeHint().width() )
@@ -360,7 +360,7 @@ class _TabWidget( QtWidgets.QTabWidget ) :
 
 		result = QtWidgets.QTabWidget.minimumSizeHint( self )
 		if self.tabBar().isHidden() :
-			if self.tabPosition() in ( self.North, self.South ) :
+			if self.tabPosition() in ( QtWidgets.QTabWidget.North, QtWidgets.QTabWidget.South ) :
 				result.setHeight( result.height() - self.tabBar().minimumSizeHint().height() )
 			else :
 				result.setWidth( result.width() - self.tabBar().minimumSizeHint().width() )
@@ -381,7 +381,7 @@ class _VisibilityLink( QtCore.QObject ) :
 	def eventFilter( self, qObject, qEvent ) :
 
 		qEventType = qEvent.type()
-		if qEventType == qEvent.Show or qEventType == qEvent.Hide :
+		if qEventType == QtCore.QEvent.Show or qEventType == QtCore.QEvent.Hide :
 			self.parent().setVisible( qObject.isVisible() )
 
 		return False

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -388,11 +388,11 @@ class _LineEdit( QtWidgets.QLineEdit ) :
 
 		# but then calculate our own width
 		numChars = self.__fixedCharacterWidth if self.__fixedCharacterWidth is not None else self.__preferredCharacterWidth
-		textMargins = self.getTextMargins()
-		contentsMargins = self.getContentsMargins()
+		textMargins = self.textMargins()
+		contentsMargins = self.contentsMargins()
 
 		width = self.fontMetrics().boundingRect( "M" * numChars ).width()
-		width += contentsMargins[0] + contentsMargins[2] + textMargins[0] + textMargins[2]
+		width += contentsMargins.left() + contentsMargins.right() + textMargins.left() + textMargins.right()
 
 		options = QtWidgets.QStyleOptionFrame()
 		self.initStyleOption( options )
@@ -408,7 +408,7 @@ class _LineEdit( QtWidgets.QLineEdit ) :
 
 	def event(self, event):
 
-		if event.type() == event.ShortcutOverride :
+		if event.type() == QtCore.QEvent.ShortcutOverride :
 			if event == QtGui.QKeySequence.Undo :
 				if not self.isModified() or not self.isUndoAvailable() :
 					return False

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -951,7 +951,7 @@ class _Model( QtCore.QAbstractTableModel ) :
 			column = self.__columns[index.column()]
 			column.accessor.setElement( index.row(), column.relativeColumnIndex, value )
 
-			if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+			if Qt.__binding__ in ( "PySide6", "PySide2", "PyQt5" ) :
 				self.dataChanged.emit( index, index, [ QtCore.Qt.DisplayRole, QtCore.Qt.EditRole ] )
 			else:
 				self.dataChanged.emit( index, index )

--- a/python/GafferUI/Viewer.py
+++ b/python/GafferUI/Viewer.py
@@ -351,7 +351,8 @@ class _Toolbar( GafferUI.Frame ) :
 		# Remove the SetMinAndMaxSize constraint that our base class added,
 		# so that we expand to the full width of the viewport, and our toolbar
 		# is centered inside.
-		self._qtWidget().layout().setSizeConstraint( self._qtWidget().layout().SetDefaultConstraint )
+		from Qt.QtWidgets import QLayout
+		self._qtWidget().layout().setSizeConstraint( QLayout.SetDefaultConstraint )
 
 		self.__edge = edge
 		self.__node = []

--- a/python/GafferUI/Widget.py
+++ b/python/GafferUI/Widget.py
@@ -815,7 +815,7 @@ class Widget( Gaffer.Signals.Trackable, metaclass = _WidgetMetaclass ) :
 		result = GafferUI.ButtonEvent.Buttons.None_
 		if qtButtons & QtCore.Qt.LeftButton :
 			result |= GafferUI.ButtonEvent.Buttons.Left
-		if qtButtons & QtCore.Qt.MidButton :
+		if qtButtons & QtCore.Qt.MiddleButton :
 			result |= GafferUI.ButtonEvent.Buttons.Middle
 		if qtButtons & QtCore.Qt.RightButton :
 			result |= GafferUI.ButtonEvent.Buttons.Right
@@ -1016,11 +1016,11 @@ class _EventFilter( QtCore.QObject ) :
 			return False
 
 		# we display tooltips and emit visibility events even on disabled widgets
-		if qEventType==qEvent.ToolTip :
+		if qEventType==QtCore.QEvent.ToolTip :
 
 			return self.__toolTip( qObject, qEvent )
 
-		elif qEventType==qEvent.Show or qEventType==qEvent.Hide :
+		elif qEventType==QtCore.QEvent.Show or qEventType==QtCore.QEvent.Hide :
 
 			return self.__showHide( qObject, qEvent )
 
@@ -1028,63 +1028,63 @@ class _EventFilter( QtCore.QObject ) :
 		if not qObject.isEnabled() :
 			return False
 
-		if qEventType==qEvent.KeyPress :
+		if qEventType==QtCore.QEvent.KeyPress :
 
 			return self.__keyPress( qObject, qEvent )
 
-		elif qEventType==qEvent.KeyRelease :
+		elif qEventType==QtCore.QEvent.KeyRelease :
 
 			return self.__keyRelease( qObject, qEvent )
 
-		elif qEventType==qEvent.MouseButtonPress :
+		elif qEventType==QtCore.QEvent.MouseButtonPress :
 
 			return self.__mouseButtonPress( qObject, qEvent )
 
-		elif qEventType==qEvent.MouseButtonRelease :
+		elif qEventType==QtCore.QEvent.MouseButtonRelease :
 
 			return self.__mouseButtonRelease( qObject, qEvent )
 
-		elif qEventType==qEvent.MouseButtonDblClick :
+		elif qEventType==QtCore.QEvent.MouseButtonDblClick :
 
 			return self.__mouseButtonDblClick( qObject, qEvent )
 
-		elif qEventType==qEvent.MouseMove :
+		elif qEventType==QtCore.QEvent.MouseMove :
 
 			return self.__mouseMove( qObject, qEvent )
 
-		elif qEventType==qEvent.Enter :
+		elif qEventType==QtCore.QEvent.Enter :
 
 			return self.__enter( qObject, qEvent )
 
-		elif qEventType==qEvent.Leave :
+		elif qEventType==QtCore.QEvent.Leave :
 
 			return self.__leave( qObject, qEvent )
 
-		elif qEventType==qEvent.Wheel :
+		elif qEventType==QtCore.QEvent.Wheel :
 
 			return self.__wheel( qObject, qEvent )
 
-		elif qEventType==qEvent.ContextMenu :
+		elif qEventType==QtCore.QEvent.ContextMenu :
 
 			return self.__contextMenu( qObject, qEvent )
 
-		elif qEventType==qEvent.ParentChange :
+		elif qEventType==QtCore.QEvent.ParentChange :
 
 			return self.__parentChange( qObject, qEvent )
 
-		elif qEventType==qEvent.DragEnter :
+		elif qEventType==QtCore.QEvent.DragEnter :
 
 			return self.__foreignDragEnter( qObject, qEvent )
 
-		elif qEventType==qEvent.DragMove :
+		elif qEventType==QtCore.QEvent.DragMove :
 
 			return self.__foreignDragMove( qObject, qEvent )
 
-		elif qEventType==qEvent.DragLeave :
+		elif qEventType==QtCore.QEvent.DragLeave :
 
 			return self.__foreignDragLeave( qObject, qEvent )
 
-		elif qEventType==qEvent.Drop :
+		elif qEventType==QtCore.QEvent.Drop :
 
 			return self.__foreignDrop( qObject, qEvent )
 

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -199,7 +199,7 @@ class Window( GafferUI.ContainerWidget ) :
 		childWindowType = QtCore.Qt.Tool if sys.platform == "darwin" else QtCore.Qt.Dialog
 		childWindowFlags = ( childWindow._qtWidget().windowFlags() & ~QtCore.Qt.WindowType_Mask ) | childWindowType
 
-		if sys.platform == "darwin" and Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+		if sys.platform == "darwin" and Qt.__binding__ in ( "PySide6", "PySide2", "PyQt5" ) :
 			# Alternative order of operations to work around crashes
 			# on OSX with Qt5.
 			childWindow._qtWidget().setParent( self._qtWidget() )

--- a/python/GafferUI/Window.py
+++ b/python/GafferUI/Window.py
@@ -204,9 +204,9 @@ class Window( GafferUI.ContainerWidget ) :
 			# on OSX with Qt5.
 			childWindow._qtWidget().setParent( self._qtWidget() )
 			childWindow._applyVisibility()
-			childWindow._qtWidget().setWindowFlags( childWindowFlags )
+			childWindow._qtWidget().setWindowFlags( childWindowFlags | QtCore.Qt.WindowCloseButtonHint )
 		else :
-			childWindow._qtWidget().setParent( self._qtWidget(), childWindowFlags )
+			childWindow._qtWidget().setParent( self._qtWidget(), childWindowFlags | QtCore.Qt.WindowCloseButtonHint )
 			childWindow._applyVisibility()
 
 		if removeOnClose :

--- a/python/GafferUI/__init__.py
+++ b/python/GafferUI/__init__.py
@@ -100,7 +100,9 @@ def __shiboken() :
 	import Qt
 	assert( "PyQt" not in Qt.__binding__ )
 
-	if Qt.__binding__ == "PySide2" :
+	if Qt.__binding__ == "PySide6" :
+		import shiboken6 as shiboken
+	elif Qt.__binding__ == "PySide2" :
 		try :
 			import PySide2.shiboken2 as shiboken
 		except ImportError :

--- a/python/GafferUITest/MenuBarTest.py
+++ b/python/GafferUITest/MenuBarTest.py
@@ -299,7 +299,7 @@ class MenuBarTest( GafferUITest.TestCase ) :
 
 	def __simulateShortcut( self, widget ) :
 
-		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+		if Qt.__binding__ in ( "PySide6", "PySide2", "PyQt5" ) :
 
 			# Qt5's handling of key events appears to have
 			# changed, such that we must manually send the

--- a/python/GafferUITest/WidgetAlgoTest.py
+++ b/python/GafferUITest/WidgetAlgoTest.py
@@ -67,7 +67,7 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 		# physical pixel size like this? Or should `grab()` downsize
 		# to return an image with the logical pixel size?
 		expectedSize = imath.V2f( b.size() )
-		if Qt.__binding__ in ( "PySide2", "PyQt5" ) :
+		if Qt.__binding__ in ( "PySide6", "PySide2", "PyQt5" ) :
 			screen= QtWidgets.QApplication.primaryScreen()
 			windowHandle = b._qtWidget().windowHandle()
 			if windowHandle :

--- a/src/GafferBindings/DependencyNodeBinding.cpp
+++ b/src/GafferBindings/DependencyNodeBinding.cpp
@@ -74,7 +74,7 @@ PyTypeObject *GafferBindings::Detail::dependencyNodeMetaclass()
 		// because it has functionality critical to making the Boost bindings
 		// work. The only thing we're doing is adding `dependencyNodeMetaclassCall`
 		// as the implementation of the `__call__` method.
-		Py_TYPE( &g_dependencyNodeMetaclass ) = &PyType_Type;
+		Py_SET_TYPE( &g_dependencyNodeMetaclass, &PyType_Type );
 		g_dependencyNodeMetaclass.tp_name = "Gaffer.DependencyNodeMetaclass";
 		g_dependencyNodeMetaclass.tp_basicsize = PyType_Type.tp_basicsize,
 		g_dependencyNodeMetaclass.tp_base = boost::python::objects::class_metatype().get();

--- a/src/GafferUIModule/GLWidgetBinding.cpp
+++ b/src/GafferUIModule/GLWidgetBinding.cpp
@@ -41,7 +41,10 @@
 #include "IECore/Exception.h"
 #include "IECore/MessageHandler.h"
 
-#include "QtOpenGL/QGLWidget"
+#include "QtCore/QtGlobal"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+	#include "QtOpenGL/QGLWidget"
+#endif
 
 #if defined( __linux__ )
 #include "GL/glx.h" // Must come after Qt!
@@ -51,6 +54,8 @@ using namespace boost::python;
 
 namespace
 {
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 
 #if defined( __linux__ )
 
@@ -133,12 +138,21 @@ class HostedGLContext : public QGLContext
 
 #endif
 
+#endif // #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+void setHostedContext( uint64_t glWidgetAddress, uint64_t glFormatAddress )
+{
+	IECore::msg( IECore::Msg::Warning, "HostedGLContext", "Not implemented on this platform." );
+}
+#else
 void setHostedContext( uint64_t glWidgetAddress, uint64_t glFormatAddress )
 {
 	QGLWidget *glWidget = reinterpret_cast<QGLWidget *>( glWidgetAddress );
 	QGLFormat *glFormat = reinterpret_cast<QGLFormat *>( glFormatAddress );
 	glWidget->setContext( new HostedGLContext( *glFormat, glWidget ) );
 }
+#endif
 
 } // namespace
 

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -341,7 +341,7 @@ QVariant dataToVariant( const IECore::Data *value, int role )
 		{
 			const IECore::DateTimeData *d = static_cast<const IECore::DateTimeData *>( value );
 			time_t t = ( d->readable() - from_time_t( 0 ) ).total_seconds();
-			return QVariant( QDateTime::fromTime_t( t ) );
+			return QVariant( QDateTime::fromSecsSinceEpoch( t ) );
 		}
 		default :
 		{


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

- This allows Gaffer to compile against Python 3.11 and Qt 6.5.3 (windows-tested)
- Aligns with VFX Platform 2024
- Very WIP, probably best to treat this PR as a guide for a better one...

### Related issues ###

- N/A

### Dependencies ###

- Python 3.11.x, Qt 6.5.3, PySide 6.5.3, Qt.py 1.4.1

### Breaking changes ###

- Anything dependent upon old Qt 5.15 or PySide2 functionality eg. OpenGL widget creation

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.

This is very much a WIP and more designed as a guide for when Gaffer officially wants to support Python 3.11/Qt 6.5.x/PySide6. There are some issues still that I'm seeing eg. with spreadsheets:

```
Traceback (most recent call last):
  File "c:\Users\alex.fuller\local_packages\gaffer\1.5.2.0\platform-windows\arch-AMD64\python-3.11\ext\python\GafferUI\SpreadsheetUI\_ProxySelectionModel.py", line 119, in __modelChanged
    self.__initModelChain()
  File "c:\Users\alex.fuller\local_packages\gaffer\1.5.2.0\platform-windows\arch-AMD64\python-3.11\ext\python\GafferUI\SpreadsheetUI\_ProxySelectionModel.py", line 125, in __initModelChain
    assert( self.model() )
            ^^^^^^^^^^^^
AssertionError
```

Also some calls to `self.qtWidget.update()` require an argument which I'm not too sure on how to solve. Maybe the whole region of the widget needs to be passed to it?

Cheers