### PR TITLE
installDependencies : Add `arm64` buildEnvironment default for macOS

### DIFF
--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -64,8 +64,8 @@ parser.add_argument(
 parser.add_argument(
 	"--buildEnvironment",
 	help = "The build environment of the dependencies archive to download.",
-	choices = [ "gcc11" ],
-	default = os.environ.get( "GAFFER_BUILD_ENVIRONMENT", "gcc11" if sys.platform == "linux" else "" ),
+	choices = [ "gcc11", "arm64" ],
+	default = os.environ.get( "GAFFER_BUILD_ENVIRONMENT", { "linux" : "gcc11", "darwin" : "arm64" }.get( sys.platform, "" ) ),
 )
 
 parser.add_argument(
@@ -85,7 +85,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 archiveURL = args.archiveURL.format(
-	platform = { "darwin" : "osx", "win32" : "windows" }.get( sys.platform, "linux" ),
+	platform = { "darwin" : "macos", "win32" : "windows" }.get( sys.platform, "linux" ),
 	buildEnvironment = "-{}".format( args.buildEnvironment ) if args.buildEnvironment else "",
 	extension = "tar.gz" if sys.platform != "win32" else "zip"
 )


### PR DESCRIPTION
This sets up the defaults a little better for any adventurous souls attempting to install dependencies on macOS.