### PR TITLE
VisualiserTool : Change viewer shortcut to `L`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Cryptomatte : Fixed handling of PxrCryptomatte output, and other files with less conventional metadata formatting.
+- VisualiserTool : Changed viewer shortcut to <kbd>L</kbd> to fix conflict with the pinning shortcut.
 
 1.5.7.0 (relative to 1.5.6.0)
 =======

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -228,7 +228,7 @@ Crop Window Tool                     | {kbd}`C`
 Crop Window Tool and crop enabled    | {kbd}`Alt` + {kbd}`C`
 Light Tool                           | {kbd}`A`
 Light Position Tool                  | {kbd}`D`
-Visualiser Tool                      | {kbd}`P`
+Visualiser Tool                      | {kbd}`L`
 Pin to numeric bookmark              | {kbd}`1` … {kbd}`9`
 
 ### 3D scenes ###

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -54,7 +54,7 @@ Gaffer.Metadata.registerNode(
 	Tool for displaying object data.
 	""",
 
-	"viewer:shortCut", "P",
+	"viewer:shortCut", "L",
 	"viewer:shouldAutoActivate", False,
 	"order", 8,
 	"tool:exclusive", False,


### PR DESCRIPTION
We can't use`P` as it conflicts with pinning the selected node.

`L` could potentially conflict in the future with a shortcut for putting the Viewer into luminance mode but it seems unlikely that we'd ever want to be able to support unmodified `R`, `G`, `B`, `A`, `L` in the SceneView for channel/luminance selection as the SceneView already responds to other shortcuts assigned to `R`, `G` and `A`.