### PR TITLE
_PointInstancerAdaptor : Control using options instead of attributes

### DIFF
--- a/python/GafferUSDTest/PromotePointInstancesTest.py
+++ b/python/GafferUSDTest/PromotePointInstancesTest.py
@@ -82,6 +82,8 @@ class PromotePointInstancesTest( GafferSceneTest.SceneTestCase ) :
 
 		referenceAdaptor = GafferUSD._PointInstancerAdaptor()
 		referenceAdaptor["in"].setInput( simpleParent["out"] )
+		referenceAdaptor["renderer"].setValue( "test" )
+		referenceAdaptor["enabledRenderers"].setValue( IECore.StringVectorData( [ "test" ] ) )
 
 		# Do a simple promote, which both tests the basic functionality, and serves as a reference scene for our
 		# expected output when we're testing trickier cases
@@ -96,6 +98,8 @@ class PromotePointInstancesTest( GafferSceneTest.SceneTestCase ) :
 
 		simplePromoteAdaptor = GafferUSD._PointInstancerAdaptor()
 		simplePromoteAdaptor["in"].setInput( simplePromotePointInstances["out"] )
+		simplePromoteAdaptor["renderer"].setValue( "test" )
+		simplePromoteAdaptor["enabledRenderers"].setValue( IECore.StringVectorData( [ "test" ] ) )
 
 
 		self.assertEqual( simplePromotePointInstances["out"].childNames( "/" ), IECore.InternedStringVectorData( [ "object", "promotedInstances" ] ) )
@@ -137,6 +141,8 @@ class PromotePointInstancesTest( GafferSceneTest.SceneTestCase ) :
 
 		pointInstancerAdaptor = GafferUSD._PointInstancerAdaptor()
 		pointInstancerAdaptor["in"].setInput( promoteInstances["out"] )
+		pointInstancerAdaptor["renderer"].setValue( "test" )
+		pointInstancerAdaptor["enabledRenderers"].setValue( IECore.StringVectorData( [ "test" ] ) )
 
 		# Reordering points should not affect the expanded output
 		self.assertScenesEqual( pointInstancerAdaptor["out"], referenceAdaptor["out"] )

--- a/python/GafferUSDUI/_PointInstancerAdaptorUI.py
+++ b/python/GafferUSDUI/_PointInstancerAdaptorUI.py
@@ -59,14 +59,14 @@ Gaffer.Metadata.registerNode(
 
 		],
 
-		"defaultEnabledPerRenderer" : [
+		"enabledRenderers" : [
 
 			"description",
 			"""
-			Controls whether the adaptor is hidden by default. Contains a dict, with a boolean value for
-			each renderer. Defaults true for any renderers not specified in the dict. Slightly weird
-			interface, but is basically internal. It should only ever be edited by the expansion menu
-			set up in startup/GafferSceneUI/usdPointInstancerAdaptor.py
+			If a renderer is listed in this space separated list, the adaptor will be enabled by default
+			for that renderer ( it can still be overridden by the option gafferUSD:pointInstancerAdaptor:enabled ).
+			This should plug only ever be edited by the expansion menu set up in
+			startup/GafferSceneUI/usdPointInstancerAdaptor.py
 			""",
 
 		],

--- a/startup/GafferSceneUI/usdPointInstancerAdaptor.py
+++ b/startup/GafferSceneUI/usdPointInstancerAdaptor.py
@@ -49,13 +49,15 @@ def __expandUSDPointInstancersMenu( menuDefinition, plugValueWidget ) :
 		return
 
 	renderer = renderAdaptor["renderer"].getValue()
-	currentDict = renderAdaptor["defaultEnabledPerRenderer"].getValue()
-	current = currentDict.get( renderer, IECore.BoolData( True ) ).value
+	currentList = list( renderAdaptor["enabledRenderers"].getValue() )
+	current = renderer in currentList
 
 	def callBackFunc( unused ):
-		modified = currentDict.copy()
-		modified[renderer] = IECore.BoolData( not current )
-		renderAdaptor["defaultEnabledPerRenderer"].setValue( modified )
+		if current:
+			modifiedList = [ i for i in currentList if i != renderer ]
+		else:
+			modifiedList = currentList + [ renderer ]
+		renderAdaptor["enabledRenderers"].setValue( IECore.StringVectorData( modifiedList ) )
 
 	menuDefinition.append( "/AttributesDivider", { "divider" : True } )
 	menuDefinition.append(


### PR DESCRIPTION
Behaviour changes as discussed this morning:

* The attribute "gafferUSD:pointInstancerAdaptor:enabled" has been replaced with the option "gafferUSD:pointInstancerAdaptor:enabled"
* The attribute "gafferUSD:pointInstancerAdaptor:attributes" has been replaced with the option "gafferUSD:pointInstancerAdaptor:attributes"
* The dictionary plug "defaultEnabledPerRenderer" has been replaced with a string plug "defaultEnabledForRenderers" holding a string separated list. A consequence of this is that it can no longer default to enabled for renderers that haven't been specified ( Should I add a special case to default enabled when `renderer` is left as empty string? That would remove the need for some of the test changes.

In addition to the behaviour changes, there's a bit of cleanup. This morning you I think you mentioned two improvements, but said they would probably be unnecessary once we did the behaviour changes. One of them was using the typed output plug of Collect rather than the untyped "enabledValues", in order to avoid needing an expression to transfer the value. We had hoped to avoid this entirely by getting rid of the whole FilterResults -> Collect thing, but in addition to checking attributes, that was also being used with PrimitiveVariableQuery to avoid processing locations that don't have points at them. I'm pretty sure you requested this for the case where a parent location is in the "usd:pointInstancers" set, but isn't actually an instancer, and we don't want to remove the children. I'm assuming we should continue doing this, so I have done the tweak to Collect to avoid using an expression.

I feel like you might have mentioned another improvement that you thought was going to become unnecessary, but I've forgotten what it was, so I'm not sure if I've done it.

I haven't written a Changes entry, since it sounded like you had a plan for how to communicate this stuff.