### PR TITLE
SceneWriter : Improve performance

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Fixes
 
 - ContactSheetCore : Fixed bugs handling changes to the input and output image formats.
 
+Improvements
+------------
+
+- SceneWriter : Improved performance. Benchmarks rewriting complex scenes via a SceneReader->SceneWriter graph show around a 2x speedup.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Fixes
 
 - ContactSheetCore : Fixed bugs handling changes to the input and output image formats.
 
+API
+---
+
+- SceneAlgo : Added `parallelGatherLocations()` function.
+
 1.5.4.0 (relative to 1.5.3.0)
 =======
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -139,6 +139,17 @@ void filteredParallelTraverse( const ScenePlug *scene, const FilterPlug *filterP
 template <class ThreadableFunctor>
 void filteredParallelTraverse( const ScenePlug *scene, const IECore::PathMatcher &filter, ThreadableFunctor &f, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
 
+/// Calls `locationFunctor` in parallel for all locations in the scene, passing the results
+/// serially to `gatherFunctor`. Parent locations are guaranteed to be passed to `gatherFunctor`
+/// before their children, but otherwise the order of execution is unspecified.
+template <class LocationFunctor, class GatherFunctor>
+void parallelGatherLocations(
+	const ScenePlug *scene,
+	LocationFunctor &&locationFunctor, // Signature : T locationFunctor( const ScenePlug *scene, const ScenePath &path )
+	GatherFunctor &&gatherFunctor, // Signature : void gatherFunctor( T &locationFunctorResult )
+	const ScenePlug::ScenePath &root = ScenePlug::ScenePath()
+);
+
 /// Searching
 /// =========
 

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -499,5 +499,22 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 				context.setFrame( frame )
 				self.assertPathsEqual( reader["out"], "/_1", sphere["out"], "/1" )
 
+	def testWriteGlobals( self ) :
+
+		# Tests a feature that only works with `.scc`, isn't used by SceneReader,
+		# and has no documented purpose. Perhaps used at Image Engine?
+
+		options = GafferScene.StandardOptions()
+		options["options"]["renderCamera"]["enabled"].setValue( True )
+		options["options"]["renderCamera"]["value"].setValue( "/camera" )
+
+		writer = GafferScene.SceneWriter()
+		writer["in"].setInput( options["out"] )
+		writer["fileName"].setValue( self.temporaryDirectory() / "test.scc" )
+		writer["task"].execute()
+
+		scene = IECoreScene.SceneCache( writer["fileName"].getValue(), IECore.IndexedIO.Read )
+		self.assertEqual( scene.readAttribute( "gaffer:globals", 1 ), writer["in"].globals() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -48,6 +48,11 @@ import GafferSceneTest
 
 class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
+	__extensions = [
+		f".{x}" for x in IECoreScene.SceneInterface.supportedExtensions( IECore.IndexedIO.Write )
+		if x not in [ "usdz" ] ## \todo Fix registration in IECoreUSD - `.usdz` isn't supported for writing
+	]
+
 	def testWrite( self ) :
 
 		s = GafferScene.Sphere()
@@ -63,15 +68,16 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		writer = GafferScene.SceneWriter()
 		script["writer"] = writer
 		writer["in"].setInput( g["out"] )
-		writer["fileName"].setValue( self.temporaryDirectory() / "test.scc" )
 
-		writer.execute()
+		for extension in self.__extensions :
+			with self.subTest( extension = extension ) :
 
-		sc = IECoreScene.SceneCache( str( self.temporaryDirectory() / "test.scc" ), IECore.IndexedIO.OpenMode.Read )
+				writer["fileName"].setValue( self.temporaryDirectory() / ("test" + extension) )
+				writer.execute()
 
-		t = sc.child( "group" )
-
-		self.assertEqual( t.readTransformAsMatrix( 0 ), imath.M44d().translate( imath.V3d( 5, 0, 2 ) ) )
+				sc = IECoreScene.SceneInterface.create( str( writer["fileName"].getValue() ), IECore.IndexedIO.OpenMode.Read )
+				t = sc.child( "group" )
+				self.assertEqual( t.readTransformAsMatrix( 0 ), imath.M44d().translate( imath.V3d( 5, 0, 2 ) ) )
 
 	def testWriteAnimation( self ) :
 
@@ -85,64 +91,71 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		script["zExpression"].setExpression( 'parent["group"]["transform"]["translate"]["z"] = context.getFrame() * 2' )
 		script["writer"] = GafferScene.SceneWriter()
 		script["writer"]["in"].setInput( script["group"]["out"] )
-		script["writer"]["fileName"].setValue( self.temporaryDirectory() / "test.scc" )
 
-		with Gaffer.Context() :
-			script["writer"].executeSequence( [ 1, 1.5, 2 ] )
+		for extension in self.__extensions :
+			with self.subTest( extension = extension ) :
 
-		sc = IECoreScene.SceneCache( str( self.temporaryDirectory() / "test.scc" ), IECore.IndexedIO.OpenMode.Read )
-		t = sc.child( "group" )
+				script["writer"]["fileName"].setValue( self.temporaryDirectory() / ("test" + extension) )
+				script["writer"].executeSequence( [ 1, 1.5, 2 ] )
 
-		self.assertEqual( t.readTransformAsMatrix( 0 ), imath.M44d().translate( imath.V3d( 1, 0, 2 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 1 / 24.0 ), imath.M44d().translate( imath.V3d( 1, 0, 2 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 1.5 / 24.0 ), imath.M44d().translate( imath.V3d( 1.5, 0, 3 ) ) )
-		self.assertEqual( t.readTransformAsMatrix( 2 / 24.0 ), imath.M44d().translate( imath.V3d( 2, 0, 4 ) ) )
 
-	def testSceneCacheRoundtrip( self ) :
+				sc = IECoreScene.SceneInterface.create( script["writer"]["fileName"].getValue(), IECore.IndexedIO.OpenMode.Read )
+				t = sc.child( "group" )
 
-		scene = IECoreScene.SceneCache( str( self.temporaryDirectory() / "fromPython.scc" ), IECore.IndexedIO.OpenMode.Write )
-		sc = scene.createChild( "a" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
-		matrix = imath.M44d().translate( imath.V3d( 1, 0, 0 ) ).rotate( imath.V3d( 0, 0, IECore.degreesToRadians( -30 ) ) )
-		sc.writeTransform( IECore.M44dData( matrix ), 0 )
-		sc = sc.createChild( "b" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
-		sc.writeTransform( IECore.M44dData( matrix ), 0 )
-		sc = sc.createChild( "c" )
-		sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
-		sc.writeTransform( IECore.M44dData( matrix ), 0 )
+				self.assertTrue( t.readTransformAsMatrix( 0 ).equalWithAbsError( imath.M44d().translate( imath.V3d( 1, 0, 2 ) ), 1e-6 ) )
+				self.assertTrue( t.readTransformAsMatrix( 1 / 24.0 ).equalWithAbsError( imath.M44d().translate( imath.V3d( 1, 0, 2 ) ), 1e-6 ) )
+				self.assertTrue( t.readTransformAsMatrix( 1.5 / 24.0 ).equalWithAbsError( imath.M44d().translate( imath.V3d( 1.5, 0, 3 ) ), 1e-6 ) )
+				self.assertTrue( t.readTransformAsMatrix( 2 / 24.0 ).equalWithAbsError( imath.M44d().translate( imath.V3d( 2, 0, 4 ) ), 1e-6 ) )
 
-		del scene, sc
+	def testSceneReaderRoundtrip( self ) :
 
-		def testCacheFile( f ) :
-			sc = IECoreScene.SceneCache( str( f ), IECore.IndexedIO.OpenMode.Read )
-			a = sc.child( "a" )
-			self.assertTrue( a.hasObject() )
-			self.assertIsInstance( a.readObject( 0 ), IECoreScene.MeshPrimitive )
-			self.assertTrue( a.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
-			b = a.child( "b" )
-			self.assertTrue( b.hasObject() )
-			self.assertIsInstance( b.readObject( 0 ), IECoreScene.MeshPrimitive )
-			self.assertTrue( b.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
-			c = b.child( "c" )
-			self.assertTrue( c.hasObject() )
-			self.assertIsInstance( c.readObject( 0 ), IECoreScene.MeshPrimitive )
-			self.assertTrue( c.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
+		for extension in self.__extensions :
+			with self.subTest( extension = extension ) :
 
-		testCacheFile( self.temporaryDirectory() / "fromPython.scc" )
+				filePath = self.temporaryDirectory() / ("fromPython" + extension)
 
-		reader = GafferScene.SceneReader()
-		reader["fileName"].setValue( self.temporaryDirectory() / "fromPython.scc" )
+				scene = IECoreScene.SceneInterface.create( str( filePath ), IECore.IndexedIO.OpenMode.Write )
+				sc = scene.createChild( "a" )
+				sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
+				matrix = imath.M44d().translate( imath.V3d( 1, 0, 0 ) ).rotate( imath.V3d( 0, 0, IECore.degreesToRadians( -30 ) ) )
+				sc.writeTransform( IECore.M44dData( matrix ), 0 )
+				sc = sc.createChild( "b" )
+				sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
+				sc.writeTransform( IECore.M44dData( matrix ), 0 )
+				sc = sc.createChild( "c" )
+				sc.writeObject( IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))), 0 )
+				sc.writeTransform( IECore.M44dData( matrix ), 0 )
 
-		script = Gaffer.ScriptNode()
-		writer = GafferScene.SceneWriter()
-		script["writer"] = writer
-		writer["in"].setInput( reader["out"] )
-		writer["fileName"].setValue( self.temporaryDirectory() / "test.scc" )
-		writer.execute()
+				del scene, sc
 
-		testCacheFile( self.temporaryDirectory() / "test.scc" )
+				def testCacheFile( f ) :
+					sc = IECoreScene.SceneInterface.create( str( filePath ), IECore.IndexedIO.OpenMode.Read )
+					a = sc.child( "a" )
+					self.assertTrue( a.hasObject() )
+					self.assertIsInstance( a.readObject( 0 ), IECoreScene.MeshPrimitive )
+					self.assertTrue( a.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
+					b = a.child( "b" )
+					self.assertTrue( b.hasObject() )
+					self.assertIsInstance( b.readObject( 0 ), IECoreScene.MeshPrimitive )
+					self.assertTrue( b.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
+					c = b.child( "c" )
+					self.assertTrue( c.hasObject() )
+					self.assertIsInstance( c.readObject( 0 ), IECoreScene.MeshPrimitive )
+					self.assertTrue( c.readTransformAsMatrix( 0 ).equalWithAbsError( matrix, 1e-6 ) )
 
+				testCacheFile( filePath )
+
+				reader = GafferScene.SceneReader()
+				reader["fileName"].setValue( filePath )
+
+				script = Gaffer.ScriptNode()
+				writer = GafferScene.SceneWriter()
+				script["writer"] = writer
+				writer["in"].setInput( reader["out"] )
+				writer["fileName"].setValue( self.temporaryDirectory() / "written.scc" )
+				writer.execute()
+
+				testCacheFile( writer["fileName"].getValue() )
 
 	def testCanWriteSets( self ):
 
@@ -159,13 +172,11 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		sphereGroup["in"][0].setInput( s["out"] )
 		sphereGroup["name"].setValue( 'sphereGroup' )
 
-
 		sn = GafferScene.Set( "Set" )
 		script.addChild( sn )
 		sn["paths"].setValue( IECore.StringVectorData( [ '/sphereGroup' ] ) )
 		sn["name"].setValue( 'foo' )
 		sn["in"].setInput( sphereGroup["out"] )
-
 
 		sn2 = GafferScene.Set( "Set" )
 		script.addChild( sn2 )
@@ -181,30 +192,28 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		g["in"][0].setInput( sn2["out"] )
 		g["in"][1].setInput( c["out"] )
 
-		writer = GafferScene.SceneWriter()
-		script.addChild( writer )
+		script["writer"] = GafferScene.SceneWriter()
+		script["writer"]["in"].setInput( g["out"] )
 
-		script["writer"] = writer
-		writer["in"].setInput( g["out"] )
-		writer["fileName"].setValue( self.temporaryDirectory() / "setTest.scc" )
+		for extension in set( self.__extensions ) - { ".abc" } : # Sets not implemented for Alembic
+			with self.subTest( extension = extension ) :
 
-		writer.execute()
+				script["writer"]["fileName"].setValue( self.temporaryDirectory() / ("setTest" + extension) )
+				script["writer"].execute()
 
-		sc = IECoreScene.SceneCache( str( self.temporaryDirectory() / "setTest.scc" ), IECore.IndexedIO.OpenMode.Read )
+				sc = IECoreScene.SceneInterface.create( str( script["writer"]["fileName"].getValue() ), IECore.IndexedIO.OpenMode.Read )
+				scGroup = sc.child( "group" )
+				scSphereGroup = scGroup.child( "sphereGroup" )
+				scSphere = scSphereGroup.child( "sphere" )
 
-		scGroup = sc.child("group")
-		scSphereGroup = scGroup.child("sphereGroup")
-		scSphere = scSphereGroup.child("sphere")
+				extraSets = [ IECore.InternedString( "ObjectType:MeshPrimitive" ) ] if extension in ( ".scc", ".lscc" ) else []
 
-		self.assertEqual(  scGroup.readTags(), [] )
+				self.assertEqual( scGroup.readTags(), [] )
+				self.assertEqual( scSphereGroup.readTags(), [ IECore.InternedString( "foo" ) ] )
+				self.assertEqual( set( scSphere.readTags() ), set( [ IECore.InternedString( "foo" ) ] + extraSets ) )
 
-		self.assertEqual( scSphereGroup.readTags(), [ IECore.InternedString("foo") ] )
-
-		self.assertEqual( set (scSphere.readTags() ), set([IECore.InternedString("foo"), IECore.InternedString("ObjectType:MeshPrimitive")]))
-
-		scCube = scGroup.child("cube")
-		self.assertEqual( scCube.readTags() , [ IECore.InternedString("ObjectType:MeshPrimitive") ] )
-
+				scCube = scGroup.child( "cube" )
+				self.assertEqual( scCube.readTags(), extraSets )
 
 	def testHash( self ) :
 
@@ -274,20 +283,6 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 		ss = s.serialise()
 		self.assertFalse( "out" in ss )
-
-	def testAlembic( self ) :
-
-		p = GafferScene.Plane()
-
-		w = GafferScene.SceneWriter()
-		w["in"].setInput( p["out"] )
-		w["fileName"].setValue( self.temporaryDirectory() / "test.abc" )
-		w["task"].execute()
-
-		r = GafferScene.SceneReader()
-		r["fileName"].setInput( w["fileName"] )
-
-		self.assertScenesEqual( p["out"], r["out"] )
 
 	def testFileNameWithArtificalFrameDependency( self ) :
 
@@ -404,12 +399,17 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 		writer = GafferScene.SceneWriter()
 		writer["in"].setInput( duplicate["out"] )
-		writer["fileName"].setValue( self.temporaryDirectory() / "test.abc" )
-		writer["task"].execute()
 
 		reader = GafferScene.SceneReader()
 		reader["fileName"].setInput( writer["fileName"] )
-		self.assertScenesEqual( reader["out"], writer["in"] )
+
+		for extension in set( self.__extensions ) - { ".scc", ".lscc" } : # SceneCache doesn't preserve order
+			with self.subTest( extension = extension ) :
+
+				writer["fileName"].setValue( self.temporaryDirectory() / ( "test" + extension ) )
+				writer["task"].execute()
+
+				self.assertScenesEqual( reader["out"], writer["in"], checks = { "childNames" } )
 
 	def testAnimatedSets( self ) :
 
@@ -428,15 +428,9 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 
 		script["fileWriter"] = GafferScene.SceneWriter()
 		script["fileWriter"]["in"].setInput( script["sphere"]["out"] )
-		script["fileWriter"]["fileName"].setValue( self.temporaryDirectory() / "testSingle.usd" )
-		script["fileWriter"]["task"].executeSequence( range( 1, 10 ) )
 
 		script["sequenceWriter"] = GafferScene.SceneWriter()
 		script["sequenceWriter"]["in"].setInput( script["sphere"]["out"] )
-		script["sequenceWriter"]["fileName"].setValue( self.temporaryDirectory() / "testSingle.usd" )
-		script["sequenceWriter"]["task"].executeSequence( range( 1, 10 ) )
-		script["sequenceWriter"]["fileName"].setValue( self.temporaryDirectory() / "sequence.#.usd" )
-		script["sequenceWriter"]["task"].executeSequence( range( 1, 10 ) )
 
 		fileReader = GafferScene.SceneReader()
 		fileReader["fileName"].setInput( script["fileWriter"]["fileName"] )
@@ -444,21 +438,30 @@ class SceneWriterTest( GafferSceneTest.SceneTestCase ) :
 		sequenceReader = GafferScene.SceneReader()
 		sequenceReader["fileName"].setInput( script["sequenceWriter"]["fileName"] )
 
-		with Gaffer.Context() as c :
-			for f in range( 1, 10 ) :
-				c.setFrame( f )
-				# Sets were only written once for the single file, so we
-				# expect them to be taken from frame 1.
-				self.assertIn( "A", fileReader["out"].setNames() )
-				self.assertNotIn( "B", fileReader["out"].setNames() )
-				# For the file-per-frame sequence, we expect exactly the
-				# right sets.
-				if f % 2 :
-					self.assertIn( "A", sequenceReader["out"].setNames() )
-					self.assertNotIn( "B", sequenceReader["out"].setNames() )
-				else :
-					self.assertNotIn( "A", sequenceReader["out"].setNames() )
-					self.assertIn( "B", sequenceReader["out"].setNames() )
+		for extension in set( self.__extensions ) - { ".abc" } : # Sets not supported for Alembix
+			with self.subTest( extension = extension ) :
+
+				script["fileWriter"]["fileName"].setValue( self.temporaryDirectory() / ( "testSingle" + extension ) )
+				script["fileWriter"]["task"].executeSequence( range( 1, 10 ) )
+
+				script["sequenceWriter"]["fileName"].setValue( self.temporaryDirectory() / ( "sequence.#" + extension ) )
+				script["sequenceWriter"]["task"].executeSequence( range( 1, 10 ) )
+
+				with Gaffer.Context() as c :
+					for f in range( 1, 10 ) :
+						c.setFrame( f )
+						# Sets were only written once for the single file, so we
+						# expect them to be taken from frame 1.
+						self.assertIn( "A", fileReader["out"].setNames() )
+						self.assertNotIn( "B", fileReader["out"].setNames() )
+						# For the file-per-frame sequence, we expect exactly the
+						# right sets.
+						if f % 2 :
+							self.assertIn( "A", sequenceReader["out"].setNames() )
+							self.assertNotIn( "B", sequenceReader["out"].setNames() )
+						else :
+							self.assertNotIn( "A", sequenceReader["out"].setNames() )
+							self.assertIn( "B", sequenceReader["out"].setNames() )
 
 	def testWriteInvalidUSDChildName( self ) :
 

--- a/python/GafferSceneTest/SceneWriterTest.py
+++ b/python/GafferSceneTest/SceneWriterTest.py
@@ -35,7 +35,6 @@
 ##########################################################################
 
 import unittest
-import threading
 import inspect
 import imath
 
@@ -43,7 +42,6 @@ import IECore
 import IECoreScene
 
 import Gaffer
-import GafferTest
 import GafferDispatch
 import GafferScene
 import GafferSceneTest

--- a/src/GafferScene/SceneWriter.cpp
+++ b/src/GafferScene/SceneWriter.cpp
@@ -266,12 +266,11 @@ void SceneWriter::executeSequence( const std::vector<float> &frames ) const
 
 	SceneInterfacePtr output;
 	tbb::mutex mutex;
-	ContextPtr context = new Context( *Context::current() );
-	Context::Scope scopedContext( context.get() );
+	Context::EditableScope scope( Context::current() );
 
-	for( std::vector<float>::const_iterator it = frames.begin(); it != frames.end(); ++it )
+	for( auto frame : frames )
 	{
-		context->setFrame( *it );
+		scope.setFrame( frame );
 
 		ConstCompoundDataPtr sets;
 		bool useSetsAPI = true;
@@ -284,7 +283,7 @@ void SceneWriter::executeSequence( const std::vector<float> &frames ) const
 			useSetsAPI = SceneReader::useSetsAPI( output.get() );
 		}
 
-		LocationWriter locationWriter( output.get(), !useSetsAPI ? sets.get() : nullptr, context->getTime(), mutex );
+		LocationWriter locationWriter( output.get(), !useSetsAPI ? sets.get() : nullptr, scope.context()->getTime(), mutex );
 		SceneAlgo::parallelProcessLocations( scene, locationWriter );
 
 		if( useSetsAPI && sets )


### PR DESCRIPTION
This uses a new `SceneAlgo::parallelGatherLocations()` method which processes the scene in parallel, passing per-location results to a single thread for subsequent processing. This is more efficient than the previous approach of using a mutex to protect the output SceneInterface from concurent writes. Which gives the following reductions in runtime for a direct SceneReader->SceneWriter process :

- ALab : 60%
- Moana : 50%
- Market : 15%

Improvements would be expected to be even greater when heavy processing is done in between the read and the write, as it provides more opportunities for parallelism.