### PR TITLE
GafferRenderMan : Fix Windows environment

### DIFF
--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -109,6 +109,9 @@ def setUpRenderMan() :
 	if sys.platform == "win32" :
 		appendToPath( rmanTree / "bin", "IECORE_DLL_DIRECTORIES" )
 		appendToPath( rmanTree / "lib", "IECORE_DLL_DIRECTORIES" )
+		appendToPath( pluginRoot / "lib", "IECORE_DLL_DIRECTORIES" )
+		appendToPath( pluginRoot / "bin", "PATH" )
+		appendToPath( pluginRoot / "lib", "PATH" )
 
 setUpRenderMan()
 


### PR DESCRIPTION
This fixes an omission from #6324 that left the environment not set up fully for `GafferRenderMan` on Windows. When I was reviewing that, I hadn't cleared out my old build so I was missing the versioned `GafferRenderMan` but picking up the old unversioned build and it appeared to work.

This won't be necessary on `main` because https://github.com/GafferHQ/gaffer/pull/6325/commits/ba58aa3c7afd6bce404ac601356805cb339a8fab adds `GafferRenderMan` as an extension so these directories are added to the paths.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
