### PR TITLE
ValuePlug : Disconnection no longer emits plugSet signal

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.x.x.x (relative to 1.6.x.x)
 =======
 
+Breaking Changes
+----------------
 
+- ValuePlug : Disconnection no longer emits plugSet signal.
 
 1.6.0.0 (relative to 1.5.16.2)
 =======

--- a/include/Gaffer/ValuePlug.h
+++ b/include/Gaffer/ValuePlug.h
@@ -68,8 +68,6 @@ class GAFFER_API ValuePlug : public Plug
 		/// derive from ValuePlug too, and they can deal with them
 		/// in setFrom().
 		bool acceptsInput( const Plug *input ) const override;
-		/// Reimplemented so that values can be propagated from inputs.
-		void setInput( PlugPtr input ) override;
 
 		PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
 

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -65,8 +65,7 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 
 		n2["op1"].setInput( None )
 
-		self.assertEqual( len( set ), 1 )
-		self.assertTrue( set[0][0].isSame( n2["op1"] ) )
+		self.assertEqual( len( set ), 0 )
 		self.assertEqual( len( dirtied ), 4 )
 		self.assertTrue( dirtied[2][0].isSame( n2["op1"] ) )
 		self.assertTrue( dirtied[3][0].isSame( n2["sum"] ) )

--- a/python/GafferTest/DependencyNodeTest.py
+++ b/python/GafferTest/DependencyNodeTest.py
@@ -55,17 +55,17 @@ class DependencyNodeTest( GafferTest.TestCase ) :
 		n1["op2"].setValue( 3 )
 
 		dirtied = GafferTest.CapturingSlot( n2.plugDirtiedSignal() )
-		set = GafferTest.CapturingSlot( n2.plugSetSignal() )
+		plugSet = GafferTest.CapturingSlot( n2.plugSetSignal() )
 		n2["op1"].setInput( n1["sum"] )
 
-		self.assertEqual( len( set ), 0 )
+		self.assertEqual( len( plugSet ), 0 )
 		self.assertEqual( len( dirtied ), 2 )
 		self.assertTrue( dirtied[0][0].isSame( n2["op1"] ) )
 		self.assertTrue( dirtied[1][0].isSame( n2["sum"] ) )
 
 		n2["op1"].setInput( None )
 
-		self.assertEqual( len( set ), 0 )
+		self.assertEqual( len( plugSet ), 0 )
 		self.assertEqual( len( dirtied ), 4 )
 		self.assertTrue( dirtied[2][0].isSame( n2["op1"] ) )
 		self.assertTrue( dirtied[3][0].isSame( n2["sum"] ) )

--- a/python/GafferTest/NumericPlugTest.py
+++ b/python/GafferTest/NumericPlugTest.py
@@ -167,20 +167,6 @@ class NumericPlugTest( GafferTest.TestCase ) :
 		self.assertEqual( n2["op1"].getInput(), None )
 		self.assertEqual( n2["op1"].getValue(), 1010 )
 
-	def testDisconnectEmitsPlugSet( self ) :
-
-		n1 = GafferTest.AddNode()
-		n2 = GafferTest.AddNode()
-
-		n2["op1"].setInput( n1["sum"] )
-
-		set = GafferTest.CapturingSlot( n2.plugSetSignal() )
-
-		n2["op1"].setInput( None )
-
-		self.assertEqual( len( set ), 1 )
-		self.assertTrue( set[0][0].isSame( n2["op1"] ) )
-
 	def testDefaultValue( self ) :
 
 		p = Gaffer.IntPlug(

--- a/src/Gaffer/ValuePlug.cpp
+++ b/src/Gaffer/ValuePlug.cpp
@@ -839,24 +839,6 @@ bool ValuePlug::acceptsInput( const Plug *input ) const
 	return true;
 }
 
-void ValuePlug::setInput( PlugPtr input )
-{
-	// set value back to what it was before
-	// we received a connection. we do that
-	// before calling Plug::setInput, so that
-	// we've got our new state set correctly before
-	// the dirty signal is emitted. we don't emit
-	// in the setValueInternal call, because we don't
-	// want to double up on the signals that the Plug
-	// is emitting for us in Plug::setInput().
-	if( getInput() && !input )
-	{
-		setValueInternal( m_staticValue, false );
-	}
-
-	Plug::setInput( input );
-}
-
 PlugPtr ValuePlug::createCounterpart( const std::string &name, Direction direction ) const
 {
 	PlugPtr result = new ValuePlug( name, direction, getFlags() );


### PR DESCRIPTION
Emitting plugSet signal at that stage was causing issues because the
signal was being triggered before the input was changed, which could
result in incorrect computation during those calls.

Besides, `plugSet` signal is meant to mean "setValue() has been called",
and not "getValue() will return something different now" (which is what
`plugDirtied` signal is meant to represent).

### Breaking changes ###

- ValuePlug : Disconnection no longer emits plugSet signal.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
