### PR TITLE
Add RenderManShader node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -43,6 +43,7 @@ API
 ---
 
 - Attributes, Options : Added protected constructors for initialising from attributes/options defined by metadata.
+- ShaderUI : Added support for `noduleLayout:visible` and `noduleLayout:defaultVisibility` metadata, which can be registered via the Metadata API in the same way as `userDefault`.
 
 1.5.6.0 (relative to 1.5.5.0)
 =======

--- a/include/GafferRenderMan/RenderManShader.h
+++ b/include/GafferRenderMan/RenderManShader.h
@@ -36,15 +36,28 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "GafferScene/Shader.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManShader : public GafferScene::Shader
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	LastTypeId = 110450
+
+	public :
+
+		RenderManShader( const std::string &name=defaultName<RenderManShader>() );
+		~RenderManShader() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManShader, RenderManShaderTypeId, GafferScene::Shader );
+
+		void loadShader( const std::string &shaderName, bool keepExistingValues=false ) override;
+
 };
+
+IE_CORE_DECLAREPTR( RenderManShader )
 
 } // namespace GafferRenderMan

--- a/python/GafferOSLUI/OSLShaderUI.py
+++ b/python/GafferOSLUI/OSLShaderUI.py
@@ -127,7 +127,9 @@ __widgetTypes = {
 	"checkBox" : "GafferUI.BoolPlugValueWidget",
 	"popup" : "GafferUI.PresetsPlugValueWidget",
 	"mapper" : "GafferUI.PresetsPlugValueWidget",
-	"filename" : "GafferUI.PathPlugValueWidget",
+	"filename" : "GafferUI.FileSystemPathPlugValueWidget",
+	# For RenderMan.
+	"assetIdInput" : "GafferUI.FileSystemPathPlugValueWidget",
 	"null" : "",
 }
 

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -91,10 +91,11 @@ def parseMetadata( argsFile ) :
 				currentParameter["description"] = element.attrib.get( "help" )
 				currentParameter["layout:section"] = ".".join( pageStack )
 				currentParameter["plugValueWidget:type"] = __widgetTypes.get( element.attrib.get( "widget" ) )
-				currentParameter["nodule:type"] = (
-					"" if element.attrib.get( "connectable", "true" ).lower() == "false" or currentParameter["plugValueWidget:type"] == ""
-					else None
-				)
+
+				if element.attrib.get( "connectable", "true" ).lower() == "false" or currentParameter["plugValueWidget:type"] == "" :
+					currentParameter["nodule:type"] = ""
+				elif element.attrib.get( "isDynamicArray" ) == "1" :
+					currentParameter["nodule:type"] = "GafferUI::CompoundNodule"
 
 				defaultValue = __parseValue( element.attrib.get( "default" ), currentParameter["__type"] )
 				if defaultValue is not None :

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -1,0 +1,180 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import GafferOSL
+import GafferRenderMan
+
+class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
+
+	def testBasicLoading( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrConstant" )
+
+		self.assertEqual( shader["name"].getValue(), "PxrConstant" )
+		self.assertEqual( shader["type"].getValue(), "ri:surface" )
+
+		self.assertEqual( shader["parameters"].keys(), [ "emitColor", "presence" ] )
+
+		self.assertIsInstance( shader["parameters"]["emitColor"], Gaffer.Color3fPlug )
+		self.assertIsInstance( shader["parameters"]["presence"], Gaffer.FloatPlug )
+
+		self.assertEqual( shader["parameters"]["emitColor"].defaultValue(), imath.Color3f( 1 ) )
+		self.assertEqual( shader["parameters"]["presence"].defaultValue(), 1.0 )
+		self.assertEqual( shader["parameters"]["presence"].minValue(), 0.0 )
+		self.assertEqual( shader["parameters"]["presence"].maxValue(), 1.0 )
+
+	def testLoadParametersInsidePages( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrVolume" )
+
+		self.assertIn( "extinctionDistance", shader["parameters"] )
+		self.assertIn( "densityColor", shader["parameters"] )
+
+	def testLoadRemovesUnnecessaryParameters( self ) :
+
+		for keepExisting in ( True, False ) :
+
+			shader = GafferRenderMan.RenderManShader()
+			shader.loadShader( "PxrDiffuse" )
+			self.assertIn( "diffuseColor", shader["parameters"] )
+
+			shader.loadShader( "PxrConstant", keepExistingValues = keepExisting )
+			self.assertNotIn( "color1", shader["parameters"] )
+			self.assertIn( "emitColor", shader["parameters"] )
+
+	def testLoadOutputs( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrSeExpr" )
+
+		self.assertIn( "resultRGB", shader["out"] )
+		self.assertIsInstance( shader["out"]["resultRGB"], Gaffer.Color3fPlug )
+
+		self.assertIn( "resultR", shader["out"] )
+		self.assertIsInstance( shader["out"]["resultR"], Gaffer.FloatPlug )
+
+		self.assertIn( "resultG", shader["out"] )
+		self.assertIsInstance( shader["out"]["resultG"], Gaffer.FloatPlug )
+
+		self.assertIn( "resultB", shader["out"] )
+		self.assertIsInstance( shader["out"]["resultB"], Gaffer.FloatPlug )
+
+	## IECoreUSD isn't round-tripping the shader type correctly yet.
+	@unittest.expectedFailure
+	def testUSDRoundTrip( self ) :
+
+		texture = GafferOSL.OSLShader( "PxrTexture" )
+		texture.loadShader( "PxrTexture" )
+		texture["parameters"]["filename"].setValue( "test.tx" )
+
+		surface = GafferRenderMan.RenderManShader( "PxrSurface" )
+		surface.loadShader( "PxrSurface" )
+		surface["parameters"]["diffuseColor"].setInput( texture["out"]["resultRGB"] )
+		surface["parameters"]["diffuseGain"].setValue( 0.5 )
+
+		plane = GafferScene.Plane()
+
+		shaderAssignment = GafferScene.ShaderAssignment()
+		shaderAssignment["in"].setInput( plane["out"] )
+		shaderAssignment["shader"].setInput( surface["out"] )
+
+		sceneWriter = GafferScene.SceneWriter()
+		sceneWriter["in"].setInput( shaderAssignment["out"] )
+		sceneWriter["fileName"].setValue( self.temporaryDirectory() / "test.usda" )
+		sceneWriter["task"].execute()
+
+		sceneReader = GafferScene.SceneReader()
+		sceneReader["fileName"].setInput( sceneWriter["fileName"] )
+
+		self.assertShaderNetworksEqual(
+			sceneReader["out"].attributes( "/plane" )["ri:surface"],
+			sceneWriter["in"].attributes( "/plane" )["ri:surface"]
+		)
+
+	def testKeepExistingValues( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrSurface" )
+		defaultValues = { p.getName() : p.getValue() for p in shader["parameters"] if hasattr( p, "getValue" ) }
+
+		shader["parameters"]["diffuseGain"].setValue( 0.25 )
+		shader["parameters"]["diffuseColor"].setValue( imath.Color3f( 1, 2, 3 ) )
+		shader["parameters"]["specularDoubleSided"].setValue( True )
+		shader["parameters"]["volumeAggregateName"].setValue( "test" )
+		modifiedValues = { p.getName() : p.getValue() for p in shader["parameters"] if hasattr( p, "getValue" ) }
+
+		shader.loadShader( "PxrSurface", keepExistingValues = True )
+		self.assertEqual(
+			{ p.getName() : p.getValue() for p in shader["parameters"] if hasattr( p, "getValue" ) },
+			modifiedValues
+		)
+
+		shader.loadShader( "PxrSurface", keepExistingValues = False )
+		self.assertEqual(
+			{ p.getName() : p.getValue() for p in shader["parameters"] if hasattr( p, "getValue" ) },
+			defaultValues
+		)
+
+	def testDisplacementShaderType( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrDisplace" )
+		self.assertEqual( shader["type"].getValue(), "ri:displacement" )
+
+		shader = GafferOSL.OSLShader()
+		shader.loadShader( "PxrDisplace" )
+		self.assertEqual( shader["type"].getValue(), "osl:displacement" )
+
+	def testUtilityPatternArray( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrSurface" )
+
+		self.assertIn( "utilityPattern", shader["parameters"] )
+		self.assertIsInstance( shader["parameters"]["utilityPattern"], Gaffer.ArrayPlug )
+		self.assertIsInstance( shader["parameters"]["utilityPattern"].elementPrototype(), Gaffer.IntPlug )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -37,6 +37,7 @@
 from .ModuleTest import ModuleTest
 from .RenderManAttributesTest import RenderManAttributesTest
 from .RenderManOptionsTest import RenderManOptionsTest
+from .RenderManShaderTest import RenderManShaderTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -1,0 +1,228 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import functools
+import pathlib
+from xml.etree import cElementTree
+
+import oslquery
+
+import IECore
+
+import Gaffer
+import GafferUI
+import GafferSceneUI
+import GafferOSL
+import GafferRenderMan
+
+##########################################################################
+# Node menu
+##########################################################################
+
+def appendShaders( menuDefinition, prefix = "/RenderMan" ) :
+
+	plugins = __plugins()
+
+	menuDefinition.append(
+		prefix + "/Shader",
+		{
+			"subMenu" : functools.partial( __shadersSubMenu, plugins ),
+		}
+	)
+
+def __plugins() :
+
+	result = {}
+
+	searchPaths = IECore.SearchPath( os.environ.get( "RMAN_RIXPLUGINPATH", "" ) )
+
+	pathsVisited = set()
+	for path in searchPaths.paths :
+
+		if path in pathsVisited :
+			continue
+		else :
+			pathsVisited.add( path )
+
+		for root, dirs, files in os.walk( path ) :
+			for file in [ f for f in files  ] :
+
+				name, extension = os.path.splitext( file )
+				if extension != ".args" :
+					continue
+
+				plugin = __plugin( os.path.join( root, file ) )
+				if plugin is not None :
+					result[name] = plugin
+
+	return result
+
+def __plugin( argsFile ) :
+
+	pluginType = None
+	classification = ""
+	for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
+		if element.tag == "shaderType" and event == "end" :
+			tag = element.find( "tag" )
+			if tag is not None :
+				pluginType = tag.attrib.get( "value" )
+		elif element.tag == "rfhdata" :
+			classification = element.attrib.get( "classification" )
+
+	if pluginType is None :
+		return None
+
+	return {
+		"type" : pluginType,
+		"classification" : classification
+	}
+
+def __loadShader( shaderName, nodeType ) :
+
+	nodeName = os.path.split( shaderName )[-1]
+	nodeName = nodeName.replace( ".", "" )
+
+	node = nodeType( nodeName )
+	node.loadShader( shaderName )
+
+	if isinstance( node, GafferOSL.OSLShader ) :
+		if "matchCppPattern" in node["parameters"] :
+			# This parameter is only useful for compatibility with RenderMan 23,
+			# which is not a concern for us since we are starting with RenderMan
+			# 26. Hide it.
+			Gaffer.Metadata.registerValue( node["parameters"]["matchCppPattern"], "layout:visibilityActivator", False )
+
+	return node
+
+def __shadersSubMenu( plugins ) :
+
+	result = IECore.MenuDefinition()
+
+	for name, plugin in plugins.items() :
+
+		if name in [ "PxrSeExpr" ] :
+			# Deprecated in RenderMan 24 - don't let folks become dependent on it.
+			continue
+
+		if plugin["type"] not in { "bxdf", "pattern", "integrator" } :
+			continue
+
+		result.append(
+			"/{0}/{1}".format( plugin["classification"], name ),
+			{
+				"command" : GafferUI.NodeMenu.nodeCreatorWrapper(
+					functools.partial( __loadShader, name, GafferRenderMan.RenderManShader )
+				)
+			}
+		)
+
+	oslDir = pathlib.Path( os.environ["RMANTREE"] ) / "lib" / "shaders"
+	for shader in sorted( oslDir.glob( "*.oso" ) ) :
+		query = oslquery.OSLQuery( str( shader ) )
+		classification = "Other"
+		for metadata in query.metadata :
+			if metadata.name == "rfh_classification" :
+				classification = metadata.value
+
+		result.append(
+			"/{}/{}".format( classification, shader.stem ),
+			{
+				"command" : GafferUI.NodeMenu.nodeCreatorWrapper(
+					functools.partial( __loadShader, shader.stem, GafferOSL.OSLShader )
+				)
+			}
+		)
+
+	return result
+
+GafferSceneUI.ShaderUI.hideShaders( IECore.PathMatcher( [ "/Pxr*" ] ) )
+
+##########################################################################
+# Metadata. We register dynamic Gaffer.Metadata entries which are
+# implemented as lookups to data queried from .args files.
+##########################################################################
+
+__metadataCache = {}
+def __shaderMetadata( node ) :
+
+	global __metadataCache
+
+	shaderName = node["name"].getValue()
+
+	try :
+		return __metadataCache[shaderName]
+	except KeyError :
+		pass
+
+	searchPaths = IECore.SearchPath( os.environ.get( "RMAN_RIXPLUGINPATH", "" ) )
+	argsFile = searchPaths.find( "Args/" + shaderName + ".args" )
+	if argsFile :
+		result = GafferRenderMan.ArgsFileAlgo.parseMetadata( argsFile )
+	else :
+		result = {}
+
+	__metadataCache[shaderName] = result
+	return result
+
+def __parameterMetadata( plug, key ) :
+
+	return __shaderMetadata( plug.node() )["parameters"].get( plug.getName(), {} ).get( key )
+
+def __nodeDescription( node ) :
+
+	defaultDescription = """Loads RenderMan shaders. Use the ShaderAssignment node to assign shaders to objects in the scene."""
+	metadata = __shaderMetadata( node )
+	return metadata.get( "description", defaultDescription )
+
+Gaffer.Metadata.registerValue( GafferRenderMan.RenderManShader, "description", __nodeDescription )
+
+for key in [
+	"label",
+	"description",
+	"layout:section",
+	"plugValueWidget:type",
+	"presetNames",
+	"presetValues",
+	"nodule:type",
+] :
+
+	Gaffer.Metadata.registerValue(
+		GafferRenderMan.RenderManShader, "parameters.*", key,
+		functools.partial( __parameterMetadata, key = key )
+	)
+
+Gaffer.Metadata.registerValue( GafferRenderMan.RenderManShader, "out", "nodule:type", lambda plug : "GafferUI::CompoundNodule" if len( plug ) else "GafferUI::StandardNodule" )

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -38,5 +38,6 @@ __import__( "GafferSceneUI" )
 
 from . import RenderManAttributesUI
 from . import RenderManOptionsUI
+from . import RenderManShaderUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -1,0 +1,156 @@
+##########################################################################
+#
+#  Copyright (c) 2018, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import os
+import pathlib
+import unittest
+from xml.etree import cElementTree
+
+import IECore
+
+import Gaffer
+import GafferUITest
+
+import GafferRenderMan
+import GafferRenderManUI
+
+class RenderManShaderUITest( GafferUITest.TestCase ) :
+
+	def testArgFileMetadata( self ) :
+
+		n = GafferRenderMan.RenderManShader()
+		n.loadShader( "PxrSurface" )
+
+		self.ignoreMessage( IECore.Msg.Level.Warning, "RenderManShader::loadShader", 'Array parameter "utilityPattern" not supported' )
+
+		self.assertEqual(
+			Gaffer.Metadata.value( n["parameters"]["diffuseGain"], "layout:section" ),
+			"Diffuse"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( n["parameters"]["diffuseExponent"], "layout:section" ),
+			"Diffuse.Advanced"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( n["parameters"]["diffuseGain"], "label" ),
+			"Gain"
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( n["parameters"]["continuationRayMode"], "presetNames" ),
+			IECore.StringVectorData( [ "Off", "Last Hit", "All Hits" ] )
+		)
+
+		self.assertEqual(
+			Gaffer.Metadata.value( n["parameters"]["continuationRayMode"], "presetValues" ),
+			IECore.IntVectorData( [ 0, 1, 2 ] )
+		)
+
+	def testCustomMetadata( self ) :
+
+		# Check that all the metadata registered by
+		# `startup/GafferRenderManUI/shaderMetadata.py` refers to shaders and
+		# parameters that actually exist.
+
+		node = GafferRenderMan.RenderManShader()
+
+		for key in [ "noduleLayout:visible", "userDefault" ] :
+			targets = Gaffer.Metadata.targetsWithMetadata( "ri:surface:*", key )
+			shaders = { t.split( ":" )[2] for t in targets }
+			for shader in shaders :
+				with self.subTest( shader = shader ) :
+					node.loadShader( shader )
+					for target in targets :
+						_, _, s, parameter = target.split( ":" )
+						if s == shader :
+							self.assertIn( parameter, node["parameters"] )
+
+	def testUtilityPatternNodule( self ) :
+
+		node = GafferRenderMan.RenderManShader()
+		node.loadShader( "PxrSurface" )
+		self.assertEqual( Gaffer.Metadata.value( node["parameters"]["utilityPattern"], "nodule:type" ), "GafferUI::CompoundNodule" )
+
+	def testLoadAllStandardShaders( self ) :
+
+		def __shaderType( argsFile ) :
+
+			for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
+				if element.tag == "shaderType" and event == "end" :
+					tag = element.find( "tag" )
+					return tag.attrib.get( "value" ) if tag is not None else None
+
+			return None
+
+		shadersLoaded = set()
+		argsDir = pathlib.Path( os.environ["RMANTREE"] ) / "lib" / "plugins" / "Args"
+		for argsFile in argsDir.glob( "*.args" ) :
+
+			if __shaderType( argsFile ) not in {
+				"bxdf", "light", "lightfilter", "samplefilter", "displayfilter", "integrator", "pattern", "displacement"
+			} :
+				continue
+
+			if argsFile.stem in {
+				"PxrCombinerLightFilter", "PxrSampleFilterCombiner", "PxrDisplayFilterCombiner",
+			} :
+				# These have `lightfilter`, `samplefilter` and `displayfilter` inputs
+				# that we don't yet load. But they're not user-facing anyway.
+				continue
+
+			with self.subTest( shader = argsFile.stem ) :
+
+				node = GafferRenderMan.RenderManShader()
+				with IECore.CapturingMessageHandler() as mh :
+					node.loadShader( argsFile.stem )
+
+				for m in mh.messages :
+					## \todo Add support for these types.
+					self.assertRegex( m.message, 'Spline parameter .* not supported|.* has unsupported type "bxdf|.* has unsupported type "struct"' )
+
+				# Trigger metadata parsing and ensure there are no errors
+				Gaffer.Metadata.value( node, "description" )
+
+				shadersLoaded.add( argsFile.stem )
+
+		# Guard against shaders being moved and this test therefore not
+		# loading anything.
+		self.assertIn( "PxrSurface", shadersLoaded )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManUITest/__init__.py
+++ b/python/GafferRenderManUITest/__init__.py
@@ -35,5 +35,6 @@
 ##########################################################################
 
 from .DocumentationTest import DocumentationTest
+from .RenderManShaderUITest import RenderManShaderUITest
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUITest" )

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -62,13 +62,18 @@ def __shaderMetadata( node, key ) :
 		node["type"].getValue() + ":" + node["name"].getValue(), key
 	)
 
-def __parameterUserDefault( plug ) :
+def __parameterMetadata( plug, key, shaderFallbackKey = None ) :
 
 	shader = plug.node()
-	return Gaffer.Metadata.value(
+	result = Gaffer.Metadata.value(
 		shader["type"].getValue() + ":" + shader["name"].getValue() + ":" + plug.relativeName( shader["parameters"] ),
-		"userDefault"
+		key
 	)
+
+	if result is not None :
+		return result
+
+	return __shaderMetadata( shader, shaderFallbackKey ) if shaderFallbackKey is not None else None
 
 Gaffer.Metadata.registerNode(
 
@@ -135,7 +140,13 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"parameters..." : [
+		"parameters.*" : [
+
+			"noduleLayout:visible", functools.partial( __parameterMetadata, key = "noduleLayout:visible", shaderFallbackKey = "noduleLayout:defaultVisibility" ),
+
+		],
+
+		"parameters.*..." : [
 
 			# Although the parameters plug is positioned
 			# as we want above, we must also register
@@ -144,7 +155,7 @@ Gaffer.Metadata.registerNode(
 			# individually.
 			"noduleLayout:section", "left",
 
-			"userDefault", __parameterUserDefault,
+			"userDefault", functools.partial( __parameterMetadata, key = "userDefault" ),
 
 		],
 

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -204,6 +204,21 @@ QueryCache &queryCache()
 
 } // namespace
 
+/////////////////////////////////////////////////////////////////////////
+// Type overrides
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+boost::container::flat_map<string, string> g_typeOverrides = {
+	{ "vdbVolume", "osl:volume" },
+	{ "dlDisplacement", "osl:displacement" },
+	{ "PxrDisplace", "osl:displacement" }
+};
+
+} // namespace
+
 //////////////////////////////////////////////////////////////////////////
 // OSLShader
 //////////////////////////////////////////////////////////////////////////
@@ -1249,21 +1264,12 @@ void OSLShader::loadShader( const std::string &shaderName, bool keepExistingValu
 
 	m_metadata = nullptr;
 	namePlug->source<StringPlug>()->setValue( shaderName );
-	// 3delight sets it's vdbVolume shader as a "shader" type but requires the
-	// attribute name be `volumeshader` which we handle when spooling the scene.
-
-	if ( std::filesystem::path( shaderName ).stem() == "vdbVolume" )
-	{
-		typePlug->source<StringPlug>()->setValue( std::string( "osl:volume" ));
-	}
-	else if ( std::filesystem::path( shaderName ).stem() == "dlDisplacement" )
-	{
-		typePlug->source<StringPlug>()->setValue( std::string( "osl:displacement" ));
-	}
-	else
-	{
-		typePlug->source<StringPlug>()->setValue( std::string( "osl:" ) + ( query->shadertype().c_str() ));
-	}
+	auto typeIt = g_typeOverrides.find( std::filesystem::path( shaderName ).stem().string() );
+	typePlug->source<StringPlug>()->setValue(
+		typeIt != g_typeOverrides.end() ?
+		typeIt->second :
+		std::string( "osl:" ) + ( query->shadertype().c_str() )
+	);
 
 	const IECore::CompoundData *metadata = OSLShader::metadata();
 	const IECore::CompoundData *parameterMetadata = nullptr;

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -1,0 +1,501 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferRenderMan/RenderManShader.h"
+
+#include "Gaffer/CompoundNumericPlug.h"
+#include "Gaffer/NumericPlug.h"
+#include "Gaffer/PlugAlgo.h"
+#include "Gaffer/StringPlug.h"
+
+#include "IECore/SearchPath.h"
+#include "IECore/MessageHandler.h"
+
+#include "boost/algorithm/string.hpp"
+#include "boost/lexical_cast.hpp"
+#include "boost/property_tree/xml_parser.hpp"
+
+#include <unordered_set>
+
+using namespace std;
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferRenderMan;
+
+//////////////////////////////////////////////////////////////////////////
+// RenderManShader
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( RenderManShader );
+
+RenderManShader::RenderManShader( const std::string &name )
+	:	GafferScene::Shader( name )
+{
+	/// \todo It would be better if the Shader base class added this
+	/// output plug, but that means changing ArnoldShader.
+	addChild( new Plug( "out", Plug::Out ) );
+}
+
+RenderManShader::~RenderManShader()
+{
+}
+
+//////////////////////////////////////////////////////////////////////////
+// Shader-specific overrides
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+using ParameterSet = unordered_set<string>;
+static const unordered_map<string, ParameterSet> g_omittedParameters = {
+	{
+		"PxrPortalLight",
+		{
+			// These shouldn't be exposed because we are going to
+			// derive the values from the dome light and other parameters
+			// like `intensityMult`.
+			"domeColorMap", "lightColor", "intensity", "exposure", "portalToDome",
+			"portalName",
+			// These shouldn't be exposed because we are going to inherit the
+			// values from the dome light.
+			/// \todo We could instead load these as `OptionalValuePlugs` to
+			/// allow a portal to override a value from the dome.
+			"colorMapGamma", "colorMapSaturation", "enableTemperature",
+			"temperature", "specular", "diffuse", "enableShadows",
+			"shadowColor", "shadowDistance", "shadowFalloff", "shadowFalloffGamma",
+			"shadowSubset", "shadowExcludeSubset", "traceLightPaths", "thinShadow",
+			"visibleInRefractionPath", "cheapCaustics", "cheapCausticsExcludeGroup",
+			"fixedSampleCount", "lightGroup", "importanceMultiplier", "msApprox",
+			"msApproxBleed", "msApproxContribution"
+		},
+	}
+};
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// Shader loading code
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+bool isVStruct( const boost::property_tree::ptree &parameter )
+{
+	if( auto tags = parameter.get_child_optional( "tags" ) )
+	{
+		for( const auto &tag : *tags )
+		{
+			if( tag.second.get<string>( "<xmlattr>.value" ) == "vstruct" )
+			{
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+template<typename PlugType>
+PlugPtr acquireNumericParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, Plug *candidatePlug )
+{
+	typedef typename PlugType::ValueType ValueType;
+
+	const ValueType defaultValue = parameter.get( "<xmlattr>.default", ValueType( 0 ) );
+	const ValueType minValue = parameter.get( "<xmlattr>.min", numeric_limits<ValueType>::lowest() );
+	const ValueType maxValue = parameter.get( "<xmlattr>.max", numeric_limits<ValueType>::max() );
+
+	auto existingPlug = runTimeCast<PlugType>( candidatePlug );
+	if(
+		existingPlug &&
+		existingPlug->defaultValue() == defaultValue &&
+		existingPlug->minValue() == minValue &&
+		existingPlug->maxValue() == maxValue
+	)
+	{
+		return existingPlug;
+	}
+
+	return new PlugType( name, direction, defaultValue, minValue, maxValue );
+}
+
+template<typename T>
+T parseCompoundNumericValue( const string &s )
+{
+	typedef typename T::BaseType BaseType;
+	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+
+	T result( 0 );
+	unsigned int i = 0;
+	for( auto token : Tokenizer( s, boost::char_separator<char>( " " ) ) )
+	{
+		if( i >= T::dimensions() )
+		{
+			break;
+		}
+		result[i++] = boost::lexical_cast<BaseType>( token );
+	}
+
+	return result;
+}
+
+template<typename PlugType>
+PlugPtr acquireCompoundNumericParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, IECore::GeometricData::Interpretation interpretation, Plug *candidatePlug )
+{
+	typedef typename PlugType::ValueType ValueType;
+	typedef typename ValueType::BaseType BaseType;
+
+	const ValueType defaultValue = parseCompoundNumericValue<ValueType>( parameter.get( "<xmlattr>.default", "0 0 0" ) );
+	const ValueType minValue( numeric_limits<BaseType>::min() );
+	const ValueType maxValue( numeric_limits<BaseType>::max() );
+
+	auto existingPlug = runTimeCast<PlugType>( candidatePlug );
+	if(
+		existingPlug &&
+		existingPlug->defaultValue() == defaultValue &&
+		existingPlug->minValue() == minValue &&
+		existingPlug->maxValue() == maxValue &&
+		existingPlug->interpretation() == interpretation
+	)
+	{
+		return existingPlug;
+	}
+
+	return new PlugType( name, direction, defaultValue, minValue, maxValue, Plug::Default, interpretation );
+}
+
+PlugPtr acquireStringParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, Plug *candidatePlug )
+{
+	const string defaultValue = parameter.get( "<xmlattr>.default", "" );
+
+	auto existingPlug = runTimeCast<StringPlug>( candidatePlug );
+	if(
+		existingPlug &&
+		existingPlug->defaultValue() == defaultValue
+	)
+	{
+		return existingPlug;
+	}
+
+	return new StringPlug( name, direction, defaultValue );
+}
+
+PlugPtr acquireMatrixParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, Plug *candidatePlug )
+{
+	auto existingPlug = runTimeCast<M44fPlug>( candidatePlug );
+	if( existingPlug )
+	{
+		return existingPlug;
+	}
+
+	return new M44fPlug( name, direction );
+}
+
+Gaffer::Plug *loadParameter( const boost::property_tree::ptree &parameter, Plug *parent )
+{
+	if( parameter.get<string>( "<xmlattr>.omitFromRender", "False" ) == "True" )
+	{
+		// Ignore those pesky "notes" parameters
+		return nullptr;
+	}
+
+	if( isVStruct( parameter ) )
+	{
+		// PxrSurface and PxrLayerSurface have funky `inputMaterial` float
+		// parameters that represent "virtual structs". These require the host
+		// to implement a bunch of extra logic to make a whole bunch of concrete
+		// connections dictated by connections to the virtual parameter and some
+		// additional metadata. It's not pretty, and the Lama shaders use a
+		// completely different mechanism for layering - hopefully we can just
+		// deal with the latter.
+		return nullptr;
+	}
+
+	const string name = parameter.get<string>( "<xmlattr>.name" );
+
+	bool array = false;
+	Plug *candidatePlug;
+	if( parameter.get<string>( "<xmlattr>.isDynamicArray", "0" ) == "1" )
+	{
+		if(
+			boost::ends_with( name, "_Knots" ) ||
+			boost::ends_with( name, "_Floats" ) ||
+			boost::ends_with( name, "_Colors" )
+		)
+		{
+			/// \todo Support spline parameters.
+			msg(
+				IECore::Msg::Debug, "RenderManShader::loadShader",
+				fmt::format( "Spline parameter \"{}\" not supported", name )
+			);
+			return nullptr;
+		}
+
+		// There are very few examples of non-spline array parameters
+		// in the standard RenderMan shaders. All seem to be used to
+		// provide an array of connections rather than values - see
+		// `PxrSurface.utilityPattern` for example. So we load as an
+		// ArrayPlug rather than as a VectorDataPlug.
+		array = true;
+		auto arrayPlug = parent->getChild<ArrayPlug>( name );
+		candidatePlug = arrayPlug ? const_cast<Plug *>( arrayPlug->elementPrototype() ) : nullptr;
+	}
+	else
+	{
+		candidatePlug = parent->getChild<Plug>( name );
+	}
+
+	PlugPtr acquiredPlug;
+	const string type = parameter.get<string>( "<xmlattr>.type" );
+	if( type == "float" )
+	{
+		acquiredPlug = acquireNumericParameter<FloatPlug>( parameter, name, Plug::In, candidatePlug );
+	}
+	else if( type == "int" )
+	{
+		acquiredPlug = acquireNumericParameter<IntPlug>( parameter, name, Plug::In, candidatePlug );
+	}
+	else if( type == "point" )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<V3fPlug>( parameter, name, Plug::In, GeometricData::Point, candidatePlug );
+	}
+	else if( type == "vector" )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<V3fPlug>( parameter, name, Plug::In, GeometricData::Vector, candidatePlug );
+	}
+	else if( type == "normal" )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<V3fPlug>( parameter, name, Plug::In, GeometricData::Normal, candidatePlug );
+	}
+	else if( type == "color" )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<Color3fPlug>( parameter, name, Plug::In, GeometricData::None, candidatePlug );
+	}
+	else if( type == "string" )
+	{
+		acquiredPlug = acquireStringParameter( parameter, name, Plug::In, candidatePlug );
+	}
+	else if( type == "matrix" )
+	{
+		acquiredPlug = acquireMatrixParameter( parameter, name, Plug::In, candidatePlug );
+	}
+	else
+	{
+		msg(
+			IECore::Msg::Warning, "RenderManShader::loadShader",
+			fmt::format( "Parameter \"{}\" has unsupported type \"{}\"", name, type )
+		);
+		return nullptr;
+	}
+
+	if( acquiredPlug != candidatePlug )
+	{
+		if( array )
+		{
+			acquiredPlug->setName( fmt::format( "{}0", name ) );
+			acquiredPlug = new ArrayPlug( name, Plug::In, acquiredPlug );
+		}
+		PlugAlgo::replacePlug( parent, acquiredPlug );
+	}
+
+	return acquiredPlug.get();
+}
+
+void loadParameters( const boost::property_tree::ptree &tree, Plug *parent, const ParameterSet *omit, std::unordered_set<const Plug *> &validPlugs )
+{
+	for( const auto &child : tree )
+	{
+		if( child.first == "param" )
+		{
+			if( omit && omit->count( child.second.get<string>( "<xmlattr>.name" ) ) )
+			{
+				continue;
+			}
+			if( Plug *p = loadParameter( child.second, parent ) )
+			{
+				validPlugs.insert( p );
+			}
+		}
+		else if( child.first == "page" )
+		{
+			loadParameters( child.second, parent, omit, validPlugs );
+		}
+	}
+}
+
+void loadParameters( const boost::property_tree::ptree &tree, Plug *parent, const ParameterSet *omit )
+{
+	// Load all the parameters
+
+	std::unordered_set<const Plug *> validPlugs;
+	loadParameters( tree, parent, omit, validPlugs );
+
+	// Remove any old plugs which it turned out we didn't need.
+
+	for( int i = parent->children().size() - 1; i >= 0; --i )
+	{
+		Plug *child = parent->getChild<Plug>( i );
+		if( validPlugs.find( child ) == validPlugs.end() )
+		{
+			parent->removeChild( child );
+		}
+	}
+}
+
+Gaffer::Plug *loadOutput( const boost::property_tree::ptree &output, Plug *parent )
+{
+	const string name = output.get<string>( "<xmlattr>.name" );
+	Plug *candidatePlug = parent->getChild<Plug>( name );
+
+	// For some reason, output type is not determined by a `type` attribute
+	// like inputs are. Instead tags are used.
+	unordered_set<string> tags;
+	for( const auto &tag : output.get_child( "tags" ) )
+	{
+		tags.insert( tag.second.get<string>( "<xmlattr>.value" ) );
+	}
+
+	PlugPtr acquiredPlug;
+	if( tags.find( "color" ) != tags.end() )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<Color3fPlug>( output, name, Plug::Out, GeometricData::None, candidatePlug );
+	}
+	else if( tags.find( "float" ) != tags.end() )
+	{
+		acquiredPlug = acquireNumericParameter<FloatPlug>( output, name, Plug::Out, candidatePlug );
+	}
+	else if( tags.find( "vector" ) != tags.end() )
+	{
+		acquiredPlug = acquireCompoundNumericParameter<V3fPlug>( output, name, Plug::Out, GeometricData::Vector, candidatePlug );
+	}
+	else
+	{
+		msg(
+			IECore::Msg::Warning, "RenderManShader::loadShader",
+			fmt::format( "Output \"{}\" has unsupported tags", name )
+		);
+		return nullptr;
+	}
+
+	if( acquiredPlug != candidatePlug )
+	{
+		PlugAlgo::replacePlug( parent, acquiredPlug );
+	}
+
+	return acquiredPlug.get();
+}
+
+void loadOutputs( const boost::property_tree::ptree &tree, Plug *parent )
+{
+	// Load all the parameters
+
+	std::unordered_set<const Plug *> validPlugs;
+	for( const auto &child : tree )
+	{
+		if( child.first == "output" )
+		{
+			if( const Plug *p = loadOutput( child.second, parent ) )
+			{
+				validPlugs.insert( p );
+			}
+		}
+	}
+
+	// Remove any old plugs which it turned out we didn't need.
+
+	for( int i = parent->children().size() - 1; i >= 0; --i )
+	{
+		Plug *child = parent->getChild<Plug>( i );
+		if( validPlugs.find( child ) == validPlugs.end() )
+		{
+			parent->removeChild( child );
+		}
+	}
+}
+
+} // namespace
+
+void RenderManShader::loadShader( const std::string &shaderName, bool keepExistingValues )
+{
+	const char *pluginPath = getenv( "RMAN_RIXPLUGINPATH" );
+	SearchPath searchPath( pluginPath ? pluginPath : "" );
+
+	boost::filesystem::path argsFilename = searchPath.find( "Args/" + shaderName + ".args" );
+	if( argsFilename.empty() )
+	{
+		throw IECore::Exception(
+			fmt::format( "Unable to find shader \"{}\" on RMAN_RIXPLUGINPATH", shaderName )
+		);
+	}
+
+	std::ifstream argsStream( argsFilename.string() );
+
+	boost::property_tree::ptree tree;
+	boost::property_tree::read_xml( argsStream, tree );
+
+	namePlug()->source<StringPlug>()->setValue( shaderName );
+
+	string shaderType = tree.get<string>( "args.shaderType.tag.<xmlattr>.value" );
+	if( shaderType == "bxdf" )
+	{
+		shaderType = "surface";
+	}
+
+	typePlug()->source<StringPlug>()->setValue( "ri:" + shaderType );
+
+	Plug *parametersPlug = this->parametersPlug()->source<Plug>();
+	if( !keepExistingValues )
+	{
+		parametersPlug->clearChildren();
+	}
+
+	auto omit = g_omittedParameters.find( shaderName );
+	loadParameters(
+		tree.get_child( "args" ), parametersPlug,
+		omit != g_omittedParameters.end() ? &omit->second : nullptr
+	);
+
+	if( !keepExistingValues )
+	{
+		outPlug()->clearChildren();
+	}
+
+	loadOutputs( tree.get_child( "args" ), outPlug() );
+
+}

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -38,6 +38,7 @@
 
 #include "GafferRenderMan/RenderManAttributes.h"
 #include "GafferRenderMan/RenderManOptions.h"
+#include "GafferRenderMan/RenderManShader.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -49,5 +50,5 @@ BOOST_PYTHON_MODULE( _GafferRenderMan )
 
 	GafferBindings::DependencyNodeClass<RenderManAttributes>();
 	GafferBindings::DependencyNodeClass<RenderManOptions>();
-
+	GafferBindings::DependencyNodeClass<RenderManShader>();
 }

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -1,0 +1,219 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+# RenderManShaderUI derives UI metadata from `.args` files automatically. But
+# this doesn't cover everything we need for a good user experience, so here we
+# manually register additional Gaffer-specific metadata for that.
+
+shaderMetadata = {
+
+	"ri:surface:PxrDisney" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "baseColor", "subsurfaceColor", "metallic", "specular", "roughness", "bumpNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:PxrDisneyBsdf" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "baseColor", "subsurfaceColor", "metallic", "specularTint", "roughness", "bumpNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaConductor" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "tint", "reflectivity", "edgeColor", "roughness", "conductorNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaDielectric" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "reflectionTint", "transmissionTint", "roughness", "normal" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaGeneralizedSchlick" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "reflectionTint", "transmissionTint", "roughness", "normal" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaHairChiang" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "colorR", "colorTT", "colorTintTT" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaIridescence" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			"roughness" : { "noduleLayout:visible" : True }
+
+		},
+
+	},
+
+	"ri:surface:LamaSSS" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "sssColor", "sssNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:LamaTricolorSSS" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "nearColor", "farColor", "shadowColor", "sssNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:PxrLayerSurface" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+	},
+
+	"ri:surface:PxrMarschnerHair" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "diffuseGain", "diffuseColor", "specularColorR", "specularColorTRT", "specularColorTT" ]
+
+		},
+
+	},
+
+	"ri:surface:PxrSurface" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "diffuseGain", "diffuseColor", "specularFaceColor", "specularEdgeColor", "specularRoughness", "subsurfaceColor", "bumpNormal" ]
+
+		},
+
+	},
+
+	"ri:surface:PxrVolume" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "diffuseColor", "emitColor", "densityFloat", "densityColor" ]
+
+		},
+
+	},
+
+}
+
+for shader, metadata in shaderMetadata.items() :
+
+	for key, value in metadata.items() :
+
+		if key == "parameters" :
+			for parameterName, parameterMetadata in value.items() :
+				for parameterKey, parameterValue in parameterMetadata.items() :
+					Gaffer.Metadata.registerValue( shader + ":" + parameterName, parameterKey, parameterValue )
+
+		else :
+
+			Gaffer.Metadata.registerValue( shader, key, value )


### PR DESCRIPTION
This adds a node for loading RenderMan shaders. For anyone who has been testing work-in-progress RenderMan builds, there are a few changes from the original :

- Added support for array parameters such as `PxrSurface.utilityPattern`.
- Removed TagPlug and support for `struct` C++ parameters. Since I originally added that in a prototype years ago, the usage of the `struct` type has dwindled all the way down to a single parameter on `aaOceanPrmanShader`. And I don't even think the old TagPlug would have helped there anyway since it won't accept a connection from the new OSL manifold shaders. Will revisit this if and when needed.
- Removed loading of `vstruct` parameters such as `PxrSurface.inputMaterial`. These weren't functional anyway - will revisit if and when needed.

I really wanted to move `PxrSurface.utilityPattern` into a sensible section in the NodeEditor in https://github.com/GafferHQ/gaffer/commit/5aee556e5a06910e354a1081ca8649f764a5d0b3, but that ran foul of what I think is a bug in our Metadata resolution. Will deal with separately when time allows.