### PR TITLE
Inference : Attempt to use CUDA before CPU

### DIFF
--- a/.github/workflows/main/installONNX.py
+++ b/.github/workflows/main/installONNX.py
@@ -42,11 +42,11 @@ from urllib.request import urlretrieve
 version = "1.19.2"
 
 if sys.platform == "linux" :
-	url = f"https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-x64-{version}.tgz"
+	url = f"https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-linux-x64-gpu-{version}.tgz"
 elif sys.platform == "darwin" :
 	url = f"https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-osx-arm64-{version}.tgz"
 elif sys.platform == "win32" :
-	url = f"https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-x64-{version}.zip"
+	url = f"https://github.com/microsoft/onnxruntime/releases/download/v{version}/onnxruntime-win-x64-gpu-{version}.zip"
 
 print( "Downloading ONNX \"{}\"".format( url ) )
 archiveFileName, headers = urlretrieve( url )

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Removed the `GAFFERRENDERMAN_FEATURE_PREVIEW` environment variable. The RenderMan extension is now automatically enabled any time the `RMANTREE` environment variable is present. While the RenderMan extension is not yet feature complete, it is considered to be mature enough for general use.
+- GafferML : Added experimental support for performing inference on CUDA devices. This can be enabled by setting the `GAFFERML_USE_CUDA` environment variable with a value of `1`. This requires an ONNX runtime containing the CUDA execution provider, with compatible versions of the CUDA toolkit and cuDNN installed.
 
 Fixes
 -----

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -258,6 +258,16 @@ def setUpONNX() :
 	onnxRoot = pathlib.Path( os.environ.get( "ONNX_ROOT" ) )
 	appendToPath( onnxRoot / "lib", libraryPath )
 
+	if "GAFFERML_USE_CUDA" not in os.environ or os.environ["GAFFERML_USE_CUDA"] == "0" :
+		return
+
+	if "CUDNN_ROOT" not in os.environ :
+		sys.stderr.write( f"WARNING : \"CUDNN_ROOT\" environment variable not found. Ensure cuDNN is installed and \"CUDNN_ROOT\" environment variable is set." )
+		return
+
+	cuDNNRoot = pathlib.Path( os.environ.get( "CUDNN_ROOT" ) )
+	appendToPath( cuDNNRoot / ( "bin" if sys.platform == "win32" else "lib" ), libraryPath )
+
 setUpONNX()
 
 # RenderMan Setup

--- a/src/GafferML/Inference.cpp
+++ b/src/GafferML/Inference.cpp
@@ -114,6 +114,21 @@ Ort::Session &acquireSession( const std::string &fileName )
 	{
 		sessionOpt.RegisterCustomOpsLibrary( customLibraryPath.c_str() );
 	}
+
+	const char *useCuda = getenv( "GAFFERML_USE_CUDA" );
+	if( useCuda && strcmp( useCuda, "0" ) != 0 )
+	{
+		try
+		{
+			OrtCUDAProviderOptions cudaOptions;
+			sessionOpt.AppendExecutionProvider_CUDA( cudaOptions );
+		}
+		catch( const std::exception &e )
+		{
+			throw IECore::Exception( fmt::format( "Error Initializing CUDA inference : {}", e.what() ) );
+		}
+	}
+
 	it = g_map.try_emplace( fileName, acquireEnv(), path.c_str(), sessionOpt ).first;
 	return it->second;
 }


### PR DESCRIPTION
This adds GPU support to the GaffML Inference node.

This isn't ready for review yet, I'm just submitting it to generate build artifacts for testing. There's probably some discussion to be had around how to expose this to users. For now it's hard coded to try CUDA and ONNX seems to fall back to the CPU if all the libraries it needs are not found.

There are a few things needed to get the GPU working :
1. Use the ONNX runtime release for your platform with `gpu` in the name. That will have `lib/onnxruntime_providers_cuda.dll` in the archive which is what onnxruntime needs.
2. Download and extract cuDNN : https://developer.nvidia.com/cudnn
3. Add the path to the extracted cuDNN `bin` directory to your `PATH` environment variable.
4. Install CUDA toolkit if you don't have it already : https://developer.nvidia.com/cuda-downloads
5. Linux might need Zlib? I've tested on Windows so not sure about that.

More instructions are at https://onnxruntime.ai/docs/install/

I found the following versions to work :
- ONNX runtime : 1.19.2
- cuDNN : 9.8.0
- CUDA toolkit : 12.8

### Checklist ###

- [ ] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Gaffer project's prevailing coding style and conventions.
