### PR TITLE
RenderMan boilerplate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,14 @@ jobs:
         echo ONNX_ROOT=$GITHUB_WORKSPACE/onnxruntime >> $GITHUB_ENV
       shell: bash
 
+    - name: Install RenderMan
+      run: echo RMANTREE=`./.github/workflows/main/installRenderMan.py` >> $GITHUB_ENV
+      shell: bash
+      env:
+        RENDERMAN_DOWNLOAD_USER: ${{ secrets.RENDERMAN_DOWNLOAD_USER }}
+        RENDERMAN_DOWNLOAD_PASSWORD: ${{ secrets.RENDERMAN_DOWNLOAD_PASSWORD }}
+      if: ${{ env.RENDERMAN_DOWNLOAD_USER != '' }}
+
     - name: Install Mesa (Windows)
       # Installed after dependencies to avoid errors from python related to existing directory `bin`.
       # Adapted from Mesa's `systemwidedeploy.cmd` `osmesa` branch.

--- a/.github/workflows/main/installRenderMan.py
+++ b/.github/workflows/main/installRenderMan.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#	 * Redistributions of source code must retain the above copyright
+#	   notice, this list of conditions and the following disclaimer.
+#
+#	 * Redistributions in binary form must reproduce the above copyright
+#	   notice, this list of conditions and the following disclaimer in the
+#	   documentation and/or other materials provided with the distribution.
+#
+#	 * Neither the name of Image Engine Design nor the names of any
+#	   other contributors to this software may be used to endorse or
+#	   promote products derived from this software without specific prior
+#	   written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import shutil
+import subprocess
+
+import requests
+
+# RenderMan is only available for download through a web interface connected to
+# the RenderMan support forums, and the download requires valid credentials.
+# Start by "logging in" with our user name and password. This will return some
+# cookies we can use to authenticate our further requests.
+
+cookies = requests.post(
+	"https://renderman.pixar.com/forum/member.php",
+	{
+		"username" : os.environ["RENDERMAN_DOWNLOAD_USER"],
+		"password" : os.environ["RENDERMAN_DOWNLOAD_PASSWORD"],
+		"url" :  "/forum/",
+		"action" : "login"
+	}
+).cookies
+
+# The various versions of RenderMan are listed on a download page, each
+# with a link that takes you to _another_ page which has the file ids
+# for the download for each platform. At some point we should scrape that
+# to figure out the files given the RenderMan version we want, but for now
+# we just hardcode the ids for RenderMan 26.3.
+
+fileId = "12544" if os.name == "nt" else "12545"
+fileName = "RenderMan.msi" if os.name == "nt" else "RenderMan.rpm"
+
+# Now we can download our file.
+
+download = requests.get(
+	"https://renderman.pixar.com/forum/download.php",
+	{
+		"fileid" : fileId,
+		"distid" : "4483",
+		"action" : "dodownload",
+	},
+	cookies = cookies,
+	allow_redirects = True,
+	stream = True,
+)
+
+with open( fileName, "wb" ) as outFile :
+	shutil.copyfileobj( download.raw, outFile )
+
+# Install.
+
+if os.name == "nt" :
+
+	subprocess.check_call(
+		[
+			"powershell.exe",
+			"Start-Process", "msiexec.exe", "-Wait", "-ArgumentList",
+			"\"/i {} /qn\"".format( os.path.abspath( fileName ) )
+		],
+	)
+
+	print( "c:\Program Files\Pixar\RenderManProServer-26.3" )
+
+else :
+
+	subprocess.check_call(
+		[ "rpm", "-i", fileName ]
+	)
+
+	print( "/opt/pixar/RenderManProServer-26.3" )

--- a/.github/workflows/main/sconsOptions
+++ b/.github/workflows/main/sconsOptions
@@ -46,6 +46,7 @@ BUILD_CACHEDIR = os.environ["GAFFER_CACHE_DIR"]
 ARNOLD_ROOT = os.environ.get( "ARNOLD_ROOT", "" )
 DELIGHT_ROOT = os.environ["DELIGHT"]
 ONNX_ROOT = os.environ["ONNX_ROOT"]
+RENDERMAN_ROOT = os.environ.get( "RMANTREE", "" )
 
 BUILD_DIR = os.environ["GAFFER_BUILD_DIR"]
 INSTALL_DIR = os.path.join( "install", os.environ["GAFFER_BUILD_NAME"] )

--- a/SConstruct
+++ b/SConstruct
@@ -167,6 +167,12 @@ options.Add(
 )
 
 options.Add(
+	"RENDERMAN_ROOT",
+	"The directory in which RenderMan is installed",
+	"",
+)
+
+options.Add(
 	"VTUNE_ROOT",
 	"The directory in which VTune is installed.",
 	""
@@ -780,6 +786,7 @@ for option, envVar in {
 	"ARNOLD_ROOT" : "ARNOLD_ROOT",
 	"DELIGHT_ROOT" : "DELIGHT",
 	"ONNX_ROOT" : "ONNX_ROOT",
+	"RENDERMAN_ROOT" : "RMANTREE",
 }.items() :
 	commandEnv["ENV"][envVar] = commandEnv[option]
 
@@ -1332,6 +1339,26 @@ libraries = {
 	"GafferCyclesUI" : { "requiredOptions" : [ "CYCLES_ROOT" ], },
 
 	"GafferCyclesUITest" : { "requiredOptions" : [ "CYCLES_ROOT" ], },
+
+	"IECoreRenderMan" : {
+		"envAppends" : {
+			"CPPPATH" : [ "$RENDERMAN_ROOT/include" ],
+			# The RenderMan headers contain deprecated functionality that we don't use,
+			# but which nonetheless emit compilation warnings. We turn them off so we
+			# can continue to compile with warnings as errors.
+			"CPPDEFINES" : [ "RMAN_RIX_NO_WARN_DEPRECATED" ],
+			"LIBS" : [
+				"GafferScene", "IECoreScene",
+				"prman" if env["PLATFORM"] != "win32" else "libprman",
+				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
+			],
+			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
+		},
+		"pythonEnvAppends" : {
+			"LIBS" : [ "IECoreRenderMan" ],
+		},
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
 
 	"GafferTractor" : {},
 

--- a/config/jh/options
+++ b/config/jh/options
@@ -52,3 +52,4 @@ VTUNE_ROOT = "/disk1/apps/intel/system_studio_2018/vtune_amplifier_2018.1.0.5353
 GAFFERCORTEX=1
 
 ONNX_ROOT = os.environ["ONNX_ROOT"]
+RENDERMAN_ROOT = os.environ["RMANTREE"]

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -1,0 +1,144 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "ParamListAlgo.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/MessageHandler.h"
+
+#include "fmt/format.h"
+
+using namespace IECore;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct ParameterConverter
+{
+
+	void operator()( const BoolData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetInteger( name, data->readable() );
+	}
+
+	void operator()( const IntData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetInteger( name, data->readable() );
+	}
+
+	void operator()( const FloatData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetFloat( name, data->readable() );
+	}
+
+	void operator()( const StringData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetString( name, RtUString( data->readable().c_str() ) );
+	}
+
+	void operator()( const Color3fData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetColor( name, RtColorRGB( data->readable().getValue() ) );
+	}
+
+	void operator()( const V2iData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetIntegerArray( name, data->readable().getValue(), 2 );
+	}
+
+	void operator()( const V2fData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetFloatArray( name, data->readable().getValue(), 2 );
+	}
+
+	void operator()( const V3fData *data, RtUString name, RtParamList &paramList ) const
+	{
+		switch( data->getInterpretation() )
+		{
+			case GeometricData::Vector :
+				paramList.SetVector( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
+				break;
+			case GeometricData::Normal :
+				paramList.SetNormal( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
+				break;
+			default :
+				paramList.SetPoint( name, reinterpret_cast<const RtVector3 &>( data->readable() ) );
+		}
+	}
+
+	void operator()( const M44fData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetMatrix( name, reinterpret_cast<const pxrcore::Matrix4x4 &>( data->readable() ) );
+	}
+
+	void operator()( const IntVectorData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetIntegerArray( name, data->readable().data(), data->readable().size() );
+	}
+
+	void operator()( const Data *data, RtUString name, RtParamList &paramList ) const
+	{
+		IECore::msg(
+			IECore::Msg::Warning,
+			"IECoreRenderMan",
+			fmt::format( "Unsupported parameter \"{}\" of type \"{}\"", name.CStr(), data->typeName() )
+		);
+	}
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Public API
+//////////////////////////////////////////////////////////////////////////
+
+void IECoreRenderMan::ParamListAlgo::convertParameter( const RtUString &name, const Data *data, RtParamList &paramList )
+{
+	dispatch( data, ParameterConverter(), name, paramList );
+}
+
+void IECoreRenderMan::ParamListAlgo::convertParameters( const IECore::CompoundDataMap &parameters, RtParamList &paramList )
+{
+	for( auto &p : parameters )
+	{
+		convertParameter( RtUString( p.first.c_str() ), p.second.get(), paramList );
+	}
+}

--- a/src/IECoreRenderMan/ParamListAlgo.h
+++ b/src/IECoreRenderMan/ParamListAlgo.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECore/CompoundData.h"
+
+#include "RiTypesHelper.h"
+
+namespace IECoreRenderMan::ParamListAlgo
+{
+
+void convertParameter( const RtUString &name, const IECore::Data *data, RtParamList &paramList );
+void convertParameters( const IECore::CompoundDataMap &parameters, RtParamList &paramList );
+
+} // namespace IECoreRenderMan::ParamListAlgo


### PR DESCRIPTION
As mentioned in the previous user group, I've been working on RenderMan support for a little while. I'm sitting on quite a lot of unmerged code at this point, and will need to get the work so far reviewed and merged while I continue to add missing features. Rather than one huge unreviewable code-dump, I'm aiming to break this up into a number of smaller, more digestible PRs, of which this is the first.

This just includes some really minimal boilerplate to start things off gently :

- An IECoreRenderMan library with a single ParamListAlgo header, for translating IECore data to RenderMan's RtParamLists.
- A CI setup for downloading RenderMan and building against it on GitHub Actions. As for the Arnold setup, this is only operational for release builds and pull requests made from `GafferHQ/gaffer`, not forks.

