### PR TITLE
SConstruct : Don't build GafferRenderManTest without RenderMan

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1401,11 +1401,17 @@ libraries = {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 	},
 
-	"GafferRenderManTest" : {},
+	"GafferRenderManTest" : {
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
 
-	"GafferRenderManUI" : {},
+	"GafferRenderManUI" : {
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
 
-	"GafferRenderManUITest" : {},
+	"GafferRenderManUITest" : {
+		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+	},
 
 	"GafferTractor" : {},
 


### PR DESCRIPTION
This was causing CI failures attempting to run RenderMan tests without having the main GafferRenderMan module available. Likewise, there is no point in building GafferRenderManUI without RenderMan.
