### PR TITLE
InspectorColumn : Add Ctrl+Enter shortcut to popup an edit pre-enabled

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 ------------
 
 - AttributeEditor : Added "Select Affected Objects" menu item to the "Linked Lights" and Arnold "Shadow Group" columns.
+- AttributeEditor, LightEditor, RenderPassEditor : Added <kbd>Ctrl</kbd> + <kbd>Enter</kbd> shortcut to edit the selected cells, enabling the edit if necessary.
 - ScriptNode : Added support for serialising metadata registered on a ScriptNode.
 
 Fixes


### PR DESCRIPTION
This adds a `Ctrl` + `Enter` shortcut to the InspectorColumn used in the Attribute Editor, Light Editor and Render Pass Editor that pops up an editor for the selected cells, ensuring that the `enabled` plug of the plug(s) being edited is enabled. This spares some clicks when you just want to get on with editing.

![editEnabledShortcut](https://github.com/user-attachments/assets/f045bc8e-1ab4-487f-a32f-46dac46fcb32)
