### PR TITLE
InteractiveRenderTest improvements

### DIFF
--- a/.github/workflows/main/installDelight.py
+++ b/.github/workflows/main/installDelight.py
@@ -43,8 +43,8 @@ if sys.version_info[0] < 3 :
 else :
     from urllib.request import urlretrieve
 
-delightVersion="2.9.39"
-delightDirectory="free/beta/2023-05-26-gbhdz8Oe"
+delightVersion="2.9.150"
+delightDirectory="free/release/2025-02-20-zHEr1XyV"
 
 baseUrl = "https://3delight-downloads.s3-us-east-2.amazonaws.com"
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.6.0)
 =======
 
+Improvements
+------------
 
+- 3Delight : Added light muting support.
 
 1.5.6.0 (relative to 1.5.5.0)
 =======

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -49,15 +49,6 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "3Delight"
 
-	# Temporarily disable this test (which is implemented in the
-	# base class) because it fails. The issue is that we're automatically
-	# instancing the geometry for the two lights, and that appears to
-	# trigger a bug in 3delight where the sampling goes awry.
-	@unittest.skip( "Awaiting feedback from 3delight developers" )
-	def testAddLight( self ) :
-
-		pass
-
 	# Disable this test for now as we don't have light linking support in
 	# 3Delight, yet.
 	@unittest.skip( "No light linking support just yet" )

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1022,19 +1022,14 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s = Gaffer.ScriptNode()
 		s["catalogue"] = GafferImage.Catalogue()
 
-		s["l"], colorPlug = self._createPointLight()
-		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
-		s["l"]["transform"]["translate"]["z"].setValue( 1 )
-
 		s["p"] = GafferScene.Plane()
 
 		s["c"] = GafferScene.Camera()
 		s["c"]["transform"]["translate"]["z"].setValue( 1 )
 
 		s["g"] = GafferScene.Group()
-		s["g"]["in"][0].setInput( s["l"]["out"] )
-		s["g"]["in"][1].setInput( s["p"]["out"] )
-		s["g"]["in"][2].setInput( s["c"]["out"] )
+		s["g"]["in"][0].setInput( s["p"]["out"] )
+		s["g"]["in"][1].setInput( s["c"]["out"] )
 
 		s["s"], unused, shaderOut = self._createMatteShader()
 		s["a"] = GafferScene.ShaderAssignment()
@@ -1077,24 +1072,21 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
-		self.assertEqual( c / c[0], imath.Color3f( 1, 0, 0 ) )
+		self.assertEqual( c, imath.Color3f( 0, 0, 0 ) )
 
 		# Add a light
 
-		s["l2"], colorPlug = self._createPointLight()
-		colorPlug.setValue( imath.Color3f( 0, 1, 0 ) )
-		s["l2"]["transform"]["translate"]["z"].setValue( 1 )
+		s["l"], colorPlug = self._createPointLight()
+		s["l"]["transform"]["translate"]["z"].setValue( 1 )
 
-		s["g"]["in"][3].setInput( s["l2"]["out"] )
+		s["g"]["in"][2].setInput( s["l"]["out"] )
 
 		# Give it time to update, and check the output.
 
 		self.uiThreadCallHandler.waitFor( 2 )
 
 		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
-		# Tolerance is high due to sampling noise in Cycles, but is more than sufficient to
-		# be sure that the new light has been added (otherwise there would be no green at all).
-		self.assertTrue( ( c / c[0] ).equalWithAbsError( imath.Color3f( 1, 1, 0 ), 0.25 ) )
+		self.assertGreater( c[1], 0.05 )
 
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -1247,6 +1247,89 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 
 		s["r"]["state"].setValue( s["r"].State.Stopped )
 
+	def testDeleteLightShader( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["catalogue"] = GafferImage.Catalogue()
+
+		s["light"], unused = self._createPointLight()
+		s["light"]["transform"]["translate"]["z"].setValue( 1 )
+
+		s["deleteAttributes"] = GafferScene.DeleteAttributes()
+		s["deleteAttributes"]["in"].setInput( s["light"]["out"] )
+
+		s["plane"] = GafferScene.Plane()
+
+		s["camera"] = GafferScene.Camera()
+		s["camera"]["transform"]["translate"]["z"].setValue( 1 )
+
+		s["group"] = GafferScene.Group()
+		s["group"]["in"][0].setInput( s["deleteAttributes"]["out"] )
+		s["group"]["in"][1].setInput( s["plane"]["out"] )
+		s["group"]["in"][2].setInput( s["camera"]["out"] )
+
+		s["shader"], unused, shaderOut = self._createMatteShader()
+		s["shaderAssignment"] = GafferScene.ShaderAssignment()
+		s["shaderAssignment"]["in"].setInput( s["group"]["out"] )
+		s["shaderAssignment"]["shader"].setInput( shaderOut )
+
+		s["outputs"] = GafferScene.Outputs()
+		s["outputs"].addOutput(
+			"beauty",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ClientDisplayDriver",
+					"displayHost" : "localhost",
+					"displayPort" : str( s['catalogue'].displayDriverServer().portNumber() ),
+					"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+					"quantize" : IECore.IntVectorData( [ 0, 0, 0, 0 ] ),
+				}
+			)
+		)
+		s["outputs"]["in"].setInput( s["shaderAssignment"]["out"] )
+
+		s["options"] = GafferScene.StandardOptions()
+		s["options"]["options"]["renderCamera"]["value"].setValue( "/group/camera" )
+		s["options"]["options"]["renderCamera"]["enabled"].setValue( True )
+		s["options"]["in"].setInput( s["outputs"]["out"] )
+
+		s["renderer"] = self._createInteractiveRender()
+		s["renderer"]["in"].setInput( s["options"]["out"] )
+
+		# Start a render, give it time to finish, and check the output.
+
+		s["renderer"]["state"].setValue( s["renderer"].State.Running )
+
+		self.uiThreadCallHandler.waitFor( 2 )
+
+		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
+		self.assertNotEqual( c[0], 0.0 )
+
+		# Break the light by removing the shader attribute.
+
+		s["deleteAttributes"]["names"].setValue( "*" )
+		self.uiThreadCallHandler.waitFor( 2 )
+
+		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
+		self.assertEqual( c[0], 0.0 )
+
+		# Fix the light back by putting the attribute back. We allow this to
+		# require the object to be regenerated if necessary.
+
+		self.ignoreMessage( IECore.Msg.Level.Warning, "RenderController", "1 attribute edit required geometry to be regenerated" )
+
+		s["deleteAttributes"]["names"].setValue( "" )
+		self.uiThreadCallHandler.waitFor( 2 )
+
+		c = self._color3fAtUV( s["catalogue"], imath.V2f( 0.5 ) )
+
+		self.assertNotEqual( c[0], 0.0 )
+
+		s["renderer"]["state"].setValue( s["renderer"].State.Stopped )
+
 	def testGlobalAttributes( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneTest/InteractiveRenderTest.py
+++ b/python/GafferSceneTest/InteractiveRenderTest.py
@@ -189,7 +189,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["o"].addOutput(
 			"beauty2",
 			IECoreScene.Output(
-				"test1",
+				"test2",
 				"ieDisplay",
 				"rgba",
 				{
@@ -218,7 +218,7 @@ class InteractiveRenderTest( GafferSceneTest.SceneTestCase ) :
 		s["o"].addOutput(
 			"beauty3",
 			IECoreScene.Output(
-				"test1",
+				"test3",
 				"ieDisplay",
 				"rgba",
 				{


### PR DESCRIPTION
This improves the coverage provided by InteractiveRenderTest, which is used to test all the renderer backends in Gaffer. The motivation for this was to test problematic cases during the development of GafferRenderMan, but I'm breaking it off as a separate PR to aid digestion. This also adds support for light muting in GafferDelight, since it was required to get one of the new tests passing.