### PR TITLE
RenderManLight nodes

### DIFF
--- a/include/GafferRenderMan/RenderManLight.h
+++ b/include/GafferRenderMan/RenderManLight.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,16 +36,47 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "GafferScene/Light.h"
+#include "GafferScene/Shader.h"
+#include "GafferScene/ShaderPlug.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManLight : public GafferScene::Light
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	LastTypeId = 110450
+
+	public :
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManLight, RenderManLightTypeId, GafferScene::Light );
+
+		RenderManLight( const std::string &name=defaultName<RenderManLight>() );
+		~RenderManLight() override;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+		void loadShader( const std::string &shaderName );
+
+	protected :
+
+		void hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECoreScene::ConstShaderNetworkPtr computeLight( const Gaffer::Context *context ) const override;
+
+	private :
+
+		GafferScene::Shader *shaderNode();
+		const GafferScene::Shader *shaderNode() const;
+
+		GafferScene::ShaderPlug *shaderInPlug();
+		const GafferScene::ShaderPlug *shaderInPlug() const;
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( RenderManLight )
 
 } // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManMeshLight.h
+++ b/include/GafferRenderMan/RenderManMeshLight.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,37 +34,32 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "GafferRenderMan/RenderManAttributes.h"
-#include "GafferRenderMan/RenderManLight.h"
-#include "GafferRenderMan/RenderManMeshLight.h"
-#include "GafferRenderMan/RenderManOptions.h"
-#include "GafferRenderMan/RenderManShader.h"
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
 
-#include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferScene/FilteredSceneProcessor.h"
 
-using namespace boost::python;
-using namespace GafferRenderMan;
-
-namespace
+namespace GafferRenderMan
 {
 
-void loadShader( RenderManLight &l, const std::string &shaderName )
+class GAFFERRENDERMAN_API RenderManMeshLight : public GafferScene::FilteredSceneProcessor
 {
-	IECorePython::ScopedGILRelease gilRelease;
-	l.loadShader( shaderName );
-}
 
-} // namespace
+	public :
 
-BOOST_PYTHON_MODULE( _GafferRenderMan )
-{
-	GafferBindings::DependencyNodeClass<RenderManLight>()
-		.def( "loadShader", &loadShader )
-	;
-	GafferBindings::DependencyNodeClass<RenderManAttributes>();
-	GafferBindings::DependencyNodeClass<RenderManOptions>();
-	GafferBindings::DependencyNodeClass<RenderManShader>();
-	GafferBindings::DependencyNodeClass<RenderManMeshLight>();
-}
+		explicit RenderManMeshLight( const std::string &name=defaultName<RenderManMeshLight>() );
+		~RenderManMeshLight() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManMeshLight, RenderManMeshLightTypeId, FilteredSceneProcessor );
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( RenderManMeshLight )
+
+} // namespace GafferRenderMan

--- a/include/GafferRenderMan/TypeIds.h
+++ b/include/GafferRenderMan/TypeIds.h
@@ -45,6 +45,7 @@ enum TypeId
 	RenderManOptionsTypeId = 110401,
 	RenderManShaderTypeId = 110402,
 	RenderManLightTypeId = 110403,
+	RenderManMeshLightTypeId = 110404,
 	LastTypeId = 110450
 };
 

--- a/python/GafferRenderManTest/RenderManLightTest.py
+++ b/python/GafferRenderManTest/RenderManLightTest.py
@@ -1,0 +1,106 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import Gaffer
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManLightTest( GafferSceneTest.SceneTestCase ) :
+
+	def testLoading( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrRectLight" )
+
+		self.assertIsInstance( light["parameters"]["intensity"], Gaffer.FloatPlug )
+		self.assertIsInstance( light["parameters"]["lightColor"], Gaffer.Color3fPlug )
+
+	def testLoadAllLightTypes( self ) :
+
+		for name in [
+			"PxrAovLight", "PxrDistantLight", "PxrMeshLight", "PxrSphereLight",
+			"PxrCylinderLight", "PxrDomeLight", "PxrPortalLight",
+			"PxrDiskLight", "PxrEnvDayLight", "PxrRectLight",
+		] :
+			with self.subTest( name = name ) :
+				light = GafferRenderMan.RenderManLight()
+				light.loadShader( name )
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["light"] = GafferRenderMan.RenderManLight()
+		script["light"].loadShader( "PxrRectLight" )
+
+		script["light"]["parameters"]["intensity"].setValue( 10 )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+
+		self.assertEqual( script2["light"]["parameters"]["intensity"].getValue(), 10 )
+
+	def testVisualiserAttributes( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrRectLight" )
+
+		self.assertNotIn( "gl:visualiser:scale", light["out"].attributes( "/light" ) )
+		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
+		self.assertIn( "gl:visualiser:scale", light["out"].attributes( "/light" ) )
+
+	def testMinMax( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrDomeLight" )
+
+		self.assertFalse( light["parameters"]["exposure"].hasMinValue() )
+		self.assertTrue( light["parameters"]["intensity"].hasMinValue() )
+		self.assertEqual( light["parameters"]["intensity"].minValue(), 0 )
+
+	def testPortalLight( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrPortalLight" )
+		self.assertEqual(
+			set( light["out"].attributes( "/light" )["ri:light"].outputShader().parameters.keys() ),
+			{ "intensityMult", "tint" }
+		)
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/RenderManMeshLightTest.py
+++ b/python/GafferRenderManTest/RenderManMeshLightTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,11 +34,52 @@
 #
 ##########################################################################
 
-__import__( "GafferSceneUI" )
+import unittest
 
-from . import RenderManAttributesUI
-from . import RenderManOptionsUI
-from . import RenderManShaderUI
-from . import RenderManMeshLightUI
+import IECore
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )
+import Gaffer
+import GafferScene
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManMeshLightTest( GafferSceneTest.SceneTestCase ) :
+
+	def testParameters( self ) :
+
+		light = GafferRenderMan.RenderManMeshLight()
+
+		# Should have all the parameters of a PxrMeshLight shader.
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrMeshLight" )
+		self.assertEqual( light["parameters"].keys(), shader["parameters"].keys() )
+
+		# Parameters should drive a light shader in the scene.
+
+		sphere = GafferScene.Sphere()
+		sphereFilter = GafferScene.PathFilter()
+		sphereFilter["paths"].setValue( IECore.StringVectorData( [ "/sphere" ] ) )
+		light["in"].setInput( sphere["out"] )
+		light["filter"].setInput( sphereFilter["out"] )
+
+		light["parameters"]["exposure"].setValue( 10 )
+		self.assertEqual( light["out"].attributes( "/sphere" )["ri:light"].outputShader().parameters["exposure"], IECore.FloatData( 10 ) )
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["light"] = GafferRenderMan.RenderManMeshLight()
+		script["light"]["parameters"]["intensity"].setValue( 10 )
+
+		serialisation = script.serialise()
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( serialisation )
+		self.assertEqual( script2["light"]["parameters"]["intensity"].getValue(), 10 )
+
+		# One for the node. None for plugs, since they are not dynamic.
+		self.assertEqual( serialisation.count( "addChild" ), 1 )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -38,6 +38,7 @@ from .ModuleTest import ModuleTest
 from .RenderManAttributesTest import RenderManAttributesTest
 from .RenderManOptionsTest import RenderManOptionsTest
 from .RenderManShaderTest import RenderManShaderTest
+from .RenderManLightTest import RenderManLightTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -39,6 +39,7 @@ from .RenderManAttributesTest import RenderManAttributesTest
 from .RenderManOptionsTest import RenderManOptionsTest
 from .RenderManShaderTest import RenderManShaderTest
 from .RenderManLightTest import RenderManLightTest
+from .RenderManMeshLightTest import RenderManMeshLightTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferRenderManUI/RenderManMeshLightUI.py
+++ b/python/GafferRenderManUI/RenderManMeshLightUI.py
@@ -1,0 +1,124 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import functools
+
+import Gaffer
+import GafferRenderMan
+
+def __shaderMetadata( plug, name ) :
+
+	return Gaffer.Metadata.value( plug.node()["__shader"].descendant( plug.relativeName( plug.node() ) ), name )
+
+Gaffer.Metadata.registerNode(
+
+	GafferRenderMan.RenderManMeshLight,
+
+	"description",
+	"""
+	Turns mesh primitives into RenderMan mesh lights by assigning
+	a PxrMeshLight shader, turning off all visibility except for camera rays,
+	and adding the meshes to the default lights set.
+	""",
+
+	plugs = {
+
+		"cameraVisibility" : [
+
+			"description",
+			"""
+			Whether or not the mesh light is visible to camera
+			rays.
+			""",
+
+			"nameValuePlugPlugValueWidget:ignoreNamePlug", True,
+
+		],
+
+		"cameraVisibility.value" : [
+
+			"plugValueWidget:type", "GafferUI.BoolPlugValueWidget",
+
+		],
+
+		"parameters" : [
+
+			"description",
+			"""
+			The parameters of the PxrMeshLight shader that is applied to the
+			meshes.
+			""",
+
+			## \todo Extend the Metadata API so we can register a provider for "*",
+			# which can automatically transfer all internal metadata.
+			"noduleLayout:section", functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
+			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
+			"noduleLayout:spacing", functools.partial( __shaderMetadata, name = "noduleLayout:spacing" ),
+			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
+			"layout:section:Basic:collapsed", False
+
+		],
+
+		"parameters.*" : [
+
+			"description", functools.partial( __shaderMetadata, name = "description" ),
+			"nodule:type", functools.partial( __shaderMetadata, name = "nodule:type" ),
+			"noduleLayout:section", functools.partial( __shaderMetadata, name = "noduleLayout:section" ),
+			"nodule:color", functools.partial( __shaderMetadata, name = "nodule:color" ),
+			"layout:section", functools.partial( __shaderMetadata, name = "layout:section" ),
+			"plugValueWidget:type", functools.partial( __shaderMetadata, name = "plugValueWidget:type" ),
+			"presetNames", functools.partial( __shaderMetadata, name = "presetNames" ),
+			"presetValues", functools.partial( __shaderMetadata, name = "presetValues" ),
+
+		],
+
+		"defaultLight" : [
+
+			"description",
+			"""
+			Whether this light illuminates all geometry by default. When
+			toggled, the light will be added to the `defaultLights` set, which
+			can be referenced in set expressions and manipulated by downstream
+			nodes.
+			""",
+
+			"layout:section", "Light Linking",
+
+		]
+
+	}
+
+)

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -353,6 +353,7 @@
 				"pointLight",
 				"diskLight",
 				"quadLight",
+				"portalLight",
 				"cylinderLight",
 				"spotLight",
 				"distantLight",

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -67,8 +67,8 @@
        only_selected="false" />
     <linearGradient
        id="exclusionRed"
-       gradientTransform="translate(0)"
-       inkscape:swatch="solid">
+       inkscape:swatch="solid"
+       gradientTransform="translate(0)">
       <stop
          style="stop-color:#ad5454;stop-opacity:1;"
          offset="0"
@@ -352,13 +352,13 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#4c4c4c"
      showgrid="false"
-     inkscape:zoom="6.984"
-     inkscape:cx="77.033219"
-     inkscape:cy="2868.7715"
-     inkscape:window-width="1501"
-     inkscape:window-height="1088"
-     inkscape:window-x="1547"
-     inkscape:window-y="231"
+     inkscape:zoom="5.656854"
+     inkscape:cx="100.23239"
+     inkscape:cy="2564.6764"
+     inkscape:window-width="2700"
+     inkscape:window-height="1247"
+     inkscape:window-x="1343"
+     inkscape:window-y="51"
      inkscape:window-maximized="0"
      inkscape:current-layer="layer1">
     <inkscape:grid
@@ -3149,7 +3149,7 @@
          x="575"
          height="16"
          width="16"
-         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:0.40000001;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:0.4;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
          inkscape:label="cylinderBlocker" />
       <rect
          id="planeBlocker"
@@ -3157,7 +3157,7 @@
          x="555"
          height="16"
          width="16"
-         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
          inkscape:label="planeBlocker" />
       <rect
          id="sphereBlocker"
@@ -3165,7 +3165,7 @@
          x="535"
          height="16"
          width="16"
-         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
          inkscape:label="sphereBlocker" />
       <rect
          id="boxBlocker"
@@ -3173,7 +3173,7 @@
          x="515"
          height="16"
          width="16"
-         style="display:inline;font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
          inkscape:label="boxBlocker" />
       <rect
          inkscape:label="diskLight"
@@ -3271,7 +3271,7 @@
          x="10"
          height="16"
          width="16"
-         style="display:inline;opacity:1;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill;font-variation-settings:normal;vector-effect:none;stroke-linecap:butt;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+         style="font-variation-settings:normal;display:inline;opacity:1;vector-effect:none;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.747018;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers stroke fill;stop-color:#000000;stop-opacity:1"
          inkscape:label="sizeGuide" />
       <rect
          id="unMuteLight"
@@ -3377,6 +3377,14 @@
          width="16"
          style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="setMemberFadedHighlighted" />
+      <rect
+         id="portalLight"
+         y="2563.9998"
+         x="70"
+         height="16"
+         width="16"
+         style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="portalLight" />
     </g>
     <g
        id="g6806"
@@ -8802,7 +8810,7 @@
        inkscape:label="sizeGuide" />
     <path
        style="display:inline;opacity:1;fill:#787878;fill-opacity:1;stroke:#434343;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:normal"
-       d="m 41,2494.5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 4.001953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,-0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -8.001953 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z m 6.5,5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 10.501953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,-0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -1.501953 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z m -8.5,5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 2.001953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,-0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 H 40.998047 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z"
+       d="m 41,2494.5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 4.001953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -8.001953 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z m 6.5,5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 10.501953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 h -1.501953 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z m -8.5,5 c -0.785527,0 -1.524794,0.3716 -1.996094,1 H 35 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 2.001953 c 0.471713,0.629 1.211833,0.9994 1.998047,1 0.785527,0 1.524794,-0.3716 1.996094,-1 H 51 c 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 H 40.998047 c -0.471713,-0.629 -1.211833,-0.9994 -1.998047,-1 z"
        transform="translate(0,52.362183)"
        id="rect1959"
        inkscape:connector-curvature="0"
@@ -9158,8 +9166,8 @@
          inkscape:label="lessThanSmall" />
       <path
          id="path1"
-         style="display:inline;font-size:16px;line-height:1.25;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro';fill:url(#foreground);stroke:url(#linearGradient10);stroke-width:0.245669"
-         d="M 250.11914 2613.4473 C 248.88714 2613.4473 247.89578 2613.9921 247.17578 2614.7441 L 247.95898 2615.4648 C 248.53498 2614.8888 249.22306 2614.5352 250.03906 2614.5352 C 251.20706 2614.5352 251.79883 2615.2079 251.79883 2616.0879 C 251.79883 2617.7199 248.91873 2618.3604 249.30273 2620.6484 L 250.4707 2620.6484 C 250.1827 2618.5684 253.0957 2618.1194 253.0957 2615.9434 C 253.0957 2614.4234 251.89514 2613.4473 250.11914 2613.4473 z M 243 2616 L 243 2618 L 247 2618 L 247 2616 L 243 2616 z M 243 2620 L 243 2622 L 247 2622 L 247 2620 L 243 2620 z M 250.00781 2622.0879 C 249.36781 2622.0879 248.83984 2622.5527 248.83984 2623.3047 C 248.83984 2624.0727 249.36781 2624.5527 250.00781 2624.5527 C 250.64781 2624.5527 251.17578 2624.0727 251.17578 2623.3047 C 251.17578 2622.5527 250.64781 2622.0879 250.00781 2622.0879 z "
+         style="font-size:16px;line-height:1.25;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro';display:inline;fill:url(#foreground);stroke:url(#linearGradient10);stroke-width:0.245669"
+         d="m 250.11914,2613.4473 c -1.232,0 -2.22336,0.5448 -2.94336,1.2968 l 0.7832,0.7207 c 0.576,-0.576 1.26408,-0.9296 2.08008,-0.9296 1.168,0 1.75977,0.6727 1.75977,1.5527 0,1.632 -2.8801,2.2725 -2.4961,4.5605 h 1.16797 c -0.288,-2.08 2.625,-2.529 2.625,-4.705 0,-1.52 -1.20056,-2.4961 -2.97656,-2.4961 z M 243,2616 v 2 h 4 v -2 z m 0,4 v 2 h 4 v -2 z m 7.00781,2.0879 c -0.64,0 -1.16797,0.4648 -1.16797,1.2168 0,0.768 0.52797,1.248 1.16797,1.248 0.64,0 1.16797,-0.48 1.16797,-1.248 0,-0.752 -0.52797,-1.2168 -1.16797,-1.2168 z"
          transform="translate(0,52.3622)"
          inkscape:label="createIfMissingSmall" />
     </g>
@@ -9458,7 +9466,7 @@
      d="m 543,2610.9937 c -1.17712,0 -2.13136,-2.969 -2.13135,-6.6314 10e-6,-3.6624 0.95424,-6.6313 2.13135,-6.6313"
      id="path130705" />
   <path
-     style="display:inline;opacity:1;fill:none;stroke:#ffab0f;stroke-width:0.737;stroke-dashoffset:1.10173;stop-color:#000000;stop-opacity:1;stroke-dasharray:none"
+     style="display:inline;opacity:1;fill:none;stroke:#ffab0f;stroke-width:0.737;stroke-dasharray:none;stroke-dashoffset:1.10173;stop-color:#000000;stop-opacity:1"
      d="m 549.63135,2604.2967 c 0,1.1771 -2.969,2.1313 -6.6314,2.1313 -3.6624,0 -6.6313,-0.9542 -6.6313,-2.1313"
      id="path134760" />
 </g>
@@ -10690,7 +10698,7 @@
       <path
          id="path68149"
          style="fill:none;fill-opacity:1;stroke:url(#brightColor);stroke-width:1.20639;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:normal;stop-color:#000000"
-         d="m 30.078557,2946.0557 c -2.285949,0 -4.321855,1.4606 -5.083825,3.6366 l -3.92308,0 v 3.6413 l 3.925425,0 c 0.763282,2.1733 2.797625,3.6273 5.08148,3.6318 2.98382,0 5.402699,-2.4422 5.402735,-5.4548 1.9e-5,-3.0127 -2.418876,-5.4549 -5.402735,-5.4549 z"
+         d="m 30.078557,2946.0557 c -2.285949,0 -4.321855,1.4606 -5.083825,3.6366 h -3.92308 v 3.6413 h 3.925425 c 0.763282,2.1733 2.797625,3.6273 5.08148,3.6318 2.98382,0 5.402699,-2.4422 5.402735,-5.4548 1.9e-5,-3.0127 -2.418876,-5.4549 -5.402735,-5.4549 z"
          sodipodi:nodetypes="scccccss" />
       <path
          id="rect69912"
@@ -10707,5 +10715,21 @@
          d="m 89.506307,2937.5727 v 15.7585 h 8.404252 v -3.6365 h -4.802422 v -12.122 z"
          sodipodi:nodetypes="ccccccc" />
     </g>
+    <rect
+       transform="matrix(0.70966652,0.70453774,-0.70966652,0.70453774,0,0)"
+       y="1804.2097"
+       x="1911.843"
+       height="6.5758076"
+       width="11.273009"
+       id="rect2474"
+       style="display:inline;fill:none;fill-opacity:0.992157;stroke:#3c3c3c;stroke-width:2.00002631;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       transform="matrix(0.70966652,0.70453774,-0.70966652,0.70453774,0,0)"
+       y="1804.2096"
+       x="1911.843"
+       height="6.5758076"
+       width="11.273009"
+       id="rect4131"
+       style="display:inline;fill:none;fill-opacity:0.992157;stroke:#f1c816;stroke-width:1.00001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
   </g>
 </svg>

--- a/src/GafferRenderMan/RenderManLight.cpp
+++ b/src/GafferRenderMan/RenderManLight.cpp
@@ -1,0 +1,115 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferRenderMan/RenderManLight.h"
+
+#include "GafferRenderMan/RenderManShader.h"
+
+using namespace Imath;
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferRenderMan;
+
+IE_CORE_DEFINERUNTIMETYPED( RenderManLight );
+
+size_t RenderManLight::g_firstPlugIndex = 0;
+
+RenderManLight::RenderManLight( const std::string &name )
+	:	GafferScene::Light( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+
+	addChild( new RenderManShader( "__shader" ) );
+	addChild( new ShaderPlug( "__shaderIn", Plug::In, Plug::Default & ~Plug::Serialisable ) );
+
+	shaderNode()->parametersPlug()->setFlags( Plug::AcceptsInputs, true );
+	shaderNode()->parametersPlug()->setInput( parametersPlug() );
+
+	shaderInPlug()->setInput( shaderNode()->outPlug() );
+}
+
+RenderManLight::~RenderManLight()
+{
+}
+
+Shader *RenderManLight::shaderNode()
+{
+	return getChild<Shader>( g_firstPlugIndex );
+}
+
+const Shader *RenderManLight::shaderNode() const
+{
+	return getChild<Shader>( g_firstPlugIndex );
+}
+
+GafferScene::ShaderPlug *RenderManLight::shaderInPlug()
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
+const GafferScene::ShaderPlug *RenderManLight::shaderInPlug() const
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex + 1 );
+}
+
+void RenderManLight::loadShader( const std::string &shaderName )
+{
+	shaderNode()->loadShader( shaderName );
+}
+
+void RenderManLight::affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	Light::affects( input, outputs );
+
+	if(
+		input == shaderInPlug()
+	)
+	{
+		outputs.push_back( outPlug()->attributesPlug() );
+	}
+}
+
+void RenderManLight::hashLight( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	h.append( shaderInPlug()->attributesHash() );
+}
+
+IECoreScene::ConstShaderNetworkPtr RenderManLight::computeLight( const Gaffer::Context *context ) const
+{
+	IECore::ConstCompoundObjectPtr shaderAttributes = shaderInPlug()->attributes();
+	return shaderAttributes->member<const IECoreScene::ShaderNetwork>( "ri:light" );
+}

--- a/src/GafferRenderMan/RenderManMeshLight.cpp
+++ b/src/GafferRenderMan/RenderManMeshLight.cpp
@@ -1,0 +1,147 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferRenderMan/RenderManMeshLight.h"
+
+#include "GafferRenderMan/RenderManAttributes.h"
+#include "GafferRenderMan/RenderManShader.h"
+
+#include "GafferScene/Set.h"
+#include "GafferScene/ShaderAssignment.h"
+
+#include "Gaffer/StringPlug.h"
+#include "Gaffer/Switch.h"
+
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferRenderMan;
+
+GAFFER_NODE_DEFINE_TYPE( RenderManMeshLight );
+
+RenderManMeshLight::RenderManMeshLight( const std::string &name )
+	:	GafferScene::FilteredSceneProcessor( name, IECore::PathMatcher::NoMatch )
+{
+
+	// RenderManAttributes node. We use this to hide the objects to everything
+	// except camera rays, since that seems a reasonable default behaviour for
+	// a mesh light. The user can turn this back on with a RenderManAttributes
+	// node, in which case the surface shader is used for ray hits.
+
+	RenderManAttributesPtr attributes = new RenderManAttributes( "__attributes" );
+	attributes->inPlug()->setInput( inPlug() );
+	attributes->filterPlug()->setInput( filterPlug() );
+	for( const auto &attributeName : { "ri:visibility:indirect", "ri:visibility:transmission" } )
+	{
+		auto plug = attributes->attributesPlug()->getChild<NameValuePlug>( attributeName );
+		plug->enabledPlug()->setValue( true );
+		plug->valuePlug<IntPlug>()->setValue( 0 );
+	}
+
+	addChild( attributes );
+
+	// Promote the camera visibility plug, since that is more likely to be used
+	// than the others.
+
+	Plug *internalCameraVisibilityPlug = attributes->attributesPlug()->getChild<Plug>( "ri:visibility:camera" );
+	PlugPtr cameraVisibilityPlug = internalCameraVisibilityPlug->createCounterpart( "cameraVisibility", Plug::In );
+	addChild( cameraVisibilityPlug );
+	internalCameraVisibilityPlug->setInput( cameraVisibilityPlug );
+
+	// Shader node. This loads the PxrMeshLight shader.
+
+	RenderManShaderPtr shader = new RenderManShader( "__shader" );
+	shader->loadShader( "PxrMeshLight" );
+	addChild( shader );
+
+	PlugPtr parametersPlug = shader->parametersPlug()->createCounterpart( "parameters", Plug::In );
+	addChild( parametersPlug );
+	for( Plug::Iterator srcIt( parametersPlug.get() ), dstIt( shader->parametersPlug() ); !srcIt.done(); ++srcIt, ++dstIt )
+	{
+		(*dstIt)->setInput( *srcIt );
+	}
+
+	// ShaderAssignment node. This assigns the PxrMeshLight shader
+	// to the objects chosen by the filter.
+
+	ShaderAssignmentPtr shaderAssignment = new ShaderAssignment( "__shaderAssignment" );
+	shaderAssignment->inPlug()->setInput( attributes->outPlug() );
+	shaderAssignment->filterPlug()->setInput( filterPlug() );
+	shaderAssignment->shaderPlug()->setInput( shader->outPlug() );
+	addChild( shaderAssignment );
+
+	// Set node. This adds the objects into the __lights set,
+	// so they will be output correctly to the renderer.
+
+	SetPtr set = new Set( "__set" );
+	set->inPlug()->setInput( shaderAssignment->outPlug() );
+	set->filterPlug()->setInput( filterPlug() );
+	set->namePlug()->setValue( "__lights" );
+	set->modePlug()->setValue( Set::Add );
+	addChild( set );
+
+	// Default lights Set node.
+
+	BoolPlugPtr defaultLightPlug = new BoolPlug( "defaultLight", Plug::In, true );
+	addChild( defaultLightPlug );
+
+	SetPtr defaultLightsSet = new Set( "__defaultLightsSet" );
+	defaultLightsSet->inPlug()->setInput( set->outPlug() );
+	defaultLightsSet->filterPlug()->setInput( filterPlug() );
+	defaultLightsSet->enabledPlug()->setInput( defaultLightPlug.get() );
+	defaultLightsSet->namePlug()->setValue( "defaultLights" );
+	defaultLightsSet->modePlug()->setValue( Set::Add );
+	addChild( defaultLightsSet );
+
+	// Switch for enabling/disabling
+
+	SwitchPtr enabledSwitch = new Switch( "__switch" );
+	enabledSwitch->setup( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 0 )->setInput( inPlug() );
+	enabledSwitch->inPlugs()->getChild<ScenePlug>( 1 )->setInput( defaultLightsSet->outPlug() );
+	enabledSwitch->indexPlug()->setValue( 1 );
+	enabledSwitch->enabledPlug()->setInput( enabledPlug() );
+	addChild( enabledSwitch );
+
+	outPlug()->setInput( enabledSwitch->outPlug() );
+	// We don't need to serialise the connection because we make
+	// it upon construction.
+	/// \todo Can we just do this in the SceneProcessor base class?
+	outPlug()->setFlags( Plug::Serialisable, false );
+}
+
+RenderManMeshLight::~RenderManMeshLight()
+{
+}

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -37,6 +37,7 @@
 #include "boost/python.hpp"
 
 #include "GafferRenderMan/RenderManAttributes.h"
+#include "GafferRenderMan/RenderManLight.h"
 #include "GafferRenderMan/RenderManOptions.h"
 #include "GafferRenderMan/RenderManShader.h"
 
@@ -45,9 +46,22 @@
 using namespace boost::python;
 using namespace GafferRenderMan;
 
-BOOST_PYTHON_MODULE( _GafferRenderMan )
+namespace
 {
 
+void loadShader( RenderManLight &l, const std::string &shaderName )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	l.loadShader( shaderName );
+}
+
+} // namespace
+
+BOOST_PYTHON_MODULE( _GafferRenderMan )
+{
+	GafferBindings::DependencyNodeClass<RenderManLight>()
+		.def( "loadShader", &loadShader )
+	;
 	GafferBindings::DependencyNodeClass<RenderManAttributes>();
 	GafferBindings::DependencyNodeClass<RenderManOptions>();
 	GafferBindings::DependencyNodeClass<RenderManShader>();

--- a/startup/GafferScene/renderManLights.py
+++ b/startup/GafferScene/renderManLights.py
@@ -1,0 +1,66 @@
+##########################################################################
+#
+#  Copyright (c) 2019, John Haddon. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+
+import imath
+
+import Gaffer
+
+for type in [
+	"PxrCyclinderLight", "PxrDomeLight", "PxrDiskLight", "PxrDistantLight",
+	"PxrEnvDayLight", "PxrMeshLight",  "PxrRectLight", "PxrSphereLight",
+] :
+
+	Gaffer.Metadata.registerValue( "ri:light:" + type, "intensityParameter", "intensity" )
+	Gaffer.Metadata.registerValue( "ri:light:" + type, "exposureParameter", "exposure" )
+	Gaffer.Metadata.registerValue( "ri:light:" + type, "colorParameter", "lightColor" )
+
+Gaffer.Metadata.registerValue( "ri:light:PxrCylinderLight", "type", "cylinder" )
+Gaffer.Metadata.registerValue( "ri:light:PxrDomeLight", "type", "environment" )
+Gaffer.Metadata.registerValue( "ri:light:PxrDiskLight", "type", "disk" )
+Gaffer.Metadata.registerValue( "ri:light:PxrEnvDayLight", "type", "environment" )
+Gaffer.Metadata.registerValue( "ri:light:PxrDistantLight", "type", "distant" )
+Gaffer.Metadata.registerValue( "ri:light:PxrMeshLight", "type", "mesh" )
+Gaffer.Metadata.registerValue( "ri:light:PxrPortalLight", "type", "portal" )
+Gaffer.Metadata.registerValue( "ri:light:PxrRectLight", "type", "quad" )
+Gaffer.Metadata.registerValue( "ri:light:PxrSphereLight", "type", "point" )
+
+Gaffer.Metadata.registerValue( "ri:light:PxrDomeLight", "textureNameParameter", "lightColorMap" )
+
+Gaffer.Metadata.registerValue( "ri:light:PxrCylinderLight", "visualiserOrientation", imath.M44f().rotate( imath.V3f( 0, 0.5 * math.pi, 0 ) ).scale( 0.5 ) )
+Gaffer.Metadata.registerValue( "ri:light:PxrDiskLight", "visualiserOrientation", imath.M44f().scale( 0.5 ) )
+Gaffer.Metadata.registerValue( "ri:light:PxrRectLight", "visualiserOrientation", imath.M44f().scale( 0.5 ) )


### PR DESCRIPTION
This adds RenderManLight and RenderManMeshLight nodes, allowing the creation of RenderMan lights in Gaffer. Support for viewport visualisers is pretty minimal at this point, and not accurate in all cases (disk light radius being one problematic one). But in the process of bootstrapping everything enough to a level where useful renders can be done, I think this is a good place to checkpoint progress. I'm also hoping I can hand over visualisation duties to someone else :)