### PR TITLE
Silence `icacls` commands

### DIFF
--- a/python/GafferImageTest/CatalogueTest.py
+++ b/python/GafferImageTest/CatalogueTest.py
@@ -624,7 +624,11 @@ class CatalogueTest( GafferImageTest.ImageTestCase ) :
 		if os.name != "nt" :
 			os.chmod( self.temporaryDirectory(), stat.S_IREAD )
 		else :
-			subprocess.check_call( [ "icacls", self.temporaryDirectory(), "/deny", "Users:(OI)(CI)(W)" ] )
+			subprocess.check_call(
+				[ "icacls", self.temporaryDirectory(), "/deny", "Users:(OI)(CI)(W)" ],
+				stdout = subprocess.DEVNULL,
+				stderr = subprocess.STDOUT
+			)
 
 		r = GafferImage.ImageReader()
 		r["fileName"].setValue( self.imagesPath() / "blurRange.exr" )

--- a/python/GafferTest/TestCase.py
+++ b/python/GafferTest/TestCase.py
@@ -116,7 +116,11 @@ class TestCase( unittest.TestCase ) :
 
 		if self.__temporaryDirectory is not None :
 			if os.name == "nt" :
-				subprocess.check_call( [ "icacls", self.__temporaryDirectory, "/grant", "Users:(OI)(CI)(W)" ] )
+				subprocess.check_call(
+					[ "icacls", self.__temporaryDirectory, "/grant", "Users:(OI)(CI)(W)" ],
+					stdout = subprocess.DEVNULL,
+					stderr = subprocess.STDOUT
+				)
 
 			for root, dirs, files in os.walk( self.__temporaryDirectory ) :
 				for fileName in [ p for p in files + dirs if not ( pathlib.Path( root ) / p ).is_symlink() ] :

--- a/python/GafferUSDTest/USDLayerWriterTest.py
+++ b/python/GafferUSDTest/USDLayerWriterTest.py
@@ -260,7 +260,11 @@ class USDLayerWriterTest( GafferSceneTest.SceneTestCase ) :
 		if os.name != "nt" :
 			self.temporaryDirectory().chmod( 444 )
 		else :
-			subprocess.check_call( [ "icacls", self.temporaryDirectory(), "/deny", "Users:(OI)(CI)(W)" ] )
+			subprocess.check_call(
+				[ "icacls", self.temporaryDirectory(), "/deny", "Users:(OI)(CI)(W)" ],
+				stdout = subprocess.DEVNULL,
+				stderr = subprocess.STDOUT
+			)
 
 		with self.assertRaisesRegex( RuntimeError, 'Failed to export layer to "{}"'.format( layerWriter["fileName"].getValue() ) ) :
 			layerWriter["task"].execute()


### PR DESCRIPTION
`icacls` was introduced in #6204 to change permissions for some Windows tests. It insists on outputting the success of the command which clutters the test results, even with the `/q` switch. Instead, we pipe the results of those subprocesses to `/dev/null`.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
