### PR TITLE
RenderMan transform, shader and geometry converters

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1351,6 +1351,8 @@ libraries = {
 				"GafferScene", "IECoreScene",
 				"prman" if env["PLATFORM"] != "win32" else "libprman",
 				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
+				"oslquery$OSL_LIB_SUFFIX",
+				"OpenImageIO_Util$OIIO_LIB_SUFFIX",
 			],
 			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
 		},

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -1,0 +1,108 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "IECoreScene/CurvesPrimitive.h"
+
+#include "RixPredefinedStrings.hpp"
+
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+void convertCurvesTopology( const IECoreScene::CurvesPrimitive *curves, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	primVars.SetDetail(
+		curves->variableSize( PrimitiveVariable::Uniform ),
+		curves->variableSize( PrimitiveVariable::Vertex ),
+		curves->variableSize( PrimitiveVariable::Varying ),
+		curves->variableSize( PrimitiveVariable::FaceVarying )
+	);
+
+	if( curves->basis().standardBasis() == StandardCubicBasis::Unknown )
+	{
+		IECore::msg( IECore::Msg::Warning, messageContext, "Unsupported CubicBasis" );
+		primVars.SetString( Rix::k_Ri_type, Rix::k_linear );
+	}
+	else if( curves->basis().standardBasis() == StandardCubicBasis::Linear )
+	{
+		primVars.SetString( Rix::k_Ri_type, Rix::k_linear );
+	}
+	else
+	{
+		primVars.SetString( Rix::k_Ri_type, Rix::k_cubic );
+		switch( curves->basis().standardBasis() )
+		{
+			case StandardCubicBasis::Bezier :
+				primVars.SetString( Rix::k_Ri_Basis, Rix::k_bezier );
+				break;
+			case StandardCubicBasis::BSpline :
+				primVars.SetString( Rix::k_Ri_Basis, Rix::k_bspline );
+				break;
+			case StandardCubicBasis::CatmullRom :
+				primVars.SetString( Rix::k_Ri_Basis, Rix::k_catmullrom );
+				break;
+			default :
+				// Should have dealt with Unknown and Linear above
+				assert( false );
+		}
+	}
+
+	primVars.SetString( Rix::k_Ri_wrap, curves->periodic() ? Rix::k_periodic : Rix::k_nonperiodic );
+	primVars.SetIntegerDetail( Rix::k_Ri_nvertices, curves->verticesPerCurve()->readable().data(), RtDetailType::k_uniform );
+}
+
+RtUString convertStaticCurves( const IECoreScene::CurvesPrimitive *curves, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	convertCurvesTopology( curves, primVars, messageContext );
+	GeometryAlgo::convertPrimitiveVariables( curves, primVars, messageContext );
+	return Rix::k_Ri_Curves;
+}
+
+RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	convertCurvesTopology( samples[0], primVars, messageContext );
+	GeometryAlgo::convertPrimitiveVariables( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
+	return Rix::k_Ri_Curves;
+}
+
+GeometryAlgo::ConverterDescription<CurvesPrimitive> g_curvesConverterDescription( convertStaticCurves, convertAnimatedCurves );
+
+} // namespace

--- a/src/IECoreRenderMan/GeometryAlgo.cpp
+++ b/src/IECoreRenderMan/GeometryAlgo.cpp
@@ -1,0 +1,407 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "ParamListAlgo.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/MessageHandler.h"
+
+#include "fmt/format.h"
+
+#include <unordered_map>
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using namespace IECoreRenderMan;
+
+struct Converters
+{
+
+	GeometryAlgo::Converter converter;
+	GeometryAlgo::MotionConverter motionConverter;
+
+};
+
+using Registry = std::unordered_map<IECore::TypeId, Converters>;
+
+Registry &registry()
+{
+	static Registry r;
+	return r;
+}
+
+RtDetailType detail( IECoreScene::PrimitiveVariable::Interpolation interpolation )
+{
+	switch( interpolation )
+	{
+		case PrimitiveVariable::Invalid :
+			throw IECore::Exception( "No detail equivalent to PrimitiveVariable::Invalid" );
+		case PrimitiveVariable::Constant :
+			return RtDetailType::k_constant;
+		case PrimitiveVariable::Uniform :
+			return RtDetailType::k_uniform;
+		case PrimitiveVariable::Vertex :
+			return RtDetailType::k_vertex;
+		case PrimitiveVariable::Varying :
+			return RtDetailType::k_varying;
+		case PrimitiveVariable::FaceVarying :
+			return RtDetailType::k_facevarying;
+		default :
+			throw IECore::Exception( "Unknown PrimtiveVariable Interpolation" );
+	}
+}
+
+RtDataType dataType( IECore::GeometricData::Interpretation interpretation )
+{
+	switch( interpretation )
+	{
+		case GeometricData::Vector :
+			return RtDataType::k_vector;
+		case GeometricData::Normal :
+			return RtDataType::k_normal;
+		default :
+			return RtDataType::k_point;
+	}
+}
+
+struct PrimitiveVariableConverter
+{
+
+	PrimitiveVariableConverter( const std::string &messageContext )
+		:	m_messageContext( messageContext )
+	{
+	}
+
+	// Simple data
+
+	void operator()( const BoolData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		const int b = data->readable();
+		primVarList.SetIntegerDetail( name, &b, detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const IntData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		primVarList.SetIntegerDetail( name, &data->readable(), detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const FloatData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		primVarList.SetFloatDetail( name, &data->readable(), detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const StringData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		RtUString s( data->readable().c_str() );
+		primVarList.SetStringDetail( name, &s, detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const Color3fData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		primVarList.SetColorDetail( name, reinterpret_cast<const RtColorRGB *>( data->readable().getValue() ), detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const V3fData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		primVarList.SetParam(
+			{
+				name,
+				dataType( data->getInterpretation() ),
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 1,
+				/* array = */ false,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			data->readable().getValue(),
+			sampleIndex
+		);
+	}
+
+	// Vector data
+
+	void operator()( const IntVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		emit(
+			data,
+			{
+				name,
+				RtDataType::k_integer,
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 1,
+				/* array = */ false,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			primitiveVariable,
+			primVarList,
+			sampleIndex
+		);
+	}
+
+	void operator()( const FloatVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		emit(
+			data,
+			{
+				name,
+				RtDataType::k_float,
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 1,
+				/* array = */ false,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			primitiveVariable,
+			primVarList,
+			sampleIndex
+		);
+	}
+
+	void operator()( const StringVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		PrimitiveVariable::IndexedView<string> view( primitiveVariable );
+		vector<RtUString> value; value.reserve( view.size() );
+		for( size_t i = 0; i < view.size(); ++i )
+		{
+			value.push_back( RtUString( view[i].c_str() ) );
+		}
+		primVarList.SetStringDetail( name, value.data(), detail( primitiveVariable.interpolation ), sampleIndex );
+	}
+
+	void operator()( const V2fVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		emit(
+			data,
+			{
+				name,
+				RtDataType::k_float,
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 2,
+				/* array = */ true,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			primitiveVariable,
+			primVarList,
+			sampleIndex
+		);
+	}
+
+	void operator()( const V3fVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		emit(
+			data,
+			{
+				name,
+				dataType( data->getInterpretation() ),
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 1,
+				/* array = */ false,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			primitiveVariable,
+			primVarList,
+			sampleIndex
+		);
+	}
+
+	void operator()( const Color3fVectorData *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		emit(
+			data,
+			{
+				name,
+				RtDataType::k_color,
+				detail( primitiveVariable.interpolation ),
+				/* length = */ 1,
+				/* array = */ false,
+				/* motion = */ sampleIndex > 0,
+				/* deduplicated = */ false
+			},
+			primitiveVariable,
+			primVarList,
+			sampleIndex
+		);
+	}
+
+	void operator()( const Data *data, RtUString name, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+	{
+		IECore::msg(
+			IECore::Msg::Warning,
+			m_messageContext,
+			fmt::format( "Unsupported primitive variable of type \"{}\"", data->typeName() )
+		);
+	}
+
+	private :
+
+		const std::string &m_messageContext;
+
+		template<typename T>
+		void emit( const T *data, const RtPrimVarList::ParamInfo &paramInfo, const PrimitiveVariable &primitiveVariable, RtPrimVarList &primVarList, unsigned sampleIndex=0 ) const
+		{
+			if( primitiveVariable.indices )
+			{
+				using Buffer = RtPrimVarList::Buffer<typename T::ValueType::value_type>;
+				Buffer buffer( primVarList, paramInfo, sampleIndex );
+				buffer.Bind();
+
+				const vector<int> &indices = primitiveVariable.indices->readable();
+				const typename T::ValueType &values = data->readable();
+				for( int i = 0, e = indices.size(); i < e; ++i )
+				{
+					buffer[i] = values[indices[i]];
+				}
+
+				buffer.Unbind();
+			}
+			else
+			{
+				primVarList.SetParam(
+					paramInfo,
+					data->readable().data(),
+					sampleIndex
+				);
+			}
+		}
+
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Implementation of external API
+//////////////////////////////////////////////////////////////////////////
+
+RtUString IECoreRenderMan::GeometryAlgo::convert( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	Registry &r = registry();
+	auto it = r.find( object->typeId() );
+	if( it == r.end() )
+	{
+		return RtUString();
+	}
+	return it->second.converter( object, primVars, messageContext );
+}
+
+RtUString IECoreRenderMan::GeometryAlgo::convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	Registry &r = registry();
+	auto it = r.find( samples.front()->typeId() );
+	if( it == r.end() )
+	{
+		return RtUString();
+	}
+	if( it->second.motionConverter )
+	{
+		return it->second.motionConverter( samples, sampleTimes, primVars, messageContext );
+	}
+	else
+	{
+		return it->second.converter( samples.front(), primVars, messageContext );
+	}
+}
+
+void IECoreRenderMan::GeometryAlgo::registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter )
+{
+	registry()[fromType] = { converter, motionConverter };
+}
+
+void IECoreRenderMan::GeometryAlgo::convertPrimitiveVariables( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext )
+{
+	const PrimitiveVariableConverter converter( messageContext );
+	for( const auto &[name, primitiveVariable] : primitive->variables )
+	{
+		const RtUString convertedName( name == "uv" ? "st" : name.c_str() );
+		dispatch( primitiveVariable.data.get(), converter, convertedName, primitiveVariable, primVarList );
+	}
+}
+
+void IECoreRenderMan::GeometryAlgo::convertPrimitiveVariables( const std::vector<const IECoreScene::Primitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext )
+{
+	const PrimitiveVariableConverter converter( messageContext );
+
+	bool haveSetTimes = false;
+	for( const auto &[name, primitiveVariable] : samples[0]->variables )
+	{
+		bool animated = false;
+		for( size_t i = 1; i < samples.size(); ++i )
+		{
+			auto it = samples[i]->variables.find( name );
+			if( it == samples[i]->variables.end() )
+			{
+				animated = false;
+				break;
+			}
+			else if( it->second != primitiveVariable )
+			{
+				animated = true;
+			}
+		}
+
+		const RtUString convertedName( name == "uv" ? "st" : name.c_str() );
+		if( animated )
+		{
+			if( !haveSetTimes )
+			{
+				primVarList.SetTimes( sampleTimes.size(), sampleTimes.data() );
+				haveSetTimes = true;
+			}
+
+			for( size_t i = 0; i < samples.size(); ++i )
+			{
+				auto it = samples[i]->variables.find( name );
+				assert( it != samples[i]->variables.end() );
+				dispatch( it->second.data.get(), converter, convertedName, primitiveVariable, primVarList, i );
+			}
+		}
+		else
+		{
+			dispatch( primitiveVariable.data.get(), converter, convertedName, primitiveVariable, primVarList );
+		}
+	}
+}

--- a/src/IECoreRenderMan/GeometryAlgo.h
+++ b/src/IECoreRenderMan/GeometryAlgo.h
@@ -1,0 +1,99 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECoreScene/Primitive.h"
+
+#include "IECore/Object.h"
+#include "IECore/VectorTypedData.h"
+
+#include "RiTypesHelper.h"
+
+#include <vector>
+
+namespace IECoreRenderMan::GeometryAlgo
+{
+
+/// Geometry conversion
+/// ===================
+
+/// Converts the specified `IECore::Object` into arguments for
+/// `Riley::CreateGeometryPrototype()`. Fills `primVars` and returns the
+/// geometry `type`. Returns an empty string if no converter is available.
+RtUString convert( const IECore::Object *object, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
+
+/// As above, but converting a moving object. If no motion converter
+/// is available, the first sample is converted instead.
+RtUString convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext = "GeometryAlgo::convert" );
+
+/// Signature of a function which can convert an IECore::Object into a geometry prototype.
+using Converter = RtUString (*)( const IECore::Object *object, RtParamList &primVars, const std::string &messageContext );
+using MotionConverter = RtUString (*)( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+
+/// Registers a converter for a specific type. Use the ConverterDescription
+/// utility class in preference to this, since it provides additional type
+/// safety.
+void registerConverter( IECore::TypeId fromType, Converter converter, MotionConverter motionConverter = nullptr );
+
+/// Class which registers a converter for type T automatically
+/// when instantiated.
+template<typename T>
+class ConverterDescription
+{
+
+	public :
+
+		/// Type-specific conversion functions.
+		using Converter = RtUString (*)( const T *object, RtPrimVarList &primVars, const std::string &messageContext );
+		using MotionConverter = RtUString (*)( const std::vector<const T *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext );
+
+		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
+		{
+			registerConverter(
+				T::staticTypeId(),
+				reinterpret_cast<GeometryAlgo::Converter>( converter ),
+				reinterpret_cast<GeometryAlgo::MotionConverter>( motionConverter )
+			);
+		}
+
+};
+
+/// PrimitiveVariable conversion
+/// ============================
+
+void convertPrimitiveVariables( const IECoreScene::Primitive *primitive, RtPrimVarList &primVarList, const std::string &messageContext = "GeometryAlgo::convertPrimitiveVariables" );
+void convertPrimitiveVariables( const std::vector<const IECoreScene::Primitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVarList, const std::string &messageContext = "GeometryAlgo::convertPrimitiveVariables" );
+
+} // namespace IECoreRenderMan::GeometryAlgo

--- a/src/IECoreRenderMan/MeshAlgo.cpp
+++ b/src/IECoreRenderMan/MeshAlgo.cpp
@@ -1,0 +1,224 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "IECoreScene/MeshPrimitive.h"
+
+#include "RixPredefinedStrings.hpp"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+int interpolateBoundary( const IECoreScene::MeshPrimitive *mesh, const std::string &messageContext  )
+{
+	const InternedString s = mesh->getInterpolateBoundary();
+	if( s == IECoreScene::MeshPrimitive::interpolateBoundaryNone )
+	{
+		return 0;
+	}
+	else if( s == IECoreScene::MeshPrimitive::interpolateBoundaryEdgeAndCorner )
+	{
+		return 1;
+	}
+	else if( s == IECoreScene::MeshPrimitive::interpolateBoundaryEdgeOnly )
+	{
+		return 2;
+	}
+	else
+	{
+		msg( Msg::Error, messageContext, fmt::format( "Unknown boundary interpolation \"{}\"", s.string() ) );
+		return 0;
+	}
+}
+
+int faceVaryingInterpolateBoundary( const IECoreScene::MeshPrimitive *mesh, const std::string &messageContext  )
+{
+	const InternedString s = mesh->getFaceVaryingLinearInterpolation();
+	if( s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationNone )
+	{
+		return 2;
+	}
+	else if(
+		s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationCornersOnly ||
+		s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationCornersPlus1 ||
+		s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationCornersPlus2
+	)
+	{
+		return 1;
+	}
+	else if( s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationBoundaries )
+	{
+		return 3;
+	}
+	else if( s == IECoreScene::MeshPrimitive::faceVaryingLinearInterpolationAll )
+	{
+		return 0;
+	}
+	else
+	{
+		msg( Msg::Error, messageContext, fmt::format( "Unknown facevarying linear interpolation \"{}\"", s.string() ) );
+		return 0;
+	}
+}
+
+int smoothTriangles( const IECoreScene::MeshPrimitive *mesh, const std::string &messageContext  )
+{
+	const InternedString s = mesh->getTriangleSubdivisionRule();
+	if( s == IECoreScene::MeshPrimitive::triangleSubdivisionRuleCatmullClark )
+	{
+		return 0;
+	}
+	else if( s == IECoreScene::MeshPrimitive::triangleSubdivisionRuleSmooth )
+	{
+		return 2;
+	}
+	else
+	{
+		msg( Msg::Error, messageContext, fmt::format( "Unknown triangle subdivision rule \"{}\"", s.string() ) );
+		return 0;
+	}
+}
+
+RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVarList &primVars, const std::string &messageContext  )
+{
+	primVars.SetDetail(
+		mesh->variableSize( PrimitiveVariable::Uniform ),
+		mesh->variableSize( PrimitiveVariable::Vertex ),
+		mesh->variableSize( PrimitiveVariable::Varying ),
+		mesh->variableSize( PrimitiveVariable::FaceVarying )
+	);
+
+	primVars.SetIntegerDetail( Rix::k_Ri_nvertices, mesh->verticesPerFace()->readable().data(), RtDetailType::k_uniform );
+	primVars.SetIntegerDetail( Rix::k_Ri_vertices, mesh->vertexIds()->readable().data(), RtDetailType::k_facevarying );
+
+	RtUString geometryType = Rix::k_Ri_PolygonMesh;
+	if( mesh->interpolation() != MeshPrimitive::interpolationLinear.string() )
+	{
+		geometryType = Rix::k_Ri_SubdivisionMesh;
+		if( mesh->interpolation() == MeshPrimitive::interpolationCatmullClark.string() )
+		{
+			primVars.SetString( Rix::k_Ri_scheme, Rix::k_catmullclark );
+		}
+		else if( mesh->interpolation() == MeshPrimitive::interpolationLoop.string() )
+		{
+			primVars.SetString( Rix::k_Ri_scheme, Rix::k_loop );
+		}
+		else
+		{
+			msg( Msg::Error, messageContext, fmt::format( "Unknown mesh interpolation \"{}\"", mesh->interpolation() ) );
+			primVars.SetString( Rix::k_Ri_scheme, Rix::k_catmullclark );
+		}
+
+		vector<RtUString> tagNames;
+		vector<RtInt> tagArgCounts;
+		vector<RtInt> tagIntArgs;
+		vector<RtFloat> tagFloatArgs;
+
+		// Creases
+
+		for( int creaseLength : mesh->creaseLengths()->readable() )
+		{
+			tagNames.push_back( Rix::k_crease );
+			tagArgCounts.push_back( creaseLength ); // integer argument count
+			tagArgCounts.push_back( 1 ); // float argument count
+			tagArgCounts.push_back( 0 ); // string argument count
+		}
+
+		tagIntArgs = mesh->creaseIds()->readable();
+		tagFloatArgs = mesh->creaseSharpnesses()->readable();
+
+		// Corners
+
+		if( mesh->cornerIds()->readable().size() )
+		{
+			tagNames.push_back( Rix::k_corner );
+			tagArgCounts.push_back( mesh->cornerIds()->readable().size() ); // integer argument count
+			tagArgCounts.push_back( mesh->cornerIds()->readable().size() ); // float argument count
+			tagArgCounts.push_back( 0 ); // string argument count
+			tagIntArgs.insert( tagIntArgs.end(), mesh->cornerIds()->readable().begin(), mesh->cornerIds()->readable().end() );
+			tagFloatArgs.insert( tagFloatArgs.end(), mesh->cornerSharpnesses()->readable().begin(), mesh->cornerSharpnesses()->readable().end() );
+		}
+
+		// Interpolation rules
+
+		tagNames.push_back( Rix::k_interpolateboundary );
+		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
+		tagIntArgs.push_back( interpolateBoundary( mesh, messageContext ) );
+
+		tagNames.push_back( Rix::k_facevaryinginterpolateboundary );
+		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
+		tagIntArgs.push_back( faceVaryingInterpolateBoundary( mesh, messageContext ) );
+
+		tagNames.push_back( Rix::k_smoothtriangles );
+		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
+		tagIntArgs.push_back( smoothTriangles( mesh, messageContext ) );
+
+		// Pseudo-primvars to hold the tags
+
+		primVars.SetStringArray( Rix::k_Ri_subdivtags, tagNames.data(), tagNames.size() );
+		primVars.SetIntegerArray( Rix::k_Ri_subdivtagnargs, tagArgCounts.data(), tagArgCounts.size() );
+		primVars.SetFloatArray( Rix::k_Ri_subdivtagfloatargs, tagFloatArgs.data(), tagFloatArgs.size() );
+		primVars.SetIntegerArray( Rix::k_Ri_subdivtagintargs, tagIntArgs.data(), tagIntArgs.size() );
+	}
+
+	return geometryType;
+}
+
+RtUString convertStaticMesh( const IECoreScene::MeshPrimitive *mesh, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	const RtUString result = convertMeshTopology( mesh, primVars, messageContext );
+	GeometryAlgo::convertPrimitiveVariables( mesh, primVars, messageContext );
+	return result;
+}
+
+RtUString convertAnimatedMesh( const std::vector<const IECoreScene::MeshPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	const RtUString result = convertMeshTopology( samples[0], primVars, messageContext );
+	GeometryAlgo::convertPrimitiveVariables( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
+	return result;
+}
+
+GeometryAlgo::ConverterDescription<MeshPrimitive> g_meshConverterDescription( convertStaticMesh, convertAnimatedMesh );
+
+} // namespace

--- a/src/IECoreRenderMan/ParamListAlgo.cpp
+++ b/src/IECoreRenderMan/ParamListAlgo.cpp
@@ -73,6 +73,11 @@ struct ParameterConverter
 		paramList.SetString( name, RtUString( data->readable().c_str() ) );
 	}
 
+	void operator()( const InternedStringData *data, RtUString name, RtParamList &paramList ) const
+	{
+		paramList.SetString( name, RtUString( data->readable().c_str() ) );
+	}
+
 	void operator()( const Color3fData *data, RtUString name, RtParamList &paramList ) const
 	{
 		paramList.SetColor( name, RtColorRGB( data->readable().getValue() ) );

--- a/src/IECoreRenderMan/PointsAlgo.cpp
+++ b/src/IECoreRenderMan/PointsAlgo.cpp
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "IECoreScene/PointsPrimitive.h"
+
+#include "RixPredefinedStrings.hpp"
+
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+void convertPointsTopology( const IECoreScene::PointsPrimitive *points, RtPrimVarList &primVars )
+{
+	primVars.SetDetail(
+		points->variableSize( PrimitiveVariable::Uniform ),
+		points->variableSize( PrimitiveVariable::Vertex ),
+		points->variableSize( PrimitiveVariable::Varying ),
+		points->variableSize( PrimitiveVariable::FaceVarying )
+	);
+}
+
+RtUString convertStaticPoints( const IECoreScene::PointsPrimitive *points, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	convertPointsTopology( points, primVars );
+	GeometryAlgo::convertPrimitiveVariables( points, primVars, messageContext );
+	return Rix::k_Ri_Points;
+}
+
+RtUString convertAnimatedPoints( const std::vector<const IECoreScene::PointsPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	convertPointsTopology( samples[0], primVars );
+	GeometryAlgo::convertPrimitiveVariables( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
+	return Rix::k_Ri_Points;
+}
+
+GeometryAlgo::ConverterDescription<PointsPrimitive> g_pointsConverterDescription( convertStaticPoints, convertAnimatedPoints );
+
+} // namespace

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -1,0 +1,378 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "ShaderNetworkAlgo.h"
+
+#include "ParamListAlgo.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/LRUCache.h"
+#include "IECore/MessageHandler.h"
+#include "IECore/SearchPath.h"
+
+#include "OSL/oslquery.h"
+
+#include "boost/container/flat_map.hpp"
+#include "boost/property_tree/xml_parser.hpp"
+
+#include "fmt/format.h"
+
+#include <unordered_set>
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+//////////////////////////////////////////////////////////////////////////
+// Internal utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+struct ShaderInfo
+{
+	riley::ShadingNode::Type type = riley::ShadingNode::Type::k_Invalid;
+	using ParameterTypeMap = std::unordered_map<InternedString, pxrcore::DataType>;
+	ParameterTypeMap parameterTypes;
+};
+
+using ConstShaderInfoPtr = std::shared_ptr<const ShaderInfo>;
+
+void loadParameterTypes( const boost::property_tree::ptree &tree, ShaderInfo::ParameterTypeMap &typeMap )
+{
+	for( const auto &child : tree )
+	{
+		if( child.first == "param" )
+		{
+			const string name = child.second.get<string>( "<xmlattr>.name" );
+			const string type = child.second.get<string>( "<xmlattr>.type" );
+			if( type == "int" )
+			{
+				typeMap[name] = pxrcore::DataType::k_integer;
+			}
+			else if( type == "float" )
+			{
+				typeMap[name] = pxrcore::DataType::k_float;
+			}
+			else if( type == "color" )
+			{
+				typeMap[name] = pxrcore::DataType::k_color;
+			}
+			else if( type == "point" )
+			{
+				typeMap[name] = pxrcore::DataType::k_point;
+			}
+			else if( type == "vector" )
+			{
+				typeMap[name] = pxrcore::DataType::k_vector;
+			}
+			else if( type == "normal" )
+			{
+				typeMap[name] = pxrcore::DataType::k_normal;
+			}
+			else if( type == "matrix" )
+			{
+				typeMap[name] = pxrcore::DataType::k_matrix;
+			}
+			else if( type == "string" )
+			{
+				typeMap[name] = pxrcore::DataType::k_string;
+			}
+			else if( type == "bxdf" )
+			{
+				typeMap[name] = pxrcore::DataType::k_bxdf;
+			}
+			else if( type == "lightfilter" )
+			{
+				typeMap[name] = pxrcore::DataType::k_lightfilter;
+			}
+			else if( type == "samplefilter" )
+			{
+				typeMap[name] = pxrcore::DataType::k_samplefilter;
+			}
+			else if( type == "displayfilter" )
+			{
+				typeMap[name] = pxrcore::DataType::k_displayfilter;
+			}
+			else if( type == "struct" )
+			{
+				typeMap[name] = pxrcore::DataType::k_struct;
+			}
+			else
+			{
+				IECore::msg( IECore::Msg::Warning, "IECoreRenderMan", fmt::format( "Unknown type `{}` for parameter \"{}\".", type, name ) );
+			}
+		}
+		else if( child.first == "page" )
+		{
+			loadParameterTypes( child.second, typeMap );
+		}
+	}
+}
+
+ConstShaderInfoPtr shaderInfoFromArgsFile( const boost::filesystem::path file )
+{
+	std::ifstream argsStream( file.string() );
+
+	boost::property_tree::ptree tree;
+	boost::property_tree::read_xml( argsStream, tree );
+
+	auto result = std::make_shared<ShaderInfo>();
+
+	// Get type
+
+	const string shaderType = tree.get<string>( "args.shaderType.tag.<xmlattr>.value" );
+	if( shaderType == "pattern" )
+	{
+		result->type = riley::ShadingNode::Type::k_Pattern;
+	}
+	else if( shaderType == "bxdf" )
+	{
+		result->type = riley::ShadingNode::Type::k_Bxdf;
+	}
+	else if( shaderType == "integrator" )
+	{
+		result->type = riley::ShadingNode::Type::k_Integrator;
+	}
+	else if( shaderType == "light" )
+	{
+		result->type = riley::ShadingNode::Type::k_Light;
+	}
+	else if( shaderType == "lightfilter" )
+	{
+		result->type = riley::ShadingNode::Type::k_LightFilter;
+	}
+	else if( shaderType == "projection" )
+	{
+		result->type = riley::ShadingNode::Type::k_Projection;
+	}
+	else if( shaderType == "displacement" )
+	{
+		result->type = riley::ShadingNode::Type::k_Displacement;
+	}
+	else if( shaderType == "samplefilter" )
+	{
+		result->type = riley::ShadingNode::Type::k_SampleFilter;
+	}
+	else if( shaderType == "displayfilter" )
+	{
+		result->type = riley::ShadingNode::Type::k_DisplayFilter;
+	}
+
+	// Load parameters
+
+	loadParameterTypes( tree.get_child( "args" ), result->parameterTypes );
+
+	return result;
+}
+
+ConstShaderInfoPtr shaderInfoFromOSLQuery( OSL::OSLQuery &query )
+{
+	auto result = std::make_shared<ShaderInfo>();
+	result->type = riley::ShadingNode::Type::k_Pattern;
+
+	for( const auto &parameter : query )
+	{
+		if( parameter.type == OIIO::TypeInt )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_integer;
+		}
+		else if( parameter.type == OIIO::TypeFloat )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_float;
+		}
+		else if( parameter.type == OIIO::TypeColor )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_color;
+		}
+		else if( parameter.type == OIIO::TypePoint )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_point;
+		}
+		else if( parameter.type == OIIO::TypeVector )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_vector;
+		}
+		else if( parameter.type == OIIO::TypeNormal )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_normal;
+		}
+		else if( parameter.type == OIIO::TypeMatrix44 )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_matrix;
+		}
+		else if( parameter.type == OIIO::TypeString )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_string;
+		}
+		else if( parameter.isstruct )
+		{
+			result->parameterTypes[parameter.name.c_str()] = pxrcore::DataType::k_struct;
+		}
+		else
+		{
+			IECore::msg(
+				IECore::Msg::Warning, "IECoreRenderMan",
+				fmt::format(
+					"Unknown type `{}` for parameter \"{}\" on shader \"{}\".",
+					parameter.type, parameter.name, query.shadername()
+				)
+			);
+		}
+	}
+
+	return result;
+}
+
+using ShaderInfoCache = IECore::LRUCache<string, ConstShaderInfoPtr>;
+
+ShaderInfoCache g_shaderInfoCache(
+
+	[]( const std::string &shaderName, size_t &cost ) -> ConstShaderInfoPtr {
+
+		cost = 1;
+
+		const char *rixPluginPath = getenv( "RMAN_RIXPLUGINPATH" );
+		SearchPath rixSearchPath( rixPluginPath ? rixPluginPath : "" );
+		boost::filesystem::path argsFileName = rixSearchPath.find( "Args/" + shaderName + ".args" );
+		if( !argsFileName.empty() )
+		{
+			return shaderInfoFromArgsFile( argsFileName );
+		}
+
+		const char *oslSearchPath = getenv( "OSL_SHADER_PATHS" );
+		OSL::OSLQuery oslQuery;
+		if( oslQuery.open( shaderName, oslSearchPath ? oslSearchPath : "" ) )
+		{
+			return shaderInfoFromOSLQuery( oslQuery );
+		}
+
+		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan", fmt::format( "Unable to find shader \"{}\".", shaderName ) );
+		return nullptr;
+	},
+
+	/* maxCost = */ 10000
+
+);
+
+void convertConnection( const IECoreScene::ShaderNetwork::Connection &connection, const ShaderInfo *shaderInfo, RtParamList &paramList )
+{
+	auto it = shaderInfo->parameterTypes.find( connection.destination.name );
+	if( it == shaderInfo->parameterTypes.end() )
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "IECoreRenderMan",
+			fmt::format(
+				"Unable to translate connection to `{}.{}` because its type is not known",
+				connection.destination.shader.string(), connection.destination.name.string()
+			)
+		);
+		return;
+	}
+
+	std::string reference = connection.source.shader;
+	if( !connection.source.name.string().empty() )
+	{
+		reference += ":" + connection.source.name.string();
+	}
+
+	const RtUString referenceU( reference.c_str() );
+
+	RtParamList::ParamInfo const info = {
+		RtUString( connection.destination.name.c_str() ),
+		it->second,
+		pxrcore::DetailType::k_reference,
+		1,
+		false,
+		false,
+		false
+	};
+
+	paramList.SetParam( info, &referenceU );
+}
+
+using HandleSet = std::unordered_set<InternedString>;
+
+void convertShaderNetworkWalk( const ShaderNetwork::Parameter &outputParameter, const IECoreScene::ShaderNetwork *shaderNetwork, vector<riley::ShadingNode> &shadingNodes, HandleSet &visited )
+{
+	if( !visited.insert( outputParameter.shader ).second )
+	{
+		return;
+	}
+
+	const IECoreScene::Shader *shader = shaderNetwork->getShader( outputParameter.shader );
+	ConstShaderInfoPtr shaderInfo = g_shaderInfoCache.get( shader->getName() );
+	if( !shaderInfo )
+	{
+		return;
+	}
+
+	riley::ShadingNode node = {
+		shaderInfo->type,
+		RtUString( shader->getName().c_str() ),
+		RtUString( outputParameter.shader.c_str() ),
+		RtParamList()
+	};
+
+	ParamListAlgo::convertParameters( shader->parameters(), node.params );
+
+	for( const auto &connection : shaderNetwork->inputConnections( outputParameter.shader ) )
+	{
+		convertShaderNetworkWalk( connection.source, shaderNetwork, shadingNodes, visited );
+		convertConnection( connection, shaderInfo.get(), node.params );
+	}
+
+	shadingNodes.push_back( node );
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// External API
+//////////////////////////////////////////////////////////////////////////
+
+std::vector<riley::ShadingNode> IECoreRenderMan::ShaderNetworkAlgo::convert( const IECoreScene::ShaderNetwork *network )
+{
+	vector<riley::ShadingNode> result;
+	result.reserve( network->size() );
+
+	HandleSet visited;
+	convertShaderNetworkWalk( network->getOutput(), network, result, visited );
+
+	return result;
+}

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.h
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.h
@@ -1,0 +1,48 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECoreScene/ShaderNetwork.h"
+
+#include "Riley.h"
+
+namespace IECoreRenderMan::ShaderNetworkAlgo
+{
+
+std::vector<riley::ShadingNode> convert( const IECoreScene::ShaderNetwork *network );
+
+} // namespace IECoreRenderMan::ShaderNetworkAlgo

--- a/src/IECoreRenderMan/SphereAlgo.cpp
+++ b/src/IECoreRenderMan/SphereAlgo.cpp
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "IECoreScene/SpherePrimitive.h"
+
+#include "RixPredefinedStrings.hpp"
+
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+RtUString convertStaticSphere( const IECoreScene::SpherePrimitive *sphere, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	primVars.SetDetail(
+		sphere->variableSize( PrimitiveVariable::Uniform ),
+		sphere->variableSize( PrimitiveVariable::Vertex ),
+		sphere->variableSize( PrimitiveVariable::Varying ),
+		sphere->variableSize( PrimitiveVariable::FaceVarying )
+	);
+
+	GeometryAlgo::convertPrimitiveVariables( sphere, primVars );
+
+	const float radius = sphere->radius();
+	const float zMin = sphere->zMin();
+	const float zMax = sphere->zMax();
+	const float thetaMax = sphere->thetaMax();
+
+	primVars.SetFloatDetail( Rix::k_Ri_radius, &radius, RtDetailType::k_constant );
+	primVars.SetFloatDetail( Rix::k_Ri_zmin, &zMin, RtDetailType::k_constant );
+	primVars.SetFloatDetail( Rix::k_Ri_zmax, &zMax, RtDetailType::k_constant );
+	primVars.SetFloatDetail( Rix::k_Ri_thetamax, &thetaMax, RtDetailType::k_constant );
+
+	return Rix::k_Ri_Sphere;
+}
+
+GeometryAlgo::ConverterDescription<SpherePrimitive> g_sphereConverterDescription( convertStaticSphere );
+
+} // namespace

--- a/src/IECoreRenderMan/Transform.h
+++ b/src/IECoreRenderMan/Transform.h
@@ -1,0 +1,101 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Imath/ImathMatrix.h"
+
+#include "Riley.h"
+
+namespace IECoreRenderMan
+{
+
+/// Utility to aid in passing a static transform to Riley.
+struct StaticTransform : riley::Transform
+{
+
+	/// Caution : `m` is referenced directly, and must live until the
+	/// StaticTransform is passed to Riley.
+	StaticTransform( const Imath::M44f &m = Imath::M44f() )
+		:	m_time( 0 )
+	{
+		samples = 1;
+		matrix = &reinterpret_cast<const RtMatrix4x4 &>( m );
+		time = &m_time;
+	}
+
+	private :
+
+		float m_time;
+
+};
+
+/// Utility to aid in passing an animated transform to Riley.
+struct AnimatedTransform : riley::Transform
+{
+
+	/// Caution : `transformSamples` and `sampleTimes` are referenced
+	/// directly, and must live until the AnimatedTransform is passed to Riley.
+	AnimatedTransform( const std::vector<Imath::M44f> &transformSamples, const std::vector<float> &sampleTimes )
+	{
+		samples = transformSamples.size();
+		matrix = reinterpret_cast<const RtMatrix4x4 *>( transformSamples.data() );
+		time = sampleTimes.data();
+	}
+
+};
+
+/// Utility for passing an identity transform to Riley.
+struct IdentityTransform : riley::Transform
+{
+
+	IdentityTransform()
+		:	m_time( 0.0f )
+	{
+		samples = 1;
+		matrix = reinterpret_cast<const RtMatrix4x4 *>( m_matrix.getValue() );
+		time = &m_time;
+	}
+
+	private :
+
+		const float m_time;
+		const Imath::M44f m_matrix;
+
+};
+
+
+} // namespace IECoreRenderMan


### PR DESCRIPTION
These will do much of the heavy lifting of the upcoming RenderMan backend. For the most part the conversions are all fairly straightforward, and the APIs should be fairly familiar due to being modelled closely on IECoreArnold. Things will get more interesting in the next PR which will actually introduce the Renderer subclass, where things get a little more involved.