### PR TITLE
ResamplePrimitiveVariables : Fix cancellation for curves and points

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 
 - RenderManShader : Fixed handling of minimum and maximum values for `color`, `vector`, `normal` and `point` parameters.
 - FreezeTransform : Fixed double transforming when the input primitive contains multiple primitive variables sharing the same data.
+- ResamplePrimitiveVariables : Fixed cancellation of long-running operations on curves and points.
 
 1.5.10.1 (relative to 1.5.10.0)
 ========

--- a/src/GafferScene/ResamplePrimitiveVariables.cpp
+++ b/src/GafferScene/ResamplePrimitiveVariables.cpp
@@ -100,11 +100,11 @@ void ResamplePrimitiveVariables::processPrimitiveVariable( const ScenePath &path
 	}
 	else if( const CurvesPrimitive *curvesPrimitive = IECore::runTimeCast<const CurvesPrimitive>( inputGeometry.get() ) )
 	{
-		CurvesAlgo::resamplePrimitiveVariable( curvesPrimitive, variable, interpolation );
+		CurvesAlgo::resamplePrimitiveVariable( curvesPrimitive, variable, interpolation, context->canceller() );
 	}
 	else if( const PointsPrimitive *pointsPrimitive = IECore::runTimeCast<const PointsPrimitive>( inputGeometry.get() ) )
 	{
-		PointsAlgo::resamplePrimitiveVariable( pointsPrimitive, variable, interpolation );
+		PointsAlgo::resamplePrimitiveVariable( pointsPrimitive, variable, interpolation, context->canceller() );
 	}
 	else
 	{


### PR DESCRIPTION
After merging #6370, I did a little search for other nodes that might have similar problems. I didn't find anything, but did spot that we weren't passing the cancellers through to the Algo in ResamplePrimitiveVariables. This fixes that.