### PR TITLE
RenderMan nodes

### DIFF
--- a/include/GafferRenderMan/BXDFPlug.h
+++ b/include/GafferRenderMan/BXDFPlug.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,23 +36,31 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "Gaffer/Plug.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+/// Plug used to represent BXDF outputs and inputs for RenderManShader.
+class GAFFERRENDERMAN_API BXDFPlug : public Gaffer::Plug
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-	BXDFPlugTypeId = 110409,
 
-	LastTypeId = 110450
+	public :
+
+		explicit BXDFPlug( const std::string &name=defaultName<BXDFPlug>(), Direction direction=In, unsigned flags=Default );
+		~BXDFPlug() override;
+
+		GAFFER_PLUG_DECLARE_TYPE( GafferRenderMan::BXDFPlug, BXDFPlugTypeId, Plug );
+
+		bool acceptsChild( const Gaffer::GraphComponent *potentialChild ) const override;
+		Gaffer::PlugPtr createCounterpart( const std::string &name, Direction direction ) const override;
+		bool acceptsInput( const Gaffer::Plug *input ) const override;
+
 };
+
+IE_CORE_DECLAREPTR( BXDFPlug );
 
 } // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManDisplayFilter.h
+++ b/include/GafferRenderMan/RenderManDisplayFilter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,22 +36,23 @@
 
 #pragma once
 
+#include "GafferRenderMan/RenderManOutputFilter.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManDisplayFilter : public RenderManOutputFilter
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
 
-	LastTypeId = 110450
+	public :
+
+		explicit RenderManDisplayFilter( const std::string &name=defaultName<RenderManDisplayFilter>() );
+		~RenderManDisplayFilter() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManDisplayFilter, RenderManDisplayFilterTypeId, RenderManOutputFilter );
+
 };
+
+IE_CORE_DECLAREPTR( RenderManDisplayFilter )
 
 } // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManIntegrator.h
+++ b/include/GafferRenderMan/RenderManIntegrator.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2019, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,18 +36,38 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "GafferScene/GlobalShader.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManIntegrator : public GafferScene::GlobalShader
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	LastTypeId = 110450
+
+	public :
+
+		RenderManIntegrator( const std::string &name=defaultName<RenderManIntegrator>() );
+		~RenderManIntegrator() override;
+
+		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferRenderMan::RenderManIntegrator, RenderManIntegratorTypeId, GafferScene::GlobalShader );
+
+	protected :
+
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+
+		bool affectsOptionName( const Gaffer::Plug *input ) const override;
+		void hashOptionName( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		std::string computeOptionName( const Gaffer::Context *context ) const override;
+
+	private :
+
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( RenderManIntegrator )
 
 } // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManOutputFilter.h
+++ b/include/GafferRenderMan/RenderManOutputFilter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,22 +36,63 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "GafferScene/GlobalsProcessor.h"
+#include "GafferScene/ShaderPlug.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+/// Base class which contains all the shared implementation for RenderManDisplayFilter
+/// and RenderManSampleFilter.
+class GAFFERRENDERMAN_API RenderManOutputFilter : public GafferScene::GlobalsProcessor
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
 
-	LastTypeId = 110450
+	public :
+
+		~RenderManOutputFilter() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManOutputFilter, RenderManOutputFilterTypeId, GafferScene::GlobalsProcessor );
+
+		enum class Mode
+		{
+			Replace,
+			InsertFirst,
+			InsertLast
+		};
+
+		GafferScene::ShaderPlug *shaderPlug();
+		const GafferScene::ShaderPlug *shaderPlug() const;
+
+		Gaffer::IntPlug *modePlug();
+		const Gaffer::IntPlug *modePlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		enum class FilterType
+		{
+			Display,
+			Sample
+		};
+
+		RenderManOutputFilter( const std::string &name, FilterType filterType );
+
+		bool acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const override;
+
+		void hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		IECore::ConstCompoundObjectPtr computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const override;
+
+	private :
+
+		const FilterType m_filterType;
+		static size_t g_firstPlugIndex;
+
 };
+
+IE_CORE_DECLAREPTR( RenderManOutputFilter )
 
 } // namespace GafferRenderMan

--- a/include/GafferRenderMan/RenderManSampleFilter.h
+++ b/include/GafferRenderMan/RenderManSampleFilter.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2024, Alex Fuller. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,22 +37,23 @@
 
 #pragma once
 
+#include "GafferRenderMan/RenderManOutputFilter.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManSampleFilter : public RenderManOutputFilter
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
 
-	LastTypeId = 110450
+	public :
+
+		explicit RenderManSampleFilter( const std::string &name=defaultName<RenderManSampleFilter>() );
+		~RenderManSampleFilter() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManSampleFilter, RenderManSampleFilterTypeId, RenderManOutputFilter );
+
 };
+
+IE_CORE_DECLAREPTR( RenderManSampleFilter )
 
 } // namespace GafferRenderMan

--- a/python/GafferRenderManTest/RenderManDisplayFilterTest.py
+++ b/python/GafferRenderManTest/RenderManDisplayFilterTest.py
@@ -1,0 +1,153 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Alex Fuller. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManDisplayFilterTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		displayFilter = GafferRenderMan.RenderManShader()
+		displayFilter.loadShader( "PxrGradeDisplayFilter" )
+
+		self.assertEqual( displayFilter["name"].getValue(), "PxrGradeDisplayFilter" )
+		self.assertEqual( displayFilter["type"].getValue(), "ri:displayfilter" )
+
+		displayFilter["parameters"]["multiply"].setValue( imath.Color3f( 1 ) )
+
+		node = GafferRenderMan.RenderManDisplayFilter()
+		node["displayFilter"].setInput( displayFilter["out"] )
+
+		for mode in node.Mode.values.values() :
+
+			# Since there is no upstream display filter, all modes
+			# should have the same effect.
+			node["mode"].setValue( mode )
+
+			self.assertEqual(
+				node["out"].globals()["option:ri:displayfilter"],
+				displayFilter.attributes()["ri:displayfilter"]
+			)
+
+	def testRejectsNonDisplayFilterInputs( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrConstant" )
+
+		node = GafferRenderMan.RenderManDisplayFilter()
+		self.assertFalse( node["displayFilter"].acceptsInput( shader["out"] ) )
+
+	def testModes( self ) :
+
+		def shaderName( scene ) :
+
+			network = scene.globals()["option:ri:displayfilter"]
+			return network.outputShader().name
+
+		def order( scene ) :
+
+			network = scene.globals()["option:ri:displayfilter"]
+			shader = network.outputShader()
+
+			if shader.name == "PxrDisplayFilterCombiner" :
+
+				result = []
+				for i in range( 0, 3 ) :
+					shaderHandle = network.input( ( network.getOutput().shader, f"filter[{i}]" ) ).shader
+					if shaderHandle :
+						result.append( network.getShader( shaderHandle ).parameters["multiply"].value.r )
+
+				return result
+
+			else:
+
+				return [ shader.parameters["multiply"].value.r ]
+
+		displayFilter1 = GafferRenderMan.RenderManShader()
+		displayFilter1.loadShader( "PxrGradeDisplayFilter" )
+		displayFilter1["parameters"]["multiply"].setValue( imath.Color3f( 1 ) )
+
+		displayFilter2 = GafferRenderMan.RenderManShader()
+		displayFilter2.loadShader( "PxrGradeDisplayFilter" )
+		displayFilter2["parameters"]["multiply"].setValue( imath.Color3f( 2 ) )
+
+		displayFilter3 = GafferRenderMan.RenderManShader()
+		displayFilter3.loadShader( "PxrGradeDisplayFilter" )
+		displayFilter3["parameters"]["multiply"].setValue( imath.Color3f( 3 ) )
+
+		node1 = GafferRenderMan.RenderManDisplayFilter()
+		node1["displayFilter"].setInput( displayFilter1["out"] )
+		# When there is only one filter, the output shader should be the filter itself
+		self.assertEqual( shaderName( node1["out"] ), "PxrGradeDisplayFilter" )
+		self.assertEqual( order( node1["out"] ), [ 1 ] )
+
+		node2 = GafferRenderMan.RenderManDisplayFilter()
+		node2["in"].setInput( node1["out"] )
+		node2["displayFilter"].setInput( displayFilter2["out"] )
+		self.assertEqual( shaderName( node2["out"] ), "PxrGradeDisplayFilter" )
+		self.assertEqual( order( node2["out"] ), [ 2 ] )
+
+		node2["mode"].setValue( GafferRenderMan.RenderManDisplayFilter.Mode.InsertLast )
+		# But 2 or more will place a combine filter as the output
+		self.assertEqual( shaderName( node2["out"] ), "PxrDisplayFilterCombiner" )
+		self.assertEqual( order( node2["out"] ), [ 1, 2 ] )
+
+		node2["mode"].setValue( GafferRenderMan.RenderManDisplayFilter.Mode.InsertFirst )
+		self.assertEqual( shaderName( node2["out"] ), "PxrDisplayFilterCombiner" )
+		self.assertEqual( order( node2["out"] ), [ 2, 1 ] )
+
+		node3 = GafferRenderMan.RenderManDisplayFilter()
+		node3["in"].setInput( node2["out"] )
+		node3["displayFilter"].setInput( displayFilter3["out"] )
+		self.assertEqual( shaderName( node3["out"] ), "PxrGradeDisplayFilter" )
+		self.assertEqual( order( node3["out"] ), [ 3 ] )
+
+		node3["mode"].setValue( GafferRenderMan.RenderManDisplayFilter.Mode.InsertLast )
+		self.assertEqual( shaderName( node3["out"] ), "PxrDisplayFilterCombiner" )
+		self.assertEqual( order( node3["out"] ), [ 2, 1, 3 ] )
+
+		node3["mode"].setValue( GafferRenderMan.RenderManDisplayFilter.Mode.InsertFirst )
+		self.assertEqual( shaderName( node3["out"] ), "PxrDisplayFilterCombiner" )
+		self.assertEqual( order( node3["out"] ), [ 3, 2, 1 ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/RenderManSampleFilterTest.py
+++ b/python/GafferRenderManTest/RenderManSampleFilterTest.py
@@ -1,0 +1,153 @@
+##########################################################################
+#
+#  Copyright (c) 2024, Alex Fuller. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import imath
+
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManSampleFilterTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		sampleFilter = GafferRenderMan.RenderManShader()
+		sampleFilter.loadShader( "PxrGradeSampleFilter" )
+
+		self.assertEqual( sampleFilter["name"].getValue(), "PxrGradeSampleFilter" )
+		self.assertEqual( sampleFilter["type"].getValue(), "ri:samplefilter" )
+
+		sampleFilter["parameters"]["multiply"].setValue( imath.Color3f(0.5 ) )
+
+		node = GafferRenderMan.RenderManSampleFilter()
+		node["sampleFilter"].setInput( sampleFilter["out"] )
+
+		for mode in node.Mode.values.values() :
+
+			# Since there is no upstream sample filter, all modes
+			# should have the same effect.
+			node["mode"].setValue( mode )
+
+			self.assertEqual(
+				node["out"].globals()["option:ri:samplefilter"],
+				sampleFilter.attributes()["ri:samplefilter"]
+			)
+
+	def testRejectsNonSampleFilterInputs( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrConstant" )
+
+		node = GafferRenderMan.RenderManSampleFilter()
+		self.assertFalse( node["sampleFilter"].acceptsInput( shader["out"] ) )
+
+	def testModes( self ) :
+
+		def shaderName( scene ) :
+
+			network = scene.globals()["option:ri:samplefilter"]
+			return network.outputShader().name
+
+		def order( scene ) :
+
+			network = scene.globals()["option:ri:samplefilter"]
+			shader = network.outputShader()
+
+			if shader.name == "PxrSampleFilterCombiner" :
+
+				result = []
+				for i in range( 0, 3 ) :
+					shaderHandle = network.input( ( network.getOutput().shader, f"filter[{i}]" ) ).shader
+					if shaderHandle :
+						result.append( network.getShader( shaderHandle ).parameters["multiply"].value.r )
+
+				return result
+
+			else:
+
+				return [ shader.parameters["multiply"].value.r ]
+
+		sampleFilter1 = GafferRenderMan.RenderManShader()
+		sampleFilter1.loadShader( "PxrGradeSampleFilter" )
+		sampleFilter1["parameters"]["multiply"].setValue( imath.Color3f( 1 ) )
+
+		sampleFilter2 = GafferRenderMan.RenderManShader()
+		sampleFilter2.loadShader( "PxrGradeSampleFilter" )
+		sampleFilter2["parameters"]["multiply"].setValue( imath.Color3f( 2 ) )
+
+		sampleFilter3 = GafferRenderMan.RenderManShader()
+		sampleFilter3.loadShader( "PxrGradeSampleFilter" )
+		sampleFilter3["parameters"]["multiply"].setValue( imath.Color3f( 3 ) )
+
+		node1 = GafferRenderMan.RenderManSampleFilter()
+		node1["sampleFilter"].setInput( sampleFilter1["out"] )
+		# When there is only one filter, the output shader should be the filter itself
+		self.assertEqual( shaderName( node1["out"] ), "PxrGradeSampleFilter" )
+		self.assertEqual( order( node1["out"] ), [ 1 ] )
+
+		node2 = GafferRenderMan.RenderManSampleFilter()
+		node2["in"].setInput( node1["out"] )
+		node2["sampleFilter"].setInput( sampleFilter2["out"] )
+		self.assertEqual( shaderName( node2["out"] ), "PxrGradeSampleFilter" )
+		self.assertEqual( order( node2["out"] ), [ 2 ] )
+
+		node2["mode"].setValue( GafferRenderMan.RenderManSampleFilter.Mode.InsertLast )
+		# But 2 or more will place a combine filter as the output
+		self.assertEqual( shaderName( node2["out"] ), "PxrSampleFilterCombiner" )
+		self.assertEqual( order( node2["out"] ), [ 1, 2 ] )
+
+		node2["mode"].setValue( GafferRenderMan.RenderManSampleFilter.Mode.InsertFirst )
+		self.assertEqual( shaderName( node2["out"] ), "PxrSampleFilterCombiner" )
+		self.assertEqual( order( node2["out"] ), [ 2, 1 ] )
+
+		node3 = GafferRenderMan.RenderManSampleFilter()
+		node3["in"].setInput( node2["out"] )
+		node3["sampleFilter"].setInput( sampleFilter3["out"] )
+		self.assertEqual( shaderName( node3["out"] ), "PxrGradeSampleFilter" )
+		self.assertEqual( order( node3["out"] ), [ 3 ] )
+
+		node3["mode"].setValue( GafferRenderMan.RenderManSampleFilter.Mode.InsertLast )
+		self.assertEqual( shaderName( node3["out"] ), "PxrSampleFilterCombiner" )
+		self.assertEqual( order( node3["out"] ), [ 2, 1, 3 ] )
+
+		node3["mode"].setValue( GafferRenderMan.RenderManSampleFilter.Mode.InsertFirst )
+		self.assertEqual( shaderName( node3["out"] ), "PxrSampleFilterCombiner" )
+		self.assertEqual( order( node3["out"] ), [ 3, 2, 1 ] )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -176,5 +176,20 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertIsInstance( shader["parameters"]["utilityPattern"], Gaffer.ArrayPlug )
 		self.assertIsInstance( shader["parameters"]["utilityPattern"].elementPrototype(), Gaffer.IntPlug )
 
+	def testBXDFParameters( self ) :
+
+		dielectric = GafferRenderMan.RenderManShader()
+		dielectric.loadShader( "LamaDielectric" )
+		self.assertEqual( dielectric["out"].keys(), [ "bxdf_out" ] )
+		self.assertIsInstance( dielectric["out"]["bxdf_out"], GafferRenderMan.BXDFPlug )
+
+		surface = GafferRenderMan.RenderManShader()
+		surface.loadShader( "LamaSurface" )
+		for parameter in ( "materialFront", "materialBack" ) :
+			self.assertIn( parameter, surface["parameters"] )
+			self.assertIsInstance( surface["parameters"][parameter], GafferRenderMan.BXDFPlug )
+
+		surface["parameters"]["materialFront"].setInput( dielectric["out"]["bxdf_out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -40,6 +40,7 @@ from .RenderManOptionsTest import RenderManOptionsTest
 from .RenderManShaderTest import RenderManShaderTest
 from .RenderManLightTest import RenderManLightTest
 from .RenderManMeshLightTest import RenderManMeshLightTest
+from .RenderManIntegratorTest import RenderManIntegratorTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -41,6 +41,8 @@ from .RenderManShaderTest import RenderManShaderTest
 from .RenderManLightTest import RenderManLightTest
 from .RenderManMeshLightTest import RenderManMeshLightTest
 from .RenderManIntegratorTest import RenderManIntegratorTest
+from .RenderManDisplayFilterTest import RenderManDisplayFilterTest
+from .RenderManSampleFilterTest import RenderManSampleFilterTest
 
 if __name__ == "__main__":
 	import unittest

--- a/python/GafferRenderManUI/RenderManDisplayFilterUI.py
+++ b/python/GafferRenderManUI/RenderManDisplayFilterUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2024, Alex Fuller. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,15 +34,34 @@
 #
 ##########################################################################
 
-__import__( "GafferSceneUI" )
+import Gaffer
+import GafferRenderMan
 
-from . import RenderManAttributesUI
-from . import RenderManOptionsUI
-from . import RenderManShaderUI
-from . import RenderManMeshLightUI
-from . import RenderManIntegratorUI
-from . import RenderManOutputFilterUI
-from . import RenderManDisplayFilterUI
-from . import RenderManSampleFilterUI
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )
+	GafferRenderMan.RenderManDisplayFilter,
+
+	"description",
+	"""
+	Assigns a display filter. This is stored as an `ri:displayfilter` option in
+	Gaffer's globals, and applied to all render outputs.
+	""",
+
+	plugs = {
+
+		"displayFilter" : [
+
+			"description",
+			"""
+			The display filter to be assigned. This should be connected to the
+			output of a RenderManShader node containing a display filter.
+			""",
+
+			"noduleLayout:section", "left",
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+	}
+
+)

--- a/python/GafferRenderManUI/RenderManIntegratorUI.py
+++ b/python/GafferRenderManUI/RenderManIntegratorUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,12 +34,32 @@
 #
 ##########################################################################
 
-__import__( "GafferSceneUI" )
+import Gaffer
+import GafferRenderMan
 
-from . import RenderManAttributesUI
-from . import RenderManOptionsUI
-from . import RenderManShaderUI
-from . import RenderManMeshLightUI
-from . import RenderManIntegratorUI
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )
+	GafferRenderMan.RenderManIntegrator,
+
+	"description",
+	"""
+	Specifies the RenderMan integrator to be used. This is stored in
+	an `ri:integrator` option in the scene globals. If not specified,
+	a default PxrPathTracer integrator is used.
+	""",
+
+	plugs = {
+
+		"shader" : [
+
+			"description",
+			"""
+			The integrator to be assigned. A RenderManShader node holding an integrator
+			such as PxrPathTracer or PxrUnified should be connected here.
+			"""
+
+		],
+
+	}
+
+)

--- a/python/GafferRenderManUI/RenderManOutputFilterUI.py
+++ b/python/GafferRenderManUI/RenderManOutputFilterUI.py
@@ -1,6 +1,7 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2024, Alex Fuller. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,15 +35,37 @@
 #
 ##########################################################################
 
-__import__( "GafferSceneUI" )
+import Gaffer
+import GafferRenderMan
 
-from . import RenderManAttributesUI
-from . import RenderManOptionsUI
-from . import RenderManShaderUI
-from . import RenderManMeshLightUI
-from . import RenderManIntegratorUI
-from . import RenderManOutputFilterUI
-from . import RenderManDisplayFilterUI
-from . import RenderManSampleFilterUI
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )
+	GafferRenderMan.RenderManOutputFilter,
+
+	plugs = {
+
+		"mode" : [
+
+			"description",
+			"""
+			The mode used to combine the filter input with any
+			filters that already exist in the scene globals.
+
+			- Replace : Removes all pre-existing filter, and replaces them with
+			  the new one.
+			- InsertFirst : Inserts the new filter so that it will be run before
+			  any pre-existing filters.
+			- InsertLast : Inserts the new filter so that it will be run after
+			  any pre-existing filters.
+			""",
+
+			"preset:Replace", GafferRenderMan.RenderManOutputFilter.Mode.Replace,
+			"preset:InsertFirst", GafferRenderMan.RenderManOutputFilter.Mode.InsertFirst,
+			"preset:InsertLast", GafferRenderMan.RenderManOutputFilter.Mode.InsertLast,
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+
+		],
+
+	}
+
+)

--- a/python/GafferRenderManUI/RenderManSampleFilterUI.py
+++ b/python/GafferRenderManUI/RenderManSampleFilterUI.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2024, Alex Fuller. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,15 +34,34 @@
 #
 ##########################################################################
 
-__import__( "GafferSceneUI" )
+import Gaffer
+import GafferRenderMan
 
-from . import RenderManAttributesUI
-from . import RenderManOptionsUI
-from . import RenderManShaderUI
-from . import RenderManMeshLightUI
-from . import RenderManIntegratorUI
-from . import RenderManOutputFilterUI
-from . import RenderManDisplayFilterUI
-from . import RenderManSampleFilterUI
+Gaffer.Metadata.registerNode(
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderManUI" )
+	GafferRenderMan.RenderManSampleFilter,
+
+	"description",
+	"""
+	Assigns a sample filter. This is stored as an `ri:samplefilter` option in
+	Gaffer's globals, and applied to all render outputs.
+	""",
+
+	plugs = {
+
+		"sampleFilter" : [
+
+			"description",
+			"""
+			The sample filter to be assigned. This should be connected to the
+			output of a RenderManShader node containing a sample filter.
+			""",
+
+			"noduleLayout:section", "left",
+			"nodule:type", "GafferUI::StandardNodule",
+
+		],
+
+	}
+
+)

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -145,11 +145,15 @@ def __shadersSubMenu( plugins ) :
 
 	for name, plugin in plugins.items() :
 
-		if name in [ "PxrSeExpr" ] :
+		if name in {
 			# Deprecated in RenderMan 24 - don't let folks become dependent on it.
+			"PxrSeExpr",
+			# Not needed because we combine filters automatically.
+			"PxrDisplayFilterCombiner", "PxrSampleFilterCombiner",
+		} :
 			continue
 
-		if plugin["type"] not in { "bxdf", "pattern", "integrator" } :
+		if plugin["type"] not in { "bxdf", "pattern", "integrator", "displayfilter", "samplefilter" } :
 			continue
 
 		result.append(

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -141,7 +141,7 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 
 				for m in mh.messages :
 					## \todo Add support for these types.
-					self.assertRegex( m.message, 'Spline parameter .* not supported|.* has unsupported type "bxdf|.* has unsupported type "struct"' )
+					self.assertRegex( m.message, 'Spline parameter .* not supported|.* has unsupported type "struct"' )
 
 				# Trigger metadata parsing and ensure there are no errors
 				Gaffer.Metadata.value( node, "description" )

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -1466,6 +1466,186 @@ class RendererTest( GafferTest.TestCase ) :
 		# Set to default explicitly.
 		self.__assertParameterEqual( options, "lpe:diffuse3", [ "Subsurface,subsurface" ] )
 
+	def testDisplayFilter( self ):
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testDisplayFilter",
+				}
+			)
+		)
+
+		# First test without any display filters.
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testDisplayFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0 ) )
+
+		# Then apply a single display filter.
+
+		renderer.option(
+			"ri:displayfilter",
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"output" : IECoreScene.Shader(
+						"PxrBackgroundDisplayFilter", "ri:displayfilter",
+						{
+							"backgroundColor" : imath.Color3f( 1, 0, 0 ),
+						}
+					),
+				},
+				output = "output"
+			)
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testDisplayFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 1, 0, 0, 0 ) )
+
+		# And finally a combined one, the grade filter should apply after the background.
+
+		renderer.option(
+			"ri:displayfilter",
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"combiner" : IECoreScene.Shader(
+						"PxrDisplayFilterCombiner", "ri:displayfilter",
+					),
+					"background" : IECoreScene.Shader(
+						"PxrBackgroundDisplayFilter", "ri:displayfilter",
+						{
+							"backgroundColor" : imath.Color3f( 1, 0, 0 ),
+						}
+					),
+					"grade" : IECoreScene.Shader(
+						"PxrGradeDisplayFilter", "ri:displayfilter",
+						{
+							"multiply" : imath.Color3f( 0.5 ),
+						}
+					),
+				},
+				connections = [
+						( ( "background", "out" ), ( "combiner", "filter[0]" ) ),
+						( ( "grade", "out" ), ( "combiner", "filter[1]" ) ),
+				],
+				output = "combiner"
+			)
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testDisplayFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0.5, 0, 0, 0 ) )
+
+		del renderer
+
+	def testSampleFilter( self ):
+
+		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"RenderMan",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Interactive
+		)
+
+		renderer.output(
+			"test",
+			IECoreScene.Output(
+				"test",
+				"ieDisplay",
+				"rgba",
+				{
+					"driverType" : "ImageDisplayDriver",
+					"handle" : "testSampleFilter",
+				}
+			)
+		)
+
+		# First test without any sample filters.
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testSampleFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0 ) )
+
+		# Then apply a single sample filter.
+
+		renderer.option(
+			"ri:samplefilter",
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"output" : IECoreScene.Shader(
+						"PxrBackgroundSampleFilter", "ri:samplefilter",
+						{
+							"backgroundColor" : imath.Color3f( 1, 0, 0 ),
+						}
+					),
+				},
+				output = "output"
+			)
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		renderer.pause()
+
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testSampleFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 1, 0, 0, 0 ) )
+
+		# And finally a combined one, the grade filter should apply after the background.
+
+		renderer.option(
+			"ri:samplefilter",
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"combiner" : IECoreScene.Shader(
+						"PxrSampleFilterCombiner", "ri:samplefilter"
+					),
+					"background" : IECoreScene.Shader(
+						"PxrBackgroundSampleFilter", "ri:samplefilter",
+						{
+							"backgroundColor" : imath.Color3f( 1, 0, 0 ),
+						}
+					),
+					"grade" : IECoreScene.Shader(
+						"PxrGradeSampleFilter", "ri:samplefilter",
+						{
+							"multiply" : imath.Color3f( 0.5 ),
+						}
+					),
+				},
+				connections = [
+						( ( "background", "out" ), ( "combiner", "filter[0]" ) ),
+						( ( "grade", "out" ), ( "combiner", "filter[1]" ) ),
+				],
+				output = "combiner"
+			)
+		)
+
+		renderer.render()
+		time.sleep( 1 )
+		image = IECoreImage.ImageDisplayDriver.storedImage( "testSampleFilter" )
+		self.assertEqual( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0.5, 0, 0, 0 ) )
+
+		del renderer
+
 	def __assertParameterEqual( self, paramList, name, data ) :
 
 		p = next( x for x in paramList if x["info"]["name"] == name )

--- a/src/GafferRenderMan/BXDFPlug.cpp
+++ b/src/GafferRenderMan/BXDFPlug.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,25 +34,39 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "GafferRenderMan/BXDFPlug.h"
 
-namespace GafferRenderMan
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferRenderMan;
+
+GAFFER_PLUG_DEFINE_TYPE( BXDFPlug );
+
+BXDFPlug::BXDFPlug( const std::string &name, Direction direction, unsigned flags )
+	:	Plug( name, direction, flags )
 {
+}
 
-enum TypeId
+BXDFPlug::~BXDFPlug()
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-	BXDFPlugTypeId = 110409,
+}
 
-	LastTypeId = 110450
-};
+bool BXDFPlug::acceptsChild( const GraphComponent *potentialChild ) const
+{
+	return false;
+}
 
-} // namespace GafferRenderMan
+Gaffer::PlugPtr BXDFPlug::createCounterpart( const std::string &name, Direction direction ) const
+{
+	return new BXDFPlug( name, direction, getFlags() );
+}
+
+bool BXDFPlug::acceptsInput( const Gaffer::Plug *input ) const
+{
+	if( !Plug::acceptsInput( input ) )
+	{
+		return false;
+	}
+
+	return !input || runTimeCast<const BXDFPlug>( input );
+}

--- a/src/GafferRenderMan/RenderManDisplayFilter.cpp
+++ b/src/GafferRenderMan/RenderManDisplayFilter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,24 +34,17 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "GafferRenderMan/RenderManDisplayFilter.h"
 
-namespace GafferRenderMan
+using namespace GafferRenderMan;
+
+GAFFER_NODE_DEFINE_TYPE( RenderManDisplayFilter );
+
+RenderManDisplayFilter::RenderManDisplayFilter( const std::string &name )
+	:	RenderManOutputFilter( name, FilterType::Display )
 {
+}
 
-enum TypeId
+RenderManDisplayFilter::~RenderManDisplayFilter()
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-
-	LastTypeId = 110450
-};
-
-} // namespace GafferRenderMan
+}

--- a/src/GafferRenderMan/RenderManOutputFilter.cpp
+++ b/src/GafferRenderMan/RenderManOutputFilter.cpp
@@ -1,0 +1,261 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Alex Fuller. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferRenderMan/RenderManOutputFilter.h"
+
+#include "GafferScene/Shader.h"
+#include "GafferScene/ShaderPlug.h"
+
+#include "Gaffer/StringPlug.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+#include "IECoreScene/ShaderNetworkAlgo.h"
+
+#include <regex>
+
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferRenderMan;
+
+namespace
+{
+
+const std::array<std::string, 2> g_shaderPlugNames = { "displayFilter", "sampleFilter" };
+const std::array<InternedString, 2> g_options = { "option:ri:displayfilter", "option:ri:samplefilter" };
+const std::array<InternedString, 2> g_shaderTypes = { "ri:displayfilter", "ri:samplefilter" };
+const std::array<std::string, 2> g_combinerShaders = { "PxrDisplayFilterCombiner", "PxrSampleFilterCombiner" };
+
+const InternedString g_out( "out" );
+const InternedString g_filter0( "filter[0]" );
+
+const std::regex g_filterIndexRegex( R"(filter\[([0-9]+)\])" );
+int connectionIndex( const ShaderNetwork::Connection &connection )
+{
+	std::smatch filterIndexMatch;
+	if( std::regex_match( connection.destination.name.string(), filterIndexMatch, g_filterIndexRegex ) )
+	{
+		return std::stoi( filterIndexMatch.str( 1 ) );
+	}
+	return -1;
+}
+
+} // namespace
+
+GAFFER_NODE_DEFINE_TYPE( RenderManOutputFilter );
+
+size_t RenderManOutputFilter::g_firstPlugIndex = 0;
+
+RenderManOutputFilter::RenderManOutputFilter( const std::string &name, FilterType filterType )
+	:	GlobalsProcessor( name ), m_filterType( filterType )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ShaderPlug( g_shaderPlugNames[(int)filterType] ) );
+	addChild( new IntPlug( "mode", Plug::In, (int)Mode::Replace, (int)Mode::Replace, (int)Mode::InsertLast ) );
+}
+
+RenderManOutputFilter::~RenderManOutputFilter()
+{
+}
+
+GafferScene::ShaderPlug *RenderManOutputFilter::shaderPlug()
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex );
+}
+
+const GafferScene::ShaderPlug *RenderManOutputFilter::shaderPlug() const
+{
+	return getChild<ShaderPlug>( g_firstPlugIndex );
+}
+
+Gaffer::IntPlug *RenderManOutputFilter::modePlug()
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::IntPlug *RenderManOutputFilter::modePlug() const
+{
+	return getChild<IntPlug>( g_firstPlugIndex + 1 );
+}
+
+bool RenderManOutputFilter::acceptsInput( const Gaffer::Plug *plug, const Gaffer::Plug *inputPlug ) const
+{
+	if( !GlobalsProcessor::acceptsInput( plug, inputPlug ) )
+	{
+		return false;
+	}
+
+	if( plug != shaderPlug() )
+	{
+		return true;
+	}
+
+	if( !inputPlug )
+	{
+		return true;
+	}
+
+	const Plug *sourcePlug = inputPlug->source();
+	auto *sourceShader = runTimeCast<const GafferScene::Shader>( sourcePlug->node() );
+	if( !sourceShader )
+	{
+		return true;
+	}
+
+	const Plug *sourceShaderOutPlug = sourceShader->outPlug();
+	if( !sourceShaderOutPlug )
+	{
+		return true;
+	}
+
+	if( sourcePlug != sourceShaderOutPlug && !sourceShaderOutPlug->isAncestorOf( sourcePlug ) )
+	{
+		return true;
+	}
+
+	return sourceShader->typePlug()->getValue() == g_shaderTypes[(int)m_filterType].string();
+}
+
+void RenderManOutputFilter::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	GlobalsProcessor::affects( input, outputs );
+
+	if( input == shaderPlug() || input == modePlug() )
+	{
+		outputs.push_back( outPlug()->globalsPlug() );
+	}
+}
+
+void RenderManOutputFilter::hashProcessedGlobals( const Gaffer::Context *context, IECore::MurmurHash &h ) const
+{
+	h.append( shaderPlug()->attributesHash() );
+	modePlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr RenderManOutputFilter::computeProcessedGlobals( const Gaffer::Context *context, IECore::ConstCompoundObjectPtr inputGlobals ) const
+{
+	ConstCompoundObjectPtr attributes = shaderPlug()->attributes();
+	if( attributes->members().empty() )
+	{
+		return inputGlobals;
+	}
+
+	const InternedString shaderType = g_shaderTypes[(int)m_filterType];
+	const IECoreScene::ShaderNetwork *network = attributes->member<IECoreScene::ShaderNetwork>( shaderType );
+	if( !network )
+	{
+		throw IECore::Exception( fmt::format( "Shader of type \"{}\" not found", shaderType.string() ) );
+	}
+
+	CompoundObjectPtr result = new CompoundObject;
+	// Since we're not going to modify any existing members (only add new ones),
+	// and our result becomes const on returning it, we can directly reference
+	// the input members in our result without copying. Be careful not to modify
+	// them though!
+	result->members() = inputGlobals->members();
+
+	const Mode mode = (Mode)modePlug()->getValue();
+	const ShaderNetwork *inputNetwork = inputGlobals->member<ShaderNetwork>( g_options[(int)m_filterType] );
+
+	ConstShaderNetworkPtr outputNetwork;
+	if( !inputNetwork || mode == Mode::Replace )
+	{
+		outputNetwork = network;
+	}
+	else
+	{
+		// Copy network, and make sure we have a combiner shader
+		ShaderNetworkPtr combinedNetwork = inputNetwork->copy();
+		InternedString combinerHandle;
+		if( combinedNetwork->outputShader()->getName() == g_combinerShaders[(int)m_filterType] )
+		{
+			combinerHandle = combinedNetwork->getOutput().shader;
+		}
+		else
+		{
+			// Insert combiner shader.
+			IECoreScene::ShaderPtr combinerShader = new IECoreScene::Shader( g_combinerShaders[(int)m_filterType], g_shaderTypes[(int)m_filterType] );
+			combinerHandle = combinedNetwork->addShader( combinerShader->getName(), std::move( combinerShader ) );
+			combinedNetwork->addConnection( { combinedNetwork->getOutput(), { combinerHandle, g_filter0 } } );
+			combinedNetwork->setOutput( { combinerHandle, g_out } );
+		}
+
+		// Insert new shader, and connect it to the combiner appropriately.
+		ShaderNetwork::Parameter insertedOut = ShaderNetworkAlgo::addShaders( combinedNetwork.get(), network );
+		ShaderNetwork::ConnectionRange connectionRange = combinedNetwork->inputConnections( combinedNetwork->getOutput().shader );
+
+		if( mode == Mode::InsertLast )
+		{
+			int lastIndex = -1;
+			for( const auto &connection : connectionRange )
+			{
+				lastIndex = std::max( lastIndex, connectionIndex( connection ) );
+			}
+			combinedNetwork->addConnection( { insertedOut, { combinerHandle, fmt::format( "filter[{}]", lastIndex + 1 ) } } );
+		}
+		else
+		{
+			assert( mode == Mode::InsertFirst );
+			// Remove old connections.
+			const std::vector<ShaderNetwork::Connection> connections( connectionRange.begin(), connectionRange.end() );
+			for( const auto &c : connections )
+			{
+				if( connectionIndex( c ) != -1 )
+				{
+					combinedNetwork->removeConnection( c );
+				}
+			}
+			// Insert new connection at front.
+			combinedNetwork->addConnection( { insertedOut, { combinerHandle, g_filter0 } } );
+			// Add old connections back again, with their indices incremented.
+			for( const auto &c : connections )
+			{
+				const int i = connectionIndex( c );
+				if( i != -1 )
+				{
+					combinedNetwork->addConnection( { c.source, { combinerHandle, fmt::format( "filter[{}]", i + 1 ) } } );
+				}
+			}
+		}
+
+		outputNetwork = combinedNetwork;
+	}
+
+	result->members()[g_options[(int)m_filterType]] = boost::const_pointer_cast<ShaderNetwork>( outputNetwork );
+	return result;
+}

--- a/src/GafferRenderMan/RenderManSampleFilter.cpp
+++ b/src/GafferRenderMan/RenderManSampleFilter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,24 +34,17 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "GafferRenderMan/RenderManSampleFilter.h"
 
-namespace GafferRenderMan
+using namespace GafferRenderMan;
+
+GAFFER_NODE_DEFINE_TYPE( RenderManSampleFilter );
+
+RenderManSampleFilter::RenderManSampleFilter( const std::string &name )
+	:	RenderManOutputFilter( name, FilterType::Sample )
 {
+}
 
-enum TypeId
+RenderManSampleFilter::~RenderManSampleFilter()
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-
-	LastTypeId = 110450
-};
-
-} // namespace GafferRenderMan
+}

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -37,10 +37,12 @@
 #include "boost/python.hpp"
 
 #include "GafferRenderMan/RenderManAttributes.h"
+#include "GafferRenderMan/RenderManDisplayFilter.h"
 #include "GafferRenderMan/RenderManIntegrator.h"
 #include "GafferRenderMan/RenderManLight.h"
 #include "GafferRenderMan/RenderManMeshLight.h"
 #include "GafferRenderMan/RenderManOptions.h"
+#include "GafferRenderMan/RenderManSampleFilter.h"
 #include "GafferRenderMan/RenderManShader.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
@@ -69,4 +71,16 @@ BOOST_PYTHON_MODULE( _GafferRenderMan )
 	GafferBindings::DependencyNodeClass<RenderManShader>();
 	GafferBindings::DependencyNodeClass<RenderManMeshLight>();
 	GafferBindings::DependencyNodeClass<RenderManIntegrator>();
+
+	{
+		scope s = GafferBindings::DependencyNodeClass<RenderManOutputFilter>( nullptr, no_init );
+		enum_<RenderManOutputFilter::Mode>( "Mode" )
+			.value( "Replace", RenderManOutputFilter::Mode::Replace )
+			.value( "InsertFirst", RenderManOutputFilter::Mode::InsertFirst )
+			.value( "InsertLast", RenderManOutputFilter::Mode::InsertLast )
+		;
+	}
+
+	GafferBindings::DependencyNodeClass<RenderManSampleFilter>();
+	GafferBindings::DependencyNodeClass<RenderManDisplayFilter>();
 }

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -37,6 +37,7 @@
 #include "boost/python.hpp"
 
 #include "GafferRenderMan/RenderManAttributes.h"
+#include "GafferRenderMan/RenderManIntegrator.h"
 #include "GafferRenderMan/RenderManLight.h"
 #include "GafferRenderMan/RenderManMeshLight.h"
 #include "GafferRenderMan/RenderManOptions.h"
@@ -67,4 +68,5 @@ BOOST_PYTHON_MODULE( _GafferRenderMan )
 	GafferBindings::DependencyNodeClass<RenderManOptions>();
 	GafferBindings::DependencyNodeClass<RenderManShader>();
 	GafferBindings::DependencyNodeClass<RenderManMeshLight>();
+	GafferBindings::DependencyNodeClass<RenderManIntegrator>();
 }

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -36,6 +36,7 @@
 
 #include "boost/python.hpp"
 
+#include "GafferRenderMan/BXDFPlug.h"
 #include "GafferRenderMan/RenderManAttributes.h"
 #include "GafferRenderMan/RenderManDisplayFilter.h"
 #include "GafferRenderMan/RenderManIntegrator.h"
@@ -46,6 +47,7 @@
 #include "GafferRenderMan/RenderManShader.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
+#include "GafferBindings/PlugBinding.h"
 
 using namespace boost::python;
 using namespace GafferRenderMan;
@@ -63,6 +65,18 @@ void loadShader( RenderManLight &l, const std::string &shaderName )
 
 BOOST_PYTHON_MODULE( _GafferRenderMan )
 {
+	GafferBindings::PlugClass<BXDFPlug>()
+		.def( init<const std::string &, Gaffer::Plug::Direction, unsigned>(
+				(
+					arg( "name" ) = Gaffer::GraphComponent::defaultName<BXDFPlug>(),
+					arg( "direction" ) = Gaffer::Plug::In,
+					arg( "flags" ) = Gaffer::Plug::Default
+				)
+			)
+		)
+	;
+
+
 	GafferBindings::DependencyNodeClass<RenderManLight>()
 		.def( "loadShader", &loadShader )
 	;

--- a/src/IECoreRenderMan/Globals.h
+++ b/src/IECoreRenderMan/Globals.h
@@ -40,6 +40,7 @@
 
 #include "IECoreScene/Output.h"
 #include "IECoreScene/Shader.h"
+#include "IECoreScene/ShaderNetwork.h"
 
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
@@ -76,6 +77,8 @@ class Globals : public boost::noncopyable
 
 		bool worldBegun();
 		void updateIntegrator();
+		void updateDisplayFilter();
+		void updateSampleFilter();
 		void updateRenderView();
 		void deleteRenderView();
 
@@ -90,6 +93,8 @@ class Globals : public boost::noncopyable
 		RtParamList m_options;
 		std::string m_cameraOption;
 		IECoreScene::ConstShaderPtr m_integratorToConvert;
+		IECoreScene::ConstShaderNetworkPtr m_displayFilterToConvert;
+		IECoreScene::ConstShaderNetworkPtr m_sampleFilterToConvert;
 		std::unordered_map<IECore::InternedString, IECoreScene::ConstOutputPtr> m_outputs;
 		RtUString m_pixelFilter;
 		riley::FilterSize m_pixelFilterSize;
@@ -111,6 +116,8 @@ class Globals : public boost::noncopyable
 		const std::vector<riley::RenderOutputId> &acquireRenderOutputs( const IECoreScene::Output *output );
 		std::unordered_map<IECore::MurmurHash, std::vector<riley::RenderOutputId>> m_renderOutputs;
 
+		riley::DisplayFilterId m_displayFilterId;
+		riley::SampleFilterId m_sampleFilterId;
 		std::vector<riley::DisplayId> m_displays;
 		riley::RenderTargetId m_renderTarget;
 		riley::Extent m_renderTargetExtent;

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -50,7 +50,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 
 	public :
 
-		Object( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session );
+		Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session );
 		~Object();
 
 		/// \todo RenderMan volumes seem to reject attempts to transform them
@@ -72,6 +72,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.
 		ConstGeometryPrototypePtr m_geometryPrototype;
+		RtParamList m_extraAttributes;
 
 };
 

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -178,7 +178,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			return new IECoreRenderMan::Object( geometryPrototype, typedAttributes, m_session );
+			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_session );
 		}
 
 		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
@@ -193,7 +193,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			return new IECoreRenderMan::Object( geometryPrototype, typedAttributes, m_session );
+			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_session );
 		}
 
 		void render() override

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -313,8 +313,8 @@ void convertConnection( const IECoreScene::ShaderNetwork::Connection &connection
 		destination = RtUString( connection.destination.name.c_str() );
 	}
 
-	auto it = shaderInfo->parameterTypes.find( destination );
-	if( it == shaderInfo->parameterTypes.end() )
+	auto typeIt = shaderInfo->parameterTypes.find( destination );
+	if( typeIt == shaderInfo->parameterTypes.end() )
 	{
 		IECore::msg(
 			IECore::Msg::Warning, "IECoreRenderMan",
@@ -327,7 +327,13 @@ void convertConnection( const IECoreScene::ShaderNetwork::Connection &connection
 	}
 
 	std::string reference = connection.source.shader;
-	if( !connection.source.name.string().empty() )
+	if(
+		connection.source.name.string().size() &&
+		// Display and sample filters don't have named outputs, and
+		// connections will silently fail if we include one.
+		typeIt->second != pxrcore::DataType::k_displayfilter &&
+		typeIt->second != pxrcore::DataType::k_samplefilter
+	)
 	{
 		reference += ":" + connection.source.name.string();
 	}
@@ -337,7 +343,7 @@ void convertConnection( const IECoreScene::ShaderNetwork::Connection &connection
 	{
 		RtParamList::ParamInfo const info = {
 			destination,
-			it->second,
+			typeIt->second,
 			pxrcore::DetailType::k_reference,
 			1,
 			false,

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -329,10 +329,11 @@ void convertConnection( const IECoreScene::ShaderNetwork::Connection &connection
 	std::string reference = connection.source.shader;
 	if(
 		connection.source.name.string().size() &&
-		// Display and sample filters don't have named outputs, and
-		// connections will silently fail if we include one.
+		// Several node types don't have named outputs, and
+		// connections will silently fail if we include a name.
 		typeIt->second != pxrcore::DataType::k_displayfilter &&
-		typeIt->second != pxrcore::DataType::k_samplefilter
+		typeIt->second != pxrcore::DataType::k_samplefilter &&
+		typeIt->second != pxrcore::DataType::k_bxdf
 	)
 	{
 		reference += ":" + connection.source.name.string();

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -59,10 +59,11 @@ if "RMANTREE" in os.environ :
 			# Things that Gaffer has renderer-agnostic attributes for already.
 			"Ri:Sides",
 			"lighting:mute",
+			# Things that we specify internally in the Renderer class.
+			"identifier:name",
 			# Things that we might want to use internally in the Renderer class.
 			"identifier:id",
 			"identifier:id2",
-			"identifier:name",
 			"stats:identifier",
 			"Ri:ReverseOrientation",
 			# Things that we probably want to expose, but which will require


### PR DESCRIPTION
This adds nodes for specifying RenderMan integrators, display filters and sample filters, and the associated Renderer backend changes needed to support them. It also adds support for Lama shaders in the RenderManShader node and in the backend.