### PR TITLE
Attribute metadata : Fix default value for `linkedLights`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- AttributeEditor : Fixed display of fallback value for `linkedLights` attribute.
 - AttributeEditor, LightEditor, RenderPassEditor :
   - Fixed bugs which prevented edits being made in "Source" scope when there was a downstream edit in an EditScope (#6172).
   - Fixed warning messages when attempting to disable a non-existent edit.

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -65,6 +65,7 @@ StandardAttributes::StandardAttributes( const std::string &name )
 
 	// light linking
 
+	/// \todo The default value is wrong - it should be "defaultLights".
 	attributes->addChild( new Gaffer::NameValuePlug( "linkedLights", new IECore::StringData( "" ), false, "linkedLights" ) );
 
 	// light filter linking

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -142,7 +142,7 @@ Gaffer.Metadata.registerValue(
 )
 
 Gaffer.Metadata.registerValue( "attribute:linkedLights", "label", "Linked Lights" )
-Gaffer.Metadata.registerValue( "attribute:linkedLights", "defaultValue", IECore.StringData( "" ) )
+Gaffer.Metadata.registerValue( "attribute:linkedLights", "defaultValue", "defaultLights" )
 Gaffer.Metadata.registerValue(
 	"attribute:linkedLights",
 	"description",


### PR DESCRIPTION
This fixes the fallback display in the AttributeEditor.

Note that the StandardAttributes node still has the wrong default value, but that changing it at this point would be a compatibility break. We'll have to deal with that in a major version change, perhaps at the same time as using the metadata to populate the node.
