### PR TITLE
RenderPassesUI : Fix custom widget registrations

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -20,6 +20,7 @@ Fixes
   - Fixed interactive denoiser configuration.
   - Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
 - RenderManLight : Added plug to control the camera visibility of the light. This defaults on to match the RenderMan defaults, but can be configured to default off with `Gaffer.Metadata.registerValue( GafferRenderMan.RenderManLight, "attributes.ri:visibility:camera.value", "userDefault", 0 )`.
+- RenderPasses : Fixed custom widget registration via `GafferSceneUI.RenderPassesUI.registerRenderPassNameWidget()`.
 
 API
 ---

--- a/python/GafferSceneUI/RenderPassesUI.py
+++ b/python/GafferSceneUI/RenderPassesUI.py
@@ -141,6 +141,7 @@ __renderPassNameWidget = _RenderPassNameWidget
 ## be emitted to inform observers of changes to, or the choice of render pass name.
 def registerRenderPassNameWidget( w ) :
 
+	global __renderPassNameWidget
 	__renderPassNameWidget = w
 
 def createRenderPassNameWidget() :


### PR DESCRIPTION
We were assigning to a local variable in `registerRenderPassNameWidget()`, instead of the global variable which is used by `createRenderPassNameWidget()`.
