### PR TITLE
ContactSheetCore : Fix Missing affects()

### DIFF
--- a/python/GafferImageTest/ContactSheetCoreTest.py
+++ b/python/GafferImageTest/ContactSheetCoreTest.py
@@ -241,5 +241,40 @@ class ContactSheetCoreTest( GafferImageTest.ImageTestCase ) :
 
 			self.assertEqual( contactSheet["__resampleMatrix"].getValue(), imath.M33f((2, 0, 0), (0, 2, 0), (0, 0, 1)) )
 
+	def testModifyFormat( self ) :
+
+		constant = GafferImage.Constant()
+		constant["format"].setValue( GafferImage.Format( 300, 200 ) )
+		constant["color"].setValue( imath.Color4f( 1, 1, 1, 1 ) )
+
+		contactSheet = GafferImage.ContactSheetCore()
+		contactSheet["in"].setInput( constant["out"] )
+		contactSheet["format"].setValue( GafferImage.Format( 300, 200 ) )
+		contactSheet["tiles"].setValue(
+			IECore.Box2fVectorData( [
+				imath.Box2f( imath.V2f( 0 ), imath.V2f( 300, 200 ) )
+			] )
+		)
+
+		# I don't really like that ContactSheetCore introduces a bit of resampling error even when the input
+		# and output tile sizes match exactly ... it seems like there could be pretty common usages where
+		# you're dealing with exact sizes, and it would be nice if there was a path that just did an Offset
+		# in those cases, and didn't slightly change pixel values. Though maybe that's not really possible with
+		# this API - since the tiles are specified in float, it might be hard to identify that they are intended
+		# to be exact matches. Anyways, not the purpose of this test, at least this doesn't crash any more.
+		self.assertImagesEqual( contactSheet["out"], constant["out"], maxDifference = 0.0000003 )
+
+		contactSheet["format"].setValue( GafferImage.Format( 600, 400 ) )
+
+		refBackground = GafferImage.Constant()
+		refBackground["format"].setValue( GafferImage.Format( 600, 400 ) )
+		refBackground["color"].setValue( imath.Color4f( 0, 0, 0, 0 ) )
+
+		refMerge = GafferImage.Merge()
+		refMerge["in"][0].setInput( refBackground["out"] )
+		refMerge["in"][1].setInput( constant["out"] )
+
+		self.assertImagesEqual( contactSheet["out"], refMerge["out"], maxDifference = 0.0000003 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferImageTest/ContactSheetCoreTest.py
+++ b/python/GafferImageTest/ContactSheetCoreTest.py
@@ -217,5 +217,29 @@ class ContactSheetCoreTest( GafferImageTest.ImageTestCase ) :
 		self.assertEqual( displayWindowStats["max"]["r"].getValue(), 1 )
 		self.assertEqual( displayWindowStats["max"]["g"].getValue(), 0 )
 
+	def testInFormatAffectsResampleMatrix( self ) :
+
+		constant = GafferImage.Constant()
+		constant["format"].setValue( GafferImage.Format( 300, 200 ) )
+		constant["color"].setValue( imath.Color4f( 1, 1, 1, 1 ) )
+
+		contactSheet = GafferImage.ContactSheetCore()
+		contactSheet["in"].setInput( constant["out"] )
+		contactSheet["format"].setValue( GafferImage.Format( 300, 200 ) )
+		contactSheet["tiles"].setValue(
+			IECore.Box2fVectorData( [
+				imath.Box2f( imath.V2f( 0 ), imath.V2f( 300, 200 ) )
+			] )
+		)
+
+		c = Gaffer.Context()
+		c["contactSheet:tileIndex"] = IECore.IntData( 0 )
+		with c:
+			self.assertEqual( contactSheet["__resampleMatrix"].getValue(), imath.M33f((1, 0, 0), (0, 1, 0), (0, 0, 1)) )
+
+			constant["format"].setValue( GafferImage.Format( 150, 100 ) )
+
+			self.assertEqual( contactSheet["__resampleMatrix"].getValue(), imath.M33f((2, 0, 0), (0, 2, 0), (0, 0, 1)) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/ContactSheetCore.cpp
+++ b/src/GafferImage/ContactSheetCore.cpp
@@ -267,7 +267,7 @@ void ContactSheetCore::affects( const Gaffer::Plug *input, AffectedPlugsContaine
 		outputs.push_back( coveragePlug() );
 	}
 
-	if( input == tilesPlug() || input == tileVariablePlug() )
+	if( input == inPlug()->formatPlug() || input == tilesPlug() || input == tileVariablePlug() )
 	{
 		outputs.push_back( resampleMatrixPlug() );
 	}

--- a/src/GafferImage/ContactSheetCore.cpp
+++ b/src/GafferImage/ContactSheetCore.cpp
@@ -262,7 +262,7 @@ void ContactSheetCore::affects( const Gaffer::Plug *input, AffectedPlugsContaine
 		outputs.push_back( outPlug()->channelNamesPlug() );
 	}
 
-	if( input == formatPlug() || input == tilesPlug() )
+	if( formatPlug()->isAncestorOf( input ) || input == tilesPlug() )
 	{
 		outputs.push_back( coveragePlug() );
 	}


### PR DESCRIPTION
Two small fixes to ContactSheetCore: one plug missing in affects(), and one plug that was being accessed wrong. This could cause inconsistent results, or crashes ( if CoverageData is smaller than required and doesn't get updated ).

I haven't made a Changes entry yet - we would usually describe how something affects the user facing stuff, but I don't think these bugs affect ContactSheet - because of how ContactSheet drives the `tiles`, I think it ends up triggering recomputes at all the right times even without this internal affects() being fully accurate. The problems only occur when building your own network using ContactSheetCore, which I guess is semi-private? So maybe this is purely internal, and doesn't need a Changes entry?