### PR TITLE
GafferScene : Disable "USDPointInstancerAdaptor"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,10 +5,6 @@ Features
 --------
 
 - Parent, Duplicate, Scatter : Added `copySourceAttributes` plug, to preserve inherited attributes when the `destination` is not parented below the source.
-- USD : Added automatic expansion of USD PointInstancers at render time.
-  - This can be controlled on a per-instancer basis using a `gafferUSD:pointInstancerAdaptor:enabled` boolean attribute.
-  - Which point cloud primitive variables are promoted to user attributes can be controlled using a `gafferUSD:pointInstancerAdaptor:attributes` string attribute.
-  - May be disabled entirely with `GafferScene.SceneAlgo.deregisterRenderAdaptor( "USDPointInstancerAdaptor" )`.
 - Viewer : Added "Expand USD Instancers" item to the Expansion menu. Defaults to on for all renderers except OpenGL.
 - PromotePointInstances : Added a new node for selectively converting a subset of a USD PointInstancer to expanded "hero" geometry.
 - Annotations :

--- a/startup/GafferScene/usdPointInstancerAdaptor.py
+++ b/startup/GafferScene/usdPointInstancerAdaptor.py
@@ -42,9 +42,8 @@ import GafferScene
 
 try:
 	import GafferUSD
-	GafferScene.SceneAlgo.registerRenderAdaptor( "USDPointInstancerAdaptor", GafferUSD._PointInstancerAdaptor, "SceneView *Render", "*" )
-except:
-	# We shouldn't have any dependency on GafferUSD in GafferScene - but we need to put this registration here
-	# instead of in startup/GafferUSD because scenes that need adapting can existing without any GafferUSD nodes
-	# in the node graph that would trigger loading of GafferUSD. So just fail silently if GafferUSD isn't available.
+	# Disabled while we work on a solution for automatically remapping prototype paths
+	# when pointclouds have been reparented in the scene hierarchy.
+	# GafferScene.SceneAlgo.registerRenderAdaptor( "USDPointInstancerAdaptor", GafferUSD._PointInstancerAdaptor, "SceneView *Render", "*" )
+except ImportError :
 	pass


### PR DESCRIPTION
We hoped to have support for remapping prototype paths for reparented instancers in time for the 1.5.5.0 release, but that hasn't transpired. Rather than hold up the release, just temporarily disabling the adaptor registration so we can get all the other new goodies released instead. We expect the adaptor to now appear in 1.5.6.0.

I also removed the comment about an unwanted dependency between GafferUSD and GafferScene. This _isn't_ a dependency - one of the main roles of the config files is to tie together otherwise independent modules to produce a desired application-level behaviour.
