### PR TITLE
StandardNodeGadget : Fix crash when animating an `enabled` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.5.0)
 =======
 
+Fixes
+-----
+
+- StandardNodeGadget : Fixed crash when animating a node's `enabled` plug (#6274).
+
 API
 ---
 

--- a/src/GafferUI/StandardNodeGadget.cpp
+++ b/src/GafferUI/StandardNodeGadget.cpp
@@ -528,7 +528,7 @@ bool hasStaticValue( const Gaffer::BoolPlug *plug )
 	// that the compute itself is disabled, and will output
 	// a default value for the plug.
 
-	auto source = plug->source<BoolPlug>();
+	auto source = plug->source<ValuePlug>();
 	if( source == plug || source->direction() != Plug::Out )
 	{
 		return false;


### PR DESCRIPTION
In this situation the source of the `enabled` plug would be a FloatPlug rather than a BoolPlug.

Fixes #6274.
