### PR TITLE
CI : Run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,8 +43,9 @@ jobs:
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
-            # test user rather than as root.
-            testRunner: su testUser -c
+            # test user rather than as root. We also run with `libSegFault.so` loaded
+            # to get more information from any crashes which occur.
+            testRunner: LD_PRELOAD=libSegFault.so su testUser -c
             sconsCacheMegabytes: 400
             jobs: 4
 
@@ -53,7 +54,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:3.0.0
-            testRunner: su testUser -c
+            testRunner: LD_PRELOAD=libSegFault.so su testUser -c
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -102,7 +103,6 @@ jobs:
         Xvfb :99 -screen 0 1280x1024x24 &
         metacity --display :99.0 &
         useradd -m testUser
-        echo LD_PRELOAD=libSegFault.so >> $GITHUB_ENV
         # The Docker container configures bash shells such that they enable the
         # software collections we want. If we could set GitHub's
         # `defaults.run.shell` to `bash` then all our build steps would pick up

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         include:
 
           - name: linux-gcc11
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             buildType: RELEASE
             publish: true
             containerImage: ghcr.io/gafferhq/build/build:3.0.0
@@ -49,7 +49,7 @@ jobs:
             jobs: 4
 
           - name: linux-debug-gcc11
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:3.0.0

--- a/.github/workflows/versionCheck.yml
+++ b/.github/workflows/versionCheck.yml
@@ -9,7 +9,7 @@ jobs:
   check:
 
     name: Version check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 

--- a/.github/workflows/whitespaceCheck.yml
+++ b/.github/workflows/whitespaceCheck.yml
@@ -2,7 +2,7 @@ name: Whitespace check
 on: [ pull_request ]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Support for 20.04 is being removed from GitHub. We have the choice of 22.04 or 24.04, and updating to the latest gives us the longest period before we have to do this again.
