### PR TITLE
Orientation Visualiser

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 1.5.x.x (relative to 1.5.11.0)
 =======
 
+Improvements
+------------
+
+- VisualiserTool : Added new visualisation for orientation (Quatf) data.
 
 
 1.5.11.0 (relative to 1.5.10.1)

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
+- PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 
 
 1.5.11.0 (relative to 1.5.10.1)

--- a/include/GafferSceneUI/Private/VisualiserTool.h
+++ b/include/GafferSceneUI/Private/VisualiserTool.h
@@ -137,7 +137,7 @@ class GAFFERSCENEUI_API VisualiserTool : public SelectionTool
 		using CursorPosition = std::optional<Imath::V2f>;
 		CursorPosition cursorPos() const;
 
-		using CursorValue = std::variant<std::monostate, int, float, Imath::V2f, Imath::V3f, Imath::Color3f>;
+		using CursorValue = std::variant<std::monostate, int, float, Imath::V2f, Imath::V3f, Imath::Color3f, Imath::Quatf>;
 		const CursorValue cursorValue() const;
 
 		GafferScene::ScenePlug *internalScenePlug();

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -265,6 +265,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 							IECore.V2fVectorData,
 							IECore.Color3fVectorData,
 							IECore.V3fVectorData,
+							IECore.QuatfVectorData,
 						)
 					) :
 						continue

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -1051,7 +1051,7 @@ class _CompoundDataAccessor( _DataAccessor ) :
 
 	def headerLabel( self, columnIndex ) :
 
-		return [ "X", "Y", "Z", "W" ][columnIndex]
+		return [ "X", "Y", "Z" ][columnIndex]
 
 	def setElement( self, rowIndex, columnIndex, value ) :
 
@@ -1132,17 +1132,21 @@ class _QuatDataAccessor( _CompoundDataAccessor ) :
 
 		return 4
 
+	def headerLabel( self, columnIndex ) :
+
+		return [ "W", "X", "Y", "Z" ][columnIndex]
+
 	def getElement( self, rowIndex, columnIndex ) :
 
 		v = self.data()[rowIndex]
 		if columnIndex == 0:
-			return GafferUI._Variant.toVariant( v.v()[0] )
-		if columnIndex == 1:
-			return GafferUI._Variant.toVariant( v.v()[1] )
-		if columnIndex == 2:
-			return GafferUI._Variant.toVariant( v.v()[2] )
-		if columnIndex == 3:
 			return GafferUI._Variant.toVariant( v.r() )
+		if columnIndex == 1:
+			return GafferUI._Variant.toVariant( v.v()[0] )
+		if columnIndex == 2:
+			return GafferUI._Variant.toVariant( v.v()[1] )
+		if columnIndex == 3:
+			return GafferUI._Variant.toVariant( v.v()[2] )
 
 _DataAccessor.registerType( IECore.QuatfVectorData.staticTypeId(), _QuatDataAccessor )
 _DataAccessor.registerType( IECore.QuatdVectorData.staticTypeId(), _QuatDataAccessor )

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -428,7 +428,8 @@ struct UniformBlockOrientationShader
 	alignas( 16 ) Imath::Color3f colorX;
 	alignas( 16 ) Imath::Color3f colorY;
 	alignas( 16 ) Imath::Color3f colorZ;
-	alignas( 16 ) float scale; // NOTE : following vec3 array must align to 16 byte address
+	alignas( 16 ) float scale;
+	alignas( 4 ) float opacity;
 };
 
 #define UNIFORM_BLOCK_ORIENTATION_GLSL_SOURCE \
@@ -437,6 +438,7 @@ struct UniformBlockOrientationShader
 	"   mat4 o2c;\n" \
 	"   vec3 color[ 3 ];\n" \
 	"   float scale;\n" \
+	"   float opacity;\n" \
 	"} uniforms;\n"
 
 #define ATTRIB_GLSL_LOCATION_QS 1
@@ -503,7 +505,7 @@ std::string const g_orientationShaderFragSource
 
 	"void main()\n"
 	"{\n"
-	"   cs = vec4( inputs.color, 1.0 );\n"
+	"   cs = vec4( inputs.color, uniforms.opacity );\n"
 	"}\n"
 );
 
@@ -1905,6 +1907,7 @@ class VisualiserGadget : public Gadget
 			uniforms.colorY = g_colorY;
 			uniforms.colorZ = g_colorZ;
 			uniforms.scale = m_tool->vectorScalePlug()->getValue();
+			uniforms.opacity = m_tool->opacityPlug()->getValue();
 
 			// Set OpenGL state
 			GLfloat lineWidth;

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -108,11 +108,6 @@ float const g_vectorScaleInc = 0.01f;
 
 const Color3f g_vectorColorDefault( 1.f, 1.f, 1.f );
 
-// Orientation constants
-const Color3f g_colorX( 1.f, 0.f, 0.f );
-const Color3f g_colorY( 0.f, 1.f, 0.f );
-const Color3f g_colorZ( 0.f, 0.f, 1.f );
-
 // Opacity and value constants
 const float g_opacityDefault = 1.0f;
 const float g_opacityMin = 0.0f;
@@ -425,9 +420,6 @@ std::string const g_vectorShaderFragSource
 struct UniformBlockOrientationShader
 {
 	alignas( 16 ) Imath::M44f o2c;
-	alignas( 16 ) Imath::Color3f colorX;
-	alignas( 16 ) Imath::Color3f colorY;
-	alignas( 16 ) Imath::Color3f colorZ;
 	alignas( 16 ) float scale;
 	alignas( 4 ) float opacity;
 };
@@ -436,7 +428,6 @@ struct UniformBlockOrientationShader
 	"layout( std140, row_major ) uniform UniformBlock\n" \
 	"{\n" \
 	"   mat4 o2c;\n" \
-	"   vec3 color[ 3 ];\n" \
 	"   float scale;\n" \
 	"   float opacity;\n" \
 	"} uniforms;\n"
@@ -465,6 +456,11 @@ std::string const g_orientationShaderVertSource
 
 	"void main()\n"
 	"{\n"
+	"   vec3 color[ 3 ];\n"
+	"   // Match colors to `StandardStyle::colorForAxes()`\n"
+	"   color[0] = vec3( 0.73, 0.17, 0.17 );\n"
+	"   color[1] = vec3( 0.2, 0.57, 0.2 );\n"
+	"   color[2] = vec3( 0.2, 0.36, 0.74 );\n"
 	"   vec3 position = ps;\n"
 	"   int axis = gl_VertexID / 2;\n"
 
@@ -489,7 +485,7 @@ std::string const g_orientationShaderVertSource
 	"   }\n"
 
 	"   gl_Position = vec4( position, 1.0 ) * uniforms.o2c;\n"
-	"   outputs.color = uniforms.color[ axis ];\n"
+	"   outputs.color = color[ axis ];\n"
 	"}\n"
 );
 
@@ -1924,9 +1920,6 @@ class VisualiserGadget : public Gadget
 			glBindBufferBase( GL_UNIFORM_BUFFER, g_uniformBlockBindingIndex, m_orientationUniformBuffer->buffer() );
 
 			UniformBlockOrientationShader uniforms;
-			uniforms.colorX = g_colorX;
-			uniforms.colorY = g_colorY;
-			uniforms.colorZ = g_colorZ;
 			uniforms.scale = m_tool->vectorScalePlug()->getValue();
 			uniforms.opacity = m_tool->opacityPlug()->getValue();
 


### PR DESCRIPTION
This adds a visualiser for quaternions to the visualiser tool.

I waffled some on the way we show the quaternion value when you mouse over vertices. The primitive variable inspector lists the imaginary (x, y, z) part first and then the real part. Imath `quatf` constructors take the real part first. I settled on matching the primitive inspector order, with the imaginary part in parenthesis to hopefully give a hint that those are the imaginary parts.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
