### PR TITLE
RenderMan light filter visualisers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1453,6 +1453,9 @@ libraries = {
 	},
 
 	"GafferRenderManUI" : {
+		"envAppends" : {
+			"LIBS" : [ "GafferScene" ],
+		},
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 		"installRoot" : renderManInstallRoot,
 	},

--- a/SConstruct
+++ b/SConstruct
@@ -1454,7 +1454,7 @@ libraries = {
 
 	"GafferRenderManUI" : {
 		"envAppends" : {
-			"LIBS" : [ "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX",],
+			"LIBS" : [ "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "OpenImageIO$OIIO_LIB_SUFFIX", "OpenImageIO_Util$OIIO_LIB_SUFFIX", ],
 		},
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 		"installRoot" : renderManInstallRoot,

--- a/SConstruct
+++ b/SConstruct
@@ -1454,7 +1454,7 @@ libraries = {
 
 	"GafferRenderManUI" : {
 		"envAppends" : {
-			"LIBS" : [ "GafferScene" ],
+			"LIBS" : [ "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX",],
 		},
 		"requiredOptions" : [ "RENDERMAN_ROOT" ],
 		"installRoot" : renderManInstallRoot,

--- a/python/GafferArnoldUI/ArnoldLightFilterUI.py
+++ b/python/GafferArnoldUI/ArnoldLightFilterUI.py
@@ -37,14 +37,6 @@
 import Gaffer
 import GafferArnold
 
-def __parameterUserDefault( plug ) :
-
-	lightFilter = plug.node()
-	return Gaffer.Metadata.value(
-		"ai:lightFilter:filter:light_blocker" + ":" + plug.relativeName( lightFilter["parameters"] ),
-		"userDefault"
-	)
-
 
 Gaffer.Metadata.registerNode(
 
@@ -59,12 +51,6 @@ Gaffer.Metadata.registerNode(
 	""",
 
 	plugs = {
-
-		"parameters..." : [
-
-			"userDefault", __parameterUserDefault,
-
-		],
 
 		# Parameters specific to Arnold's "light_blocker" shader
 

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -34,6 +34,21 @@
 #
 ##########################################################################
 
+import ctypes
+import platform
+
+# There is no `GafferRenderManUI` Python module, so we load the root module
+# manually in order to register the light filter visualisers.
+
+prefix, suffix = {
+	"Darwin" : ( "lib", ".dylib" ),
+	"Windows" : ( "", ".dll" ),
+}.get( platform.system(), ( "lib", ".so" ) )
+
+ctypes.CDLL( f"{prefix}GafferRenderManUI{suffix}" )
+
+del ctypes, platform
+
 __import__( "GafferSceneUI" )
 
 from . import RenderManAttributesUI

--- a/python/GafferSceneUI/LightFilterUI.py
+++ b/python/GafferSceneUI/LightFilterUI.py
@@ -41,6 +41,30 @@ import GafferUI
 
 import GafferScene
 
+def __parameterUserDefault( plug ) :
+
+	lightFilter = plug.node()
+	result = Gaffer.Metadata.value(
+		"{}:{}:{}".format(
+			lightFilter["__shader"]["type"].getValue(),
+			lightFilter["__shader"]["name"].getValue(),
+			plug.relativeName( lightFilter["parameters"] )
+		),
+		"userDefault"
+	)
+	if result is None :
+		# \todo Remove this fallback when the `filter` suffix is removed
+		# from `GafferScene::LightFilter` internal shader.
+		result = Gaffer.Metadata.value(
+			"{}:filter:{}:{}".format(
+				lightFilter["__shader"]["type"].getValue(),
+				lightFilter["__shader"]["name"].getValue(),
+				plug.relativeName( lightFilter["parameters"] )
+			),
+			"userDefault"
+		)
+	return result
+
 Gaffer.Metadata.registerNode(
 
 	GafferScene.LightFilter,
@@ -101,6 +125,12 @@ Gaffer.Metadata.registerNode(
 			# individually.
 			"noduleLayout:section", "left",
 			"nodule:type", "",
+
+		],
+
+		"parameters..." : [
+
+			"userDefault", __parameterUserDefault,
 
 		],
 

--- a/src/GafferRenderManUI/BarnVisualiser.cpp
+++ b/src/GafferRenderManUI/BarnVisualiser.cpp
@@ -1,0 +1,82 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
+
+using namespace Imath;
+using namespace IECoreGLPreview;
+using namespace IECoreScene;
+using namespace IECore;
+using namespace IECoreGL;
+
+namespace
+{
+
+class BarnVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( BarnVisualiser )
+
+		BarnVisualiser();
+		~BarnVisualiser() override;
+
+		Visualisations visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<BarnVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( BarnVisualiser )
+
+// Register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<BarnVisualiser> BarnVisualiser::g_visualiserDescription( "ri:lightFilter", "PxrBarnLightFilter" );
+
+BarnVisualiser::BarnVisualiser()
+{
+}
+
+BarnVisualiser::~BarnVisualiser()
+{
+}
+
+Visualisations BarnVisualiser::visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+{
+	return {};
+}
+
+}  // namespace

--- a/src/GafferRenderManUI/CookieVisualiser.cpp
+++ b/src/GafferRenderManUI/CookieVisualiser.cpp
@@ -73,13 +73,20 @@ const char *texturedFragSource()
 		"#define in varying\n"
 		"#endif\n"
 		""
+		"#include \"IECoreGL/ColorAlgo.h\"\n"
+		""
 		"in vec2 fragmentuv;"
 		""
 		"uniform sampler2D texture;"
+		"uniform vec3 tint;"
+		"uniform float saturation;"
 		""
 		"void main()"
 		"{"
-			"gl_FragColor = texture2D( texture, fragmentuv );"
+			"vec3 c = texture2D( texture, fragmentuv ).xyz;"
+			"c = ieAdjustSaturation( c, saturation );"
+			"c *= tint;"
+			"gl_FragColor = vec4( c, 1.0 );"
 		"}"
 	;
 }
@@ -170,6 +177,13 @@ Visualisations CookieVisualiser::visualise( const InternedString &attributeName,
 			const IntData *maxTextureResolutionData = attributes->member<IntData>( "gl:visualiser:maxTextureResolution" );
 			const int resolution = maxTextureResolutionData ? maxTextureResolutionData->readable() : 512;
 			shaderParameters->members()["texture:maxResolution"] = new IntData( resolution );
+
+			shaderParameters->members()["tint"] = new Color3fData(
+				parameterOrDefault( filterParameters, "tint", Color3f( 1.f ) )
+			);
+			shaderParameters->members()["saturation"] = new FloatData(
+				parameterOrDefault( filterParameters, "saturation", 1.f )
+			);
 
 			result->getState()->add(
 				new IECoreGL::ShaderStateComponent(

--- a/src/GafferRenderManUI/CookieVisualiser.cpp
+++ b/src/GafferRenderManUI/CookieVisualiser.cpp
@@ -1,0 +1,199 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "LightFilterVisualiserAlgo.h"
+
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
+
+#include "IECoreGL/CurvesPrimitive.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/QuadPrimitive.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/TextureLoader.h"
+
+using namespace Imath;
+using namespace IECoreGLPreview;
+using namespace IECoreScene;
+using namespace IECore;
+using namespace IECoreGL;
+
+namespace
+{
+
+/// \todo We have similar methods in several places. Can we consolidate them all somewhere? Perhaps a new
+/// method of CompoundData?
+template<typename T>
+T parameterOrDefault( const IECore::CompoundData *parameters, const IECore::InternedString &name, const T &defaultValue )
+{
+	if( const auto d = parameters->member<TypedData<T>>( name ) )
+	{
+		return d->readable();
+	}
+
+	return defaultValue;
+}
+
+const char *texturedFragSource()
+{
+	return
+		"#if __VERSION__ <= 120\n"
+		"#define in varying\n"
+		"#endif\n"
+		""
+		"in vec2 fragmentuv;"
+		""
+		"uniform sampler2D texture;"
+		""
+		"void main()"
+		"{"
+			"gl_FragColor = texture2D( texture, fragmentuv );"
+		"}"
+	;
+}
+
+void addWireframeCurveState( IECoreGL::Group *group )
+{
+	group->getState()->add( new IECoreGL::Primitive::DrawWireframe( false ) );
+	group->getState()->add( new IECoreGL::Primitive::DrawSolid( true ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+	group->getState()->add( new IECoreGL::LineSmoothingStateComponent( true ) );
+}
+
+class CookieVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( CookieVisualiser )
+
+		CookieVisualiser();
+		~CookieVisualiser() override;
+
+		Visualisations visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<CookieVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( CookieVisualiser )
+
+// Register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<CookieVisualiser> CookieVisualiser::g_visualiserDescription( "ri:lightFilter", "PxrCookieLightFilter" );
+
+CookieVisualiser::CookieVisualiser()
+{
+}
+
+CookieVisualiser::~CookieVisualiser()
+{
+}
+
+Visualisations CookieVisualiser::visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+{
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	const StringData *visualiserDrawingModeData = attributes->member<StringData>( "gl:light:drawingMode" );
+	const std::string visualiserDrawingMode = visualiserDrawingModeData ? visualiserDrawingModeData->readable() : "texture";
+
+	const CompoundData *filterParameters = filterShaderNetwork->outputShader()->parametersData();
+
+	CompoundObjectPtr shaderParameters = new CompoundObject();
+
+	const V2f size( parameterOrDefault( filterParameters, "width", 1.f ), parameterOrDefault( filterParameters, "height", 1.f ) );
+
+	if( visualiserDrawingMode != "wireframe" )
+	{
+		IECoreGL::PrimitivePtr quadPrimitive = new IECoreGL::QuadPrimitive( size.x, size.y );
+
+		const std::string map = parameterOrDefault( filterParameters, "map", std::string() );
+
+		if( map.empty() || visualiserDrawingMode == "color" )
+		{
+			result->getState()->add(
+				new IECoreGL::ShaderStateComponent(
+					ShaderLoader::defaultShaderLoader(),
+					TextureLoader::defaultTextureLoader(),
+					"",
+					"",
+					IECoreGL::Shader::constantFragmentSource(),
+					shaderParameters
+				)
+			);
+			quadPrimitive->addPrimitiveVariable(
+				"Cs",
+				PrimitiveVariable(
+					IECoreScene::PrimitiveVariable::Interpolation::Constant,
+					new Color3fData( map.empty() ? Color3f( 0.f ) : Color3f( 1.f ) )
+				)
+			);
+		}
+		else
+		{
+			shaderParameters->members()["texture"] = new StringData( map );
+
+			const IntData *maxTextureResolutionData = attributes->member<IntData>( "gl:visualiser:maxTextureResolution" );
+			const int resolution = maxTextureResolutionData ? maxTextureResolutionData->readable() : 512;
+			shaderParameters->members()["texture:maxResolution"] = new IntData( resolution );
+
+			result->getState()->add(
+				new IECoreGL::ShaderStateComponent(
+					ShaderLoader::defaultShaderLoader(),
+					TextureLoader::defaultTextureLoader(),
+					"",
+					"",
+					texturedFragSource(),
+					shaderParameters
+				)
+			);
+		}
+
+		result->addChild(quadPrimitive );
+	}
+
+	IECoreGL::GroupPtr outlineResult = new IECoreGL::Group();
+	addWireframeCurveState( outlineResult.get() );
+	outlineResult->addChild( GafferRenderManUI::lightFilterRectangles( size, 0, V2f( 1.f ), V4f( 0.f ), V4f( 0.f ), 0.f ) );
+
+	return {
+		Visualisation::createGeometry( result, IECoreGLPreview::Visualisation::ColorSpace::Scene ),
+		Visualisation::createGeometry( outlineResult )
+	};
+}
+
+}  // namespace

--- a/src/GafferRenderManUI/LightFilterVisualiserAlgo.cpp
+++ b/src/GafferRenderManUI/LightFilterVisualiserAlgo.cpp
@@ -1,0 +1,161 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "LightFilterVisualiserAlgo.h"
+
+#include "IECoreGL/CurvesPrimitive.h"
+#include "IECoreGL/Group.h"
+
+#include "IECoreScene/PrimitiveVariable.h"
+
+#include "IECore/SimpleTypedData.h"
+#include "IECore/VectorTypedData.h"
+
+#include <array>
+
+using namespace Imath;
+using namespace IECore;
+
+namespace
+{
+
+void addRect(
+	const V2f &innerSize,
+	const V2f &innerScale,
+	const V4f &innerOffset,  // Convenient way to pass top, left, bottom, right, in that order
+	const float radius,
+	const float falloffWidth,
+	const V4f &falloffScale,  // Same order as above
+	std::vector<int> &vertsPerCurve,
+	std::vector<V3f> &p
+)
+{
+	const V3f halfSize( innerSize.x * 0.5f, innerSize.y * 0.5f, 0.f );
+	const V3f scale( innerScale.x, innerScale.y, 0.f );
+
+	if( radius == 0 && falloffWidth == 0.f )
+	{
+		const V3f halfSizeScaled = halfSize * scale;
+		vertsPerCurve.push_back( 4 );
+		p.push_back( V3f( -halfSizeScaled.x - innerOffset[1] * innerScale.x, -halfSizeScaled.y - innerOffset[2] * innerScale.y, 0.f ) );
+		p.push_back( V3f( halfSizeScaled.x + innerOffset[3] * innerScale.x, -halfSizeScaled.y - innerOffset[2] * innerScale.y, 0.f ) );
+		p.push_back( V3f( halfSizeScaled.x + innerOffset[3] * innerScale.x, halfSizeScaled.y + innerOffset[0] * innerScale.y, 0.f ) );
+		p.push_back( V3f( -halfSizeScaled.x - innerOffset[1] * innerScale.x, halfSizeScaled.y + innerOffset[0] * innerScale.y, 0.f ) );
+
+		return;
+	}
+
+	const int numDivisions = 100;
+	vertsPerCurve.push_back( numDivisions + 4 );
+
+	for(
+		const auto &[startIndex, quadrantMult, quadrantOffset, falloffMult] : std::array<std::tuple<int, V3f, V3f, V3f>, 4> {
+			std::tuple<int, V3f, V3f, V3f>{
+				0,
+				V3f( 1.f, 1.f, 0.f ),
+				V3f( innerOffset[3], innerOffset[0], 0.f ),
+				V3f( falloffScale[3], falloffScale[0], 0.f )
+			},  // Top-right
+			std::tuple<int, V3f, V3f, V3f>{
+				numDivisions / 4,
+				V3f( -1.f, 1.f, 0.f ),
+				V3f( -innerOffset[1], innerOffset[0], 0.f ),
+				V3f( falloffScale[1], falloffScale[0], 0.f )
+			},  // Top-left
+			std::tuple<int, V3f, V3f, V3f>{
+				numDivisions / 2,
+				V3f( -1.f, -1.f, 0.f ),
+				V3f( -innerOffset[1], -innerOffset[2], 0.f ),
+				V3f( falloffScale[1], falloffScale[2], 0.f )
+			},  // Bottom-left
+			std::tuple<int, V3f, V3f, V3f>{
+				( numDivisions * 3 ) / 4,
+				V3f( 1.f, -1.f, 0.f ),
+				V3f( innerOffset[3], -innerOffset[2], 0.f ),
+				V3f( falloffScale[3], falloffScale[2], 0.f )
+			}  // Bottom-right
+		}
+	)
+	{
+		for( int i = startIndex, eI = startIndex + ( numDivisions / 4 ); i <= eI; ++i )
+		{
+			const float angle = 2.f * M_PI * (float)i / (float)numDivisions;
+			const V3f delta( cos( angle ), sin( angle ), 0.f );
+			p.push_back( ( delta * radius + ( halfSize * quadrantMult ) + quadrantOffset ) * scale + ( delta * falloffWidth * falloffMult ) );
+		}
+	}
+}
+
+}  // namespace
+
+IECoreGL::GroupPtr GafferRenderManUI::lightFilterRectangles( const V2f &innerSize, const float radius, const V2f &innerScale, const V4f &innerOffset, const V4f &falloffScale, const float edge )
+{
+	IntVectorDataPtr innerVertsPerCurveData = new IntVectorData();
+	V3fVectorDataPtr innerPData = new V3fVectorData();
+
+	std::vector<int> &innerVertsPerCurve = innerVertsPerCurveData->writable();
+	std::vector<V3f> &innerP = innerPData->writable();
+
+	addRect( innerSize, innerScale, innerOffset, radius, 0.f, V4f( 0.f ), innerVertsPerCurve, innerP );
+
+	IECoreGL::CurvesPrimitivePtr rect = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), /* periodic */ true, innerVertsPerCurveData );
+	rect->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, innerPData ) );
+	rect->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( Color3f( 255.f / 255.f, 171.f / 255.f, 15.f / 255.f ) ) ) );
+
+	IECoreGL::GroupPtr group = new IECoreGL::Group();
+	group->addChild( rect );
+
+	if( edge > 0 )
+	{
+		IECoreGL::GroupPtr edgeGroup = new IECoreGL::Group();
+		edgeGroup->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 1.0f ) );
+
+		IntVectorDataPtr edgeVertsPerCurveData = new IntVectorData();
+		V3fVectorDataPtr edgePData = new V3fVectorData();
+
+		std::vector<int> &edgeVertsPerCurve = edgeVertsPerCurveData->writable();
+		std::vector<V3f> &edgeP = edgePData->writable();
+
+		addRect( innerSize, innerScale, innerOffset, radius, edge, falloffScale, edgeVertsPerCurve, edgeP );
+
+		IECoreGL::CurvesPrimitivePtr edgeRect = new IECoreGL::CurvesPrimitive( IECore::CubicBasisf::linear(), /* periodic */ true, edgeVertsPerCurveData );
+		edgeRect->addPrimitiveVariable( "P", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, edgePData ) );
+		edgeRect->addPrimitiveVariable( "Cs", IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, new Color3fData( Color3f( 0.f ) ) ) );
+
+		edgeGroup->addChild( edgeRect );
+		group->addChild( edgeGroup );
+	}
+
+	return group;
+}

--- a/src/GafferRenderManUI/LightFilterVisualiserAlgo.h
+++ b/src/GafferRenderManUI/LightFilterVisualiserAlgo.h
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreGL/Group.h"
+
+#include "Imath/ImathVec.h"
+
+namespace GafferRenderManUI
+{
+
+IECoreGL::GroupPtr lightFilterRectangles( const Imath::V2f &innerSize, const float radius, const Imath::V2f &innerScale, const Imath::V4f &innerOffset, const Imath::V4f &falloffScale, const float edge );
+
+}  // namespace GafferRenderManUI

--- a/src/GafferRenderManUI/RodVisualiser.cpp
+++ b/src/GafferRenderManUI/RodVisualiser.cpp
@@ -1,0 +1,200 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Cinesite VFX Ltd. nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/Private/IECoreGLPreview/LightFilterVisualiser.h"
+
+#include "LightFilterVisualiserAlgo.h"
+
+#include "IECoreGL/CurvesPrimitive.h"
+#include "IECoreGL/Group.h"
+#include "IECoreGL/Primitive.h"
+#include "IECoreGL/ShaderLoader.h"
+#include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/TextureLoader.h"
+
+using namespace Imath;
+using namespace IECoreGLPreview;
+using namespace IECoreScene;
+using namespace IECore;
+using namespace IECoreGL;
+
+namespace
+{
+
+/// \todo We have similar methods in several places. Can we consolidate them all somewhere? Perhaps a new
+/// method of CompoundData?
+template<typename T>
+T parameterOrDefault( const IECore::CompoundData *parameters, const IECore::InternedString &name, const T &defaultValue )
+{
+	if( const auto d = parameters->member<TypedData<T>>( name ) )
+	{
+		return d->readable();
+	}
+
+	return defaultValue;
+}
+
+void addWireframeCurveState( IECoreGL::Group *group )
+{
+	group->getState()->add( new IECoreGL::Primitive::DrawWireframe( false ) );
+	group->getState()->add( new IECoreGL::Primitive::DrawSolid( true ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::UseGLLines( true ) );
+	group->getState()->add( new IECoreGL::CurvesPrimitive::GLLineWidth( 2.0f ) );
+	group->getState()->add( new IECoreGL::LineSmoothingStateComponent( true ) );
+}
+
+class RodVisualiser final : public LightFilterVisualiser
+{
+
+	public :
+
+		IE_CORE_DECLAREMEMBERPTR( RodVisualiser )
+
+		RodVisualiser();
+		~RodVisualiser() override;
+
+		Visualisations visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const override;
+
+	protected :
+
+		static LightFilterVisualiser::LightFilterVisualiserDescription<RodVisualiser> g_visualiserDescription;
+
+};
+
+IE_CORE_DECLAREPTR( RodVisualiser )
+
+// Register the new visualiser
+LightFilterVisualiser::LightFilterVisualiserDescription<RodVisualiser> RodVisualiser::g_visualiserDescription( "ri:lightFilter", "PxrRodLightFilter" );
+
+RodVisualiser::RodVisualiser()
+{
+}
+
+RodVisualiser::~RodVisualiser()
+{
+}
+
+Visualisations RodVisualiser::visualise( const InternedString &attributeName, const ShaderNetwork *filterShaderNetwork, const ShaderNetwork *lightShaderNetwork, const CompoundObject *attributes, IECoreGL::ConstStatePtr &state ) const
+{
+	const CompoundData *filterParameters = filterShaderNetwork->outputShader()->parametersData();
+
+	IECoreGL::GroupPtr result = new IECoreGL::Group();
+
+	addWireframeCurveState( result.get() );
+
+	CompoundObjectPtr parameters = new CompoundObject();
+	result->getState()->add(
+		new IECoreGL::ShaderStateComponent( ShaderLoader::defaultShaderLoader(), TextureLoader::defaultTextureLoader(), "", "", IECoreGL::Shader::constantFragmentSource(), parameters )
+	);
+
+	for(
+		const auto &[innerSize, radius, innerScale, innerOffset, falloffScale, edge, transform] : std::vector<std::tuple<V2f, float, V2f, V4f, V4f, float, M44f>> {
+			{
+				V2f( parameterOrDefault( filterParameters, "width", 1.f ) * 2.f, parameterOrDefault( filterParameters, "height", 1.f ) * 2.f ),
+				parameterOrDefault( filterParameters, "radius", 0.f ),
+				V2f(
+					parameterOrDefault( filterParameters, "scaleWidth", 1.f ),
+					parameterOrDefault( filterParameters, "scaleHeight", 1.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "top", 0.f ),
+					parameterOrDefault( filterParameters, "left", 0.f ),
+					parameterOrDefault( filterParameters, "bottom", 0.f ),
+					parameterOrDefault( filterParameters, "right", 0.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "topEdge", 1.f ),
+					parameterOrDefault( filterParameters, "leftEdge", 1.f ),
+					parameterOrDefault( filterParameters, "bottomEdge", 1.f ),
+					parameterOrDefault( filterParameters, "rightEdge", 1.f )
+				),
+				parameterOrDefault( filterParameters, "edge", 0.f ),
+				M44f()
+			},
+			{
+				V2f( parameterOrDefault( filterParameters, "width", 1.f ) * 2.f, parameterOrDefault( filterParameters, "depth", 1.f ) * 2.f ),
+				parameterOrDefault( filterParameters, "radius", 0.f ),
+				V2f(
+					parameterOrDefault( filterParameters, "scaleWidth", 1.f ),
+					parameterOrDefault( filterParameters, "scaleDepth", 1.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "back", 0.f ),
+					parameterOrDefault( filterParameters, "left", 0.f ),
+					parameterOrDefault( filterParameters, "front", 0.f ),
+					parameterOrDefault( filterParameters, "right", 0.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "backEdge", 1.f ),
+					parameterOrDefault( filterParameters, "leftEdge", 1.f ),
+					parameterOrDefault( filterParameters, "frontEdge", 1.f ),
+					parameterOrDefault( filterParameters, "rightEdge", 1.f )
+				),
+				parameterOrDefault( filterParameters, "edge", 0.f ),
+				M44f().rotate( V3f( -M_PI * 0.5f, 0.f, 0.f ) )
+			},
+			{
+				V2f( parameterOrDefault( filterParameters, "depth", 1.f ) * 2.f, parameterOrDefault( filterParameters, "height", 1.f ) * 2.f ),
+				parameterOrDefault( filterParameters, "radius", 0.f ),
+				V2f(
+					parameterOrDefault( filterParameters, "scaleDepth", 1.f ),
+					parameterOrDefault( filterParameters, "scaleHeight", 1.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "top", 0.f ),
+					parameterOrDefault( filterParameters, "front", 0.f ),
+					parameterOrDefault( filterParameters, "bottom", 0.f ),
+					parameterOrDefault( filterParameters, "back", 0.f )
+				),
+				V4f(
+					parameterOrDefault( filterParameters, "topEdge", 1.f ),
+					parameterOrDefault( filterParameters, "frontEdge", 1.f ),
+					parameterOrDefault( filterParameters, "bottomEdge", 1.f ),
+					parameterOrDefault( filterParameters, "backEdge", 1.f )
+				),
+				parameterOrDefault( filterParameters, "edge", 0.f ),
+				M44f().rotate( V3f( 0.f, M_PI * 0.5f, 0.f ) )
+			}
+		}
+	)
+	{
+		IECoreGL::GroupPtr axisGroup = GafferRenderManUI::lightFilterRectangles( innerSize, radius, innerScale, innerOffset, falloffScale, edge );
+		axisGroup->setTransform( transform );
+		result->addChild( axisGroup );
+	}
+
+	return { Visualisation::createGeometry( result ) };
+}
+
+}  // namespace

--- a/src/GafferScene/LightFilter.cpp
+++ b/src/GafferScene/LightFilter.cpp
@@ -86,6 +86,8 @@ void LightFilter::loadShader( const std::string &shaderName, bool keepExistingVa
 	/// but historically we had one, so for now we are preserving that behaviour
 	/// for all but the new RenderManLightFilter. We should remove the suffix
 	/// and update the Arnold backend to use `ai:lightFilter` attributes directly.
+	/// We should also remove the fallback check for the "filter" suffix in
+	/// `LightFilterUI.py`.
 	if( strcmp( typeName(), "GafferRenderMan::RenderManLightFilter" ) )
 	{
 		shaderNode()->attributeSuffixPlug()->setValue( "filter" );

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -217,3 +217,6 @@ for shader, metadata in shaderMetadata.items() :
 		else :
 
 			Gaffer.Metadata.registerValue( shader, key, value )
+
+# Reset the map from its default which uses the `pixar` format and can't be read by OIIO.
+Gaffer.Metadata.registerValue( "ri:lightFilter:PxrCookieLightFilter:map", "userDefault", "" )


### PR DESCRIPTION
This adds OpenGL visualisers for RenderMan's light filters. It was initially based on a work-in-progress build of RenderMan that had initial support for light filters, so I've checked that the shapes line up from that source. When filters are supported in GafferRenderMan, I'll check this against those again to make sure they are accurate.

There are a few things I'm intentionally leaving out for now :
1. For cookies and barns, the notion of the frustum coming from a light that other DCCs show is not included. Since filters are linked to sets, it's not entirely clear how to place the apex of the frustum.
2. I'm not drawing differently between using physical and analytic modes, which includes ignoring parameters like `shear*` and `apex`.
3. For cookies, I'm visualising `tint` and `saturation` but not `constrast` (which also depends on `midpoint` and `whitepoint`).

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
