### PR TITLE
DispatchDialogue : Fix layout in "Completed" state

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,7 +31,9 @@ Fixes
 
 - ContactSheetCore : Fixed bugs handling changes to the input and output image formats.
 - InteractiveRender : Fixed potential leak of `scene:path` context variable when computing the value for `resolvedRenderer`.
-- Dispatch app : Fixed configuration bug which caused GafferSceneUI to be loaded unnecessarily (#6239).
+- Dispatch app :
+  - Fixed configuration bug which caused GafferSceneUI to be loaded unnecessarily (#6239).
+  - Fixed poor UI layout in "Completed" dialogue state (#6244).
 
 1.5.4.0 (relative to 1.5.3.0)
 =======

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -40,6 +40,8 @@ import sys
 import threading
 import traceback
 
+import imath
+
 import IECore
 
 import Gaffer
@@ -119,6 +121,8 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 		# build a ui element for progress feedback and messages
 		with GafferUI.ListContainer( spacing = 4 ) as self.__progressUI :
 
+			GafferUI.Spacer( imath.V2i( 0 ) )
+
 			with GafferUI.ListContainer( parenting = { "horizontalAlignment" : GafferUI.HorizontalAlignment.Center, "verticalAlignment" : GafferUI.VerticalAlignment.Center } ) :
 				self.__progressIconFrame = GafferUI.Frame( borderStyle = GafferUI.Frame.BorderStyle.None_, parenting = { "horizontalAlignment" : GafferUI.HorizontalAlignment.Center } )
 				self.__progressLabel = GafferUI.Label( parenting = { "horizontalAlignment" : GafferUI.HorizontalAlignment.Center } )
@@ -128,6 +132,8 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 				# connect to the collapsible state change so we can increase the window
 				# size when the details pane is first shown.
 				self.__messageCollapsibleConnection = self.__messageCollapsible.stateChangedSignal().connect( Gaffer.WeakMethod( self.__messageCollapsibleChanged ) )
+
+			GafferUI.Spacer( imath.V2i( 0 ) )
 
 		self.__backButton = self._addButton( "Back" )
 		self.__backButton.clickedSignal().connectFront( Gaffer.WeakMethod( self.__initiateSettings ) )


### PR DESCRIPTION
This was affected by bb1f4327d6cab26de4f2a1b1770d42f08f402447, which fixed a bug which made ListContainer greedy for space as soon as any children had an alignment specified. If we want to expand into space now, we need to use Spacers explicitly.

Fixes #6244
