### PR TITLE
MessageWidget : Fix message column width

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.4.15.x (relative to 1.4.15.5)
 ========
 
+Fixes
+-----
+
+- MessageWidget : Fixed bug preventing the horizontal scroll bar from appearing when displaying messages with long lines.
+
 1.4.15.5 (relative to 1.4.15.4)
 ========
 

--- a/python/GafferUI/MessageWidget.py
+++ b/python/GafferUI/MessageWidget.py
@@ -778,7 +778,7 @@ class _MessageTableView( GafferUI.Widget ) :
 
 			# Fortunately we have a fixed set of known message levels so its ok to hard code this here
 			tableView.setColumnWidth( 0, 75 )
-			tableView.horizontalHeader().setStretchLastSection( True )
+			tableView.horizontalHeader().setSectionResizeMode( 1, QtWidgets.QHeaderView.ResizeToContents )
 
 			tableView.setHorizontalScrollBarPolicy( QtCore.Qt.ScrollBarAsNeeded )
 


### PR DESCRIPTION
It was recently reported on the gaffer-dev mailing list that the horizontal scroll bar wasn't visible when viewing long log lines of an interactive render.

The MessageWidget was setting an appropriate `horizontalScrollBarPolicy`, but the messages column was set to stretch, which would only fill the available width so the scroll bar was never required.