### PR TITLE
LocalDispatcher, SystemCommand, `gaffer env` : Preserve env-var case on Windows

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,17 @@ Improvements
 
 - DeleteAttributes : Optimised case where all attributes are deleted. The input attributes are no longer accessed at all in this case.
 
+Fixes
+-----
+
+- LocalDispatcher, SystemCommand, `gaffer env` : Fixed unwanted upper-casing of environment variable names on Windows (#6371).
+
+API
+---
+
+- Gaffer module : Added `environment()` method, returning a dictionary containing all current environment variables. Unlike `os.environ`, this preserves
+  case on Windows.
+
 Breaking Changes
 ----------------
 

--- a/apps/env/env-1.py
+++ b/apps/env/env-1.py
@@ -99,7 +99,7 @@ class env( Gaffer.Application ) :
 
 		# get environment
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		i = 0
 		while i < len( args["arguments"] ) :
 			s = args["arguments"][i].split( "=" )

--- a/python/GafferArnoldUITest/ArnoldShaderUITest.py
+++ b/python/GafferArnoldUITest/ArnoldShaderUITest.py
@@ -178,7 +178,7 @@ root["SceneWriter"].execute()
 		with open( scriptPath, "w" ) as outFile :
 			outFile.write( script )
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		subprocess.check_call(
 			[ str( Gaffer.executablePath() ), "env", "python", str( scriptPath ) ],
 			env = env

--- a/python/GafferDispatch/LocalDispatcher.py
+++ b/python/GafferDispatch/LocalDispatcher.py
@@ -316,7 +316,7 @@ class LocalDispatcher( GafferDispatch.Dispatcher ) :
 			# we can capture everything and then let the LocalJobs UI filter
 			# it dynamically.
 
-			env = os.environ.copy()
+			env = Gaffer.environment()
 			env["IECORE_LOG_LEVEL"] = "DEBUG"
 
 			# Launch process.

--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -78,7 +78,7 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 		command = self["command"].getValue()
 		command = command.format( **substitutions )
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		environmentVariables = IECore.CompoundData()
 		self["environmentVariables"].fillCompoundData( environmentVariables )
 		for name, value in environmentVariables.items() :

--- a/python/GafferImageTest/ColorSpaceTest.py
+++ b/python/GafferImageTest/ColorSpaceTest.py
@@ -194,7 +194,7 @@ class ColorSpaceTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( scriptFileName )
 		s.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["OCIO"] = str( self.openColorIOPath() / "context.ocio" )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"

--- a/python/GafferImageTest/DisplayTransformTest.py
+++ b/python/GafferImageTest/DisplayTransformTest.py
@@ -175,7 +175,7 @@ class DisplayTransformTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( scriptFileName )
 		s.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["OCIO"] = str( self.openColorIOPath() / "context.ocio" )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"

--- a/python/GafferImageTest/LookTransformTest.py
+++ b/python/GafferImageTest/LookTransformTest.py
@@ -91,7 +91,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( scriptFileName )
 		s.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["OCIO"] = str( self.ocioConfig )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
@@ -136,7 +136,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( scriptFileName )
 		s.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["OCIO"] = str( self.ocioConfig )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"
@@ -182,7 +182,7 @@ class LookTransformTest( GafferImageTest.ImageTestCase ) :
 		s["fileName"].setValue( scriptFileName )
 		s.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["OCIO"] = str( self.ocioConfig )
 		env["LUT"] = "srgb.spi1d"
 		env["CDL"] = "cineon.spi1d"

--- a/python/GafferMLTest/InferenceTest.py
+++ b/python/GafferMLTest/InferenceTest.py
@@ -129,7 +129,7 @@ class InferenceTest( GafferTest.TestCase ) :
 		if os.environ.get( "GAFFERML_MODEL_PATHS", "" ) != testPath :
 
 			self.assertRaises( RuntimeError, node.loadModel )
-			env = os.environ.copy()
+			env = Gaffer.environment()
 			env["GAFFERML_MODEL_PATHS"] = testPath
 			try :
 				subprocess.check_output(

--- a/python/GafferRenderManTest/ModuleTest.py
+++ b/python/GafferRenderManTest/ModuleTest.py
@@ -53,7 +53,7 @@ class ModuleTest( GafferTest.TestCase ) :
 		# of it having been set when our wrapper ran earlier. And in that subprocess,
 		# check that we can still load the GUI configs cleanly.
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		for var in ( "RMANTREE", "PYTHONPATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "GAFFER_STARTUP_PATHS" ) :
 			env.pop( var, None )
 

--- a/python/GafferSceneTest/InstancerTest.py
+++ b/python/GafferSceneTest/InstancerTest.py
@@ -3687,7 +3687,7 @@ parent["radius"] = ( 2 + context.getFrame() ) * 15
 
 	def testRelativePrototypePathsWithExplicitAbsolute( self ):
 		try :
-			env = os.environ.copy()
+			env = Gaffer.environment()
 			env["GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS"] = "1"
 			subprocess.check_output(
 				[ str( Gaffer.executablePath() ), "test", "GafferSceneTest.InstancerTest.testRelativePrototypePaths" ],

--- a/python/GafferSceneTest/ShaderAssignmentTest.py
+++ b/python/GafferSceneTest/ShaderAssignmentTest.py
@@ -550,7 +550,7 @@ class ShaderAssignmentTest( GafferSceneTest.SceneTestCase ) :
 
 		def assertAssignment( expected, envVar ) :
 
-			env = os.environ.copy()
+			env = Gaffer.environment()
 			if envVar is not None :
 				env["GAFFERSCENE_SHADERASSIGNMENT_OSL_PREFIX"] = envVar
 

--- a/python/GafferTest/ExpressionTest.py
+++ b/python/GafferTest/ExpressionTest.py
@@ -1641,7 +1641,7 @@ class ExpressionTest( GafferTest.TestCase ) :
 		script["fileName"].setValue( self.temporaryDirectory() / "test.gfr" )
 		script.save()
 
-		env = os.environ.copy()
+		env = Gaffer.environment()
 		env["GAFFERTEST_SCRIPT_FILENAME"] = script["fileName"].getValue()
 		try :
 			subprocess.check_output(

--- a/python/GafferUITest/LayoutsTest.py
+++ b/python/GafferUITest/LayoutsTest.py
@@ -89,7 +89,7 @@ class LayoutsTest( GafferUITest.TestCase ) :
 			# Run test in subprocess, because we don't want to pollute the other
 			# tests with the configs we load.
 			try :
-				env = os.environ.copy()
+				env = Gaffer.environment()
 				env["GAFFERUITEST_LAYOUTTEST_SUBPROCESS"] = "1"
 				subprocess.check_output(
 					[ str( Gaffer.executablePath() ), "test", "GafferUITest.LayoutsTest.testNoPersistentLayoutsInDefaultConfigs" ],

--- a/python/IECoreArnoldTest/UniverseBlockTest.py
+++ b/python/IECoreArnoldTest/UniverseBlockTest.py
@@ -80,7 +80,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 			# Relaunch test in subprocess with our metadata on the plugin path.
 
-			env = os.environ.copy()
+			env = Gaffer.environment()
 			env["ARNOLD_PLUGIN_PATH"] = env["ARNOLD_PLUGIN_PATH"] + os.pathsep + str( metadataPath )
 
 			try :


### PR DESCRIPTION
On Windows, environment variable names are case-preserving but case-insensitive. Python's `os.environ` mapping has a botched emulation for this which implements the case-insensitive part by trashing the case and making everything upper-case. See https://bugs.python.org/issue28824.

This caused us problems where we were using `os.environ.copy()` as the source for a child environment we constructed for use with `subprocess`. The child environment now had all-upper-case environment variables instead of the originals. And that caused problems with `Context.substitute( "${var}" )` in the child process, because context variable lookups are case-sensitive.

In the absence of a fix to Python itself, for now we add a `Gaffer.environment()` function that builds a dictionary from the ground truth of the process' environment table. And use that everywhere we're running subprocesses on behalf of the user.

Fixes #6371.
