### PR TITLE
_StylizedAOVAdaptor : Add RenderMan NPR AOVs automatically

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.10.1)
 =======
 
+Improvements
+------------
+
+- RenderMan : Stylized Looks no longer require manual AOV setup. The relevant AOVs are added automatically whenever a stylized display filter is present.
+
 Fixes
 -----
 

--- a/python/GafferRenderMan/_StylizedAOVAdaptor.py
+++ b/python/GafferRenderMan/_StylizedAOVAdaptor.py
@@ -1,0 +1,134 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import inspect
+
+import IECore
+import IECoreScene
+
+import Gaffer
+import GafferScene
+
+# RenderMan requires three separate setup steps to use Stylized Looks :
+#
+# 1. Assign PxrStylizedControl shaders to objects.
+# 2. Add appropriate display filters.
+# 3. Set up a bunch of AOVs used to pass data between the components.
+#
+# Steps 1 and 2 require user input, because the user will be dialing in the
+# settings on the shaders and filters. But setting up the AOVs is fiddly and
+# error-prone and shouldn't be left to users. So this adaptor adds the AOVs to
+# the scene automatically when it detects that Stylized display filters are
+# present.
+class _StylizedAOVAdaptor( GafferScene.SceneProcessor ) :
+
+	def __init__( self, name = "_StylizedAOVAdaptor" ) :
+
+		GafferScene.SceneProcessor.__init__( self, name )
+
+		self["out"].setInput( self["in"] )
+
+		self["__globalsExpression"] = Gaffer.Expression()
+		self["__globalsExpression"].setExpression( inspect.cleandoc(
+			"""
+			import GafferRenderMan
+			parent["out"]["globals"] = GafferRenderMan._StylizedAOVAdaptor._adaptedGlobals( parent["in"]["globals"] )
+			"""
+		) )
+
+	__stylizedFilters = {
+		"PxrStylizedCanvas", "PxrStylizedHatching", "PxrStylizedLines", "PxrStylizedToon",
+	}
+
+	__aovDefinitions = {
+
+		"albedo" : "lpe nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C<.S'passthru'>*((U2L)|O)",
+		"diffuse" : "lpe C(D[DS]*[LO])|[LO]",
+		"directSpecular" : "lpe C<RS>[<L.>O]",
+		"sampleCount" : "float sampleCount",
+		"P" : "color P",
+		"NPRshadow" : "lpe shadows;C[DS]+<L.>",
+
+	} | {
+
+		name : f"color {name}"
+		for name in [
+			"NPRNtriplanar", "NPRPtriplanar", "NPRalbedo", "NPRcurvature",
+			"NPRdistort", "NPRhatchOut", "NPRlineAlbedo", "NPRlineCamdist", "NPRmask", "NPRlineNZ",
+			"NPRlineOut", "NPRlineOutAlpha", "NPRlineWidth", "NPRoutline", "NPRsections",
+			"NPRtextureCoords", "NPRtoonOut", "Nn",
+		]
+
+	}
+
+	@staticmethod
+	def _adaptedGlobals( inputGlobals ) :
+
+		# See if any of the Stylized Looks display filters are in use. If they're
+		# not then we have no work to do.
+
+		displayFilter = inputGlobals.get( "option:ri:displayfilter" )
+		if displayFilter is None or not isinstance( displayFilter, IECoreScene.ShaderNetwork ) :
+			return inputGlobals
+
+		displayFilters = {
+			shader.name for shader in displayFilter.shaders().values()
+		}
+
+		if not displayFilters.intersection( _StylizedAOVAdaptor.__stylizedFilters ) :
+			return inputGlobals
+
+		# Stylized Looks are in use, so add all the AOVs needed. We use a `null`
+		# display driver for this - if the user wants to write them to disk then
+		# they can specify separate outputs for that themselves.
+
+		outputGlobals = inputGlobals.copy()
+		for aov in _StylizedAOVAdaptor.__aovDefinitions :
+
+			output = IECoreScene.Output(
+				aov, "null", _StylizedAOVAdaptor.__aovDefinitions[aov],
+				{ "layerName" : aov }
+			)
+			if aov == "sampleCount" :
+				output.parameters()["ri:accumulationRule"] = IECore.StringData( "sum" )
+
+			outputGlobals[f"output:_StylizedAOVAdaptor:{aov}"] = output
+
+		return outputGlobals
+
+IECore.registerRunTimeTyped( _StylizedAOVAdaptor, typeName = "GafferRenderMan::_StylizedAOVAdaptor" )
+
+GafferScene.SceneAlgo.registerRenderAdaptor( "RenderManStylizedAOVAdaptor", _StylizedAOVAdaptor, "*Render", "RenderMan" )

--- a/python/GafferRenderMan/__init__.py
+++ b/python/GafferRenderMan/__init__.py
@@ -39,5 +39,6 @@ __import__( "GafferScene" )
 from ._GafferRenderMan import *
 from . import ArgsFileAlgo
 from ._InteractiveDenoiserAdaptor import _InteractiveDenoiserAdaptor
+from ._StylizedAOVAdaptor import _StylizedAOVAdaptor
 
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferRenderMan" )

--- a/python/GafferRenderManTest/StylizedAOVAdaptorTest.py
+++ b/python/GafferRenderManTest/StylizedAOVAdaptorTest.py
@@ -1,0 +1,111 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECoreScene
+
+import GafferScene
+import GafferSceneTest
+import GafferRenderMan
+
+class StylizedAOVAdaptorTest( GafferSceneTest.SceneTestCase ) :
+
+	def testNoOp( self ) :
+
+		scene = GafferScene.StandardOptions()
+		scene["options"]["renderCamera"]["enabled"].setValue( True )
+
+		adaptor = GafferRenderMan._StylizedAOVAdaptor()
+		adaptor["in"].setInput( scene["out"] )
+
+		self.assertEqual( adaptor["out"].globals(), adaptor["in"].globals() )
+
+	def testAOVs( self ) :
+
+		toonFilter = GafferRenderMan.RenderManShader()
+		toonFilter.loadShader( "PxrStylizedToon" )
+
+		displayFilter = GafferRenderMan.RenderManDisplayFilter()
+		displayFilter["displayFilter"].setInput( toonFilter["out"] )
+
+		adaptor = GafferRenderMan._StylizedAOVAdaptor()
+		adaptor["in"].setInput( displayFilter["out"] )
+
+		aovData = {
+			output.getData()
+			for name, output in
+			adaptor["out"].globals().items()
+			if name.startswith( "output:" )
+		}
+
+		self.assertEqual(
+			aovData,
+			{
+				"lpe nothruput;noinfinitecheck;noclamp;unoccluded;overwrite;C<.S'passthru'>*((U2L)|O)",
+				"color NPRlineOutAlpha", "color NPRlineOut", "color P", "color Nn", "color NPRlineWidth",
+				"color NPRalbedo", "color NPRhatchOut", "color NPRlineNZ", "color NPRtextureCoords",
+				"color NPRoutline", "color NPRtoonOut", "color NPRcurvature",
+				"color NPRNtriplanar", "color NPRlineAlbedo", "color NPRlineCamdist", "color NPRPtriplanar",
+				"color NPRmask", "color NPRdistort", "lpe shadows;C[DS]+<L.>", "color NPRsections",
+				"float sampleCount", "lpe C(D[DS]*[LO])|[LO]", "lpe C<RS>[<L.>O]",
+			}
+		)
+
+	def testKeepsExistingAOVs( self ) :
+
+		toonFilter = GafferRenderMan.RenderManShader()
+		toonFilter.loadShader( "PxrStylizedToon" )
+
+		displayFilter = GafferRenderMan.RenderManDisplayFilter()
+		displayFilter["displayFilter"].setInput( toonFilter["out"] )
+
+		outputs = GafferScene.Outputs()
+		outputs["in"].setInput( displayFilter["out"] )
+
+		outputs.addOutput(
+			"Test",
+			IECoreScene.Output(
+				"test.exr",
+				"exr",
+				"color NPRhatchOut"
+			)
+		)
+
+		adaptor = GafferRenderMan._StylizedAOVAdaptor()
+		adaptor["in"].setInput( outputs["out"] )
+
+		# Check that our own AOV has been retained even though it
+		# uses the same data as one the adaptor wants to create.
+		self.assertEqual( adaptor["out"].globals()["output:Test"], adaptor["in"].globals()["output:Test"] )

--- a/python/GafferRenderManTest/__init__.py
+++ b/python/GafferRenderManTest/__init__.py
@@ -47,6 +47,7 @@ from .RenderManRenderTest import RenderManRenderTest
 from .InteractiveRenderManRenderTest import InteractiveRenderManRenderTest
 from .RenderPassAdaptorTest import RenderPassAdaptorTest
 from .RenderManLightFilterTest import RenderManLightFilterTest
+from .StylizedAOVAdaptorTest import StylizedAOVAdaptorTest
 
 if __name__ == "__main__":
 	import unittest


### PR DESCRIPTION
We trigger this based on the existence of one of the stylised display filters in the scene. This automates the fiddliest part of the setup when using Stylized Looks (and the only part that requires no artistic input). I went through several iterations on this, with the final version being the simplest of them all. I started by adding the minimal subset required by the specific filters present, since not all filters require all AOVs. Then I discovered that some of the filters depend on different AOVs based on their parameter settings, and it seemed rather over-complex to extend the scene analysis that far. For any realistic purposes you're going to end up needing most of the AOVs anyway, and its a decent reduction in complexity just to request them all unconditionally. Likewise, I made no effort to deduplicate the outputs declared by this and the _InteractiveDenoiserAdaptor. The RenderMan backend will deduplicate to a single `riley::RenderOutput` where relevant anyway, and the `null` display driver presumably has very little overhead.
