### PR TITLE
GafferScene : Add ShuffleRenderPasses node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.9.0)
 =======
 
+Features
+--------
+
+- ShuffleRenderPasses : Added a new node for shuffling render passes.
+
 Fixes
 -----
 

--- a/include/GafferScene/ShuffleRenderPasses.h
+++ b/include/GafferScene/ShuffleRenderPasses.h
@@ -1,0 +1,95 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/ScenePlug.h"
+
+#include "Gaffer/ContextProcessor.h"
+#include "Gaffer/ShufflePlug.h"
+
+namespace GafferScene
+{
+
+class GAFFERSCENE_API ShuffleRenderPasses : public Gaffer::ContextProcessor
+{
+
+	public :
+
+		explicit ShuffleRenderPasses( const std::string &name=defaultName<ShuffleRenderPasses>() );
+		~ShuffleRenderPasses() override;
+
+		GAFFER_NODE_DECLARE_TYPE( GafferScene::ShuffleRenderPasses, ShuffleRenderPassesTypeId, Gaffer::ContextProcessor );
+
+		GafferScene::ScenePlug *inPlug();
+		const GafferScene::ScenePlug *inPlug() const;
+
+		GafferScene::ScenePlug *outPlug();
+		const GafferScene::ScenePlug *outPlug() const;
+
+		Gaffer::ShufflesPlug *shufflesPlug();
+		const Gaffer::ShufflesPlug *shufflesPlug() const;
+
+		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
+
+	protected :
+
+		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
+		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
+
+		bool affectsContext( const Gaffer::Plug *input ) const override;
+		void processContext( Gaffer::Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const override;
+
+	private :
+
+		class ProcessedScope;
+
+		Gaffer::StringPlug *sourceNamePlug();
+		const Gaffer::StringPlug *sourceNamePlug() const;
+
+		Gaffer::ObjectPlug *mappingPlug();
+		const Gaffer::ObjectPlug *mappingPlug() const;
+
+		void hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const;
+		IECore::ConstCompoundObjectPtr computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const;
+
+		static size_t g_firstPlugIndex;
+
+};
+
+IE_CORE_DECLAREPTR( ShuffleRenderPasses );
+
+} // namespace GafferScene

--- a/include/GafferScene/TypeIds.h
+++ b/include/GafferScene/TypeIds.h
@@ -187,6 +187,7 @@ enum TypeId
 	MergeMeshesTypeId = 110643,
 	MergePointsTypeId = 110644,
 	MergeCurvesTypeId = 110645,
+	ShuffleRenderPassesTypeId = 110646,
 
 	PreviewPlaceholderTypeId = 110647,
 	PreviewGeometryTypeId = 110648,

--- a/python/GafferSceneTest/ShuffleRenderPassesTest.py
+++ b/python/GafferSceneTest/ShuffleRenderPassesTest.py
@@ -1,0 +1,127 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferScene
+import GafferSceneTest
+
+class ShuffleRenderPassesTest( GafferSceneTest.SceneTestCase ) :
+
+	def test( self ) :
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["names"].setValue( IECore.StringVectorData( [ "c", "a", "b" ] ) )
+
+		shuffle = GafferScene.ShuffleRenderPasses()
+		shuffle["in"].setInput( renderPasses["out"] )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "b" ] ) )
+
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "a", "d" ) )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "d", "b" ] ) )
+
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "a", "ad" ) )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "ad", "d", "b" ] ) )
+
+		shuffle["shuffles"][1]["enabled"].setValue( False )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "d", "b" ] ) )
+
+		shuffle["shuffles"][0]["deleteSource"].setValue( True )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "d", "b" ] ) )
+
+		renderPasses["names"].setValue( IECore.StringVectorData( [ "c", "a", "b", "z" ] ) )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "d", "b", "z" ] ) )
+
+		shuffle["shuffles"][0]["deleteSource"].setValue( False )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "d", "b", "z" ] ) )
+
+		shuffle["shuffles"][1]["enabled"].setValue( True )
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "ad", "d", "b", "z" ] ) )
+
+		shuffle["enabled"].setValue( False )
+		self.assertEqual( shuffle["out"].globals(), shuffle["in"].globals() )
+
+	def testNameRemapping( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "test:sourceName", "${renderPass}" ) )
+
+		renderPasses = GafferScene.RenderPasses()
+		renderPasses["in"].setInput( options["out"] )
+		renderPasses["names"].setValue( IECore.StringVectorData( [ "c", "a", "b" ] ) )
+
+		shuffle = GafferScene.ShuffleRenderPasses()
+		shuffle["in"].setInput( renderPasses["out"] )
+		shuffle["shuffles"].addChild( Gaffer.ShufflePlug( "a", "d" ) )
+
+		self.assertEqual( shuffle["out"].globals()["option:renderPass:names"], IECore.StringVectorData( [ "c", "a", "d", "b" ] ) )
+		self.assertEqual( shuffle["__sourceName"].getValue(), "" )
+		self.assertEqual( shuffle["out"].globals()["option:test:sourceName"].value, "" )
+
+		with Gaffer.Context() as context :
+
+			for renderPass in [ "", "a", "c", "d", "other" ] :
+				context["renderPass"] = renderPass
+				self.assertEqual( shuffle["__sourceName"].getValue(), renderPass if renderPass != "d" else "a" )
+				self.assertEqual( shuffle["out"].globals()["option:test:sourceName"].value, renderPass if renderPass != "d" else "a" )
+
+			shuffle["shuffles"][0]["source"].setValue( "c" )
+			context["renderPass"] = "d"
+			self.assertEqual( shuffle["__sourceName"].getValue(), "c" )
+			self.assertEqual( shuffle["out"].globals()["option:test:sourceName"].value, "c" )
+
+			shuffle["shuffles"][0]["source"].setValue( "*" )
+			shuffle["shuffles"][0]["destination"].setValue( "${source}_test" )
+
+			for source, destination in [
+				( "", "" ),
+				( "a", "a" ),
+				( "a", "a_test" ),
+				( "b", "b" ),
+				( "b", "b_test" ),
+				( "c", "c" ),
+				( "c", "c_test" ),
+				( "other", "other" ),
+			] :
+				context["renderPass"] = destination
+				self.assertEqual( shuffle["__sourceName"].getValue(), source )
+				self.assertEqual( shuffle["out"].globals()["option:test:sourceName"].value, source )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneTest/__init__.py
+++ b/python/GafferSceneTest/__init__.py
@@ -187,6 +187,7 @@ from .MergeMeshesTest import MergeMeshesTest
 from .MergePointsTest import MergePointsTest
 from .MergeCurvesTest import MergeCurvesTest
 from .ShaderPlugTest import ShaderPlugTest
+from .ShuffleRenderPassesTest import ShuffleRenderPassesTest
 
 from .IECoreScenePreviewTest import *
 from .IECoreGLPreviewTest import *

--- a/python/GafferSceneUI/ShuffleRenderPassesUI.py
+++ b/python/GafferSceneUI/ShuffleRenderPassesUI.py
@@ -1,0 +1,86 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+Gaffer.Metadata.registerNode(
+
+	GafferScene.ShuffleRenderPasses,
+
+	"description",
+	"""
+	Shuffles render passes, allowing them to be copied and/or renamed.
+
+	An additional context variable `${source}` can be used on the destination plugs
+	to insert the name of each source render pass. For example, to prefix all render
+	passes with `test_` set the source to `*` and the destination to `test_${source}`.
+	""",
+
+	plugs = {
+
+		"in" : [
+
+			"description",
+			"""
+			The input scene.
+			""",
+
+		],
+
+		"out" : [
+
+			"description",
+			"""
+			The processed output scene.
+			""",
+
+		],
+
+		"shuffles" : [
+
+			"description",
+			"""
+			The definition of the shuffling to be performed - an
+			arbitrary number of render pass edits can be made by adding
+			ShufflePlugs as children of this plug.
+			""",
+
+		],
+
+	}
+
+)

--- a/python/GafferSceneUI/ShuffleRenderPassesUI.py
+++ b/python/GafferSceneUI/ShuffleRenderPassesUI.py
@@ -81,6 +81,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"shuffles.*.source" : [
+
+			"ui:scene:acceptsRenderPassName", True,
+
+		]
+
 	}
 
 )

--- a/python/GafferSceneUI/__init__.py
+++ b/python/GafferSceneUI/__init__.py
@@ -205,6 +205,7 @@ from . import MergePointsUI
 from . import MergeCurvesUI
 from . import VisualiserToolUI
 from . import PrimitiveVariableTweaksUI
+from . import ShuffleRenderPassesUI
 
 # then all the PathPreviewWidgets. note that the order
 # of import controls the order of display.

--- a/src/GafferScene/ShuffleRenderPasses.cpp
+++ b/src/GafferScene/ShuffleRenderPasses.cpp
@@ -1,0 +1,345 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/ShuffleRenderPasses.h"
+
+#include "Gaffer/ContextAlgo.h"
+
+#include "IECore/NullObject.h"
+
+#include <memory>
+
+using namespace IECore;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace std;
+
+namespace
+{
+
+struct MappingData : public IECore::Data
+{
+
+	MappingData( const StringVectorData *renderPassNames, const ShufflesPlug *shuffles )
+	{
+		if( !renderPassNames )
+		{
+			return;
+		}
+
+		unordered_map<string, size_t> indexMap;
+		const auto &names = renderPassNames->readable();
+		for( size_t i = 0; i < names.size(); ++i )
+		{
+			m_mapping.insert( { names[i], names[i] } );
+			indexMap.insert( { names[i], i } );
+		}
+
+		m_mapping = shuffles->shuffle( m_mapping );
+
+		// Sort shuffled names to preserve the original order of each
+		// source name. We do this to maintain the input order, preserving
+		// the position of renamed render passes while newly copied
+		// render passes are sorted immediately after their source.
+		vector< tuple<size_t, bool, string> > shuffledNames;
+		shuffledNames.reserve( m_mapping.size() );
+		for( const auto &[destination, source] : m_mapping )
+		{
+			shuffledNames.push_back( { indexMap[source], destination != source, destination } );
+		}
+		std::sort( shuffledNames.begin(), shuffledNames.end() );
+
+		vector<string> orderedNames;
+		orderedNames.reserve( m_mapping.size() );
+		for( const auto &n : shuffledNames )
+		{
+			orderedNames.push_back( get<2>( n ) );
+		}
+
+		m_outRenderPassNames = new StringVectorData( orderedNames );
+	}
+
+	const StringVectorData *outRenderPassNames() const { return m_outRenderPassNames.get(); }
+
+	const string sourceRenderPassName( const string &renderPassName ) const
+	{
+		auto it = m_mapping.find( renderPassName );
+		if( it == m_mapping.end() )
+		{
+			return renderPassName;
+		}
+		return it->second;
+	}
+
+	private :
+
+		StringVectorDataPtr m_outRenderPassNames;
+
+		using Map = unordered_map<string, string>;
+		Map m_mapping;
+
+};
+
+IE_CORE_DECLAREPTR( MappingData )
+
+bool enabled( const BoolPlug *enabledPlug, const Gaffer::Context *context )
+{
+	const BoolPlug *sourcePlug = enabledPlug->source<BoolPlug>();
+	if( !sourcePlug || sourcePlug->direction() == Plug::Out )
+	{
+		ScenePlug::GlobalScope globalScope( context );
+		return sourcePlug ? sourcePlug->getValue() : enabledPlug->getValue();
+	}
+	else
+	{
+		// Value is not computed so context is irrelevant.
+		// Avoid overhead of context creation.
+		return sourcePlug->getValue();
+	}
+}
+
+} // namespace
+
+class ShuffleRenderPasses::ProcessedScope : public Context::EditableScope
+{
+
+	public :
+
+		ProcessedScope( const Context *context, const ShuffleRenderPasses *processor )
+			:	EditableScope( context )
+		{
+			ContextAlgo::GlobalScope globalScope( context, processor->inPlug() );
+			if( processor->enabledPlug()->getValue() )
+			{
+				processor->processContext( *this, m_storage );
+			}
+		}
+
+	private :
+
+		IECore::ConstRefCountedPtr m_storage;
+
+};
+
+GAFFER_NODE_DEFINE_TYPE( ShuffleRenderPasses );
+
+const InternedString g_inPlugName( "in" );
+const InternedString g_outPlugName( "out" );
+const std::string g_renderPassNamesOptionName = "option:renderPass:names";
+const std::string g_renderPassContextName = "renderPass";
+
+size_t ShuffleRenderPasses::g_firstPlugIndex = 0;
+
+ShuffleRenderPasses::ShuffleRenderPasses( const std::string &name )
+	:	ContextProcessor( name )
+{
+	storeIndexOfNextChild( g_firstPlugIndex );
+	addChild( new ShufflesPlug( "shuffles" ) );
+	addChild( new StringPlug( "__sourceName", Plug::Out, "" ) );
+	addChild( new ObjectPlug( "__mapping", Plug::Out, IECore::NullObject::defaultNullObject() ) );
+
+	setup( new ScenePlug() );
+}
+
+ShuffleRenderPasses::~ShuffleRenderPasses()
+{
+}
+
+GafferScene::ScenePlug *ShuffleRenderPasses::inPlug()
+{
+	return static_cast<ScenePlug *>( getChild<Plug>( g_inPlugName ) );
+}
+
+const GafferScene::ScenePlug *ShuffleRenderPasses::inPlug() const
+{
+	return static_cast<const ScenePlug *>( getChild<Plug>( g_inPlugName ) );
+}
+
+GafferScene::ScenePlug *ShuffleRenderPasses::outPlug()
+{
+	return static_cast<ScenePlug *>( getChild<Plug>( g_outPlugName ) );
+}
+
+const GafferScene::ScenePlug *ShuffleRenderPasses::outPlug() const
+{
+	return static_cast<const ScenePlug *>( getChild<Plug>( g_outPlugName ) );
+}
+
+Gaffer::ShufflesPlug *ShuffleRenderPasses::shufflesPlug()
+{
+	return getChild<Gaffer::ShufflesPlug>( g_firstPlugIndex );
+}
+
+const Gaffer::ShufflesPlug *ShuffleRenderPasses::shufflesPlug() const
+{
+	return getChild<Gaffer::ShufflesPlug>( g_firstPlugIndex );
+}
+
+Gaffer::StringPlug *ShuffleRenderPasses::sourceNamePlug()
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::StringPlug *ShuffleRenderPasses::sourceNamePlug() const
+{
+	return getChild<Gaffer::StringPlug>( g_firstPlugIndex + 1 );
+}
+
+Gaffer::ObjectPlug *ShuffleRenderPasses::mappingPlug()
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 2 );
+}
+
+const Gaffer::ObjectPlug *ShuffleRenderPasses::mappingPlug() const
+{
+	return getChild<ObjectPlug>( g_firstPlugIndex + 2 );
+}
+
+void ShuffleRenderPasses::affects( const Plug *input, AffectedPlugsContainer &outputs ) const
+{
+	ContextProcessor::affects( input, outputs );
+
+	if( shufflesPlug()->isAncestorOf( input ) || input == inPlug()->globalsPlug() )
+	{
+		outputs.push_back( mappingPlug() );
+	}
+
+	if( input == mappingPlug() )
+	{
+		outputs.push_back( sourceNamePlug() );
+		outputs.push_back( outPlug()->globalsPlug() );
+	}
+}
+
+void ShuffleRenderPasses::hash( const ValuePlug *output, const Context *context, IECore::MurmurHash &h ) const
+{
+	if( output == mappingPlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		inPlug()->globalsPlug()->hash( h );
+		shufflesPlug()->hash( h );
+		return;
+	}
+	else if( output == sourceNamePlug() )
+	{
+		ComputeNode::hash( output, context, h );
+		h.append( context->get<string>( g_renderPassContextName, "" ) );
+		mappingPlug()->hash( h );
+		return;
+	}
+	else if( output == outPlug()->globalsPlug() && enabled( enabledPlug(), context ) )
+	{
+		hashGlobals( context, outPlug(), h );
+		return;
+	}
+
+	ContextProcessor::hash( output, context, h );
+}
+
+void ShuffleRenderPasses::compute( ValuePlug *output, const Context *context ) const
+{
+	if( output == mappingPlug() )
+	{
+		ConstCompoundObjectPtr globals = inPlug()->globals();
+		static_cast<ObjectPlug *>( output )->setValue(
+			new MappingData( globals->member<IECore::StringVectorData>( g_renderPassNamesOptionName ), shufflesPlug() )
+		);
+		return;
+	}
+	else if( output == sourceNamePlug() )
+	{
+		auto mapping = boost::static_pointer_cast<const MappingData>( mappingPlug()->getValue() );
+		static_cast<StringPlug *>( output )->setValue(
+			mapping->sourceRenderPassName( context->get<string>( g_renderPassContextName, "" ) )
+		);
+		return;
+	}
+	else if( output == outPlug()->globalsPlug() && enabled( enabledPlug(), context ) )
+	{
+		static_cast<CompoundObjectPlug *>( output )->setValue(
+			computeGlobals( context, outPlug() )
+		);
+		return;
+	}
+
+	ContextProcessor::compute( output, context );
+}
+
+bool ShuffleRenderPasses::affectsContext( const Gaffer::Plug *input ) const
+{
+	return input == sourceNamePlug();
+}
+
+void ShuffleRenderPasses::processContext( Gaffer::Context::EditableScope &context, IECore::ConstRefCountedPtr &storage ) const
+{
+	const auto currentRenderPass = context.context()->get<string>( g_renderPassContextName, "" );
+	if( currentRenderPass != "" )
+	{
+		const auto sourceName = sourceNamePlug()->getValue();
+		if( sourceName != currentRenderPass )
+		{
+			IECore::StringDataPtr nameStorage = new IECore::StringData( sourceName );
+			context.set( g_renderPassContextName, &nameStorage->readable() );
+			storage = std::move( nameStorage );
+		}
+	}
+}
+
+void ShuffleRenderPasses::hashGlobals( const Gaffer::Context *context, const ScenePlug *parent, IECore::MurmurHash &h ) const
+{
+	ComputeNode::hash( outPlug()->globalsPlug(), context, h );
+	ProcessedScope processedScope( context, this );
+	inPlug()->globalsPlug()->hash( h );
+	shufflesPlug()->hash( h );
+}
+
+IECore::ConstCompoundObjectPtr ShuffleRenderPasses::computeGlobals( const Gaffer::Context *context, const ScenePlug *parent ) const
+{
+	ProcessedScope processedScope( context, this );
+	IECore::ConstCompoundObjectPtr inputGlobals = inPlug()->globalsPlug()->getValue();
+	if( shufflesPlug()->children().empty() || inputGlobals->members().empty() || !inputGlobals->members().count( g_renderPassNamesOptionName ) )
+	{
+		return inputGlobals;
+	}
+
+	IECore::CompoundObjectPtr result = new IECore::CompoundObject;
+	result->members() = inputGlobals->members();
+
+	auto mapping = boost::static_pointer_cast<const MappingData>( mappingPlug()->getValue() );
+	result->members()[g_renderPassNamesOptionName] = const_cast<IECore::StringVectorData *>( mapping->outRenderPassNames() );
+
+	return result;
+}

--- a/src/GafferSceneModule/GlobalsBinding.cpp
+++ b/src/GafferSceneModule/GlobalsBinding.cpp
@@ -46,6 +46,7 @@
 #include "GafferScene/RenderPasses.h"
 #include "GafferScene/RenderPassShader.h"
 #include "GafferScene/Set.h"
+#include "GafferScene/ShuffleRenderPasses.h"
 
 #include "GafferBindings/DependencyNodeBinding.h"
 
@@ -126,5 +127,10 @@ void GafferSceneModule::bindGlobals()
 	}
 	DependencyNodeClass<RenderPasses>();
 	DependencyNodeClass<RenderPassShader>();
+	DependencyNodeClass<ShuffleRenderPasses>();
+	// ShuffleRenderPasses is a ContextProcessor that calls `setup()` in its constructor so we register
+	// the standard NodeSerialiser in place of the ContextProcessor's SetupBasedNodeSerialiser to avoid
+	// serialising another `setup()` call.
+	Serialisation::registerSerialiser( ShuffleRenderPasses::staticTypeId(), new NodeSerialiser() );
 
 }

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -370,6 +370,7 @@ nodeMenu.append( "/Scene/Passes/Render Passes", GafferScene.RenderPasses, search
 nodeMenu.append( "/Scene/Passes/Delete Render Passes", GafferScene.DeleteRenderPasses, searchText = "DeleteRenderPasses" )
 nodeMenu.append( "/Scene/Passes/Render Pass Wedge", GafferScene.RenderPassWedge, searchText = "RenderPassWedge" )
 nodeMenu.append( "/Scene/Passes/Render Pass Shader", GafferScene.RenderPassShader, searchText = "RenderPassShader" )
+nodeMenu.append( "/Scene/Passes/Shuffle Render Passes", GafferScene.ShuffleRenderPasses, searchText = "ShuffleRenderPasses" )
 nodeMenu.append( "/Scene/Render/Render", GafferScene.Render )
 nodeMenu.append( "/Scene/Render/Interactive Render", GafferScene.InteractiveRender, searchText = "InteractiveRender" )
 


### PR DESCRIPTION
This adds a ShuffleRenderPasses node allowing procedural renaming and copying of render passes.

Shuffling a render pass updates the contents of the `renderPass:names` option in the scene output by the node, and remaps the value of the `${renderPass}` context variable upstream of the node. This node opens up new workflows where users can create "child" or "derived" render passes that inherit their settings from an upstream render pass, though it likely hastens the need for inspecting the history of a particular render pass and for warnings in the Render Pass Editor if you attempt to edit a shuffled render pass in an edit scope upstream of its originating ShuffleRenderPasses node...