### PR TITLE
Wrapper : Require GAFFERENDERMAN_FEATURE_PREVIEW to enable RenderMan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,7 @@ jobs:
     env:
       ARNOLD_LICENSE_ORDER: none # Don't waste time looking for a license that doesn't exist
       ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL: 0 # And don't abort because the license isn't found
+      GAFFERRENDERMAN_FEATURE_PREVIEW: 1
       GAFFER_BUILD_DIR: "./build"
       GAFFER_CACHE_DIR: "./sconsCache"
 

--- a/SConstruct
+++ b/SConstruct
@@ -1481,7 +1481,7 @@ libraries = {
 	},
 
 	"scripts" : {
-		"additionalFiles" : [ "bin/__gaffer.py" ],
+		"additionalFiles" : [ "bin/_gaffer.py", "bin/__gaffer.py" ],
 	},
 
 	"misc" : {

--- a/SConstruct
+++ b/SConstruct
@@ -37,6 +37,7 @@
 ##########################################################################
 
 import os
+import pathlib
 import re
 import sys
 import glob
@@ -941,6 +942,41 @@ if env["ARNOLD_ROOT"] :
 	arnoldInstallRoot = "${{BUILD_DIR}}/arnold/{ARCH}.{MAJOR}".format( **arnoldVersions )
 
 ###############################################################################################
+# RenderMan configuration
+###############################################################################################
+
+renderManInstallRoot = ""
+if env["RENDERMAN_ROOT"] :
+
+	# Version
+
+	renderManHeader = pathlib.Path( env.subst( "$RENDERMAN_ROOT/include/prmanapi.h" ) )
+	if not renderManHeader.exists() :
+		sys.stderr.write( "ERROR : unable to find \"{}\".\n".format( renderManHeader ) )
+		Exit( 1 )
+
+	renderManVersions = {}
+	for line in open( renderManHeader ) :
+		m = re.match( r"^#define _PRMANAPI_VERSION_(MAJOR|MINOR)_\s*([0-9]+)", line )
+		if m :
+			renderManVersions[m.group(1)] = m.group( 2 )
+
+	if set( renderManVersions.keys() ) != { "MAJOR", "MINOR" } :
+		sys.stderr.write( "ERROR : unable to parse \"{}\".\n".format( renderManHeader ) )
+		Exit( 1 )
+
+	# Install root. We install to different roots by RenderMan version, in
+	# anticipation of wanting to support multiple versions concurrently at some
+	# point. It's not really clear what we should use for the version number;
+	# the official Rix APIs advertise compatibility within a major version, but
+	# as far as I can tell, the Riley API doesn't provide any guarantees at all.
+	# It has a separate `RILEY_LIBRARY_VERSION_MAJOR` define, which is currently
+	# at 0.4. So we use PRMan's `{MAJOR}.{MINOR}` to hedge against Riley
+	# changes, and because it provides a more easily recognised number.
+
+	renderManInstallRoot = "${{BUILD_DIR}}/renderMan/{MAJOR}.{MINOR}".format( **renderManVersions )
+
+###############################################################################################
 # Cycles configuration
 ###############################################################################################
 
@@ -1368,6 +1404,7 @@ libraries = {
 			"LIBS" : [ "IECoreRenderMan", "IECoreScene$CORTEX_LIB_SUFFIX" ],
 		},
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"IECoreRenderManDisplay" : {
@@ -1378,12 +1415,14 @@ libraries = {
 		"envReplacements" : {
 			"SHLIBPREFIX" : "",
 		},
-		"installName" : "renderManPlugins/d_ieDisplay",
+		"installName" : "plugins/d_ieDisplay",
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"IECoreRenderManTest" : {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"GafferRenderMan" : {
@@ -1405,18 +1444,22 @@ libraries = {
 			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
 		},
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"GafferRenderManTest" : {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"GafferRenderManUI" : {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"GafferRenderManUITest" : {
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
+		"installRoot" : renderManInstallRoot,
 	},
 
 	"GafferTractor" : {},

--- a/SConstruct
+++ b/SConstruct
@@ -941,7 +941,7 @@ if env["ARNOLD_ROOT"] :
 	arnoldInstallRoot = "${{BUILD_DIR}}/arnold/{ARCH}.{MAJOR}".format( **arnoldVersions )
 
 ###############################################################################################
-# Definitions for the libraries we wish to build
+# Cycles configuration
 ###############################################################################################
 
 # When Cycles is built, it uses several preprocessor variables that enable and
@@ -976,6 +976,10 @@ cyclesDefines = [
 	( "WITH_CUDA_DYNLOAD" ),
 	( "WITH_OPTIX" ),
 ]
+
+###############################################################################################
+# Definitions for the libraries we wish to build
+###############################################################################################
 
 libraries = {
 

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -35,9 +35,8 @@
 #
 ##########################################################################
 
-# Note: This file is generally considered private. Those wishing to launch
-# gaffer should use the gaffer wrapper script (also in this directory)
-# as it ensures the correct process environment is set up prior to launch.
+# This script is private and should not be called directly. Use the `gaffer`
+# command to launch Gaffer (`gaffer.cmd` on Windows).
 
 import os
 import sys

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -68,7 +68,7 @@ def setUpRenderMan() :
 
 	# Determine RenderMan version.
 
-	if "RMANTREE" not in os.environ :
+	if "RMANTREE" not in os.environ or os.environ.get( "GAFFERRENDERMAN_FEATURE_PREVIEW", "0" ) != "1" :
 		return
 
 	rmanTree = pathlib.Path( os.environ.get( "RMANTREE" ) )

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -1,0 +1,106 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+# This script is private and should not be called directly. Use the `gaffer`
+# command to launch Gaffer (`gaffer.cmd` on Windows).
+import os
+import pathlib
+import re
+import sys
+
+# Utilities
+# =========
+
+libraryPath = {
+	"linux" : "LD_LIBRARY_PATH",
+	"darwin" : "DYLD_LIBRARY_PATH"
+}.get( sys.platform )
+
+def appendToPath( pathToAppend, envVar ) :
+
+	pathToAppend = str( pathToAppend )
+
+	path = os.environ.get( envVar )
+	path = path.split( os.pathsep ) if path else []
+
+	if pathToAppend not in path :
+		path.append( pathToAppend )
+
+	os.environ[envVar] = os.pathsep.join( path )
+
+# RenderMan Setup
+# ===============
+
+def setUpRenderMan() :
+
+	if "RMANTREE" not in os.environ :
+		return
+
+	rmanTree = pathlib.Path( os.environ.get( "RMANTREE" ) )
+	pluginRoot = pathlib.Path( os.environ.get( "GAFFER_ROOT" ) )
+
+	if libraryPath :
+		appendToPath( rmanTree / "lib", libraryPath )
+
+	appendToPath( rmanTree / "bin", "PATH" )
+	appendToPath( rmanTree / "bin", "PYTHONPATH" )
+	appendToPath( rmanTree / "lib" / "plugins", "RMAN_RIXPLUGINPATH" )
+	appendToPath( pluginRoot / "renderManPlugins", "RMAN_DISPLAYS_PATH" )
+	appendToPath( rmanTree / "lib" / "shaders", "OSL_SHADER_PATHS" )
+
+	if sys.platform == "win32" :
+		appendToPath( rmanTree / "bin", "IECORE_DLL_DIRECTORIES" )
+		appendToPath( rmanTree / "lib", "IECORE_DLL_DIRECTORIES" )
+
+setUpRenderMan()
+
+# Exec `__gaffer.py`
+# ==================
+
+args = [
+	sys.executable,
+	str( pathlib.Path( sys.argv[0] ).with_name( "__gaffer.py" ) )
+] + sys.argv[1:]
+
+if sys.platform != "win32" :
+	os.execv( sys.executable, args )
+else :
+	# On Windows, Python emulates `execv()` badly by launching another process
+	# (rather than replacing this one) and not even waiting for it to finish.
+	# Use `subprocess.run()` so we can at least wait and pass on the return
+	# value.
+	import subprocess
+	sys.exit( subprocess.run( args ).returncode )

--- a/bin/gaffer
+++ b/bin/gaffer
@@ -36,10 +36,11 @@
 #
 ##########################################################################
 
-# Wrapper script for gaffer. This ensures that relevant environment
-# variables are set appropriately and then runs gaffer.py in the
-# correct python interpreter.
-##########################################################################
+# Public-facing launch script for gaffer. This sets up the Python interpreter
+# and then defers to `_gaffer.py` to set up the appropriate environment
+# and finally launch `__gaffer.py`.
+#
+## \todo Move all remaining environment setup to `_gaffer.py`.
 
 set -e
 
@@ -318,25 +319,6 @@ if [[ -n $ONNX_ROOT ]] ; then
 
 fi
 
-# Set up RenderMan
-##########################################################################
-
-if [[ -n $RMANTREE ]] ; then
-
-	if [[ `uname` = "Linux" ]] ; then
-		appendToPath "$RMANTREE/lib" LD_LIBRARY_PATH
-	else
-		appendToPath "$RMANTREE/lib" DYLD_LIBRARY_PATH
-	fi
-
-	appendToPath "$RMANTREE/bin" PATH
-	appendToPath "$RMANTREE/bin" PYTHONPATH
-	appendToPath "$RMANTREE/lib/plugins" RMAN_RIXPLUGINPATH
-	appendToPath "$GAFFER_ROOT/renderManPlugins" RMAN_DISPLAYS_PATH
-	appendToPath "$RMANTREE/lib/shaders" OSL_SHADER_PATHS
-
-fi
-
 # Set up 3rd Party extensions
 ##########################################################################
 
@@ -389,7 +371,7 @@ if [[ -n $GAFFER_DEBUG ]] ; then
 		fi
 	fi
 	# Using `which` because lldb doesn't seem to respect $PATH
-	exec $GAFFER_DEBUGGER `which python` "$GAFFER_ROOT/bin/__gaffer.py" "$@"
+	exec $GAFFER_DEBUGGER `which python` "$GAFFER_ROOT/bin/_gaffer.py" "$@"
 else
-	exec python "$GAFFER_ROOT/bin/__gaffer.py" "$@"
+	exec python "$GAFFER_ROOT/bin/_gaffer.py" "$@"
 fi

--- a/bin/gaffer.cmd
+++ b/bin/gaffer.cmd
@@ -1,5 +1,11 @@
 @echo off
 
+rem Public-facing launch script for gaffer. This sets up the Python interpreter
+rem and then defers to `_gaffer.py` to set up the appropriate environment
+rem and finally launch `__gaffer.py`.
+rem
+rem \todo Move all remaining environment setup to `_gaffer.py`.
+
 setlocal EnableDelayedExpansion
 
 set GAFFER_ROOT=%~dp0%..
@@ -147,17 +153,6 @@ if "%ONNX_ROOT%" NEQ "" (
 	call :appendToPath "%ONNX_ROOT%\lib" PATH
 )
 
-rem RenderMan
-rem =========
-
-if "%RMANTREE%" NEQ "" (
-	call :appendToPath "%RMANTREE%" GAFFER_EXTENSION_PATHS
-	call :appendToPath "%RMANTREE%\bin" PYTHONPATH
-	call :appendToPath "%RMANTREE%\lib\plugins" RMAN_RIXPLUGINPATH
-	call :appendToPath "%RMANTREE%\lib\shaders" OSL_SHADER_PATHS
-	call :appendToPath "%GAFFER_ROOT%\renderManPlugins" RMAN_DISPLAYS_PATH
-)
-
 rem Set up 3rd party extensions
 rem Batch files are awkward at `for` loops. The default `for`, without `/f`
 rem uses semi-colons AND spaces as delimiters, meaning we would not be able
@@ -188,9 +183,9 @@ for /f "tokens=1* delims=;" %%A in ("%EXTENSION_PATH%") do (
 )
 
 if "%GAFFER_DEBUG%" NEQ "" (
-	%GAFFER_DEBUGGER% "%GAFFER_ROOT%"\bin\python.exe "%GAFFER_ROOT%"/bin/__gaffer.py %*
+	%GAFFER_DEBUGGER% "%GAFFER_ROOT%"\bin\python.exe "%GAFFER_ROOT%"/bin/_gaffer.py %*
 ) else (
-	"%GAFFER_ROOT%"\bin\python.exe "%GAFFER_ROOT%"/bin/__gaffer.py %*
+	"%GAFFER_ROOT%"\bin\python.exe "%GAFFER_ROOT%"/bin/_gaffer.py %*
 )
 
 ENDLOCAL

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -47,7 +47,7 @@ import Gaffer
 # metadata conventions. This is then used to populate the RenderManAttributes
 # node and the AttributeEditor etc.
 
-if "RMANTREE" in os.environ :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferRenderMan.ArgsFileAlgo
 

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -45,7 +45,7 @@ import Gaffer
 # and register them using Gaffer's standard metadata conventions. This is then
 # used to populate the RenderManOptions node and the RenderPassEditor etc.
 
-if "RMANTREE" in os.environ :
+with IECore.IgnoredExceptions( ImportError ) :
 
 	import GafferRenderMan.ArgsFileAlgo
 


### PR DESCRIPTION
This also moves the GafferRenderMan module into a separately versioned `$GAFFER_ROOT/renderMan/26.3` subdirectory, mirroring what we do for GafferArnold. I couldn't face writing the header-parsing logic in both bash and whatever `gaffer.cmd` is, so I've made steps to refactor the environment setup into a Python-based wrapper. In this PR I've just moved the RenderMan setup there, but I'll follow up with another PR to move all setup there for 1.6.