### PR TITLE
RenderPassPlugValueWidget : Support configuration via plug metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Improvements
 - Tweaks nodes : Added automatic conversion between numeric types. For example, an integer tweak value can now be applied to a float.
 - SceneWriter : Improved performance. Benchmarks rewriting complex scenes via a SceneReader->SceneWriter graph show around a 2x speedup.
 - USDLayerWriter : Improved performance, including a 50x speedup for one benchmark.
+- RenderPassMenu : Added configuration of the default state of "Hide Disabled" and "Display Grouped" via `renderPassPlugValueWidget:hideDisabled` and `renderPassPlugValueWidget:displayGrouped` metadata registered in a startup file. For example, "Hide Disabled" can be enabled with the following registration `Gaffer.Metadata.registerValue( Gaffer.ScriptNode, "variables.renderPass.value", "renderPassPlugValueWidget:hideDisabled", True )`.
 
 Fixes
 -----

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1099,8 +1099,8 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__currentRenderPass = ""
 		self.__renderPasses = {}
 
-		self.__displayGrouped = False
-		self.__hideDisabled = False
+		self.__displayGrouped = Gaffer.Metadata.value( plug, "renderPassPlugValueWidget:displayGrouped" ) or False
+		self.__hideDisabled = Gaffer.Metadata.value( plug, "renderPassPlugValueWidget:hideDisabled" ) or False
 
 		self.__focusChangedConnection = plug.node().scriptNode().focusChangedSignal().connect(
 			Gaffer.WeakMethod( self.__focusChanged ), scoped = True


### PR DESCRIPTION
This adds support for configuring the initial state of the "Hide Disabled" and "Display Grouped" options via metadata registered to the plug in a startup file. 

For example: `Gaffer.Metadata.registerValue( Gaffer.ScriptNode, "variables.renderPass.value", "renderPassPlugValueWidget:hideDisabled", True )`
