### PR TITLE
SConstruct : Enable 3Delight during doc generation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,11 @@ API
 - RenderPassEditor : Added optional `index` argument to `registerOption()` and `registerColumn()`. This can be used to specify the column's position in the UI.
 - Metadata : Added `targetsWithMetadata()` function, returning all the string targets which match a pattern and have a specific metadata key.
 
+Documentation
+-------------
+
+- 3Delight : Added GafferDelight to the node reference section.
+
 1.5.3.0 (relative to 1.5.2.0)
 =======
 

--- a/SConstruct
+++ b/SConstruct
@@ -774,11 +774,14 @@ else:
 
 commandEnv["ENV"]["PYTHONPATH"] = commandEnv.subst( os.path.pathsep.join( [ "$BUILD_DIR/python" ] + split( commandEnv["LOCATE_DEPENDENCY_PYTHONPATH"] ) ) )
 
-# SIP on MacOS prevents DYLD_LIBRARY_PATH being passed down so we make sure
-# we also pass through to gaffer the other base vars it uses to populate paths
-# for third-party support.
-for v in ( 'ARNOLD_ROOT', 'DELIGHT_ROOT', 'ONNX_ROOT' ) :
-	commandEnv["ENV"][ v ] = commandEnv[ v ]
+# Set up the environment variables that the Gaffer wrapper will use to
+# populate paths used to support third-party software.
+for option, envVar in {
+	"ARNOLD_ROOT" : "ARNOLD_ROOT",
+	"DELIGHT_ROOT" : "DELIGHT",
+	"ONNX_ROOT" : "ONNX_ROOT",
+}.items() :
+	commandEnv["ENV"][envVar] = commandEnv[option]
 
 def runCommand( command ) :
 


### PR DESCRIPTION
This gets GafferDelight into the auto-generated node reference. I've also updated the comment to clarify that these environment variables are needed on Linux as well.
