### PR TITLE
CI : Set `LD_PRELOAD` in container env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,8 @@ jobs:
             # GitHub container builds run as root. This causes failures for tests that
             # assert that filesystem permissions are respected, because root doesn't
             # respect permissions. So we run the final test suite as a dedicated
-            # test user rather than as root. We also run with `libSegFault.so` loaded
-            # to get more information from any crashes which occur.
-            testRunner: LD_PRELOAD=libSegFault.so su testUser -c
+            # test user rather than as root.
+            testRunner: su testUser -c
             sconsCacheMegabytes: 400
             jobs: 4
 
@@ -54,7 +53,7 @@ jobs:
             buildType: DEBUG
             publish: false
             containerImage: ghcr.io/gafferhq/build/build:3.2.0
-            testRunner: LD_PRELOAD=libSegFault.so su testUser -c
+            testRunner: su testUser -c
             testArguments: -excludedCategories performance
             # Debug builds are ludicrously big, so we must use a larger cache
             # limit. In practice this compresses down to 4-500Mb.
@@ -75,6 +74,10 @@ jobs:
 
     container:
       image: ${{ matrix.containerImage }}
+      env:
+        # We preload `libSegFault.so` to get more information from any crashes
+        # which might occur during CI.
+        LD_PRELOAD: libSegFault.so
       # This MAC address is required by our RenderMan license.
       options: --mac-address a4:bb:6d:cf:40:7a
 


### PR DESCRIPTION
In 8f8437c3cac6f855c7ba7a32a115b17c7241e34d we moved this to the `testRunner` command, because we couldn't set it in the global environment due to `libSegFault.so` not being available on `ubuntu-24.04`. But that meant that it wasn't set for things like the build itself (including the documentation build). Moving to the container environment should mean that it is set for everything that matters, without causing problems on the outer Ubuntu host.
