### PR TITLE
RenderMan render pass type adaptors

### DIFF
--- a/python/GafferCyclesTest/RenderPassAdaptorTest.py
+++ b/python/GafferCyclesTest/RenderPassAdaptorTest.py
@@ -45,10 +45,6 @@ class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
 
 	renderer = "Cycles"
 
-	## \todo Default camera is facing down +ve Z but should be facing
-	# down -ve Z.
-	reverseCamera = True
-
 	# Cycles outputs black shadows on a white background.
 	shadowColor = imath.Color4f( 0 )
 	litColor = imath.Color4f( 1, 1, 1, 0 )
@@ -81,7 +77,7 @@ class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
 
 		options = GafferCycles.CyclesOptions()
 		options["options"]["samples"]["enabled"].setValue( True )
-		options["options"]["samples"]["value"].setValue( 20 )
+		options["options"]["samples"]["value"].setValue( 16 )
 		return options
 
 if __name__ == "__main__":

--- a/python/GafferRenderManTest/RenderPassAdaptorTest.py
+++ b/python/GafferRenderManTest/RenderPassAdaptorTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2018, John Haddon. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -34,19 +34,52 @@
 #
 ##########################################################################
 
-from .ModuleTest import ModuleTest
-from .RenderManAttributesTest import RenderManAttributesTest
-from .RenderManOptionsTest import RenderManOptionsTest
-from .RenderManShaderTest import RenderManShaderTest
-from .RenderManLightTest import RenderManLightTest
-from .RenderManMeshLightTest import RenderManMeshLightTest
-from .RenderManIntegratorTest import RenderManIntegratorTest
-from .RenderManDisplayFilterTest import RenderManDisplayFilterTest
-from .RenderManSampleFilterTest import RenderManSampleFilterTest
-from .RenderManRenderTest import RenderManRenderTest
-from .InteractiveRenderManRenderTest import InteractiveRenderManRenderTest
-from .RenderPassAdaptorTest import RenderPassAdaptorTest
+import unittest
+
+import imath
+
+import IECoreRenderMan
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
+
+	renderer = "RenderMan"
+
+	shadowColor = imath.Color4f( 1, 1, 1, 0 )
+	litColor = imath.Color4f( 0 )
+
+	## \todo Remove once light linking is supported.
+	@unittest.skip( "Light linking not supported yet" )
+	def testReflectionCasterLightLinks( self ) :
+
+		pass
+
+	def _createDistantLight( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrDistantLight" )
+		light["parameters"]["exposure"].setValue( 2.0 )
+		return light, light["parameters"]["lightColor"]
+
+	def _createStandardShader( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrSurface" )
+		return shader, shader["parameters"]["diffuseColor"]
+
+	def _createFlatShader( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrConstant" )
+		return shader, shader["parameters"]["emitColor"]
+
+	def _createOptions( self ) :
+
+		options = GafferRenderMan.RenderManOptions()
+		options["options"]["ri:hider:maxsamples"]["enabled"].setValue( True )
+		options["options"]["ri:hider:maxsamples"]["value"].setValue( 16 )
+		return options
 
 if __name__ == "__main__":
-	import unittest
 	unittest.main()

--- a/python/GafferSceneTest/RenderPassAdaptorTest.py
+++ b/python/GafferSceneTest/RenderPassAdaptorTest.py
@@ -51,10 +51,6 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 	# to be tested.
 	renderer = None
 
-	# Derived classes may set `reverseCamera` if their default camera
-	# faces down +ve Z rather than -ve Z.
-	reverseCamera = False
-
 	# Derived classes may set `shadowColor` and `litColor` to match
 	# their renderer's shadow catcher behaviour.
 	shadowColor = imath.Color4f( 1 )
@@ -80,13 +76,21 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["cube"]["dimensions"].setValue( imath.V3f( 0.3 ) )
 
 		s["light"], _ = self._createDistantLight()
-		s["light"]["transform"]["rotate"]["x"].setValue( 120 if self.reverseCamera else -60 )
+		s["light"]["transform"]["rotate"]["x"].setValue( -60 )
 
 		s["group"] = GafferScene.Group()
-		s["group"]["transform"]["translate"]["z"].setValue( 1 if self.reverseCamera else -1 )
+		s["group"]["transform"]["translate"]["z"].setValue( -1 )
 		s["group"]["in"][0].setInput( s["cube"]["out"] )
 		s["group"]["in"][1].setInput( s["plane"]["out"] )
 		s["group"]["in"][2].setInput( s["light"]["out"] )
+
+		s["camera"] = GafferScene.Camera()
+		s["camera"]["fieldOfView"].setValue( 90 )
+
+		s["parent"] = GafferScene.Parent()
+		s["parent"]["parent"].setValue( "/" )
+		s["parent"]["in"].setInput( s["group"]["out"] )
+		s["parent"]["children"]["child0"].setInput( s["camera"]["out"] )
 
 		s["shader"], colorPlug = self._createStandardShader()
 		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
@@ -95,7 +99,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["filter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube", "/group/plane" ] ) )
 
 		s["assignment"] = GafferScene.ShaderAssignment()
-		s["assignment"]["in"].setInput( s["group"]["out"] )
+		s["assignment"]["in"].setInput( s["parent"]["out"] )
 		s["assignment"]["shader"].setInput( s["shader"]["out"] )
 		s["assignment"]["filter"].setInput( s["filter"]["out"] )
 
@@ -117,6 +121,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:type", "shadow" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraInclusions", "/group/plane" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraExclusions", "/group/cube" ) )
+		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:camera", "/camera" ) )
 
 		s["rendererOptions"] = self._createOptions()
 		s["rendererOptions"]["in"].setInput( s["options"]["out"] )
@@ -158,12 +163,20 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 
 		s["cube"] = GafferScene.Cube()
 		# translate cube behind camera so it is only visible in reflection
-		s["cube"]["transform"]["translate"]["z"].setValue( -3 if self.reverseCamera else 3 )
+		s["cube"]["transform"]["translate"]["z"].setValue( 3 )
 
 		s["group"] = GafferScene.Group()
-		s["group"]["transform"]["translate"]["z"].setValue( 1 if self.reverseCamera else -1 )
+		s["group"]["transform"]["translate"]["z"].setValue( -1 )
 		s["group"]["in"][0].setInput( s["cube"]["out"] )
 		s["group"]["in"][1].setInput( s["plane"]["out"] )
+
+		s["camera"] = GafferScene.Camera()
+		s["camera"]["fieldOfView"].setValue( 90 )
+
+		s["parent"] = GafferScene.Parent()
+		s["parent"]["parent"].setValue( "/" )
+		s["parent"]["in"].setInput( s["group"]["out"] )
+		s["parent"]["children"]["child0"].setInput( s["camera"]["out"] )
 
 		s["flatRed"], colorPlug = self._createFlatShader()
 		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
@@ -172,7 +185,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube" ] ) )
 
 		s["assignment"] = GafferScene.ShaderAssignment()
-		s["assignment"]["in"].setInput( s["group"]["out"] )
+		s["assignment"]["in"].setInput( s["parent"]["out"] )
 		s["assignment"]["shader"].setInput( s["flatRed"]["out"] )
 		s["assignment"]["filter"].setInput( s["cubeFilter"]["out"] )
 
@@ -210,6 +223,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:type", "reflection" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraInclusions", "/group/plane" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraExclusions", "/group/cube" ) )
+		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:camera", "/camera" ) )
 
 		s["rendererOptions"] = self._createOptions()
 		s["rendererOptions"]["in"].setInput( s["options"]["out"] )
@@ -257,12 +271,20 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 
 		s["cube"] = GafferScene.Cube()
 		# translate cube behind camera so it is only visible in reflection
-		s["cube"]["transform"]["translate"]["z"].setValue( -3 if self.reverseCamera else 3 )
+		s["cube"]["transform"]["translate"]["z"].setValue( 3 )
 
 		s["group"] = GafferScene.Group()
-		s["group"]["transform"]["translate"]["z"].setValue( 1 if self.reverseCamera else -1 )
+		s["group"]["transform"]["translate"]["z"].setValue( -1 )
 		s["group"]["in"][0].setInput( s["cube"]["out"] )
 		s["group"]["in"][1].setInput( s["plane"]["out"] )
+
+		s["camera"] = GafferScene.Camera()
+		s["camera"]["fieldOfView"].setValue( 90 )
+
+		s["parent"] = GafferScene.Parent()
+		s["parent"]["parent"].setValue( "/" )
+		s["parent"]["in"].setInput( s["group"]["out"] )
+		s["parent"]["children"]["child0"].setInput( s["camera"]["out"] )
 
 		s["flat"], colorPlug = self._createFlatShader()
 		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
@@ -271,7 +293,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["filter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube", "/group/plane" ] ) )
 
 		s["assignment"] = GafferScene.ShaderAssignment()
-		s["assignment"]["in"].setInput( s["group"]["out"] )
+		s["assignment"]["in"].setInput( s["parent"]["out"] )
 		s["assignment"]["shader"].setInput( s["flat"]["out"] )
 		s["assignment"]["filter"].setInput( s["filter"]["out"] )
 
@@ -298,6 +320,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:type", "reflectionAlpha" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraInclusions", "/group/plane" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraExclusions", "/group/cube" ) )
+		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:camera", "/camera" ) )
 
 		s["rendererOptions"] = self._createOptions()
 		s["rendererOptions"]["in"].setInput( s["options"]["out"] )
@@ -345,16 +368,24 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 
 		s["cube"] = GafferScene.Cube()
 		# translate cube behind camera so it is only visible in reflection
-		s["cube"]["transform"]["translate"]["z"].setValue( -3 if self.reverseCamera else 3 )
+		s["cube"]["transform"]["translate"]["z"].setValue( 3 )
 
 		s["light"], _ = self._createDistantLight()
-		s["light"]["transform"]["rotate"]["x"].setValue( 30 if self.reverseCamera else -150 )
+		s["light"]["transform"]["rotate"]["x"].setValue( -150 )
 
 		s["group"] = GafferScene.Group()
-		s["group"]["transform"]["translate"]["z"].setValue( 1 if self.reverseCamera else -1 )
+		s["group"]["transform"]["translate"]["z"].setValue( -1 )
 		s["group"]["in"][0].setInput( s["cube"]["out"] )
 		s["group"]["in"][1].setInput( s["plane"]["out"] )
 		s["group"]["in"][2].setInput( s["light"]["out"] )
+
+		s["camera"] = GafferScene.Camera()
+		s["camera"]["fieldOfView"].setValue( 90 )
+
+		s["parent"] = GafferScene.Parent()
+		s["parent"]["parent"].setValue( "/" )
+		s["parent"]["in"].setInput( s["group"]["out"] )
+		s["parent"]["children"]["child0"].setInput( s["camera"]["out"] )
 
 		s["flatRed"], colorPlug = self._createStandardShader()
 		colorPlug.setValue( imath.Color3f( 1, 0, 0 ) )
@@ -363,7 +394,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["cubeFilter"]["paths"].setValue( IECore.StringVectorData( [ "/group/cube" ] ) )
 
 		s["assignment"] = GafferScene.ShaderAssignment()
-		s["assignment"]["in"].setInput( s["group"]["out"] )
+		s["assignment"]["in"].setInput( s["parent"]["out"] )
 		s["assignment"]["shader"].setInput( s["flatRed"]["out"] )
 		s["assignment"]["filter"].setInput( s["cubeFilter"]["out"] )
 
@@ -401,6 +432,7 @@ class RenderPassAdaptorTest( GafferSceneTest.SceneTestCase ) :
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "renderPass:type", "reflection" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraInclusions", "/group" ) )
 		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:cameraExclusions", "/group/cube" ) )
+		s["options"]["options"].addChild( Gaffer.NameValuePlug( "render:camera", "/camera" ) )
 
 		s["rendererOptions"] = self._createOptions()
 		s["rendererOptions"]["in"].setInput( s["options"]["out"] )

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -351,6 +351,13 @@ void Render::executeInternal( bool flushCaches ) const
 		GafferScene::Private::RendererAlgo::RenderSets renderSets( adaptedInPlug() );
 		GafferScene::Private::RendererAlgo::LightLinks lightLinks;
 
+		if( renderer->name().string() == "RenderMan" )
+		{
+			// Workaround for RenderMan API limitations. The backend needs to acquire the Riley
+			// session before we commence multithreaded calls to the Renderer API.
+			renderer->command( "ri:acquireRiley", {} );
+		}
+
 		GafferScene::Private::RendererAlgo::outputCameras( adaptedInPlug(), renderOptions, renderSets, renderer.get() );
 		GafferScene::Private::RendererAlgo::outputLights( adaptedInPlug(), renderOptions, renderSets, &lightLinks, renderer.get() );
 		GafferScene::Private::RendererAlgo::outputLightFilters( adaptedInPlug(), renderOptions, renderSets, &lightLinks, renderer.get() );

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1689,6 +1689,13 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 			m_defaultAttributes = m_renderer->attributes( defaultAttributes.get() );
 		}
 
+		if( m_renderer->name().string() == "RenderMan" )
+		{
+			// Workaround for RenderMan API limitations. The backend needs to acquire the Riley
+			// session before we commence multithreaded calls to the Renderer API.
+			m_renderer->command( "ri:acquireRiley", {} );
+		}
+
 		for( int i = SceneGraph::FirstType; i <= SceneGraph::LastType; ++i )
 		{
 			SceneGraph *sceneGraph = m_sceneGraphs[i].get();

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -159,6 +159,7 @@ const IECoreScene::ConstShaderNetworkPtr g_emptyShaderNetwork = new IECoreScene:
 Globals::Globals( IECoreScenePreview::Renderer::RenderType renderType, const IECore::MessageHandlerPtr &messageHandler )
 	:	m_renderType( renderType ), m_messageHandler( messageHandler ),
 		m_pixelFilter( g_defaultPixelFilter ), m_pixelFilterSize( g_defaultPixelFilterSize ), m_pixelVariance( g_defaultPixelVariance ),
+		m_expectedSessionCreationThreadId( std::this_thread::get_id() ),
 		m_renderTargetExtent()
 {
 	// Initialise `m_integratorToConvert`.
@@ -367,6 +368,15 @@ Session *Globals::acquireSession()
 {
 	if( !m_session )
 	{
+		if( m_expectedSessionCreationThreadId != std::this_thread::get_id() )
+		{
+			IECore::msg(
+				Msg::Error,
+				"RenderMan",
+				"You must call `Renderer::command( \"ri:acquireSession\" )` before commencing "
+				"multithreaded geometry output (RenderMan limitation)."
+			);
+		}
 		m_session = std::make_unique<Session>( m_renderType, m_options, m_messageHandler );
 	}
 

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -709,7 +709,7 @@ const std::vector<riley::RenderOutputId> &Globals::acquireRenderOutputs( const I
 {
 	// Identify type and source.
 
-	const string layerName = parameter<string>( output->parameters(), g_layerName, "" );
+	const string layerName = parameter<string>( output->parameters(), g_layerName, "__undefined__" );
 
 	std::optional<riley::RenderOutputType> type;
 	RtUString source;
@@ -766,7 +766,7 @@ const std::vector<riley::RenderOutputId> &Globals::acquireRenderOutputs( const I
 	// doesn't need to be unique among all render outputs.
 
 	RtUString renderOutputName = source;
-	if( !layerName.empty() )
+	if( layerName != "__undefined__" )
 	{
 		renderOutputName = RtUString( layerName.c_str() );
 	}

--- a/src/IECoreRenderMan/Globals.h
+++ b/src/IECoreRenderMan/Globals.h
@@ -89,6 +89,11 @@ class Globals : public boost::noncopyable
 		// called `Riley::SetOptions()`. So we buffer all the options and outputs
 		// into the following member variables, and create the Riley session
 		// only when we must.
+		//
+		/// \todo This strategy has fun afoul of Riley threading limitations -
+		/// see  `Renderer::acquireSession()` and the "ri:acquireRiley" command.
+		/// Perhaps a better approach would be to change the Renderer API so
+		/// that the initial options must be passed to the Renderer constructor?
 
 		RtParamList m_options;
 		std::string m_cameraOption;
@@ -103,6 +108,7 @@ class Globals : public boost::noncopyable
 		// When we require the Riley session, we create it in `acquireSession()`.
 
 		std::unique_ptr<Session> m_session;
+		std::thread::id m_expectedSessionCreationThreadId;
 
 		// Then once we have the session, we are free to use the Riley API
 		// to populate the scene, which we store in the following members.

--- a/src/IECoreRenderManDisplay/Display.cpp
+++ b/src/IECoreRenderManDisplay/Display.cpp
@@ -84,7 +84,11 @@ PtDspyError DspyImageOpen( PtDspyImageHandle *image, const char *driverName, con
 
 		vector<string> tokens;
 		StringAlgo::tokenize( format[i].name, '.', tokens );
-		if( tokens.size() > 1 && std::all_of( tokens[1].begin(), tokens[1].end(), [] ( unsigned char c ) { return std::isdigit( c ); } ) )
+		if( tokens.size() == 2 && std::all_of( tokens[0].begin(), tokens[0].end(), [] ( unsigned char c ) { return std::isdigit( c ); } ) )
+		{
+			tokens.erase( tokens.begin() );
+		}
+		else if( tokens.size() > 1 && std::all_of( tokens[1].begin(), tokens[1].end(), [] ( unsigned char c ) { return std::isdigit( c ); } ) )
 		{
 			tokens.erase( tokens.begin() + 1 );
 		}


### PR DESCRIPTION
This adds support for our standard `reflection`, `reflectionAlpha` and `shadow` render pass types. The skipped `testReflectionCasterLightLinks` test should be removed once we support light linking.