### PR TITLE
RenderMan _InteractiveDenoiserAdaptor : Fix path to driver

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,7 +14,9 @@ Improvements
 Fixes
 -----
 
-- RenderMan : Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
+- RenderMan :
+  - Fixed interactive denoiser configuration.
+  - Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
 
 1.5.9.0 (relative to 1.5.8.0)
 =======

--- a/python/GafferRenderMan/_InteractiveDenoiserAdaptor.py
+++ b/python/GafferRenderMan/_InteractiveDenoiserAdaptor.py
@@ -94,7 +94,7 @@ class _InteractiveDenoiserAdaptor( GafferScene.SceneProcessor ) :
 
 		if templateOutput.getType() == "ieDisplay" :
 			templateOutput.parameters()["dspyDSOPath"] = IECore.StringData(
-				str( Gaffer.rootPath() / "renderManPlugins" / "d_ieDisplay.so" )
+				str( pathlib.Path( __file__ ).parents[2] / "plugins" / "d_ieDisplay.so" )
 			)
 		else :
 			templateOutput.parameters()["dspyDSOPath"] = IECore.StringData(


### PR DESCRIPTION
This was broken by
29e6bac4b349126498bc0d10056319d394188e09, which switched the install location to a versioned subdirectory.
