### PR TITLE
NodeReference : Include versioned GafferRenderMan module

### DIFF
--- a/.github/workflows/main/sconsOptions
+++ b/.github/workflows/main/sconsOptions
@@ -39,7 +39,7 @@ import sys
 import glob
 import subprocess
 
-ENV_VARS_TO_IMPORT = "PATH"
+ENV_VARS_TO_IMPORT = "PATH GAFFERRENDERMAN_FEATURE_PREVIEW"
 
 BUILD_CACHEDIR = os.environ["GAFFER_CACHE_DIR"]
 

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,11 @@ API
 
 - Light : Added `attributes` plug.
 
+Documentation
+-------------
+
+- RenderMan : Added GafferRenderMan to the node reference section.
+
 1.5.9.0 (relative to 1.5.8.0)
 =======
 

--- a/doc/source/Reference/NodeReference/generate.py
+++ b/doc/source/Reference/NodeReference/generate.py
@@ -4,14 +4,25 @@
 import Gaffer
 import GafferUI
 
+modules = []
+
 # GafferArnold isn't installed under the standard module path
 # (so we can support multiple Arnold versions) so we must
 # specify it explicitly.
 try :
 	import GafferArnold
 	import GafferArnoldUI
-	modules = [ GafferArnold ]
+	modules.append( GafferArnold )
 except ImportError :
-	modules = []
+	pass
+
+# GafferRenderMan isn't installed under the standard module path
+# so we must specify it explicitly.
+try :
+	import GafferRenderMan
+	import GafferRenderManUI
+	modules.append( GafferRenderMan )
+except ImportError :
+	pass
 
 GafferUI.DocumentationAlgo.exportNodeReference( "./", modules = modules, modulePath = "$GAFFER_ROOT/python" )

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -80,6 +80,9 @@ def exportNodeReference( directory, modules = [], modulePath = "" ) :
 			except :
 				continue
 
+			if name.startswith( "_" ) :
+				continue
+
 			if not node.__module__.startswith( module.__name__ + "." ) :
 				# Skip nodes which look like they've been injected from
 				# another module by one of the compatibility config files.


### PR DESCRIPTION
With GafferRenderMan moved to being installed under versioned subdirectories, we need to explicitly include it in the node reference.
