### PR TITLE
Arnold : Fix crashes caused by shapes without valid points

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- Arnold : Fixed handling of `shaping:cone:softness` values greater than one on USD lights. These are now translated identically to `hdArnold`, rather than being ignored.
+- Arnold :
+  - Fixed handling of `shaping:cone:softness` values greater than one on USD lights. These are now translated identically to `hdArnold`, rather than being ignored.
+  - Fixed crashes caused by invalid `P` primitive variables.
 - Cycles : Fixed incorrect particle motion blur shape (#5862).
 - SceneAlgo : Fixed errors and crashes caused by calling `registerRenderAdaptor()` from an adaptor creation function.
 

--- a/include/IECoreArnold/ShapeAlgo.h
+++ b/include/IECoreArnold/ShapeAlgo.h
@@ -46,6 +46,11 @@ namespace IECoreArnold
 namespace ShapeAlgo
 {
 
+/// \todo Rename to `convertP()`. The only difference is the return value.
+IECOREARNOLD_API bool convertPChecked( const IECoreScene::Primitive *primitive, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
+IECOREARNOLD_API bool convertPChecked( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
+
+/// \todo Remove.
 IECOREARNOLD_API void convertP( const IECoreScene::Primitive *primitive, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
 IECOREARNOLD_API void convertP( const std::vector<const IECoreScene::Primitive *> &samples, AtNode *shape, const AtString name, const std::string &messageContext = "ShapeAlgo::convertP" );
 

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -196,9 +196,13 @@ void objectInterfaceTransform2( Renderer::ObjectInterface &objectInterface, obje
 
 void objectInterfaceLink( Renderer::ObjectInterface &objectInterface, const IECore::InternedString &type, object pythonObjectSet )
 {
-	std::vector<Renderer::ObjectInterfacePtr> objectVector;
-	container_utils::extend_container( objectVector, pythonObjectSet );
-	auto objectSet = std::make_shared<Renderer::ObjectSet>( objectVector.begin(), objectVector.end() );
+	IECoreScenePreview::Renderer::ConstObjectSetPtr objectSet;
+	if( pythonObjectSet != object() )
+	{
+		std::vector<Renderer::ObjectInterfacePtr> objectVector;
+		container_utils::extend_container( objectVector, pythonObjectSet );
+		objectSet = std::make_shared<Renderer::ObjectSet>( objectVector.begin(), objectVector.end() );
+	}
 	objectInterface.link( type, objectSet );
 }
 

--- a/src/IECoreArnold/CurvesAlgo.cpp
+++ b/src/IECoreArnold/CurvesAlgo.cpp
@@ -193,7 +193,15 @@ AtNode *convert( const IECoreScene::CurvesPrimitive *curves, AtUniverse *univers
 	ConstCurvesPrimitivePtr resampledCurves = ::resampleCurves( curves, messageContext );
 
 	AtNode *result = convertCommon( resampledCurves.get(), universe, nodeName, parentNode, messageContext );
-	ShapeAlgo::convertP( resampledCurves.get(), result, g_pointsArnoldString, messageContext );
+
+	if( !ShapeAlgo::convertPChecked( resampledCurves.get(), result, g_pointsArnoldString, messageContext ) )
+	{
+		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
+		/// so we don't do manual deletion like this.
+		AiNodeDestroy( result );
+		return nullptr;
+	}
+
 	ShapeAlgo::convertRadius( resampledCurves.get(), result, messageContext );
 
 	// Convert "N" to orientations
@@ -236,7 +244,12 @@ AtNode *convert( const std::vector<const IECoreScene::CurvesPrimitive *> &sample
 
 	AtNode *result = convertCommon( updatedSamples.front().get(), universe, nodeName, parentNode, messageContext );
 
-	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString, messageContext );
+	if( !ShapeAlgo::convertPChecked( primitiveSamples, result, g_pointsArnoldString, messageContext ) )
+	{
+		AiNodeDestroy( result );
+		return nullptr;
+	}
+
 	ShapeAlgo::convertRadius( primitiveSamples, result, messageContext );
 	if( nSamples.size() == samples.size() )
 	{

--- a/src/IECoreArnold/MeshAlgo.cpp
+++ b/src/IECoreArnold/MeshAlgo.cpp
@@ -379,7 +379,13 @@ AtNode *convert( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, c
 {
 	AtNode *result = convertCommon( mesh, universe, nodeName, parentNode, messageContext );
 
-	ShapeAlgo::convertP( mesh, result, g_vlistArnoldString, messageContext );
+	if( !ShapeAlgo::convertPChecked( mesh, result, g_vlistArnoldString, messageContext ) )
+	{
+		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
+		/// so we don't do manual deletion like this.
+		AiNodeDestroy( result );
+		return nullptr;
+	}
 
 	// add normals
 
@@ -403,7 +409,11 @@ AtNode *convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples,
 	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
 
 	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
-	ShapeAlgo::convertP( primitiveSamples, result, g_vlistArnoldString, messageContext );
+	if( !ShapeAlgo::convertPChecked( primitiveSamples, result, g_vlistArnoldString, messageContext ) )
+	{
+		AiNodeDestroy( result );
+		return nullptr;
+	}
 
 	// add normals
 

--- a/src/IECoreArnold/PointsAlgo.cpp
+++ b/src/IECoreArnold/PointsAlgo.cpp
@@ -98,7 +98,14 @@ AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *univers
 {
 	AtNode *result = convertCommon( points, universe, nodeName, parentNode, messageContext );
 
-	ShapeAlgo::convertP( points, result, g_pointsArnoldString, messageContext );
+	if( !ShapeAlgo::convertPChecked( points, result, g_pointsArnoldString, messageContext ) )
+	{
+		/// \todo Would be nice to refactor `ObjectAlgo::convert()` to return `unique_ptr<AtNode>`
+		/// so we don't do manual deletion like this.
+		AiNodeDestroy( result );
+		return nullptr;
+	}
+
 	ShapeAlgo::convertRadius( points, result, messageContext );
 
 	/// \todo Aspect, rotation
@@ -111,7 +118,12 @@ AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &sample
 	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode, messageContext );
 
 	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
-	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString, messageContext );
+	if( !ShapeAlgo::convertPChecked( primitiveSamples, result, g_pointsArnoldString, messageContext ) )
+	{
+		AiNodeDestroy( result );
+		return nullptr;
+	}
+
 	ShapeAlgo::convertRadius( primitiveSamples, result, messageContext );
 
 


### PR DESCRIPTION
If we instance an Arnold shape without setting the points attribute, we get warnings like this when doing the render :

`WARNING |   [ginstance] /pointless: trying to clone a NULL object`

Then later in an interactive render, we get crashes in `AiNodeResetParameter()` when `ArnoldObject::link()` tries to edit the `ginstance`. I think this is an Arnold bug, so we work around it by not even creating the instance when we don't have valid points.

I'm not overly happy with the approach of making the AtNode then deleting it if we fail to set the points. But I settled on it as the best of a bad bunch out of these other alternatives :

- Having `ShapeAlgo::convertP()` be responsible for creating the AtNode, returning `nullptr` if it couldn't. This resulted in a function with a _lot_ of arguments, which wasn't ideal. But the thing that I liked least was that it wasn't generalisable. There are lots of other plausible states for objects that
might crash Arnold - invalid mesh topology for instance. And _everyone_ can't be responsible for making the node.
- Having a `bool ShapeAlgo::checkP()` function that everyone calls before making a node. This could be generalised by adding other checks for other things before creating the node. But it duplicates work in the common case where everything is OK.

Although making an object only to delete it is pretty ugly, it means there is only unnecessary overhead in the exceptional case, and well-behaved geometry doesn't pay any penalty.