### PR TITLE
RenderPassEditor : Add Rename Render Pass menu item

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Features
 Improvements
 ------------
 
+- RenderPassEditor : Added ability to rename a render pass within the edit scope it was originally created in. A render pass can be renamed from the "Name" column via the "Rename Selected Render Pass..." menu item, double clicking on a cell or selecting a cell and pressing <kbd>Enter</kbd> or <kbd>Return</kbd>.
 - VisualiserTool :
   - Changed naming requirements for visualising primitive variables. Values in `dataName` now prefix the primitive variable name with `primitiveVariable:`. Setting `dataName` to `vertex:index` will display vertex indices.
   - Added `mode` plug. The available modes are :

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,11 @@ Fixes
 - InteractiveRender : Fixed potential leak of `scene:path` context variable when computing the value for `resolvedRenderer`.
 - Dispatch app : Fixed poor UI layout in "Completed" dialogue state (#6244).
 
+API
+---
+
+- EditScopeAlgo : Added `renameRenderPass()` and `renameRenderPassNonEditableReason()` functions.
+
 1.5.4.1 (relative to 1.5.4.0)
 =======
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -438,6 +438,7 @@ Toggle cell selection                                | {kbd}`Ctrl` + {{leftClick
 Edit selected cells                                  | {kbd}`Return`<br>or<br>{kbd}`Enter`
 Disable edit                                         | {kbd}`D`
 Toggle a render pass as active                       | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the {{activeRenderPass}} column
+Rename a render pass                                 | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the "Name" column
 
 ## Color Chooser Color Field ##
 

--- a/include/GafferScene/EditScopeAlgo.h
+++ b/include/GafferScene/EditScopeAlgo.h
@@ -161,6 +161,10 @@ GAFFERSCENE_API void removeRenderPassOptionEdit( Gaffer::EditScope *scope, const
 GAFFERSCENE_API const Gaffer::GraphComponent *renderPassOptionEditReadOnlyReason( const Gaffer::EditScope *scope, const std::string &renderPass, const std::string &option );
 
 GAFFERSCENE_API const Gaffer::GraphComponent *renderPassesReadOnlyReason( const Gaffer::EditScope *scope );
+/// Renames the render pass `oldName` to `newName` inside `scope`. Returns `true` if renaming occurred.
+GAFFERSCENE_API bool renameRenderPass( Gaffer::EditScope *scope, const std::string &oldName, const std::string &newName );
+/// Returns the reason why a render pass could not be renamed to `newName`.
+GAFFERSCENE_API std::optional<std::string> renameRenderPassNonEditableReason( const Gaffer::EditScope *scope, const std::string &newName );
 
 } // namespace EditScopeAlgo
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -357,6 +357,11 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		if event.button == event.Buttons.Left :
 			column = pathListing.columnAt( event.line.p0 )
+			if column == self.__renderPassNameColumn :
+				if self.__canEditRenderPasses() and len( self.__selectedRenderPasses() ) == 1 :
+					self.__renameSelectedRenderPass()
+					return True
+
 			if column == self.__renderPassActiveColumn :
 				self.__setActiveRenderPass( pathListing )
 				return True
@@ -368,6 +373,11 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		if event.modifiers == event.Modifiers.None_ :
 
 			if event.key == "Return" or event.key == "Enter" :
+				selectedRenderPasses = self.__selectedRenderPasses()
+				if self.__canEditRenderPasses() and len( selectedRenderPasses ) == 1 :
+					self.__renameSelectedRenderPass()
+					return True
+
 				selection = pathListing.getSelection()
 				if len( selection[1].paths() ) :
 					self.__setActiveRenderPass( pathListing )
@@ -435,6 +445,16 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 			# Render pass operations
 
 			menuDefinition.append(
+				"Rename Selected Render Pass...",
+				{
+					"command" : Gaffer.WeakMethod( self.__renameSelectedRenderPass ),
+					"active" : self.__canEditRenderPasses() and len( self.__selectedRenderPasses() ) == 1
+				}
+			)
+
+			menuDefinition.append( "__DeleteDivider__", { "divider" : True } )
+
+			menuDefinition.append(
 				"Delete Selected Render Passes",
 				{
 					"command" : Gaffer.WeakMethod( self.__deleteSelectedRenderPasses ),
@@ -488,6 +508,63 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 
 		with Gaffer.UndoScope( editScope.ancestor( Gaffer.ScriptNode ) ) :
 			renderPassesProcessor["names"].setValue( renderPasses )
+
+	def __warningPopup( self, title, message ) :
+
+		with GafferUI.PopupWindow() as self.__popup :
+			with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) :
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+					GafferUI.Image( "warningSmall.png" )
+					GafferUI.Label( "<h4>{}</h4>".format( title ) )
+				GafferUI.Label( message )
+
+		self.__popup.popup( parent = self )
+
+	def __renameSelectedRenderPass( self ) :
+
+		selectedRenderPasses = self.__selectedRenderPasses()
+		if len( selectedRenderPasses ) != 1 :
+			return
+
+		editScope = self.editScope()
+		if editScope is None :
+			return
+
+		renderPassesProcessor = editScope.acquireProcessor( "RenderPasses", createIfNecessary = False )
+		if renderPassesProcessor is None or selectedRenderPasses[0] not in renderPassesProcessor["names"].getValue() :
+			self.__warningPopup( "Unable to rename", "Pass was not created in {}.".format( editScope.relativeName( self.scriptNode() ) ) )
+			return
+
+		dialogue = _RenderPassCreationDialogue(
+			existingNames = [ x for x in self.__renderPassNames( self.settings()["in"] ) if x != selectedRenderPasses[0] ],
+			editScope = editScope,
+			title = "Rename Render Pass",
+			confirmLabel = "Rename",
+			actionDescription = "Rename render pass in",
+			defaultName = selectedRenderPasses[0],
+			message = "<h4>Renaming will only affect the current edit scope.</h4>\nReferences elsewhere in the node graph may need to be updated manually."
+		)
+
+		renderPassName = dialogue.waitForRenderPassName( parentWindow = self.ancestor( GafferUI.Window ) )
+		if renderPassName is not None and renderPassName != selectedRenderPasses[0] :
+
+			nonEditableReason = GafferScene.EditScopeAlgo.renameRenderPassNonEditableReason( editScope, renderPassName )
+			if nonEditableReason is not None :
+				self.__warningPopup( "Unable to rename", nonEditableReason )
+				return
+
+			with Gaffer.UndoScope( editScope.ancestor( Gaffer.ScriptNode ) ) :
+				GafferScene.EditScopeAlgo.renameRenderPass( editScope, selectedRenderPasses[0], renderPassName )
+
+			if self.settings()["displayGrouped"].getValue() :
+				renamedPath = GafferScene.ScenePlug.stringToPath( self.pathGroupingFunction()( renderPassName ) )
+				renamedPath.append( renderPassName )
+			else :
+				renamedPath = renderPassName
+
+			self.__pathListing.setSelection(
+				[ IECore.PathMatcher( [ renamedPath ] ) if i == 0 else IECore.PathMatcher() for i in range( len( self.__pathListing.getSelection() ) ) ]
+			)
 
 	def __disableRenderPasses( self, renderPasses, editScope ) :
 
@@ -863,7 +940,7 @@ class _SearchFilterWidget( GafferUI.PathFilterWidget ) :
 
 class _RenderPassCreationDialogue( GafferUI.Dialogue ) :
 
-	def __init__( self, existingNames = [], editScope = None, title = "Add Render Pass", cancelLabel = "Cancel", confirmLabel = "Add", **kw ) :
+	def __init__( self, existingNames = [], editScope = None, title = "Add Render Pass", cancelLabel = "Cancel", confirmLabel = "Add", actionDescription = "Add render pass to", defaultName = "", message = "", **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=GafferUI.Window.SizeMode.Fixed, **kw )
 
@@ -873,13 +950,24 @@ class _RenderPassCreationDialogue( GafferUI.Dialogue ) :
 		with self.__column :
 			if editScope :
 				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
-					GafferUI.Label( "Add render pass to" )
+					GafferUI.Label( actionDescription )
 					editScopeColor = Gaffer.Metadata.value( editScope, "nodeGadget:color" )
 					if editScopeColor :
 						GafferUI.Image.createSwatch( editScopeColor )
 					GafferUI.Label( "<h4>{}</h4>".format( editScope.relativeName( editScope.ancestor( Gaffer.ScriptNode ) ) ) )
 
+			if message != "" :
+				lines = message.split( "\n" )
+				with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, spacing = 4 ) :
+					with GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 ) :
+						GafferUI.Image( "infoSmall.png" )
+						GafferUI.Label( "{}".format( lines[0] ) )
+					for line in lines[1:] :
+						GafferUI.Label( "{}".format( line ) )
+
 			self.__renderPassNameWidget = GafferSceneUI.RenderPassesUI.createRenderPassNameWidget()
+			if defaultName != "" :
+				self.__renderPassNameWidget.setRenderPassName( defaultName )
 
 		self._setWidget( self.__column )
 

--- a/src/GafferSceneModule/EditScopeAlgoBinding.cpp
+++ b/src/GafferSceneModule/EditScopeAlgoBinding.cpp
@@ -263,6 +263,19 @@ GraphComponentPtr renderPassesReadOnlyReasonWrapper( Gaffer::EditScope &scope )
 	return const_cast<GraphComponent *>( EditScopeAlgo::renderPassesReadOnlyReason( &scope ) );
 }
 
+bool renameRenderPassWrapper( Gaffer::EditScope &scope, const std::string &oldName, const std::string &newName )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return EditScopeAlgo::renameRenderPass( &scope, oldName, newName );
+}
+
+object renameRenderPassNonEditableReasonWrapper( Gaffer::EditScope &scope, const std::string &newName )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	std::optional<std::string> result = EditScopeAlgo::renameRenderPassNonEditableReason( &scope, newName );
+	return result ? object( result.value() ) : object();
+}
+
 } // namespace
 
 namespace GafferSceneModule
@@ -326,6 +339,8 @@ void bindEditScopeAlgo()
 	def( "renderPassOptionEditReadOnlyReason", &renderPassOptionEditReadOnlyReasonWrapper, ( arg( "scope" ), arg( "renderPass" ), arg( "option" ) ) );
 
 	def( "renderPassesReadOnlyReason", &renderPassesReadOnlyReasonWrapper );
+	def( "renameRenderPass", &renameRenderPassWrapper, ( arg( "scope" ), arg( "oldName" ), arg( "newName" ) ) );
+	def( "renameRenderPassNonEditableReason", &renameRenderPassNonEditableReasonWrapper, ( arg( "scope" ), arg( "newName" ) ) );
 
 }
 


### PR DESCRIPTION
This adds a "Rename Selected Render Pass" menu item to the "Name" column's popup menu with the ability to rename a render pass within the edit scope it was originally created. This action covers simple cases, such as fixing a typo in a newly created render pass name.

References to the old render pass name outside of the originating edit scope are left unchanged by this action and would still need to be updated by the user, including those in other edit scopes.

![renameSelectedRenderPass](https://github.com/user-attachments/assets/29f90132-0694-463d-b55b-1ee0ae10d3d3)