### PR TITLE
Instancer : Support relative prototype paths

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - USDLight : Added Cycles-specific light parameters.
+- Instancer : Added support for prototype paths that are relative to an instancer. When using the same scene connected to both `in` and `prototypes`, this allows relocating an instancer together with its prototypes to a different location in the hierarchy. Prototype paths beginning with "./" are treated as relative, or you can set the environment variable `GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS` to treat any path not beginning with "/" as relative ( this may be the default in the future ).
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,11 @@ Features
 --------
 
 - USDLight : Added Cycles-specific light parameters.
+- USD : Added automatic expansion of USD PointInstancers at render time.
+  - This can be controlled on a per-instancer basis using a `gafferUSD:pointInstancerAdaptor:enabled` boolean attribute.
+  - Which point cloud primitive variables are promoted to user attributes can be controlled using a `gafferUSD:pointInstancerAdaptor:attributes` string attribute.
+  - May be disabled entirely with `GafferScene.SceneAlgo.deregisterRenderAdaptor( "USDPointInstancerAdaptor" )`.
+- Viewer : Added "Expand USD Instancers" item to the Expansion menu. Defaults to on for all renderers except OpenGL.
 - Instancer : Added support for prototype paths that are relative to an instancer. When using the same scene connected to both `in` and `prototypes`, this allows relocating an instancer together with its prototypes to a different location in the hierarchy. Prototype paths beginning with "./" are treated as relative, or you can set the environment variable `GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS` to treat any path not beginning with "/" as relative ( this may be the default in the future ).
 
 Improvements

--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Improvements
   - The vector value being visualised for the vertex nearest the cursor is shown next to the vertex.
 - NameSwitch : Added `enabledNames` output plug.
 - ColorSwatchPlugValueWidget : Changed the display transform of the color chooser dialogue to match that of the `ColorSwatchPlugValueWidget` creating it instead of the script window.
+- Instancer : Improved hashing of instancer capsules. Prevents unnecessary recomputation of instancers when editing something unrelated.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
 - NumericPlug : Fixed serialisation of plugs with infinite min/max values, for example the promoted outputs of an ImageStats node.
 - VisualiserTool : Changed viewer shortcut to <kbd>P</kbd> to fix conflict with the Transform Tool.
 - Render Pass menu : Fixed bug evaluating image nodes in wrong context.
+- Instancer : Fixed obscure bug that could occasionally cause errors while interactively editing prototype hierarchy.
 
 Build
 -----

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -51,6 +51,12 @@ signal.signal( signal.SIGINT, signal.SIG_DFL )
 # to catch all the naughty deprecated things we do.
 warnings.simplefilter( "default", DeprecationWarning )
 
+# Load USD PointInstancer prototypes as relative paths by default. This allows
+# the _PointInstancerAdaptor to function even when the instancers are reparented
+# in the Gaffer hierarchy.
+if "IECOREUSD_POINTINSTANCER_RELATIVE_PROTOTYPES" not in os.environ :
+	os.environ["IECOREUSD_POINTINSTANCER_RELATIVE_PROTOTYPES"] = "1"
+
 import Gaffer
 Gaffer._Gaffer._nameProcess()
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -263,7 +263,7 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 			PrototypeScope( const EngineData *engine, const Gaffer::Context *context, const ScenePath *parentPath, const ScenePath *branchPath );
 			private :
 				ScenePlug::ScenePath m_prototypePath;
-				void setPrototype( const EngineData *engine, const ScenePath *branchPath );
+				void setPrototype( const EngineData *engine, const ScenePath *sourcePath, const ScenePath *branchPath );
 
 				// Used when PrototypeScope retrieves the EngineData itself, and needs to keep it alive
 				ConstEngineDataPtr m_engine;

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -245,6 +245,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::PathMatcherDataPlug *setCollaboratePlug();
 		const Gaffer::PathMatcherDataPlug *setCollaboratePlug() const;
 
+		Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug();
+		const Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug() const;
+
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 

--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -248,6 +248,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug();
 		const Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug() const;
 
+		Gaffer::IntPlug *nodeIdPlug();
+		const Gaffer::IntPlug *nodeIdPlug() const;
+
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -2196,10 +2196,10 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 						[ "foo%i"%(i//34) for i in range( 100 ) ]
 					) )
 		points["unindexedRoots"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.StringVectorData(
-						[ ["cube","plane","sphere"][i//34] for i in range( 100 ) ]
+						[ ["/cube","/plane","/sphere"][i//34] for i in range( 100 ) ]
 					) )
 		points["indexedRoots"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex,
-			IECore.StringVectorData( [ "cube","plane","sphere"] ),
+			IECore.StringVectorData( [ "/cube","/plane","/sphere"] ),
 			IECore.IntVectorData( [(i//34) for i in range( 100 )] ),
 		)
 		pointsSource = GafferScene.ObjectToScene()
@@ -2373,14 +2373,14 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 		self.assertEncapsulatedRendersSame( instancer )
 
-		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ "withAttrs", "cube", "plane", "sphere" ] ) )
+		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/withAttrs", "/cube", "/plane", "/sphere" ] ) )
 		testAttributes( frameAttr = [ 1 ] * 25, floatAttr = floatExpected )
 		self.assertEqual( uniqueCounts(), { "" : 20, "floatVar" : 5 } )
 
 		self.assertEncapsulatedRendersSame( instancer )
 
 		# Test an empty root
-		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ "withAttrs", "", "plane", "sphere" ] ) )
+		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/withAttrs", "", "/plane", "/sphere" ] ) )
 		self.assertEqual( uniqueCounts(), { "" : 15, "floatVar" : 5 } )
 
 		self.assertEncapsulatedRendersSame( instancer )
@@ -3032,7 +3032,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 	def testVaryingPrimvars( self ) :
 		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
 		plane["varyingFloat"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( [ 16.25, 16.5, 16.75, 17.0 ] ) )
-		plane["varyingString"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.StringVectorData( [ "a", "b", "d", "c" ] ) )
+		plane["varyingString"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.StringVectorData( [ "/a", "/b", "/d", "/c" ] ) )
 
 		objectToScene = GafferScene.ObjectToScene()
 		objectToScene["object"].setValue( plane )
@@ -3091,7 +3091,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		curves["P"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 4 ) ] ) )
 		curves["varyingString"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.StringVectorData( [ "c", "c" ] ) )
 		curves["varyingFloat"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( [ 3, 7 ] ) )
-		curves["vertexString"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.StringVectorData( [ "a", "b", "d", "c" ] ) )
+		curves["vertexString"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.StringVectorData( [ "/a", "/b", "/d", "/c" ] ) )
 		self.assertTrue( curves.arePrimitiveVariablesValid() )
 
 		objectToScene["object"].setValue( curves )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3392,6 +3392,13 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testChildNamesHashPerf( self ):
+		nodes = self.initSimpleInstancer()
+		with GafferTest.TestRunner.PerformanceScope() :
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/sphere" )
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/cube" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testChildNamesPerf( self ):
 		nodes = self.initSimpleInstancer()
 		with GafferTest.TestRunner.PerformanceScope() :

--- a/python/GafferSceneUI/InstancerUI.py
+++ b/python/GafferSceneUI/InstancerUI.py
@@ -220,8 +220,9 @@ class _ColumnHeadings( GafferUI.ListContainer ):
 		GafferUI.ListContainer.__init__( self, GafferUI.ListContainer.Orientation.Horizontal, spacing = 4 )
 		with self:
 			GafferUI.Label( "<h4><b>" + headings[0] + "</b></h4>", toolTip = toolTipOverride )._qtWidget().setFixedWidth( GafferUI.PlugWidget.labelWidth() )
-			GafferUI.Spacer( imath.V2i( 25, 2 ) ) # approximate width of a BoolWidget Switch
+			GafferUI.Spacer( imath.V2i( 25, 2 ), imath.V2i( 25, 2 ) ) # approximate width of a BoolWidget Switch
 			self.addChild( GafferUI.Label( "<h4><b>" + headings[1] + "</b></h4>", toolTip = toolTipOverride ), expand = True, horizontalAlignment=GafferUI.HorizontalAlignment.Left )
+			GafferUI.Spacer( imath.V2i( 0 ) )
 			GafferUI.Label( "<h4><b>" + headings[2] + "</b></h4>", toolTip = toolTipOverride )._qtWidget().setFixedWidth( _variationsPlugValueWidgetWidth() )
 
 # Would be really nice if we could specify constructor arguments for widgets in the metadata,
@@ -295,50 +296,50 @@ Gaffer.Metadata.registerNode(
 
 	"layout:customWidget:seedColumnHeadings:widgetType", "GafferSceneUI.InstancerUI._SeedColumnHeadings",
 	"layout:customWidget:seedColumnHeadings:section", "Context Variations",
-	"layout:customWidget:seedColumnHeadings:index", 19,
+	"layout:customWidget:seedColumnHeadings:index", 100,
 
 	"layout:customWidget:idContextCountSpacer:widgetType", "GafferSceneUI.InstancerUI._SeedCountSpacer",
 	"layout:customWidget:idContextCountSpacer:section", "Context Variations",
-	"layout:customWidget:idContextCountSpacer:index", 20,
+	"layout:customWidget:idContextCountSpacer:index", 101,
 	"layout:customWidget:idContextCountSpacer:accessory", True,
 
 	"layout:customWidget:idContextCount:widgetType", "GafferSceneUI.InstancerUI._SeedCountWidget",
 	"layout:customWidget:idContextCount:section", "Context Variations",
-	"layout:customWidget:idContextCount:index", 20,
+	"layout:customWidget:idContextCount:index", 101,
 	"layout:customWidget:idContextCount:accessory", True,
 
 	"layout:customWidget:seedVariableSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedVariableSpacer:section", "Context Variations",
-	"layout:customWidget:seedVariableSpacer:index", 21,
+	"layout:customWidget:seedVariableSpacer:index", 102,
 	"layout:customWidget:seedVariableSpacer:accessory", True,
 
 	"layout:customWidget:seedsSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedsSpacer:section", "Context Variations",
-	"layout:customWidget:seedsSpacer:index", 22,
+	"layout:customWidget:seedsSpacer:index", 103,
 	"layout:customWidget:seedsSpacer:accessory", True,
 
 	"layout:customWidget:seedPermutationSpacer:widgetType", "GafferSceneUI.InstancerUI._VariationSpacer",
 	"layout:customWidget:seedPermutationSpacer:section", "Context Variations",
-	"layout:customWidget:seedPermutationSpacer:index", 23,
+	"layout:customWidget:seedPermutationSpacer:index", 104,
 	"layout:customWidget:seedPermutationSpacer:accessory", True,
 
 	"layout:customWidget:seedSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:seedSpacer:section", "Context Variations",
-	"layout:customWidget:seedSpacer:index", 24,
+	"layout:customWidget:seedSpacer:index", 105,
 
 	"layout:customWidget:timeOffsetHeadings:widgetType", "GafferSceneUI.InstancerUI._TimeOffsetColumnHeadings",
 	"layout:customWidget:timeOffsetHeadings:section", "Context Variations",
-	"layout:customWidget:timeOffsetHeadings:index", 25,
+	"layout:customWidget:timeOffsetHeadings:index", 106,
 	"layout:customWidget:timeOffsetHeadings:description", "Testing description",
 
 	"layout:customWidget:timeOffsetSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:timeOffsetSpacer:section", "Context Variations",
-	"layout:customWidget:timeOffsetSpacer:index", 26,
+	"layout:customWidget:timeOffsetSpacer:index", 107,
 	"layout:customWidget:timeOffsetSpacer:divider", True,
 
 	"layout:customWidget:totalSpacer:widgetType", "GafferSceneUI.InstancerUI._SectionSpacer",
 	"layout:customWidget:totalSpacer:section", "Context Variations",
-	"layout:customWidget:totalSpacer:index", 27,
+	"layout:customWidget:totalSpacer:index", 108,
 
 	plugs = {
 
@@ -624,6 +625,7 @@ Gaffer.Metadata.registerNode(
 			be used with a Random node to randomise properties of the prototype.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 101,
 		],
 
 		"seedVariable" : [
@@ -632,6 +634,7 @@ Gaffer.Metadata.registerNode(
 			Name of the context variable to put the seed value in.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 102,
 			"layout:visibilityActivator", "seedEnabled",
 		],
 
@@ -642,6 +645,7 @@ Gaffer.Metadata.registerNode(
 			to be driven by the seed, increasing the total number of variations required.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 103,
 			"layout:visibilityActivator", "seedEnabled",
 			"layout:activator", "seedParameters",
 		],
@@ -653,6 +657,7 @@ Gaffer.Metadata.registerNode(
 			grouping of which instances end up with the same seed.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 104,
 			"layout:visibilityActivator", "seedEnabled",
 			"layout:activator", "seedParameters",
 		],
@@ -666,6 +671,7 @@ Gaffer.Metadata.registerNode(
 			total instances.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 105,
 			"layout:visibilityActivator", "seedEnabled",
 		],
 
@@ -678,6 +684,7 @@ Gaffer.Metadata.registerNode(
 			prototypes scene too many times.
 			""",
 			"layout:section", "Context Variations",
+			"layout:index", 106,
 			"plugValueWidget:type", "GafferSceneUI.InstancerUI._ContextVariableListWidget",
 		],
 
@@ -711,6 +718,7 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"Modify the current time when evaluating the prototypes network, by adding a primvar.",
 			"layout:section", "Context Variations",
+			"layout:index", 107,
 			"plugValueWidget:type", "GafferSceneUI.InstancerUI._TimeOffsetContextVariableWidget",
 		],
 		"timeOffset.name" : [
@@ -751,7 +759,7 @@ Gaffer.Metadata.registerNode(
 			Note that variations are measured across all locations in the scene where the instancer is filtered.
 			""",
 			"layout:section", "Context Variations",
-			"layout:index", 27,
+			"layout:index", 108,
 			"plugValueWidget:type", "GafferSceneUI.InstancerUI._TotalCountWidget",
 		],
 	}


### PR DESCRIPTION
I'm deleting the previous discussion here, and starting over, because this is a completely different PR to the first time around.

It is now built on top of #6258, #6272, and #6271, ( in addition to requiring the cortex change https://github.com/ImageEngine/cortex/pull/1451 ). Assuming you want to review this in one go, those other PRs can be closed.

I'm feeling fairly good about this - seems to do what we want, with fairly decent test coverage. This includes performance tests - the one noticeable regression is testPrototypeHashPerf, which went from 0.02s to 0.13s. This test was written specifically to demonstrate worst case behaviour - in practice, we usually need to actually evaluate capsules, not just hash them, and the gain in consistency and performance from reusing capsules when possible should outweigh the cost of the much more accurate hash.

While I'm feeling fairly good, this is a significant change to some code that interacts in fairly complicated ways, so it does call for careful review. If you have access to production data from the users requesting the feature, it would be great to confirm that it works as desired in practice.

The only thing I know still needs doing is writing changelog entries - since this isn't getting merged this week, I'm expecting to need to do some rebasing, so I'll write changelog entries afterwards.