### PR TITLE
PrimitiveAlgoTest : Increase transformPrimitive cancellation threshold

### DIFF
--- a/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/PrimitiveAlgoTest.py
@@ -40,6 +40,7 @@ import itertools
 import math
 import pathlib
 import random
+import sys
 import threading
 import time
 
@@ -171,7 +172,7 @@ class PrimitiveAlgoTest( GafferTest.TestCase ) :
 		# than being avoided entirely.
 		time.sleep( 0.01 )
 
-		acceptableCancellationDelay = 0.01 if GafferTest.inCI() else 0.001
+		acceptableCancellationDelay = { "win32" : 0.04 }.get( sys.platform, 0.01 ) if GafferTest.inCI() else 0.001
 
 		canceller.cancel()
 		thread.join()


### PR DESCRIPTION
This test one of a few intermittent failures that occur when running tests on Windows CI. The failure case appears to be usually around 0.03-0.04 seconds, so I've increased the threshold to 0.05 on Windows only.
