### PR TITLE
ScriptNodeAlgo : Fix potential crash at shutdown

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
   - Fixed interactive denoiser configuration.
   - Fixed bug preventing startup files from being loaded from versioned GafferRenderMan modules.
 - RenderPasses : Fixed custom widget registration via `GafferSceneUI.RenderPassesUI.registerRenderPassNameWidget()`.
+- ScriptNodeAlgo : Fixed potential crash during shutdown.
 
 API
 ---

--- a/src/GafferSceneUI/ScriptNodeAlgo.cpp
+++ b/src/GafferSceneUI/ScriptNodeAlgo.cpp
@@ -83,8 +83,11 @@ void contextChanged( IECore::InternedString variable, ScriptNode *script, Change
 
 ChangedSignals &changedSignals( ScriptNode *script )
 {
-	static std::unordered_map<const ScriptNode *, ChangedSignals> g_signals;
-	ChangedSignals &result = g_signals[script];
+	// Deliberately "leaking" map as it may contain Python slots which can't
+	// be destroyed during static destruction (because Python has already
+	// shut down at that point).
+	static std::unordered_map<const ScriptNode *, ChangedSignals> *g_signals = new std::unordered_map<const ScriptNode *, ChangedSignals>;
+	ChangedSignals &result = (*g_signals)[script];
 	if( !result.connection.connected() )
 	{
 		// Either we just made the signals, or an old ScriptNode


### PR DESCRIPTION
Since `g_signals` contains Signals, it may indirectly reference arbitrary Python objects via slots connected to the signals. Python shuts down before static destructors are run, so if we try to delete the Python objects in the static destructors bad things happen. So we just don't bother deleting them since we're shutting down completely anyway.
