### PR TITLE
SceneViewInspector : Support RenderMan lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - Wrapper :
   - Added warning when GafferRenderMan is not available for current RenderMan version.
   - An empty `RMANTREE` variable now disables GafferRenderMan startup, instead of emitting a warning.
+- Viewer : Added support for RenderMan lights in the floating inspector panel.
 
 Fixes
 -----

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -65,6 +65,7 @@ _rendererAttributePrefixes = {
 	"gl" : "OpenGL",
 	"osl" : "OSL",
 	"cycles" : "Cycles",
+	"ri" : "RenderMan",
 	"" : "USD",
 };
 

--- a/startup/GafferSceneUI/sceneViewInspector.py
+++ b/startup/GafferSceneUI/sceneViewInspector.py
@@ -68,3 +68,8 @@ for p in [ "intensity", "exposure", "color", "enableColorTemperature", "colorTem
 
 for p in [ "diffuseColor", "emissiveColor", "useSpecularWorkflow", "specularColor", "metallic", "roughness", "clearcoat", "clearcoatRoughness" ] :
 	GafferSceneUI._SceneViewInspector.registerShaderParameter( "surface", p )
+
+# RenderMan
+
+for p in [ "intensity", "exposure", "angleExtent", "lightColor", "enableTemperature", "temperature", "coneAngle", "coneSoftness", "lightGroup" ] :
+	GafferSceneUI._SceneViewInspector.registerShaderParameter( "ri:light", p )


### PR DESCRIPTION
This registration is based on the registration for USD lights, matching the ordering of parameters in the Node Editor and including the "lightGroup" parameter like we do for the Arnold "aov" parameter.