### PR TITLE
RenderMan Metadata Refactor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,10 @@ Improvements
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 
+API
+---
+
+- ShaderUI : Added support for automatically looking up metadata registered to `{shaderType}:{shaderName}:{parameterName}` metadata targets.
 
 1.5.11.0 (relative to 1.5.10.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 ---
 
 - ShaderUI : Added support for automatically looking up metadata registered to `{shaderType}:{shaderName}:{parameterName}` metadata targets.
+- USDLight : Added support for `userDefault` metadata registered to `light:{lightName}:{parameterName}`.
 
 1.5.11.0 (relative to 1.5.10.1)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,14 @@ Improvements
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 
+Fixes
+-----
+
+- RenderMan UI : Fixed various metadata-related problems :
+  - PxrUnified, PxrBarnLightFilter, PxrCookieLightFilter, PxrRodLightFilter : Hid unwanted inputs in the GraphEditor.
+  - PxrCookieLightFilter : Added button for reloading the map.
+  - PxrSurface, PxrLayerSurface : Moved `utilityPattern` parameter to "Globals" section.
+
 API
 ---
 

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
   - PxrUnified, PxrBarnLightFilter, PxrCookieLightFilter, PxrRodLightFilter : Hid unwanted inputs in the GraphEditor.
   - PxrCookieLightFilter : Added button for reloading the map.
   - PxrSurface, PxrLayerSurface : Moved `utilityPattern` parameter to "Globals" section.
+  - Fixed formatting of parameter tooltips, and Node Reference descriptions.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
   - PxrCookieLightFilter : Added button for reloading the map.
   - PxrSurface, PxrLayerSurface : Moved `utilityPattern` parameter to "Globals" section.
   - Fixed formatting of parameter tooltips, and Node Reference descriptions.
+- RenderManShader : Fixed loading of C++ pattern shaders such as `aaOceanPrmanShader`.
 
 API
 ---

--- a/contrib/scripts/renderManPrototypeAttributes.py
+++ b/contrib/scripts/renderManPrototypeAttributes.py
@@ -36,11 +36,11 @@
 
 import os
 import pathlib
-from xml.etree import cElementTree
+from xml.etree import ElementTree
 
 file = pathlib.Path( os.environ["RMANTREE"] ) / "lib" / "defaults" / "PRManPrimVars.args"
 
-for event, element in cElementTree.iterparse( file, events = ( "start", ) ) :
+for event, element in ElementTree.iterparse( file, events = ( "start", ) ) :
 
 	if element.tag == "param" :
 		print( '{{ "ri:{name}", RtUString( "{name}" ) }},'.format( name = element.attrib.get( "name" ) ) )

--- a/python/GafferArnoldUI/ArnoldLightUI.py
+++ b/python/GafferArnoldUI/ArnoldLightUI.py
@@ -39,33 +39,11 @@ import functools
 import Gaffer
 import GafferArnold
 
-# Defer parameter metadata lookups to the internal shader node
-# aside from nodule:type, which we handle manually to prevent
-# some connectable plugs appearing.
-
-## \todo Refactor the GafferScene::Light base class so this can be
-# registered there, and work for all subclasses. The main issue is that
-# there is no simple generic way of querying the required "ai:light:"
-# prefix from the subclass.
-def __parameterUserDefault( plug ) :
-
-	light = plug.node()
-	return Gaffer.Metadata.value(
-		"ai:light:" + light["__shader"]["name"].getValue() + ":" + plug.relativeName( light["parameters"] ),
-		"userDefault"
-	)
-
 Gaffer.Metadata.registerNode(
 
 	GafferArnold.ArnoldLight,
 
 	plugs = {
-
-		"parameters..." : [
-
-			"userDefault", __parameterUserDefault,
-
-		],
 
 		"parameters.*" : [
 

--- a/python/GafferCyclesUI/CyclesLightUI.py
+++ b/python/GafferCyclesUI/CyclesLightUI.py
@@ -37,18 +37,6 @@
 import Gaffer
 import GafferCycles
 
-## \todo Refactor the GafferScene::Light base class so this can be
-# registered there, and work for all subclasses. The main issue is that
-# there is no simple generic way of querying the required "ai:light:"
-# prefix from the subclass.
-def __parameterUserDefault( plug ) :
-
-	light = plug.node()
-	return Gaffer.Metadata.value(
-		"cycles:light:" + light["__shader"]["name"].getValue() + ":" + plug.relativeName( light["parameters"] ),
-		"userDefault"
-	)
-
 Gaffer.Metadata.registerNode(
 
 	GafferCycles.CyclesLight,
@@ -59,12 +47,6 @@ Gaffer.Metadata.registerNode(
 
 			# Most light parameters are not connectable.
 			"nodule:type", "",
-
-		],
-
-		"parameters..." : [
-
-			"userDefault", __parameterUserDefault,
 
 		],
 

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -43,27 +43,13 @@ import IECore
 
 import Gaffer
 
-## Parses a RenderMan `.args` file, converting it to a dictionary
-# using Gaffer's standard metadata conventions :
-#
-# ```
-# {
-#	"description" : ...,
-#	"parameters" : {
-# 		"parameter1" : {
-#       	"description" : ...
-#       	"plugValueWidget:type" : ...
-#           ...
-#		}
-#   }
-# }
-# ```
-def parseMetadata( argsFile ) :
-
-	result = { "parameters" : {} }
+## Parses a RenderMan `.args` file, registering Gaffer metadata for it and all its parameters.
+# Parameter metadata is registered to `{target}:{parameterName}`.
+def registerMetadata( argsFile, target, parametersToIgnore = set() ) :
 
 	pageStack = []
-	currentParameter = None
+	currentParameterTarget = None
+	currentParameterType = None
 	for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
 
 		if element.tag == "page" :
@@ -77,71 +63,50 @@ def parseMetadata( argsFile ) :
 
 			if event == "start" :
 
-				currentParameter = {}
-				result["parameters"][element.attrib["name"]] = currentParameter
+				if element.attrib["name"] in parametersToIgnore :
+					continue
+
+				currentParameterTarget = "{}:{}".format( target, element.attrib["name"] )
 
 				# We need to know the parameter type to be able to parse presets and
 				# default values. There are two different ways this is defined, so try
 				# to normalise on the "Sdr" type.
-				currentParameter["__type"] = element.attrib.get( "sdrUsdDefinitionType" )
-				if currentParameter["__type"] is None :
-					currentParameter["__type"] = element.attrib["type"] + element.attrib.get( "arraySize", "" )
+				currentParameterType = element.attrib.get( "sdrUsdDefinitionType" )
+				if currentParameterType is None :
+					currentParameterType = element.attrib["type"] + element.attrib.get( "arraySize", "" )
 
-				currentParameter["label"] = element.attrib.get( "label" )
-				currentParameter["description"] = element.attrib.get( "help" )
-				currentParameter["layout:section"] = ".".join( pageStack )
-				currentParameter["plugValueWidget:type"] = __widgetTypes.get( element.attrib.get( "widget" ) )
+				Gaffer.Metadata.registerValue( currentParameterTarget, "label", element.attrib.get( "label" ) )
+				Gaffer.Metadata.registerValue( currentParameterTarget, "description", element.attrib.get( "help" ) )
+				Gaffer.Metadata.registerValue( currentParameterTarget, "layout:section", ".".join( pageStack ) )
+				Gaffer.Metadata.registerValue( currentParameterTarget, "plugValueWidget:type", __widgetTypes.get( element.attrib.get( "widget" ) ) )
 
-				if element.attrib.get( "connectable", "true" ).lower() == "false" or currentParameter["plugValueWidget:type"] == "" :
-					currentParameter["nodule:type"] = ""
+				if element.attrib.get( "connectable", "true" ).lower() == "false" or element.attrib.get( "widget" ) == "null" :
+					Gaffer.Metadata.registerValue( currentParameterTarget, "nodule:type", "" )
 				elif element.attrib.get( "isDynamicArray" ) == "1" :
-					currentParameter["nodule:type"] = "GafferUI::CompoundNodule"
+					Gaffer.Metadata.registerValue( currentParameterTarget, "nodule:type", "GafferUI::CompoundNodule" )
 
-				defaultValue = __parseValue( element.attrib.get( "default" ), currentParameter["__type"] )
+				defaultValue = __parseValue( element.attrib.get( "default" ), currentParameterType )
 				if defaultValue is not None :
-					currentParameter["defaultValue"] = defaultValue
+					Gaffer.Metadata.registerValue( currentParameterTarget, "defaultValue", defaultValue )
 
 				if element.attrib.get( "options" ) :
-					__parsePresets( element.attrib.get( "options" ), currentParameter )
+					__parsePresets( element.attrib.get( "options" ), currentParameterTarget, currentParameterType )
 
 			elif event == "end" :
 
-				del currentParameter["__type"] # Implementation detail not for public consumption
-				currentParameter = None
+				currentParameterTarget = None
+				currentParameterType = None
 
 		elif element.tag == "help" and event == "end" :
 
-			if currentParameter :
-				currentParameter["description"] = element.text
-			else :
-				result["description"] = element.text
+			Gaffer.Metadata.registerValue( currentParameterTarget or target, "description", element.text )
 
 		elif element.tag == "hintdict" and element.attrib.get( "name" ) == "options" :
-			if event == "end" :
-				__parsePresets( element, currentParameter )
+			if event == "end" and currentParameterTarget :
+				__parsePresets( element, currentParameterTarget, currentParameterType )
 
 		elif element.tag == "rfhdata" and event == "end" :
-			result["classification"] = element.attrib.get( "classification" )
-
-	return result
-
-## Parses a RenderMan `.args` file, registering Gaffer metadata for it and all its parameters.
-# Parameter metadata is registered to `{target}:{parameterName}`.
-def registerMetadata( argsFile, target, parametersToIgnore = set() ) :
-
-	metadata = parseMetadata( argsFile )
-
-	Gaffer.Metadata.registerValue( target, "description", metadata.get( "description", "" ) )
-	Gaffer.Metadata.registerValue( target, "classification", metadata.get( "classification", "Other" ) )
-
-	for name, values in metadata["parameters"].items() :
-
-		if name in parametersToIgnore :
-			continue
-
-		parameterTarget = f"{target}:{name}"
-		for key, value in values.items() :
-			Gaffer.Metadata.registerValue( parameterTarget, key, value )
+			Gaffer.Metadata.registerValue( target, "classification", element.attrib.get( "classification" ) )
 
 __widgetTypes = {
 	"number" : "GafferUI.NumericPlugValueWidget",
@@ -210,9 +175,9 @@ __presetContainers = {
 	"string" : IECore.StringVectorData,
 }
 
-def __parsePresets( options, parameter ) :
+def __parsePresets( options, parameterTarget, parameterType ) :
 
-	containerType = __presetContainers.get( parameter["__type"] )
+	containerType = __presetContainers.get( parameterType )
 	if containerType is None :
 		return
 
@@ -224,11 +189,11 @@ def __parsePresets( options, parameter ) :
 			optionSplit = option.split( ":" )
 			if len( optionSplit ) == 2 :
 				name = optionSplit[0]
-				value = __parseValue( optionSplit[1], parameter["__type"] )
+				value = __parseValue( optionSplit[1], parameterType )
 			else :
 				assert( len( optionSplit ) == 1 )
 				name = IECore.CamelCase.toSpaced( optionSplit[0] )
-				value = __parseValue( optionSplit[0], parameter["__type"] )
+				value = __parseValue( optionSplit[0], parameterType )
 			presetNames.append( name )
 			presetValues.append( value )
 	else :
@@ -239,7 +204,7 @@ def __parsePresets( options, parameter ) :
 			if name is None :
 				name = IECore.CamelCase.toSpaced( value )
 			presetNames.append( name )
-			presetValues.append( __parseValue( value, parameter["__type"] ) )
+			presetValues.append( __parseValue( value, parameterType ) )
 
-	parameter["presetNames"] = presetNames
-	parameter["presetValues"] = presetValues
+	Gaffer.Metadata.registerValue( parameterTarget, "presetNames", presetNames )
+	Gaffer.Metadata.registerValue( parameterTarget, "presetValues", presetValues )

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -35,7 +35,7 @@
 ##########################################################################
 
 import functools
-from xml.etree import cElementTree
+from xml.etree import ElementTree
 
 import imath
 
@@ -53,7 +53,7 @@ def registerMetadata( argsFile, parametersToIgnore = set() ) :
 	targetDescription = ""
 	currentParameterTarget = None
 	currentParameterType = None
-	for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
+	for event, element in ElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
 
 		if element.tag == "shaderType" and event == "end" :
 

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -120,21 +120,28 @@ def parseMetadata( argsFile ) :
 			if event == "end" :
 				__parsePresets( element, currentParameter )
 
+		elif element.tag == "rfhdata" and event == "end" :
+			result["classification"] = element.attrib.get( "classification" )
+
 	return result
 
-## Parses a RenderMan `.args` file, registering Gaffer metadata for all its parameters
-# against targets named `{targetPrefix}{parameterName}`.
-def registerMetadata( argsFile, targetPrefix, parametersToIgnore = set() ) :
+## Parses a RenderMan `.args` file, registering Gaffer metadata for it and all its parameters.
+# Parameter metadata is registered to `{target}:{parameterName}`.
+def registerMetadata( argsFile, target, parametersToIgnore = set() ) :
 
 	metadata = parseMetadata( argsFile )
+
+	Gaffer.Metadata.registerValue( target, "description", metadata.get( "description", "" ) )
+	Gaffer.Metadata.registerValue( target, "classification", metadata.get( "classification", "Other" ) )
+
 	for name, values in metadata["parameters"].items() :
 
 		if name in parametersToIgnore :
 			continue
 
-		target = f"{targetPrefix}{name}"
+		parameterTarget = f"{target}:{name}"
 		for key, value in values.items() :
-			Gaffer.Metadata.registerValue( target, key, value )
+			Gaffer.Metadata.registerValue( parameterTarget, key, value )
 
 __widgetTypes = {
 	"number" : "GafferUI.NumericPlugValueWidget",

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -167,6 +167,12 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "PxrDisplace" )
 		self.assertEqual( shader["type"].getValue(), "osl:displacement" )
 
+	def testPatternShaderType( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrBakePointCloud" )
+		self.assertEqual( shader["type"].getValue(), "ri:shader" )
+
 	def testUtilityPatternArray( self ) :
 
 		shader = GafferRenderMan.RenderManShader()

--- a/python/GafferRenderManUI/RenderManShaderUI.py
+++ b/python/GafferRenderManUI/RenderManShaderUI.py
@@ -37,7 +37,6 @@
 import os
 import functools
 import pathlib
-from xml.etree import cElementTree
 
 import GafferRenderMan.ArgsFileAlgo
 import oslquery
@@ -59,30 +58,8 @@ def registerMetadata() :
 	searchPaths = IECore.SearchPath( os.environ.get( "RMAN_RIXPLUGINPATH", "" ) )
 
 	for path in set( searchPaths.paths ) :
-
 		for argsFile in pathlib.Path( path ).glob( "**/*.args" ) :
-
-			pluginType = None
-			for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
-				if element.tag == "shaderType" and event == "end" :
-					tag = element.find( "tag" )
-					pluginType = tag.attrib.get( "value" ) if tag is not None else None
-					break
-
-			metadataPrefix = {
-				"bxdf" : "ri:surface",
-				"pattern" : "ri:shader",
-				"light" : "ri:light",
-				"displayfilter" : "ri:displayfilter",
-				"samplefilter" : "ri:samplefilter",
-				"lightfilter" : "ri:lightFilter",
-				"integrator" : "ri:integrator",
-			}.get( pluginType )
-
-			if metadataPrefix is None :
-				continue
-
-			GafferRenderMan.ArgsFileAlgo.registerMetadata( argsFile, f"{metadataPrefix}:{argsFile.stem}" )
+			GafferRenderMan.ArgsFileAlgo.registerMetadata( argsFile )
 
 def appendShaders( menuDefinition, prefix = "/RenderMan" ) :
 

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -144,6 +144,14 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 					## \todo Add support for these types.
 					self.assertRegex( m.message, 'Spline parameter .* not supported|.* has unsupported type "struct"' )
 
+				for parameter in node["parameters"] :
+					description = Gaffer.Metadata.value( parameter, "description" )
+					if description is not None :
+						self.assertNotIn( "<help>", description )
+						self.assertNotIn( "</help>", description )
+						self.assertNotIn( "{}:".format( parameter.getName() ), description )
+						self.assertEqual( description.count( "<p>" ), description.count( "</p>" ) )
+
 				shadersLoaded.add( argsFile.stem )
 
 		# Guard against shaders being moved and this test therefore not

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -79,6 +79,9 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 			IECore.IntVectorData( [ 0, 1, 2 ] )
 		)
 
+		n.loadShader( "PxrVisualizer" )
+		self.assertIn( "A utility integrator to navigate and inspect large scenes interactively", Gaffer.Metadata.value( n, "description" ) )
+
 	def testCustomMetadata( self ) :
 
 		# Check that all the metadata registered by
@@ -140,9 +143,6 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 				for m in mh.messages :
 					## \todo Add support for these types.
 					self.assertRegex( m.message, 'Spline parameter .* not supported|.* has unsupported type "struct"' )
-
-				# Trigger metadata parsing and ensure there are no errors
-				Gaffer.Metadata.value( node, "description" )
 
 				shadersLoaded.add( argsFile.stem )
 

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -37,7 +37,7 @@
 import os
 import pathlib
 import unittest
-from xml.etree import cElementTree
+from xml.etree import ElementTree
 
 import IECore
 
@@ -111,7 +111,7 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 
 		def __shaderType( argsFile ) :
 
-			for event, element in cElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
+			for event, element in ElementTree.iterparse( argsFile, events = ( "start", "end" ) ) :
 				if element.tag == "shaderType" and event == "end" :
 					tag = element.find( "tag" )
 					return tag.attrib.get( "value" ) if tag is not None else None

--- a/python/GafferRenderManUITest/RenderManShaderUITest.py
+++ b/python/GafferRenderManUITest/RenderManShaderUITest.py
@@ -54,8 +54,6 @@ class RenderManShaderUITest( GafferUITest.TestCase ) :
 		n = GafferRenderMan.RenderManShader()
 		n.loadShader( "PxrSurface" )
 
-		self.ignoreMessage( IECore.Msg.Level.Warning, "RenderManShader::loadShader", 'Array parameter "utilityPattern" not supported' )
-
 		self.assertEqual(
 			Gaffer.Metadata.value( n["parameters"]["diffuseGain"], "layout:section" ),
 			"Diffuse"

--- a/python/GafferSceneUI/LightFilterUI.py
+++ b/python/GafferSceneUI/LightFilterUI.py
@@ -152,6 +152,7 @@ for key in [
 	"noduleLayout:label",
 	"layout:divider",
 	"layout:section",
+	"layout:accessory",
 	"presetNames",
 	"presetValues",
 	"plugValueWidget:type",

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -160,6 +160,12 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"parameters..." : [
+
+			"userDefault", functools.partial( __parameterMetadata, key = "userDefault" ),
+
+		],
+
 		"defaultLight" : [
 
 			"description",

--- a/python/GafferSceneUI/LightUI.py
+++ b/python/GafferSceneUI/LightUI.py
@@ -61,6 +61,20 @@ def __attributeMetadata( plug, key ) :
 	target = "attribute:" + plug["name"].getValue()
 	return Gaffer.Metadata.value( target, key )
 
+def __parameterMetadata( plug, key ) :
+
+	node = plug.node()
+	shader = node.getChild( "__shader" )
+	if shader is None :
+		## \todo Refactor Light base class to require the usage
+		# of an internal Shader node.
+		return None
+
+	return Gaffer.Metadata.value(
+		shader["type"].getValue() + ":" + shader["name"].getValue() + ":" + plug.relativeName( node["parameters"] ),
+		key
+	)
+
 Gaffer.Metadata.registerNode(
 
 	GafferScene.Light,
@@ -124,6 +138,17 @@ Gaffer.Metadata.registerNode(
 		],
 
 		"parameters.*" : [
+
+			"label", functools.partial( __parameterMetadata, key = "label" ),
+			"description", functools.partial( __parameterMetadata, key = "description" ),
+			"layout:section", functools.partial( __parameterMetadata, key = "layout:section" ),
+			"layout:accessory", functools.partial( __parameterMetadata, key = "layout:accessory" ),
+			"layout:divider", functools.partial( __parameterMetadata, key = "layout:divider" ),
+			"plugValueWidget:type", functools.partial( __parameterMetadata, key = "plugValueWidget:type" ),
+			"presetNames", functools.partial( __parameterMetadata, key = "presetNames" ),
+			"presetValues", functools.partial( __parameterMetadata, key = "presetValues" ),
+			"nodule:type", functools.partial( __parameterMetadata, key = "nodule:type" ),
+			"noduleLayout:visible", functools.partial( __parameterMetadata, key = "noduleLayout:visible" ),
 
 			# Although the parameters plug is positioned
 			# as we want above, we must also register

--- a/python/GafferSceneUI/SceneViewUI.py
+++ b/python/GafferSceneUI/SceneViewUI.py
@@ -572,7 +572,7 @@ class _ShadingModePlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			if self.__shadingModeToggle is not None :
 				if result :
-					result += "\n"
+					result += "\n\n"
 				result += "## Actions\n\n"
 				result += "- <kbd>Ctrl</kbd> + click to toggle shading to `{}`\n".format( self.__shadingModeToggle if self.getPlug().isSetToDefault() else "Default" )
 

--- a/python/GafferSceneUI/ShaderUI.py
+++ b/python/GafferSceneUI/ShaderUI.py
@@ -62,6 +62,15 @@ def __shaderMetadata( node, key ) :
 		node["type"].getValue() + ":" + node["name"].getValue(), key
 	)
 
+def __nodeDescriptionMetadata( node ) :
+
+	description =__shaderMetadata( node, "description" )
+	if description :
+		return description
+
+	renderer = node.typeName().rpartition( ":" )[-1].replace( "Shader", "" )
+	return f"Loads {renderer} shaders. Use a ShaderAssignment node to assign the shader to objects in the scene."
+
 def __parameterMetadata( plug, key, shaderFallbackKey = None ) :
 
 	shader = plug.node()
@@ -79,11 +88,7 @@ Gaffer.Metadata.registerNode(
 
 	GafferScene.Shader,
 
-	"description",
-	"""
-	The base type for all nodes which create shaders. Use the
-	ShaderAssignment node to assign them to objects in the scene.
-	""",
+	"description", __nodeDescriptionMetadata,
 
 	"nodeGadget:minWidth", 0.0,
 	"nodeGadget:color", functools.partial( __shaderMetadata, key = "nodeGadget:color" ),
@@ -142,6 +147,15 @@ Gaffer.Metadata.registerNode(
 
 		"parameters.*" : [
 
+			"label", functools.partial( __parameterMetadata, key = "label" ),
+			"description", functools.partial( __parameterMetadata, key = "description" ),
+			"layout:section", functools.partial( __parameterMetadata, key = "layout:section" ),
+			"layout:accessory", functools.partial( __parameterMetadata, key = "layout:accessory" ),
+			"layout:divider", functools.partial( __parameterMetadata, key = "layout:divider" ),
+			"plugValueWidget:type", functools.partial( __parameterMetadata, key = "plugValueWidget:type" ),
+			"presetNames", functools.partial( __parameterMetadata, key = "presetNames" ),
+			"presetValues", functools.partial( __parameterMetadata, key = "presetValues" ),
+			"nodule:type", functools.partial( __parameterMetadata, key = "nodule:type" ),
 			"noduleLayout:visible", functools.partial( __parameterMetadata, key = "noduleLayout:visible", shaderFallbackKey = "noduleLayout:defaultVisibility" ),
 
 		],

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -272,7 +272,7 @@ Gaffer.Metadata.registerNode(
 			false to disable that, losing the memory savings. This can be useful
 			in certain cases like using world space displacement and wanting multiple
 			copies to displace differently. Disabling is currently only supported by
-			the Arnold render backend.
+			the Arnold and RenderMan renderer backends.
 			""",
 
 			"layout:section", "Instancing",

--- a/python/GafferUI/ConnectionPlugValueWidget.py
+++ b/python/GafferUI/ConnectionPlugValueWidget.py
@@ -84,7 +84,7 @@ class ConnectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if srcNode is not None :
 			if result :
-				result += "\n"
+				result += "\n\n"
 			result += "## Actions\n\n"
 			result += " - Left drag to drag source plug\n"
 			result += " - Left click to edit source node\n"

--- a/python/GafferUI/LabelPlugValueWidget.py
+++ b/python/GafferUI/LabelPlugValueWidget.py
@@ -128,7 +128,7 @@ class LabelPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self.getPlugs() :
 			if result :
-				result += "\n"
+				result += "\n\n"
 			result += "## Actions\n\n"
 			result += "- Left drag to connect\n"
 			if all( [ hasattr( p, "getValue" ) for p in self.getPlugs() ] ) :

--- a/python/GafferUI/NumericPlugValueWidget.py
+++ b/python/GafferUI/NumericPlugValueWidget.py
@@ -75,8 +75,8 @@ class NumericPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self.getPlugs() :
 			if result :
-				result += "\n"
-			result += "## Actions\n"
+				result += "\n\n"
+			result += "## Actions\n\n"
 			result += " - Cursor up/down or <kbd>Ctrl</kbd> + scroll wheel to increment/decrement\n"
 			result += " - Use `+`, `-`, `*`, `/` and `%` to perform simple maths\n"
 

--- a/python/GafferUI/RampPlugValueWidget.py
+++ b/python/GafferUI/RampPlugValueWidget.py
@@ -126,7 +126,7 @@ class RampPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		if self.getPlug() is not None :
 			if result :
-				result += "\n"
+				result += "\n\n"
 			result += "## Actions\n\n"
 			result += "- Click empty space in slider to add handle\n"
 			result += "- Click handle to select\n"

--- a/python/GafferUI/StringPlugValueWidget.py
+++ b/python/GafferUI/StringPlugValueWidget.py
@@ -78,7 +78,10 @@ class StringPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
-		result += "\n## Actions\n"
+		if result :
+			result += "\n\n"
+
+		result += "## Actions\n\n"
 		result += " - <kbd>Alt</kbd> + middle-click to show context variable substitutions\n"
 
 		return result

--- a/python/GafferUI/ViewUI.py
+++ b/python/GafferUI/ViewUI.py
@@ -277,7 +277,7 @@ class _TogglePlugValueWidget( GafferUI.PlugValueWidget ) :
 		result = GafferUI.PlugValueWidget.getToolTip( self )
 
 		if result :
-			result += "\n"
+			result += "\n\n"
 		result += "## Actions\n\n"
 		result += "- Click to toggle to/from default value\n"
 

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -519,6 +519,10 @@ void RenderManShader::loadShader( const std::string &shaderName, bool keepExisti
 	{
 		shaderType = "surface";
 	}
+	else if( shaderType == "pattern" )
+	{
+		shaderType = "shader";
+	}
 	else if( shaderType == "lightfilter" )
 	{
 		shaderType = "lightFilter";

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -165,6 +165,19 @@ shaderMetadata = {
 
 		"noduleLayout:defaultVisibility" : False,
 
+		"parameters" : {
+
+			"utilityPattern" : {
+
+				# PxrMarschnerHair puts this tidily away in the Globals section,
+				# but PxrLayerSurface and PxrSurface leave it dangling outside.
+				# Tidy it up.
+				"layout:section" : "Globals",
+
+			},
+
+		},
+
 	},
 
 	"ri:surface:PxrMarschnerHair" : {
@@ -189,6 +202,14 @@ shaderMetadata = {
 			k : { "noduleLayout:visible" : True }
 			for k in [ "diffuseGain", "diffuseColor", "specularFaceColor", "specularEdgeColor", "specularRoughness", "subsurfaceColor", "bumpNormal" ]
 
+		} | {
+
+			"utilityPattern" : {
+
+				"layout:section" : "Globals",
+
+			},
+
 		},
 
 	},
@@ -201,6 +222,85 @@ shaderMetadata = {
 
 			k : { "noduleLayout:visible" : True }
 			for k in [ "diffuseColor", "emitColor", "densityFloat", "densityColor" ]
+
+		},
+
+	},
+
+
+	"ri:lightFilter:PxrBarnLightFilter" : {
+
+		"parameters" : {
+
+			"colorRamp" : {
+
+				"nodule:type" : "",
+
+			},
+
+		},
+
+	},
+
+	"ri:lightFilter:PxrCookieLightFilter" : {
+
+		"parameters" : {
+
+			"map" : {
+
+				# The default map is in the `pixar` format and can't be read by OIIO,
+				# which messes up our visualiser.
+				"userDefault" : "",
+
+			},
+
+			"refreshMap" : {
+
+				# Turn into a button and tuck alongside map field.
+				"label" : "",
+				"layout:accessory" : True,
+				"plugValueWidget:type" : "GafferUI.RefreshPlugValueWidget",
+
+			},
+
+			"linearize" : {
+
+				"nodule:type" : "",
+
+			},
+
+		},
+
+	},
+
+	"ri:lightFilter:PxrRodLightFilter" : {
+
+		"parameters" : {
+
+			"colorRamp" : {
+
+				"nodule:type" : "",
+
+			},
+
+		},
+
+	},
+
+	"ri:integrator:PxrUnified" : {
+
+		"parameters" : {
+
+			k : { "nodule:type" : "" }
+			for k in [
+				"accumOpacity", "allowMultilobeIndirect", "catchAllLights", "causticClamp", "directClamp", "emissionMultiplier", "enableSampleTimers",
+				"enableShadingTimers", "enableVolumeCaustics", "indirectClamp", "indirectDirectionalBlurRadius", "indirectOversampling", "indirectSpatialBlurRadius",
+				"indirectTrainingSamples", "jointSampling", "manifoldWalk", "maxIndirectBounces", "maxInterfaces", "maxIterations", "maxNonStochasticOpacityEvents",
+				"maxRayDistance", "numBxdfSamples", "numIndirectSamples", "numLightSamples", "numVolumeAggregateSamples", "photonAdaptive", "photonEstimationNumber",
+				"photonEstimationRadius", "photonVisibilityRod", "photonVisibilityRodDirectProb", "photonVisibilityRodMax", "photonVisibilityRodMin", "risPathGuiding",
+				"rouletteDepth", "rouletteLightDepth", "rouletteThreshold", "sssOversampling", "suppressNaNs", "traceLightPaths", "useTraceDepth", "volumeAggregate",
+				"volumeAggregateNameCamera", "volumeAggregateNameIndirect", "volumeAggregateNameTransmission", "walkThreshold"
+			]
 
 		},
 
@@ -221,5 +321,3 @@ for shader, metadata in shaderMetadata.items() :
 
 			Gaffer.Metadata.registerValue( shader, key, value )
 
-# Reset the map from its default which uses the `pixar` format and can't be read by OIIO.
-Gaffer.Metadata.registerValue( "ri:lightFilter:PxrCookieLightFilter:map", "userDefault", "" )

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -35,10 +35,13 @@
 ##########################################################################
 
 import Gaffer
+import GafferRenderManUI
 
 # RenderManShaderUI derives UI metadata from `.args` files automatically. But
 # this doesn't cover everything we need for a good user experience, so here we
 # manually register additional Gaffer-specific metadata for that.
+
+GafferRenderManUI.RenderManShaderUI.registerMetadata()
 
 shaderMetadata = {
 

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -54,7 +54,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManAttributes.args", "attribute:ri:",
+		rmanTree / "lib" / "defaults" / "PRManAttributes.args", "attribute:ri",
 		parametersToIgnore = {
 			# Things that Gaffer has renderer-agnostic attributes for already.
 			"Ri:Sides",
@@ -84,7 +84,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	)
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManPrimVars.args", "attribute:ri:",
+		rmanTree / "lib" / "defaults" / "PRManPrimVars.args", "attribute:ri",
 		parametersToIgnore = {
 			# Things which we probably need to handle automatically in the
 			# Renderer class.

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -54,7 +54,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManAttributes.args", "attribute:ri",
+		rmanTree / "lib" / "defaults" / "PRManAttributes.args",
 		parametersToIgnore = {
 			# Things that Gaffer has renderer-agnostic attributes for already.
 			"Ri:Sides",
@@ -84,7 +84,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	)
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManPrimVars.args", "attribute:ri",
+		rmanTree / "lib" / "defaults" / "PRManPrimVars.args",
 		parametersToIgnore = {
 			# Things which we probably need to handle automatically in the
 			# Renderer class.

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -52,7 +52,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManOptions.args", "option:ri",
+		rmanTree / "lib" / "defaults" / "PRManOptions.args",
 		parametersToIgnore = {
 			# Gaffer handles all of these in a renderer-agnostic manner.
 			"Ri:Frame",

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -52,7 +52,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	rmanTree = pathlib.Path( os.environ["RMANTREE"] )
 
 	GafferRenderMan.ArgsFileAlgo.registerMetadata(
-		rmanTree / "lib" / "defaults" / "PRManOptions.args", "option:ri:",
+		rmanTree / "lib" / "defaults" / "PRManOptions.args", "option:ri",
 		parametersToIgnore = {
 			# Gaffer handles all of these in a renderer-agnostic manner.
 			"Ri:Frame",


### PR DESCRIPTION
This rejigs the handling of metadata for RenderManShader and RenderManLight. Instead of registering the metadata directly to the plugs of the node, we register it to string targets for the individual shaders and then let the base class look that up for plugs when necessary. This removes a bunch of code, but more importantly allows anyone to override the metadata registrations easily for a particular shader. This allows us to fix up a few annoyances arising from the default metadata.

I've included a bunch of other metadata-related improvements, including some fixes for poor formatting of description metadata for certain shaders and filters.