### PR TITLE
_RenderPassPlugValueWidget : Scope context before evaluating image

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 
 - SceneWriter : Fixed writing of animated attributes and bounds to USD.
 - NumericPlug : Fixed serialisation of plugs with infinite min/max values, for example the promoted outputs of an ImageStats node.
+- Render Pass menu : Fixed bug evaluating image nodes in wrong context.
 
 Build
 -----

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1322,7 +1322,8 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 				None
 			)
 			if outputImage is not None :
-				return GafferScene.SceneAlgo.sourceScene( outputImage )
+				with self.context() :
+					return GafferScene.SceneAlgo.sourceScene( outputImage )
 
 		return None
 


### PR DESCRIPTION
Otherwise we get errors when a critical variable is missing, or an image doesn't exist on the default frame.
