### PR TITLE
Arnold metadata : Add `transmission_shadow_density` parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - AttributeEditor, LightEditor, RenderPassEditor : Added drag and drop editing. Edits can be created or updated by dropping a value into a cell. Cells representing a set expression or string array can be modified by holding <kbd>Shift</kbd> to append to an existing edit, or <kbd>Control</kbd> may be held to remove from an existing edit.
 
+Improvements
+------------
+
+- ArnoldShader : Moved Arnold 7.3.7.0's new `transmission_shadow_density` parameters to a "Transmission" section of the UI.
+
 Fixes
 -----
 

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -2207,6 +2207,8 @@
 	[attr transmission_dispersion_scale]
 		page STRING "Transmission"
 		label STRING "Dispersion Scale"
+	[attr transmission_shadow_density]
+		page STRING "Transmission"
 	[attr transmission_transmit_aovs]
 		page STRING "Transmission"
 		label STRING "Transmit AOVs"
@@ -2666,6 +2668,8 @@
 	[attr transmission_dispersion]
 		page STRING "Transmission"
 	[attr transmission_extra_roughness]
+		page STRING "Transmission"
+	[attr transmission_shadow_density]
 		page STRING "Transmission"
 	[attr transmit_aovs]
 		page STRING "Transmission"


### PR DESCRIPTION
These were introduced in Arnold 7.3.7.0.
