### PR TITLE
RenderManOptions and RenderManAttributes nodes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             os: ubuntu-20.04
             buildType: RELEASE
             publish: true
-            containerImage: ghcr.io/gafferhq/build/build:3.0.0
+            containerImage: ghcr.io/gafferhq/build/build:3.2.0
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
@@ -52,7 +52,7 @@ jobs:
             os: ubuntu-20.04
             buildType: DEBUG
             publish: false
-            containerImage: ghcr.io/gafferhq/build/build:3.0.0
+            containerImage: ghcr.io/gafferhq/build/build:3.2.0
             testRunner: su testUser -c
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,11 @@ Build
 
 - Cortex : Updated to version 10.5.13.0.
 
+API
+---
+
+- Attributes, Options : Added protected constructors for initialising from attributes/options defined by metadata.
+
 1.5.6.0 (relative to 1.5.5.0)
 =======
 

--- a/SConstruct
+++ b/SConstruct
@@ -1380,6 +1380,33 @@ libraries = {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 	},
 
+	"GafferRenderMan" : {
+		"envAppends" : {
+			"CPPPATH" : [ "$RENDERMAN_ROOT/include" ],
+			# The RenderMan headers contain deprecated functionality that we don't use,
+			# but which nonetheless emit compilation warnings. We turn them off so we
+			# can continue to compile with warnings as errors.
+			"CPPDEFINES" : [ "RMAN_RIX_NO_WARN_DEPRECATED" ],
+			"LIBS" : [
+				"Iex$OPENEXR_LIB_SUFFIX", "Gaffer", "GafferDispatch", "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX",
+				"prman" if env["PLATFORM"] != "win32" else "libprman",
+				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
+			],
+			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
+		},
+		"pythonEnvAppends" : {
+			"LIBS" : [ "GafferBindings", "GafferDispatch", "GafferRenderMan", "GafferScene" ],
+			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
+		},
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
+
+	"GafferRenderManTest" : {},
+
+	"GafferRenderManUI" : {},
+
+	"GafferRenderManUITest" : {},
+
 	"GafferTractor" : {},
 
 	"GafferTractorTest" : {},

--- a/include/GafferRenderMan/Export.h
+++ b/include/GafferRenderMan/Export.h
@@ -1,0 +1,43 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "IECore/Export.h"
+
+#ifdef GafferRenderMan_EXPORTS
+	#define GAFFERRENDERMAN_API IECORE_EXPORT
+#else
+	#define GAFFERRENDERMAN_API IECORE_IMPORT
+#endif

--- a/include/GafferRenderMan/RenderManAttributes.h
+++ b/include/GafferRenderMan/RenderManAttributes.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,20 +34,28 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "GafferRenderMan/RenderManAttributes.h"
-#include "GafferRenderMan/RenderManOptions.h"
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferScene/Attributes.h"
 
-using namespace boost::python;
-using namespace GafferRenderMan;
-
-BOOST_PYTHON_MODULE( _GafferRenderMan )
+namespace GafferRenderMan
 {
 
-	GafferBindings::DependencyNodeClass<RenderManAttributes>();
-	GafferBindings::DependencyNodeClass<RenderManOptions>();
+class GAFFERRENDERMAN_API RenderManAttributes : public GafferScene::Attributes
+{
 
-}
+	public :
+
+		RenderManAttributes( const std::string &name=defaultName<RenderManAttributes>() );
+		~RenderManAttributes() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManAttributes, RenderManAttributesTypeId, GafferScene::Attributes );
+
+};
+
+IE_CORE_DECLAREPTR( RenderManAttributes )
+
+} // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManOptions.h
+++ b/include/GafferRenderMan/RenderManOptions.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,18 +34,28 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "GafferRenderMan/RenderManOptions.h"
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferScene/Options.h"
 
-using namespace boost::python;
-using namespace GafferRenderMan;
-
-BOOST_PYTHON_MODULE( _GafferRenderMan )
+namespace GafferRenderMan
 {
 
-	GafferBindings::DependencyNodeClass<RenderManOptions>();
+class GAFFERRENDERMAN_API RenderManOptions : public GafferScene::Options
+{
 
-}
+	public :
+
+		RenderManOptions( const std::string &name=defaultName<RenderManOptions>() );
+		~RenderManOptions() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManOptions, RenderManOptionsTypeId, GafferScene::Options );
+
+};
+
+IE_CORE_DECLAREPTR( RenderManOptions );
+
+} // namespace GafferRenderMan

--- a/include/GafferRenderMan/TypeIds.h
+++ b/include/GafferRenderMan/TypeIds.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,57 +36,14 @@
 
 #pragma once
 
-namespace GafferUI
+namespace GafferRenderMan
 {
 
 enum TypeId
 {
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	AuxiliaryConnectionsGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	AuxiliaryNodeGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	ConnectionCreatorTypeId = 110272,
-	CompoundNumericNoduleTypeId = 110273,
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
-	NoduleLayoutTypeId = 110284,
-	TranslateHandleTypeId = 110285,
-	ScaleHandleTypeId = 110286,
-	RotateHandleTypeId = 110287,
-	AnimationGadgetTypeId = 110288,
-	AnnotationsGadgetTypeId = 110289,
-	GraphGadgetSetPositionsActionTypeId = 110290,
-	ToolContainerTypeId = 110291,
-	FPSGadgetTypeId = 110292,
-	ViewDisplayTransformTypeId = 110293,
-	DragEditGadgetTypeId = 110294,
-
-	LastTypeId = 110399
+	RenderManAttributesTypeId = 110400,
+	RenderManOptionsTypeId = 110401,
+	LastTypeId = 110450
 };
 
-} // namespace GafferUI
+} // namespace GafferRenderMan

--- a/include/GafferScene/Attributes.h
+++ b/include/GafferScene/Attributes.h
@@ -68,6 +68,10 @@ class GAFFERSCENE_API Attributes : public AttributeProcessor
 
 	protected :
 
+		/// Automatically adds plugs for all attributes for the specified renderer, based
+		/// on `attribute:{rendererPrefix}:*` metadata registrations.
+		Attributes( const std::string &name, const std::string &rendererPrefix );
+
 		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const override;
 

--- a/include/GafferScene/Options.h
+++ b/include/GafferScene/Options.h
@@ -64,6 +64,10 @@ class GAFFERSCENE_API Options : public GlobalsProcessor
 
 	protected :
 
+		/// Automatically adds plugs for all options for the specified renderer, based
+		/// on `option:{rendererPrefix}:*` metadata registrations.
+		Options( const std::string &name, const std::string &rendererPrefix );
+
 		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
 

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -1,0 +1,237 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+from xml.etree import cElementTree
+
+import imath
+
+import IECore
+
+import Gaffer
+
+## Parses a RenderMan `.args` file, converting it to a dictionary
+# using Gaffer's standard metadata conventions :
+#
+# ```
+# {
+#	"description" : ...,
+#	"parameters" : {
+# 		"parameter1" : {
+#       	"description" : ...
+#       	"plugValueWidget:type" : ...
+#           ...
+#		}
+#   }
+# }
+# ```
+def parseMetadata( argsFile ) :
+
+	result = { "parameters" : {} }
+
+	pageStack = []
+	currentParameter = None
+	for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
+
+		if element.tag == "page" :
+
+			if event == "start" :
+				pageStack.append( element.attrib["name"] )
+			else :
+				pageStack.pop()
+
+		elif element.tag == "param" :
+
+			if event == "start" :
+
+				currentParameter = {}
+				result["parameters"][element.attrib["name"]] = currentParameter
+
+				# We need to know the parameter type to be able to parse presets and
+				# default values. There are two different ways this is defined, so try
+				# to normalise on the "Sdr" type.
+				currentParameter["__type"] = element.attrib.get( "sdrUsdDefinitionType" )
+				if currentParameter["__type"] is None :
+					currentParameter["__type"] = element.attrib["type"] + element.attrib.get( "arraySize", "" )
+
+				currentParameter["label"] = element.attrib.get( "label" )
+				currentParameter["description"] = element.attrib.get( "help" )
+				currentParameter["layout:section"] = ".".join( pageStack )
+				currentParameter["plugValueWidget:type"] = __widgetTypes.get( element.attrib.get( "widget" ) )
+				currentParameter["nodule:type"] = (
+					"" if element.attrib.get( "connectable", "true" ).lower() == "false" or currentParameter["plugValueWidget:type"] == ""
+					else None
+				)
+
+				defaultValue = __parseValue( element.attrib.get( "default" ), currentParameter["__type"] )
+				if defaultValue is not None :
+					currentParameter["defaultValue"] = defaultValue
+
+				if element.attrib.get( "options" ) :
+					__parsePresets( element.attrib.get( "options" ), currentParameter )
+
+			elif event == "end" :
+
+				del currentParameter["__type"] # Implementation detail not for public consumption
+				currentParameter = None
+
+		elif element.tag == "help" and event == "end" :
+
+			if currentParameter :
+				currentParameter["description"] = element.text
+			else :
+				result["description"] = element.text
+
+		elif element.tag == "hintdict" and element.attrib.get( "name" ) == "options" :
+			if event == "end" :
+				__parsePresets( element, currentParameter )
+
+	return result
+
+## Parses a RenderMan `.args` file, registering Gaffer metadata for all its parameters
+# against targets named `{targetPrefix}{parameterName}`.
+def registerMetadata( argsFile, targetPrefix, parametersToIgnore = set() ) :
+
+	metadata = parseMetadata( argsFile )
+	for name, values in metadata["parameters"].items() :
+
+		if name in parametersToIgnore :
+			continue
+
+		target = f"{targetPrefix}{name}"
+		for key, value in values.items() :
+			Gaffer.Metadata.registerValue( target, key, value )
+
+__widgetTypes = {
+	"number" : "GafferUI.NumericPlugValueWidget",
+	"string" : "GafferUI.StringPlugValueWidget",
+	"boolean" : "GafferUI.BoolPlugValueWidget",
+	"checkBox" : "GafferUI.BoolPlugValueWidget",
+	"popup" : "GafferUI.PresetsPlugValueWidget",
+	"mapper" : "GafferUI.PresetsPlugValueWidget",
+	"filename" : "GafferUI.PathPlugValueWidget",
+	"assetIdInput" : "GafferUI.PathPlugValueWidget",
+	"null" : "",
+}
+
+def __boolParser( string ) :
+
+	return bool( int( string ) )
+
+def __floatParser( string ) :
+
+	if string.endswith( "f" ) :
+		string = string[:-1]
+
+	return float( string )
+
+def __vectorParser( string, vectorType, baseType ) :
+
+	return vectorType( *[ baseType( x ) for x in string.split() ] )
+
+def __stringVectorDataParser( string ) :
+
+	return IECore.StringVectorData( string.split( "," ) )
+
+__valueParsers = {
+	"bool" : __boolParser,
+	"int" : int,
+	"float" : __floatParser,
+	"string" : str,
+	"int2" : functools.partial( __vectorParser, vectorType = imath.V2i, baseType = int ),
+	"float2" : functools.partial( __vectorParser, vectorType = imath.V2f, baseType = float ),
+	"float3" : functools.partial( __vectorParser, vectorType = imath.V3f, baseType = float ),
+	"float4" : functools.partial( __vectorParser, vectorType = imath.V4f, baseType = float ),
+	"point" : functools.partial( __vectorParser, vectorType = imath.V3f, baseType = float ),
+	"vector" : functools.partial( __vectorParser, vectorType = imath.V3f, baseType = float ),
+	"normal" : functools.partial( __vectorParser, vectorType = imath.V3f, baseType = float ),
+	"color" : functools.partial( __vectorParser, vectorType = imath.Color3f, baseType = float ),
+	"string2" : __stringVectorDataParser,
+}
+
+def __parseValue( string, parameterType ) :
+
+	if string is None :
+		return None
+
+	parser = __valueParsers.get( parameterType )
+	if parser is None :
+		return None
+
+	try :
+		return parser( string )
+	except :
+		return None
+
+__presetContainers = {
+	"int" : IECore.IntVectorData,
+	"float" : IECore.FloatVectorData,
+	"string" : IECore.StringVectorData,
+}
+
+def __parsePresets( options, parameter ) :
+
+	containerType = __presetContainers.get( parameter["__type"] )
+	if containerType is None :
+		return
+
+	presetNames = IECore.StringVectorData()
+	presetValues = containerType()
+
+	if isinstance( options, str ) :
+		for option in options.split( "|" ) :
+			optionSplit = option.split( ":" )
+			if len( optionSplit ) == 2 :
+				name = optionSplit[0]
+				value = __parseValue( optionSplit[1], parameter["__type"] )
+			else :
+				assert( len( optionSplit ) == 1 )
+				name = IECore.CamelCase.toSpaced( optionSplit[0] )
+				value = __parseValue( optionSplit[0], parameter["__type"] )
+			presetNames.append( name )
+			presetValues.append( value )
+	else :
+		# Hint dict
+		for option in options :
+			value = option.attrib["value"]
+			name = option.attrib.get( "name" )
+			if name is None :
+				name = IECore.CamelCase.toSpaced( value )
+			presetNames.append( name )
+			presetValues.append( __parseValue( value, parameter["__type"] ) )
+
+	parameter["presetNames"] = presetNames
+	parameter["presetValues"] = presetValues

--- a/python/GafferRenderMan/__init__.py
+++ b/python/GafferRenderMan/__init__.py
@@ -37,5 +37,6 @@
 __import__( "GafferScene" )
 
 from ._GafferRenderMan import *
+from . import ArgsFileAlgo
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderMan" )

--- a/python/GafferRenderMan/__init__.py
+++ b/python/GafferRenderMan/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2017, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+__import__( "GafferScene" )
+
+from ._GafferRenderMan import *
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderMan" )

--- a/python/GafferRenderManTest/ModuleTest.py
+++ b/python/GafferRenderManTest/ModuleTest.py
@@ -1,0 +1,47 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferTest
+
+class ModuleTest( GafferTest.TestCase ) :
+
+	def testDoesNotImportUI( self ) :
+
+		self.assertModuleDoesNotImportUI( "GafferRenderMan" )
+		self.assertModuleDoesNotImportUI( "GafferRenderManTest" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/ModuleTest.py
+++ b/python/GafferRenderManTest/ModuleTest.py
@@ -34,6 +34,10 @@
 #
 ##########################################################################
 
+import os
+import subprocess
+
+import Gaffer
 import GafferTest
 
 class ModuleTest( GafferTest.TestCase ) :
@@ -42,6 +46,24 @@ class ModuleTest( GafferTest.TestCase ) :
 
 		self.assertModuleDoesNotImportUI( "GafferRenderMan" )
 		self.assertModuleDoesNotImportUI( "GafferRenderManTest" )
+
+	def testCanLoadGUIConfigsWithoutRenderMan( self ) :
+
+		# Start a subprocess without RMANTREE set, and without the side-effects
+		# of it having been set when our wrapper ran earlier. And in that subprocess,
+		# check that we can still load the GUI configs cleanly.
+
+		env = os.environ.copy()
+		for var in ( "RMANTREE", "PYTHONPATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "GAFFER_STARTUP_PATHS" ) :
+			env.pop( var, None )
+
+		try :
+			subprocess.check_output(
+				[ str( Gaffer.executablePath() ), "test", "GafferUITest.TestCase.assertCanLoadGUIConfigs" ],
+				env = env, stderr = subprocess.STDOUT
+			)
+		except subprocess.CalledProcessError as e :
+			self.fail( e.output )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManAttributesTest.py
+++ b/python/GafferRenderManTest/RenderManAttributesTest.py
@@ -1,0 +1,87 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManAttributesTest( GafferSceneTest.SceneTestCase ) :
+
+	def testAttributeMetadata( self ) :
+
+		# Check a few of the registrations we expect from `startup/GafferScene/renderManAttributes.py`.
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:bakebboxmin", "label" ), "Baking bbox min" )
+		# Yes, the double-namespacing of `ri:Ri` is absurd, but that's the logical consequence of adhering to the
+		# RenderMan naming, and matches the `PxrAttributesAPI` USD schema.
+		self.assertEqual( Gaffer.Metadata.value( "attribute:ri:Ri:Matte", "label" ), "Matte" )
+
+	def testAllAttributeMetadataHasDefaultValue( self ) :
+
+		self.assertTrue(
+			Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "label" ),
+		)
+
+		self.assertEqual(
+			set( Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "label" ) ),
+			set( Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "defaultValue" ) ),
+		)
+
+	def testOmittedAttributesMetadata( self ) :
+
+		# We don't register these because we deal with them in a renderer-agnostic way, and we don't
+		# want users to specify them directly.
+		self.assertFalse( Gaffer.Metadata.registeredValues( "attribute:ri:Ri:Sides" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "attribute:ri:lighting:mute" ) )
+
+	def testNodeConstructsWithAllAttributes( self ) :
+
+		node = GafferRenderMan.RenderManAttributes()
+		for attribute in Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "defaultValue" ) :
+			attribute = attribute[10:]
+			with self.subTest( attribute = attribute ) :
+				self.assertIn( attribute, node["attributes"] )
+				self.assertEqual( node["attributes"][attribute]["name"].getValue(), attribute )
+				self.assertEqual(
+					node["attributes"][attribute]["value"].defaultValue(),
+					Gaffer.Metadata.value( f"attribute:{attribute}", "defaultValue" )
+				)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/RenderManOptionsTest.py
+++ b/python/GafferRenderManTest/RenderManOptionsTest.py
@@ -1,0 +1,107 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManOptionsTest( GafferSceneTest.SceneTestCase ) :
+
+	def testOptionMetadata( self ) :
+
+		# Check a few of the registrations we expect from `startup/GafferScene/renderManOptions.py`.
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:bakebboxmin", "label" ), "Baking bbox min" )
+		# Yes, the double-namespacing of `ri:Ri` is absurd, but that's the logical consequence of adhering to the
+		# RenderMan naming, and matches the `PxrOptionsAPI` USD schema.
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:Ri:PixelFilterName", "label" ), " Pixel Filter" )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:bakemode", "presetNames" ), IECore.StringVectorData( [ "Pattern", "Integrator", "All" ] ) )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:bakemode", "presetValues" ), IECore.StringVectorData( [ "pattern", "integrator", "all" ] ) )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:bakemode", "plugValueWidget:type" ), "GafferUI.PresetsPlugValueWidget" )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:hider:adaptivemetric", "defaultValue" ), "variance" )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:osl:verbose", "presetNames" ), IECore.StringVectorData( [ "0 - Silent", "1 - Severe", "2 - Error", "3 - Message", "4 - Warning", "5 - Info" ] ) )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:osl:verbose", "presetValues" ), IECore.IntVectorData( [ 0, 1, 2, 3, 4, 5 ] ) )
+		self.assertEqual( Gaffer.Metadata.value( "option:ri:shade:debug", "defaultValue" ), False )
+
+	def testAllOptionMetadataHasDefaultValue( self ) :
+
+		self.assertTrue(
+			Gaffer.Metadata.targetsWithMetadata( "option:ri:*", "label" ),
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.targetsWithMetadata( "option:ri:*", "label" ),
+			Gaffer.Metadata.targetsWithMetadata( "option:ri:*", "defaultValue" ),
+		)
+
+	def testOmittedOptionMetadata( self ) :
+
+		# We don't register these because we deal with them in a renderer-agnostic way, and we don't
+		# want users to specify them directly.
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:Frame" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:FrameAspectRatio" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:ScreenWindow" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:CropWindow" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:FormatPixelAspectRatio" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:FormatResolution" ) )
+		self.assertFalse( Gaffer.Metadata.registeredValues( "option:ri:Ri:Shutter" ) )
+		# Check we're not leaking implementation details of the parser.
+		self.assertIsNone( Gaffer.Metadata.value( "option:ri:hider:adaptivemetric", "__type" ) )
+
+	def testOmittedPresets( self ) :
+
+		adaptiveMetrics = Gaffer.Metadata.value( "option:ri:hider:adaptivemetric", "presetValues" )
+		self.assertNotIn( "contrast-v22", adaptiveMetrics )
+		self.assertNotIn( "variance-v22", adaptiveMetrics )
+
+	def testNodeConstructsWithAllOptions( self ) :
+
+		node = GafferRenderMan.RenderManOptions()
+		for option in Gaffer.Metadata.targetsWithMetadata( "option:ri:*", "defaultValue" ) :
+			option = option[7:]
+			with self.subTest( option = option ) :
+				self.assertIn( option, node["options"] )
+				self.assertEqual( node["options"][option]["name"].getValue(), option )
+				self.assertEqual(
+					node["options"][option]["value"].defaultValue(),
+					Gaffer.Metadata.value( f"option:{option}", "defaultValue" )
+				)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -1,0 +1,41 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from .ModuleTest import ModuleTest
+
+if __name__ == "__main__":
+	import unittest
+	unittest.main()

--- a/python/GafferRenderManUI/RenderManAttributesUI.py
+++ b/python/GafferRenderManUI/RenderManAttributesUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2019, John Haddon. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,10 +34,18 @@
 #
 ##########################################################################
 
-from .ModuleTest import ModuleTest
-from .RenderManAttributesTest import RenderManAttributesTest
-from .RenderManOptionsTest import RenderManOptionsTest
+import IECore
 
-if __name__ == "__main__":
-	import unittest
-	unittest.main()
+import Gaffer
+import GafferRenderMan
+
+Gaffer.Metadata.registerNode(
+
+	GafferRenderMan.RenderManAttributes,
+
+	"description",
+	"""
+	Applies RenderMan attributes to objects in the scene.
+	""",
+
+)

--- a/python/GafferRenderManUI/RenderManOptionsUI.py
+++ b/python/GafferRenderManUI/RenderManOptionsUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2019, John Haddon. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,9 +34,18 @@
 #
 ##########################################################################
 
-from .ModuleTest import ModuleTest
-from .RenderManOptionsTest import RenderManOptionsTest
+import Gaffer
+import GafferRenderMan
 
-if __name__ == "__main__":
-	import unittest
-	unittest.main()
+Gaffer.Metadata.registerNode(
+
+	GafferRenderMan.RenderManOptions,
+
+	"description",
+	"""
+	Sets global scene options applicable to the RenderMan
+	renderer. Use the StandardOptions node to set
+	global options applicable to all renderers.
+	""",
+
+)

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -36,4 +36,6 @@
 
 __import__( "GafferSceneUI" )
 
+from . import RenderManOptionsUI
+
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -36,6 +36,7 @@
 
 __import__( "GafferSceneUI" )
 
+from . import RenderManAttributesUI
 from . import RenderManOptionsUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -1,0 +1,39 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+__import__( "GafferSceneUI" )
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )

--- a/python/GafferRenderManUITest/DocumentationTest.py
+++ b/python/GafferRenderManUITest/DocumentationTest.py
@@ -1,0 +1,56 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import GafferUITest
+
+import GafferScene
+import GafferRenderMan
+import GafferRenderManUI
+
+class DocumentationTest( GafferUITest.TestCase ) :
+
+	def test( self ) :
+
+		self.maxDiff = None
+		self.assertNodesAreDocumented(
+			GafferRenderMan,
+			additionalTerminalPlugTypes = ( GafferScene.ScenePlug, )
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManUITest/__init__.py
+++ b/python/GafferRenderManUITest/__init__.py
@@ -1,0 +1,39 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+from .DocumentationTest import DocumentationTest
+
+__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUITest" )

--- a/python/GafferSceneUI/AttributesUI.py
+++ b/python/GafferSceneUI/AttributesUI.py
@@ -35,9 +35,15 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
-
 import GafferScene
+
+def __attributeMetadata( plug, key ) :
+
+	if not isinstance( plug, Gaffer.NameValuePlug ) :
+		plug = plug.parent()
+
+	target = "attribute:" + plug["name"].getValue()
+	return Gaffer.Metadata.value( target, key )
 
 Gaffer.Metadata.registerNode(
 
@@ -68,6 +74,18 @@ Gaffer.Metadata.registerNode(
 		"attributes.*" : [
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+			"description", lambda plug : __attributeMetadata( plug, "description" ),
+			"label", lambda plug : __attributeMetadata( plug, "label" ),
+			"layout:section", lambda plug : __attributeMetadata( plug, "layout:section" ),
+
+		],
+
+		"attributes.*.value" : [
+
+			"plugValueWidget:type", lambda plug : __attributeMetadata( plug, "plugValueWidget:type" ),
+			"presetNames", lambda plug : __attributeMetadata( plug, "presetNames" ),
+			"presetValues", lambda plug : __attributeMetadata( plug, "presetValues" ),
 
 		],
 

--- a/python/GafferSceneUI/OptionsUI.py
+++ b/python/GafferSceneUI/OptionsUI.py
@@ -35,8 +35,15 @@
 ##########################################################################
 
 import Gaffer
-import GafferUI
 import GafferScene
+
+def __optionMetadata( plug, key ) :
+
+	if not isinstance( plug, Gaffer.NameValuePlug ) :
+		plug = plug.parent()
+
+	target = "option:" + plug["name"].getValue()
+	return Gaffer.Metadata.value( target, key )
 
 Gaffer.Metadata.registerNode(
 
@@ -65,6 +72,18 @@ Gaffer.Metadata.registerNode(
 		"options.*" : [
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+			"description", lambda plug : __optionMetadata( plug, "description" ),
+			"label", lambda plug : __optionMetadata( plug, "label" ),
+			"layout:section", lambda plug : __optionMetadata( plug, "layout:section" ),
+
+		],
+
+		"options.*.value" : [
+
+			"plugValueWidget:type", lambda plug : __optionMetadata( plug, "plugValueWidget:type" ),
+			"presetNames", lambda plug : __optionMetadata( plug, "presetNames" ),
+			"presetValues", lambda plug : __optionMetadata( plug, "presetValues" ),
 
 		],
 

--- a/python/GafferUITest/ExamplesTest.py
+++ b/python/GafferUITest/ExamplesTest.py
@@ -37,7 +37,6 @@
 import Gaffer
 import GafferUI
 import GafferUITest
-import GafferScene
 
 class ExamplesTest( GafferUITest.TestCase ) :
 
@@ -108,7 +107,7 @@ class ExamplesTest( GafferUITest.TestCase ) :
 
 		e1key = self.__testKeys[0]
 		e1path = "/nodes/a"
-		e1nodes = [ GafferScene.Camera, GafferScene.Group ]
+		e1nodes = [ Gaffer.ContextQuery, Gaffer.ContextVariables ]
 
 		e2key = self.__testKeys[1]
 		e2path = "/nodes/b"
@@ -129,11 +128,11 @@ class ExamplesTest( GafferUITest.TestCase ) :
 		self.assertNotIn( e1key, examples )
 		self.assertIn( e2key, examples )
 
-		examples = GafferUI.Examples.registeredExamples( node = GafferScene.Camera )
+		examples = GafferUI.Examples.registeredExamples( node = Gaffer.ContextQuery )
 		self.assertIn( e1key, examples )
 		self.assertNotIn( e2key, examples )
 
-		examples = GafferUI.Examples.registeredExamples( node = GafferScene.Group )
+		examples = GafferUI.Examples.registeredExamples( node = Gaffer.ContextVariables )
 		self.assertIn( e1key, examples )
 		self.assertNotIn( e2key, examples )
 

--- a/python/GafferUITest/TestCase.py
+++ b/python/GafferUITest/TestCase.py
@@ -180,6 +180,11 @@ class TestCase( GafferTest.TestCase ) :
 			del script
 			self.assertIsNone( weakScript() )
 
+	def assertCanLoadGUIConfigs( self ) :
+
+		app = Gaffer.Application()
+		app._executeStartupFiles( "gui" )
+
 	@staticmethod
 	def __widgetInstances() :
 

--- a/src/GafferRenderMan/RenderManAttributes.cpp
+++ b/src/GafferRenderMan/RenderManAttributes.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,20 +34,18 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
-
 #include "GafferRenderMan/RenderManAttributes.h"
-#include "GafferRenderMan/RenderManOptions.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
+using namespace Gaffer;
 using namespace GafferRenderMan;
 
-BOOST_PYTHON_MODULE( _GafferRenderMan )
+IE_CORE_DEFINERUNTIMETYPED( RenderManAttributes );
+
+RenderManAttributes::RenderManAttributes( const std::string &name )
+	:	GafferScene::Attributes( name, "ri" )
 {
+}
 
-	GafferBindings::DependencyNodeClass<RenderManAttributes>();
-	GafferBindings::DependencyNodeClass<RenderManOptions>();
-
+RenderManAttributes::~RenderManAttributes()
+{
 }

--- a/src/GafferRenderMan/RenderManOptions.cpp
+++ b/src/GafferRenderMan/RenderManOptions.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,18 +34,20 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
-
 #include "GafferRenderMan/RenderManOptions.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
-
-using namespace boost::python;
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
 using namespace GafferRenderMan;
 
-BOOST_PYTHON_MODULE( _GafferRenderMan )
+IE_CORE_DEFINERUNTIMETYPED( RenderManOptions );
+
+RenderManOptions::RenderManOptions( const std::string &name )
+	:	GafferScene::Options( name, "ri" )
 {
+}
 
-	GafferBindings::DependencyNodeClass<RenderManOptions>();
-
+RenderManOptions::~RenderManOptions()
+{
 }

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2012, John Haddon. All rights reserved.
-//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,59 +34,10 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "boost/python.hpp"
 
-namespace GafferUI
+using namespace boost::python;
+
+BOOST_PYTHON_MODULE( _GafferRenderMan )
 {
-
-enum TypeId
-{
-	GadgetTypeId = 110251,
-	NodeGadgetTypeId = 110252,
-	GraphGadgetTypeId = 110253,
-	ContainerGadgetTypeId = 110254,
-	AuxiliaryConnectionsGadgetTypeId = 110255,
-	TextGadgetTypeId = 110256,
-	NameGadgetTypeId = 110257,
-	IndividualContainerTypeId = 110258,
-	FrameTypeId = 110259,
-	StyleTypeId = 110260,
-	StandardStyleTypeId = 110261,
-	NoduleTypeId = 110262,
-	LinearContainerTypeId = 110263,
-	ConnectionGadgetTypeId = 110264,
-	StandardNodeGadgetTypeId = 110265,
-	AuxiliaryNodeGadgetTypeId = 110266,
-	StandardNoduleTypeId = 110267,
-	CompoundNoduleTypeId = 110268,
-	ImageGadgetTypeId = 110269,
-	ViewportGadgetTypeId = 110270,
-	ViewTypeId = 110271,
-	ConnectionCreatorTypeId = 110272,
-	CompoundNumericNoduleTypeId = 110273,
-	PlugGadgetTypeId = 110274,
-	GraphLayoutTypeId = 110275,
-	StandardGraphLayoutTypeId = 110276,
-	BackdropNodeGadgetTypeId = 110277,
-	SpacerGadgetTypeId = 110278,
-	StandardConnectionGadgetTypeId = 110279,
-	HandleTypeId = 110280,
-	ToolTypeId = 110281,
-	DotNodeGadgetTypeId = 110282,
-	PlugAdderTypeId = 110283,
-	NoduleLayoutTypeId = 110284,
-	TranslateHandleTypeId = 110285,
-	ScaleHandleTypeId = 110286,
-	RotateHandleTypeId = 110287,
-	AnimationGadgetTypeId = 110288,
-	AnnotationsGadgetTypeId = 110289,
-	GraphGadgetSetPositionsActionTypeId = 110290,
-	ToolContainerTypeId = 110291,
-	FPSGadgetTypeId = 110292,
-	ViewDisplayTransformTypeId = 110293,
-	DragEditGadgetTypeId = 110294,
-
-	LastTypeId = 110399
-};
-
-} // namespace GafferUI
+}

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -1,0 +1,154 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import pathlib
+import re
+
+import IECore
+
+import Gaffer
+
+# Pull all the attribute definitions out of RenderMan's `PRManAttributes.args`
+# and `PRManPrimVars.args` files, and register them using Gaffer's standard
+# metadata conventions. This is then used to populate the RenderManAttributes
+# node and the AttributeEditor etc.
+
+if "RMANTREE" in os.environ :
+
+	import GafferRenderMan.ArgsFileAlgo
+
+	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
+
+	GafferRenderMan.ArgsFileAlgo.registerMetadata(
+		rmanTree / "lib" / "defaults" / "PRManAttributes.args", "attribute:ri:",
+		parametersToIgnore = {
+			# Things that Gaffer has renderer-agnostic attributes for already.
+			"Ri:Sides",
+			"lighting:mute",
+			# Things that we might want to use internally in the Renderer class.
+			"identifier:id",
+			"identifier:id2",
+			"identifier:name",
+			"stats:identifier",
+			"Ri:ReverseOrientation",
+			# Things that we probably want to expose, but which will require
+			# additional plumbing before they will be useful.
+			"lightfilter:subset",
+			"lighting:excludesubset",
+			"lighting:subset",
+			"trace:reflectexcludesubset",
+			"trace:reflectsubset",
+			"trace:shadowexcludesubset",
+			"trace:shadowsubset",
+			"trace:transmitexcludesubset",
+			"trace:transmitsubset",
+			# Might it be better if we populate this automatically based on set
+			# memberships and/or light links? Don't expose it until we know.
+			"grouping:membership",
+		}
+	)
+
+	GafferRenderMan.ArgsFileAlgo.registerMetadata(
+		rmanTree / "lib" / "defaults" / "PRManPrimVars.args", "attribute:ri:",
+		parametersToIgnore = {
+			# Things which we probably need to handle automatically in the
+			# Renderer class.
+			"identifier:object",
+			"stats:prototypeIdentifier",
+			"Ri:Bound",
+			"Ri:Orientation",
+			# Things that we might want to expose but which might need extra
+			# plumbing to make work.
+			"dice:referencecamera",
+			"dice:referenceinstance",
+			"shade:faceset",
+			"trimcurve:sense",
+			# Things that we think might just be too esoteric or which have no
+			# documentation to explain them. People can always use
+			# CustomAttributes to specify these.
+			"polygon:concave",
+			"displacement:ignorereferenceinstance",
+			"stitchbound:CoordinateSystem",
+			"stitchbound:sphere",
+		}
+	)
+
+	# Override dodgy bits with our own metadata.
+
+	Gaffer.Metadata.registerValue( "attribute:ri:derivatives:extrapolate", "label", "Extrapolate Derivatives" )
+	Gaffer.Metadata.registerValue( "attribute:ri:trace:sssautobias", "label", "SSS Auto Trace Bias" )
+	Gaffer.Metadata.registerValue( "attribute:ri:trace:sssbias", "label", "SSS Trace Bias" )
+	Gaffer.Metadata.registerValue( "attribute:ri:dice:strategy", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+
+	# Move displacement stuff into its own section. This simplifies the very
+	# long shading section and allows us to use shorter labels that fit the
+	# available space.
+
+	for attribute in [
+		"trace:displacements",
+		"displacementbound:CoordinateSystem",
+		"displacementbound:CoordinateSystem",
+		"displacementbound:offscreen",
+		"displacementbound:sphere",
+	] :
+		target = f"attribute:ri:{attribute}"
+		Gaffer.Metadata.registerValue( target, "layout:section", "Displacement" )
+		if attribute == "trace:displacements" :
+			label = "Trace"
+		else :
+			label = re.sub( r"[dD]isplacement ?", "", Gaffer.Metadata.value( target, "label" ) )
+		Gaffer.Metadata.registerValue( target, "label", label )
+
+	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "presetNames", IECore.StringVectorData( [ "Object", "World" ] ) )
+	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "presetValues", IECore.StringVectorData( [ "object", "world" ] ) )
+
+	# Register BoolPlugValueWidget for attributes which are actually integers
+	# but would more logically be bools. We can't change their type, because
+	# then we're not going to line up with USD on export/import. But we can at
+	# least improve the user interaction.
+
+	for attribute in [
+		"visibility:camera",
+		"visibility:indirect",
+		"visibility:transmission",
+		"trace:holdout",
+		"Ri:Matte",
+		"curves:widthaffectscurvature",
+		"displacementbound:offscreen",
+	] :
+		Gaffer.Metadata.registerValue( f"attribute:ri:{attribute}", "plugValueWidget:type", "GafferUI.BoolPlugValueWidget" )

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -1,0 +1,189 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import pathlib
+
+import IECore
+
+import Gaffer
+
+# Pull all the option definitions out of RenderMan's `PRManOptions.args` file
+# and register them using Gaffer's standard metadata conventions. This is then
+# used to populate the RenderManOptions node and the RenderPassEditor etc.
+
+if "RMANTREE" in os.environ :
+
+	import GafferRenderMan.ArgsFileAlgo
+
+	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
+
+	GafferRenderMan.ArgsFileAlgo.registerMetadata(
+		rmanTree / "lib" / "defaults" / "PRManOptions.args", "option:ri:",
+		parametersToIgnore = {
+			# Gaffer handles all of these in a renderer-agnostic manner.
+			"Ri:Frame",
+			"Ri:FrameAspectRatio",
+			"Ri:ScreenWindow",
+			"Ri:CropWindow",
+			"Ri:FormatPixelAspectRatio",
+			"Ri:FormatResolution",
+			"Ri:Shutter",
+			"hider:samplemotion",
+			# These are for back-compatibility with a time before Gaffer
+			# supported RenderMan, so we don't need them. The fewer settings
+			# people have to wrestle with, the better.
+			"statistics:displace_ratios",
+			"statistics:filename",
+			"statistics:level",
+			"statistics:maxdispwarnings",
+			"statistics:shaderprofile",
+			"statistics:stylesheet",
+			"statistics:texturestatslevel",
+			"statistics:xmlfilename",
+			"trace:incorrectCurveBias",
+			"shade:chiangCompatibilityVersion",
+			"shade:subsurfaceTypeDefaultFromVersion24",
+			# https://rmanwiki-26.pixar.com/space/REN26/19661831/Sampling+Modes#Adaptive-Sampling-Error-Metrics
+			# implies that this is only used by the obsolete adaptive metrics.
+			"hider:darkfalloff",
+			# These are XPU-only, and we don't yet support XPU. They also
+			# sound somewhat fudgy.
+			"interactive:displacementupdatemode",
+			"interactive:displacementupdatedebug",
+			# These just don't make much sense in Gaffer.
+			"ribparse:varsubst",
+			# These aren't documented, and will cause GafferRenderManUITest.DocumentationTest
+			# to fail if we load them. We'll let them back in if we determine they are relevant
+			# and can come up with a sensible documentation string of our own.
+			"limits:gridsize",
+			"limits:proceduralbakingclumpsize",
+			"limits:ptexturemaxfiles",
+			"limits:textureperthreadmemoryratio",
+		}
+	)
+
+	# Omit obsolete adaptive metrics.
+
+	for key in [ "presetNames", "presetValues" ] :
+		Gaffer.Metadata.registerValue(
+			"option:ri:hider:adaptivemetric", key,
+			IECore.StringVectorData( [
+				x for x in Gaffer.Metadata.value( "option:ri:hider:adaptivemetric", key )
+				if "v22" not in x
+			] )
+		)
+
+	# Omit pixel filters with negative lobes, since they are not compatible
+	# with filter importance sampling (we don't expose weighted sampling).
+
+	for key in [ "presetNames", "presetValues" ] :
+		Gaffer.Metadata.registerValue(
+			"option:ri:Ri:PixelFilterName", key,
+			IECore.StringVectorData( [
+				x for x in Gaffer.Metadata.value( "option:ri:Ri:PixelFilterName", key )
+				if x.lower() not in { "catmull-rom", "separable-catmull-rom", "mitchell", "sinc", "bessel", "lanczos" }
+			] )
+		)
+
+	# Move some stray options into a more logical section of the layout.
+
+	for option in [
+		"shade:debug",
+		"shade:roughnessmollification",
+		"shade:shadowBumpTerminator",
+	] :
+		Gaffer.Metadata.registerValue( f"option:ri:{option}", "layout:section", "Shading" )
+
+	# Add options used to define custom LPE lobes. RenderMan does understand these, but they aren't
+	# reported in `PRManOptions.args` for some reason, and don't actually have the
+	# default values that are documented here :
+	#
+	#    https://rmanwiki-26.pixar.com/space/REN26/19661883/Light+Path+Expressions#Per-Lobe-LPEs
+	#
+	# Furthermore, the documented defaults are different from the defaults used in other bridge
+	# products, which include additional lobes for compatibility with Lama shaders. The defaults
+	# we use below are the superset of those from the documentation and RenderMan for Blender. This
+	# reportedly also matches RenderMan for Maya.
+	#
+	# > Note : These must be kept in sync with the list in `src/IECoreRenderMan/Globals.cpp`, where
+	# > we actually apply the "defaults".
+
+	for name, lobe, defaultValue in [
+		# RfB adds "diffuse,translucent,hair4,irradiance"
+		( "lpe:diffuse2", "D2", "Diffuse,HairDiffuse,diffuse,translucent,hair4,irradiance" ),
+		# RfB adds "subsurface"
+		( "lpe:diffuse3", "D3", "Subsurface,subsurface" ),
+		( "lpe:diffuse4", "D4", "" ),
+		# RfB adds "specular,hair1"
+		( "lpe:specular2", "S2", "Specular,HairSpecularR,specular,hair1" ),
+		# RfB adds "hair3"
+		( "lpe:specular3", "S3", "RoughSpecular,HairSpecularTRT,hair3" ),
+		( "lpe:specular4", "S4", "Clearcoat" ),
+		( "lpe:specular5", "S5", "Iridescence" ),
+		( "lpe:specular6", "S6", "Fuzz,HairSpecularGLINTS" ),
+		# RfB adds "hair2"
+		( "lpe:specular7", "S7", "SingleScatter,HairSpecularTT,hair2" ),
+		# RfB adds "specular"
+		( "lpe:specular8", "S8", "Glass,specular" ),
+		( "lpe:user2", "U2", "Albedo,DiffuseAlbedo,SubsurfaceAlbedo,HairAlbedo" ),
+		# Not defined in RfB
+		( "lpe:user3", "U3", "Position" ),
+		# Not defined in RfB
+		( "lpe:user4", "U4", "UserColor" ),
+		( "lpe:user5", "U5", "" ),
+		# Not defined in RfB, but required by the default denoising outputs.
+		( "lpe:user6", "U6", "Normal,DiffuseNormal,HairTangent,SubsurfaceNormal,SpecularNormal,RoughSpecularNormal,SingleScatterNormal,FuzzNormal,IridescenceNormal,GlassNormal" ),
+		( "lpe:user7", "U7", "" ),
+		( "lpe:user8", "U8", "" ),
+		# RfB goes up to 12, but if folks really need to indulge that much
+		# they can use a CustomOptions node.
+	] :
+
+		Gaffer.Metadata.registerValue( f"option:ri:{name}", "defaultValue", defaultValue )
+		Gaffer.Metadata.registerValue( f"option:ri:{name}", "description",
+			f"""
+			Defines the contents of the `{lobe}` custom LPE lobe.
+			"""
+		)
+		Gaffer.Metadata.registerValue( f"option:ri:{name}", "label", lobe )
+		Gaffer.Metadata.registerValue( f"option:ri:{name}", "layout:section", "Custom LPE Lobes" )
+
+	# Add widgets and presets that are missing from the `.args` file.
+
+	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
+	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "presetNames", IECore.StringVectorData( [ "World", "Camera" ] ) )
+	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "presetValues", IECore.StringVectorData( [ "world", "camera" ] ) )


### PR DESCRIPTION
This adds the beginnings of a GafferRenderMan module, to expose the recently added IECoreRenderMan backend to users. Initially this just contains RenderManOptions and RenderManAttributes nodes, but more will follow in future PRs.

The new nodes both take a "metadata first" approach to defining attributes and options, with the plugs on the nodes being created from central metadata definitions that will also be used to populate the AttributeEditor and RenderPassEditor. This is the direction we are slowly moving in for older nodes like ArnoldOptions. Pleasingly, RenderMan ships with `.args` files which declare the vast majority of built-in options and attributes, so we can source the definitions directly from those with minimal tweaks.

At this point the new nodes are not available in the node menu : we'll only expose things directly to the user when we have everything else merged too.