### PR TITLE
GraphEditor: Add shortCut (Ctrl+Return) to Show Contents

### DIFF
--- a/python/GafferUI/GraphEditor.py
+++ b/python/GafferUI/GraphEditor.py
@@ -284,7 +284,10 @@ class GraphEditor( GafferUI.Editor ) :
 			return
 
 		menuDefinition.append( "/ContentsDivider", { "divider" : True } )
-		menuDefinition.append( "/Show Contents...", { "command" : functools.partial( cls.acquire, node ) } )
+		menuDefinition.append( "/Show Contents...", {
+			"command" : functools.partial( cls.acquire, node ),
+			"shortCut" : "Ctrl+Return"
+		} )
 
 	__nodeDoubleClickSignal = GafferUI.WidgetEventSignal()
 	## Returns a signal which is emitted whenever a node is double clicked.
@@ -425,6 +428,10 @@ class GraphEditor( GafferUI.Editor ) :
 			selection = self.scriptNode().selection()
 			if len( selection ) > 0 :
 				self.scriptNode().setFocus( selection[0] )
+		elif event.key == "Return" and event.modifiers == event.modifiers.Control :
+			selection = self.scriptNode().selection()
+			if len( selection ) > 0 :
+				GraphEditor.acquire( selection[0] )
 		elif event.key == "Down" :
 			selection = self.scriptNode().selection()
 			if selection.size() == 1 and selection[0].parent() == self.graphGadget().getRoot() :


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed

Based on my post with UX remarks on the mailing list I added this shortCut. It mimics Nukes workflow of showing the contents of a box/editscope in a new tab after pressing Ctrl+Return.


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
