### PR TITLE
RenderManLightFilter : Add node for creating RenderMan light filters

### DIFF
--- a/include/GafferRenderMan/RenderManLightFilter.h
+++ b/include/GafferRenderMan/RenderManLightFilter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,23 +36,26 @@
 
 #pragma once
 
+#include "GafferRenderMan/Export.h"
+#include "GafferRenderMan/TypeIds.h"
+
+#include "GafferScene/LightFilter.h"
+
 namespace GafferRenderMan
 {
 
-enum TypeId
+class GAFFERRENDERMAN_API RenderManLightFilter : public GafferScene::LightFilter
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-	BXDFPlugTypeId = 110409,
-	RenderManLightFilterTypeId = 110410,
-	LastTypeId = 110450
+
+	public :
+
+		GAFFER_NODE_DECLARE_TYPE( GafferRenderMan::RenderManLightFilter, RenderManLightFilterTypeId, GafferScene::LightFilter );
+
+		explicit RenderManLightFilter( const std::string &name=defaultName<RenderManLightFilter>() );
+		~RenderManLightFilter() override;
+
 };
+
+IE_CORE_DECLAREPTR( RenderManLightFilter )
 
 } // namespace GafferRenderMan

--- a/python/GafferRenderManTest/RenderManLightFilterTest.py
+++ b/python/GafferRenderManTest/RenderManLightFilterTest.py
@@ -1,0 +1,91 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECoreScene
+
+import Gaffer
+import GafferSceneTest
+import GafferRenderMan
+
+class RenderManLightFilterTest( GafferSceneTest.SceneTestCase ) :
+
+	def testLoadShader( self ) :
+
+		lightFilter = GafferRenderMan.RenderManLightFilter()
+		lightFilter.loadShader( "PxrBarnLightFilter" )
+
+		for name, value in {
+			"width" : 1.0,
+			"height" : 1.0,
+			"radius" : 0.5,
+			"density" : 1.0,
+		}.items() :
+
+			self.assertIn( name, lightFilter["parameters"] )
+			self.assertEqual( lightFilter["parameters"][name].getValue(), value )
+			self.assertEqual( lightFilter["parameters"][name].defaultValue(), value )
+
+	def testAttributes( self ) :
+
+		lightFilter = GafferRenderMan.RenderManLightFilter()
+		lightFilter.loadShader( "PxrBarnLightFilter" )
+
+		attributes = lightFilter["out"].attributes( "/lightFilter" )
+		self.assertEqual( attributes.keys(), [ "ri:lightFilter" ] )
+		network = attributes["ri:lightFilter"]
+		self.assertIsInstance( network, IECoreScene.ShaderNetwork )
+		self.assertEqual( len( network.shaders() ), 1 )
+		shader = network.outputShader()
+		self.assertEqual( shader.name, "PxrBarnLightFilter" )
+		self.assertEqual( shader.parameters["width"].value, 1.0 )
+
+	def testSerialisation( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["lightFilter"] = GafferRenderMan.RenderManLightFilter()
+		script["lightFilter"].loadShader( "PxrCookieLightFilter" )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+
+		self.assertEqual( script2["lightFilter"]["parameters"].keys(), script2["lightFilter"]["parameters"].keys() )
+
+		for plug in script2["lightFilter"]['parameters'].values():
+			relativeName = plug.relativeName( script2["lightFilter"] )
+			self.assertEqual( plug.getValue(), script["lightFilter"].descendant( relativeName ).getValue() )
+
+		self.assertEqual( script2["lightFilter"]["out"].attributes( "/lightFilter" ), script["lightFilter"]["out"].attributes( "/lightFilter" ) )

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -46,6 +46,7 @@ from .RenderManSampleFilterTest import RenderManSampleFilterTest
 from .RenderManRenderTest import RenderManRenderTest
 from .InteractiveRenderManRenderTest import InteractiveRenderManRenderTest
 from .RenderPassAdaptorTest import RenderPassAdaptorTest
+from .RenderManLightFilterTest import RenderManLightFilterTest
 
 if __name__ == "__main__":
 	import unittest

--- a/src/GafferRenderMan/RenderManLightFilter.cpp
+++ b/src/GafferRenderMan/RenderManLightFilter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -34,25 +34,21 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "GafferRenderMan/RenderManLightFilter.h"
 
-namespace GafferRenderMan
+#include "GafferRenderMan/RenderManShader.h"
+
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferRenderMan;
+
+GAFFER_NODE_DEFINE_TYPE( RenderManLightFilter );
+
+RenderManLightFilter::RenderManLightFilter( const std::string &name )
+	:	GafferScene::LightFilter( new RenderManShader(), name )
 {
+}
 
-enum TypeId
+RenderManLightFilter::~RenderManLightFilter()
 {
-	RenderManAttributesTypeId = 110400,
-	RenderManOptionsTypeId = 110401,
-	RenderManShaderTypeId = 110402,
-	RenderManLightTypeId = 110403,
-	RenderManMeshLightTypeId = 110404,
-	RenderManIntegratorTypeId = 110405,
-	RenderManOutputFilterTypeId = 110406,
-	RenderManDisplayFilterTypeId = 110407,
-	RenderManSampleFilterTypeId = 110408,
-	BXDFPlugTypeId = 110409,
-	RenderManLightFilterTypeId = 110410,
-	LastTypeId = 110450
-};
-
-} // namespace GafferRenderMan
+}

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -510,6 +510,10 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 	{
 		shaderType = "surface";
 	}
+	else if( shaderType == "lightfilter" )
+	{
+		shaderType = "lightFilter";
+	}
 
 	typePlug()->source<StringPlug>()->setValue( "ri:" + shaderType );
 

--- a/src/GafferRenderManModule/GafferRenderManModule.cpp
+++ b/src/GafferRenderManModule/GafferRenderManModule.cpp
@@ -41,6 +41,7 @@
 #include "GafferRenderMan/RenderManDisplayFilter.h"
 #include "GafferRenderMan/RenderManIntegrator.h"
 #include "GafferRenderMan/RenderManLight.h"
+#include "GafferRenderMan/RenderManLightFilter.h"
 #include "GafferRenderMan/RenderManMeshLight.h"
 #include "GafferRenderMan/RenderManOptions.h"
 #include "GafferRenderMan/RenderManSampleFilter.h"
@@ -80,6 +81,7 @@ BOOST_PYTHON_MODULE( _GafferRenderMan )
 	GafferBindings::DependencyNodeClass<RenderManLight>()
 		.def( "loadShader", &loadShader )
 	;
+	GafferBindings::DependencyNodeClass<RenderManLightFilter>();
 	GafferBindings::DependencyNodeClass<RenderManAttributes>();
 	GafferBindings::DependencyNodeClass<RenderManOptions>();
 	GafferBindings::DependencyNodeClass<RenderManShader>();

--- a/src/GafferScene/LightFilter.cpp
+++ b/src/GafferScene/LightFilter.cpp
@@ -82,7 +82,14 @@ void LightFilter::loadShader( const std::string &shaderName, bool keepExistingVa
 {
 	shaderNode()->loadShader( shaderName, keepExistingValues );
 	shaderPlug()->setInput( shaderNode()->outPlug() );
-	shaderNode()->attributeSuffixPlug()->setValue( "filter" );
+	/// \todo We don't really want an attribute suffix for _any_ light filters,
+	/// but historically we had one, so for now we are preserving that behaviour
+	/// for all but the new RenderManLightFilter. We should remove the suffix
+	/// and update the Arnold backend to use `ai:lightFilter` attributes directly.
+	if( strcmp( typeName(), "GafferRenderMan::RenderManLightFilter" ) )
+	{
+		shaderNode()->attributeSuffixPlug()->setValue( "filter" );
+	}
 }
 
 GafferScene::Shader *LightFilter::shaderNode()


### PR DESCRIPTION
This is the smallest part of the puzzle when it comes to adding support for RenderMan light filters. I'm making a separate PR for it in the hope that it allows @ericmehl to open a PR with his visualisers earlier, so it can be reviewed in parallel with my continuing work on the backend. Eric, note that I tweaked the attribute name, so you'll need to update the visualisers to be registered against `ri:lightFilter` rather than the messy `ri:lightfilter:filter` we had before.