### PR TITLE
PlugAlgo improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,11 @@ Fixes
 
 - RenderMan : Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
 
+API
+---
+
+- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData.
+
 1.5.9.0 (relative to 1.5.8.0)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - Wrapper : Added warning when GafferRenderMan is not available for current RenderMan version.
+- Spreadsheet : A wider range of types are converted when copy/pasting values between cells, such as BoolData to IntData, FloatData to IntData, etc.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,7 @@ Fixes
 API
 ---
 
-- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData.
+- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
 
 1.5.9.0 (relative to 1.5.8.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -19,7 +19,9 @@ Fixes
 API
 ---
 
-- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
+- PlugAlgo :
+  - Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
+  - Added `setValueOrAddKeyFromData()`.
 
 1.5.9.0 (relative to 1.5.8.0)
 =======

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -109,6 +109,11 @@ GAFFER_API bool setValueFromData( const ValuePlug *plug, ValuePlug *leafPlug, co
 /// If value is provided, then return true if it can be set from Data with this type id
 GAFFER_API bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value = nullptr );
 
+/// Sets the value of an existing plug to the specified data. If the plug has existing
+/// animation then a key will be added at `time`.
+/// Returns `true` on success and `false` on failure.
+GAFFER_API bool setValueOrAddKeyFromData( ValuePlug *plug, float time, const IECore::Data *value );
+
 [[deprecated( "Use `getValueAsData()` instead" )]]
 GAFFER_API IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1193,6 +1193,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 			self.assertEqual( plug.getValue(), " ".join( data ) )
 			self.assertEqual( plug.isSetToDefault(), len( data ) == 0 )
 
+	def testSetStringVectorValueFromStringData( self ) :
+
+		plug = Gaffer.StringVectorDataPlug()
+
+		for data in [
+			IECore.StringData( "a b c" ),
+			IECore.StringData( "a" ),
+			IECore.StringData()
+		] :
+
+			self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+			self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+			self.assertEqual( plug.getValue(), IECore.StringVectorData( data.value.split( " " ) ) if data.value != "" else IECore.StringVectorData() )
+			self.assertEqual( plug.isSetToDefault(), data.value == "" )
+
 	def testDependsOnCompute( self ) :
 
 		add = GafferTest.AddNode()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1104,20 +1104,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 				self.assertEqual( plug.getValue(), value )
 				self.assertFalse( plug.isSetToDefault() )
 
-				# Array length 2, can't set
+				# Array length 2, can't set unless setting StringVectorData on StringPlug
 
+				canSetArray = isinstance( data, IECore.StringVectorData ) and plugType == Gaffer.StringPlug
 				data.append( data[0] )
 				plug.setToDefault()
-				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
-				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
-				self.assertTrue( plug.isSetToDefault() )
+				self.assertEqual( Gaffer.PlugAlgo.canSetValueFromData( plug, data ), canSetArray )
+				self.assertEqual( Gaffer.PlugAlgo.setValueFromData( plug, data ), canSetArray )
+				self.assertNotEqual( plug.isSetToDefault(), canSetArray )
 
-				# Array length 0, can't set
+				# Array length 0, can't set unless setting StringVectorData on a StringPlug
 
 				data.resize( 0 )
 				plug.setToDefault()
-				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
-				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertEqual( Gaffer.PlugAlgo.canSetValueFromData( plug, data ), canSetArray )
+				self.assertEqual( Gaffer.PlugAlgo.setValueFromData( plug, data ), canSetArray )
 				self.assertTrue( plug.isSetToDefault() )
 
 	def testSetBoxValueFromVectorData( self ) :
@@ -1176,6 +1177,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 					for componentPlug in childPlug :
 						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
 				self.assertTrue( plug.isSetToDefault() )
+
+	def testSetStringValueFromStringVectorData( self ) :
+
+		plug = Gaffer.StringPlug()
+
+		for data in [
+			IECore.StringVectorData( [ "a", "b", "c" ] ),
+			IECore.StringVectorData( [ "a" ] ),
+			IECore.StringVectorData()
+		] :
+
+			self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+			self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+			self.assertEqual( plug.getValue(), " ".join( data ) )
+			self.assertEqual( plug.isSetToDefault(), len( data ) == 0 )
 
 	def testDependsOnCompute( self ) :
 

--- a/python/GafferUITest/SpreadsheetUITest.py
+++ b/python/GafferUITest/SpreadsheetUITest.py
@@ -706,6 +706,36 @@ class SpreadsheetUITest( GafferUITest.TestCase ) :
 		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), 2.0 )
 		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 2 )
 
+		s["rows"][1]["cells"][0]["value"].setValue( 3.0 )
+
+		data = _ClipboardAlgo.valueMatrix( [ [ row["cells"][0] ] ] )
+		_ClipboardAlgo.pasteCells( data, [ [ row["cells"][1] ] ], 0 )
+
+		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), 3.0 )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 3 )
+
+	def testBoolToIntConversion( self ) :
+
+		s = Gaffer.Spreadsheet()
+		s["rows"].addColumn( Gaffer.BoolPlug( defaultValue = False ) )
+		s["rows"].addColumn( Gaffer.IntPlug( defaultValue = 2 ) )
+		row = s["rows"].addRow()
+
+		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), False )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 2 )
+
+		data = _ClipboardAlgo.valueMatrix( [ [ row["cells"][1] ] ] )
+		_ClipboardAlgo.pasteCells( data, [ [ row["cells"][0] ] ], 0 )
+
+		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), True )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 2 )
+
+		data = _ClipboardAlgo.valueMatrix( [ [ row["cells"][0] ] ] )
+		_ClipboardAlgo.pasteCells( data, [ [ row["cells"][1] ] ], 0 )
+
+		self.assertEqual( s["rows"][1]["cells"][0]["value"].getValue(), True )
+		self.assertEqual( s["rows"][1]["cells"][1]["value"].getValue(), 1 )
+
 	def testStringConversion( self ) :
 
 		s = Gaffer.Spreadsheet()

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -37,6 +37,7 @@
 
 #include "Gaffer/PlugAlgo.h"
 
+#include "Gaffer/Animation.h"
 #include "Gaffer/Box.h"
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/ComputeNode.h"
@@ -1374,6 +1375,62 @@ bool setValueFromData( const ValuePlug *plug, ValuePlug *leafPlug, const IECore:
 
 	return setValueFromData( leafPlug, value );
 
+}
+
+bool setValueOrAddKeyFromData( ValuePlug *plug, float time, const IECore::Data *value )
+{
+	if( Animation::isAnimated( plug ) )
+	{
+		// convert input data to a float value for a keyframe
+		float keyValue = 0.0f;
+		switch( value->typeId() )
+		{
+			case HalfDataTypeId :
+				keyValue = static_cast<const HalfData *>( value )->readable();
+				break;
+			case FloatDataTypeId :
+				keyValue = static_cast<const FloatData *>( value )->readable();
+				break;
+			case DoubleDataTypeId :
+				keyValue = static_cast<const DoubleData *>( value )->readable();
+				break;
+			case CharDataTypeId :
+				keyValue = static_cast<const CharData *>( value )->readable();
+				break;
+			case UCharDataTypeId :
+				keyValue = static_cast<const UCharData *>( value )->readable();
+				break;
+			case ShortDataTypeId :
+				keyValue = static_cast<const ShortData *>( value )->readable();
+				break;
+			case UShortDataTypeId :
+				keyValue = static_cast<const UShortData *>( value )->readable();
+				break;
+			case IntDataTypeId :
+				keyValue = static_cast<const IntData *>( value )->readable();
+				break;
+			case UIntDataTypeId :
+				keyValue = static_cast<const UIntData *>( value )->readable();
+				break;
+			case Int64DataTypeId :
+				keyValue = static_cast<const Int64Data *>( value )->readable();
+				break;
+			case UInt64DataTypeId :
+				keyValue = static_cast<const UInt64Data *>( value )->readable();
+				break;
+			case BoolDataTypeId :
+				keyValue = static_cast<const BoolData *>( value )->readable();
+				break;
+			default :
+				return false;
+		}
+
+		Animation::CurvePlug *curve = Animation::acquire( plug );
+		curve->insertKey( time, keyValue );
+		return true;
+	}
+
+	return setValueFromData( plug, value );
 }
 
 }  // namespace PlugAlgo

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -56,6 +56,7 @@
 #include "IECore/DataAlgo.h"
 #include "IECore/SplineData.h"
 
+#include "boost/algorithm/string/join.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
 
@@ -761,12 +762,8 @@ bool setStringPlugValue( StringPlug *plug, const Data *value )
 			return true;
 		case IECore::StringVectorDataTypeId : {
 			const auto *data = static_cast<const StringVectorData *>( value );
-			if( data->readable().size() == 1 )
-			{
-				plug->setValue( data->readable()[0] );
-				return true;
-			}
-			return false;
+			plug->setValue( boost::algorithm::join( data->readable(), " " ) );
+			return true;
 		}
 		case IECore::InternedStringVectorDataTypeId : {
 			const auto *data = static_cast<const InternedStringVectorData *>( value );
@@ -1047,8 +1044,8 @@ bool canSetStringPlugValue( const Data *value )
 	{
 		case IECore::StringDataTypeId:
 		case IECore::InternedStringDataTypeId:
-			return true;
 		case IECore::StringVectorDataTypeId:
+			return true;
 		case IECore::InternedStringVectorDataTypeId:
 			return IECore::size( value ) == 1;
 		default:

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -129,6 +129,12 @@ bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value )
 	return PlugAlgo::canSetValueFromData( plug, value );
 }
 
+bool setValueOrAddKeyFromData( ValuePlug *plug, float time, const IECore::Data *value )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return PlugAlgo::setValueOrAddKeyFromData( plug, time, value );
+}
+
 PlugPtr promote( Plug &plug, Plug *parent, const IECore::StringAlgo::MatchPattern &excludeMetadata )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -167,6 +173,7 @@ void GafferModule::bindPlugAlgo()
 	def( "setValueFromData", &setLeafValueFromData );
 	def( "setValueFromData", &setValueFromData );
 	def( "canSetValueFromData", &canSetValueFromData, ( arg( "plug" ), arg( "value" ) = object() ) );
+	def( "setValueOrAddKeyFromData", &setValueOrAddKeyFromData );
 
 	def( "canPromote", &PlugAlgo::canPromote, ( arg( "plug" ), arg( "parent" ) = object() ) );
 	def( "promote", &promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ) );


### PR DESCRIPTION
This adds a few small improvements to PlugAlgo, allowing StringVectorData to be set on StringPlugs and vice-versa. This matches the existing automatic conversion when connecting StringVectorDataPlugs and StringPlugs. 

We also add `PlugAlgo::setValueOrAddKeyFromData()` to make it easier to key previously animated plugs. These improvements are initially used to begin simplifying the Spreadsheet's `_ClipboardAlgo` where it was handling such conversions itself, though we could go further and replace the local implementations of `setValueOrAddKey()` in the various Camera/Transform/LightTools.