### PR TITLE
VisualiserTool : Change viewer shortcut to `P`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 
 - SceneWriter : Fixed writing of animated attributes and bounds to USD.
 - NumericPlug : Fixed serialisation of plugs with infinite min/max values, for example the promoted outputs of an ImageStats node.
+- VisualiserTool : Changed viewer shortcut to <kbd>P</kbd> to fix conflict with the Transform Tool.
 
 Build
 -----

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -289,6 +289,17 @@ Action                                        | Control or shortcut
 Set shadow target position                    | {kbd}`V` + {{leftClick}}
 Set shadow pivot position                     | {kbd}`Shift` + {kbd}`V` + {{leftClick}}
 
+### Visualiser Tool ###
+
+> Note :
+> For the following controls and shortcuts, the Visualiser Tool must be active.
+
+Action                                        | Control or shortcut
+----------------------------------------------|--------------------
+Increase vertex label size                    | {kbd}`+`
+Decrease vertex label size                    | {kbd}`-`
+Increase vector size                          | {kbd}`Shift` + {kbd}`+`
+Decrease vector size                          | {kbd}`Shift` + {kbd}`-`
 
 ### 2D images ###
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -222,7 +222,6 @@ Pause processing                     | {kbd}`Escape`
 Selection Tool                       | {kbd}`Q`
 Translate Tool                       | {kbd}`W`
 Rotate Tool                          | {kbd}`E`
-Cycle Transform Tool Orientation     | {kbd}`O`
 Scale Tool                           | {kbd}`R`
 Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`
@@ -268,7 +267,7 @@ Add animation key to transform of selected object(s)| {kbd}`S`
 Adjust, fine precision                              | Hold {kbd}`Shift` during action
 Adjust, snapping to rounded increments              | Hold {kbd}`Ctrl` during action
 Target mode (Translate and Rotate only)             | Hold {kbd}`V` then {{leftClick}} on target geometry
-
+Cycle tool orientation (Translate and Rotate only)  | {kbd}`O`
 
 ### Light Tool ###
 

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -228,6 +228,7 @@ Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`
 Crop Window Tool and crop enabled    | {kbd}`Alt` + {kbd}`C`
 Light Position Tool                  | {kbd}`D`
+Visualiser Tool                      | {kbd}`P`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
 
 ### 3D scenes ###

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -227,6 +227,7 @@ Scale Tool                           | {kbd}`R`
 Camera Tool                          | {kbd}`T`
 Crop Window Tool                     | {kbd}`C`
 Crop Window Tool and crop enabled    | {kbd}`Alt` + {kbd}`C`
+Light Tool                           | {kbd}`A`
 Light Position Tool                  | {kbd}`D`
 Visualiser Tool                      | {kbd}`P`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -54,7 +54,7 @@ Gaffer.Metadata.registerNode(
 	Tool for displaying object data.
 	""",
 
-	"viewer:shortCut", "O",
+	"viewer:shortCut", "P",
 	"viewer:shouldAutoActivate", False,
 	"order", 8,
 	"tool:exclusive", False,


### PR DESCRIPTION
This changes the VisualiserTool shortcut to `P`, as `O` was already occupied by the TransformTool orientation cycling.

This also updates ControlsAndShortcuts to include the VisualiserTool shortcuts and makes a few other small improvements noticed while I was there...