### PR TITLE
IECoreRenderMan : Apply normal AOV type hack to normal_mse as well

### DIFF
--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -649,7 +649,7 @@ const std::vector<riley::RenderOutputId> &Globals::acquireRenderOutputs( const I
 			}
 			else if( tokens[0] == "lpe" )
 			{
-				if( layerName == "normal" )
+				if( layerName == "normal" || layerName == "normal_mse" )
 				{
 					type = riley::RenderOutputType::k_Vector;
 				}


### PR DESCRIPTION
This isn't the most elegant solution to this AOV type, but if we're doing this for "normal", we might as well do it for "normal_mse" as well. This seems to be necessary to get the PRMan denoiser working properly.