### PR TITLE
RenderManShader : Fix handling of min/max for colors and vectors

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.10.0)
 =======
 
+Fixes
+-----
 
+- RenderManShader : Fixed handling of minimum and maximum values for `color`, `vector`, `normal` and `point` parameters.
 
 1.5.10.0 (relative to 1.5.9.0)
 ========

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -191,5 +191,26 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 
 		surface["parameters"]["materialFront"].setInput( dielectric["out"]["bxdf_out"] )
 
+	def testMinAndMaxValues( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrSurface" )
+
+		self.assertTrue( shader["parameters"]["diffuseGain"].hasMinValue() )
+		self.assertEqual( shader["parameters"]["diffuseGain"].minValue(), 0.0 )
+
+		self.assertFalse( shader["parameters"]["diffuseExponent"].hasMinValue() )
+		self.assertFalse( shader["parameters"]["diffuseExponent"].hasMaxValue() )
+		self.assertFalse( shader["parameters"]["diffuseColor"].hasMinValue() )
+		self.assertFalse( shader["parameters"]["diffuseColor"].hasMaxValue() )
+
+		shader.loadShader( "PxrDisney" )
+
+		self.assertTrue( shader["parameters"]["subsurfaceColor"].hasMinValue() )
+		self.assertEqual( shader["parameters"]["subsurfaceColor"].minValue(), imath.Color3f( 0 ) )
+
+		self.assertTrue( shader["parameters"]["subsurfaceColor"].hasMaxValue() )
+		self.assertEqual( shader["parameters"]["subsurfaceColor"].maxValue(), imath.Color3f( 1 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -184,8 +184,17 @@ PlugPtr acquireCompoundNumericParameter( const boost::property_tree::ptree &para
 	typedef typename ValueType::BaseType BaseType;
 
 	const ValueType defaultValue = parseCompoundNumericValue<ValueType>( parameter.get( "<xmlattr>.default", "0 0 0" ) );
-	const ValueType minValue( numeric_limits<BaseType>::min() );
-	const ValueType maxValue( numeric_limits<BaseType>::max() );
+
+	ValueType minValue( numeric_limits<BaseType>::lowest() );
+	if( auto m = parameter.get_optional<std::string>( "<xmlattr>.min" ) )
+	{
+		minValue = parseCompoundNumericValue<ValueType>( *m );
+	}
+	ValueType maxValue( numeric_limits<BaseType>::max() );
+	if( auto m = parameter.get_optional<std::string>( "<xmlattr>.max" ) )
+	{
+		maxValue = parseCompoundNumericValue<ValueType>( *m );
+	}
 
 	auto existingPlug = runTimeCast<PlugType>( candidatePlug );
 	if(


### PR DESCRIPTION
We weren't making any attempt to read the min/max from the `.args` file at all. Very few compound parameters have min/max though, so this wasn't particularly noticeable.

What was far worse was that we were defaulting min to the confusingly named `std::numeric_limits::min()`, which for a floating point type is actually the smallest representable _positive value_. We actually want the most negative value possible, which is `std::numeric_limits::lowest()`, as we were using already when acquiring NumericPlugs. Sorting this out fixes some very confusing behaviour when trying to set values to zero in the UI.
