### PR TITLE
_gaffer.py : Fix missing RenderMan startup path

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.9.0)
 =======
 
+Fixes
+-----
 
+- RenderMan : Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
 
 1.5.9.0 (relative to 1.5.8.0)
 =======

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -61,6 +61,18 @@ def appendToPath( pathToAppend, envVar ) :
 
 	os.environ[envVar] = os.pathsep.join( path )
 
+def prependToPath( pathToPrepend, envVar ) :
+
+	pathToPrepend = str( pathToPrepend )
+
+	path = os.environ.get( envVar )
+	path = path.split( os.pathsep ) if path else []
+
+	if pathToPrepend not in path :
+		path.insert( 0, pathToPrepend )
+
+	os.environ[envVar] = os.pathsep.join( path )
+
 # RenderMan Setup
 # ===============
 
@@ -105,6 +117,7 @@ def setUpRenderMan() :
 	appendToPath( rmanTree / "lib" / "plugins", "RMAN_RIXPLUGINPATH" )
 	appendToPath( pluginRoot / "plugins", "RMAN_DISPLAYS_PATH" )
 	appendToPath( rmanTree / "lib" / "shaders", "OSL_SHADER_PATHS" )
+	prependToPath( pluginRoot / "startup", "GAFFER_STARTUP_PATHS" )
 
 	if sys.platform == "win32" :
 		appendToPath( rmanTree / "bin", "IECORE_DLL_DIRECTORIES" )


### PR DESCRIPTION
This fixes a regression from #6324 preventing `shaderMetadata.py` from being loaded, and shouldn't be necessary on `main`.