### PR TITLE
VectorDataWidget single value drop fix

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Fixes
 -----
 
 - MessageWidget : Fixed bug preventing the horizontal scroll bar from appearing when displaying messages with long lines.
-- VectorDataWidget : Fixed bug preventing dropping a single value onto the `+` and `-` buttons.
+- VectorDataWidget, VectorDataPlugValueWidget : Fixed bug preventing dropping a single value onto the `+` and `-` buttons and the plug name.
 
 1.4.15.5 (relative to 1.4.15.4)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - MessageWidget : Fixed bug preventing the horizontal scroll bar from appearing when displaying messages with long lines.
+- VectorDataWidget : Fixed bug preventing dropping a single value onto the `+` and `-` buttons.
 
 1.4.15.5 (relative to 1.4.15.4)
 ========

--- a/python/GafferUI/VectorDataPlugValueWidget.py
+++ b/python/GafferUI/VectorDataPlugValueWidget.py
@@ -107,6 +107,17 @@ class VectorDataPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		self.__dataWidget.setEditable( self._editable() )
 
+	def _convertValue( self, value ) :
+
+		plugValueType = type( self.getPlug().defaultValue() )
+		if hasattr( value, "value" ) and isinstance(
+			value.value,
+			IECore.DataTraits.valueTypeFromSequenceType( plugValueType )
+		) :
+			return plugValueType( [ value.value ] )
+		else :
+			return GafferUI.PlugValueWidget._convertValue( self, value )
+
 	def __dataPlugs( self ) :
 
 		if not len( self.getPlug() ) :


### PR DESCRIPTION
This fixes dropping a single value onto a `VectorDataWidget` / `VectorDataPlugValueWidget`. Previously, if you dropped a single value, the `+` and `-` buttons would not activate. This meant it reverted to the `PlugValueWidget` behavior, which attempts to convert the dropped data into the data type expected by the widget.

`*VectorData` objects can take a single value in their constructor. For `IntVectorData`, this creates a vector of length equal to the value being dropped. `StringVectorData` similarly turns a string constructor argument into a vector where each letter is an element.

So the data would convert and the drop would succeed but with unexpected values.

This PR handles those cases by converting to single-element vectors instead, for correct dropping onto `VectorDataWidget`, including the `+`, `-` and overall plug (effectively the plug name)`.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
