### PR TITLE
VisualiserTool : Handle `ScenePlug` exceptions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 - RenderManShader : Fixed handling of minimum and maximum values for `color`, `vector`, `normal` and `point` parameters.
 - FreezeTransform : Fixed double transforming when the input primitive contains multiple primitive variables sharing the same data.
 - 3Delight : Fixed rendering of `dlToon` outlines for `Beauty` and `Outlines` outputs.
+- VisualiserTool : Fixed broken OpenGL viewer when an error occurs on an upstream node when visualisation is active.
 
 1.5.10.1 (relative to 1.5.10.0)
 ========


### PR DESCRIPTION
This fixes a bug caused by the VisualiserTool where it would break the OpenGL viewer if the tool was active and the node being viewed, or one upstream of it, throws an exception. It's common in the Visualiser to query `ScenePlug` children after setting various GL state, and an exception would cause us to miss out on all the GL cleanup.

As noted in a comment in the code, it would be better to do this with `IECoreGL::State` and its buddies, but we're using a few things that can't do right now, so the try / catch blocks are a decent solution for the time being.

I'm not sure if we really need the try / catch around the `existsPlug()->getValue()`, maybe that's overkill?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
