### PR TITLE
Cryptomatte : Fix handling of output from PxrCryptomatte

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,11 @@
 
 
 
+Fixes
+-----
+
+- Cryptomatte : Fixed handling of PxrCryptomatte output, and other files with less conventional metadata formatting.
+
 1.5.7.0 (relative to 1.5.6.0)
 =======
 


### PR DESCRIPTION
PxrCryptomatte uses a non-conventional metadata naming convention. Rather than using the first seven characters of the hash of the layer name, it uses the _last_ seven characters. But the cryptomatte specification does allow this - in fact it allows any key as long as it doesn't exceed 7 characters. So we must search for a `cryptomatte/{key}/name` entry whose value matches the layer name, and take the key from that.
