### PR TITLE
Arnold ShaderMenu : Use `ui.name` metadata if available

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - 3Delight : Added light muting support.
+- Arnold : Added support for specifying the name of a shader in the node menu using Arnold's `ui.name` metadata. This improves the formatting of the OpenPBR Surface menu item.
 
 1.5.6.0 (relative to 1.5.5.0)
 =======

--- a/python/GafferArnoldUI/ShaderMenu.py
+++ b/python/GafferArnoldUI/ShaderMenu.py
@@ -69,7 +69,11 @@ def appendShaders( menuDefinition, prefix="/Arnold" ) :
 
 			nodeEntry = arnold.AiNodeEntryIteratorGetNext( it )
 			shaderName = arnold.AiNodeEntryGetName( nodeEntry )
-			displayName = " ".join( [ IECore.CamelCase.toSpaced( x ) for x in shaderName.split( "_" ) ] )
+
+			displayName = __aiMetadataGetStr( nodeEntry, "", "ui.name" )
+			if displayName is None :
+				displayName = " ".join( [ IECore.CamelCase.toSpaced( x ) for x in shaderName.split( "_" ) ] )
+
 			nodeName = displayName.replace( " ", "" )
 
 			category = __aiMetadataGetStr( nodeEntry, "", "gaffer.nodeMenu.category" )


### PR DESCRIPTION
In Arnold 7.3.7.0 onwards, this gives us nicer formatting for the "OpenPBR Surface" menu item, which used to read "Openpbr Surface".

A more interesting addition in 7.3.7.0 is a way of sharing our own memory buffers with Arnold via `AiArrayMakeShared()`, but we won't be able to use that until we set 7.3.7.0 as a minimum version. Perhaps for Gaffer 1.6?