### PR TITLE
CI : Fix error in release validation

### DIFF
--- a/config/validateRelease.py
+++ b/config/validateRelease.py
@@ -62,7 +62,8 @@ parser.add_argument(
 	"--skipPaths",
 	nargs = '+',
 	default = [],
-	help = "A list of paths to skip the checks for."
+	help = "A list of paths to skip the checks for.",
+	action = "extend",
 )
 
 args = parser.parse_args()


### PR DESCRIPTION
I broke this in af40ec4ae0da84ec6530a60e1e47851f523a2840, resulting in this error for PRs made from forks :

```
Validation failed
Error: ERROR: arnold is missing from the archive
```

We are passing `--skipPaths arnold --skipPaths renderMan` in this case, so need to accumulate the arguments rather than let the second one clobber the first.
