### PR TITLE
Instancer : More Robust Prototype Hashing

### DIFF
--- a/include/GafferScene/Instancer.h
+++ b/include/GafferScene/Instancer.h
@@ -245,6 +245,9 @@ class GAFFERSCENE_API Instancer : public BranchCreator
 		Gaffer::PathMatcherDataPlug *setCollaboratePlug();
 		const Gaffer::PathMatcherDataPlug *setCollaboratePlug() const;
 
+		Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug();
+		const Gaffer::Int64VectorDataPlug *capsuleComputedHashPlug() const;
+
 		ConstEngineDataPtr engine( const ScenePath &sourcePath, const Gaffer::Context *context ) const;
 		void engineHash( const ScenePath &sourcePath, const Gaffer::Context *context, IECore::MurmurHash &h ) const;
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3426,6 +3426,13 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 
 	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testChildNamesHashPerf( self ):
+		nodes = self.initSimpleInstancer()
+		with GafferTest.TestRunner.PerformanceScope() :
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/sphere" )
+			nodes["instancer"]["out"].childNamesHash( "/plane/instances/cube" )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
 	def testChildNamesPerf( self ):
 		nodes = self.initSimpleInstancer()
 		with GafferTest.TestRunner.PerformanceScope() :

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -1307,7 +1307,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		script["instancer"]["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 	def testIndexedRootsVariable( self ) :
@@ -1361,7 +1361,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		script["variables"]["primitiveVariables"]["prototypeRoots"]["value"].setValue( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 		script["instancer"]["prototypeRoots"].setValue( "notAPrimVar" )
@@ -1436,7 +1436,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		updateRoots( IECore.StringVectorData( [ "/foo", "/does/not/exist" ] ), IECore.IntVectorData( [ 0, 1, 1, 0 ] ) )
 		self.assertRaisesRegex(
 			Gaffer.ProcessException, '.*Prototype root "/does/not/exist" does not exist.*',
-			script["instancer"]["out"].childNames, "/object/instances",
+			script["instancer"]["out"].childNames, "/object/instances/exist",
 		)
 
 		script["instancer"]["prototypeRoots"].setValue( "notAPrimVar" )

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3278,6 +3278,40 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 			IECore.PathMatcherData( IECore.PathMatcher( ['/plane/prototypes/cube/prototypes/sphere'] ) )
 		)
 
+	def testInvalidPrototypeScene( self ) :
+		points = GafferScene.Sphere( "points" )
+		points["name"].setValue( 'points' )
+		points["divisions"].setValue( imath.V2i( 3, 6 ) )
+
+		pointsFilter = GafferScene.PathFilter( "pointsFilter" )
+		pointsFilter["paths"].setValue( IECore.StringVectorData( [ '/points' ] ) )
+
+		group = GafferScene.Group( "group" )
+
+		instancer = GafferScene.Instancer( "instancer" )
+		instancer["in"].setInput( points["out"] )
+		instancer["filter"].setInput( pointsFilter["out"] )
+		instancer["prototypes"].setInput( group["out"] )
+		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ '/group/sphere' ] ) )
+
+		# Access a location that doesn't exist
+		with self.assertRaisesRegex( RuntimeError, 'Prototype root "/group/sphere" does not exist in the `prototypes` scene' ) :
+			instancer["out"].childNames( "/points/instances/sphere" )
+
+		# Make the locations exist
+		sphere = GafferScene.Sphere( "sphere" )
+		group["in"][0].setInput( sphere["out"] )
+
+		self.assertEqual( instancer["out"].object( "/points/instances/sphere/0" ), sphere["out"].object( "/sphere" ) )
+
+		# Now make the location not exist again ( to make sure that we aren't incorrectly caching that it exists )
+		group["in"][0].setInput( None )
+
+		with self.assertRaisesRegex( RuntimeError, 'Prototype root "/group/sphere" does not exist in the `prototypes` scene' ) :
+			instancer["out"].childNames( "/points/instances/sphere" )
+
+
+
 	@GafferTest.TestRunner.PerformanceTestMethod( repeat = 10 )
 	def testBoundPerformance( self ) :
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3481,5 +3481,127 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 		with GafferTest.TestRunner.PerformanceScope() :
 			nodes["instancer"]["out"].object( "/plane/instances" ).render( renderer )
 
+	def testUnrelatedPrototypeChange( self ):
+
+		points = GafferScene.Plane()
+		points["divisions"].setValue( imath.V2i( 10 ) )
+
+		sphere = GafferScene.Sphere()
+		cube = GafferScene.Cube()
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( sphere["out"] )
+		group["in"][1].setInput( cube["out"] )
+
+		unrelated = GafferScene.Group()
+		unrelated["name"].setValue( "unrelated" )
+
+		parent = GafferScene.Parent()
+		parent["parent"].setValue( '/' )
+		parent["in"].setInput( group["out"] )
+		parent["children"][0].setInput( unrelated["out"] )
+
+
+		# Instancer
+		instancerFilter = GafferScene.PathFilter()
+		instancerFilter["paths"].setValue( IECore.StringVectorData( [ '/plane' ] ) )
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( points["out"] )
+		instancer["filter"].setInput( instancerFilter["out"] )
+		instancer["prototypes"].setInput( parent["out"] )
+		instancer["prototypeMode"].setValue( GafferScene.Instancer.PrototypeMode.IndexedRootsList )
+		instancer["prototypeRootsList"].setValue( IECore.StringVectorData( [ "/group/cube", "/group/sphere" ] ) )
+		instancer["encapsulate"].setValue( True )
+
+		# Changing an unrelated part of the prototype scene should not affect the capsule hash
+		h1 = instancer["out"].objectHash( "/plane/instances" )
+		unrelated["transform"]["translate"]["x"].setValue( 7 )
+		self.assertEqual( instancer["out"].objectHash( "/plane/instances" ), h1 )
+
+		# But changing a prototype that is used does change the hash
+		cube["dimensions"]["x"].setValue( 7 )
+		h2 = instancer["out"].objectHash( "/plane/instances" )
+		self.assertNotEqual( h2, h1 )
+		sphere["radius"].setValue( 7 )
+		h3 = instancer["out"].objectHash( "/plane/instances" )
+		self.assertNotEqual( h3, h1 )
+		self.assertNotEqual( h3, h2 )
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testPrototypeHashPerf( self ):
+		points = GafferScene.Plane()
+		points["divisions"].setValue( imath.V2i( 10 ) )
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( sphere["out"] )
+		duplicate["filter"].setInput( sphereFilter["out"] )
+		duplicate["copies"].setValue( 40000 )
+
+		# Instancer
+		instancerFilter = GafferScene.PathFilter()
+		instancerFilter["paths"].setValue( IECore.StringVectorData( [ '/plane' ] ) )
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( points["out"] )
+		instancer["filter"].setInput( instancerFilter["out"] )
+		instancer["prototypes"].setInput( duplicate["out"] )
+		instancer["encapsulate"].setValue( True )
+
+		with GafferTest.TestRunner.PerformanceScope() :
+			instancer["out"].objectHash( "/plane/instances" )
+
+
+	@GafferTest.TestRunner.PerformanceTestMethod()
+	def testCacheExpensivePrototypeHash( self ):
+		points = GafferScene.Plane()
+		points["divisions"].setValue( imath.V2i( 10 ) )
+
+		unrelated = GafferScene.Plane()
+		unrelated["name"].setValue( "unrelated" )
+
+		parent = GafferScene.Parent()
+		parent["parent"].setValue( '/' )
+		parent["in"].setInput( points["out"] )
+		parent["children"][0].setInput( unrelated["out"] )
+
+		sphere = GafferScene.Sphere()
+
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ '/sphere' ] ) )
+
+		duplicate = GafferScene.Duplicate()
+		duplicate["in"].setInput( sphere["out"] )
+		duplicate["filter"].setInput( sphereFilter["out"] )
+		duplicate["copies"].setValue( 40000 )
+
+		group = GafferScene.Group()
+		group["in"][0].setInput( duplicate["out"] )
+
+		# Instancer
+		instancerFilter = GafferScene.PathFilter()
+		instancerFilter["paths"].setValue( IECore.StringVectorData( [ '/plane' ] ) )
+
+		instancer = GafferScene.Instancer()
+		instancer["in"].setInput( parent["out"] )
+		instancer["filter"].setInput( instancerFilter["out"] )
+		instancer["prototypes"].setInput( group["out"] )
+		instancer["encapsulate"].setValue( True )
+
+		# Cache the current capsule
+		instancer["out"].object( "/plane/instances" )
+
+		unrelated["divisions"].setValue( imath.V2i( 7 ) )
+
+		# It should be very cheap to retrieve the cached capsule since we've only changed something irrelevant
+		with GafferTest.TestRunner.PerformanceScope() :
+
+			instancer["out"].object( "/plane/instances" )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -387,7 +387,6 @@ class Instancer::EngineData : public Data
 			const std::string &prototypeIndexName,
 			const std::string &rootsVariable,
 			const StringVectorData *rootsList,
-			const ScenePlug *prototypes,
 			const std::string &idName,
 			bool omitDuplicateIds,
 			const std::string &position,
@@ -413,7 +412,7 @@ class Instancer::EngineData : public Data
 				return;
 			}
 
-			initPrototypes( mode, prototypeIndexName, rootsVariable, rootsList, prototypes );
+			initPrototypes( mode, prototypeIndexName, rootsVariable, rootsList );
 
 			m_ids.initialize( m_primitive.get(), idName );
 			if( m_ids.size() && m_ids.size() != numPoints() )
@@ -935,7 +934,7 @@ class Instancer::EngineData : public Data
 			}
 		}
 
-		void initPrototypes( PrototypeMode mode, const std::string &prototypeIndex, const std::string &rootsVariable, const StringVectorData *rootsList, const ScenePlug *prototypes )
+		void initPrototypes( PrototypeMode mode, const std::string &prototypeIndex, const std::string &rootsVariable, const StringVectorData *rootsList )
 		{
 			const std::vector<std::string> *rootStrings = nullptr;
 			std::vector<std::string> rootStringsAlloc;
@@ -1043,11 +1042,6 @@ class Instancer::EngineData : public Data
 			for( const auto &root : *rootStrings )
 			{
 				ScenePlug::stringToPath( root, path );
-				if( !prototypes->exists( path ) )
-				{
-					throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", root ) );
-				}
-
 				if( path.empty() )
 				{
 					if( root == "/" )
@@ -2008,7 +2002,6 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 				prototypeIndexPlug()->getValue(),
 				prototypeRootsPlug()->getValue(),
 				prototypeRootsList.get(),
-				prototypesPlug(),
 				idPlug()->getValue(),
 				omitDuplicateIdsPlug()->getValue(),
 				positionPlug()->getValue(),
@@ -2543,6 +2536,9 @@ void Instancer::hashBranchChildNames( const ScenePath &sourcePath, const ScenePa
 		BranchCreator::hashBranchChildNames( sourcePath, branchPath, context, h );
 		engineSplitPrototypesHash( sourcePath, context, h );
 		h.append( branchPath.back() );
+
+		PrototypeScope scope( enginePlug(), context, &sourcePath, &branchPath );
+		h.append( prototypesPlug()->existsPlug()->hash() );
 	}
 	else
 	{
@@ -2588,6 +2584,12 @@ IECore::ConstInternedStringVectorDataPtr Instancer::computeBranchChildNames( con
 		ids.reserve( pointIndicesForPrototype.size() );
 
 		const EngineData *engineData = esp->engine();
+		const ScenePlug::ScenePath *prototypeRoot = engineData->prototypeRoot( branchPath[1] );
+		if( !prototypesPlug()->exists( *prototypeRoot ) )
+		{
+			throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", ScenePlug::pathToString( *prototypeRoot ) ) );
+		}
+
 		for( size_t q : pointIndicesForPrototype )
 		{
 			ids.push_back( engineData->instanceId( q ) );
@@ -2866,6 +2868,10 @@ struct Prototype : public IECore::RefCounted
 		Context::EditableScope scope( prototypeContext );
 
 		scope.set( ScenePlug::scenePathContextName, prototypeRoot );
+		if( !prototypesPlug->existsPlug()->getValue() )
+		{
+			throw IECore::Exception( fmt::format( "Prototype root \"{}\" does not exist in the `prototypes` scene", ScenePlug::pathToString( *prototypeRoot ) ) );
+		}
 
 		m_attributes = prototypesPlug->attributesPlug()->getValue();
 		if( prepareRendererAttributes )


### PR DESCRIPTION
Building on top of the recently merged hierarchyHash, and the previous fix that hasn't been merged yet #6258, this addresses the issue we identified where an unrelated change to the scene would force instancer capsules to be regenerated.

I'm not sure what the right strategy is for merging these ... it's close enough now that it might make sense to roll on ahead and get the relative prototype path thing working properly, and confirm that this work all works for where we want to get to. Maybe then we merge it as one big PR? Or maybe we come back and start merging these partial steps once we've confirmed they get us where we need to be?

For the moment though, the main thing I'd like to verify is that you're happy with the last commit here, which adds an extra plug for caching the new expensive hash. It's a bit of extra complexity, but it's necessary if we don't want a performance regression in the case of making changes to the input scene that don't affect the engine, while using heavy prototypes that are independent from the input scene.
