### PR TITLE
Project config : Do not import GafferSceneUI in headless mode

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 -----
 
 - ContactSheetCore : Fixed bugs handling changes to the input and output image formats.
+- Dispatch app : Fixed configuration bug which caused GafferSceneUI to be loaded unnecessarily (#6239).
 
 1.5.4.0 (relative to 1.5.3.0)
 =======

--- a/startup/gui/project.py
+++ b/startup/gui/project.py
@@ -45,8 +45,6 @@ import GafferImage
 import GafferDispatch
 import GafferTractor
 
-import GafferSceneUI
-
 ##########################################################################
 # Note this file is shared with the `dispatch` app. We need to ensure any
 # changes here have the desired behaviour in both applications.
@@ -69,8 +67,14 @@ def __scriptAdded( container, script ) :
 
 	GafferImage.FormatPlug.acquireDefaultFormatPlug( script )
 
-	renderPassPlug = GafferSceneUI.ScriptNodeAlgo.acquireRenderPassPlug( script )
-	Gaffer.Metadata.registerValue( renderPassPlug["value"], "plugValueWidget:type", "GafferSceneUI.RenderPassEditor._RenderPassPlugValueWidget" )
+	# We don't want to load UI modules unless we're in a UI context.
+	## \todo We plan to eventually migrate ScriptNodeAlgo to GafferScene,
+	# which will allow us to remove this hack.
+	if "GafferUI" in sys.modules :
+		import GafferSceneUI
+
+		renderPassPlug = GafferSceneUI.ScriptNodeAlgo.acquireRenderPassPlug( script )
+		Gaffer.Metadata.registerValue( renderPassPlug["value"], "plugValueWidget:type", "GafferSceneUI.RenderPassEditor._RenderPassPlugValueWidget" )
 
 application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
 


### PR DESCRIPTION
Longer term we plan to migrate ScriptNodeAlgo to GafferScene once we can remove GafferSceneUI::ContextAlgo.

Fixes #6239