### PR TITLE
SConstruct : Sanitise commandEnv environment variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -788,7 +788,8 @@ for option, envVar in {
 	"ONNX_ROOT" : "ONNX_ROOT",
 	"RENDERMAN_ROOT" : "RMANTREE",
 }.items() :
-	commandEnv["ENV"][envVar] = commandEnv[option]
+	if commandEnv[option] != "" :
+		commandEnv["ENV"][envVar] = commandEnv[option]
 
 def runCommand( command ) :
 


### PR DESCRIPTION
Otherwise the `RENDERMAN_ROOT` "" default turns into `RMANTREE = ""`, which leads to [errors](https://github.com/GafferHQ/gaffer/actions/runs/13578916234/job/37961179989?pr=6290#step:15:98) in the documentation build as we try to import GafferRenderMan in situations where it wasn't built.