### PR TITLE
USD IES parameters to Arnold

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Stylized Looks no longer require manual AOV setup. The relevant AOVs are added automatically whenever a stylized display filter is present.
+- Arnold : Added translation of UsdLux IES parameters to Arnold.
 
 Fixes
 -----

--- a/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreArnoldTest/ShaderNetworkAlgoTest.py
@@ -996,6 +996,87 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"sphereLightToPhotometricLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "photometric.ies",
+					}
+				),
+
+				IECoreScene.Shader(
+					"photometric_light", "light",
+					expectedLightParameters( {
+						"filename" : "photometric.ies",
+						"radius" : 0.5,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotometricLightEmptyFile" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "",
+					}
+				),
+
+				IECoreScene.Shader(
+					"point_light", "light",
+					expectedLightParameters( {
+						"radius" : 0.5,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotometricLightNotSpot" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+						"shaping:ies:file" : "photometric.ies",
+					}
+				),
+
+				IECoreScene.Shader(
+					"photometric_light", "light",
+					expectedLightParameters( {
+						"filename" : "photometric.ies",
+						"radius" : 0.5,
+					} )
+				),
+
+			],
+
+			"sphereLightToSpotLightEmptyIESFile" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "",
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"spot_light", "light",
+					expectedLightParameters( {
+						"cone_angle" : 40.0,
+						"penumbra_angle" : 20.0,
+						"cosine_power" : 0.0,
+						"radius" : 0.5,
+					} )
+				),
+
+			],
+
 			# SphereLight (with softness greater than 1)
 
 			"sphereLightHighSoftness" : [

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -691,6 +691,7 @@ const InternedString g_shadowColorParameter( "shadow:color" );
 const InternedString g_shadowColorArnoldParameter( "shadow_color" );
 const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
 const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
+const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
 const InternedString g_shapingSoftnessParameter( "shaping:softness" );
 const InternedString g_sourceColorSpaceParameter( "sourceColorSpace" );
 const InternedString g_specularParameter( "specular" );
@@ -748,6 +749,15 @@ void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHa
 
 void transferUSDShapingParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
 {
+	if( auto dFile = usdShader->parametersData()->member<StringData>( g_shapingIesFileParameter ) )
+	{
+		if( !dFile->readable().empty() )
+		{
+			shader->setName( "photometric_light" );
+			shader->parameters()[g_filenameParameter] = new StringData( dFile->readable() );
+			return;
+		}
+	}
 	if( auto d = usdShader->parametersData()->member<FloatData>( g_shapingConeAngleParameter ) )
 	{
 		shader->setName( "spot_light" );


### PR DESCRIPTION
This adds support for transferring USD IES parameters to Arnold. I'm handling the file name and the normalization parameters, but not `shaping:ies:angleScale`. The USD documentation says that "Rescales the angular distribution of the IES profile." which is unclear to me and it seems the USD people too, because it has a note "TODO: clarify semantics". Arnold's own USD Hydra implementation doesn't handle it, so I think it's safe to leave out?

Also noting that choosing IES over spot light behavior in the case of both shaping parameters set is also what Arnold's Hydra renderer does.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
