### PR TITLE
RendererTest : `testInteractiveNodeParameters` fix

### DIFF
--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -4615,6 +4615,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.render()
 		assertCameraParameter( renderer, "/camera1" )
 
+		renderer.pause()
 		del camera1, plane
 		del renderer
 


### PR DESCRIPTION
This is expected to fix an intermittent test failure of `IECoreArnoldTest.RendererTest.testInteractiveNodeParameters`. It was crashing after a `warning : cannot destroy node "/camera1" while rendering; ignoring call to AiNodeDestroy()`.

I couldn't reproduce it locally, but it might be due to the CI machines being a bit slower and surfacing this crash. We think pausing the renderer before destroying the camera should prevent this.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
