### PR TITLE
Delight Renderer : Support toon outlines automatically

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 
 - RenderManShader : Fixed handling of minimum and maximum values for `color`, `vector`, `normal` and `point` parameters.
 - FreezeTransform : Fixed double transforming when the input primitive contains multiple primitive variables sharing the same data.
+- 3Delight : Fixed rendering of `dlToon` outlines for `Beauty` and `Outlines` outputs.
 
 1.5.10.1 (relative to 1.5.10.0)
 ========

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -269,7 +269,7 @@ class DelightOutput : public IECore::RefCounted
 			ParameterList driverParams;
 			for( const auto &[parameterName, parameterValue] : output->parameters() )
 			{
-				if( parameterName != "filter" && parameterName != "filterwidth" && parameterName != "scalarformat" && parameterName != "colorprofile" && parameterName != "layername" && parameterName != "layerName" && parameterName != "withalpha" )
+				if( parameterName != "filter" && parameterName != "filterwidth" && parameterName != "scalarformat" && parameterName != "colorprofile" && parameterName != "layername" && parameterName != "layerName" && parameterName != "withalpha" && parameterName != "drawoutlines" )
 				{
 					driverParams.add( parameterName.c_str(), parameterValue.get() );
 				}
@@ -380,6 +380,14 @@ class DelightOutput : public IECore::RefCounted
 			layerParams.add( "layertype", layerType );
 			layerParams.add( "layername", layerName );
 			layerParams.add( { "withalpha", &withAlpha, NSITypeInteger, 0, 1, 0 } );
+
+			const int drawOutlines = 1;
+			if( variableName == "Ci" || variableName == "outlines" )
+			{
+				// Enable toon outlines for these outputs by default. This can
+				// still be overridden by an explicit parameter added to the output.
+				layerParams.add( { "drawoutlines", &drawOutlines, NSITypeInteger, 0, 1, 0 } );
+			}
 
 			scalarFormat = parameter<string>( output->parameters(), "scalarformat", scalarFormat );
 			string colorProfile = parameter<string>( output->parameters(), "colorprofile", "linear" );


### PR DESCRIPTION
This fixes the display of toon outlines rendered to `beauty` or `outlines` outputs by always enabling "drawoutlines" on those outputs. This follows the approach taken in the other 3Delight bridges, such as in [hdNSI](https://gitlab.com/3Delight/HydraNSI/-/blob/master/hdNSI/renderPass.cpp#L583).

This also allows toon outlines to render when using 3Delight as the Viewer renderer, as long as the dlToon shader is in use when the viewport renderer is changed or restarted. Enabling 3Delight in the Viewer and then switching the shading mode from `Flat` to `Full` results in no outlines until you look through a different camera or restart the render by toggling back to OpenGL. FWIW, I see the same behaviour in regular interactive renders...

![toonOutlines](https://github.com/user-attachments/assets/c5f2f7b3-d00a-4a32-8a94-8b6ee332e852)
