### PR TITLE
Arnold 7.4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
         import sys
         import os
 
-        for arnoldVersion in [ "7.2.1.0", "7.3.1.0" ] :
+        for arnoldVersion in [ "7.2.1.0", "7.3.1.0", "7.4.1.0" ] :
           arnoldRoot = os.path.join( os.environ["GITHUB_WORKSPACE"], "arnoldRoot", arnoldVersion )
           os.environ["ARNOLD_ROOT"] = arnoldRoot
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.8.0)
 =======
 
+Features
+--------
+
+- Arnold : Added support for Arnold 7.4.
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.8.0)
 =======
 
+Improvements
+------------
+
+- ArnoldOptions : Added `reportFileName` option, to specify the destination for Arnold 7.4's new HTML reports.
+
 Fixes
 -----
 

--- a/python/GafferArnoldUI/ArnoldOptionsUI.py
+++ b/python/GafferArnoldUI/ArnoldOptionsUI.py
@@ -206,6 +206,8 @@ def __statisticsSummary( plug ) :
 		info.append( "Stats File: " + plug["statisticsFileName"]["value"].getValue() )
 	if plug["profileFileName"]["enabled"].getValue() :
 		info.append( "Profile File: " + plug["profileFileName"]["value"].getValue() )
+	if plug["reportFileName"]["enabled"].getValue() :
+		info.append( "Report File: " + plug["reportFileName"]["value"].getValue() )
 
 	return ", ".join( info )
 
@@ -1119,6 +1121,19 @@ Gaffer.Metadata.registerNode(
 
 			"layout:section", "Statistics",
 			"label", "Profile File",
+
+		],
+
+		"options.reportFileName" : [
+
+			"description",
+			"""
+			The name of a an HTML file where Arnold will store a
+			detailed statistics report in an easily browsable form.
+			""",
+
+			"layout:section", "Statistics",
+			"label", "HTML Report File",
 
 		],
 

--- a/src/GafferArnold/ArnoldOptions.cpp
+++ b/src/GafferArnold/ArnoldOptions.cpp
@@ -167,6 +167,7 @@ ArnoldOptions::ArnoldOptions( const std::string &name )
 	// Statistics
 	options->addChild( new Gaffer::NameValuePlug( "ai:statisticsFileName", new IECore::StringData( "" ), false, "statisticsFileName" ) );
 	options->addChild( new Gaffer::NameValuePlug( "ai:profileFileName", new IECore::StringData( "" ), false, "profileFileName" ) );
+	options->addChild( new Gaffer::NameValuePlug( "ai:reportFileName", new IECore::StringData( "" ), false, "reportFileName" ) );
 
 	// Licensing
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -3213,6 +3213,7 @@ const IECore::InternedString g_logMaxWarningsOptionName( "ai:log:max_warnings" )
 const IECore::InternedString g_pluginSearchPathOptionName( "ai:plugin_searchpath" );
 const IECore::InternedString g_profileFileNameOptionName( "ai:profileFileName" );
 const IECore::InternedString g_progressiveMinAASamplesOptionName( "ai:progressive_min_AA_samples" );
+const IECore::InternedString g_reportFileNameOptionName( "ai:reportFileName" );
 const IECore::InternedString g_sampleMotionOptionName( "sampleMotion" );
 const IECore::InternedString g_statisticsFileNameOptionName( "ai:statisticsFileName" );
 const IECore::InternedString g_subdivDicingCameraOptionName( "ai:subdiv_dicing_camera" );
@@ -3461,6 +3462,36 @@ class ArnoldGlobals
 
 					AiProfileSetFileName( d->readable().c_str() );
 				}
+				return;
+			}
+			else if( name == g_reportFileNameOptionName )
+			{
+#if ARNOLD_VERSION_NUM >= 70400
+				if( value == nullptr )
+				{
+					AiReportSetFileName( "" );
+				}
+				else if( const IECore::StringData *d = reportedCast<const IECore::StringData>( value, "option", name ) )
+				{
+					if( !d->readable().empty() )
+					{
+						try
+						{
+							std::filesystem::create_directories(
+								std::filesystem::path( d->readable() ).parent_path()
+							);
+						}
+						catch( const std::exception &e )
+						{
+							IECore::msg( IECore::Msg::Error, "ArnoldRenderer::option()", e.what() );
+						}
+					}
+					AiReportSetFileName( d->readable().c_str() );
+
+				}
+#else
+				IECore::msg( IECore::Msg::Error, "ArnoldRenderer::option()", fmt::format( "\"\" requires Arnold 7.4 or later", g_reportFileNameOptionName.string() ) );
+#endif
 				return;
 			}
 			else if( name == g_logMaxWarningsOptionName )


### PR DESCRIPTION
This adds Arnold 7.4.1.0 to our build matrix, and adds control over Arnold's new HTML statistics reporting to the ArnoldOptions node.