### PR TITLE
SceneReaderTest : testReadSets only tests extensions that can be written

### DIFF
--- a/python/GafferSceneTest/SceneReaderTest.py
+++ b/python/GafferSceneTest/SceneReaderTest.py
@@ -658,7 +658,7 @@ class SceneReaderTest( GafferSceneTest.SceneTestCase ) :
 		reader = GafferScene.SceneReader()
 		reader["fileName"].setInput( writer["fileName"] )
 
-		for extension in IECoreScene.SceneInterface.supportedExtensions() :
+		for extension in IECoreScene.SceneInterface.supportedExtensions( IECore.IndexedIO.OpenMode.Write ) :
 
 			if extension in { "abc", "usdz", "vdb" } :
 				# - `IECoreAlembic::AlembicScene::writeSet()` hasn't been implemented properly for


### PR DESCRIPTION
At ImageEngine, "cob" extensions are returned by `IECoreScene.SceneInterface.supportedExtensions()`, but then the code would fail when trying to write out the file, since there is no support for writing them using the SceneInterface.

Given that this test requires the capability to write out the files that way, it seems reasonable to limit the extensions to those that have write support.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
