### PR TITLE
AboutTest : Remove special case for handling IE's environment

### DIFF
--- a/python/GafferTest/AboutTest.py
+++ b/python/GafferTest/AboutTest.py
@@ -58,17 +58,6 @@ class AboutTest( GafferTest.TestCase ) :
 			if "source" in d :
 				self.assertTrue( urllib.request.urlopen( d["source"] ) )
 
-# Image Engine internal builds don't package all the dependencies with
-# Gaffer, so the license tests above would fail. We try to detect such
-# builds and mark the test as being an expected failure, so as to cut
-# down on noise.
-packagedWithDependencies = False
-for f in glob.glob( os.path.expandvars( "$GAFFER_ROOT/lib/*" ) ) :
-	if "Gaffer" not in os.path.basename( f ) :
-		packagedWithDependencies = True
-
-if not packagedWithDependencies :
-	AboutTest.test = unittest.expectedFailure( AboutTest.test )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Continuing our effort to get the Gaffer tests working at IE, we found we don't need this special case anymore when running the `GafferTest.AboutTest`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
