### PR TITLE
IECoreRenderMan Windows

### DIFF
--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -147,6 +147,17 @@ if "%ONNX_ROOT%" NEQ "" (
 	call :appendToPath "%ONNX_ROOT%\lib" PATH
 )
 
+rem RenderMan
+rem =========
+
+if "%RMANTREE%" NEQ "" (
+	call :appendToPath "%RMANTREE%" GAFFER_EXTENSION_PATHS
+	call :appendToPath "%RMANTREE%\bin" PYTHONPATH
+	call :appendToPath "%RMANTREE%\lib\plugins" RMAN_RIXPLUGINPATH
+	call :appendToPath "%RMANTREE%\lib\shaders" OSL_SHADER_PATHS
+	call :appendToPath "%GAFFER_ROOT%\renderManPlugins" RMAN_DISPLAYS_PATH
+)
+
 rem Set up 3rd party extensions
 rem Batch files are awkward at `for` loops. The default `for`, without `/f`
 rem uses semi-colons AND spaces as delimiters, meaning we would not be able

--- a/python/IECoreRenderMan/__init__.py
+++ b/python/IECoreRenderMan/__init__.py
@@ -35,3 +35,12 @@
 ##########################################################################
 
 from ._IECoreRenderMan import *
+
+import os
+import ctypes
+if os.name == "nt" :
+	# Because `_IECoreRenderMan.pyd` currently doesn't require any symbols
+	# from `IECoreRenderMan.dll`, the Windows linker omits the latter. Load
+	# it explicitly, because it registers the renderer.
+	ctypes.CDLL( "IECoreRenderMan.dll" )
+del os, ctypes

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -121,12 +121,16 @@ class RendererTest( GafferTest.TestCase ) :
 		del r
 
 		self.assertTrue( ( self.temporaryDirectory() / "rgb.exr" ).is_file() )
-		imageSpec = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgb.exr" ) ).spec()
+		imageFile = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgb.exr" ) )
+		imageSpec = imageFile.spec()
+		imageFile.close()
 		self.assertEqual( imageSpec.nchannels, 3 )
 		self.assertEqual( imageSpec.channelnames, ( "R", "G", "B" ) )
 
 		self.assertTrue( ( self.temporaryDirectory() / "rgba.exr" ).is_file() )
-		imageSpec = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgba.exr" ) ).spec()
+		imageFile = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "rgba.exr" ) )
+		imageSpec = imageFile.spec()
+		imageFile.close()
 		self.assertEqual( imageSpec.nchannels, 4 )
 		self.assertEqual( imageSpec.channelnames, ( "R", "G", "B", "A" ) )
 

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -184,6 +184,7 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( messageHandler.messages[0].level, IECore.MessageHandler.Level.Warning )
 		self.assertEqual( messageHandler.messages[0].message, "Unable to find shader \"BadShader\"." )
 
+		del lightAttributes
 		del light
 		del renderer
 


### PR DESCRIPTION
This adds the basics to get `IECoreRenderMan` running and passing tests on Windows. As with #6271, it doesn't run tests on CI yet. The use of `ctypes` in 8c1dff86d6a1a1aaa8f32f3b3202e7c4c78cee8d should be removable when we export at least one symbol from `_IECoreRenderMan.pyd` Python module, so that Windows will actually import the symbols from the `IECoreRenderMan.dll` file that registers the renderer.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
