### PR TITLE
VisibleSet Bookmarks

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 
 - RenderPassEditor : Added optional `index` argument to `registerOption()` and `registerColumn()`. This can be used to specify the column's position in the UI.
 - Metadata : Added `targetsWithMetadata()` function, returning all the string targets which match a pattern and have a specific metadata key.
+- VisibleSetData : Implemented `save()` and `load()`.
 
 1.5.3.0 (relative to 1.5.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - AttributeEditor : Added "Select Affected Objects" menu item to the "Linked Lights" and Arnold "Shadow Group" columns.
+- ScriptNode : Added support for serialising metadata registered on a ScriptNode.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ API
 - RenderPassEditor : Added optional `index` argument to `registerOption()` and `registerColumn()`. This can be used to specify the column's position in the UI.
 - Metadata : Added `targetsWithMetadata()` function, returning all the string targets which match a pattern and have a specific metadata key.
 - VisibleSetData : Implemented `save()` and `load()`.
+- ScriptNodeAlgo : Added functions for managing VisibleSet bookmarks.
 
 1.5.3.0 (relative to 1.5.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.3.0)
 =======
 
+Features
+--------
+
+- HierarchyView : Added ability to store and recall the Visible Set in named bookmarks that are saved with the script.
+
 Improvements
 ------------
 

--- a/include/GafferScene/VisibleSetData.h
+++ b/include/GafferScene/VisibleSetData.h
@@ -43,7 +43,7 @@
 
 namespace IECore
 {
-	IECORE_DECLARE_TYPEDDATA( VisibleSetData, GafferScene::VisibleSet, void, IECore::SimpleDataHolder );
+	IECORE_DECLARE_TYPEDDATA( VisibleSetData, GafferScene::VisibleSet, void, IECore::SharedDataHolder );
 } // namespace IECore
 
 namespace GafferScene

--- a/include/GafferSceneUI/ScriptNodeAlgo.h
+++ b/include/GafferSceneUI/ScriptNodeAlgo.h
@@ -123,6 +123,22 @@ GAFFERSCENEUI_API void setCurrentRenderPass( Gaffer::ScriptNode *script, std::st
 /// Returns the current render pass for the script.
 GAFFERSCENEUI_API std::string getCurrentRenderPass( const Gaffer::ScriptNode *script );
 
+/// Visible Set Bookmarks
+/// =====================
+
+/// Visible Set bookmarks can be used to store named bookmarks containing a VisibleSet as
+/// metadata on the ScriptNode, allowing users to bookmark important VisibleSets to be
+/// recalled later.
+
+/// Stores a VisibleSet as a named bookmark for the script.
+GAFFERSCENEUI_API void addVisibleSetBookmark( Gaffer::ScriptNode *script, const std::string &name, const GafferScene::VisibleSet &visibleSet, bool persistent = true );
+/// Returns the VisibleSet previously bookmarked as `name`.
+GAFFERSCENEUI_API GafferScene::VisibleSet getVisibleSetBookmark( const Gaffer::ScriptNode *script, const std::string &name );
+/// Removes the bookmark previously stored as `name`.
+GAFFERSCENEUI_API void removeVisibleSetBookmark( Gaffer::ScriptNode *script, const std::string &name );
+/// Returns the names of all VisibleSet bookmarks stored on `script`.
+GAFFERSCENEUI_API std::vector<std::string> visibleSetBookmarks( const Gaffer::ScriptNode *script );
+
 } // namespace ScriptNodeAlgo
 
 } // namespace GafferSceneUI

--- a/python/GafferSceneTest/VisibleSetDataTest.py
+++ b/python/GafferSceneTest/VisibleSetDataTest.py
@@ -77,6 +77,26 @@ class VisibleSetDataTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( vd2c, vd2 )
 		self.assertEqual( vd2c.hash(), vd2.hash() )
 
+	def testSerialisation( self ) :
+
+		v = GafferScene.VisibleSet()
+		v.expansions = IECore.PathMatcher( [ "/a" ] )
+		v.inclusions = IECore.PathMatcher( [ "/b" ] )
+		v.exclusions = IECore.PathMatcher( [ "/c" ] )
+
+		d = GafferScene.VisibleSetData( v )
+
+		m = IECore.MemoryIndexedIO( IECore.CharVectorData(), [], IECore.IndexedIO.OpenMode.Write )
+
+		d.save( m, "f" )
+
+		m2 = IECore.MemoryIndexedIO( m.buffer(), [], IECore.IndexedIO.OpenMode.Read )
+		d2 = IECore.Object.load( m2, "f" )
+
+		self.assertEqual( d2, d )
+		self.assertEqual( d2.hash(), d.hash() )
+		self.assertEqual( d2.value, v )
+
 	def testStoreInContext( self ) :
 
 		v = GafferScene.VisibleSet()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -378,6 +378,43 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( s2["n"], "serialisationTest" ), 1 )
 		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "serialisationTest" ), 2 )
 
+	def testScriptNodeSerialisation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		Gaffer.Metadata.registerValue( s, "serialisationTest", 1 )
+		Gaffer.Metadata.registerValue( s["variables"], "serialisationTest", 2 )
+
+		s2 = Gaffer.ScriptNode()
+		s2.execute( s.serialise() )
+
+		self.assertEqual( Gaffer.Metadata.value( s2, "serialisationTest" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["variables"], "serialisationTest" ), 2 )
+
+	def testScriptNodeMetadataDoesntLeak( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"].addChild( s )
+
+		s["n"] = GafferTest.AddNode()
+
+		Gaffer.Metadata.registerValue( s, "scriptNodeSerialisationTest", 1 )
+		Gaffer.Metadata.registerValue( s["n"], "serialisationTest", 1 )
+		Gaffer.Metadata.registerValue( s["n"]["op1"], "serialisationTest", 2 )
+
+		s2 = Gaffer.ScriptNode()
+		a["scripts"].addChild( s2 )
+
+		s.selection().add( s["n"] )
+		s.copy( parent = s, filter = s.selection() )
+
+		s2.paste()
+
+		self.assertNotIn( "scriptNodeSerialisationTest", Gaffer.Metadata.registeredValues( s2 ) )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"], "serialisationTest" ), 1 )
+		self.assertEqual( Gaffer.Metadata.value( s2["n"]["op1"], "serialisationTest" ), 2 )
+
 	def testStringSerialisationWithNewlinesAndQuotes( self ) :
 
 		trickyStrings = [

--- a/src/Gaffer/ScriptNode.cpp
+++ b/src/Gaffer/ScriptNode.cpp
@@ -901,6 +901,14 @@ std::string ScriptNode::serialiseInternal( const Node *parent, const Set *filter
 	{
 		throw IECore::Exception( "Serialisation not available - please link to libGafferBindings." );
 	}
+
+	Context::EditableScope scope( Context::current() );
+	if( ( !parent || parent == this ) && !filter )
+	{
+		static const bool includeParentMetadata = true;
+		scope.set( "serialiser:includeParentMetadata", &includeParentMetadata );
+	}
+
 	return g_serialiseFunction( parent ? parent : this, filter );
 }
 

--- a/src/GafferSceneUIModule/ScriptNodeAlgoBinding.cpp
+++ b/src/GafferSceneUIModule/ScriptNodeAlgoBinding.cpp
@@ -115,6 +115,28 @@ std::string getCurrentRenderPassWrapper( ScriptNode &script )
 	return getCurrentRenderPass( &script );
 }
 
+void addVisibleSetBookmarkWrapper( ScriptNode &script, const std::string &name, const GafferScene::VisibleSet &visibleSet, bool persistent )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	addVisibleSetBookmark( &script, name, visibleSet, persistent );
+}
+
+void removeVisibleSetBookmarkWrapper( ScriptNode &script, const std::string &name )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	removeVisibleSetBookmark( &script, name );
+}
+
+list visibleSetBookmarksWrapper( const ScriptNode &script )
+{
+	list result;
+	for( const auto &n : visibleSetBookmarks( &script ) )
+	{
+		result.append( n );
+	}
+	return result;
+}
+
 } // namespace
 
 void GafferSceneUIModule::bindScriptNodeAlgo()
@@ -137,4 +159,9 @@ void GafferSceneUIModule::bindScriptNodeAlgo()
 	def( "acquireRenderPassPlug", &acquireRenderPassPlugWrapper, ( arg( "script" ), arg( "createIfMissing" ) = true ) );
 	def( "setCurrentRenderPass", &setCurrentRenderPassWrapper );
 	def( "getCurrentRenderPass", &getCurrentRenderPassWrapper );
+
+	def( "addVisibleSetBookmark", &addVisibleSetBookmarkWrapper, ( arg( "script" ), arg( "name" ), arg( "visibleSet" ), arg( "persistent" ) = true ) );
+	def( "getVisibleSetBookmark", getVisibleSetBookmark, ( arg( "script" ), arg( "name" ) ) );
+	def( "removeVisibleSetBookmark", &removeVisibleSetBookmarkWrapper, ( arg( "script" ), arg( "name" ) ) );
+	def( "visibleSetBookmarks", &visibleSetBookmarksWrapper, ( arg( "script" ) ) );
 }


### PR DESCRIPTION
This adds a new Expansion menu button to the Hierarchy View that provides the ability to store the current Visible Set ( scene expansion, inclusions & exclusions ) as a named bookmark that is saved with the script. This makes it fairly straightforward to bookmark one or more common states for quick access.

https://github.com/user-attachments/assets/0064cab2-43b0-486d-9d3a-935f32565298

As these bookmarks are saved with the script, there is some cost in increased file size when bookmarking large expansions. For example, a bookmark expanding ~43,000 locations in the ALab results in an additional 860KB of data saved in the Gaffer script. Comparing this to bookmarking the same ~43,000 location expansion using an equivalent feature in a leading commercial DCC results in an ~11MB increase in their scene file, so we're not doing _terribly_ by comparison...  and if you were to instead bookmark an inclusion of the root of the ALab, that would only be a 1.3KB increase in the Gaffer script.

I've structured this a more generic Expansion menu with a Bookmarks submenu in case we want to add other expansion related actions here in the future ( collapse all, clear inclusions, etc ), though happy to refine if anyone has better ideas.