### PR TITLE
GafferScene startup : Initial RenderMan render adaptor configuration

### DIFF
--- a/python/GafferSceneTest/RenderAdaptorTest.py
+++ b/python/GafferSceneTest/RenderAdaptorTest.py
@@ -443,6 +443,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ai:visibility:camera", True, True ) )
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "cycles:visibility:camera", True, True ) )
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "dl:visibility.camera", True, True ) )
+		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ri:visibility:camera", True, True ) )
 
 		exclusionAttributesFilter = GafferScene.SetFilter()
 		exclusionAttributes = GafferScene.CustomAttributes()
@@ -451,6 +452,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ai:visibility:camera", False, True ) )
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "cycles:visibility:camera", False, True ) )
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "dl:visibility.camera", False, True ) )
+		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ri:visibility:camera", False, True ) )
 
 		# Create adaptors for the CapturingRenderer
 		testAdaptors = GafferScene.SceneAlgo.createRenderAdaptors()
@@ -487,7 +489,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 
 			for path in allPaths :
 				capturedObject = renderer.capturedObject( path )
-				for attribute in [ "ai:visibility:camera", "cycles:visibility:camera", "dl:visibility.camera" ] :
+				for attribute in [ "ai:visibility:camera", "cycles:visibility:camera", "dl:visibility.camera", "ri:visibility:camera" ] :
 					if path in paths :
 						# path is visible by the absence of the attribute, or its presence with a value of True
 						if attribute in capturedObject.capturedAttributes().attributes() :

--- a/python/GafferSceneTest/RenderAdaptorTest.py
+++ b/python/GafferSceneTest/RenderAdaptorTest.py
@@ -581,6 +581,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ai:matte", True, True, "aiMatte" ) )
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "cycles:use_holdout", True, True, "cyclesUseHoldout" ) )
 		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "dl:matte", True, True, "dlMatte" ) )
+		inclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ri:Ri:Matte", True, True, "riMatte" ) )
 
 		exclusionAttributesFilter = GafferScene.SetFilter()
 		exclusionAttributes = GafferScene.CustomAttributes()
@@ -589,6 +590,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ai:matte", False, True, "aiMatte" ) )
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "cycles:use_holdout", False, True, "cyclesUseHoldout" ) )
 		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "dl:matte", False, True, "dlMatte" ) )
+		exclusionAttributes["attributes"].addChild( Gaffer.NameValuePlug( "ri:Ri:Matte", False, True, "riMatte" ) )
 
 		# Create adaptors for the CapturingRenderer
 		testAdaptors = GafferScene.SceneAlgo.createRenderAdaptors()
@@ -622,7 +624,7 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 
 			for path in allPaths :
 				capturedObject = renderer.capturedObject( path )
-				for attribute in [ "ai:matte", "cycles:use_holdout", "dl:matte" ] :
+				for attribute in [ "ai:matte", "cycles:use_holdout", "dl:matte", "ri:Ri:Matte" ] :
 					if path in paths :
 						# path is matte only by the presence of the attribute with a value of True
 						self.assertTrue( attribute in capturedObject.capturedAttributes().attributes() )

--- a/startup/GafferScene/cameraVisibilityAdaptor.py
+++ b/startup/GafferScene/cameraVisibilityAdaptor.py
@@ -41,6 +41,8 @@ import GafferScene
 
 def __cameraVisibilityAdaptor() :
 
+	__cameraVisibilityAttributes = [ "ai:visibility:camera", "cycles:visibility:camera", "dl:visibility.camera", "ri:visibility:camera" ]
+
 	processor = GafferScene.SceneProcessor()
 
 	processor["__optionQuery"] = GafferScene.OptionQuery()
@@ -71,9 +73,9 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__allCameraExcluded"] = GafferScene.CustomAttributes()
 	processor["__allCameraExcluded"]["in"].setInput( processor["in"] )
-	processor["__allCameraExcluded"]["attributes"].addChild( Gaffer.NameValuePlug( "ai:visibility:camera", Gaffer.BoolPlug() ) )
-	processor["__allCameraExcluded"]["attributes"].addChild( Gaffer.NameValuePlug( "cycles:visibility:camera", Gaffer.BoolPlug() ) )
-	processor["__allCameraExcluded"]["attributes"].addChild( Gaffer.NameValuePlug( "dl:visibility.camera", Gaffer.BoolPlug() ) )
+	for attribute in __cameraVisibilityAttributes :
+		processor["__allCameraExcluded"]["attributes"].addChild( Gaffer.NameValuePlug( attribute, Gaffer.BoolPlug() ) )
+
 	processor["__allCameraExcluded"]["global"].setValue( True )
 	# __allCameraExcluded is only required when `render:cameraInclusions` exists and does not match the root of the scene.
 	processor["__allCameraExcludedExpression"] = Gaffer.Expression()
@@ -83,9 +85,8 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__cameraInclusions"] = GafferScene.AttributeTweaks()
 	processor["__cameraInclusions"]["in"].setInput( processor["__allCameraExcluded"]["out"] )
-	processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "ai:visibility:camera", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "cycles:visibility:camera", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "dl:visibility.camera", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
+	for attribute in __cameraVisibilityAttributes :
+		processor["__cameraInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attribute, Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__cameraInclusions"]["filter"].setInput( processor["__cameraInclusionsFilter"]["out"] )
 	# __cameraInclusions is only required when `render:cameraInclusions` exists
@@ -96,9 +97,8 @@ def __cameraVisibilityAdaptor() :
 
 	processor["__cameraExclusions"] = GafferScene.AttributeTweaks()
 	processor["__cameraExclusions"]["in"].setInput( processor["__cameraInclusions"]["out"] )
-	processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "ai:visibility:camera", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "cycles:visibility:camera", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "dl:visibility.camera", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
+	for attribute in __cameraVisibilityAttributes :
+		processor["__cameraExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attribute, Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__cameraExclusions"]["filter"].setInput( processor["__cameraExclusionsFilter"]["out"] )
 	# __cameraExclusions is only required when `render:cameraExclusions` exists

--- a/startup/GafferScene/matteAdaptor.py
+++ b/startup/GafferScene/matteAdaptor.py
@@ -41,6 +41,8 @@ import GafferScene
 
 def __matteAdaptor() :
 
+	__matteAttributes = [ "ai:matte", "cycles:use_holdout", "dl:matte", "ri:Ri:Matte" ]
+
 	processor = GafferScene.SceneProcessor()
 
 	processor["__optionQuery"] = GafferScene.OptionQuery()
@@ -71,18 +73,17 @@ def __matteAdaptor() :
 
 	processor["__allMatte"] = GafferScene.CustomAttributes()
 	processor["__allMatte"]["in"].setInput( processor["in"] )
-	processor["__allMatte"]["attributes"].addChild( Gaffer.NameValuePlug( "ai:matte", Gaffer.BoolPlug( defaultValue = True ) ) )
-	processor["__allMatte"]["attributes"].addChild( Gaffer.NameValuePlug( "cycles:use_holdout", Gaffer.BoolPlug( defaultValue = True ) ) )
-	processor["__allMatte"]["attributes"].addChild( Gaffer.NameValuePlug( "dl:matte", Gaffer.BoolPlug( defaultValue = True ) ) )
+	for attribute in __matteAttributes :
+		processor["__allMatte"]["attributes"].addChild( Gaffer.NameValuePlug( attribute, Gaffer.BoolPlug( defaultValue = True ) ) )
+
 	processor["__allMatte"]["global"].setValue( True )
 	# all locations are matte if `render:matteInclusions` matches the root of the scene
 	processor["__allMatte"]["enabled"].setInput( processor["__filterQuery"]["exactMatch"] )
 
 	processor["__matteInclusions"] = GafferScene.AttributeTweaks()
 	processor["__matteInclusions"]["in"].setInput( processor["__allMatte"]["out"] )
-	processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "ai:matte", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "cycles:use_holdout", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "dl:matte", Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
+	for attribute in __matteAttributes :
+		processor["__matteInclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attribute, Gaffer.BoolPlug( defaultValue = True ), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__matteInclusions"]["filter"].setInput( processor["__matteInclusionsFilter"]["out"] )
 	# __matteInclusions is only required when `render:matteInclusions` exists and the root of the scene hasn't been set as matte
@@ -96,9 +97,8 @@ def __matteAdaptor() :
 
 	processor["__matteExclusions"] = GafferScene.AttributeTweaks()
 	processor["__matteExclusions"]["in"].setInput( processor["__matteInclusions"]["out"] )
-	processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "ai:matte", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "cycles:use_holdout", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
-	processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( "dl:matte", Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
+	for attribute in __matteAttributes :
+		processor["__matteExclusions"]["tweaks"].addChild( Gaffer.TweakPlug( attribute, Gaffer.BoolPlug(), mode = Gaffer.TweakPlug.Mode.CreateIfMissing ) )
 
 	processor["__matteExclusions"]["filter"].setInput( processor["__matteExclusionsFilter"]["out"] )
 	# __matteExclusions is only required when `render:matteExclusions` exists


### PR DESCRIPTION
This adds the necessary RenderMan-specific attributes to the CameraVisibilityAdaptor and MatteAdaptor, providing RenderMan support for the Render Pass Editor's "Camera Inclusions", "Camera Exclusions", "Matte Inclusions" & "Matte Exclusions" columns.

Further configuration still needs to be added to add RenderMan support for Gaffer's standard Render Pass Types, but that is dependent on other work in the RenderMan backend, such as support for Light Linking and Display Filters.