### PR TITLE
RenderPassChooserWidget : Fix handling of add/remove of `renderPass` plug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - Cryptomatte : Fixed handling of PxrCryptomatte output, and other files with less conventional metadata formatting.
 - VisualiserTool : Changed viewer shortcut to <kbd>L</kbd> to fix conflict with the pinning shortcut.
+- RenderPassMenu : Fixed handling of the addition and removal of the render pass plug.
 
 1.5.7.0 (relative to 1.5.6.0)
 =======


### PR DESCRIPTION
The bug could be triggered by simply doing `root.load()` to reload the current script from the PythonEditor. This would delete the old plug and replace it with a new one. But the RenderPassChooserWidget would just carry on showing the old plug, which was no longer parented to anything, meaning that all updates failed and we got BackgroundTask errors about there being no ScriptNode.

We now track addition and removal of the render pass plug, and create and remove the widget as necessary.

> Note : This also means that the RenderPassChooserWidget no longer creates the render pass plug if it is missing. But `startup/gui/project.py` is already creating the plug for us anyway, so we should always end up with one anyway.
