### PR TITLE
RenderMan UI config

### DIFF
--- a/startup/GafferScene/renderManLights.py
+++ b/startup/GafferScene/renderManLights.py
@@ -40,8 +40,12 @@ import imath
 
 import Gaffer
 
+# Register metadata so that StandardLightVisualiser will visualise the RenderMan
+# lights for us.
+## \todo I think we'd be better off with some dedicated visualisers instead.
+
 for type in [
-	"PxrCyclinderLight", "PxrDomeLight", "PxrDiskLight", "PxrDistantLight",
+	"PxrCylinderLight", "PxrDomeLight", "PxrDiskLight", "PxrDistantLight",
 	"PxrEnvDayLight", "PxrMeshLight",  "PxrRectLight", "PxrSphereLight",
 ] :
 

--- a/startup/GafferScene/renderers.py
+++ b/startup/GafferScene/renderers.py
@@ -55,6 +55,7 @@ for renderer, module in [
 	( "Arnold", "IECoreArnold" ),
 	( "3Delight", "IECoreDelight" ),
 	( "3Delight Cloud", "IECoreDelight" ),
+	( "RenderMan", "IECoreRenderMan" ),
 ] :
 	if renderer in GafferScene.Private.IECoreScenePreview.Renderer.types() :
 		# Already registered

--- a/startup/gui/attributeEditor.py
+++ b/startup/gui/attributeEditor.py
@@ -183,6 +183,25 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:matte", "Shading" )
 
+if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		# This import appears unused, but it is intentional; it prevents us from
+		# registering when RenderMan isn't available.
+		import GafferRenderMan
+
+		Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:RenderMan", "RenderMan" )
+
+		# Register all options we have metadata for.
+		## \todo We should probably do things this way for the other renderers too. The
+		# AttributeEditor could just read the metadata itself then, and we wouldn't
+		# need `registerAttribute()` at all.
+		for target in Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "defaultValue" ) :
+			GafferSceneUI.AttributeEditor.registerAttribute(
+				"RenderMan", target[10:], Gaffer.Metadata.value( target, "layout:section" ), Gaffer.Metadata.value( target, "label" )
+			)
+
 Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:OpenGL", "OpenGL" )
 
 GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:solid", "Shading" )

--- a/startup/gui/lightEditor.py
+++ b/startup/gui/lightEditor.py
@@ -165,6 +165,83 @@ with IECore.IgnoredExceptions( ImportError ) :
 			columnName = parameter.replace( "arnold:", "" )
 		)
 
+# RenderMan lights
+
+if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		# This import appears unused, but it is intentional; it prevents us from
+		# registering when RenderMan isn't available.
+		import GafferRenderMan
+
+		Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "preset:RenderMan", "ri:light" )
+		# If RenderMan is available, then assume it is the renderer of choice.
+		Gaffer.Metadata.registerValue( GafferSceneUI.LightEditor.Settings, "attribute", "userDefault", "ri:light" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "intensity" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "exposure" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "lightColor" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "enableTemperature" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "temperature" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "lightColorMap" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "colorMapGamma" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "colorMapSaturation" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "angleExtent" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "textureColor" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "emissionFocus", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "emissionFocusNormalize", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "emissionFocusTint", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "specular", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "diffuse", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "intensityNearDist", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "specularNearDist", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "diffuseNearDist", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "coneAngle", "Refine" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "coneSoftness", "Refine" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "iesProfile", "Light Profile" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "iesProfileScale", "Light Profile" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "iesProfileNormalize", "Light Profile" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "enableShadows", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowColor", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowDistance", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowFalloff", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowFalloffGamma", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowSubset", "Shadows" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "shadowExcludeSubset", "Shadows" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "sunDirection", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "haziness", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "skyTint", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "sunTint", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "sunSize", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "groundMode", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "groundColor", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "month", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "day", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "year", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "hour", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "zone", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "latitude", "Day Light" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "longitude", "Day Light" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "areaNormalize", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "traceLightPaths", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "thinShadow", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "visibleInRefractionPath", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "cheapCaustics", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "cheapCausticsExcludeGroup", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "fixedSampleCount", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "lightGroup", "Advanced" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "importanceMultiplier", "Advanced" )
+
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "msApprox", "Multi-Scattering Approx" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "msApproxBleed", "Multi-Scattering Approx" )
+		GafferSceneUI.LightEditor.registerParameter( "ri:light", "msApproxContribution", "Multi-Scattering Approx" )
+
 # Register generic light attributes
 for attributeName in [
 	"gl:visualiser:scale",

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -236,6 +236,31 @@ if os.environ.get( "CYCLES_ROOT" ) and moduleSearchPath.find( "GafferCycles" ) :
 		stacktrace = traceback.format_exc()
 		IECore.msg( IECore.Msg.Level.Error, "startup/gui/menus.py", "Error loading Cycles module - \"%s\".\n %s" % ( m, stacktrace ) )
 
+# RenderMan nodes
+
+if (
+	"RMANTREE" in os.environ and
+	moduleSearchPath.find( "GafferRenderMan" ) and
+	os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1"
+) :
+	try :
+
+		import GafferRenderMan
+		import GafferRenderManUI
+
+		GafferRenderManUI.RenderManShaderUI.appendShaders( nodeMenu.definition() )
+
+		nodeMenu.append( "/RenderMan/Attributes", GafferRenderMan.RenderManAttributes, searchText = "RenderManAttributes" )
+		nodeMenu.append( "/RenderMan/Integrator", GafferRenderMan.RenderManIntegrator, searchText = "RenderManIntegrator" )
+		nodeMenu.append( "/RenderMan/Options", GafferRenderMan.RenderManOptions, searchText = "RenderManOptions" )
+		nodeMenu.append( "/RenderMan/Display Filter", GafferRenderMan.RenderManDisplayFilter, searchText = "RenderManDisplayFilter" )
+		nodeMenu.append( "/RenderMan/Sample Filter", GafferRenderMan.RenderManSampleFilter, searchText = "RenderManSampleFilter" )
+
+	except Exception as m :
+
+		stacktrace = traceback.format_exc()
+		IECore.msg( IECore.Msg.Level.Error, "startup/gui/menus.py", "Error loading RenderMan module - \"%s\".\n %s" % ( m, stacktrace ) )
+
 # Scene nodes
 
 nodeMenu.append( "/Scene/File/Reader", GafferScene.SceneReader, searchText = "SceneReader" )

--- a/startup/gui/renderPassEditor.py
+++ b/startup/gui/renderPassEditor.py
@@ -124,6 +124,24 @@ with IECore.IgnoredExceptions( ImportError ) :
 	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:GI_volume_depth", "Ray Depth", "Volume" )
 	GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "ai:auto_transparency_depth", "Ray Depth", "Transparency" )
 
+if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		# This import appears unused, but it is intentional; it prevents us from
+		# registering when RenderMan isn't available.
+		import GafferRenderMan
+
+		Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "preset:RenderMan", "RenderMan" )
+		Gaffer.Metadata.registerValue( GafferSceneUI.RenderPassEditor.Settings, "tabGroup", "userDefault", "RenderMan" )
+
+		# Register all options we have metadata for.
+		## \todo We should probably do things this way for the other renderers too.
+		for target in Gaffer.Metadata.targetsWithMetadata( "option:ri:*", "defaultValue" ) :
+			GafferSceneUI.RenderPassEditor.registerOption(
+				"RenderMan", target[7:], Gaffer.Metadata.value( target, "layout:section" ), Gaffer.Metadata.value( target, "label" )
+			)
+
 # Register the default grouping function used to display render passes in a hierarchy.
 # This groups render passes based on the first token in their name delimited by "_".
 def __defaultPathGroupingFunction( renderPassName ) :

--- a/startup/gui/shaderPresets.py
+++ b/startup/gui/shaderPresets.py
@@ -84,6 +84,19 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 	] )
 
+if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		import GafferRenderMan
+
+		__registerShaderPresets( [
+
+			( "RenderMan Surface", "ri:surface" ),
+			( "RenderMan Light", "ri:light" ),
+
+		] )
+
 __registerShaderPresets( [
 
 		( "OpenGL Surface", "gl:surface" ),

--- a/startup/gui/viewer.py
+++ b/startup/gui/viewer.py
@@ -260,6 +260,24 @@ if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "
 			functools.partial( __loadRendererSettings, os.path.join( os.path.dirname( __file__ ), "cyclesViewerSettings.gfr" ) )
 		)
 
+
+if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
+
+	with IECore.IgnoredExceptions( ImportError ) :
+
+		import GafferRenderMan
+
+		__registerShadingModes( [
+
+			( "Diagnostic/RenderMan/Shader Assignment", GafferScene.AttributeVisualiser, { "attributeName" : "ri:surface", "mode" : GafferScene.AttributeVisualiser.Mode.ShaderNodeColor } ),
+			( "Diagnostic/RenderMan/Camera Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:camera" } ),
+			( "Diagnostic/RenderMan/Transmission Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:transmission" } ),
+			( "Diagnostic/RenderMan/Indirect Visibility", GafferScene.AttributeVisualiser, { "attributeName" : "ri:visibility:indirect" } ),
+			( "Diagnostic/RenderMan/Matte", GafferScene.AttributeVisualiser, { "attributeName" : "ri:Ri:Matte" } ),
+			( "Diagnostic/RenderMan/Holdout", GafferScene.AttributeVisualiser, { "attributeName" : "ri:trace:holdout" } ),
+
+		] )
+
 # Add catalogue hotkeys to viewers, eg: up/down navigation
 GafferUI.Editor.instanceCreatedSignal().connect( GafferImageUI.CatalogueUI.addCatalogueHotkeys )
 GafferUI.Editor.instanceCreatedSignal().connect( GafferSceneUI.EditScopeUI.addPruningActions )


### PR DESCRIPTION
This builds on #6324 (the first 4 commits here are from that) and surfaces all the GafferRenderMan work in the UI in all the various places it belongs. A `GAFFERRENDERMAN_HIDE_UI` environment variable allows you to hide all the UI features to avoid confusion in cases where RenderMan is available in the environment but shouldn't be used for a particular show.