### PR TITLE
Add RenderMan renderer backend

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1348,7 +1348,7 @@ libraries = {
 			# can continue to compile with warnings as errors.
 			"CPPDEFINES" : [ "RMAN_RIX_NO_WARN_DEPRECATED" ],
 			"LIBS" : [
-				"GafferScene", "IECoreScene",
+				"GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX",
 				"prman" if env["PLATFORM"] != "win32" else "libprman",
 				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
 				"oslquery$OSL_LIB_SUFFIX",

--- a/SConstruct
+++ b/SConstruct
@@ -1376,6 +1376,10 @@ libraries = {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 	},
 
+	"IECoreRenderManTest" : {
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
+
 	"GafferTractor" : {},
 
 	"GafferTractorTest" : {},

--- a/SConstruct
+++ b/SConstruct
@@ -1364,6 +1364,18 @@ libraries = {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 	},
 
+	"IECoreRenderManDisplay" : {
+		"envAppends" : {
+			"LIBS" : [ "IECoreImage$CORTEX_LIB_SUFFIX" ],
+			"CPPPATH" : [ "$RENDERMAN_ROOT/include" ],
+		},
+		"envReplacements" : {
+			"SHLIBPREFIX" : "",
+		},
+		"installName" : "renderManPlugins/d_ieDisplay",
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
+
 	"GafferTractor" : {},
 
 	"GafferTractorTest" : {},

--- a/SConstruct
+++ b/SConstruct
@@ -1349,10 +1349,12 @@ libraries = {
 			"CPPDEFINES" : [ "RMAN_RIX_NO_WARN_DEPRECATED" ],
 			"LIBS" : [
 				"GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX",
+				"IECoreVDB$CORTEX_LIB_SUFFIX",
 				"prman" if env["PLATFORM"] != "win32" else "libprman",
 				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
 				"oslquery$OSL_LIB_SUFFIX",
 				"OpenImageIO_Util$OIIO_LIB_SUFFIX",
+				"openvdb$VDB_LIB_SUFFIX",
 			],
 			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
 		},

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -318,6 +318,25 @@ if [[ -n $ONNX_ROOT ]] ; then
 
 fi
 
+# Set up RenderMan
+##########################################################################
+
+if [[ -n $RMANTREE ]] ; then
+
+	if [[ `uname` = "Linux" ]] ; then
+		appendToPath "$RMANTREE/lib" LD_LIBRARY_PATH
+	else
+		appendToPath "$RMANTREE/lib" DYLD_LIBRARY_PATH
+	fi
+
+	appendToPath "$RMANTREE/bin" PATH
+	appendToPath "$RMANTREE/bin" PYTHONPATH
+	appendToPath "$RMANTREE/lib/plugins" RMAN_RIXPLUGINPATH
+	appendToPath "$GAFFER_ROOT/renderManPlugins" RMAN_DISPLAYS_PATH
+	appendToPath "$RMANTREE/lib/shaders" OSL_SHADER_PATHS
+
+fi
+
 # Set up 3rd Party extensions
 ##########################################################################
 

--- a/contrib/scripts/renderManPrototypeAttributes.py
+++ b/contrib/scripts/renderManPrototypeAttributes.py
@@ -1,0 +1,46 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import pathlib
+from xml.etree import cElementTree
+
+file = pathlib.Path( os.environ["RMANTREE"] ) / "lib" / "defaults" / "PRManPrimVars.args"
+
+for event, element in cElementTree.iterparse( file, events = ( "start", ) ) :
+
+	if element.tag == "param" :
+		print( '{{ "ri:{name}", RtUString( "{name}" ) }},'.format( name = element.attrib.get( "name" ) ) )

--- a/python/IECoreRenderMan/__init__.py
+++ b/python/IECoreRenderMan/__init__.py
@@ -1,0 +1,37 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from ._IECoreRenderMan import *

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1,0 +1,1381 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+import time
+import unittest
+
+import imath
+
+import OpenImageIO
+
+import IECore
+import IECoreImage
+import IECoreScene
+import IECoreRenderManTest
+
+import GafferTest
+import GafferScene
+
+@unittest.skipIf( GafferTest.inCI(), "RenderMan license not available" )
+class RendererTest( GafferTest.TestCase ) :
+
+	def setUp( self ) :
+
+		GafferTest.TestCase.setUp( self )
+		# Get "RenderMan" Renderer registered.
+		import IECoreRenderMan
+
+	def testFactory( self ) :
+
+		self.assertTrue( "RenderMan" in GafferScene.Private.IECoreScenePreview.Renderer.types() )
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create( "RenderMan" )
+		self.assertTrue( isinstance( r, GafferScene.Private.IECoreScenePreview.Renderer ) )
+
+	def testTwoRenderers( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create( "RenderMan" )
+		# This looks unused, but is needed to trigger the deferred creation of
+		# the Riley session.
+		attributes = renderer.attributes( IECore.CompoundObject() )
+
+		with self.assertRaisesRegex( RuntimeError, "RenderMan doesn't allow multiple active sessions" ) as handler :
+			# RenderMan only allows there to be one renderer at a time.
+			GafferScene.Private.IECoreScenePreview.Renderer.create( "RenderMan" )
+
+		handler.exception.__traceback__ = None
+
+	def testSceneDescription( self ) :
+
+		with self.assertRaisesRegex( RuntimeError, "SceneDescription mode not supported" ) :
+			GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"RenderMan",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+				( self.temporaryDirectory() / "test.rib" ).as_posix()
+			)
+
+	def testOutput( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		r.output(
+			"testRGB",
+			IECoreScene.Output(
+				( self.temporaryDirectory() / "rgb.exr" ).as_posix(),
+				"exr",
+				"rgb",
+				{
+				}
+			)
+		)
+
+		r.output(
+			"testRGBA",
+			IECoreScene.Output(
+				( self.temporaryDirectory() / "rgba.exr" ).as_posix(),
+				"exr",
+				"rgba",
+				{
+				}
+			)
+		)
+
+		r.render()
+		del r
+
+		self.assertTrue( ( self.temporaryDirectory() / "rgb.exr" ).is_file() )
+		imageSpec = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgb.exr" ) ).spec()
+		self.assertEqual( imageSpec.nchannels, 3 )
+		self.assertEqual( imageSpec.channelnames, ( "R", "G", "B" ) )
+
+		self.assertTrue( ( self.temporaryDirectory() / "rgba.exr" ).is_file() )
+		imageSpec = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgba.exr" ) ).spec()
+		self.assertEqual( imageSpec.nchannels, 4 )
+		self.assertEqual( imageSpec.channelnames, ( "R", "G", "B", "A" ) )
+
+	def testObject( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "myLovelySphere",
+				}
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject() )
+		)
+
+		renderer.render()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( max( image["A"] ), 1 )
+
+	def testMissingLightShader( self ) :
+
+		messageHandler = IECore.CapturingMessageHandler()
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive,
+			messageHandler = messageHandler
+		)
+
+		lightShader = IECoreScene.ShaderNetwork( { "light" : IECoreScene.Shader( "BadShader", "ri:light" ), }, output = ( "light", "out" ) )
+		lightAttributes = renderer.attributes(
+			IECore.CompoundObject( { "ri:light" : lightShader } )
+		)
+
+		# Exercises our workarounds for crashes in Riley when a light
+		# doesn't have a valid shader.
+		light = renderer.light( "/light", None, lightAttributes )
+		light.transform( imath.M44f().translate( imath.V3f( 1, 2, 3 ) ) )
+
+		self.assertEqual( len( messageHandler.messages ), 1 )
+		self.assertEqual( messageHandler.messages[0].level, IECore.MessageHandler.Level.Warning )
+		self.assertEqual( messageHandler.messages[0].message, "Unable to find shader \"BadShader\"." )
+
+		del light
+		del renderer
+
+	def testIntegratorEdit( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "myLovelySphere",
+				}
+			)
+		)
+
+		object = renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject() )
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 1 ) )
+
+		renderer.option(
+			"ri:integrator",
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"integrator" : IECoreScene.Shader(
+						"PxrVisualizer", "ri:integrator",
+						{
+							"style" : "objectnormals",
+							"wireframe" : False,
+						}
+					),
+				},
+				output = "integrator"
+			)
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertNotEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0, 0.514117, 0.515205, 1 ) )
+
+		del object
+		del renderer
+
+	def testEXRLayerNames( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		outputs = [
+			# Data source, layer name, expected EXR channel names.
+			( "rgb", None, ( "R", "G", "B" ) ),
+			( "rgba", None, ( "R", "G", "B", "A" ) ),
+			( "float z", "Z", ( "Z", ) ),
+			( "lpe C<RD>[<L.>O]", None, ( "R", "G", "B" ) ),
+			# Really we want the "rgb" suffixes to be capitalised to match
+			# the EXR specification, but that's not what RenderMan does.
+			# Gaffer's ImageReader will correct for it on loading though.
+			( "lpe C<RD>[<L.>O]", "directDiffuse", ( "directDiffuse.r", "directDiffuse.g", "directDiffuse.b" ) ),
+		]
+
+		for i, output in enumerate( outputs ) :
+
+			parameters = {}
+			if output[1] is not None :
+				parameters["layerName"] = output[1]
+
+			renderer.output(
+				f"test{i}",
+				IECoreScene.Output(
+					str( self.temporaryDirectory() / f"test{i}.exr" ),
+					"exr",
+					output[0],
+					parameters
+				)
+			)
+
+		renderer.render()
+		del renderer
+
+		for i, output in enumerate( outputs ) :
+			with self.subTest( source = output[0], layerName = output[1] ) :
+				image = OpenImageIO.ImageBuf( str( self.temporaryDirectory() / f"test{i}.exr" ) )
+				self.assertEqual( image.spec().channelnames, output[2] )
+
+	def testMultiLayerEXR( self ) :
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		outputs = [
+			# Data source, layer name.
+			( "rgba", None ),
+			( "float z", "Z" ),
+			# Really we want the "rgb" suffixes to be capitalised to match
+			# the EXR specification, but that's not what RenderMan does.
+			# Gaffer's ImageReader will correct for it on loading though.
+			( "lpe C<RD>[<L.>O]", "directDiffuse" ),
+		]
+
+		for i, output in enumerate( outputs ) :
+
+			parameters = {}
+			if output[1] is not None :
+				parameters["layerName"] = output[1]
+
+			renderer.output(
+				f"test{i}",
+				IECoreScene.Output(
+					fileName,
+					"exr",
+					output[0],
+					parameters
+				)
+			)
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( set( image.spec().channelnames ), { "R", "G", "B", "A", "Z", "directDiffuse.r", "directDiffuse.g", "directDiffuse.b" } )
+
+	def testMultiLayerIEDisplay( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		outputs = [
+			# Data source, layer name.
+			( "rgba", None ),
+			( "float z", "Z" ),
+			# Really we want the "rgb" suffixes to be capitalised to match
+			# the EXR specification, but that's not what RenderMan does.
+			# Gaffer's ImageReader will correct for it on loading though.
+			( "lpe C<RD>[<L.>O]", "directDiffuse" ),
+		]
+
+		for i, output in enumerate( outputs ) :
+
+			parameters = {
+				"driverType" : "ImageDisplayDriver",
+				"handle" : "multiLayerTest",
+			}
+			if output[1] is not None :
+				parameters["layerName"] = output[1]
+
+			renderer.output(
+				f"test{i}",
+				IECoreScene.Output(
+					"test",
+					"ieDisplay",
+					output[0],
+					parameters
+				)
+			)
+
+		renderer.render()
+		del renderer
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "multiLayerTest" )
+		self.assertEqual( set( image.keys() ), { "R", "G", "B", "A", "Z", "directDiffuse.R", "directDiffuse.G", "directDiffuse.B" } )
+
+	def testOutputAccumulationRule( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		renderer.option( "ri:hider:maxsamples", IECore.IntData( 8 ) )
+		renderer.option( "ri:hider:minsamples", IECore.IntData( 8 ) )
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				fileName,
+				"exr",
+				"float sampleCount",
+				{
+					"ri:accumulationRule" : "sum",
+				},
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrDiffuse" )
+					},
+					output = "output",
+				)
+			} ) )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( image.getpixel( 320, 240, 0 ), ( 8.0, ) )
+
+	def testEXRHeaderMetadata( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				fileName,
+				"exr",
+				"rgba",
+				{
+					"header:testInt" : 1,
+					"header:testFloat" : 2.0,
+					"header:testString" : "foo",
+					"header:testBool" : True,
+					"header:testV2i" : imath.V2i( 1, 2 ),
+				},
+			)
+		)
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( image.spec().get_int_attribute( "testInt" ), 1 )
+		self.assertEqual( image.spec().get_float_attribute( "testFloat" ), 2.0 )
+		self.assertEqual( image.spec().get_string_attribute( "testString" ), "foo" )
+		self.assertEqual( image.spec().get_int_attribute( "testBool" ), 1 )
+		self.assertEqual( image.spec().getattribute( "testV2i" ), ( 1, 2 ) )
+
+	def testOneRenderOutputTwoDrivers( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		renderer.output(
+			"test1",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test1.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		renderer.output(
+			"test2",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test2.exr" ),
+				"exr",
+				"rgba",
+				{}
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject() )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+		del renderer
+
+		image1 = OpenImageIO.ImageBuf( str( self.temporaryDirectory() / "test1.exr" ) )
+		image2 = OpenImageIO.ImageBuf( str( self.temporaryDirectory() / "test2.exr" ) )
+
+		self.assertFalse( OpenImageIO.ImageBufAlgo.compare( image1, image2, failthresh = 0, warnthresh=0 ).error )
+
+	def testUserAttribute( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				fileName,
+				"exr",
+				"rgba",
+				{
+				},
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"attribute" : IECoreScene.Shader(
+							"PxrAttribute", "osl:shader", {
+								"varname" : "user:myColor",
+								"type" : "color",
+							}
+						),
+						"output" : IECoreScene.Shader( "PxrConstant", "ri:surface" ),
+					},
+					connections = [
+						( ( "attribute", "resultRGB" ), ( "output", "emitColor" ) )
+					],
+					output = "output",
+				),
+				"user:myColor" : IECore.Color3fData( imath.Color3f( 1, 0.5, 0.25 ) ),
+			} ) )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( image.getpixel( 320, 240, 0 ), ( 1.0, 0.5, 0.25, 1.0 ) )
+
+	def testPortalLight( self ) :
+
+		# Render with a dome light on its own.
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "myLovelySphere",
+				}
+			)
+		)
+
+		sphere = renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrDiffuse" )
+					},
+					output = "output",
+				)
+			} ) )
+		)
+		sphere.transform( imath.M44f().translate( imath.V3f( 0, 0, -2 ) ) )
+
+		dome = renderer.light(
+			"dome",
+			None,
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrDomeLight", "ri:light", { "exposure" : 4.0 } ),
+					},
+					output = "output",
+				),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} ) )
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		# We should be illuminating the whole sphere.
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )[0], 0.5 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0.5 )
+
+		# Add a portal light.
+
+		portal = renderer.light(
+			"portal",
+			None,
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrPortalLight", "ri:light", {} ),
+					},
+					output = "output",
+				),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} ) )
+		)
+		portal.transform( imath.M44f().translate( imath.V3f( 1, 0, -1 ) ).rotate( imath.V3f( 0, math.pi / 2, 0 ) ) )
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		# We should only be illuminating the side the portal is on.
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )[0], 0 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0.5 )
+
+		# Delete the portal light. We should be back to illuminating
+		# on both sides.
+
+		del portal
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.4, 0.5 ) )[0], 0.5 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0.5 )
+
+		# Recreate the portal light. We should only be illuminating on
+		# one side again.
+
+		portal = renderer.light(
+			"portal",
+			None,
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrPortalLight", "ri:light", { "exposure" : 4.0 } ),
+					},
+					output = "output",
+				),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} ) )
+		)
+		portal.transform( imath.M44f().translate( imath.V3f( 1, 0, -1 ) ).rotate( imath.V3f( 0, math.pi / 2, 0 ) ) )
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )[0], 0 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0.5 )
+
+		# Now delete the dome light. We should get no illumination at all.
+
+		del dome
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )[0], 0 )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0 )
+
+		# Recreate the dome light. We should again be illuminating only on one side.
+
+		dome = renderer.light(
+			"dome",
+			None,
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader( "PxrDomeLight", "ri:light", { "exposure" : 4.0 } ),
+					},
+					output = "output",
+				),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} ) )
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )[0], 0 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.6, 0.5 ) )[0], 0.5 )
+
+		del sphere, portal, dome
+		del renderer
+
+	def testMeshLight( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "meshLightTest",
+				}
+			)
+		)
+
+		sphere = renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader(
+							"PxrDiffuse",
+							parameters = {
+								"diffuseColor" : imath.Color3f( 1.0, 1.0, 0.0 )
+							}
+						)
+					},
+					output = "output",
+				)
+			} ) )
+		)
+		sphere.transform( imath.M44f().translate( imath.V3f( 0, 0, -2 ) ) )
+
+		lightShader = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader(
+					"PxrMeshLight", "ri:light",
+					{ "lightColor" : imath.Color3f( 0.0, 1.0, 1.0 ) }
+				),
+			},
+			output = "output",
+		)
+
+		light = renderer.light(
+			"meshLight",
+			IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) ),
+			renderer.attributes( IECore.CompoundObject( { "ri:light" : lightShader } ) )
+		)
+		light.transform( imath.M44f().translate( imath.V3f( 1, 0, -1 ) ).rotate( imath.V3f( 0, math.pi / 2, 0 ) ) )
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		# Sphere should appear green.
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "meshLightTest" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[0], 0.0 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[1], 0.1 )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[2], 0.0 )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[3], 1.0 )
+
+		# Light is camera visible and should be cyan.
+
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.75, 0.5 ) ), imath.Color4f( 0, 1, 1, 1 ) )
+
+		# Can also assign a surface shader to lights, in which case
+		# RenderMan will use it for ray hits. RenderMan seems to sum
+		# this with the light shader, so adding a red surface shader
+		# makes our cyan light white.
+
+		light.attributes(
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : lightShader,
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"output" : IECoreScene.Shader(
+							"PxrConstant", "ri:surface",
+							{ "emitColor" : imath.Color3f( 1.0, 0.0, 0.0 ) }
+						),
+					},
+					output = "output",
+				),
+			} ) )
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "meshLightTest" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.75, 0.5 ) ), imath.Color4f( 1, 1, 1, 1 ) )
+
+		# Make the light invisible to camera. It should continue to illuminate
+		# the sphere, but no longer be visible in the render.
+
+		light.attributes(
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:light" : lightShader,
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} ) )
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		# Green sphere.
+		image = IECoreImage.ImageDisplayDriver.storedImage( "meshLightTest" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[0], 0.0 )
+		self.assertGreater( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[1], 0.1 )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[2], 0.0 )
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )[3], 1.0 )
+
+		# No light in beauty.
+		self.assertEqual( self.__colorAtUV( image, imath.V2f( 0.75, 0.5 ) ), imath.Color4f( 0 ) )
+
+		del sphere, light
+		del renderer
+
+	def testConnectionToMissingShader( self ) :
+
+		# This test doesn't assert anything, but demonstrates that making
+		# a connection to a missing shader doesn't throw an exception or
+		# crash. Both of which we did at one point.
+
+		messageHandler = IECore.CapturingMessageHandler()
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+			messageHandler = messageHandler
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				str( self.temporaryDirectory() / "test.exr" ),
+				"exr",
+				"rgba",
+				{
+				},
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"attribute" : IECoreScene.Shader( "PxrAttribute", "osl:shader", {} ),
+						"output" : IECoreScene.Shader( "MissingShader", "ri:surface" ),
+					},
+					connections = [
+						( ( "attribute", "resultRGB" ), ( "output", "emitColor" ) )
+					],
+					output = "output",
+				),
+			} ) )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+
+		self.assertEqual( len( messageHandler.messages ), 1 )
+		self.assertEqual( messageHandler.messages[0].level, IECore.MessageHandler.Level.Warning )
+		self.assertEqual( messageHandler.messages[0].message, "Unable to find shader \"MissingShader\"." )
+
+		del renderer
+
+	def testConnectionToOSLShader( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		fileName = str( self.temporaryDirectory() / "test.exr" )
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				fileName,
+				"exr",
+				"rgba",
+				{
+				},
+			)
+		)
+
+		renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive(),
+			renderer.attributes( IECore.CompoundObject( {
+				"ri:surface" : IECoreScene.ShaderNetwork(
+					shaders = {
+						"mix" : IECoreScene.Shader( "PxrMix", "osl:shader", { "color1" : imath.Color3f( 1, 1, 0 ) } ),
+						"correct" : IECoreScene.Shader( "PxrColorCorrect", "osl:shader" ),
+						"output" : IECoreScene.Shader( "PxrConstant", "ri:surface" ),
+					},
+					connections = [
+						( ( "mix", "resultRGB" ), ( "correct", "inputRGB" ) ),
+						( ( "correct", "resultRGB" ), ( "output", "emitColor" ) ),
+					],
+					output = "output",
+				),
+			} ) )
+		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+
+		renderer.render()
+		del renderer
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual( image.getpixel( 320, 240, 0 ), ( 1.0, 1.0, 0.0, 1.0 ) )
+
+	def testWarningForPerOutputPixelFilter( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+
+			renderer.output(
+				"test",
+				IECoreScene.Output(
+					"test.exr",
+					"exr",
+					"rgba",
+					{
+						"filter" : "gaussian",
+						"filterwidth" : imath.V2f( 4, 4 ),
+					},
+				)
+			)
+
+		self.assertEqual( len( mh.messages ), 2 )
+		for m in mh.messages :
+			self.assertEqual( m.level, IECore.Msg.Level.Warning )
+			self.assertIn( "Ignoring unsupported parameter", m.message )
+
+	def testSubdivInterpolatedBoundary( self ) :
+
+		for interpolateBoundary, expected in [
+			( IECoreScene.MeshPrimitive.interpolateBoundaryNone, 0 ),
+			( IECoreScene.MeshPrimitive.interpolateBoundaryEdgeAndCorner, 1 ),
+			( IECoreScene.MeshPrimitive.interpolateBoundaryEdgeOnly, 2 ),
+		] :
+
+			with self.subTest( interpolateBoundary = interpolateBoundary ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						"RenderMan",
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+					mesh.setInterpolation( "catmullClark" )
+					mesh.setInterpolateBoundary( interpolateBoundary )
+
+					renderer.object(
+						"mesh", mesh, renderer.attributes( IECore.CompoundObject() )
+					)
+
+					del mesh, renderer
+
+				proto = next(
+					x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+				)
+				self.__assertInTags(
+					proto, "interpolateboundary", intArgs = [ expected ]
+				)
+
+	def testSubdivFaceVaryingLinearInterpolation( self ) :
+
+		for faceVaryingLinearInterpolation, expected in [
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationNone, 2 ),
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationCornersOnly, 1 ),
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationCornersPlus1, 1 ),
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationCornersPlus2, 1 ),
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationBoundaries, 3 ),
+			( IECoreScene.MeshPrimitive.faceVaryingLinearInterpolationAll, 0 ),
+		] :
+
+			with self.subTest( faceVaryingLinearInterpolation = faceVaryingLinearInterpolation ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						"RenderMan",
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+					mesh.setInterpolation( "catmullClark" )
+					mesh.setFaceVaryingLinearInterpolation( faceVaryingLinearInterpolation )
+
+					renderer.object(
+						"mesh", mesh, renderer.attributes( IECore.CompoundObject() )
+					)
+
+					del mesh, renderer
+
+				proto = next(
+					x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+				)
+				self.__assertInTags(
+					proto, "facevaryinginterpolateboundary", intArgs = [ expected ]
+				)
+
+	def testSubdivTriangleSubdivisionRule( self ) :
+
+		for rule, expected in [
+			( IECoreScene.MeshPrimitive.triangleSubdivisionRuleCatmullClark, 0 ),
+			( IECoreScene.MeshPrimitive.triangleSubdivisionRuleSmooth, 2 ),
+		] :
+
+			with self.subTest( rule = rule ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						"RenderMan",
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+					mesh.setInterpolation( "catmullClark" )
+					mesh.setTriangleSubdivisionRule( rule )
+
+					renderer.object(
+						"mesh", mesh, renderer.attributes( IECore.CompoundObject() )
+					)
+
+					del mesh, renderer
+
+				proto = next(
+					x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+				)
+				self.__assertInTags(
+					proto, "smoothtriangles", intArgs = [ expected ]
+				)
+
+	def testSubdivisionScheme( self ) :
+
+		for interpolation, scheme in [
+			( IECoreScene.MeshPrimitive.interpolationLinear, None ),
+			( IECoreScene.MeshPrimitive.interpolationCatmullClark, "catmull-clark" ),
+			( IECoreScene.MeshPrimitive.interpolationLoop, "loop" ),
+		] :
+
+			with self.subTest( interpolation = interpolation ) :
+
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						"RenderMan",
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+					mesh.setInterpolation( interpolation )
+
+					renderer.object(
+						"mesh", mesh, renderer.attributes( IECore.CompoundObject() )
+					)
+
+					del mesh, renderer
+
+				proto = next(
+					x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+				)
+
+				if scheme is not None :
+					self.assertEqual( proto["type"], "Ri:SubdivisionMesh" )
+					self.__assertPrimitiveVariableEqual( proto, "Ri:scheme", [ scheme ] )
+				else :
+					self.__assertNotInPrimitiveVariables( proto, "Ri:scheme" )
+					self.assertEqual( proto["type"], "Ri:PolygonMesh" )
+
+	def testAutomaticInstancingAttribute( self ) :
+
+		for instancingEnabled in ( True, False ) :
+			with self.subTest( instancingEnabled = instancingEnabled ) :
+				with IECoreRenderManTest.RileyCapture() as capture :
+
+					renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+						"RenderMan",
+						GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+					)
+
+					mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+					attributes = renderer.attributes( IECore.CompoundObject( { "gaffer:automaticInstancing" : IECore.BoolData( instancingEnabled ) } )  )
+					for i in range( 0, 10 ) :
+						renderer.object( f"mesh{i}", mesh, attributes )
+
+					del renderer
+
+				self.assertEqual(
+					sum( 1 for x in capture.json if x["method"] == "CreateGeometryPrototype" ),
+					1 if instancingEnabled else 10
+				)
+				self.assertEqual(
+					sum( 1 for x in capture.json if x["method"] == "CreateGeometryInstance" ),
+					10
+				)
+
+	def testPrototypeAndInstanceAttributes( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"RenderMan",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+			)
+
+			mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+			attributes = renderer.attributes(
+				IECore.CompoundObject( {
+					"ri:shade:minsamples" : IECore.IntData( 5 ),
+					"ri:polygon:concave" : IECore.BoolData( 1 ),
+				} )
+			)
+			renderer.object( "mesh", mesh, attributes )
+
+			del renderer
+
+		prototype = next(
+			x for x in capture.json if x["method"] == "CreateGeometryPrototype"
+		)
+
+		self.__assertPrimitiveVariableEqual( prototype, "polygon:concave", [ 1 ] )
+		self.__assertNotInPrimitiveVariables( prototype, "shade:minsamples" )
+
+		instance = next(
+			x for x in capture.json if x["method"] == "CreateGeometryInstance"
+		)
+		self.__assertParameterEqual( instance["attributes"]["params"], "shade:minsamples", [ 5 ] )
+		self.__assertNotInParameters( instance["attributes"]["params"], "polygon:concave" )
+
+	def testAutomaticInstancingRespectsPrototypeAttributes( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"RenderMan",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+			)
+
+			mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+			concaveAttributes = renderer.attributes(
+				IECore.CompoundObject( {
+					"ri:polygon:concave" : IECore.BoolData( 1 ),
+				} )
+			)
+			convexAttributes = renderer.attributes(
+				IECore.CompoundObject( {
+					"ri:polygon:concave" : IECore.BoolData( 0 ),
+				} )
+			)
+
+			renderer.object( "concave1", mesh, concaveAttributes )
+			renderer.object( "convex1", mesh, convexAttributes )
+			renderer.object( "concave2", mesh, concaveAttributes )
+			renderer.object( "convex2", mesh, convexAttributes )
+
+			del renderer
+
+		prototypes = [ x for x in capture.json if x["method"] == "CreateGeometryPrototype" ]
+		self.assertEqual( len( prototypes ), 2 )
+		self.__assertPrimitiveVariableEqual( prototypes[0], "polygon:concave", [ 1 ] )
+		self.__assertPrimitiveVariableEqual( prototypes[1], "polygon:concave", [ 0 ] )
+
+		instances = [ x for x in capture.json if x["method"] == "CreateGeometryInstance" ]
+		self.assertEqual( len( instances ), 4 )
+		self.assertEqual( instances[0]["geoMasterId"], prototypes[0]["result"] )
+		self.assertEqual( instances[1]["geoMasterId"], prototypes[1]["result"] )
+		self.assertEqual( instances[2]["geoMasterId"], prototypes[0]["result"] )
+		self.assertEqual( instances[3]["geoMasterId"], prototypes[1]["result"] )
+
+	def testChangingPrototypeAttributesCausesEditFailure( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		concaveAttributes = renderer.attributes(
+			IECore.CompoundObject( {
+				"ri:polygon:concave" : IECore.BoolData( 1 ),
+			} )
+		)
+		meshObject = renderer.object( "mesh", mesh, concaveAttributes )
+
+		# Can change instance-level attributes OK.
+		concaveAttributesPlus = renderer.attributes(
+			IECore.CompoundObject( {
+				"ri:polygon:concave" : IECore.BoolData( True ),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} )
+		)
+		self.assertTrue( meshObject.attributes( concaveAttributesPlus ) )
+
+		# But changing prototype-level attribute should cause edit failure.
+		convexAttributes = renderer.attributes(
+			IECore.CompoundObject( {
+				"ri:polygon:concave" : IECore.BoolData( False ),
+				"ri:visibility:camera" : IECore.BoolData( False ),
+			} )
+		)
+		self.assertFalse( meshObject.attributes( convexAttributes ) )
+
+		del meshObject, concaveAttributes, concaveAttributesPlus, convexAttributes, renderer
+
+	def testDisplacement( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"RenderMan",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+			)
+
+			mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+
+			displacementAttributes1 = renderer.attributes(
+				IECore.CompoundObject( {
+					"osl:displacement" : IECoreScene.ShaderNetwork(
+						shaders = {
+							"output" : IECoreScene.Shader( "PxrDisplace", "osl:displacement", { "dispAmount" : 1.0 } )
+						},
+						output = ( "output", "result" )
+					),
+				} )
+			)
+
+			displacementAttributes2 = renderer.attributes(
+				IECore.CompoundObject( {
+					"osl:displacement" : IECoreScene.ShaderNetwork(
+						shaders = {
+							"output" : IECoreScene.Shader( "PxrDisplace", "osl:displacement", { "dispAmount" : 2.0 } )
+						},
+						output = ( "output", "result" )
+					),
+				} )
+			)
+
+			renderer.object( "mesh1A", mesh, displacementAttributes1 )
+			renderer.object( "mesh2A", mesh, displacementAttributes2 )
+			renderer.object( "mesh1B", mesh, displacementAttributes1 )
+			renderer.object( "mesh2B", mesh, displacementAttributes2 )
+
+			del renderer
+
+		displacements = [ x for x in capture.json if x["method"] == "CreateDisplacement" ]
+		self.assertEqual( len( displacements ), 2 )
+
+		prototypes = [ x for x in capture.json if x["method"] == "CreateGeometryPrototype" ]
+		self.assertEqual( len( prototypes ), 2 )
+		self.assertEqual( prototypes[0]["displacementId"], displacements[0]["result"] )
+		self.assertEqual( prototypes[1]["displacementId"], displacements[1]["result"] )
+
+		instances = [ x for x in capture.json if x["method"] == "CreateGeometryInstance" ]
+		self.assertEqual( len( instances ), 4 )
+		self.assertEqual( instances[0]["geoMasterId"], prototypes[0]["result"] )
+		self.assertEqual( instances[1]["geoMasterId"], prototypes[1]["result"] )
+		self.assertEqual( instances[2]["geoMasterId"], prototypes[0]["result"] )
+		self.assertEqual( instances[3]["geoMasterId"], prototypes[1]["result"] )
+
+	def testTransformMotionBlur( self ) :
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+		)
+
+		# RenderMan needs the shutter upfront when the Riley object is created,
+		# so until we can come up with something, the renderer client is responsible
+		# for passing the shutter separately from the camera.
+		renderer.option( "ri:Ri:Shutter", IECore.V2fData( imath.V2f( 0, 1 ) ) )
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "transformMotion",
+				}
+			)
+		)
+
+		object = renderer.object(
+			"sphere",
+			IECoreScene.SpherePrimitive( 1 ),
+			renderer.attributes( IECore.CompoundObject() )
+		)
+		object.transform(
+			[ imath.M44f().translate( imath.V3f( x, 0, -3 ) ) for x in [ -3, 3 ] ],
+			[ 0.0, 1.0 ],
+		)
+
+		renderer.render()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "transformMotion" )
+
+		for i in range( 0, 10 ) :
+			u = i / 9.0
+			self.assertEqual( self.__colorAtUV( image, imath.V2f( u, 0.1 ) ).a, 0 )
+			self.assertGreaterEqual( self.__colorAtUV( image, imath.V2f( u, 0.5 ) ).a, 0.1 )
+			self.assertEqual( self.__colorAtUV( image, imath.V2f( u, 0.9 ) ).a, 0 )
+
+	def __assertParameterEqual( self, paramList, name, data ) :
+
+		p = next( x for x in paramList if x["info"]["name"] == name )
+		self.assertEqual( p["data"], data )
+
+	def __assertNotInParameters( self, paramList, name ) :
+
+		self.assertNotIn(
+			name, { x["info"]["name"] for x in paramList }
+		)
+
+	def __assertPrimitiveVariableEqual( self, geometryPrototype, name, data ) :
+
+		self.__assertParameterEqual( geometryPrototype["primvars"]["params"], name, data )
+
+	def __assertNotInPrimitiveVariables( self, geometryPrototype, name ) :
+
+		self.__assertNotInParameters( geometryPrototype["primvars"]["params"], name )
+
+	def __assertInTags( self, geometryPrototype, tag, intArgs = [], floatArgs = [] ) :
+
+		tags = next( x for x in geometryPrototype["primvars"]["params"] if x["info"]["name"] == "Ri:subdivtags" )["data"]
+		numArgs = next( x for x in geometryPrototype["primvars"]["params"] if x["info"]["name"] == "Ri:subdivtagnargs" )["data"]
+		ints = next( x for x in geometryPrototype["primvars"]["params"] if x["info"]["name"] == "Ri:subdivtagintargs" )["data"]
+		floats = next( x for x in geometryPrototype["primvars"]["params"] if x["info"]["name"] == "Ri:subdivtagfloatargs" )["data"]
+
+		foundTag = False
+		for t in tags :
+
+			if t == tag :
+				self.assertEqual( numArgs[0:3], [ len( intArgs ), len( floatArgs ), 0 ] )
+				self.assertEqual( ints[0:len(intArgs)], intArgs )
+				self.assertEqual( floats[0:len(floatArgs)], floatArgs )
+				foundTag = True
+
+			# Move to next tag
+			del ints[0:numArgs[0]]
+			del floats[0:numArgs[1]]
+			del numArgs[0:3]
+
+		self.assertEqual( len( numArgs ), 0 )
+		self.assertEqual( len( ints ), 0 )
+		self.assertEqual( len( floats ), 0 )
+
+		self.assertTrue( foundTag )
+
+	def __colorAtUV( self, image, uv ) :
+
+		dimensions = image.dataWindow.size() + imath.V2i( 1 )
+
+		ix = int( uv.x * ( dimensions.x - 1 ) )
+		iy = int( uv.y * ( dimensions.y - 1 ) )
+		i = iy * dimensions.x + ix
+
+		return imath.Color4f( image["R"][i], image["G"][i], image["B"][i], image["A"][i] if "A" in image.keys() else 0.0 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1349,6 +1349,28 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertGreaterEqual( self.__colorAtUV( image, imath.V2f( u, 0.5 ) ).a, 0.1 )
 			self.assertEqual( self.__colorAtUV( image, imath.V2f( u, 0.9 ) ).a, 0 )
 
+	def testUnknownCommands( self ) :
+
+		messageHandler = IECore.CapturingMessageHandler()
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+			messageHandler = messageHandler
+		)
+
+		renderer.command( "ri:unknown", {} )
+		self.assertEqual( len( messageHandler.messages ), 1 )
+		self.assertEqual( messageHandler.messages[0].level, IECore.Msg.Level.Warning )
+		self.assertEqual( messageHandler.messages[0].message, 'Unknown command "ri:unknown".' )
+
+		renderer.command( "unknown", {} )
+		self.assertEqual( len( messageHandler.messages ), 2 )
+		self.assertEqual( messageHandler.messages[1].level, IECore.Msg.Level.Warning )
+		self.assertEqual( messageHandler.messages[1].message, 'Unknown command "unknown".' )
+
+		renderer.command( "ai:unknown", {} ) # Shouldn't warn, because command is for another renderer.
+		self.assertEqual( len( messageHandler.messages ), 2 )
+
 	def __assertParameterEqual( self, paramList, name, data ) :
 
 		p = next( x for x in paramList if x["info"]["name"] == name )

--- a/python/IECoreRenderManTest/RileyCapture.py
+++ b/python/IECoreRenderManTest/RileyCapture.py
@@ -1,0 +1,66 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+
+## Captures the stream of commands sent to Riley into a `json` member.
+# Useful for performing unit testing without resorting to comparing
+# rendered images.
+class RileyCapture :
+
+	def __init__( self ) :
+
+		self.__dir = pathlib.Path( tempfile.mkdtemp( prefix = "rileyCapture" ) )
+		self.__fileName = self.__dir / "capture.json"
+		self.json = {}
+
+	def __enter__( self ) :
+
+		os.environ["RILEY_CAPTURE"] = str( self.__fileName )
+		os.environ["RILEY_CAPTURE_FORMAT"] = "json"
+
+		return self
+
+	def __exit__( self, type, value, traceBack ) :
+
+		del os.environ["RILEY_CAPTURE"]
+		del os.environ["RILEY_CAPTURE_FORMAT"]
+		self.json = json.load( open( self.__fileName ) )
+		shutil.rmtree( self.__dir )

--- a/python/IECoreRenderManTest/__init__.py
+++ b/python/IECoreRenderManTest/__init__.py
@@ -1,0 +1,42 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from .RileyCapture import RileyCapture
+from .RendererTest import RendererTest
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -1,0 +1,323 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Attributes.h"
+
+#include "ParamListAlgo.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+
+#include "IECore/SimpleTypedData.h"
+
+#include "RixPredefinedStrings.hpp"
+
+#include "boost/algorithm/string.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+#include "boost/container/flat_map.hpp"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+// List generated from `$RMANTREE/lib/defaults/PRManPrimVars.args` using
+// `contrib/scripts/renderManPrototypeAttributes.py`.
+boost::container::flat_map<InternedString, RtUString> g_prototypeAttributes = {
+	{ "ri:identifier:object", RtUString( "identifier:object" ) },
+	{ "ri:stats:prototypeIdentifier", RtUString( "stats:prototypeIdentifier" ) },
+	{ "ri:derivatives:extrapolate", RtUString( "derivatives:extrapolate" ) },
+	{ "ri:trace:autobias", RtUString( "trace:autobias" ) },
+	{ "ri:trace:bias", RtUString( "trace:bias" ) },
+	{ "ri:trace:sssautobias", RtUString( "trace:sssautobias" ) },
+	{ "ri:trace:sssbias", RtUString( "trace:sssbias" ) },
+	{ "ri:trace:displacements", RtUString( "trace:displacements" ) },
+	{ "ri:displacementbound:CoordinateSystem", RtUString( "displacementbound:CoordinateSystem" ) },
+	{ "ri:displacementbound:offscreen", RtUString( "displacementbound:offscreen" ) },
+	{ "ri:displacementbound:sphere", RtUString( "displacementbound:sphere" ) },
+	{ "ri:displacement:ignorereferenceinstance", RtUString( "displacement:ignorereferenceinstance" ) },
+	{ "ri:Ri:Orientation", RtUString( "Ri:Orientation" ) },
+	{ "ri:dice:micropolygonlength", RtUString( "dice:micropolygonlength" ) },
+	{ "ri:dice:offscreenstrategy", RtUString( "dice:offscreenstrategy" ) },
+	{ "ri:dice:rasterorient", RtUString( "dice:rasterorient" ) },
+	{ "ri:dice:referencecamera", RtUString( "dice:referencecamera" ) },
+	{ "ri:dice:referenceinstance", RtUString( "dice:referenceinstance" ) },
+	{ "ri:dice:strategy", RtUString( "dice:strategy" ) },
+	{ "ri:dice:worlddistancelength", RtUString( "dice:worlddistancelength" ) },
+	{ "ri:Ri:GeometricApproximationFocusFactor", RtUString( "Ri:GeometricApproximationFocusFactor" ) },
+	{ "ri:dice:offscreenmultiplier", RtUString( "dice:offscreenmultiplier" ) },
+	{ "ri:falloffpower", RtUString( "falloffpower" ) },
+	{ "ri:curve:opacitysamples", RtUString( "curve:opacitysamples" ) },
+	{ "ri:curve:widthaffectscurvature", RtUString( "curve:widthaffectscurvature" ) },
+	{ "ri:dice:minlength", RtUString( "dice:minlength" ) },
+	{ "ri:dice:minlengthspace", RtUString( "dice:minlengthspace" ) },
+	{ "ri:Ri:Bound", RtUString( "Ri:Bound" ) },
+	{ "ri:volume:aggregate", RtUString( "volume:aggregate" ) },
+	{ "ri:volume:dsominmax", RtUString( "volume:dsominmax" ) },
+	{ "ri:volume:fps", RtUString( "volume:fps" ) },
+	{ "ri:volume:shutteroffset", RtUString( "volume:shutteroffset" ) },
+	{ "ri:volume:velocityshuttercorrection", RtUString( "volume:velocityshuttercorrection" ) },
+	{ "ri:volume:aggregaterespectvisibility", RtUString( "volume:aggregaterespectvisibility" ) },
+	{ "ri:volume:dsovelocity", RtUString( "volume:dsovelocity" ) },
+	{ "ri:dice:pretessellate", RtUString( "dice:pretessellate" ) },
+	{ "ri:dice:watertight", RtUString( "dice:watertight" ) },
+	{ "ri:shade:faceset", RtUString( "shade:faceset" ) },
+	{ "ri:stitchbound:CoordinateSystem", RtUString( "stitchbound:CoordinateSystem" ) },
+	{ "ri:stitchbound:sphere", RtUString( "stitchbound:sphere" ) },
+	{ "ri:trimcurve:sense", RtUString( "trimcurve:sense" ) },
+	{ "ri:polygon:concave", RtUString( "polygon:concave" ) },
+	{ "ri:polygon:smoothdisplacement", RtUString( "polygon:smoothdisplacement" ) },
+	{ "ri:polygon:smoothnormals", RtUString( "polygon:smoothnormals" ) },
+	{ "ri:procedural:immediatesubdivide", RtUString( "procedural:immediatesubdivide" ) },
+	{ "ri:procedural:reentrant", RtUString( "procedural:reentrant" ) }
+};
+
+const string g_renderManPrefix( "ri:" );
+const IECore::InternedString g_automaticInstancingAttributeName( "gaffer:automaticInstancing" );
+const InternedString g_displacementAttributeName( "displacement" );
+const InternedString g_doubleSidedAttributeName( "doubleSided" );
+const InternedString g_lightMuteAttributeName( "light:mute" );
+const InternedString g_lightShaderAttributeName( "light" );
+const InternedString g_oslDisplacementAttributeName( "osl:displacement" );
+const InternedString g_renderManDisplacementAttributeName( "ri:displacement" );
+const InternedString g_renderManLightShaderAttributeName( "ri:light" );
+const InternedString g_renderManSurfaceAttributeName( "ri:surface" );
+const InternedString g_surfaceAttributeName( "surface" );
+
+template<typename T>
+T *attributeCast( const IECore::RunTimeTyped *v, const IECore::InternedString &name )
+{
+	if( !v )
+	{
+		return nullptr;
+	}
+
+	T *t = IECore::runTimeCast<T>( v );
+	if( t )
+	{
+		return t;
+	}
+
+	IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Renderer", fmt::format( "Expected {} but got {} for attribute \"{}\".", T::staticTypeName(), v->typeName(), name.c_str() ) );
+	return nullptr;
+}
+
+template<typename T>
+T attributeCast( const IECore::RunTimeTyped *v, const IECore::InternedString &name, const T &defaultValue )
+{
+	using DataType = IECore::TypedData<T>;
+	auto d = attributeCast<const DataType>( v, name );
+	return d ? d->readable() : defaultValue;
+}
+
+template<typename T>
+const T *attribute( const CompoundObject::ObjectMap &attributes, IECore::InternedString name )
+{
+	auto it = attributes.find( name );
+	if( it == attributes.end() )
+	{
+		return nullptr;
+	}
+
+	return attributeCast<const T>( it->second.get(), name );
+}
+
+template<typename T>
+T attributeValue( const CompoundObject::ObjectMap &attributes, IECore::InternedString name, const T &defaultValue )
+{
+	using DataType = IECore::TypedData<T>;
+	const DataType *data = attribute<DataType>( attributes, name );
+	return data ? data->readable() : defaultValue;
+}
+
+bool isMeshLight( const IECoreScene::ShaderNetwork *lightShader )
+{
+	const IECoreScene::Shader *outputShader = lightShader->outputShader();
+	return outputShader && outputShader->getName() == "PxrMeshLight";
+}
+
+IECoreScene::ConstShaderNetworkPtr g_facingRatio = []() {
+
+	ShaderNetworkPtr result = new ShaderNetwork;
+
+	const InternedString facingRatioHandle = result->addShader(
+		"facingRatio", new Shader( "PxrFacingRatio" )
+	);
+	const InternedString toFloat3Handle = result->addShader(
+		"toFloat3", new Shader( "PxrToFloat3" )
+	);
+	const InternedString constantHandle = result->addShader(
+		"constant", new Shader( "PxrConstant" )
+	);
+
+	result->addConnection( { { facingRatioHandle, "resultF" }, { toFloat3Handle, "input" } } );
+	result->addConnection( { { toFloat3Handle, "resultRGB" }, { constantHandle, "emitColor" } } );
+	result->setOutput( { "constant", "out" } );
+
+	return result;
+
+} ();
+
+IECoreScene::ConstShaderNetworkPtr g_black = []() {
+
+	ShaderNetworkPtr result = new ShaderNetwork;
+	const InternedString facingRatioHandle = result->addShader(
+		"black", new Shader( "PxrBlack" )
+	);
+	result->setOutput( { "black", "out" } );
+
+	return result;
+
+} ();
+
+} // namespace
+
+Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache *materialCache )
+{
+	const ShaderNetwork *surface = attribute<ShaderNetwork>( attributes->members(), g_renderManSurfaceAttributeName );
+	surface = surface ? surface : attribute<ShaderNetwork>( attributes->members(), g_surfaceAttributeName );
+	m_surfaceMaterial = materialCache->getMaterial( surface ? surface : g_facingRatio.get() );
+
+	const ShaderNetwork *displacement = attribute<ShaderNetwork>( attributes->members(), g_renderManDisplacementAttributeName );
+	displacement = displacement ? displacement : attribute<ShaderNetwork>( attributes->members(), g_oslDisplacementAttributeName );
+	displacement = displacement ? displacement : attribute<ShaderNetwork>( attributes->members(), g_displacementAttributeName );
+	if( displacement )
+	{
+		m_displacement = materialCache->getDisplacement( displacement );
+	}
+
+	m_lightShader = attribute<ShaderNetwork>( attributes->members(), g_renderManLightShaderAttributeName );
+	m_lightShader = m_lightShader ? m_lightShader : attribute<ShaderNetwork>( attributes->members(), g_lightShaderAttributeName );
+	if( m_lightShader && isMeshLight( m_lightShader.get() ) )
+	{
+		// Mesh lights default to having a black material so they don't appear
+		// in indirect rays, but the user can override with a surface assignment
+		// if they want further control. Other lights don't have materials.
+		m_lightMaterial = materialCache->getMaterial( surface ? surface : g_black.get() );
+	}
+
+	if( attributeValue<bool>( attributes->members(), g_automaticInstancingAttributeName, true ) )
+	{
+		m_prototypeHash.emplace( IECore::MurmurHash() );
+		if( displacement )
+		{
+			displacement->hash( *m_prototypeHash );
+		}
+	}
+
+	for( const auto &[name, value] : attributes->members() )
+	{
+		auto data = runTimeCast<const Data>( value.get() );
+		if( !data )
+		{
+			continue;
+		}
+
+		if( name == g_lightMuteAttributeName )
+		{
+			ParamListAlgo::convertParameter( Rix::k_lighting_mute, data, m_instanceAttributes );
+		}
+		else if( name == g_doubleSidedAttributeName )
+		{
+			int sides = attributeCast<bool>( value.get(), name, true ) ? 2 : 1;
+			m_instanceAttributes.SetInteger( Rix::k_Ri_Sides, sides );
+		}
+		else if( boost::starts_with( name.c_str(), "user:" ) )
+		{
+			ParamListAlgo::convertParameter( RtUString( name.c_str() ), data, m_instanceAttributes );
+		}
+
+		if( !boost::starts_with( name.c_str(), g_renderManPrefix.c_str() ) )
+		{
+			continue;
+		}
+
+		auto it = g_prototypeAttributes.find( name );
+		if( it != g_prototypeAttributes.end() )
+		{
+			ParamListAlgo::convertParameter( it->second, data, m_prototypeAttributes );
+			if( m_prototypeHash )
+			{
+				/// \todo Make the hash match between non-specified attributes and attributes which
+				/// are explicitly specified with their default values.
+				data->hash( *m_prototypeHash );
+			}
+		}
+		else
+		{
+			ParamListAlgo::convertParameter( RtUString( name.c_str() + g_renderManPrefix.size() ), data, m_instanceAttributes );
+
+		}
+	}
+}
+
+Attributes::~Attributes()
+{
+}
+
+const std::optional<IECore::MurmurHash> &Attributes::prototypeHash() const
+{
+	return m_prototypeHash;
+}
+
+const RtParamList &Attributes::prototypeAttributes() const
+{
+	return m_prototypeAttributes;
+}
+
+const RtParamList &Attributes::instanceAttributes() const
+{
+	return m_instanceAttributes;
+}
+
+const Material *Attributes::surfaceMaterial() const
+{
+	return m_surfaceMaterial.get();
+}
+
+const Material *Attributes::lightMaterial() const
+{
+	return m_lightMaterial.get();
+}
+
+const IECoreScene::ShaderNetwork *Attributes::lightShader() const
+{
+	return m_lightShader.get();
+}

--- a/src/IECoreRenderMan/Attributes.h
+++ b/src/IECoreRenderMan/Attributes.h
@@ -1,0 +1,91 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "MaterialCache.h"
+
+namespace IECoreRenderMan
+{
+
+class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
+{
+
+	public :
+
+		Attributes( const IECore::CompoundObject *attributes, MaterialCache *materialCache );
+		~Attributes();
+
+		/// Returns a hash of everything in `prototypeParamList()`, to be
+		/// used by GeometryPrototypeCache when automaticaly deduplicating
+		/// objects. Returns `std::nullopt` if automatic instancing is
+		/// turned off.
+		/// \todo Should we have different hashes for different object types,
+		/// so attributes for curves (for example) don't mess with instancing
+		/// of meshes?
+		const std::optional<IECore::MurmurHash> &prototypeHash() const;
+		/// Attributes to be applied when creating GeometryPrototypes.
+		const RtParamList &prototypeAttributes() const;
+		/// Attributes to be applied to GeometryInstances.
+		const RtParamList &instanceAttributes() const;
+
+		const Material *surfaceMaterial() const;
+		const Displacement *displacement() const { return m_displacement.get(); }
+
+		const IECoreScene::ShaderNetwork *lightShader() const;
+		/// Material to be assigned to lights. RenderMan uses this to
+		/// shade ray hits on mesh lights, while using `lightShader()` for
+		/// light emission. Returns `nullptr` for all non-mesh lights.
+		const Material *lightMaterial() const;
+
+	private :
+
+		std::optional<IECore::MurmurHash> m_prototypeHash;
+		RtParamList m_prototypeAttributes;
+		RtParamList m_instanceAttributes;
+		ConstMaterialPtr m_surfaceMaterial;
+		ConstDisplacementPtr m_displacement;
+		/// \todo Could we use the material cache for these too?
+		IECoreScene::ConstShaderNetworkPtr m_lightShader;
+		ConstMaterialPtr m_lightMaterial;
+
+};
+
+IE_CORE_DECLAREPTR( Attributes )
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -1,0 +1,198 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Camera.h"
+
+#include "ParamListAlgo.h"
+#include "Transform.h"
+
+#include "RixPredefinedStrings.hpp"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+const RtUString g_projectionHandle( "projection" );
+const RtUString g_pxrCamera( "PxrCamera" );
+const RtUString g_pxrOrthographic( "PxrOrthographic" );
+
+} // namespace
+
+/// \todo Overscan, depth of field
+Camera::Camera( const std::string &name, const IECoreScene::Camera *camera, Session *session )
+	:	m_session( session )
+{
+	// Parameters
+
+	RtParamList cameraParamList;
+	cameraParamList.SetFloat( Rix::k_nearClip, camera->getClippingPlanes()[0] );
+	cameraParamList.SetFloat( Rix::k_farClip, camera->getClippingPlanes()[1] );
+
+	const Box2f frustum = camera->frustum();
+	array<float, 4> screenWindow = { frustum.min.x, frustum.max.x, frustum.min.y, frustum.max.y };
+	cameraParamList.SetFloatArray( Rix::k_Ri_ScreenWindow, screenWindow.data(), screenWindow.size() );
+
+	// Projection shader
+
+	const string projection = camera->getProjection();
+	RtUString projectionShaderName = g_pxrCamera;
+	if( projection == "perspective" )
+	{
+		projectionShaderName = g_pxrCamera;
+	}
+	else if( projection == "orthographic" )
+	{
+		projectionShaderName = g_pxrOrthographic;
+	}
+	else if( boost::starts_with( projection, "ri:" ) )
+	{
+		projectionShaderName = RtUString( projection.c_str() + 3 );
+	}
+	else
+	{
+		IECore::msg( IECore::Msg::Warning, "Camera", fmt::format( "Unknown projection \"{}\"", projection ) );
+	}
+
+	RtParamList projectionParamList;
+	for( const auto &[parameterName, parameterValue] : camera->parameters() )
+	{
+		if( boost::starts_with( name.c_str(), "ri:" ) )
+		{
+			ParamListAlgo::convertParameter( RtUString( parameterName.c_str() + 3 ), parameterValue.get(), projectionParamList );
+		}
+	}
+
+	riley::ShadingNode projectionShader = {
+		/* type = */ riley::ShadingNode::Type::k_Projection,
+		/* name = */ projectionShaderName,
+		/* handle = */ g_projectionHandle,
+		/* params = */ projectionParamList
+	};
+
+	// Options. We specify things like format and crop on `IECoreScene::Camera`
+	// objects, but RenderMan wants them to be specified as options. We figure
+	// out the options here and store them in the Session for later usage.
+
+	RtParamList options;
+
+	const Imath::V2i resolution = camera->renderResolution();
+	options.SetIntegerArray( Rix::k_Ri_FormatResolution, resolution.getValue(), 2 );
+	options.SetFloat( Rix::k_Ri_FormatPixelAspectRatio, camera->getPixelAspectRatio() );
+
+	Box2f cropWindow = camera->getCropWindow();
+	if( cropWindow.isEmpty() )
+	{
+		/// \todo Would be better if IECoreScene::Camera defaulted to this rather
+		/// than empty box.
+		cropWindow = Box2f( V2f( 0 ), V2f( 1 ) );
+	}
+	float renderManCropWindow[4] = { cropWindow.min.x, cropWindow.max.x, cropWindow.min.y, cropWindow.max.y };
+	options.SetFloatArray( Rix::k_Ri_CropWindow, renderManCropWindow, 4 );
+
+	// Camera
+
+	m_cameraId = m_session->createCamera(
+		RtUString( name.c_str() ),
+		projectionShader,
+		IdentityTransform(),
+		cameraParamList,
+		options
+	);
+
+}
+
+Camera::~Camera()
+{
+	if( m_session->renderType == IECoreScenePreview::Renderer::Interactive )
+	{
+		if( m_cameraId != riley::CameraId::InvalidId() )
+		{
+			m_session->deleteCamera( m_cameraId );
+		}
+	}
+}
+
+void Camera::transform( const Imath::M44f &transform )
+{
+	transformInternal( { transform }, { 0.0f } );
+}
+
+void Camera::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+{
+	transformInternal( samples, times );
+}
+
+bool Camera::attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+{
+	return true;
+}
+
+void Camera::link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects )
+{
+}
+
+void Camera::assignID( uint32_t id )
+{
+}
+
+void Camera::transformInternal( std::vector<Imath::M44f> samples, const std::vector<float> &times )
+{
+	for( auto &m : samples )
+	{
+		m = M44f().scale( V3f( 1, 1, -1 ) ) * m;
+	}
+
+	AnimatedTransform transform( samples, times );
+
+	const auto result = m_session->riley->ModifyCamera(
+		m_cameraId,
+		nullptr,
+		&transform,
+		nullptr
+	);
+
+	if( result != riley::CameraResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Camera::transform", "Unexpected edit failure" );
+	}
+}

--- a/src/IECoreRenderMan/Camera.h
+++ b/src/IECoreRenderMan/Camera.h
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Session.h"
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+namespace IECoreRenderMan
+{
+
+class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
+{
+
+	public :
+
+		Camera( const std::string &name, const IECoreScene::Camera *camera, Session *session );
+		~Camera();
+
+		void transform( const Imath::M44f &transform ) override;
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
+		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
+		void assignID( uint32_t id ) override;
+
+	private :
+
+		void transformInternal( std::vector<Imath::M44f> samples, const std::vector<float> &times );
+
+		Session *m_session;
+		riley::CameraId m_cameraId;
+
+};
+
+IE_CORE_DECLAREPTR( Camera );
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/GeometryPrototypeCache.cpp
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.cpp
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryPrototypeCache.h"
+
+#include "GeometryAlgo.h"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+GeometryPrototypeCache::GeometryPrototypeCache( const Session *session )
+	:	m_session( session )
+{
+}
+
+GeometryPrototypePtr GeometryPrototypeCache::get( const IECore::Object *object, const Attributes *attributes, const std::string &messageContext )
+{
+	if( !object )
+	{
+		return nullptr;
+	}
+
+	return get( { object }, { 0.0f }, attributes, messageContext );
+}
+
+GeometryPrototypePtr GeometryPrototypeCache::get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, const Attributes *attributes, const std::string &messageContext )
+{
+	auto converter = [&] ( const vector<const IECore::Object *> &samples, const vector<float> &sampleTimes, const Attributes *attributes, const Session *session, GeometryPrototypePtr &result ) {
+
+		riley::DisplacementId displacement;
+		if( auto d = attributes->displacement() )
+		{
+			displacement = d->id();
+		}
+
+		RtPrimVarList primVars;
+		RtUString type;
+		if( samples.size() == 1 )
+		{
+			/// \todo Remove static conversions from GeometryAlgo?
+			type = GeometryAlgo::convert( samples[0], primVars, messageContext );
+		}
+		else
+		{
+			type = GeometryAlgo::convert( samples, sampleTimes, primVars, messageContext );
+		}
+
+		if( !type.Empty() )
+		{
+			primVars.RtParamList::Inherit( attributes->prototypeAttributes() );
+			result = new GeometryPrototype(
+				session->riley->CreateGeometryPrototype( riley::UserId(), type, displacement, primVars ),
+				session
+			);
+		}
+
+	};
+
+	std::optional<IECore::MurmurHash> attributesHash = attributes->prototypeHash();
+	if( !attributesHash )
+	{
+		// Automatic instancing disabled.
+		GeometryPrototypePtr result;
+		converter( samples, sampleTimes, attributes, m_session, result );
+		return result;
+	}
+
+	IECore::MurmurHash h = *attributesHash;
+	for( size_t i = 0; i < samples.size(); ++i )
+	{
+		samples[i]->hash( h );
+		h.append( sampleTimes[i] );
+	}
+
+	auto [it, inserted] = m_cache.emplace(
+		std::piecewise_construct, std::forward_as_tuple( h ), std::make_tuple()
+	);
+	std::call_once( it->second.onceFlag, converter, samples, sampleTimes, attributes, m_session, it->second.prototype );
+
+	return it->second.prototype;
+}
+
+void GeometryPrototypeCache::clearUnused()
+{
+	for( auto it = m_cache.begin(); it != m_cache.end(); )
+	{
+		if( it->second.prototype && it->second.prototype->refCount() == 1 )
+		{
+			// Only one reference - this is ours, so nothing outside of the
+			// cache is using the geometry prototype.
+			it = m_cache.unsafe_erase( it );
+		}
+		else
+		{
+			++it;
+		}
+	}
+}

--- a/src/IECoreRenderMan/GeometryPrototypeCache.h
+++ b/src/IECoreRenderMan/GeometryPrototypeCache.h
@@ -1,0 +1,83 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECore/RefCounted.h"
+
+#include "Attributes.h"
+#include "RefCountedId.h"
+#include "Session.h"
+
+#include "tbb/concurrent_unordered_map.h"
+
+#include <mutex>
+
+namespace IECoreRenderMan
+{
+
+using GeometryPrototype = RefCountedId<riley::GeometryPrototypeId>;
+IE_CORE_DECLAREPTR( GeometryPrototype )
+
+class GeometryPrototypeCache
+{
+
+	public :
+
+		GeometryPrototypeCache( const Session *session );
+
+		// Can be called concurrently with other calls to `get()`.
+		GeometryPrototypePtr get( const IECore::Object *object, const Attributes *attributes, const std::string &messageContext );
+		GeometryPrototypePtr get( const std::vector<const IECore::Object *> &samples, const std::vector<float> &sampleTimes, const Attributes *attributes, const std::string &messageContext );
+
+		// Must not be called concurrently with anything.
+		void clearUnused();
+
+	private :
+
+		const Session *m_session;
+
+		struct CacheEntry
+		{
+			std::once_flag onceFlag;
+			GeometryPrototypePtr prototype;
+		};
+		using Cache = tbb::concurrent_unordered_map<IECore::MurmurHash, CacheEntry>;
+		Cache m_cache;
+
+};
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -1,0 +1,683 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Globals.h"
+#include "ParamListAlgo.h"
+#include "Transform.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+
+#include "IECore/SimpleTypedData.h"
+#include "IECore/StringAlgo.h"
+
+#include "RixPredefinedStrings.hpp"
+
+#include "boost/algorithm/string.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+const string g_renderManPrefix( "ri:" );
+const IECore::InternedString g_cameraOption( "camera" );
+const IECore::InternedString g_layerName( "layerName" );
+const IECore::InternedString g_sampleMotionOption( "sampleMotion" );
+const IECore::InternedString g_frameOption( "frame" );
+const IECore::InternedString g_integratorOption( "ri:integrator" );
+const IECore::InternedString g_pixelFilterNameOption( "ri:Ri:PixelFilterName" );
+const IECore::InternedString g_pixelFilterWidthOption( "ri:Ri:PixelFilterWidth" );
+const IECore::InternedString g_pixelVarianceOption( "ri:Ri:PixelVariance" );
+
+const RtUString g_defaultPixelFilter = Rix::k_gaussian;
+riley::FilterSize g_defaultPixelFilterSize = { 2, 2 };
+float g_defaultPixelVariance = 0.015;
+
+const vector<InternedString> g_rejectedOutputFilterParameters = {
+	"filter",
+	"filterwidth"
+};
+
+template<typename T>
+T *optionCast( const IECore::RunTimeTyped *v, const IECore::InternedString &name )
+{
+	if( !v )
+	{
+		return nullptr;
+	}
+
+	T *t = IECore::runTimeCast<T>( v );
+	if( t )
+	{
+		return t;
+	}
+
+	IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Renderer", fmt::format( "Expected {} but got {} for option \"{}\".", T::staticTypeName(), v->typeName(), name.c_str() ) );
+	return nullptr;
+}
+
+template<typename T>
+T parameter( const CompoundDataMap &parameters, const IECore::InternedString &name, const T &defaultValue )
+{
+	auto it = parameters.find( name );
+	if( it == parameters.end() )
+	{
+		return defaultValue;
+	}
+
+	using DataType = IECore::TypedData<T>;
+	if( auto data = runTimeCast<DataType>( it->second.get() ) )
+	{
+		return data->readable();
+	}
+
+	IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Renderer", fmt::format( "Expected {} but got {} for parameter \"{}\".", DataType::staticTypeName(), it->second->typeName(), name.c_str() ) );
+	return defaultValue;
+}
+
+} // namespace
+
+Globals::Globals( IECoreScenePreview::Renderer::RenderType renderType, const IECore::MessageHandlerPtr &messageHandler )
+	:	m_renderType( renderType ), m_messageHandler( messageHandler ),
+		m_pixelFilter( g_defaultPixelFilter ), m_pixelFilterSize( g_defaultPixelFilterSize ), m_pixelVariance( g_defaultPixelVariance ),
+		m_renderTargetExtent()
+{
+	// Initialise `m_integratorToConvert`.
+	option( g_integratorOption, nullptr );
+
+	if( char *p = getenv( "RMAN_DISPLAYS_PATH" ) )
+	{
+		string searchPath = string( p ) + ":@";
+		m_options.SetString( Rix::k_searchpath_display, RtUString( searchPath.c_str() ) );
+	}
+
+	if( char *p = getenv( "OSL_SHADER_PATHS" ) )
+	{
+		string searchPath = string( p ) + ":@";
+		m_options.SetString( Rix::k_searchpath_shader, RtUString( searchPath.c_str() ) );
+	}
+
+	if( renderType == IECoreScenePreview::Renderer::Interactive )
+	{
+		m_options.SetInteger( Rix::k_hider_incremental, 1 );
+		m_options.SetString( Rix::k_bucket_order, RtUString( "circle" ) );
+	}
+
+	// The RenderMan documentation tells you to use "CU6L" as the normal AOV
+	// for the denoiser, but that doesn't actually work unless the right user
+	// lobe has been defined. So we define it here.
+	/// \todo Consider defining other LPE defaults.
+	m_options.SetString(
+		RtUString( "lpe:user6" ),
+		RtUString( "Normal,DiffuseNormal,HairTangent,SubsurfaceNormal,SpecularNormal,RoughSpecularNormal,SingleScatterNormal,FuzzNormal,IridescenceNormal,GlassNormal" )
+	);
+}
+
+Globals::~Globals()
+{
+	pause();
+}
+
+void Globals::option( const IECore::InternedString &name, const IECore::Object *value )
+{
+	if( name == g_pixelVarianceOption )
+	{
+		// Store value for next time we create a render target. And update
+		// any existing render target.
+		auto *d = optionCast<const FloatData>( value, name );
+		m_pixelVariance = d ? d->readable() : g_defaultPixelVariance;
+		if( m_renderTarget != riley::RenderTargetId() )
+		{
+			m_session->riley->ModifyRenderTarget( m_renderTarget, nullptr, nullptr, nullptr, &m_pixelVariance, nullptr );
+		}
+		// Fall through so that we update `m_options` as well. It's completely
+		// unclear whether Riley uses the value from the target or from the
+		// option, but certainly for interactive edits the option needs to be
+		// updated to see a change.
+	}
+
+	if( name == g_integratorOption )
+	{
+		if( auto *network = optionCast<const ShaderNetwork>( value, name ) )
+		{
+			m_integratorToConvert = network->outputShader();
+		}
+		else
+		{
+			m_integratorToConvert = new Shader( "PxrPathTracer", "ri:integrator" );
+		}
+	}
+	else if( name == g_cameraOption )
+	{
+		if( auto *d = optionCast<const StringData>( value, name ) )
+		{
+			m_cameraOption = d->readable();
+		}
+	}
+	else if( name == g_frameOption )
+	{
+		if( auto *d = optionCast<const IntData>( value, name ) )
+		{
+			m_options.SetInteger( RtUString( "Ri:Frame" ), d->readable() );
+		}
+		else
+		{
+			m_options.Remove( RtUString( "Ri:Frame" ) );
+		}
+	}
+	else if( name == g_sampleMotionOption )
+	{
+		if( auto *d = optionCast<const BoolData>( value, name ) )
+		{
+			m_options.SetInteger( RtUString( "hider:samplemotion" ), d->readable() );
+		}
+		else
+		{
+			m_options.Remove( RtUString( "hider:samplemotion" ) );
+		}
+	}
+	else if( name == g_pixelFilterNameOption )
+	{
+		// We're in a strange situation here. RenderMan has deprecated the
+		// `Ri:PixelFilterName` option, and instead expects pixel filters to be
+		// specified on a per-output basis. But denoising has become so
+		// ubiquitous that "importance" is the only `filterMode` you'd
+		// realistically use. And of course, in that mode, you can't have
+		// different filters per output - it just uses the filter from the first
+		// output. So exposing per-output filters to the user would be
+		// completely misleading.
+		//
+		// So we emulate the deprecated option, and forward it on to all
+		// of our outputs. Hopefully at some point the Riley API will be
+		// simplified to avoid all this ambiguity.
+		auto *d = optionCast<const StringData>( value, name );
+		m_pixelFilter = d ? RtUString( d->readable().c_str() ) : g_defaultPixelFilter;
+		deleteRenderView();
+	}
+	else if( name == g_pixelFilterWidthOption )
+	{
+		// See above.
+		auto *d = optionCast<const V2fData>( value, name );
+		m_pixelFilterSize = d ? riley::FilterSize( { d->readable().x, d->readable().y } ) : g_defaultPixelFilterSize;
+		deleteRenderView();
+	}
+	else if( boost::starts_with( name.c_str(), g_renderManPrefix.c_str() ) )
+	{
+		const RtUString renderManName( name.c_str() + g_renderManPrefix.size() );
+		if( auto data = optionCast<const Data>( value, name ) )
+		{
+			ParamListAlgo::convertParameter( renderManName, data, m_options );
+		}
+		else
+		{
+			m_options.Remove( renderManName );
+		}
+	}
+	else if( boost::starts_with( name.c_str(), "user:" ) )
+	{
+		const RtUString renderManName( name.c_str() );
+		if( auto data = optionCast<const Data>( value, name ) )
+		{
+			ParamListAlgo::convertParameter( renderManName, data, m_options );
+		}
+		else
+		{
+			m_options.Remove( renderManName );
+		}
+	}
+}
+
+void Globals::output( const IECore::InternedString &name, const Output *output )
+{
+	if( output )
+	{
+		OutputPtr copy = output->copy();
+		for( const auto &n : g_rejectedOutputFilterParameters )
+		{
+			if( copy->parameters().erase( n ) )
+			{
+				IECore::msg( IECore::Msg::Warning, "RenderManRenderer", fmt::format( "Ignoring unsupported parameter \"{}\" on output \"{}\". Filters must be specified via global options.", n.string(), name.string() ) );
+			}
+		}
+		m_outputs[name] = copy;
+	}
+	else
+	{
+		m_outputs.erase( name );
+	}
+
+	deleteRenderView();
+}
+
+Session *Globals::acquireSession()
+{
+	if( !m_session )
+	{
+		m_session = std::make_unique<Session>( m_renderType, m_options, m_messageHandler );
+	}
+
+	return m_session.get();
+}
+
+void Globals::updateIntegrator()
+{
+	if( !m_integratorToConvert )
+	{
+		return;
+	}
+
+	if( m_integratorId != riley::IntegratorId::InvalidId() )
+	{
+		// Note : we update the render view to use the new integrator in
+		// `updateRenderView()`, called immediately after `updateIntegrator()`.
+		// So far it seems to be OK that the render view has a dangling
+		// integrator in the meantime.
+		m_session->riley->DeleteIntegrator( m_integratorId );
+	}
+
+	RtParamList integratorParamList;
+	ParamListAlgo::convertParameters( m_integratorToConvert->parameters(), integratorParamList );
+
+	riley::ShadingNode integratorNode = {
+		riley::ShadingNode::Type::k_Integrator,
+		RtUString( m_integratorToConvert->getName().c_str() ),
+		RtUString( "integrator" ),
+		integratorParamList
+	};
+
+	m_integratorId = m_session->riley->CreateIntegrator( riley::UserId(), integratorNode );
+	m_integratorToConvert = nullptr;
+}
+
+void Globals::render()
+{
+	acquireSession();
+	updateIntegrator();
+	updateRenderView();
+	m_session->updatePortals();
+
+	/// \todo Is it worth avoiding this work when nothing has changed?
+	Session::CameraInfo camera = m_session->cameraInfo( m_cameraOption );
+	m_options.Update( camera.options );
+	m_session->riley->SetOptions( m_options );
+
+	switch( m_session->renderType )
+	{
+		case IECoreScenePreview::Renderer::Batch : {
+			RtParamList renderOptions;
+			renderOptions.SetString( RtUString( "renderMode" ), RtUString( "batch" ) );
+			m_session->riley->Render( { 1, &m_renderView }, renderOptions );
+			break;
+		}
+		case IECoreScenePreview::Renderer::Interactive :
+			/// \todo Would it reduce latency if we reused the same thread?
+			m_interactiveRenderThread = std::thread(
+				[this] {
+					RtParamList renderOptions;
+					renderOptions.SetString( RtUString( "renderMode" ), RtUString( "interactive" ) );
+					m_session->riley->Render( { 1, &m_renderView }, renderOptions );
+				}
+			);
+			break;
+		case IECoreScenePreview::Renderer::SceneDescription :
+			// Protected against in RenderManRenderer constructor
+			assert( 0 );
+	}
+}
+
+void Globals::pause()
+{
+	if( m_interactiveRenderThread.joinable() )
+	{
+		m_session->riley->Stop();
+		m_interactiveRenderThread.join();
+	}
+}
+
+void Globals::updateRenderView()
+{
+	// Find camera.
+
+	Session::CameraInfo camera = m_session->cameraInfo( m_cameraOption );
+	if( camera.id == riley::CameraId::InvalidId() )
+	{
+		/// \todo Should the Camera and/or Session class be responsible for
+		/// providing a default camera?
+		if( m_defaultCamera == riley::CameraId::InvalidId() )
+		{
+			const auto matrix = Imath::M44f().scale( Imath::V3f( 1, 1, -1 ) );
+			m_defaultCamera = m_session->riley->CreateCamera(
+				riley::UserId(),
+				RtUString( "ieCoreRenderMan:defaultCamera" ),
+				/// \todo Projection?
+				{
+					riley::ShadingNode::Type::k_Projection, RtUString( "PxrCamera" ),
+					RtUString( "projection" ), RtParamList()
+				},
+				StaticTransform( matrix ),
+				RtParamList()
+			);
+		}
+		camera.id = m_defaultCamera;
+	}
+
+	riley::Extent extent = { 640, 480, 0 };
+	if( auto *resolution = camera.options.GetIntegerArray( Rix::k_Ri_FormatResolution, 2 ) )
+	{
+		extent.x = resolution[0];
+		extent.y = resolution[1];
+	}
+
+	// If we still have a render view, then it is valid for
+	// `m_outputs`, and all we need to do is update the camera and
+	// resolution.
+
+	if( m_renderView != riley::RenderViewId::InvalidId() )
+	{
+		if( extent.x != m_renderTargetExtent.x || extent.y != m_renderTargetExtent.y )
+		{
+			// Must only modify this if it has actually changed, because it causes
+			// Riley to close and reopen all the display drivers.
+			m_session->riley->ModifyRenderTarget(
+				m_renderTarget, nullptr, &extent, nullptr, nullptr, nullptr
+			);
+			m_renderTargetExtent = extent;
+		}
+		m_session->riley->ModifyRenderView(
+			m_renderView, nullptr, &camera.id, &m_integratorId, nullptr, nullptr, nullptr
+		);
+		return;
+	}
+
+	// Otherwise we need to build the render view from our list of outputs.
+
+	struct DisplayDefinition
+	{
+		RtUString driver;
+		vector<riley::RenderOutputId> outputs;
+		RtParamList driverParamList;
+	};
+
+	std::unordered_map<std::string, DisplayDefinition> displayDefinitions;
+	vector<riley::RenderOutputId> renderTargetOutputs;
+
+	for( const auto &[name, output] : m_outputs )
+	{
+		// Render outputs.
+
+		const vector<riley::RenderOutputId> &renderOutputs = acquireRenderOutputs( output.get());
+		if( renderOutputs.empty() )
+		{
+			IECore::msg( IECore::Msg::Warning, "RenderManRenderer", fmt::format( "Ignoring unsupported output {}", name.c_str() ) );
+			continue;
+		}
+
+		// Display driver. We allow multiple outputs to write to the same driver
+		// if their output (file)name matches.
+
+		DisplayDefinition &display = displayDefinitions[output->getName()];
+
+		string driver = output->getType();
+		if( driver == "exr" )
+		{
+			driver = "openexr";
+
+			int asRGBA = 0;
+			display.driverParamList.GetInteger( RtUString( "asrgba" ), asRGBA );
+			const string layerName = parameter<string>( output->parameters(), g_layerName, "" );
+			if( layerName.empty() || output->getData() == "rgb" || output->getData() == "rgba" )
+			{
+				asRGBA = 1;
+			}
+			display.driverParamList.SetInteger( RtUString( "asrgba" ), asRGBA );
+
+			for( const auto &[parameterName, parameterValue] : output->parameters() )
+			{
+				if( boost::starts_with( parameterName.c_str(), "header:" ) )
+				{
+					const string exrName = "exrheader_" + parameterName.string().substr( 7 );
+					ParamListAlgo::convertParameter( RtUString( exrName.c_str() ), parameterValue.get(), display.driverParamList );
+				}
+			}
+		}
+
+		/// \todo Check and warn for conflicting driver requirements. Also use a
+		/// prefix to identify driver parameters?
+		display.driver = RtUString( driver.c_str() );
+		ParamListAlgo::convertParameters( output->parameters(), display.driverParamList );
+
+		// For the most part it doesn't seem to matter what order we put the outputs
+		// in. But the `quicklyNoiseless` driver assumes that the first 4 channels are
+		// the ones to be passed through before denoising happens. So make sure we insert
+		// the beauty first - it is the only one to have two render outputs (the second
+		// one being for alpha).
+
+		const bool beauty = renderOutputs.size() == 2;
+
+		display.outputs.insert(
+			beauty ? display.outputs.begin() : display.outputs.end(),
+			renderOutputs.begin(), renderOutputs.end()
+		);
+
+		renderTargetOutputs.insert(
+			beauty ? renderTargetOutputs.begin() : renderTargetOutputs.end(),
+			renderOutputs.begin(), renderOutputs.end()
+		);
+	}
+
+	m_renderTarget = m_session->riley->CreateRenderTarget(
+		riley::UserId(),
+		{ (uint32_t)renderTargetOutputs.size(), renderTargetOutputs.data() },
+		// Why must the resolution be specified both here _and_ via the
+		// `k_Ri_FormatResolution` option? Riley only knows.
+		extent,
+		RtUString( "importance" ),
+		// Likewise, it's unclear what the relationship is between this
+		// and the `k_Ri_PixelVariance` option. We just specify them both
+		// to be on the safe side.
+		m_pixelVariance,
+		RtParamList()
+	);
+	m_renderTargetExtent = extent;
+
+	for( const auto &[name, definition] : displayDefinitions )
+	{
+		m_displays.push_back(
+			m_session->riley->CreateDisplay(
+				riley::UserId(),
+				m_renderTarget,
+				RtUString( name.c_str() ),
+				definition.driver,
+				{ (uint32_t)definition.outputs.size(), definition.outputs.data() },
+				definition.driverParamList
+			)
+		);
+	}
+
+	m_renderView = m_session->riley->CreateRenderView(
+		riley::UserId(),
+		m_renderTarget,
+		camera.id,
+		m_integratorId,
+		{ 0, nullptr },
+		{ 0, nullptr },
+		RtParamList()
+	);
+
+}
+
+void Globals::deleteRenderView()
+{
+	if( m_renderView == riley::RenderViewId::InvalidId() )
+	{
+		return;
+	}
+
+	m_session->riley->DeleteRenderView( m_renderView );
+	m_renderView = riley::RenderViewId::InvalidId();
+
+	for( const auto &display : m_displays )
+	{
+		m_session->riley->DeleteDisplay( display );
+	}
+	m_displays.clear();
+
+	m_session->riley->DeleteRenderTarget( m_renderTarget );
+	m_renderTarget = riley::RenderTargetId::InvalidId();
+}
+
+const std::vector<riley::RenderOutputId> &Globals::acquireRenderOutputs( const IECoreScene::Output *output )
+{
+	// Identify type and source.
+
+	const string layerName = parameter<string>( output->parameters(), g_layerName, "" );
+
+	std::optional<riley::RenderOutputType> type;
+	RtUString source;
+	if( output->getData() == "rgb" || output->getData() == "rgba" )
+	{
+		type = riley::RenderOutputType::k_Color;
+		source = RtUString( "Ci" );
+	}
+	else
+	{
+		vector<string> tokens;
+		StringAlgo::tokenize( output->getData(), ' ', tokens );
+		if( tokens.size() == 2 )
+		{
+			source = RtUString( tokens[1].c_str() );
+			if( tokens[0] == "color" )
+			{
+				type = riley::RenderOutputType::k_Color;
+			}
+			else if( tokens[0] == "float" )
+			{
+				type = riley::RenderOutputType::k_Float;
+			}
+			else if( tokens[0] == "int" )
+			{
+				type = riley::RenderOutputType::k_Integer;
+			}
+			else if( tokens[0] == "vector" )
+			{
+				type = riley::RenderOutputType::k_Vector;
+			}
+			else if( tokens[0] == "lpe" )
+			{
+				if( layerName == "normal" )
+				{
+					type = riley::RenderOutputType::k_Vector;
+				}
+				else
+				{
+					type = riley::RenderOutputType::k_Color;
+				}
+				source = RtUString( ( "lpe:" + tokens[1] ).c_str() );
+			}
+		}
+	}
+
+	if( !type )
+	{
+		static const vector<riley::RenderOutputId> g_emptyOutputs;
+		return g_emptyOutputs;
+	}
+
+	// The name that will be passed to the display driver. Note that this
+	// doesn't need to be unique among all render outputs.
+
+	RtUString renderOutputName = source;
+	if( !layerName.empty() )
+	{
+		renderOutputName = RtUString( layerName.c_str() );
+	}
+
+	// Additional parameters.
+
+	const RtUString accumulationRule( parameter( output->parameters(), "ri:accumulationRule", string( "filter" ) ).c_str() );
+	const float relativePixelVariance = parameter( output->parameters(), "ri:relativePixelVariance", 0.0f );
+
+	// Hash.
+
+	MurmurHash hash;
+	hash.append( renderOutputName.CStr() );
+	hash.append( *type );
+	hash.append( source.CStr() );
+	hash.append( accumulationRule.CStr() );
+	hash.append( m_pixelFilter.CStr() );
+	hash.append( m_pixelFilterSize.width );
+	hash.append( m_pixelFilterSize.height );
+	hash.append( output->getData() == "rgba" );
+
+	// Return previously created result if we have one.
+
+	vector<riley::RenderOutputId> &result = m_renderOutputs[hash];
+	if( result.size() )
+	{
+		return result;
+	}
+
+	// Otherwise create and return.
+
+	result.push_back(
+		m_session->riley->CreateRenderOutput(
+			riley::UserId(),
+			renderOutputName, *type, source,
+			accumulationRule, m_pixelFilter, m_pixelFilterSize, relativePixelVariance,
+			RtParamList()
+		)
+	);
+
+	if( output->getData() == "rgba" )
+	{
+		result.push_back(
+			m_session->riley->CreateRenderOutput(
+				riley::UserId(),
+				RtUString( "a" ), riley::RenderOutputType::k_Float, Rix::k_a,
+				accumulationRule, m_pixelFilter, m_pixelFilterSize, relativePixelVariance,
+				RtParamList()
+			)
+		);
+	}
+
+	return result;
+}

--- a/src/IECoreRenderMan/Globals.h
+++ b/src/IECoreRenderMan/Globals.h
@@ -1,0 +1,126 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Session.h"
+
+#include "IECoreScene/Output.h"
+#include "IECoreScene/Shader.h"
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "boost/noncopyable.hpp"
+
+#include <thread>
+
+namespace IECoreRenderMan
+{
+
+/// Handles global operations for Renderer. Creates and owns the
+/// Session, because a session cannot be created without a complete
+/// set of options.
+class Globals : public boost::noncopyable
+{
+
+	public :
+
+		Globals( IECoreScenePreview::Renderer::RenderType renderType, const IECore::MessageHandlerPtr &messageHandler );
+		~Globals();
+
+		void option( const IECore::InternedString &name, const IECore::Object *value );
+		void output( const IECore::InternedString &name, const IECoreScene::Output *output );
+
+		/// Creates the session on first call, using all the options specified
+		/// so far. We want to defer this call until the last moment possible,
+		/// as Riley doesn't support subsequent edits to many scene options.
+		Session *acquireSession();
+
+		void render();
+		void pause();
+
+	private :
+
+		bool worldBegun();
+		void updateIntegrator();
+		void updateRenderView();
+		void deleteRenderView();
+
+		const IECoreScenePreview::Renderer::RenderType m_renderType;
+		const IECore::MessageHandlerPtr m_messageHandler;
+
+		// We are not allowed to call anything in the Riley API before we've
+		// called `Riley::SetOptions()`. So we buffer all the options and outputs
+		// into the following member variables, and create the Riley session
+		// only when we must.
+
+		RtParamList m_options;
+		std::string m_cameraOption;
+		IECoreScene::ConstShaderPtr m_integratorToConvert;
+		std::unordered_map<IECore::InternedString, IECoreScene::ConstOutputPtr> m_outputs;
+		RtUString m_pixelFilter;
+		riley::FilterSize m_pixelFilterSize;
+		float m_pixelVariance;
+
+		// When we require the Riley session, we create it in `acquireSession()`.
+
+		std::unique_ptr<Session> m_session;
+
+		// Then once we have the session, we are free to use the Riley API
+		// to populate the scene, which we store in the following members.
+
+		riley::IntegratorId m_integratorId;
+		riley::CameraId m_defaultCamera;
+
+		// We assume RenderOutputs to be lightweight, and equivalent to
+		// an RiDisplayChannel. So we just make them on demand, and never
+		// destroy them in case we might reuse them later.
+		const std::vector<riley::RenderOutputId> &acquireRenderOutputs( const IECoreScene::Output *output );
+		std::unordered_map<IECore::MurmurHash, std::vector<riley::RenderOutputId>> m_renderOutputs;
+
+		std::vector<riley::DisplayId> m_displays;
+		riley::RenderTargetId m_renderTarget;
+		riley::Extent m_renderTargetExtent;
+		riley::RenderViewId m_renderView;
+
+		std::thread m_interactiveRenderThread;
+
+};
+
+
+
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -1,0 +1,237 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Light.h"
+
+#include "ShaderNetworkAlgo.h"
+#include "Transform.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+M44f correctiveTransform( const Attributes *attributes )
+{
+	if( !attributes->lightShader() )
+	{
+		return M44f();
+	}
+
+	const IECoreScene::Shader *lightShader = attributes->lightShader()->outputShader();
+	if( !lightShader )
+	{
+		return M44f();
+	}
+
+	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" )
+	{
+		return M44f().rotate( V3f( -M_PI_2, M_PI_2, 0.0f ) );
+	}
+	else if( lightShader->getName() == "PxrMeshLight" )
+	{
+		return M44f();
+	}
+	else
+	{
+		return M44f().scale( V3f( 1, 1, -1 ) );
+	}
+}
+
+} // namespace
+
+Light::Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, Session *session )
+	:	m_session( session ), m_lightShader( riley::LightShaderId::InvalidId() ),
+		m_lightInstance( riley::LightInstanceId::InvalidId() ), m_correctiveTransform( correctiveTransform( attributes ) ),
+		m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
+{
+	updateLightShader( attributes );
+	if( m_lightShader == riley::LightShaderId::InvalidId() )
+	{
+		// Riley crashes if we try to edit the transform on a light
+		// without a shader, so we just don't make such lights.
+		return;
+	}
+
+	const Material *material = attributes->lightMaterial();
+	m_lightInstance = m_session->createLightInstance(
+		m_geometryPrototype ? m_geometryPrototype->id() : riley::GeometryPrototypeId(),
+		material ? material->id() : riley::MaterialId(), m_lightShader, IdentityTransform(), attributes->instanceAttributes()
+	);
+}
+
+Light::~Light()
+{
+	if( m_session->renderType == IECoreScenePreview::Renderer::Interactive )
+	{
+		if( m_lightInstance != riley::LightInstanceId::InvalidId() )
+		{
+			m_session->deleteLightInstance( m_lightInstance );
+		}
+		if( m_lightShader != riley::LightShaderId::InvalidId() )
+		{
+			m_session->riley->DeleteLightShader( m_lightShader );
+		}
+	}
+}
+
+void Light::transform( const Imath::M44f &transform )
+{
+	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
+	{
+		return;
+	}
+
+	const M44f correctedTransform = m_correctiveTransform * transform;
+	StaticTransform staticTransform( correctedTransform );
+
+	const riley::LightInstanceResult result = m_session->modifyLightInstance(
+		m_lightInstance,
+		/* material = */ nullptr,
+		/* light shader = */ nullptr,
+		&staticTransform,
+		/* attributes = */ nullptr
+	);
+
+	if( result != riley::LightInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManLight::transform", "Unexpected edit failure" );
+	}
+}
+
+void Light::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+{
+	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
+	{
+		return;
+	}
+
+	vector<Imath::M44f> correctedSamples = samples;
+	for( auto &m : correctedSamples )
+	{
+		m = m_correctiveTransform * m;
+	}
+	AnimatedTransform animatedTransform( correctedSamples, times );
+
+	const riley::LightInstanceResult result = m_session->modifyLightInstance(
+		m_lightInstance,
+		/* material = */ nullptr,
+		/* light shader = */ nullptr,
+		&animatedTransform,
+		/* attributes = */ nullptr
+	);
+
+	if( result != riley::LightInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManLight::transform", "Unexpected edit failure" );
+	}
+}
+
+bool Light::attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+{
+	auto renderManAttributes = static_cast<const Attributes *>( attributes );
+	if( correctiveTransform( renderManAttributes ) != m_correctiveTransform )
+	{
+		// This can only happen when the light type changes, which is pretty unlikely.
+		// We don't know the light's transform, so just request that it be recreated.
+		return false;
+	}
+
+	updateLightShader( renderManAttributes );
+
+	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
+	{
+		// Occurs when we were created without a valid shader. We can't
+		// magic the light into existence now, even if the new
+		// attributes have a valid shader, because we don't know the
+		// transform. If we now have a shader, then return false to
+		// request that the whole object is sent again from scratch.
+		return m_lightShader == riley::LightShaderId::InvalidId();
+	}
+
+	if( m_lightShader == riley::LightShaderId::InvalidId() )
+	{
+		// Riley crashes when a light doesn't have a valid shader, so we delete the light.
+		// If we get a valid shader from a later attribute edit, we'll handle that above.
+		m_session->deleteLightInstance( m_lightInstance );
+		m_lightInstance = riley::LightInstanceId::InvalidId();
+		return true;
+	}
+
+	const Material *material = renderManAttributes->lightMaterial();
+	const riley::LightInstanceResult result = m_session->modifyLightInstance(
+		m_lightInstance,
+		/* material = */ material ? &material->id() : nullptr,
+		/* light shader = */ &m_lightShader,
+		/* xform = */ nullptr,
+		&renderManAttributes->instanceAttributes()
+	);
+
+	m_attributes = renderManAttributes;
+
+	if( result != riley::LightInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManLight::attributes", "Unexpected edit failure" );
+		return false;
+	}
+	return true;
+}
+
+void Light::link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects )
+{
+}
+
+void Light::assignID( uint32_t id )
+{
+}
+
+void Light::updateLightShader( const Attributes *attributes )
+{
+	if( m_lightShader != riley::LightShaderId::InvalidId() )
+	{
+		m_session->deleteLightShader( m_lightShader );
+		m_lightShader = riley::LightShaderId::InvalidId();
+	}
+
+	/// \todo Could manage light shaders in MaterialCache.
+	if( attributes->lightShader() )
+	{
+		std::vector<riley::ShadingNode> nodes = ShaderNetworkAlgo::convert( attributes->lightShader() );
+		m_lightShader = m_session->createLightShader( { (uint32_t)nodes.size(), nodes.data() } );
+	}
+}

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -1,0 +1,79 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "Attributes.h"
+#include "GeometryPrototypeCache.h"
+#include "Session.h"
+
+#include "Riley.h"
+
+namespace IECoreRenderMan
+{
+
+class Light : public IECoreScenePreview::Renderer::ObjectInterface
+{
+
+	public :
+
+		Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, Session *session );
+		~Light();
+
+		void transform( const Imath::M44f &transform ) override;
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
+		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
+		void assignID( uint32_t id ) override;
+
+	private :
+
+		void updateLightShader( const Attributes *attributes );
+
+		Session *m_session;
+		riley::LightShaderId m_lightShader;
+		riley::LightInstanceId m_lightInstance;
+		Imath::M44f m_correctiveTransform;
+		/// Used to keep material etc alive as long as we need it.
+		ConstAttributesPtr m_attributes;
+		/// Used to keep geometry prototype alive as long as we need it.
+		ConstGeometryPrototypePtr m_geometryPrototype;
+
+};
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/MaterialCache.cpp
+++ b/src/IECoreRenderMan/MaterialCache.cpp
@@ -1,0 +1,110 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "MaterialCache.h"
+
+#include "ShaderNetworkAlgo.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+MaterialCache::MaterialCache( const Session *session )
+	:	m_session( session )
+{
+}
+
+ConstMaterialPtr MaterialCache::getMaterial( const IECoreScene::ShaderNetwork *network )
+{
+	Cache::accessor a;
+	m_cache.insert( a, network ? network->Object::hash() : IECore::MurmurHash() );
+	if( !a->second )
+	{
+		std::vector<riley::ShadingNode> nodes = ShaderNetworkAlgo::convert( network );
+		riley::MaterialId id = m_session->riley->CreateMaterial( riley::UserId(), { (uint32_t)nodes.size(), nodes.data() }, RtParamList() );
+		a->second = new Material( id, m_session );
+	}
+	return a->second;
+}
+
+ConstDisplacementPtr MaterialCache::getDisplacement( const IECoreScene::ShaderNetwork *network )
+{
+	DisplacementCache::accessor a;
+	m_displacementCache.insert( a, network->Object::hash() );
+	if( !a->second )
+	{
+		std::vector<riley::ShadingNode> nodes = ShaderNetworkAlgo::convert( network );
+		a->second = new Displacement(
+			m_session->riley->CreateDisplacement( riley::UserId(), { (uint32_t)nodes.size(), nodes.data() }, RtParamList() ),
+			m_session
+		);
+	}
+	return a->second;
+}
+
+// Must not be called concurrently with anything.
+void MaterialCache::clearUnused()
+{
+	vector<IECore::MurmurHash> toErase;
+	for( const auto &m : m_cache )
+	{
+		if( m.second->refCount() == 1 )
+		{
+			// Only one reference - this is ours, so
+			// nothing outside of the cache is using the
+			// shader.
+			toErase.push_back( m.first );
+		}
+	}
+	for( const auto &e : toErase )
+	{
+		m_cache.erase( e );
+	}
+
+	toErase.clear();
+	for( const auto &m : m_displacementCache )
+	{
+		if( m.second->refCount() == 1 )
+		{
+			toErase.push_back( m.first );
+		}
+	}
+	for( const auto &e : toErase )
+	{
+		m_displacementCache.erase( e );
+	}
+}

--- a/src/IECoreRenderMan/MaterialCache.cpp
+++ b/src/IECoreRenderMan/MaterialCache.cpp
@@ -51,7 +51,7 @@ MaterialCache::MaterialCache( const Session *session )
 ConstMaterialPtr MaterialCache::getMaterial( const IECoreScene::ShaderNetwork *network )
 {
 	Cache::accessor a;
-	m_cache.insert( a, network ? network->Object::hash() : IECore::MurmurHash() );
+	m_cache.insert( a, network->Object::hash() );
 	if( !a->second )
 	{
 		std::vector<riley::ShadingNode> nodes = ShaderNetworkAlgo::convert( network );
@@ -68,10 +68,8 @@ ConstDisplacementPtr MaterialCache::getDisplacement( const IECoreScene::ShaderNe
 	if( !a->second )
 	{
 		std::vector<riley::ShadingNode> nodes = ShaderNetworkAlgo::convert( network );
-		a->second = new Displacement(
-			m_session->riley->CreateDisplacement( riley::UserId(), { (uint32_t)nodes.size(), nodes.data() }, RtParamList() ),
-			m_session
-		);
+		riley::DisplacementId id = m_session->riley->CreateDisplacement( riley::UserId(), { (uint32_t)nodes.size(), nodes.data() }, RtParamList() );
+		a->second = new Displacement( id, m_session );
 	}
 	return a->second;
 }

--- a/src/IECoreRenderMan/MaterialCache.h
+++ b/src/IECoreRenderMan/MaterialCache.h
@@ -1,0 +1,82 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECoreScene/ShaderNetwork.h"
+
+#include "IECore/RefCounted.h"
+
+#include "RefCountedId.h"
+#include "Session.h"
+
+#include "tbb/concurrent_hash_map.h"
+
+namespace IECoreRenderMan
+{
+
+using Material = RefCountedId<riley::MaterialId>;
+IE_CORE_DECLAREPTR( Material );
+using Displacement = RefCountedId<riley::DisplacementId>;
+IE_CORE_DECLAREPTR( Displacement );
+
+class MaterialCache
+{
+
+	public :
+
+		MaterialCache( const Session *session );
+
+		// Can be called concurrently with other calls to `get()`
+		ConstMaterialPtr getMaterial( const IECoreScene::ShaderNetwork *network );
+		ConstDisplacementPtr getDisplacement( const IECoreScene::ShaderNetwork *network );
+
+		// Must not be called concurrently with anything.
+		void clearUnused();
+
+	private :
+
+		const Session *m_session;
+
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, ConstMaterialPtr>;
+		Cache m_cache;
+
+		using DisplacementCache = tbb::concurrent_hash_map<IECore::MurmurHash, ConstDisplacementPtr>;
+		DisplacementCache m_displacementCache;
+
+};
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -1,0 +1,143 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Object.h"
+
+#include "Transform.h"
+
+using namespace std;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+static riley::CoordinateSystemList g_emptyCoordinateSystems = { 0, nullptr };
+
+} // namespace
+
+Object::Object( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session )
+	:	m_session( session ), m_geometryInstance( riley::GeometryInstanceId::InvalidId() ), m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
+{
+	m_geometryInstance = m_session->riley->CreateGeometryInstance(
+		riley::UserId(),
+		/* group = */ riley::GeometryPrototypeId::InvalidId(),
+		m_geometryPrototype->id(),
+		m_attributes->surfaceMaterial()->id(),
+		g_emptyCoordinateSystems,
+		IdentityTransform(),
+		m_attributes->instanceAttributes()
+	);
+}
+
+Object::~Object()
+{
+	if( m_session->renderType == IECoreScenePreview::Renderer::Interactive )
+	{
+		if( m_geometryInstance != riley::GeometryInstanceId::InvalidId() )
+		{
+			m_session->riley->DeleteGeometryInstance( riley::GeometryPrototypeId::InvalidId(), m_geometryInstance );
+		}
+	}
+}
+
+void Object::transform( const Imath::M44f &transform )
+{
+	StaticTransform staticTransform( transform );
+	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(
+		/* group = */ riley::GeometryPrototypeId::InvalidId(),
+		m_geometryInstance,
+		/* material = */ nullptr,
+		/* coordsys = */ nullptr,
+		&staticTransform,
+		/* attributes = */ nullptr
+	);
+
+	if( result != riley::GeometryInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManObject::transform", "Unexpected edit failure" );
+	}
+}
+
+void Object::transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times )
+{
+	AnimatedTransform animatedTransform( samples, times );
+	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(
+		/* group = */ riley::GeometryPrototypeId::InvalidId(),
+		m_geometryInstance,
+		/* material = */ nullptr,
+		/* coordsys = */ nullptr,
+		&animatedTransform,
+		/* attributes = */ nullptr
+	);
+
+	if( result != riley::GeometryInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManObject::transform", "Unexpected edit failure" );
+	}
+}
+
+bool Object::attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
+{
+	const Attributes *typedAttributes = static_cast<const Attributes *>( attributes );
+	if( typedAttributes->prototypeHash() != m_attributes->prototypeHash() )
+	{
+		return false;
+	}
+
+	const riley::GeometryInstanceResult result = m_session->riley->ModifyGeometryInstance(
+		/* group = */ riley::GeometryPrototypeId::InvalidId(),
+		m_geometryInstance,
+		&typedAttributes->surfaceMaterial()->id(),
+		/* coordsys = */ nullptr,
+		/* xform = */ nullptr,
+		&typedAttributes->instanceAttributes()
+	);
+	m_attributes = typedAttributes;
+
+	if( result != riley::GeometryInstanceResult::k_Success )
+	{
+		IECore::msg( IECore::Msg::Warning, "RenderManObject::attributes", "Unexpected edit failure" );
+	}
+	return true;
+}
+
+void Object::link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects )
+{
+}
+
+void Object::assignID( uint32_t id )
+{
+}

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -1,0 +1,78 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Attributes.h"
+#include "GeometryPrototypeCache.h"
+#include "Session.h"
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+namespace IECoreRenderMan
+{
+
+class Object : public IECoreScenePreview::Renderer::ObjectInterface
+{
+
+	public :
+
+		Object( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session );
+		~Object();
+
+		/// \todo RenderMan volumes seem to reject attempts to transform them
+		/// after creation, althought we get lucky and the first one works
+		/// despite returning a failure code. Perhaps we need to add transform
+		/// arguments to `Renderer::object()` and to be able to return a `bool`
+		/// here to request that the object is sent again instead?
+		void transform( const Imath::M44f &transform ) override;
+		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;
+		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
+		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
+		void assignID( uint32_t id ) override;
+
+	private :
+
+		const Session *m_session;
+		riley::GeometryInstanceId m_geometryInstance;
+		/// Used to keep material etc alive as long as we need it.
+		ConstAttributesPtr m_attributes;
+		/// Used to keep geometry prototype alive as long as we need it.
+		ConstGeometryPrototypePtr m_geometryPrototype;
+
+};
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/RefCountedId.h
+++ b/src/IECoreRenderMan/RefCountedId.h
@@ -1,0 +1,94 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECore/RefCounted.h"
+
+#include "Session.h"
+
+namespace IECoreRenderMan
+{
+
+/// A reference-counted Riley Id, allowing an Id to be shared between multiple
+/// clients. When the last client drops ownership, the Riley entity corresponding
+/// to the Id is deleted.
+template<typename T>
+class RefCountedId : public IECore::RefCounted
+{
+
+	public :
+
+		RefCountedId( T id, const Session *session )
+			:	m_session( session ), m_id( id )
+		{
+
+		}
+
+		~RefCountedId() override
+		{
+			if( m_session->renderType != IECoreScenePreview::Renderer::Interactive )
+			{
+				return;
+			}
+
+			if constexpr( std::is_same_v<T, riley::MaterialId> )
+			{
+				m_session->riley->DeleteMaterial( m_id );
+			}
+			else if constexpr( std::is_same_v<T, riley::DisplacementId> )
+			{
+				m_session->riley->DeleteDisplacement( m_id );
+			}
+			// Deliberately not checking type for the last case, so that we get
+			// a compilation error if compiled for types we haven't added a
+			// delete for.
+			else
+			{
+				m_session->riley->DeleteGeometryPrototype( m_id );
+			}
+		}
+
+		const T &id() const { return m_id; }
+
+	private :
+
+		const Session *m_session;
+		T m_id;
+
+};
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -1,0 +1,254 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Attributes.h"
+#include "Camera.h"
+#include "GeometryAlgo.h"
+#include "GeometryPrototypeCache.h"
+#include "Globals.h"
+#include "Light.h"
+#include "MaterialCache.h"
+#include "Globals.h"
+#include "Object.h"
+#include "ParamListAlgo.h"
+#include "Session.h"
+#include "Transform.h"
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "IECoreScene/MeshPrimitive.h"
+
+#include "IECore/SimpleTypedData.h"
+
+#include "Riley.h"
+#include "RixPredefinedStrings.hpp"
+
+#include "tbb/spin_rw_mutex.h"
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+const CompoundDataMap::value_type g_forMeshLightBlindData( "__ieCoreRenderMan:forMeshLight", new BoolData( true ) );
+
+class RenderManRenderer final : public IECoreScenePreview::Renderer
+{
+
+	public :
+
+		RenderManRenderer( RenderType renderType, const std::string &fileName, const MessageHandlerPtr &messageHandler )
+			:	m_messageHandler( messageHandler ), m_session( nullptr )
+		{
+			if( renderType == SceneDescription )
+			{
+				throw IECore::Exception( "SceneDescription mode not supported by RenderMan" );
+			}
+
+			bool haveInstance = false;
+			if( !g_haveInstance.compare_exchange_strong( haveInstance, true ) )
+			{
+				throw IECore::Exception( "RenderMan doesn't allow multiple active sessions" );
+			}
+
+			m_globals = std::make_unique<Globals>( renderType, messageHandler );
+		}
+
+		~RenderManRenderer() override
+		{
+			m_materialCache.reset();
+			m_geometryPrototypeCache.reset();
+			m_globals.reset();
+			g_haveInstance = false;
+		}
+
+		IECore::InternedString name() const override
+		{
+			return "RenderMan";
+		}
+
+		void option( const IECore::InternedString &name, const IECore::Object *value ) override
+		{
+			m_globals->option( name, value );
+		}
+
+		void output( const IECore::InternedString &name, const Output *output ) override
+		{
+			m_globals->output( name, output );
+		}
+
+		Renderer::AttributesInterfacePtr attributes( const IECore::CompoundObject *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+			return new Attributes( attributes, m_materialCache.get() );
+		}
+
+		ObjectInterfacePtr camera( const std::string &name, const IECoreScene::Camera *camera, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			IECoreRenderMan::CameraPtr result = new IECoreRenderMan::Camera( name, camera, acquireSession() );
+			result->attributes( attributes );
+			return result;
+		}
+
+		ObjectInterfacePtr light( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+
+			auto typedAttributes = static_cast<const Attributes *>( attributes );
+
+			ConstGeometryPrototypePtr geometryPrototype;
+			if( auto mesh = runTimeCast<const MeshPrimitive>( object ) )
+			{
+				// RenderMan refuses to share mesh prototypes between GeometryInstances and
+				// LightInstances, so we insert some blind data to give the mesh geometry
+				// a different hash, causing the GeometryPrototypeCache to create a prototype
+				// that won't be used by `Renderer::object()`.
+				MeshPrimitivePtr meshCopy = mesh->copy();
+				meshCopy->blindData()->writable().insert( g_forMeshLightBlindData );
+				geometryPrototype = m_geometryPrototypeCache->get( meshCopy.get(), typedAttributes, /* messageContext = */ name );
+			}
+
+			return new IECoreRenderMan::Light( geometryPrototype, typedAttributes, m_session );
+		}
+
+		ObjectInterfacePtr lightFilter( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			return nullptr;
+		}
+
+		Renderer::ObjectInterfacePtr object( const std::string &name, const IECore::Object *object, const AttributesInterface *attributes ) override
+		{
+			if( !object )
+			{
+				return nullptr;
+			}
+
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+
+			auto typedAttributes = static_cast<const Attributes *>( attributes );
+			ConstGeometryPrototypePtr geometryPrototype = m_geometryPrototypeCache->get( object, typedAttributes, /* messageContext = */ name );
+			if( !geometryPrototype )
+			{
+				return nullptr;
+			}
+
+			return new IECoreRenderMan::Object( geometryPrototype, typedAttributes, m_session );
+		}
+
+		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+
+			auto typedAttributes = static_cast<const Attributes *>( attributes );
+			ConstGeometryPrototypePtr geometryPrototype = m_geometryPrototypeCache->get( samples, times, typedAttributes, /* messageContext = */ name );
+			if( !geometryPrototype )
+			{
+				return nullptr;
+			}
+
+			return new IECoreRenderMan::Object( geometryPrototype, typedAttributes, m_session );
+		}
+
+		void render() override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			acquireSession();
+			m_materialCache->clearUnused();
+			m_globals->render();
+		}
+
+		void pause() override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			m_globals->pause();
+		}
+
+		IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters ) override
+		{
+			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			return nullptr;
+		}
+
+	private :
+
+		IECore::MessageHandlerPtr m_messageHandler;
+		std::unique_ptr<Globals> m_globals;
+
+		// Used to acquire the Session via `m_globals` at the first point we need it.
+		// Also initialises other members that depend on the session. Needs to be thread-safe
+		// because it is called from `object()`, `attributes()` etc.
+		Session *acquireSession()
+		{
+			tbb::spin_rw_mutex::scoped_lock lock( m_acquireSessionMutex, /* write = */ false );
+			if( !m_session )
+			{
+				lock.upgrade_to_writer();
+				if( !m_session )
+				{
+					m_session = m_globals->acquireSession();
+					m_materialCache = std::make_unique<MaterialCache>( m_session );
+					m_geometryPrototypeCache = std::make_unique<GeometryPrototypeCache>( m_session );
+				}
+			}
+			return m_session;
+		}
+
+		tbb::spin_rw_mutex m_acquireSessionMutex;
+		// The following members may only be accessed after calling
+		// `acquireSession()`.
+		Session *m_session;
+		std::unique_ptr<MaterialCache> m_materialCache;
+		std::unique_ptr<GeometryPrototypeCache> m_geometryPrototypeCache;
+
+		static Renderer::TypeDescription<RenderManRenderer> g_typeDescription;
+		static std::atomic_bool g_haveInstance;
+
+};
+
+IECoreScenePreview::Renderer::TypeDescription<RenderManRenderer> RenderManRenderer::g_typeDescription( "RenderMan" );
+std::atomic_bool RenderManRenderer::g_haveInstance = false;
+
+} // namespace

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -56,7 +56,11 @@
 #include "Riley.h"
 #include "RixPredefinedStrings.hpp"
 
+#include "boost/algorithm/string/predicate.hpp"
+
 #include "tbb/spin_rw_mutex.h"
+
+#include "fmt/format.h"
 
 using namespace std;
 using namespace Imath;
@@ -209,6 +213,10 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 		IECore::DataPtr command( const IECore::InternedString name, const IECore::CompoundDataMap &parameters ) override
 		{
 			const IECore::MessageHandler::Scope messageScope( m_messageHandler.get() );
+			if( boost::starts_with( name.string(), "ri:" ) || name.string().find( ":" ) == string::npos )
+			{
+				IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Renderer::command", fmt::format( "Unknown command \"{}\".", name.c_str() ) );
+			}
 			return nullptr;
 		}
 

--- a/src/IECoreRenderMan/Session.cpp
+++ b/src/IECoreRenderMan/Session.cpp
@@ -74,7 +74,7 @@ const riley::CoordinateSystemList g_emptyCoordinateSystems = { 0, nullptr };
 //
 // I don't really know why this is, but I assume that somehow the name
 // is used to share an acceleration table or some such behind the scenes.
-// Why it is should be our responsibility to facilitate that is beyond me.
+// Why it should be our responsibility to facilitate that is beyond me.
 RtUString portalName( RtUString colorMap, const RtMatrix4x4 domeTransform, const RtMatrix4x4 portalTransform )
 {
 	Imath::V3f domeRotation;

--- a/src/IECoreRenderMan/Session.cpp
+++ b/src/IECoreRenderMan/Session.cpp
@@ -1,0 +1,457 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "Session.h"
+
+#include "Imath/ImathMatrixAlgo.h"
+
+#include "RixPredefinedStrings.hpp"
+#include "XcptErrorCodes.h"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+const RtUString g_domeColorMapUStr( "domeColorMap" );
+const RtUString g_intensityUStr( "intensity" );
+const RtUString g_intensityMultUStr( "intensityMult" );
+const RtUString g_lightingMuteUStr( "lighting:mute" );
+const RtUString g_lightColorUStr( "lightColor" );
+const RtUString g_lightColorMapUStr( "lightColorMap" );
+const RtUString g_portalNameUStr( "portalName" );
+const RtUString g_portalToDomeUStr( "portalToDome" );
+const RtUString g_pxrDomeLightUStr( "PxrDomeLight" );
+const RtUString g_pxrPortalLightUStr( "PxrPortalLight" );
+const RtUString g_tintUStr( "tint" );
+
+const riley::CoordinateSystemList g_emptyCoordinateSystems = { 0, nullptr };
+
+// Returns a unique portal name based on a color map and rotation, to
+// satisfy these requirements from the RenderMan docs :
+//
+// > All portal lights that are associated with the same parent dome light
+// > and the same portal name must have the same rotation. If you need
+// > to change a portal light's rotation, then you need to have a new portal
+// > name. However, different translation and scaling can share the same portal
+// > name.
+//
+// I don't really know why this is, but I assume that somehow the name
+// is used to share an acceleration table or some such behind the scenes.
+// Why it is should be our responsibility to facilitate that is beyond me.
+RtUString portalName( RtUString colorMap, const RtMatrix4x4 domeTransform, const RtMatrix4x4 portalTransform )
+{
+	Imath::V3f domeRotation;
+	Imath::extractEulerXYZ( Imath::M44f( domeTransform.m ), domeRotation );
+
+	Imath::V3f portalRotation;
+	Imath::extractEulerXYZ( Imath::M44f( portalTransform.m ), portalRotation );
+
+	IECore::MurmurHash h;
+	if( !colorMap.Empty() )
+	{
+		h.append( colorMap.CStr() );
+	}
+	h.append( domeRotation );
+	h.append( portalRotation );
+
+	return RtUString( h.toString().c_str() );
+}
+
+} // namespace
+
+struct Session::ExceptionHandler : public RixXcpt::XcptHandler
+{
+
+	ExceptionHandler( const IECore::MessageHandlerPtr &messageHandler )
+		:	m_messageHandler( messageHandler )
+	{
+	}
+
+	void HandleXcpt( int code, int severity, const char *message ) override
+	{
+		IECore::Msg::Level level;
+		switch( severity )
+		{
+			case RIE_INFO :
+				level = IECore::Msg::Level::Info;
+				break;
+			case RIE_WARNING :
+				level = IECore::Msg::Level::Warning;
+				break;
+			default :
+				level = IECore::Msg::Level::Error;
+				break;
+		}
+
+		m_messageHandler->handle( level, "RenderMan", message );
+	}
+
+	void HandleExitRequest( int code ) override
+	{
+		/// \todo Not sure how best to handle this. We don't want
+		/// to exit the application, but perhaps we want to prevent
+		/// any further attempt to interact with the renderer?
+	}
+
+	private :
+
+		IECore::MessageHandlerPtr m_messageHandler;
+
+};
+
+
+Session::Session( IECoreScenePreview::Renderer::RenderType renderType, const RtParamList &options, const IECore::MessageHandlerPtr &messageHandler )
+	:	riley( nullptr ), renderType( renderType ), m_portalsDirty( false )
+{
+	// `argv[0]==""` prevents RenderMan doing its own signal handling.
+	vector<const char *> args = { "" };
+	PRManSystemBegin( args.size(), args.data() );
+	PRManRenderBegin( args.size(), args.data() );
+
+	if( messageHandler )
+	{
+		m_exceptionHandler = std::make_unique<ExceptionHandler>( messageHandler );
+		auto rixXcpt = (RixXcpt *)RixGetContext()->GetRixInterface( k_RixXcpt );
+		rixXcpt->Register( m_exceptionHandler.get() );
+	}
+
+	auto rileyManager = (RixRileyManager *)RixGetContext()->GetRixInterface( k_RixRileyManager );
+	/// \todo What is the `rileyVariant` argument for? XPU?
+	riley = rileyManager->CreateRiley( RtUString(), RtParamList() );
+
+	riley->SetOptions( options );
+}
+
+Session::~Session()
+{
+	auto rileyManager = (RixRileyManager *)RixGetContext()->GetRixInterface( k_RixRileyManager );
+	rileyManager->DestroyRiley( riley );
+
+	if( m_exceptionHandler )
+	{
+		auto rixXcpt = (RixXcpt *)RixGetContext()->GetRixInterface( k_RixXcpt );
+		rixXcpt->Unregister( m_exceptionHandler.get() );
+	}
+
+	PRManRenderEnd();
+	PRManSystemEnd();
+}
+
+riley::CameraId Session::createCamera( RtUString name, const riley::ShadingNode &projection, const riley::Transform &transform, const RtParamList &properties, const RtParamList &options )
+{
+	riley::CameraId result = riley->CreateCamera( riley::UserId(), name, projection, transform, properties );
+	std::lock_guard lock( m_camerasMutex );
+	m_cameras.insert( { name.CStr(), result, options } );
+	return result;
+}
+
+void Session::deleteCamera( riley::CameraId cameraId )
+{
+	riley->DeleteCamera( cameraId );
+	std::lock_guard lock( m_camerasMutex );
+	m_cameras.erase( cameraId );
+}
+
+
+riley::LightShaderId Session::createLightShader( const riley::ShadingNetwork &light )
+{
+	riley::LightShaderId result = riley->CreateLightShader( riley::UserId(), light, { 0, nullptr } );
+	RtUString type = light.nodeCount ? light.nodes[light.nodeCount-1].name : RtUString();
+	if( type == g_pxrDomeLightUStr || type == g_pxrPortalLightUStr )
+	{
+		LightShaderInfo &lightShaderInfo = m_domeAndPortalShaders[result.AsUInt32()];
+		assert( lightShaderInfo.shaders.empty() ); // ID should be unique.
+		lightShaderInfo.shaders.insert( lightShaderInfo.shaders.end(), light.nodes, light.nodes + light.nodeCount );
+		m_portalsDirty = true;
+	}
+
+	return result;
+}
+
+void Session::deleteLightShader( riley::LightShaderId lightShaderId )
+{
+	riley->DeleteLightShader( lightShaderId );
+	auto it = m_domeAndPortalShaders.find( lightShaderId.AsUInt32() );
+	if( it != m_domeAndPortalShaders.end() )
+	{
+		// We can't erase from the map immediately because that isn't
+		// thread-safe. Instead just clear the shaders and erase in
+		// `updatePortals()`. We can safely call `clear()` because
+		// there will be no concurrent access to this _particular_ map
+		// entry - the light shader is being deleted, so it would be
+		// a coding error to try to use it in another thread anyway.
+		it->second.shaders.clear();
+		m_portalsDirty = true;
+	}
+}
+
+riley::LightInstanceId Session::createLightInstance( riley::GeometryPrototypeId geometry, riley::MaterialId materialId, riley::LightShaderId lightShaderId, const riley::Transform &transform, const RtParamList &attributes )
+{
+	riley::LightInstanceId result = riley->CreateLightInstance(
+		riley::UserId(), riley::GeometryPrototypeId(), geometry,
+		materialId, lightShaderId,
+		g_emptyCoordinateSystems, transform, attributes
+	);
+
+	if( m_domeAndPortalShaders.count( lightShaderId.AsUInt32() ) )
+	{
+		m_domeAndPortalLights[result.AsUInt32()] = {
+			lightShaderId,
+			*transform.matrix,
+			attributes
+		};
+		m_portalsDirty = true;
+	}
+
+	return result;
+}
+
+riley::LightInstanceResult Session::modifyLightInstance(
+	riley::LightInstanceId lightInstanceId, const riley::MaterialId *materialId, const riley::LightShaderId *lightShaderId, const riley::Transform *transform,
+	const RtParamList *attributes
+)
+{
+	riley::LightInstanceResult result = riley->ModifyLightInstance(
+		riley::GeometryPrototypeId(), lightInstanceId,
+		materialId, lightShaderId, nullptr, transform, attributes
+	);
+
+	/// \todo Consider the possibility of a non-portal/dome turning
+	/// into a portal/dome. We'll have incomplete information, so
+	/// perhaps should fail the edit, and cause the controller to
+	/// re-send.
+
+	auto it = m_domeAndPortalLights.find( lightInstanceId.AsUInt32() );
+	if( it != m_domeAndPortalLights.end() )
+	{
+		if( lightShaderId )
+		{
+			it->second.lightShader = *lightShaderId;
+		}
+		if( transform )
+		{
+			it->second.transform = *(transform->matrix);
+		}
+		if( attributes )
+		{
+			it->second.attributes = *attributes;
+		}
+		m_portalsDirty = true;
+	}
+
+	return result;
+}
+
+void Session::deleteLightInstance( riley::LightInstanceId lightInstanceId )
+{
+	riley->DeleteLightInstance( riley::GeometryPrototypeId(), lightInstanceId );
+	auto it = m_domeAndPortalLights.find( lightInstanceId.AsUInt32() );
+	if( it != m_domeAndPortalLights.end() )
+	{
+		// Can't erase now - mark for removal in `updatePortals()`.
+		it->second.lightShader = riley::LightShaderId::InvalidId();
+		m_portalsDirty = true;
+	}
+}
+
+Session::CameraInfo Session::cameraInfo( const std::string &name ) const
+{
+	std::lock_guard lock( m_camerasMutex );
+	const auto &nameIndex = m_cameras.get<1>();
+	auto it = nameIndex.find( name );
+	if( it != nameIndex.end() )
+	{
+		return *it;
+	}
+
+	return { "", riley::CameraId::InvalidId(), RtParamList() };
+}
+
+void Session::updatePortals()
+{
+	if( !m_portalsDirty )
+	{
+		return;
+	}
+
+	// Clean up any zombies created by `deleteLightShader()`.
+
+	for( auto it = m_domeAndPortalShaders.begin(); it != m_domeAndPortalShaders.end(); )
+	{
+		if( it->second.shaders.empty() )
+		{
+			it = m_domeAndPortalShaders.unsafe_erase( it );
+		}
+		else
+		{
+			++it;
+		}
+	}
+
+	// Find the dome light, while cleaning up any zombies created
+	// by `deleteLightInstance()`.
+
+	auto isPortal = [&] ( riley::LightShaderId lightShader ) {
+		auto it = m_domeAndPortalShaders.find( lightShader.AsUInt32() );
+		if( it != m_domeAndPortalShaders.end() )
+		{
+			return it->second.shaders.back().name == g_pxrPortalLightUStr;
+		}
+		return false;
+	};
+
+	const LightInfo *domeLight = nullptr;
+	bool havePortals = false;
+	size_t numDomes = 0;
+	for( auto it = m_domeAndPortalLights.begin(); it != m_domeAndPortalLights.end(); )
+	{
+		if( it->second.lightShader == riley::LightShaderId::InvalidId() )
+		{
+			it = m_domeAndPortalLights.unsafe_erase( it );
+			continue;
+		}
+
+		if( isPortal( it->second.lightShader ) )
+		{
+			havePortals = true;
+		}
+		else
+		{
+			numDomes++;
+			if( !domeLight )
+			{
+				domeLight = &it->second;
+			}
+		}
+		++it;
+	}
+
+	if( havePortals && numDomes > 1 )
+	{
+		/// \todo To support multiple domes, we need to add a mechanism for
+		/// linking them to portals. Perhaps this can be achieved via
+		/// `ObjectInterface::link()`?
+		IECore::msg( IECore::Msg::Warning, "IECoreRenderMan::Renderer", "PxrPortalLights combined with multiple PxrDomeLights are not yet supported" );
+	}
+
+	// Link the lights appropriately.
+
+	RtParamList mutedAttributes;
+	mutedAttributes.SetInteger( Rix::k_lighting_mute, 1 );
+
+	for( const auto &[id, info] : m_domeAndPortalLights )
+	{
+		if( isPortal( info.lightShader ) )
+		{
+			// Connect portals to dome if we have one,
+			// otherwise mute them.
+			if( domeLight )
+			{
+				// Copy parameters from dome to portal, since we want users
+				// to control them all in one place, not on each individual portal.
+				// Portal lights have all the same parameters as dome lights, so this
+				// is easy.
+				const RtParamList &domeParams = m_domeAndPortalShaders.at( domeLight->lightShader.AsUInt32() ).shaders.back().params;
+				LightShaderInfo &portalShader = m_domeAndPortalShaders.at( info.lightShader.AsUInt32() );
+				RtParamList &portalParams = portalShader.shaders.back().params;
+				portalParams.Update( domeParams );
+				//  Except that `lightColorMap` is unhelpfully renamed to
+				// `domeColorMap`, so sort that out.
+				portalParams.Remove( g_lightColorMapUStr );
+				RtUString colorMap; domeParams.GetString( g_lightColorMapUStr, colorMap );
+				portalParams.SetString( g_domeColorMapUStr, colorMap );
+				// And of course the portal shader couldn't possibly apply tint
+				// etc itself. That is obviously the responsibility of every
+				// single bridge project.
+				float intensity = 1;
+				portalParams.GetFloat( g_intensityUStr, intensity );
+				float intensityMult = 1;
+				portalParams.GetFloat( g_intensityMultUStr, intensityMult );
+				pxrcore::ColorRGB lightColor( 1, 1, 1 );
+				portalParams.GetColor( g_lightColorUStr, lightColor );
+				pxrcore::ColorRGB tint( 1, 1, 1 );
+				portalParams.GetColor( g_tintUStr, tint );
+				intensity = intensity * intensityMult;
+				portalParams.SetFloat( g_intensityUStr, intensity );
+				lightColor = lightColor * tint;
+				portalParams.SetColor( g_lightColorUStr, lightColor );
+
+				// We are also responsible for adding a parameter providing the
+				// transform between the portal and the dome.
+				RtMatrix4x4 domeInverse; domeInverse.Identity();
+				domeLight->transform.Inverse( &domeInverse );
+				const RtMatrix4x4 portalToDome = info.transform * domeInverse;
+				portalParams.SetMatrix( g_portalToDomeUStr, portalToDome );
+
+				// And most bizarrely of all, we are required to compute `portalName`,
+				// which must change any time the rotation does.
+				portalParams.SetString( g_portalNameUStr, portalName( colorMap, domeLight->transform, info.transform ) );
+
+				// Update the light shader. We can modify the existing one in
+				// place because we know we're only using it on this one light.
+				riley::ShadingNetwork shaders = { (uint32_t)portalShader.shaders.size(), portalShader.shaders.data() };
+				riley->ModifyLightShader( info.lightShader, &shaders, /* lightFilter = */ nullptr );
+
+				// Unmute, in case we muted previously due to lack of a dome.
+				riley->ModifyLightInstance(
+					riley::GeometryPrototypeId(), riley::LightInstanceId( id ),
+					nullptr, nullptr, nullptr, nullptr, &info.attributes
+				);
+			}
+			else
+			{
+				riley->ModifyLightInstance(
+					riley::GeometryPrototypeId(), riley::LightInstanceId( id ),
+					nullptr, nullptr, nullptr, nullptr, &mutedAttributes
+				);
+			}
+		}
+		else
+		{
+			// Mute domes if there are portals.
+			riley->ModifyLightInstance(
+				riley::GeometryPrototypeId(), riley::LightInstanceId( id ),
+				nullptr, nullptr, nullptr, nullptr, havePortals ? &mutedAttributes : &info.attributes
+			);
+		}
+	}
+
+	m_portalsDirty = false;
+}

--- a/src/IECoreRenderMan/Session.h
+++ b/src/IECoreRenderMan/Session.h
@@ -1,0 +1,174 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+
+#include "Riley.h"
+
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/ordered_index.hpp"
+#include "boost/multi_index_container.hpp"
+
+#include "tbb/concurrent_hash_map.h"
+#include "tbb/concurrent_unordered_map.h"
+
+#include <mutex>
+
+namespace IECoreRenderMan
+{
+
+/// Owns a Riley instance and tracks shared state to facilitate communication
+/// between the various Renderer subcomponents. Riley is essentially a "write only"
+/// API, so if we want access to any state we need to track it ourselves.
+struct Session
+{
+
+	/// Options must be provided at construction time, as Riley requires them to
+	/// be set before any other operations can take place (and indeed, will crash
+	/// if the Riley instance is destroyed without `SetOptions()` being called).
+	Session( IECoreScenePreview::Renderer::RenderType renderType, const RtParamList &options, const IECore::MessageHandlerPtr &messageHandler );
+	~Session();
+
+	riley::Riley *riley;
+	const IECoreScenePreview::Renderer::RenderType renderType;
+
+	/// Riley API Wrappers
+	/// ==================
+	///
+	/// These functions all wrap the equivalent Riley methods directly, allowing
+	/// the Session to track state that Riley does not provide queries for. This
+	/// is necessary for handling some of the more awkward mappings from the
+	/// `IECoreScene::Renderer` API to the Riley API.
+	///
+	/// > Note : Where a wrapper exists, you _must_ use it in preference to calling
+	/// > Riley directly. Where no wrapper exists for a Riley method, then that method
+	/// > may be called directly.
+
+	/// Cameras
+	/// -------
+
+	/// > Note : The `options` argument is not for `Riley::CreateCamera()`, but is
+	/// > a session-specific argument used to pass resolution etc from the camera to
+	/// > the session's options.
+	riley::CameraId createCamera( RtUString name, const riley::ShadingNode &projection, const riley::Transform &transform, const RtParamList &properties, const RtParamList &options );
+	void deleteCamera( riley::CameraId cameraId );
+
+	/// Lights
+	/// ------
+
+	riley::LightShaderId createLightShader( const riley::ShadingNetwork &light );
+	void deleteLightShader( riley::LightShaderId lightShaderId );
+
+	riley::LightInstanceId createLightInstance( riley::GeometryPrototypeId geometry, riley::MaterialId materialId, riley::LightShaderId lightShaderId, const riley::Transform &transform, const RtParamList &attributes );
+	riley::LightInstanceResult modifyLightInstance(
+		riley::LightInstanceId lightInstanceId, const riley::MaterialId *materialId, const riley::LightShaderId *lightShaderId, const riley::Transform *transform,
+		const RtParamList *attributes
+	);
+	void deleteLightInstance( riley::LightInstanceId lightInstanceId );
+
+	/// Camera Queries
+	/// ==============
+
+	struct CameraInfo
+	{
+		std::string name;
+		riley::CameraId id;
+		RtParamList options;
+	};
+
+	/// Returns information about the camera with the specified name.
+	CameraInfo cameraInfo( const std::string &name ) const;
+
+	/// Light Synchronisation
+	/// =====================
+
+	/// Should be called before rendering to update the links between
+	/// portal lights and the associated dome light.
+	void updatePortals();
+
+	private :
+
+		struct ExceptionHandler;
+		std::unique_ptr<ExceptionHandler> m_exceptionHandler;
+
+		// Map for tracking cameras. We need to index this with both CameraId and name,
+		// so use `multi_index_container`. We don't anticipate many cameras being created
+		// concurrently so are content to use a mutex to provide thread safety.
+		mutable std::mutex m_camerasMutex;
+		using CameraMap = boost::multi_index::multi_index_container<
+			CameraInfo,
+			boost::multi_index::indexed_by<
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<CameraInfo, riley::CameraId, &CameraInfo::id>
+				>,
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<CameraInfo, std::string, &CameraInfo::name>
+				>
+			>
+		>;
+		CameraMap m_cameras;
+
+		struct LightShaderInfo
+		{
+			std::vector<riley::ShadingNode> shaders;
+		};
+
+		// Keys are `riley::LightShaderId`. The `concurrent_unordered_map` gives
+		// us thread-safety for the map data structure itself, but not for the
+		// values within. This is exactly what we need, as we may be editing shaders
+		// from many threads, but any particular shader will only be modified by
+		// a single thread at a time.
+		using LightShaderMap = tbb::concurrent_unordered_map<uint32_t, LightShaderInfo>;
+		LightShaderMap m_domeAndPortalShaders;
+
+		struct LightInfo
+		{
+			riley::LightShaderId lightShader;
+			RtMatrix4x4 transform;
+			RtParamList attributes;
+		};
+		// Keys are `riley::LightInstanceId`.
+		using LightInstanceMap = tbb::concurrent_unordered_map<uint32_t, LightInfo>;
+		LightInstanceMap m_domeAndPortalLights;
+		std::atomic_bool m_portalsDirty;
+
+};
+
+IE_CORE_DECLAREPTR( Session );
+
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/Transform.h
+++ b/src/IECoreRenderMan/Transform.h
@@ -49,7 +49,7 @@ struct StaticTransform : riley::Transform
 
 	/// Caution : `m` is referenced directly, and must live until the
 	/// StaticTransform is passed to Riley.
-	StaticTransform( const Imath::M44f &m = Imath::M44f() )
+	StaticTransform( const Imath::M44f &m )
 		:	m_time( 0 )
 	{
 		samples = 1;

--- a/src/IECoreRenderMan/VolumeAlgo.cpp
+++ b/src/IECoreRenderMan/VolumeAlgo.cpp
@@ -1,0 +1,144 @@
+
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GeometryAlgo.h"
+
+#include "IECoreVDB/VDBObject.h"
+
+#include "RixPredefinedStrings.hpp"
+
+#include "fmt/format.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreVDB;
+using namespace IECoreRenderMan;
+
+namespace
+{
+
+const RtUString g_implOpenVDB( "blobbydso:impl_openvdb" );
+
+RtUString convertVDBObject( const IECoreVDB::VDBObject *vdbObject, RtPrimVarList &primVars, const std::string &messageContext )
+{
+	string fileName = vdbObject->fileName();
+	if( fileName.empty() || !vdbObject->unmodifiedFromFile() )
+	{
+		/// \todo Pass in-memory grids via RixStorage. Since we have to
+		/// load the grids below anyway, we could possibly always pass via
+		/// RixStorage. We'll need to worry about ABI compatibility between
+		/// the OpenVDB lib that we use and RenderMan uses though.
+		return RtUString();
+	}
+
+	primVars.SetString( Rix::k_Ri_type, g_implOpenVDB );
+	// Dimensions is a required parameter so we have to set it.
+	// I think it is only useful if you want to provide the volume
+	// data as a dense grid via primvars. We're providing the data via
+	// VDB so can set it all to zeroes.
+	const int dimensions[] = { 0, 0, 0 };
+	primVars.SetIntegerArray( Rix::k_Ri_dimensions, dimensions, 3 );
+	// Because dimensions is 0, all primvar details are size 0 too,
+	// except for constant.
+	primVars.SetDetail( 1, 0, 0, 0 );
+
+	// Declare primitive variables for each grid, while also trying
+	// to find the names of the best grids to use for density and velocity.
+	string densityName;
+	string velocityName;
+	for( const auto &gridName : vdbObject->gridNames() )
+	{
+		openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridName );
+
+		if( grid->isType<openvdb::FloatGrid>() )
+		{
+			if( gridName == "density" || densityName.empty() )
+			{
+				// RenderMan docs state that if the grid is a level set, it will
+				// get converted to fog automatically. But if the grid doesn't have
+				// class metadata, we must apply a suffix to reassure RenderMan that
+				// it can treat it as a fog volume directly.
+				const string classSuffix = grid->getGridClass() == openvdb::GridClass::GRID_LEVEL_SET ? ":levelset" : ":fogvolume";
+				densityName = gridName + classSuffix;
+			}
+			primVars.SetFloatDetail( RtUString( gridName.c_str() ), nullptr, RtDetailType::k_varying );
+		}
+		else if( grid->isType<openvdb::Vec3fGrid>() )
+		{
+			if( gridName == "velocity" || gridName == "vel" || gridName == "v" )
+			{
+				// Velocity must be a fog volume, and if untagged as such in the file,
+				// we have to add a suffix to reassure RenderMan.
+				velocityName = gridName + ":fogvolume";
+			}
+			primVars.SetVectorDetail( RtUString( gridName.c_str() ), nullptr, RtDetailType::k_varying );
+		}
+		else
+		{
+			IECore::msg(
+				IECore::Msg::Warning, messageContext,
+				fmt::format(
+					"Ignoring grid \"{}\" with unsupported type \"{}\"",
+					gridName, grid->valueType()
+				)
+			);
+		}
+	}
+
+	if( densityName.empty() )
+	{
+		IECore::msg( IECore::Msg::Warning, messageContext, "No density field found" );
+		return RtUString();
+	}
+
+	std::array<RtUString, 4> stringArgs = {
+		RtUString( fileName.c_str() ),
+		RtUString( densityName.c_str() ),
+		RtUString( velocityName.c_str() ),
+		/// \todo It is possible to send additional parameters via a little JSON
+		/// dictionary - `filterWidth`, `velocityScale`, `densityMult` and `densityRolloff`.
+		/// Where would we get those from? Attributes perhaps?
+		RtUString( "{}" )
+	};
+	primVars.SetStringArray( Rix::k_blobbydso_stringargs, stringArgs.data(), stringArgs.size() );
+
+	return Rix::k_Ri_Volume;
+}
+
+GeometryAlgo::ConverterDescription<VDBObject> g_meshConverterDescription( convertVDBObject );
+
+} // namespace

--- a/src/IECoreRenderManDisplay/Display.cpp
+++ b/src/IECoreRenderManDisplay/Display.cpp
@@ -1,0 +1,394 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2010-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreImage/DisplayDriver.h"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
+#include "IECore/StringAlgo.h"
+#include "IECore/VectorTypedData.h"
+
+#include "ndspy.h"
+
+#include "fmt/format.h"
+
+#include <vector>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+
+/// \todo This code originated from `src/IECoreDelight/Display.cpp`, with modifications
+/// to deal with RenderMan-specific issues. It's probably possible to refactor them both
+/// into a single class, although it's not clear where we'd host that. Consider if this
+/// is worthwhile or if we should just let them diverge further.
+
+extern "C"
+{
+
+// Implementation
+// ==============
+
+PtDspyError DspyImageOpen( PtDspyImageHandle *image, const char *driverName, const char *fileName, int width, int height, int paramcount, const UserParameter *parameters, int formatCount, PtDspyDevFormat *format, PtFlagStuff *flags )
+{
+	*image = nullptr;
+
+	// Get channel names.
+
+	vector<string> channels;
+
+	for( int i = 0; i < formatCount; i++ )
+	{
+		// RenderMan gives us names in the following format :
+		//
+		// `<outputName>.<annoyingInteger>[.<channeName>]`
+		//
+		// Where `channelName` is lower case, or is omitted for single-channel
+		// outputs. The `quicklyNoiseless` man-in-the-middle driver gives us
+		// similar names but without the annoying integer in the middle.
+		//
+		// Parse this mess into a channel name conformant with the EXR/Gaffer
+		// specification.
+
+		vector<string> tokens;
+		StringAlgo::tokenize( format[i].name, '.', tokens );
+		if( tokens.size() > 1 && std::all_of( tokens[1].begin(), tokens[1].end(), [] ( unsigned char c ) { return std::isdigit( c ); } ) )
+		{
+			tokens.erase( tokens.begin() + 1 );
+		}
+
+		string layerName;
+		string baseName;
+		if( tokens.size() == 1 )
+		{
+			baseName = tokens[0];
+		}
+		else if( tokens.size() == 2 )
+		{
+			if( tokens[0] != "Ci" )
+			{
+				layerName = tokens[0];
+			}
+			baseName = tokens[1];
+		}
+		else
+		{
+			msg( Msg::Error, "Dspy::imageOpen",  fmt::format( "Unexpected format name \"{}\"", format[i].name ) );
+			return PkDspyErrorBadParams;
+		}
+
+		if( baseName == "r" ) baseName = "R";
+		if( baseName == "g" ) baseName = "G";
+		if( baseName == "b" ) baseName = "B";
+		if( baseName == "a" ) baseName = "A";
+		if( baseName == "z" && layerName.empty() ) baseName = "Z";
+
+		if( layerName.empty() )
+		{
+			channels.push_back( baseName );
+		}
+		else
+		{
+			channels.push_back( layerName + "." + baseName );
+		}
+
+		format[i].type = PkDspyFloat32 | PkDspyByteOrderNative;
+	}
+
+	// Process the parameter list. We use some of the parameters to help determine
+	// the display and data windows, and the others we convert ready to passed to
+	// `DisplayDriver::create()`.
+
+	V2i originalSize( width, height );
+	V2i origin( 0 );
+
+	CompoundDataPtr convertedParameters = new CompoundData;
+
+	for( int p = 0; p < paramcount; p++ )
+	{
+		if ( !strcmp( parameters[p].name, "OriginalSize" ) && parameters[p].vtype == (char)'i' && parameters[p].vcount == (char)2 && parameters[p].nbytes == (int) (parameters[p].vcount * sizeof(int)) )
+		{
+			originalSize.x = static_cast<const int *>(parameters[p].value)[0];
+			originalSize.y = static_cast<const int *>(parameters[p].value)[1];
+		}
+		else if ( !strcmp( parameters[p].name, "origin" ) && parameters[p].vtype == (char)'i' && parameters[p].vcount == (char)2 && parameters[p].nbytes == (int)(parameters[p].vcount * sizeof(int)) )
+		{
+			origin.x = static_cast<const int *>(parameters[p].value)[0];
+			origin.y = static_cast<const int *>(parameters[p].value)[1];
+		}
+		else
+		{
+			DataPtr newParam;
+
+			if ( !parameters[p].nbytes )
+			{
+				continue;
+			}
+
+			const int *pInt;
+			const float *pFloat;
+			char const **pChar;
+
+			// generic converter
+			switch( parameters[p].vtype )
+			{
+			case 'i':
+				// sanity check
+				if ( parameters[p].nbytes / parameters[p].vcount != sizeof(int) )
+				{
+					msg( Msg::Error, "Dspy::imageOpen", "Invalid int data size" );
+					continue;
+				}
+				pInt = static_cast<const int *>(parameters[p].value);
+				if ( parameters[p].vcount == 1 )
+				{
+					newParam = new IntData( pInt[0] );
+				}
+				else
+				{
+					std::vector< int > newVec( pInt, pInt + parameters[p].vcount );
+					newParam = new IntVectorData( newVec );
+				}
+				break;
+			case 'f':
+				if ( parameters[p].nbytes / parameters[p].vcount != sizeof(float) )
+				{
+					msg( Msg::Error, "Dspy::imageOpen", "Invalid float data size" );
+					continue;
+				}
+				pFloat = static_cast<const float *>(parameters[p].value);
+				if ( parameters[p].vcount == 1 )
+				{
+					newParam = new FloatData( pFloat[0] );
+				}
+				else
+				{
+					std::vector< float > newVec( pFloat, pFloat + parameters[p].vcount );
+					newParam = new FloatVectorData( newVec );
+				}
+				break;
+			case 's':
+				pChar = (const char **)(parameters[p].value);
+				if ( parameters[p].vcount == 1 )
+				{
+					newParam = new StringData( pChar[0] );
+				}
+				else
+				{
+					StringVectorDataPtr newStringVec = new StringVectorData();
+					for ( int s = 0; s < parameters[p].vcount; s++ )
+					{
+						newStringVec->writable().push_back( pChar[s] );
+					}
+					newParam = newStringVec;
+				}
+				break;
+			default :
+				// We shouldn't ever get here...
+				break;
+			}
+			if( newParam )
+			{
+				convertedParameters->writable()[ parameters[p].name ] = newParam;
+			}
+		}
+	}
+
+	convertedParameters->writable()[ "fileName" ] = new StringData( fileName );
+
+	// Calculate display and data windows
+
+	Box2i displayWindow(
+		V2i( 0 ),
+		originalSize - V2i( 1 )
+	);
+
+	Box2i dataWindow(
+		origin,
+		origin + V2i( width - 1, height - 1)
+	);
+
+	// Create the display driver
+
+	IECoreImage::DisplayDriverPtr dd = nullptr;
+	try
+	{
+		const StringData *driverType = convertedParameters->member<StringData>( "driverType", true /* throw if missing */ );
+		dd = IECoreImage::DisplayDriver::create( driverType->readable(), displayWindow, dataWindow, channels, convertedParameters );
+	}
+	catch( std::exception &e )
+	{
+		msg( Msg::Error, "Dspy::imageOpen", e.what() );
+		return PkDspyErrorUnsupported;
+	}
+
+	if( !dd )
+	{
+		msg( Msg::Error, "Dspy::imageOpen", "DisplayDriver::create returned 0." );
+		return PkDspyErrorUnsupported;
+	}
+
+	// Update flags and return
+
+	if( dd->scanLineOrderOnly() )
+	{
+		flags->flags |= PkDspyFlagsWantsScanLineOrder;
+	}
+
+	dd->addRef(); // This will be removed in imageClose()
+	*image = (PtDspyImageHandle)dd.get();
+	return PkDspyErrorNone;
+
+}
+
+
+PtDspyError DspyImageQuery( PtDspyImageHandle image, PtDspyQueryType type, int size, void *data )
+{
+	IECoreImage::DisplayDriver *dd = static_cast<IECoreImage::DisplayDriver *>( image );
+
+	if( type == PkRedrawQuery )
+	{
+		if( (!dd->scanLineOrderOnly()) && dd->acceptsRepeatedData() )
+		{
+			((PtDspyRedrawInfo *)data)->redraw = 1;
+		}
+		else
+		{
+			((PtDspyRedrawInfo *)data)->redraw = 0;
+		}
+		return PkDspyErrorNone;
+	}
+
+	return PkDspyErrorUnsupported;
+}
+
+PtDspyError DspyImageData( PtDspyImageHandle image, int xMin, int xMaxPlusOne, int yMin, int yMaxPlusOne, int entrySize, const unsigned char *data )
+{
+	IECoreImage::DisplayDriver *dd = static_cast<IECoreImage::DisplayDriver *>( image );
+	Box2i dataWindow = dd->dataWindow();
+
+	// Convert coordinates from cropped image to original image coordinates.
+	Box2i box( V2i( xMin + dataWindow.min.x, yMin + dataWindow.min.y ), V2i( xMaxPlusOne - 1 + dataWindow.min.x, yMaxPlusOne - 1 + dataWindow.min.y ) );
+	int channels = dd->channelNames().size();
+	int blockSize = (xMaxPlusOne - xMin) * (yMaxPlusOne - yMin);
+	int bufferSize = channels * blockSize;
+
+	if( entrySize % sizeof(float) )
+	{
+		msg( Msg::Error, "Dspy::imageData", "The entry size is not multiple of sizeof(float)!" );
+		return PkDspyErrorUnsupported;
+	}
+
+	const float *buffer;
+	vector<float> bufferStorage;
+
+	/// \todo Integer ID support
+
+	if( entrySize == (int)(channels*sizeof(float)) )
+	{
+		// This is the case we like - we can just send the data as-is.
+		buffer = (const float *)data;
+	}
+	else
+	{
+		// PRMan seems to pad pixels sometimes for unknown reasons, and we need
+		// to unpad them before sending. This is a pity.
+		/// \todo Figure out why this is happening, and see if we can avoid it.
+		bufferStorage.reserve( bufferSize );
+		auto source = (const float *)data;
+		const size_t stride = entrySize / sizeof( float );
+		for( int i = 0; i < blockSize; ++i )
+		{
+			for( int c = 0; c < channels; ++c )
+			{
+				bufferStorage.push_back( source[c] );
+			}
+			source += stride;
+		}
+		buffer = bufferStorage.data();
+	}
+
+	try
+	{
+		dd->imageData( box, buffer, bufferSize );
+	}
+	catch( std::exception &e )
+	{
+		if( strcmp( e.what(), "stop" ) == 0 )
+		{
+			/// \todo Is this even used?
+			return PkDspyErrorUndefined;
+		}
+		else
+		{
+			msg( Msg::Error, "Dspy::imageData", e.what() );
+			return PkDspyErrorUndefined;
+		}
+	}
+
+	return PkDspyErrorNone;
+}
+
+PtDspyError DspyImageClose( PtDspyImageHandle image )
+{
+	if ( !image )
+	{
+		return PkDspyErrorNone;
+	}
+
+	IECoreImage::DisplayDriver *dd = static_cast<IECoreImage::DisplayDriver*>( image );
+	try
+	{
+		dd->imageClose();
+	}
+	catch( std::exception &e )
+	{
+		msg( Msg::Error, "Dspy::imageClose", e.what() );
+	}
+
+	try
+	{
+		dd->removeRef();
+	}
+	catch( std::exception &e )
+	{
+		msg( Msg::Error, "DspyImageData", e.what() );
+		return PkDspyErrorBadParams;
+	}
+
+	return PkDspyErrorNone;
+}
+
+} // extern "C"

--- a/src/IECoreRenderManModule/IECoreRenderManModule.cpp
+++ b/src/IECoreRenderManModule/IECoreRenderManModule.cpp
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+using namespace boost::python;
+
+BOOST_PYTHON_MODULE( _IECoreRenderMan )
+{
+	// The module exists solely to link in libIECoreRenderMan, to
+	// register the RenderMan renderer.
+}


### PR DESCRIPTION
This builds on top of the recent IECoreRenderMan PRs by adding a functioning renderer backend for RenderMan, along with a display driver and unit tests. None of this is exposed in Gaffer yet - although you could import IECoreRenderMan and render to RenderMan, it won't be much use until a future PR provides nodes for building RenderMan shader networks and settings options and attributes.

It's unavoidable that there's quite a lot of code here, but I've tried to split the commits down component-by-component in an order that guides you through things such that at least each component arrives after the others it depends on.

There are plenty of todos in the code, but at this point I consider them much lower priority to making progress on as-yet untouched features. Likewise I haven't yet done the licensing dance needed to run the unit tests in CI, although you should be able to run them locally to satisfy yourself that things are working as advertised. Unless you're on Windows, since I haven't done the env setup work for that yet. I'll deal with that and the CI testing in a future PR.