### PR TITLE
VisualiserTool : Vector visualiser

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
   - The `vectorScale` plug can be used to scale the vector line. The <kbd>Shift</kbd> + <kbd>+</kbd> and <kbd>Shift</kbd> + <kbd>-</kbd> keyboard shortcuts can also be used to change the scale.
   - The `vectorColor` plug can be used to change the color of the vector line.
   - The vector value being visualised for the vertex nearest the cursor is shown next to the vertex.
+- ColorSwatchPlugValueWidget : Changed the display transform of the color chooser dialogue to match that of the `ColorSwatchPlugValueWidget` creating it instead of the script window.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 
 - 3Delight : Added light muting support.
 - Arnold : Added support for specifying the name of a shader in the node menu using Arnold's `ui.name` metadata. This improves the formatting of the OpenPBR Surface menu item.
+- VisualiserTool : Added new visualisation for vector (V3f) data.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - VisualiserTool : Added new visualisation for vector (V3f) data.
   - The `vectorScale` plug can be used to scale the vector line. The <kbd>Shift</kbd> + <kbd>+</kbd> and <kbd>Shift</kbd> + <kbd>-</kbd> keyboard shortcuts can also be used to change the scale.
   - The `vectorColor` plug can be used to change the color of the vector line.
+  - The vector value being visualised for the vertex nearest the cursor is shown next to the vertex.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - 3Delight : Added light muting support.
 - Arnold : Added support for specifying the name of a shader in the node menu using Arnold's `ui.name` metadata. This improves the formatting of the OpenPBR Surface menu item.
 - VisualiserTool : Added new visualisation for vector (V3f) data.
+  - The `vectorScale` plug can be used to scale the vector line. The <kbd>Shift</kbd> + <kbd>+</kbd> and <kbd>Shift</kbd> + <kbd>-</kbd> keyboard shortcuts can also be used to change the scale.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - Arnold : Added support for specifying the name of a shader in the node menu using Arnold's `ui.name` metadata. This improves the formatting of the OpenPBR Surface menu item.
 - VisualiserTool : Added new visualisation for vector (V3f) data.
   - The `vectorScale` plug can be used to scale the vector line. The <kbd>Shift</kbd> + <kbd>+</kbd> and <kbd>Shift</kbd> + <kbd>-</kbd> keyboard shortcuts can also be used to change the scale.
+  - The `vectorColor` plug can be used to change the color of the vector line.
 
 Fixes
 -----

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -99,6 +99,9 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		Gaffer::FloatPlug *sizePlug();
 		const Gaffer::FloatPlug *sizePlug() const;
 
+		Gaffer::FloatPlug *vectorScalePlug();
+		const Gaffer::FloatPlug *vectorScalePlug() const;
+
 	private:
 
 		friend VisualiserGadget;

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -114,17 +114,20 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		{
 			Selection(
 				const GafferScene::ScenePlug &scene,
+				const GafferScene::ScenePlug &uniformPScene,
 				const GafferScene::ScenePlug::ScenePath &path,
 				const Gaffer::Context &context
 			);
 
 			const GafferScene::ScenePlug &scene() const;
+			const GafferScene::ScenePlug &uniformPScene() const;
 			const GafferScene::ScenePlug::ScenePath &path() const;
 			const Gaffer::Context &context() const;
 
 			private:
 
 				GafferScene::ConstScenePlugPtr m_scene;
+				GafferScene::ConstScenePlugPtr m_uniformPScene;
 				GafferScene::ScenePlug::ScenePath m_path;
 				Gaffer::ConstContextPtr m_context;
 		};
@@ -139,6 +142,9 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 
 		GafferScene::ScenePlug *internalScenePlug();
 		const GafferScene::ScenePlug *internalScenePlug() const;
+
+		GafferScene::ScenePlug *internalSceneUniformPPlug();
+		const GafferScene::ScenePlug *internalSceneUniformPPlug() const;
 
 		void connectOnActive();
 		void disconnectOnInactive();

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -102,6 +102,9 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		Gaffer::FloatPlug *vectorScalePlug();
 		const Gaffer::FloatPlug *vectorScalePlug() const;
 
+		Gaffer::Color3fPlug *vectorColorPlug();
+		const Gaffer::Color3fPlug *vectorColorPlug() const;
+
 	private:
 
 		friend VisualiserGadget;

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -60,6 +60,7 @@ Gaffer.Metadata.registerNode(
 	"tool:exclusive", False,
 
 	"toolbarLayout:activator:modeIsColor", lambda node : node["mode"].getValue() == GafferSceneUI.VisualiserTool.Mode.Color,
+	"toolbarLayout:activator:modeIsAuto", lambda node : node["mode"].getValue() == GafferSceneUI.VisualiserTool.Mode.Auto,
 
 	plugs = {
 
@@ -90,7 +91,7 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"toolbarLayout:section", "Bottom",
-			"toolbarLayout:width", 100,
+			"toolbarLayout:width", 45,
 
 		],
 		"mode" : [
@@ -156,6 +157,19 @@ Gaffer.Metadata.registerNode(
 			""",
 
 			"plugValueWidget:type", ""
+
+		],
+		"vectorScale" : [
+
+			"description",
+			"""
+			The scale factor to apply to vectors.
+			""",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 45,
+
+			"toolbarLayout:visibilityActivator", "modeIsAuto",
 
 		],
 

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -186,10 +186,20 @@ Gaffer.Metadata.registerNode(
 			"toolbarLayout:visibilityActivator", "modeIsAuto",
 			"colorPlugValueWidget:colorChooserButtonVisible", False,
 
+			"plugValueWidget:type", "GafferSceneUI.VisualiserToolUI._UntransformedColorWidget",
+
 		],
 
 	},
 )
+
+class _UntransformedColorWidget( GafferUI.ColorPlugValueWidget ) :
+
+	def __init__( self, plugs, **kw ) :
+
+		GafferUI.ColorPlugValueWidget.__init__( self, plugs, **kw )
+
+		self.setDisplayTransform( GafferUI.Widget.identityDisplayTransform )
 
 class _DataNameChooser( GafferUI.PlugValueWidget ) :
 

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -173,6 +173,21 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"vectorColor" : [
+
+			"description",
+			"""
+			The colour to use for drawing vectors.
+			""",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 175,
+
+			"toolbarLayout:visibilityActivator", "modeIsAuto",
+			"colorPlugValueWidget:colorChooserButtonVisible", False,
+
+		],
+
 	},
 )
 

--- a/python/GafferUI/ColorPlugValueWidget.py
+++ b/python/GafferUI/ColorPlugValueWidget.py
@@ -70,7 +70,7 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 			sole( Gaffer.Metadata.value( plug, "colorPlugValueWidget:colorChooserVisible" ) for plug in self.getPlugs() )
 		)
 
-		self.__chooserButton.setVisible( not any( p.direction() == Gaffer.Plug.Direction.Out for p in self.getPlugs() ) )
+		self.__chooserButton.setVisible( self.__chooserButtonVisible() )
 
 		self.__blinkBehaviour = None
 
@@ -122,7 +122,7 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.__swatch.setPlugs( plugs )
 
 		# Update widget visibility if the plug directions changed
-		self.__chooserButton.setVisible( not any( p.direction() == Gaffer.Plug.Direction.Out for p in self.getPlugs() ) )
+		self.__chooserButton.setVisible( self.__chooserButtonVisible() )
 		self.setColorChooserVisible( self.__colorChooserVisible )
 
 	def setHighlighted( self, highlighted ) :
@@ -162,6 +162,13 @@ class ColorPlugValueWidget( GafferUI.PlugValueWidget ) :
 		# we construct a widget for one of these plugs.
 		for plug in self.getPlugs() :
 			Gaffer.Metadata.registerValue( plug, "colorPlugValueWidget:colorChooserVisible", visible, persistent = False )
+
+	def __chooserButtonVisible( self ) :
+
+		return (
+			not any( p.direction() == Gaffer.Plug.Direction.Out for p in self.getPlugs() ) and
+			not any( Gaffer.Metadata.value( p, "colorPlugValueWidget:colorChooserButtonVisible" ) == False for p in self.getPlugs() )
+		)
 
 GafferUI.PlugValueWidget.registerType( Gaffer.Color3fPlug, ColorPlugValueWidget )
 GafferUI.PlugValueWidget.registerType( Gaffer.Color4fPlug, ColorPlugValueWidget )

--- a/python/GafferUI/ColorSwatchPlugValueWidget.py
+++ b/python/GafferUI/ColorSwatchPlugValueWidget.py
@@ -101,7 +101,7 @@ class ColorSwatchPlugValueWidget( GafferUI.PlugValueWidget ) :
 		if not self._editable() :
 			return False
 
-		_ColorPlugValueDialogue.acquire( self.getPlugs() )
+		_ColorPlugValueDialogue.acquire( self.getPlugs(), self.displayTransform() )
 
 		return True
 
@@ -125,11 +125,12 @@ def _colorFromPlugs( plugs ) :
 # actually be functionality of CompoundEditor?
 class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 
-	def __init__( self, plugs, parentWindow ) :
+	def __init__( self, plugs, parentWindow, displayTransform ) :
 
 		GafferUI.ColorChooserDialogue.__init__(
 			self,
-			color = _colorFromPlugs( plugs )
+			color = _colorFromPlugs( plugs ),
+			displayTransform = displayTransform
 		)
 
 		# we use these to decide which actions to merge into a single undo
@@ -192,7 +193,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 		parentWindow.addChildWindow( self, removeOnClose = True )
 
 	@classmethod
-	def acquire( cls, plugs ) :
+	def acquire( cls, plugs, displayTransform ) :
 
 		plug = next( iter( plugs ) )
 
@@ -212,7 +213,7 @@ class _ColorPlugValueDialogue( GafferUI.ColorChooserDialogue ) :
 				window.setVisible( True )
 				return window
 
-		window = _ColorPlugValueDialogue( plugs, scriptWindow )
+		window = _ColorPlugValueDialogue( plugs, scriptWindow, displayTransform )
 		window.setVisible( True )
 		return False
 

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -1143,19 +1143,17 @@ class VisualiserGadget : public Gadget
 						continue;
 					}
 
-					if( mode == VisualiserTool::Mode::Auto && vData->typeId() == V3fVectorDataTypeId )
-					{
-						// Will be handled by `renderVectorVisualiser()` instead.
-						continue;
-					}
-
 					if(
 						mode == VisualiserTool::Mode::Auto &&
 						primitive->typeId() == MeshPrimitive::staticTypeId() &&
-						vData->typeId() != IntVectorDataTypeId
+						vData->typeId() != IntVectorDataTypeId &&
+						vData->typeId() != V3fVectorDataTypeId
 					)
 					{
 						// Will be handled by `renderColorVisualiser()` instead.
+						// If the data type is V3f data, we continue right before
+						// drawing the per-vertex label in order to get and display
+						// the value closest to the cursor.
 						continue;
 					}
 
@@ -1427,6 +1425,13 @@ class VisualiserGadget : public Gadget
 										std::swap( cursorVertexRasterPos, rasterPos );
 										minDistance2 = distance2;
 									}
+								}
+
+								if( mode == VisualiserTool::Mode::Auto && vData && vData->typeId() == V3fVectorDataTypeId )
+								{
+									// Do everything except drawing the per-vertex value. That will
+									// be handled by `renderVectorVisualiser()` instead.
+									continue;
 								}
 
 								// Draw value label

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -99,10 +99,12 @@ const float g_textSizeDefault = 9.0f;
 const float g_textSizeMin = 6.0f;
 const float g_textSizeInc = 0.5f;
 
-// Vector scale constants
+// Vector constants
 const float g_vectorScaleDefault = 1.f;
 const float g_vectorScaleMin = 10.f * std::numeric_limits< float >::min();
 float const g_vectorScaleInc = 0.01f;
+
+const Color3f g_vectorColorDefault( 1.f, 1.f, 1.f );
 
 // Opacity and value constants
 const float g_opacityDefault = 1.0f;
@@ -1521,7 +1523,7 @@ class VisualiserGadget : public Gadget
 			glBindBufferBase( GL_UNIFORM_BUFFER, g_uniformBlockBindingIndex, m_vectorUniformBuffer->buffer() );
 
 			UniformBlockVectorShader uniforms;
-			uniforms.color = Color3f( 1.f );
+			uniforms.color = m_tool->vectorColorPlug()->getValue();
 			uniforms.scale = m_tool->vectorScalePlug()->getValue();
 
 			// Get the world to view and view to clip space matrices
@@ -1798,6 +1800,7 @@ VisualiserTool::VisualiserTool( SceneView *view, const std::string &name ) : Sel
 	addChild( new V3fPlug( "valueMax", Plug::In, g_valueMaxDefault ) );
 	addChild( new FloatPlug( "size", Plug::In, g_textSizeDefault, g_textSizeMin ) );
 	addChild( new FloatPlug( "vectorScale", Plug::In, g_vectorScaleDefault, g_vectorScaleMin ) );
+	addChild( new Color3fPlug( "vectorColor", Plug::In, g_vectorColorDefault ) );
 	addChild( new ScenePlug( "__scene", Plug::In ) );
 
 	internalScenePlug()->setInput( view->inPlug<ScenePlug>() );
@@ -1933,14 +1936,24 @@ const FloatPlug *VisualiserTool::vectorScalePlug() const
 	return getChild<FloatPlug>( g_firstPlugIndex + 6 );
 }
 
+Color3fPlug *VisualiserTool::vectorColorPlug()
+{
+	return getChild<Color3fPlug>( g_firstPlugIndex + 7 );
+}
+
+const Color3fPlug *VisualiserTool::vectorColorPlug() const
+{
+	return getChild<Color3fPlug>( g_firstPlugIndex + 7 );
+}
+
 ScenePlug *VisualiserTool::internalScenePlug()
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 7 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 8 );
 }
 
 const ScenePlug *VisualiserTool::internalScenePlug() const
 {
-	return getChild<ScenePlug>( g_firstPlugIndex + 7 );
+	return getChild<ScenePlug>( g_firstPlugIndex + 8 );
 }
 
 const std::vector<VisualiserTool::Selection> &VisualiserTool::selection() const
@@ -2179,7 +2192,8 @@ void VisualiserTool::plugDirtied( const Plug *plug )
 		plug == valueMaxPlug() ||
 		plug == sizePlug() ||
 		plug == modePlug() ||
-		plug == vectorScalePlug()
+		plug == vectorScalePlug() ||
+		plug == vectorColorPlug()
 	)
 	{
 		m_gadgetDirty = true;

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -1106,6 +1106,8 @@ class VisualiserGadget : public Gadget
 			const std::string dataName = m_tool->dataNamePlug()->getValue();
 			const std::string primitiveVariableName = primitiveVariableFromDataName( dataName );
 
+			float cursorVertexValueTextScale = 2.f;
+
 			// Loop through current selection
 
 			for( const auto &location : m_tool->selection() )
@@ -1167,6 +1169,15 @@ class VisualiserGadget : public Gadget
 					{
 						continue;
 					}
+				}
+
+				if( mode == VisualiserTool::Mode::Auto && vData && vData->typeId() == V3fVectorDataTypeId )
+				{
+					cursorVertexValueTextScale = 1.f;
+				}
+				else
+				{
+					cursorVertexValueTextScale = 2.f;
 				}
 
 				// Find "P" vertex attribute
@@ -1477,9 +1488,9 @@ class VisualiserGadget : public Gadget
 				drawStrokedText(
 					viewportGadget,
 					text,
-					scale.x * 2.f,
+					scale.x * cursorVertexValueTextScale,
 					V2f(
-						cursorVertexRasterPos.value().x - style->textBound( GafferUI::Style::LabelText, text ).size().x * scale.x,
+						cursorVertexRasterPos.value().x - style->textBound( GafferUI::Style::LabelText, text ).size().x * 0.5f * cursorVertexValueTextScale * scale.x,
 						cursorVertexRasterPos.value().y
 					),
 					style,

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -372,9 +372,6 @@ enum class VisualiserShaderType
 	VertexLabel
 };
 
-std::array<std::string, 2> g_vertSources = { g_colorShaderVertSource, g_vertexLabelShaderVertSource };
-std::array<std::string, 2> g_fragSources = { g_colorShaderFragSource, g_vertexLabelShaderFragSource };
-
 // The gadget that does the actual opengl drawing of the shaded primitive
 class VisualiserGadget : public Gadget
 {


### PR DESCRIPTION
This adds a new visualiser mode for showing vector values.

I didn't add a dedicated mode for vector visualisation because I don't know that it makes much sense to visualise anything except V3f data. That's covered by the `Auto` mode. But I'm open to other ideas if we think it would be good to have such a mode.

I also added recognition of a new metadata entry for `ColorPlugValueWidget` - `colorPlugValueWidget:colorChooserButtonVisible`. This is for hiding the button to display the inline color picker on the `vectorColor` plug. Allowing that to be shown on the viewer tool shifts all the tools around and is fairly messy. I didn't see an entry for the already existing `colorPlugValueWidget:colorChooserVisible` metadata in the change log or documentation, so I'm following that lead here and treating my new metadata as "private".

There's one outstanding issue that I haven't sorted out yet. The test at https://github.com/ericmehl/gaffer/blob/01e23d87960cb22df228353498c51110ad85ff31/src/GafferSceneUI/VisualiserTool.cpp#L2373-L2379 prevents doing the mesh evaluation to get interpolated values for the variable when we're doing vertex label visualisation and the value can't be acquired (for example if the variable does not use vertex interpolation).

I'm piggy-backing on the vertex label code to figure out the closest point. But this introduces another case that needs to prevent doing the interpolation. That is, if we are doing vector visualisation and the value doesn't have vertex interpolation. I'm checking the cursor value to see if it is `std::monostate`, i.e.  not set to anything meaningful, to indicate that finding the closest point wasn't done, so we should interpolate the value. But now there are two reasons it might be `monostate` - we're meant to be drawing interpolated values, or we want to draw per-vertex values but can't.

I went down a few avenues to fix that, but none were feeling all that satisfactory, so I'm all ears on a better solution.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
