### PR TITLE
Arnold ShaderNetworkAlgo : Align cone softness with `hdArnold`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- Arnold : Fixed handling of `shaping:cone:softness` values greater than one on USD lights. These are now translated identically to `hdArnold`, rather than being ignored.
 - Cycles : Fixed incorrect particle motion blur shape (#5862).
 - SceneAlgo : Fixed errors and crashes caused by calling `registerRenderAdaptor()` from an adaptor creation function.
 

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -996,15 +996,15 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
-			# SphereLight (with bogus out-of-range Houdini softness)
+			# SphereLight (with softness greater than 1)
 
-			"houdiniPenumbra" : [
+			"sphereLightHighSoftness" : [
 
 				IECoreScene.Shader(
 					"SphereLight", "light",
 					{
 						"shaping:cone:angle" : 20.0,
-						"shaping:cone:softness" : 60.0,
+						"shaping:cone:softness" : 2.0,
 					}
 				),
 
@@ -1012,6 +1012,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 					"spot_light", "light",
 					expectedLightParameters( {
 						"cone_angle" : 40.0,
+						"penumbra_angle" : 80.0,
 						"cosine_power" : 0.0,
 						"radius" : 0.5,
 					} )

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -761,19 +761,7 @@ void transferUSDShapingParameters( ShaderNetwork *network, InternedString shader
 		// - https://groups.google.com/u/1/g/usd-interest/c/Ybe4aroAKbc/m/0Ui3DKMyCgAJ, in
 		//   which folks take their best guess.
 		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.0f );
-		if( softness > 1.0 )
-		{
-			// Houdini apparently has (or had?) its own interpretation of softness, with the "bar scene"
-			// containing lights with an angle of 20 degrees and a softness of 60! We have no idea how
-			// to interpret that, so punt for now.
-			/// \todo Hopefully things get more standardised and we can remove this, because the RenderMan
-			/// docs do imply that values above one are allowed.
-			IECore::msg( IECore::Msg::Warning, "transferUSDShapingParameters", "Ignoring `shaping:cone:softness` as it is greater than 1" );
-		}
-		else
-		{
-			shader->parameters()[g_penumbraAngleParameter] = new FloatData( d->readable() * 2.0f * softness );
-		}
+		shader->parameters()[g_penumbraAngleParameter] = new FloatData( d->readable() * 2.0f * softness );
 		// Same here.
 		shader->parameters()[g_cosinePowerParameter] = new FloatData( parameterValue( usdShader, g_shapingSoftnessParameter, 0.0f ) );
 	}


### PR DESCRIPTION
We now translate values above 1 into penumbra angles bigger than the cone angle, which is what `arnold-usd` does, and seems to do something reasonable sensible in Arnold.