### PR TITLE
ScriptWindow configuration fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- OpenColorIO : Fixed UI Display Transform, which was not being applied correctly when a script was loaded.
 - LocalJobs : Fixed shutdown confirmation dialogue, which was no longer being shown when there were unfinished local jobs running.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.4.0)
 =======
 
+API
+---
+
+- ScriptWindow : Added `instanceCreatedSignal()`.
+
 1.5.4.0 (relative to 1.5.3.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.4.0)
 =======
 
+Fixes
+-----
+
+- LocalJobs : Fixed shutdown confirmation dialogue, which was no longer being shown when there were unfinished local jobs running.
+
 API
 ---
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -954,6 +954,9 @@ class RenderPassChooserWidget( GafferUI.Widget ) :
 
 	def __init__( self, settingsNode, **kw ) :
 
+		## \todo It would probably be better if we created the plug in `startup/gui/project.py`, giving
+		# us explicit control over its ordering with respect to the other plugs. Then this widget would
+		# just show the plug if it exists, and if it doesn't show nothing.
 		renderPassPlug = GafferSceneUI.ScriptNodeAlgo.acquireRenderPassPlug( settingsNode["__scriptNode"].getInput().node() )
 		self.__renderPassPlugValueWidget = _RenderPassPlugValueWidget(
 			renderPassPlug["value"],

--- a/python/GafferUI/ScriptWindow.py
+++ b/python/GafferUI/ScriptWindow.py
@@ -81,6 +81,7 @@ class ScriptWindow( GafferUI.Window ) :
 		self.closedSignal().connect( Gaffer.WeakMethod( self.__closed ) )
 
 		ScriptWindow.__instances.append( weakref.ref( self ) )
+		ScriptWindow.__instanceCreatedSignal( self )
 
 	def menuBar( self ) :
 
@@ -207,6 +208,13 @@ class ScriptWindow( GafferUI.Window ) :
 		applicationRoot._scriptWindowMenuDefinition = menuDefinition
 
 		return menuDefinition
+
+	__instanceCreatedSignal = Gaffer.Signals.Signal1()
+	## A signal emitted whenever a ScriptWindow has been created.
+	@classmethod
+	def instanceCreatedSignal( cls ) :
+
+		return cls.__instanceCreatedSignal
 
 	## This function provides the top level functionality for instantiating
 	# the UI. Once called, new ScriptWindows will be instantiated for each

--- a/python/GafferUITest/ScriptWindowTest.py
+++ b/python/GafferUITest/ScriptWindowTest.py
@@ -38,6 +38,7 @@ import unittest
 import weakref
 
 import Gaffer
+import GafferTest
 import GafferUI
 import GafferUITest
 
@@ -136,6 +137,33 @@ class ScriptWindowTest( GafferUITest.TestCase ) :
 
 		w.setTitle( "b" )
 		self.assertEqual( self.__title, "b" )
+
+	def testInstanceCreatedSignal( self ) :
+
+		cs = GafferTest.CapturingSlot( GafferUI.ScriptWindow.instanceCreatedSignal() )
+
+		script1 = Gaffer.ScriptNode()
+		script2 = Gaffer.ScriptNode()
+		self.assertEqual( len( cs ), 0 )
+
+		scriptWindow1 = GafferUI.ScriptWindow( script1 )
+		self.assertEqual( len( cs ), 1 )
+		self.assertIs( cs[0][0], scriptWindow1 )
+
+		scriptWindow2 = GafferUI.ScriptWindow.acquire( script2 )
+		self.assertEqual( len( cs ), 2 )
+		self.assertIs( cs[1][0], scriptWindow2 )
+
+		application = Gaffer.Application()
+		GafferUI.ScriptWindow.connect( application.root() )
+		application.root()["scripts"].addChild( Gaffer.ScriptNode() )
+		self.assertEqual( len( cs ), 3 )
+		self.assertIs(
+			cs[2][0],
+			GafferUI.ScriptWindow.acquire( application.root()["scripts"][0], createIfNecessary = False )
+		)
+
+		del application.root()["scripts"][0]
 
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/gui/localDispatcher.py
+++ b/startup/gui/localDispatcher.py
@@ -76,12 +76,8 @@ def __scriptWindowPreClose( scriptWindow ) :
 	# If `Cancel` was pressed, prevent the window from being closed.
 	return dialogue.waitForConfirmation( parentWindow = scriptWindow ) == False
 
-def __scriptAdded( container, script ) :
+def __scriptWindowCreated( scriptWindow ) :
 
-	window = GafferUI.ScriptWindow.acquire( script, createIfNecessary = False )
-	if window is None :
-		return
+	scriptWindow.preCloseSignal().connect( __scriptWindowPreClose )
 
-	window.preCloseSignal().connect( __scriptWindowPreClose )
-
-application.root()["scripts"].childAddedSignal().connect( __scriptAdded )
+GafferUI.ScriptWindow.instanceCreatedSignal().connect( __scriptWindowCreated )


### PR DESCRIPTION
This fixes a couple of regressions caused by https://github.com/GafferHQ/gaffer/commit/c942d4030970efe2edee47a6868e0fe12e8b8639, which was released in 1.5.3.0. That commit moved the ScriptWindow's `__scriptAdded` slot to the _back_ of the slot list, while before it had been at the front. This means that ScriptWindows are now created last, after all other `scriptAdded` slots have run. This is a good thing - letting everyone configure the script how they want, and only _then_ making the UI for it is far more natural.

But we had a couple of configs which were using `ScriptWindow.acquire( createIfNecessary = False )`, now at a time when the ScriptWindow hasn't been created yet. So they were skipping the configuration of the ScriptWindow that we needed. This PR solves that by introducing a new `ScriptWindow.instanceCreatedSignal()` which is emitted whenever a ScriptWindow is made, and using that in the configs instead.

I've targeted this PR to a new `1.5.4_maintenance` branch with the intention that we'll push the fix out immediately in a 1.5.4.1 release rather than waiting for 1.5.5.0. We want to get this fix out quickly, and there are a couple of extra things we still want to get into 1.5.5.0, and things currently merged that should wait for them. We'll just need to merge `1.5.4_maintenance` to `1.5_maintenance` after making the release and then we should be back to our regular flow.