### PR TITLE
renderPassEditor : Fix errors when script is not parented to Application

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - ContactSheetCore : Fixed bugs handling changes to the input and output image formats.
 - InteractiveRender : Fixed potential leak of `scene:path` context variable when computing the value for `resolvedRenderer`.
 - Dispatch app : Fixed poor UI layout in "Completed" dialogue state (#6244).
+- renderPassEditor : Fixed errors when script is not parented to an Application.
 
 1.5.4.1 (relative to 1.5.4.0)
 =======

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -134,7 +134,8 @@ GafferSceneUI.RenderPassEditor.registerPathGroupingFunction( __defaultPathGroupi
 
 def __compoundEditorCreated( editor ) :
 
-	if editor.scriptNode().ancestor( Gaffer.ApplicationRoot ).getName() == "gui" :
+	applicationRoot = editor.scriptNode().ancestor( Gaffer.ApplicationRoot )
+	if applicationRoot and applicationRoot.getName() == "gui" :
 
 		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:widgetType", "GafferSceneUI.RenderPassEditor.RenderPassChooserWidget" )
 		Gaffer.Metadata.registerValue( editor.settings(), "layout:customWidget:renderPassSelector:section", "Settings" )


### PR DESCRIPTION
### Related issues ###

At IE we create a custom ScriptNode that holds Jabuka nodes, and then show node editors to edit/view the asset properties.
In the latest gaffer release, we were seeing errors because the `renderPassEditor.py` gui startup config would run for those scripts when inside the gaffer app, and it expected that the script would be parented to an application.

We were seeing similar errors before, but I had been able to deal with those without a change in gaffer (by never trying to create a  `ScriptWindow` for the `JabukaScriptNode`).

But this latest error is trickier for us to fix without a major redesign of `Jabuka`, since there are plug widgets in gaffer that require that the node being edited is parented to a script that as a corresponding `ScriptWindow` (like the color swatch widget). I guess an option would be to parent the `JabukaScriptWindow` to the `gaffer` application, but that likely would cause other sorts of issues (now or in the future).

So I'm suggesting this simple safeguard in gaffer for now.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
