### PR TITLE
ShuffleImageMetadata : Add node for shuffling image metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.7.0)
 =======
 
+Features
+--------
 
+- ShuffleImageMetadata : Added a new node for shuffling image metadata.
 
 1.5.7.0 (relative to 1.5.6.0)
 =======

--- a/include/GafferImage/ShuffleImageMetadata.h
+++ b/include/GafferImage/ShuffleImageMetadata.h
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferImage/MetadataProcessor.h"
+
+#include "Gaffer/ShufflePlug.h"
+
+namespace GafferImage
+{
+
+class GAFFERIMAGE_API ShuffleImageMetadata : public MetadataProcessor
+{
+
+	public :
+
+		explicit ShuffleImageMetadata( const std::string &name=defaultName<ShuffleImageMetadata>() );
+		~ShuffleImageMetadata() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferImage::ShuffleImageMetadata, ShuffleImageMetadataTypeId, MetadataProcessor );
+
+		Gaffer::ShufflesPlug *shufflesPlug();
+		const Gaffer::ShufflesPlug *shufflesPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundDataPtr computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( ShuffleImageMetadata );
+
+} // namespace GafferImage

--- a/include/GafferImage/TypeIds.h
+++ b/include/GafferImage/TypeIds.h
@@ -58,7 +58,7 @@ enum TypeId
 	GradeTypeId = 110763,
 	ShuffleTypeId = 110764,
 	ConstantTypeId = 110765,
-	ShuffleChannelPlugTypeId = 110766, // Obsolete - available for reuse
+	ShuffleImageMetadataTypeId = 110766,
 	ChannelMaskPlugTypeId = 110767,
 	WarpTypeId = 110768,
 	VectorWarpTypeId = 110769,

--- a/python/GafferImageTest/ShuffleImageMetadataTest.py
+++ b/python/GafferImageTest/ShuffleImageMetadataTest.py
@@ -1,0 +1,70 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferImage
+import GafferImageTest
+
+class ShuffleImageMetadataTest( GafferImageTest.ImageTestCase ) :
+
+	def test( self ) :
+
+		constant = GafferImage.Constant()
+
+		metadata = GafferImage.ImageMetadata()
+		metadata["in"].setInput( constant["out"] )
+		metadata["metadata"].addChild( Gaffer.NameValuePlug( "a", "A" ) )
+		metadata["metadata"].addChild( Gaffer.NameValuePlug( "b", "B" ) )
+
+		shuffle = GafferImage.ShuffleImageMetadata()
+		shuffle["in"].setInput( metadata["out"] )
+		self.assertEqual( shuffle["out"].metadata(), IECore.CompoundData( { "a" : "A", "b" : "B" } ) )
+
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "a", "c" ) )
+		self.assertEqual( shuffle["out"].metadata(), IECore.CompoundData( { "a" : "A", "b" : "B", "c" : "A" } ) )
+
+		shuffle["shuffles"][0]["deleteSource"].setValue( True )
+		self.assertEqual( shuffle["out"].metadata(), IECore.CompoundData( { "b" : "B", "c" : "A" } ) )
+
+		shuffle["enabled"].setValue( False )
+		self.assertEqual( shuffle["out"].metadata(), shuffle["in"].metadata() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferImageTest/__init__.py
+++ b/python/GafferImageTest/__init__.py
@@ -118,6 +118,7 @@ from .OpenColorIOConfigPlugTest import OpenColorIOConfigPlugTest
 from .DeepSliceTest import DeepSliceTest
 from .ContactSheetCoreTest import ContactSheetCoreTest
 from .ContactSheetTest import ContactSheetTest
+from .ShuffleImageMetadataTest import ShuffleImageMetadataTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferImageUI/ShuffleImageMetadataUI.py
+++ b/python/GafferImageUI/ShuffleImageMetadataUI.py
@@ -1,0 +1,64 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferImage
+
+Gaffer.Metadata.registerNode(
+
+	GafferImage.ShuffleImageMetadata,
+
+	"description",
+	"""
+	Shuffles image metadata, allowing entries to be copied and/or renamed.
+	""",
+
+	plugs = {
+
+		"shuffles" : [
+
+			"description",
+			"""
+			The definition of the shuffling to be performed - an
+			arbitrary number of metadata edits can be made by adding
+			ShufflePlugs as children of this plug.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferImageUI/__init__.py
+++ b/python/GafferImageUI/__init__.py
@@ -126,5 +126,6 @@ from . import DeepSliceUI
 from . import ContactSheetCoreUI
 from . import ContactSheetUI
 from . import MetadataOverlayUI
+from . import ShuffleImageMetadataUI
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferImageUI" )

--- a/src/GafferImage/ShuffleImageMetadata.cpp
+++ b/src/GafferImage/ShuffleImageMetadata.cpp
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferImage/ShuffleImageMetadata.h"
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferImage;
+
+GAFFER_NODE_DEFINE_TYPE( ShuffleImageMetadata );
+
+size_t ShuffleImageMetadata::g_firstPlugIndex = 0;
+
+ShuffleImageMetadata::ShuffleImageMetadata( const std::string &name )
+	:	MetadataProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ShufflesPlug( "shuffles" ) );
+}
+
+ShuffleImageMetadata::~ShuffleImageMetadata()
+{
+}
+
+Gaffer::ShufflesPlug *ShuffleImageMetadata::shufflesPlug()
+{
+	return getChild<Gaffer::ShufflesPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::ShufflesPlug *ShuffleImageMetadata::shufflesPlug() const
+{
+	return getChild<Gaffer::ShufflesPlug>( g_firstPlugIndex );
+}
+
+void ShuffleImageMetadata::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	MetadataProcessor::affects( input, outputs );
+
+	if( shufflesPlug()->isAncestorOf( input ) )
+	{
+		outputs.push_back( outPlug()->metadataPlug() );
+	}
+}
+
+void ShuffleImageMetadata::hashProcessedMetadata( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	shufflesPlug()->hash( h );
+}
+
+IECore::ConstCompoundDataPtr ShuffleImageMetadata::computeProcessedMetadata( const Gaffer::Context *context, const IECore::CompoundData *inputMetadata ) const
+{
+	CompoundDataPtr result = new CompoundData();
+	result->writable() = shufflesPlug()->shuffle( inputMetadata->readable() );
+	return result;
+}

--- a/src/GafferImageModule/MetadataBinding.cpp
+++ b/src/GafferImageModule/MetadataBinding.cpp
@@ -40,6 +40,7 @@
 #include "GafferImage/DeleteImageMetadata.h"
 #include "GafferImage/ImageMetadata.h"
 #include "GafferImage/MetadataProcessor.h"
+#include "GafferImage/ShuffleImageMetadata.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -54,5 +55,6 @@ void GafferImageModule::bindMetadata()
 	GafferBindings::DependencyNodeClass<ImageMetadata>();
 	GafferBindings::DependencyNodeClass<DeleteImageMetadata>();
 	GafferBindings::DependencyNodeClass<CopyImageMetadata>();
+	GafferBindings::DependencyNodeClass<ShuffleImageMetadata>();
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -403,6 +403,7 @@ nodeMenu.append( "/Image/Channels/Collect", GafferImage.CollectImages, searchTex
 nodeMenu.append( "/Image/Utility/Metadata", GafferImage.ImageMetadata, searchText = "ImageMetadata" )
 nodeMenu.append( "/Image/Utility/Delete Metadata", GafferImage.DeleteImageMetadata, searchText = "DeleteImageMetadata" )
 nodeMenu.append( "/Image/Utility/Copy Metadata", GafferImage.CopyImageMetadata, searchText = "CopyImageMetadata" )
+nodeMenu.append( "/Image/Utility/Shuffle Metadata", GafferImage.ShuffleImageMetadata, searchText = "ShuffleImageMetadata" )
 nodeMenu.append( "/Image/Utility/Metadata Overlay", GafferImage.MetadataOverlay, searchText = "MetadataOverlay" )
 nodeMenu.append( "/Image/Utility/Stats", GafferImage.ImageStats, searchText = "ImageStats" )
 nodeMenu.append( "/Image/Utility/Sampler", GafferImage.ImageSampler, searchText = "ImageSampler" )


### PR DESCRIPTION
I thought I was going to use this for testing #6304 but it turned out to be easier to use an expression. But this could still be useful, and fleshes out our metadata support more fully.