### PR TITLE
SceneAlgo::hierarchyHash

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ API
 
 - SceneAlgo :
   - Added `parallelReduceLocations()` for implementing functions that need to combine results while traversing a ScenePlug.
+  - Added `hierarchyHash()` for hashing all children of a scene location.
 
 
 1.5.5.0 (relative to 1.5.4.1)

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.5.0)
 =======
 
+API
+---
+
+- SceneAlgo :
+  - Added `parallelReduceLocations()` for implementing functions that need to combine results while traversing a ScenePlug.
 
 
 1.5.5.0 (relative to 1.5.4.1)

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -315,6 +315,12 @@ GAFFERSCENE_API IECore::PathMatcher linkedLights( const ScenePlug *scene, const 
 /// Returns the paths to all lights which are linked to at least one of the specified objects.
 GAFFERSCENE_API IECore::PathMatcher linkedLights( const ScenePlug *scene, const IECore::PathMatcher &objects );
 
+/// Complex hashing
+/// ===============
+
+// Hashes all properties of a location and all its children. Does not include set membership.
+GAFFERSCENE_API IECore::MurmurHash hierarchyHash( const ScenePlug *scene, const ScenePlug::ScenePath &root );
+
 /// Miscellaneous
 /// =============
 

--- a/include/GafferScene/SceneAlgo.h
+++ b/include/GafferScene/SceneAlgo.h
@@ -150,6 +150,29 @@ void parallelGatherLocations(
 	const ScenePlug::ScenePath &root = ScenePlug::ScenePath()
 );
 
+/// Calls `locationFunctor` in parallel for all locations in the scene, merging all results
+/// using `reduceFunctor`.
+template <typename T, typename LocationFunctor, typename ReduceFunctor>
+T parallelReduceLocations(
+	const ScenePlug *scene,
+	const T& identity,
+	LocationFunctor &&locationFunctor, // Signature : T locationFunctor( const ScenePlug *scene, const ScenePath &path )
+	ReduceFunctor &&reduceFunctor, // Signature : void reduceFunctor( T &result, const T &other )
+	const ScenePlug::ScenePath &root = ScenePlug::ScenePath()
+);
+
+/// Calls `locationFunctor` in parallel for all locations in the scene. The results from sibling locations
+/// are merged using `reduceFunctor`, and results from children are merged using `mergeChildrenFunctor`.
+template <typename T, typename LocationFunctor, typename MergeChildrenFunctor, typename ReduceFunctor>
+T parallelReduceLocations(
+	const ScenePlug *scene,
+	const T& identity,
+	LocationFunctor &&locationFunctor, // Signature : T locationFunctor( const ScenePlug *scene, const ScenePath &path )
+	MergeChildrenFunctor &&mergeChildrenFunctor, // Signature : void mergeChildrenFunctor( T &result, const T &childrenResult )
+	ReduceFunctor &&reduceFunctor, // Signature : void reduceFunctor( T &result, const T &sibling )
+	const ScenePlug::ScenePath &root = ScenePlug::ScenePath()
+);
+
 /// Searching
 /// =========
 

--- a/src/GafferSceneModule/SceneAlgoBinding.cpp
+++ b/src/GafferSceneModule/SceneAlgoBinding.cpp
@@ -363,6 +363,12 @@ IECore::PathMatcher linkedLightsWrapper2( const GafferScene::ScenePlug &scene, c
 	return SceneAlgo::linkedLights( &scene, objects );
 }
 
+IECore::MurmurHash hierarchyHashWrapper( const ScenePlug &scene, const ScenePlug::ScenePath &location )
+{
+	IECorePython::ScopedGILRelease r;
+	return SceneAlgo::hierarchyHash( &scene, location );
+}
+
 struct RenderAdaptorWrapper
 {
 
@@ -492,6 +498,10 @@ void bindSceneAlgo()
 	def( "linkedObjects", &linkedObjectsWrapper2 );
 	def( "linkedLights", &linkedLightsWrapper1 );
 	def( "linkedLights", &linkedLightsWrapper2 );
+
+	// Complex hashing
+
+	def( "hierarchyHash", &hierarchyHashWrapper );
 
 	// Render adaptors
 


### PR DESCRIPTION
I'm feeling fairly good about this overall, and how it fits in with what we're planning for Instancer.

I don't really like the current structure of this code though - my initial implementation was pretty clean, but it incorrectly included hashes of full path, not relative paths ( which would cause problems when we want to use this for Instancers with relative prototypes ). To fix that, I really want to do a parallel reduce, similar to what you needed in USDLayerWriter. I realized I can actually do a reduce using the way that functors are allocated by parallelProcessLocations, which is sort of neat, but this workaround is not good for clarity. If we're not currently adding a parallelGatherLocations, I should probably just implement my own walk function, same as is currently done in USDLayerWriter.

The constraint that we want identical subhierarchies to hash the same is an interesting one - we require different valeus to have different hashes, but we don't generally require the same value to have the same hash. I suspect there are a lot of ways of constructing identical hierarchies where their hashes would end up being different, but this code does now seem to be working when the hashes of each element are consistent. ( When I first tested it, I was testing on the root location, and then tried to get the hash of a variety of stuff at the root to match the same stuff under a group ... but I wasn't able to get it to match. I suspect this is because evaluating the `objectPlug` at the root is a special case, and its hash will never match another location - even if that location doesn't have any object either. Anyway, for now I've just changed the test to compare two groups, one of which is nested an extra layer deep, and those do have matching hashes. )