### PR TITLE
Context: Fix Context.substitute only recognize uppercase env vars on Windows

### DIFF
--- a/src/Gaffer/Context.cpp
+++ b/src/Gaffer/Context.cpp
@@ -42,6 +42,7 @@
 #include "IECore/PathMatcherData.h"
 
 #include "boost/lexical_cast.hpp"
+#include "boost/algorithm/string.hpp"
 
 // Headers needed to access environment - these differ
 // between OS X and Linux.
@@ -599,6 +600,14 @@ const std::string &Context::SubstitutionProvider::variable( const boost::string_
 		// variable not in context - try environment
 		return *v;
 	}
+
+	#ifdef _WIN32
+	else if( const std::string *v = g_environment.get( boost::to_upper_copy( internedName.string() ) ) )
+	{
+		// on Windows backend gaffer app, env vars will be convert to uppercase by Python's os.environ
+		return *v;
+	}
+	#endif
 
 	m_formattedString.clear();
 	return m_formattedString;


### PR DESCRIPTION
Environment variables which not in Context Variables will be convert to uppercase so that `Context.substitute()` method only recognize uppercase environment variables when use `gaffer env python` or `gaffer dispatch` to execute some background command line task. This PR will let `Context.substitute()` caseinsensitive for env vars on Windows to meet cross platform production needs.

- Fix Context.substitute only recognize uppercase env vars on Windows

### Related issues ###

- [Context.substitute only recognize uppercase env vars on Windows](https://github.com/GafferHQ/gaffer/issues/6371)


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
