### PR TITLE
Possible Solution To (some) Deadlocks?

### DIFF
--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -84,8 +84,17 @@ const ScriptNode *scriptNode( const GraphComponent *subject )
 	// UI classes often house their own internal plugs which receive their input
 	// from nodes in the graph. Follow the inputs to see if we can find the
 	// graph.
+	/// \todo This is an old mechanism that has been superceded by
+	/// the View/Settings mechanism below. We _think_ it can be removed.
 	if( auto p = runTimeCast<const Plug>( subject ) )
 	{
+		if( !p->node() )
+		{
+			// Avoid triggering cancellation when plugs/nodes are undergoing
+			// destruction - see `EditorTest.testIssue5877Variant`.
+			return nullptr;
+		}
+
 		if( auto s = scriptNode( p->getInput() ) )
 		{
 			return s;


### PR DESCRIPTION
My main objective here was just to figure out what's going on, but since it ends up looking like this might reasonable, I figured I might as well put it in a PR.

The question I was investigating was: if the cause of this deadlock at IE is a FarmDispatcher that is temporarily created by a script, and then freed, and is being cleaned up by the garbage collector at an inopportune time - why is it finding the script to trigger a cancellation? Shouldn't it no longer be part of the script at the point where it is being freed?

It appears that the answer to this is this branch in BackgroundTask::scriptNode(): `UI classes often house their own internal plugs which receive their input from nodes in the graph. Follow the inputs to see if we can find the graph`. At the point where the deadlock occurs, the GraphComponent triggering the cancellations is `tasks.task0`. It's highest ancestor is `tasks` - I'm assuming this means that this is a plug from the FarmDispatcher that is currently being destructed, and it has already been disconnected from its parent.

The branch in scriptNode() finds a ScriptNode from the input - the comment says that this is intended for UI classes with "internal plugs" - I think this is probably intended for UI classes that have internal nodes, and plugs on those nodes, rather than free floating plugs that aren't a part of nodes at all? If I add a check for whether the plug has a node, it prevents the crash ... I'm just not sure what else I might be breaking. Maybe it would catch every case if I test whether the plug is either part of a node, or has an output connection?