### PR TITLE
Instancer hash bug

### DIFF
--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3426,6 +3426,13 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testChildNamesHashPerf( self ):
+		nodes = self.initSimpleInstancer()
+		with GafferTest.TestRunner.PerformanceScope() :
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/sphere" )
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/cube" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testChildNamesPerf( self ):
 		nodes = self.initSimpleInstancer()
 		with GafferTest.TestRunner.PerformanceScope() :

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1307,7 +1307,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 	def testIndexedRootsVariable( self ) :
@@ -1361,7 +1361,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		script["variables"]["primitiveVariables"]["prototypeRoots"]["value"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 		script["instancer"]["prototypeRoots"].setValue( "notAPrimVar" )
@@ -1436,7 +1436,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		updateRoots( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ), IECore.IntVectorData( [ 0, 1, 1, 0 ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 		script["instancer"]["prototypeRoots"].setValue( "notAPrimVar" )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3278,6 +3278,40 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 			IECore.PathMatcherData( IECore.PathMatcher( ['/plane/prototypes/cube/prototypes/sphere'] ) )
 		)
 
+	def testInvalidPrototypeScene( self ) :
+		points = GafferScene.Sphere( "points" )
+		points["name"].setValue( 'points' )
+		points["divisions"].setValue( imath.V2i( 3, 6 ) )
+
+		pointsFilter = GafferScene.PathFilter( "pointsFilter" )
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ '/points' ] ) )
+
+		group = GafferScene.Group( "group" )
+
+		instancer = GafferScene.Instancer( "instancer" )
+		instancer["in"].setInput( points["out"] )
+		instancer["filter"].setInput( pointsFilter["out"] )
+		instancer["prototypes"].setInput( group["out"] )
+		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ '/group/sphere' ] ) )
+
+		# Access a location that doesn't exist
+		with self.assertRaisesRegex( RuntimeError, 'Prototype root "/group/sphere" does not exist in the `prototypes` scene' ) :
+			instancer["out"].childNames( "/points/instances/sphere" )
+
+		# Make the locations exist
+		sphere = GafferScene.Sphere( "sphere" )
+		group["in"][0].setInput( sphere["out"] )
+
+		self.assertEqual( instancer["out"].object( "/points/instances/sphere/0" ), sphere["out"].object( "/sphere" ) )
+
+		# Now make the location not exist again ( to make sure that we aren't incorrectly caching that it exists )
+		group["in"][0].setInput( None )
+
+		with self.assertRaisesRegex( RuntimeError, 'Prototype root "/group/sphere" does not exist in the `prototypes` scene' ) :
+			instancer["out"].childNames( "/points/instances/sphere" )
+
+
+
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 10 )
 	def testBoundPerformance( self ) :
 

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -387,7 +387,6 @@ class Instancer::EngineData : public Data
 			const std::string &prototypeIndexName,
 			const std::string &rootsVariable,
 			const StringVectorData *rootsList,
-			const ScenePlug *prototypes,
 			const std::string &idName,
 			bool omitDuplicateIds,
 			const std::string &position,
@@ -413,7 +412,7 @@ class Instancer::EngineData : public Data
 				return;
 			}
 
-			initPrototypes( mode, prototypeIndexName, rootsVariable, rootsList, prototypes );
+			initPrototypes( mode, prototypeIndexName, rootsVariable, rootsList );
 
 			m_ids.initialize( m_primitive.get(), idName );
 			if( m_ids.size() && m_ids.size() != numPoints() )
@@ -935,7 +934,7 @@ class Instancer::EngineData : public Data
 			}
 		}
 
-		void initPrototypes( PrototypeMode mode, const std::string &prototypeIndex, const std::string &rootsVariable, const StringVectorData *rootsList, const ScenePlug *prototypes )
+		void initPrototypes( PrototypeMode mode, const std::string &prototypeIndex, const std::string &rootsVariable, const StringVectorData *rootsList )
 		{
 			const std::vector<std::string> *rootStrings = nullptr;
 			std::vector<std::string> rootStringsAlloc;
@@ -1043,11 +1042,6 @@ class Instancer::EngineData : public Data
 			for( const auto &root : *rootStrings )
 			{
 				ScenePlug::stringToPath( root, path );
-				if( !prototypes->exists( path ) )
-				{
-					throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", root ) );
-				}
-
 				if( path.empty() )
 				{
 					if( root == "/" )
@@ -2008,7 +2002,6 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 				prototypeIndexPlug()->getValue(),
 				prototypeRootsPlug()->getValue(),
 				prototypeRootsList.get(),
-				prototypesPlug(),
 				idPlug()->getValue(),
 				omitDuplicateIdsPlug()->getValue(),
 				positionPlug()->getValue(),
@@ -2543,6 +2536,9 @@ void Instancer::hashBranchChildNames( const ScenePath &sourcePath, const ScenePa
 		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
 		engineSplitPrototypesHash( sourcePath, context, h );
 		h.append( branchPath.back() );
+
+		PrototypeScope scope( enginePlug(), context, &sourcePath, &branchPath );
+		h.append( prototypesPlug()->existsPlug()->hash() );
 	}
 	else
 	{
@@ -2588,6 +2584,12 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 		ids.reserve( pointIndicesForPrototype.size() );
 
 		const EngineData *engineData = esp->engine();
+		const ScenePlug::ScenePath *prototypeRoot = engineData->prototypeRoot( branchPath[1] );
+		if( !prototypesPlug()->exists( *prototypeRoot ) )
+		{
+			throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", ScenePlug::pathToString( *prototypeRoot ) ) );
+		}
+
 		for( size_t q : pointIndicesForPrototype )
 		{
 			ids.push_back( engineData->instanceId( q ) );
@@ -2866,6 +2868,10 @@ struct Prototype : public IECore::RefCounted
 		Context::EditableScope scope( prototypeContext );
 
 		scope.set( ScenePlug::scenePathContextName, prototypeRoot );
+		if( !prototypesPlug->existsPlug()->getValue() )
+		{
+			throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", ScenePlug::pathToString( *prototypeRoot ) ) );
+		}
 
 		m_attributes = prototypesPlug->attributesPlug()->getValue();
 		if( prepareRendererAttributes )


### PR DESCRIPTION
I've added a test and a fix for the instancer hash bug I noticed.

Seems reasonably straightforward, and moves things a bit in the direction we want to go anyway to support relative prototype paths.

The main loss of performance is that we now compute the engine while hashing childNames for ".../instances/<prototypeName>" ... but in order to evaluate that, we must have already evaluated the childNames one level above, which would have evaluated the engine anyway. So this doesn't seem to be a problem in practice. I quickly hacked together a test to show some performance loss, which shows 15%, but this loss is completely negligible in any of the more practical tests.

I've made this a draft PR because I don't think it makes sense to merge this before we figure out how it fits in with all the other Instancer stuff we're looking at now, but in isolation, I think it could be quite a reasonable change. 