### PR TITLE
Inspector direct editing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.5.0)
 =======
 
+Features
+--------
+
+- AttributeEditor, LightEditor, RenderPassEditor : Added drag and drop editing. Edits can be created or updated by dropping a value into a cell.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -12,7 +12,7 @@ API
 - SceneAlgo :
   - Added `parallelReduceLocations()` for implementing functions that need to combine results while traversing a ScenePlug.
   - Added `hierarchyHash()` for hashing all children of a scene location.
-
+- PathColumn : Added `dragEnterSignal()`, `dragMoveSignal()`, `dragLeaveSignal()` and `dropSignal()`.
 
 1.5.5.0 (relative to 1.5.4.1)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Features
 --------
 
-- AttributeEditor, LightEditor, RenderPassEditor : Added drag and drop editing. Edits can be created or updated by dropping a value into a cell.
+- AttributeEditor, LightEditor, RenderPassEditor : Added drag and drop editing. Edits can be created or updated by dropping a value into a cell. Cells representing a set expression or string array can be modified by holding <kbd>Shift</kbd> to append to an existing edit, or <kbd>Control</kbd> may be held to remove from an existing edit.
 
 Fixes
 -----

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -67,7 +67,7 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history) const override;
 		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
-		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history) const override;
+		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
 
 		bool attributeExists() const;
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -170,8 +170,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		/// history class?
 		virtual Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const;
 
-		using EditFunction = std::function<Gaffer::ValuePlugPtr ( bool createIfNecessary )>;
-		using EditFunctionOrFailure = std::variant<EditFunction, std::string>;
+		using AcquireEditFunction = std::function<Gaffer::ValuePlugPtr ( bool createIfNecessary )>;
+		using AcquireEditFunctionOrFailure = std::variant<AcquireEditFunction, std::string>;
 		/// Should be implemented to return a function that will acquire
 		/// an edit from the EditScope at the specified point in the history.
 		/// If this is not possible, should return an error explaining why
@@ -181,7 +181,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RefCounted, public Gaffer::Si
 		/// > Note : Where an EditScope already contains an edit, it is expected
 		/// > that this will be dealt with in `source()`, returning a result
 		/// > that edits the processor itself.
-		virtual EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const;
+		virtual AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const;
 
 		using DisableEditFunction = std::function<void ()>;
 		using DisableEditFunctionOrFailure = std::variant<DisableEditFunction, std::string>;
@@ -376,8 +376,7 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 
 		struct Editors
 		{
-			/// \todo Rename to `acquireEditFunction`?
-			EditFunctionOrFailure editFunction;
+			AcquireEditFunctionOrFailure acquireEditFunction;
 			std::string editWarning;
 			DisableEditFunctionOrFailure disableEditFunction;
 		};

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -65,7 +65,7 @@ class GAFFERSCENEUI_API OptionInspector : public Inspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
 		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
-		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -69,7 +69,7 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 		IECore::ConstObjectPtr value( const GafferScene::SceneAlgo::History *history ) const override;
 		IECore::ConstObjectPtr fallbackValue( const GafferScene::SceneAlgo::History *history, std::string &description ) const override;
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
-		EditFunctionOrFailure editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
+		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
 
 		const IECoreScene::ShaderNetwork::Parameter m_parameter;
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -60,15 +60,6 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 			IECore::InternedString setName
 		);
 
-		/// Convenience method to acquire an edit from `inspection` and
-		/// edit the set membership to include or exclude `path`. Returns true
-		/// if an edit was made, false otherwise.
-		bool editSetMembership(
-			const Result *inspection,
-			const GafferScene::ScenePlug::ScenePath &path,
-			GafferScene::EditScopeAlgo::SetMembership setMembership
-		) const;
-
 		IE_CORE_DECLAREMEMBERPTR( SetMembershipInspector );
 
 	protected :

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -83,6 +83,8 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
 		DisableEditFunctionOrFailure disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const override;
+		CanEditFunction canEditFunction( const GafferScene::SceneAlgo::History *history ) const override;
+		EditFunction editFunction( const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -81,7 +81,7 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 		/// appropriate row of a set membership processor spreadsheet or `nullptr` if none of
 		/// those are found.
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
-		EditFunctionOrFailure editFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
+		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
 		DisableEditFunctionOrFailure disableEditFunction( Gaffer::ValuePlug *plug, const GafferScene::SceneAlgo::History *history ) const override;
 
 	private :

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -37,8 +37,10 @@
 #pragma once
 
 #include "GafferUI/ButtonEvent.h"
+#include "GafferUI/DragDropEvent.h"
 #include "GafferUI/EventSignalCombiner.h"
 #include "GafferUI/Export.h"
+#include "GafferUI/Gadget.h"
 #include "GafferUI/KeyEvent.h"
 
 #include "Gaffer/Path.h"
@@ -172,6 +174,12 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		KeySignal &keyPressSignal();
 		KeySignal &keyReleaseSignal();
 
+		using DragDropSignal = Gaffer::Signals::Signal<bool ( PathColumn &column, Gaffer::Path &path, PathListingWidget &widget, const DragDropEvent &event ), EventSignalCombiner<bool>>;
+		DragDropSignal &dragEnterSignal();
+		DragDropSignal &dragMoveSignal();
+		DragDropSignal &dragLeaveSignal();
+		DragDropSignal &dropSignal();
+
 		/// Creation
 		/// ========
 
@@ -190,6 +198,10 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ContextMenuSignal m_contextMenuSignal;
 		KeySignal m_keyPressSignal;
 		KeySignal m_keyReleaseSignal;
+		DragDropSignal m_dragEnterSignal;
+		DragDropSignal m_dragMoveSignal;
+		DragDropSignal m_dragLeaveSignal;
+		DragDropSignal m_dropSignal;
 
 		SizeMode m_sizeMode;
 

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -78,6 +78,7 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		};
 
 		explicit PathColumn( SizeMode sizeMode = Default );
+		~PathColumn();
 
 		/// Returns the current column size mode.
 		SizeMode getSizeMode() const;
@@ -198,10 +199,6 @@ class GAFFERUI_API PathColumn : public IECore::RefCounted, public Gaffer::Signal
 		ContextMenuSignal m_contextMenuSignal;
 		KeySignal m_keyPressSignal;
 		KeySignal m_keyReleaseSignal;
-		DragDropSignal m_dragEnterSignal;
-		DragDropSignal m_dragMoveSignal;
-		DragDropSignal m_dragLeaveSignal;
-		DragDropSignal m_dropSignal;
 
 		SizeMode m_sizeMode;
 

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -242,21 +242,14 @@ def __selectedSetExpressions( pathListing ) :
 	# { path1 : set( setExpression1, setExpression2 ), path2 : set( setExpression1 ), ... }
 	result = {}
 
-	# Map of Inspectors to metadata prefixes.
-	prefixMap = {
-		GafferSceneUI.Private.OptionInspector : "option:",
-		GafferSceneUI.Private.AttributeInspector : "attribute:"
-	}
-
 	path = pathListing.getPath().copy()
 	for columnSelection, column in zip( pathListing.getSelection(), pathListing.getColumns() ) :
 		if (
 			not columnSelection.isEmpty() and (
-				type( column.inspector() ) not in prefixMap.keys() or
 				not (
-					Gaffer.Metadata.value( prefixMap.get( type( column.inspector() ) ) + column.inspector().name(), "ui:scene:acceptsSetName" ) or
-					Gaffer.Metadata.value( prefixMap.get( type( column.inspector() ) ) + column.inspector().name(), "ui:scene:acceptsSetNames" ) or
-					Gaffer.Metadata.value( prefixMap.get( type( column.inspector() ) ) + column.inspector().name(), "ui:scene:acceptsSetExpression" )
+					__columnMetadata( column, "ui:scene:acceptsSetName" ) or
+					__columnMetadata( column, "ui:scene:acceptsSetNames" ) or
+					__columnMetadata( column, "ui:scene:acceptsSetExpression" )
 				)
 			)
 		) :

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -1082,5 +1082,11 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		self.assertEqual( acquiredEdit["enabled"].getValue(), True )
 		self.assertEqual( acquiredEdit["value"].getValue(), 789.0 )
 
+		# Editing an existing edit should set its mode to `Create`
+		acquiredEdit["mode"].setValue( Gaffer.TweakPlug.Mode.Multiply )
+		assertEdit( inspection, IECore.FloatData( 123.0 ), "" )
+		self.assertEqual( acquiredEdit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( acquiredEdit["value"].getValue(), 123.0 )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -936,5 +936,151 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		self.assertFalse( inspection.canDisableEdit() )
 		self.assertEqual( inspection.nonDisableableReason(), "light.visualiserAttributes.scale.enabled is not enabled." )
 
+	def testCanEdit( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( sphere["out"] )
+		customAttributes["filter"].setInput( sphereFilter["out"] )
+		customAttributes["attributes"].addChild(
+			Gaffer.NameValuePlug(
+				"test:attr",
+				IECore.FloatData( 1.0 ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testPlug"
+			)
+		)
+		customAttributes["attributes"].addChild(
+			Gaffer.NameValuePlug(
+				"test:stringAttr",
+				IECore.StringData( "bar" ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testStringPlug"
+			)
+		)
+
+		def assertCanEdit( inspection, data, nonEditableReason ) :
+
+			self.assertEqual( inspection.canEdit( data ), nonEditableReason == "" )
+			self.assertEqual( inspection.nonEditableReason( data ), nonEditableReason )
+
+		inspection = self.__inspect( customAttributes["out"], "/sphere", "test:attr", None )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "" )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "" )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "Data of type \"StringData\" is not compatible." )
+
+		inspection = self.__inspect( customAttributes["out"], "/sphere", "test:stringAttr", None )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "Data of type \"FloatData\" is not compatible." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "" )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( customAttributes["out"] )
+		editScope["in"].setInput( customAttributes["out"] )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "" )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "" )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "Data of type \"StringData\" is not compatible." )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:stringAttr", editScope )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "Data of type \"FloatData\" is not compatible." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "" )
+
+		editScope["enabled"].setValue( False )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "The target edit scope EditScope is disabled." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "The target edit scope EditScope is disabled." )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "The target edit scope EditScope is disabled." )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:stringAttr", editScope )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "The target edit scope EditScope is disabled." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "The target edit scope EditScope is disabled." )
+		assertCanEdit( inspection, IECore.StringData( "foo" ), "The target edit scope EditScope is disabled." )
+
+	def testEdit( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( sphere["out"] )
+		customAttributes["filter"].setInput( sphereFilter["out"] )
+		customAttributes["attributes"].addChild(
+			Gaffer.NameValuePlug(
+				"test:attr",
+				IECore.FloatData( 1.0 ),
+				Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic,
+				"testPlug"
+			)
+		)
+
+		def assertEdit( inspection, data, nonEditableReason ) :
+
+			self.assertEqual( inspection.canEdit( data ), nonEditableReason == "" )
+			self.assertEqual( inspection.nonEditableReason( data ), nonEditableReason )
+			if nonEditableReason == "" :
+				inspection.edit( data )
+			else :
+				self.assertRaisesRegex( IECore.Exception, "Not editable : " + nonEditableReason, inspection.edit, data )
+
+		Gaffer.MetadataAlgo.setReadOnly( customAttributes["attributes"]["testPlug"]["enabled"], True )
+		inspection = self.__inspect( customAttributes["out"], "/sphere", "test:attr", None )
+		assertEdit( inspection, IECore.FloatData( 123.0 ), "CustomAttributes.attributes.testPlug.enabled is locked." )
+		Gaffer.MetadataAlgo.setReadOnly( customAttributes["attributes"]["testPlug"]["enabled"], False )
+
+		Gaffer.MetadataAlgo.setReadOnly( customAttributes, True )
+		inspection = self.__inspect( customAttributes["out"], "/sphere", "test:attr", None )
+		assertEdit( inspection, IECore.FloatData( 123.0 ), "CustomAttributes is locked." )
+		Gaffer.MetadataAlgo.setReadOnly( customAttributes, False )
+
+		inspection = self.__inspect( customAttributes["out"], "/sphere", "test:attr", None )
+		assertEdit( inspection, IECore.FloatData( 123.0 ), "" )
+		self.assertEqual( inspection.source(), customAttributes["attributes"]["testPlug"] )
+		self.assertEqual( customAttributes["attributes"]["testPlug"]["value"].getValue(), 123.0 )
+
+		assertEdit( inspection, IECore.StringData( "foo" ), "Data of type \"StringData\" is not compatible." )
+		self.assertEqual( customAttributes["attributes"]["testPlug"]["value"].getValue(), 123.0 )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( customAttributes["out"] )
+		editScope["in"].setInput( customAttributes["out"] )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertEdit( inspection, IECore.StringData( "foo" ), "Data of type \"StringData\" is not compatible." )
+
+		Gaffer.MetadataAlgo.setReadOnly( editScope, True )
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertEdit( inspection, IECore.FloatData( 456.0 ), "EditScope is locked." )
+		Gaffer.MetadataAlgo.setReadOnly( editScope, False )
+
+		editScope["enabled"].setValue( False )
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertEdit( inspection, IECore.FloatData( 456.0 ), "The target edit scope EditScope is disabled." )
+		editScope["enabled"].setValue( True )
+
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		# Calling `edit()` should create a new edit within the target edit scope
+		assertEdit( inspection, IECore.FloatData( 456.0 ), "" )
+		self.assertEqual( customAttributes["attributes"]["testPlug"]["value"].getValue(), 123.0 )
+		acquiredEdit = inspection.acquireEdit()
+		self.assertTrue( editScope.isAncestorOf( acquiredEdit ) )
+		self.assertEqual( acquiredEdit["value"].getValue(), 456.0 )
+
+		# Editing a disabled edit within an edit scope should re-enable it
+		acquiredEdit["enabled"].setValue( False )
+		inspection = self.__inspect( editScope["out"], "/sphere", "test:attr", editScope )
+		assertEdit( inspection, IECore.FloatData( 789.0 ), "" )
+		self.assertEqual( acquiredEdit["enabled"].getValue(), True )
+		self.assertEqual( acquiredEdit["value"].getValue(), 789.0 )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -1094,5 +1094,11 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		self.assertTrue( acquiredEdit["enabled"].getValue() )
 		self.assertEqual( acquiredEdit["value"].getValue(), "/anotherCamera" )
 
+		# Editing an existing edit should set its mode to `Create`
+		acquiredEdit["mode"].setValue( Gaffer.TweakPlug.Mode.ListAppend )
+		assertEdit( inspection, IECore.StringData( "/existingCamera" ), "" )
+		self.assertEqual( acquiredEdit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( acquiredEdit["value"].getValue(), "/existingCamera" )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -1004,5 +1004,95 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		inspection.disableEdit()
 		self.assertFalse( cameraEdit["enabled"].getValue() )
 
+	def testCanEdit( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+		s["standardOptions"]["options"]["resolutionMultiplier"]["enabled"].setValue( True )
+
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope1"].setup( s["standardOptions"]["out"] )
+		s["editScope1"]["in"].setInput( s["standardOptions"]["out"] )
+
+		def assertCanEdit( inspection, data, nonEditableReason ) :
+
+			self.assertEqual( inspection.canEdit( data ), nonEditableReason == "" )
+			self.assertEqual( inspection.nonEditableReason( data ), nonEditableReason )
+
+		inspection = self.__inspect( s["standardOptions"]["out"], "render:camera", None )
+		assertCanEdit( inspection, IECore.StringData( "/otherCamera" ), "" )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "Data of type \"FloatData\" is not compatible." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+
+		inspection = self.__inspect(  s["standardOptions"]["out"], "render:resolutionMultiplier", None )
+		assertCanEdit( inspection, IECore.FloatData( 2.0 ), "" )
+		assertCanEdit( inspection, IECore.IntData( 2 ), "" )
+		assertCanEdit( inspection, IECore.StringData( "invalid" ), "Data of type \"StringData\" is not compatible." )
+
+		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope1"] )
+		assertCanEdit( inspection, IECore.StringData( "/editScopeCamera" ), "" )
+		assertCanEdit( inspection, IECore.FloatData( 123.0 ), "Data of type \"FloatData\" is not compatible." )
+		assertCanEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+
+	def testEdit( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["standardOptions"] = GafferScene.StandardOptions()
+		s["standardOptions"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["standardOptions"]["options"]["renderCamera"]["value"].setValue( "/defaultCamera" )
+
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope1"].setup( s["standardOptions"]["out"] )
+		s["editScope1"]["in"].setInput( s["standardOptions"]["out"] )
+
+		def assertEdit( inspection, data, nonEditableReason ) :
+
+			self.assertEqual( inspection.canEdit( data ), nonEditableReason == "" )
+			self.assertEqual( inspection.nonEditableReason( data ), nonEditableReason )
+			if nonEditableReason == "" :
+				inspection.edit( data )
+			else :
+				self.assertRaisesRegex( IECore.Exception, "Not editable : " + nonEditableReason, inspection.edit, data )
+
+		Gaffer.MetadataAlgo.setReadOnly( s["standardOptions"]["options"]["renderCamera"]["value"], True )
+		inspection = self.__inspect( s["standardOptions"]["out"], "render:camera", None )
+		assertEdit( inspection, IECore.StringData( "/otherCamera" ), "standardOptions.options.renderCamera.value is locked." )
+		Gaffer.MetadataAlgo.setReadOnly( s["standardOptions"]["options"]["renderCamera"]["value"], False )
+
+		Gaffer.MetadataAlgo.setReadOnly( s["standardOptions"], True )
+		inspection = self.__inspect( s["standardOptions"]["out"], "render:camera", None )
+		assertEdit( inspection, IECore.StringData( "/otherCamera" ), "standardOptions is locked." )
+		Gaffer.MetadataAlgo.setReadOnly( s["standardOptions"], False )
+
+		inspection = self.__inspect( s["standardOptions"]["out"], "render:camera", None )
+		self.assertTrue( inspection.canEdit( IECore.StringData( "/otherCamera" ) ) )
+		assertEdit( inspection, IECore.StringData( "/otherCamera" ), "" )
+
+		self.assertEqual( s["standardOptions"]["options"]["renderCamera"]["value"].getValue(), "/otherCamera" )
+
+		assertEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+		self.assertEqual( s["standardOptions"]["options"]["renderCamera"]["value"].getValue(), "/otherCamera" )
+
+		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope1"] )
+		assertEdit( inspection, IECore.IntData( 123 ), "Data of type \"IntData\" is not compatible." )
+
+		# Calling `edit()` should create a new edit within the target edit scope
+		assertEdit( inspection, IECore.StringData( "/editScopeCamera" ), "" )
+		acquiredEdit = inspection.acquireEdit()
+		self.assertTrue( s["editScope1"].isAncestorOf( acquiredEdit ) )
+		self.assertTrue( acquiredEdit["enabled"].getValue() )
+		self.assertEqual( acquiredEdit["value"].getValue(), "/editScopeCamera" )
+
+		# Editing a disabled edit within an edit scope should re-enable it
+		acquiredEdit["enabled"].setValue( False )
+		inspection = self.__inspect( s["editScope1"]["out"], "render:camera", s["editScope1"] )
+		assertEdit( inspection, IECore.StringData( "/anotherCamera" ), "" )
+		self.assertTrue( acquiredEdit["enabled"].getValue() )
+		self.assertEqual( acquiredEdit["value"].getValue(), "/anotherCamera" )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -1269,5 +1269,11 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.assertTrue( acquiredEdit["enabled"].getValue() )
 		self.assertEqual( acquiredEdit["value"].getValue(), 789.0 )
 
+		# Editing an existing edit should set its mode to `Create`
+		acquiredEdit["mode"].setValue( Gaffer.TweakPlug.Mode.Max )
+		assertEdit( inspection, IECore.FloatData( 123.0 ), "" )
+		self.assertEqual( acquiredEdit["mode"].getValue(), Gaffer.TweakPlug.Mode.Create )
+		self.assertEqual( acquiredEdit["value"].getValue(), 123.0 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -482,7 +482,8 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "group", "plane" ] )
 			inspection = inspector.inspect()
 
-		self.assertTrue( inspector.editSetMembership( inspection, "/group/plane", GafferScene.EditScopeAlgo.SetMembership.Added ) )
+		self.assertTrue( inspection.canEdit( IECore.BoolData( True ) ) )
+		inspection.edit( IECore.BoolData( True ) )
 
 		planeSet = parent["out"].set( "planeSet" ).value
 
@@ -495,7 +496,8 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 		# And remove it
 
-		self.assertTrue( inspector.editSetMembership( inspection, "/group/plane", GafferScene.EditScopeAlgo.SetMembership.Removed ) )
+		self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+		inspection.edit( IECore.BoolData( False ) )
 
 		planeSet = parent["out"].set( "planeSet" ).value
 
@@ -535,7 +537,8 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 			c["scene:path"] = IECore.InternedStringVectorData( [ "group", "plane" ] )
 			inspection = inspector.inspect()
 
-		self.assertTrue( inspector.editSetMembership( inspection, "/group/plane", GafferScene.EditScopeAlgo.SetMembership.Added ) )
+		self.assertTrue( inspection.canEdit( IECore.BoolData( True ) ) )
+		inspection.edit( IECore.BoolData( True ) )
 
 		planeSet = editScope["out"].set( "planeSet" ).value
 
@@ -557,7 +560,9 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 		# And remove it
 
-		self.assertTrue( inspector.editSetMembership( inspection, "/group/plane", GafferScene.EditScopeAlgo.SetMembership.Removed ) )
+		self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+		inspection.edit( IECore.BoolData( False ) )
+
 		planeSet = parent["out"].set( "planeSet" ).value
 
 		for path, result in [
@@ -602,7 +607,9 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 
 		self.assertEqual( inspection.source(), setNode["name"] )
 
-		self.assertFalse( inspector.editSetMembership( inspection, "/plane", GafferScene.EditScopeAlgo.SetMembership.Removed ) )
+		self.assertFalse( inspection.canEdit( IECore.BoolData( False ) ) )
+		self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "Cannot edit nodes of type \"GafferScene::Set\"." )
+		self.assertRaises( IECore.Exception, inspection.edit, IECore.BoolData( False ) )
 
 	def testAcquireEditCreateIfNecessary( self ) :
 

--- a/python/GafferSceneUITest/SetMembershipInspectorTest.py
+++ b/python/GafferSceneUITest/SetMembershipInspectorTest.py
@@ -705,5 +705,119 @@ class SetMembershipInspectorTest( GafferUITest.TestCase ) :
 				GafferScene.EditScopeAlgo.SetMembership.Unchanged
 			)
 
+	def testCanEdit( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["plane"] = GafferScene.Plane()
+		s["plane"]["sets"].setValue( "planeSetA planeSetB" )
+
+		s["editScope1"] = Gaffer.EditScope()
+		s["editScope1"].setup( s["plane"]["out"] )
+		s["editScope1"]["in"].setInput( s["plane"]["out"] )
+
+		for setName in [ "planeSetA", "planeSetB", "planeSetC" ] :
+
+			inspection = self.__inspect( s["plane"]["out"], "/plane", setName, None )
+			self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+			self.assertFalse( inspection.canEdit( IECore.StringData( "someOtherSet" ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.StringData( "someOtherSet" ) ), "Data of type \"StringData\" is not compatible." )
+			self.assertFalse( inspection.canEdit( IECore.IntData( 1 ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.IntData( 1 ) ), "Data of type \"IntData\" is not compatible." )
+
+			Gaffer.MetadataAlgo.setReadOnly( s["plane"]["sets"], True )
+			inspection = self.__inspect( s["plane"]["out"], "/plane", setName, None )
+			self.assertFalse( inspection.canEdit( IECore.BoolData( True ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( True ) ), "plane.sets is locked." )
+
+			Gaffer.MetadataAlgo.setReadOnly( s["plane"]["sets"], False )
+			inspection = self.__inspect( s["plane"]["out"], "/plane", setName, None )
+			self.assertTrue( inspection.canEdit( IECore.BoolData( True ) ) )
+
+			inspection = self.__inspect( s["editScope1"]["out"], "/plane", setName, s["editScope1"] )
+			self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "" )
+			self.assertFalse( inspection.canEdit( IECore.StringData( "someOtherSet" ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.StringData( "someOtherSet" ) ), "Data of type \"StringData\" is not compatible." )
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], True )
+			inspection = self.__inspect( s["editScope1"]["out"], "/plane", setName, s["editScope1"] )
+			self.assertFalse( inspection.canEdit( IECore.BoolData( True ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( True ) ), "editScope1 is locked." )
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], False )
+			inspection = self.__inspect( s["editScope1"]["out"], "/plane", setName, s["editScope1"] )
+			self.assertTrue( inspection.canEdit( IECore.BoolData( True ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( True ) ), "" )
+
+		s["filter"] = GafferScene.PathFilter()
+		s["filter"]["paths"].setValue( IECore.StringVectorData( [ "/plane" ] ) )
+
+		s["set"] = GafferScene.Set()
+		s["set"]["in"].setInput( s["editScope1"]["out"] )
+		s["set"]["name"].setValue( "planeSetC" )
+		s["set"]["filter"].setInput( s["filter"]["out"] )
+
+		# We don't allow direct editing of Set nodes
+		inspection = self.__inspect( s["set"]["out"], "/plane", "planeSetC", None )
+		self.assertEqual( inspection.source(), s["set"]["name"] )
+		self.assertFalse( inspection.canEdit( IECore.BoolData( False ) ) )
+		self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "Cannot edit nodes of type \"GafferScene::Set\"." )
+
+	def testEdit( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["plane"] = GafferScene.Plane()
+		s["plane"]["sets"].setValue( "planeSetA planeSetB" )
+
+		s["group"] = GafferScene.Group()
+
+		s["editScope1"] = Gaffer.EditScope()
+
+		s["group"]["in"][0].setInput( s["plane"]["out"] )
+
+		Gaffer.MetadataAlgo.setReadOnly( s["plane"]["sets"], True )
+		inspection = self.__inspect( s["group"]["out"], "/group/plane", "planeSetA", None )
+		self.assertFalse( inspection.canEdit( IECore.BoolData( False ) ) )
+
+		Gaffer.MetadataAlgo.setReadOnly( s["plane"]["sets"], False )
+		inspection = self.__inspect( s["group"]["out"], "/group/plane", "planeSetA", None )
+		self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+		self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "" )
+		self.assertFalse( inspection.canEdit( IECore.StringData( "False" ) ) )
+		self.assertEqual( inspection.nonEditableReason( IECore.StringData( "False" ) ), "Data of type \"StringData\" is not compatible." )
+		self.assertRaisesRegex( IECore.Exception, "Not editable : Data of type \"StringData\" is not compatible.", inspection.edit, IECore.StringData( "False" ) )
+
+		inspection.edit( IECore.BoolData( False ) )
+		self.assertEqual( s["plane"]["sets"].getValue(), "planeSetB" )
+
+		inspection = self.__inspect( s["group"]["out"], "/group/plane", "planeSetB", None )
+		inspection.edit( IECore.BoolData( False ) )
+		self.assertEqual( s["plane"]["sets"].getValue(), "" )
+
+		s["editScope1"].setup( s["group"]["out"] )
+		s["editScope1"]["in"].setInput( s["group"]["out"] )
+
+		for membership in ( GafferScene.EditScopeAlgo.SetMembership.Added, GafferScene.EditScopeAlgo.SetMembership.Removed ) :
+
+			inspection = self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSetEditScope", s["editScope1"] )
+			inspection.edit( IECore.BoolData( membership == GafferScene.EditScopeAlgo.SetMembership.Added ) )
+			self.assertEqual(
+				GafferScene.EditScopeAlgo.getSetMembership( s["editScope1"], "/group/plane", "planeSetEditScope"),
+				membership
+			)
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], True )
+			inspection = self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSetEditScope", s["editScope1"] )
+			self.assertFalse( inspection.canEdit( IECore.BoolData( False ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "editScope1 is locked." )
+			self.assertRaisesRegex( IECore.Exception, "Not editable : editScope1 is locked.", inspection.edit, IECore.BoolData( False ) )
+
+			Gaffer.MetadataAlgo.setReadOnly( s["editScope1"], False )
+			inspection = self.__inspect( s["editScope1"]["out"], "/group/plane", "planeSetEditScope", s["editScope1"] )
+			self.assertTrue( inspection.canEdit( IECore.BoolData( False ) ) )
+			self.assertEqual( inspection.nonEditableReason( IECore.BoolData( False ) ), "" )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -367,7 +367,7 @@ Gaffer::ValuePlugPtr AttributeInspector::source( const GafferScene::SceneAlgo::H
 	return nullptr;
 }
 
-Inspector::EditFunctionOrFailure AttributeInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+Inspector::AcquireEditFunctionOrFailure AttributeInspector::acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	InternedString attributeName = m_attribute;
 	if( auto attributeHistory = dynamic_cast<const SceneAlgo::AttributeHistory *>( history ) )
@@ -444,7 +444,7 @@ void AttributeInspector::nodeMetadataChanged( IECore::InternedString key, const 
 	)
 	{
 		// Might affect `EditScopeAlgo::attributeEditReadOnlyReason()`
-		// which we call in `editFunction()`.
+		// which we call in `acquireEditFunction()`.
 		/// \todo Can we ditch the signal processing and call `attributeEditReadOnlyReason()`
 		/// just-in-time from `editable()`? In the past that wasn't possible
 		/// because editability changed the appearance of the UI, but it isn't

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -215,6 +215,7 @@ void edit( Gaffer::ValuePlug *plug, const IECore::Object *value )
 	else if( auto tweakPlug = runTimeCast<TweakPlug>( plug ) )
 	{
 		tweakPlug->enabledPlug()->setValue( true );
+		tweakPlug->modePlug()->setValue( TweakPlug::Mode::Create );
 		valuePlug = tweakPlug->valuePlug();
 	}
 	else if( auto optionalValuePlug = runTimeCast<OptionalValuePlug>( plug ) )

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -263,7 +263,7 @@ Gaffer::ValuePlugPtr OptionInspector::source( const GafferScene::SceneAlgo::Hist
 	return nullptr;
 }
 
-Inspector::EditFunctionOrFailure OptionInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+Inspector::AcquireEditFunctionOrFailure OptionInspector::acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	// If our history's context contains a non-empty `renderPass` variable,
 	// we'll want to make a specific edit for that render pass.
@@ -377,7 +377,7 @@ void OptionInspector::nodeMetadataChanged( IECore::InternedString key, const Gaf
 	)
 	{
 		// Might affect `EditScopeAlgo::optionEditReadOnlyReason()`
-		// which we call in `editFunction()`.
+		// which we call in `acquireEditFunction()`.
 		/// \todo Can we ditch the signal processing and call `optionEditReadOnlyReason()`
 		/// just-in-time from `editable()`? In the past that wasn't possible
 		/// because editability changed the appearance of the UI, but it isn't

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -181,7 +181,7 @@ Gaffer::ValuePlugPtr ParameterInspector::source( const GafferScene::SceneAlgo::H
 	return nullptr;
 }
 
-Inspector::EditFunctionOrFailure ParameterInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+Inspector::AcquireEditFunctionOrFailure ParameterInspector::acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	auto attributeHistory = static_cast<const SceneAlgo::AttributeHistory *>( history );
 

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -246,11 +246,6 @@ m_setName( setName )
 	Metadata::nodeValueChangedSignal().connect( boost::bind( &SetMembershipInspector::nodeMetadataChanged, this, ::_2, ::_3 ) );
 }
 
-bool SetMembershipInspector::editSetMembership( const Result *inspection, const ScenePlug::ScenePath &path, EditScopeAlgo::SetMembership setMembership ) const
-{
-	return ::editSetMembership( inspection->acquireEdit().get(), m_setName.string(), path, setMembership );
-}
-
 GafferScene::SceneAlgo::History::ConstPtr SetMembershipInspector::history() const
 {
 	if( !m_scene->existsPlug()->getValue() )

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -315,7 +315,7 @@ Gaffer::ValuePlugPtr SetMembershipInspector::source( const GafferScene::SceneAlg
 	return nullptr;
 }
 
-Inspector::EditFunctionOrFailure SetMembershipInspector::editFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
+Inspector::AcquireEditFunctionOrFailure SetMembershipInspector::acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const
 {
 	const GraphComponent *readOnlyReason = EditScopeAlgo::setMembershipReadOnlyReason(
 		editScope,
@@ -398,9 +398,9 @@ void SetMembershipInspector::nodeMetadataChanged( IECore::InternedString key, co
 		( MetadataAlgo::readOnlyAffectedByChange( key ) && scope->isAncestorOf( node ) )
 	)
 	{
-		// Might affect `EditScopeAlgo::setMembershipEditReadOnlyReason()`
-		// which we call in `editFunction()`.
-		/// \todo Can we ditch the signal processing and call `setMembershipEditReadOnlyReason()`
+		// Might affect `EditScopeAlgo::setMembershipReadOnlyReason()`
+		// which we call in `acquireEditFunction()`.
+		/// \todo Can we ditch the signal processing and call `setMembershipReadOnlyReason()`
 		/// just-in-time from `editable()`? In the past that wasn't possible
 		/// because editability changed the appearance of the UI, but it isn't
 		/// doing that currently.

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -84,6 +84,18 @@ void disableEditWrapper( GafferSceneUI::Private::Inspector::Result &result )
 	return result.disableEdit();
 }
 
+bool canEditWrapper( GafferSceneUI::Private::Inspector::Result &result, const IECore::Object *value )
+{
+	std::string reason;
+	return result.canEdit( value, reason );
+}
+
+void editWrapper( GafferSceneUI::Private::Inspector::Result &result, const IECore::Object *value )
+{
+	ScopedGILRelease gilRelease;
+	result.edit( value );
+}
+
 bool editSetMembershipWrapper(
 	const GafferSceneUI::Private::SetMembershipInspector &inspector,
 	const GafferSceneUI::Private::Inspector::Result &inspection,
@@ -138,12 +150,14 @@ void GafferSceneUIModule::bindInspector()
 			.def( "sourceType", &Inspector::Result::sourceType )
 			.def( "fallbackDescription", &Inspector::Result::fallbackDescription, return_value_policy<copy_const_reference>() )
 			.def( "editable", &Inspector::Result::editable )
-			.def( "nonEditableReason", &Inspector::Result::nonEditableReason )
+			.def( "nonEditableReason", &Inspector::Result::nonEditableReason, ( arg( "value" ) = object() ) )
 			.def( "acquireEdit", &acquireEditWrapper, ( arg( "createIfNecessary" ) = true ) )
 			.def( "editWarning", &Inspector::Result::editWarning )
 			.def( "canDisableEdit", &Inspector::Result::canDisableEdit )
 			.def( "nonDisableableReason", &Inspector::Result::nonDisableableReason )
 			.def( "disableEdit", &disableEditWrapper )
+			.def( "canEdit", &canEditWrapper )
+			.def( "edit", &editWrapper, ( arg( "value") ) )
 		;
 
 		enum_<Inspector::Result::SourceType>( "SourceType" )

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -96,17 +96,6 @@ void editWrapper( GafferSceneUI::Private::Inspector::Result &result, const IECor
 	result.edit( value );
 }
 
-bool editSetMembershipWrapper(
-	const GafferSceneUI::Private::SetMembershipInspector &inspector,
-	const GafferSceneUI::Private::Inspector::Result &inspection,
-	const GafferScene::ScenePlug::ScenePath &path,
-	GafferScene::EditScopeAlgo::SetMembership setMembership
-)
-{
-	ScopedGILRelease gilRelease;
-	return inspector.editSetMembership( &inspection, path, setMembership );
-}
-
 struct DirtiedSlotCaller
 {
 	void operator()( boost::python::object slot, InspectorPtr inspector )
@@ -191,7 +180,6 @@ void GafferSceneUIModule::bindInspector()
 				( arg( "scene" ), arg( "editScope" ), arg( "setName" ) )
 			)
 		)
-		.def( "editSetMembership", &editSetMembershipWrapper)
 	;
 
 	RefCountedClass<OptionInspector, Inspector>( "OptionInspector" )

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -47,6 +47,9 @@
 
 #include "fmt/format.h"
 
+#include <memory>
+#include <unordered_map>
+
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferUI;
@@ -69,6 +72,11 @@ const std::string basisName( StandardCubicBasis basis )
 	return "Unknown";
 }
 
+std::unordered_map<const PathColumn *, std::unique_ptr<PathColumn::DragDropSignal>> g_dragEnterSignals;
+std::unordered_map<const PathColumn *, std::unique_ptr<PathColumn::DragDropSignal>> g_dragMoveSignals;
+std::unordered_map<const PathColumn *, std::unique_ptr<PathColumn::DragDropSignal>> g_dragLeaveSignals;
+std::unordered_map<const PathColumn *, std::unique_ptr<PathColumn::DragDropSignal>> g_dropSignals;
+
 }  // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -78,6 +86,18 @@ const std::string basisName( StandardCubicBasis basis )
 PathColumn::PathColumn( SizeMode sizeMode )
 	:	m_sizeMode( sizeMode )
 {
+	g_dragEnterSignals[this] = std::make_unique<PathColumn::DragDropSignal>();
+	g_dragMoveSignals[this] = std::make_unique<PathColumn::DragDropSignal>();
+	g_dragLeaveSignals[this] = std::make_unique<PathColumn::DragDropSignal>();
+	g_dropSignals[this] = std::make_unique<PathColumn::DragDropSignal>();
+}
+
+PathColumn::~PathColumn()
+{
+	g_dragEnterSignals.erase( this );
+	g_dragMoveSignals.erase( this );
+	g_dragLeaveSignals.erase( this );
+	g_dropSignals.erase( this );
 }
 
 PathColumn::SizeMode PathColumn::getSizeMode() const
@@ -127,22 +147,22 @@ PathColumn::KeySignal &PathColumn::keyReleaseSignal()
 
 PathColumn::DragDropSignal &PathColumn::dragEnterSignal()
 {
-	return m_dragEnterSignal;
+	return *( g_dragEnterSignals[this] );
 }
 
 PathColumn::DragDropSignal &PathColumn::dragMoveSignal()
 {
-	return m_dragMoveSignal;
+	return *( g_dragMoveSignals[this] );
 }
 
 PathColumn::DragDropSignal &PathColumn::dragLeaveSignal()
 {
-	return m_dragLeaveSignal;
+	return *( g_dragLeaveSignals[this] );
 }
 
 PathColumn::DragDropSignal &PathColumn::dropSignal()
 {
-	return m_dropSignal;
+	return *( g_dropSignals[this] );
 }
 
 PathColumn::PathColumnSignal &PathColumn::instanceCreatedSignal()

--- a/src/GafferUI/PathColumn.cpp
+++ b/src/GafferUI/PathColumn.cpp
@@ -125,6 +125,26 @@ PathColumn::KeySignal &PathColumn::keyReleaseSignal()
 	return m_keyReleaseSignal;
 }
 
+PathColumn::DragDropSignal &PathColumn::dragEnterSignal()
+{
+	return m_dragEnterSignal;
+}
+
+PathColumn::DragDropSignal &PathColumn::dragMoveSignal()
+{
+	return m_dragMoveSignal;
+}
+
+PathColumn::DragDropSignal &PathColumn::dragLeaveSignal()
+{
+	return m_dragLeaveSignal;
+}
+
+PathColumn::DragDropSignal &PathColumn::dropSignal()
+{
+	return m_dropSignal;
+}
+
 PathColumn::PathColumnSignal &PathColumn::instanceCreatedSignal()
 {
 	static PathColumnSignal g_instanceCreatedSignal;


### PR DESCRIPTION
This adds support for "direct" editing to the private Inspector API with new `edit()` and `canEdit()` methods on `Inspector::Result` that allow creating an edit directly from a value and checking whether an edit could be made from a value. 

This PR includes two usages of this API, one which allows us to simplify the toggling of bool values in `_InspectorColumn` (and remove `SetMembershipInspector::editSetMembership()` in the process). The other brings drag and drop editing to the AttributeEditor, LightEditor and RenderPassEditor.

![editorDragAndDrop](https://github.com/user-attachments/assets/b1c8349f-c083-4ebf-a0a6-4606e48c0ff3)

We also plan to use this API to provide copy/paste editing in the same editors in a future PR.