### PR TITLE
PythonEditor : Fix text insertion from dropped VectorData

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.4.15.x (relative to 1.4.15.4)
 ========
 
+Fixes
+-----
 
+- PythonEditor : Fixed bug preventing values from being inserted when dragging most VectorData types into the PythonEditor.
 
 1.4.15.4 (relative to 1.4.15.3)
 ========

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -159,7 +159,7 @@ class PythonEditor( GafferUI.Editor ) :
 
 	def __dropText( self, widget, dragData ) :
 
-		if isinstance( dragData, IECore.StringVectorData ) :
+		if IECore.DataTraits.isSequenceDataType( dragData ) :
 			return repr( list( dragData ) )
 		elif isinstance( dragData, Gaffer.GraphComponent ) :
 			if self.scriptNode().isAncestorOf( dragData ) :


### PR DESCRIPTION
We had a special case only for StringVectorData, this now opens things up to the other *VectorData types.

`ExpressionWidget.__dropText()` could also stand to be improved, though would need some consideration for the mix of languages.