### PR TITLE
browser : Use QtWidgets.QApplication.primaryScreen

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - ScriptNodeAlgo : Fixed crash during shutdown (#6363).
+- Browser app : Fixed `QDesktopWidget.availableGeometry()` deprecation warning.
 
 1.5.10.0 (relative to 1.5.9.0)
 ========

--- a/apps/browser/browser-1.py
+++ b/apps/browser/browser-1.py
@@ -93,7 +93,7 @@ class browser( Gaffer.Application ) :
 		# centre the window on the primary screen at 3/4 size.
 		## \todo Implement save/restore of geometry, and do all this without using Qt APIs
 		# in the app itself.
-		desktop = QtWidgets.QApplication.instance().desktop()
+		desktop = QtWidgets.QApplication.primaryScreen()
 		geometry = desktop.availableGeometry()
 		adjustment = geometry.size() / 8
 		geometry.adjust( adjustment.width(), adjustment.height(), -adjustment.width(), -adjustment.height() )


### PR DESCRIPTION
I noticed this while using the Gaffer Browser app to check out an scc. 

`QDesktopWidget.availableGeometry` is deprecated so I updated the code to use `QtWidgets.QApplication.primaryScreen`

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
