### PR TITLE
IECoreRenderMan : UsdLux lights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@ Improvements
 
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
+- RenderMan : Added support for USDLux lights.
 
 
 1.5.11.0 (relative to 1.5.10.1)

--- a/include/IECoreRenderMan/ShaderNetworkAlgo.h
+++ b/include/IECoreRenderMan/ShaderNetworkAlgo.h
@@ -53,9 +53,12 @@ std::vector<riley::ShadingNode> convert( const IECoreScene::ShaderNetwork *netwo
 /// host to do this combining.
 IECoreScene::ConstShaderNetworkPtr combineLightFilters( const std::vector<const IECoreScene::ShaderNetwork *> networks );
 
-/// Converts any UsdPreviewSurface shaders into native RenderMan shaders. This conversion
+/// Converts any UsdPreviewSurface and UsdLux shaders into native RenderMan shaders. This conversion
 /// is performed automatically by `preprocessedNetwork()` and is mainly just exposed for the unit
 /// tests.
 IECORERENDERMAN_API void convertUSDShaders( IECoreScene::ShaderNetwork *shaderNetwork );
+
+/// Returns the matrix needed to transform a Pxr*Light to match a UsdLux shader.
+IECORERENDERMAN_API Imath::M44f USDLightTransform( const IECoreScene::Shader *lightShader );
 
 } // namespace IECoreRenderMan::ShaderNetworkAlgo

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -381,7 +381,43 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 					"PxrCylinderLight", "light",
 					expectedLightParameters( {} )
 				)
-			]
+			],
+
+			"treatAsPoint" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"treatAsPoint" : True,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"areaNormalize" : True,
+					} )
+				),
+
+			],
+
+			"treatAsLine" : [
+
+				IECoreScene.Shader(
+					"CylinderLight", "light",
+					{
+						"treatAsLine" : True,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrCylinderLight", "light",
+					expectedLightParameters( {
+						"areaNormalize" : True,
+					} )
+				),
+
+			],
 
 		}.items() :
 			with self.subTest( testName = testName ) :
@@ -407,6 +443,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
 			IECoreScene.Shader( "CylinderLight", "light", { "length" : 2.0, "radius" : 4.0 } ) : imath.M44f().scale( imath.V3f( 2.0, 8.0, 8.0 ) ),
+			IECoreScene.Shader( "SphereLight", "light", { "treatAsPoint" : True } ) : imath.M44f().scale( imath.V3f( 0.002 ) ),
+			IECoreScene.Shader( "CylinderLight", "light", { "treatAsLine" : True } ) : imath.M44f().scale( imath.V3f( 1.0, 0.002, 0.002 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -367,6 +367,22 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 				),
 			],
 
+			"cylinderLight" : [
+
+				IECoreScene.Shader(
+					"CylinderLight", "light",
+					{
+						"length" : 2.0,
+						"radius" : 4.0,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrCylinderLight", "light",
+					expectedLightParameters( {} )
+				)
+			]
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -390,6 +406,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
+			IECoreScene.Shader( "CylinderLight", "light", { "length" : 2.0, "radius" : 4.0 } ) : imath.M44f().scale( imath.V3f( 2.0, 8.0, 8.0 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -315,6 +315,39 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"distantLightDefault" : [
+
+				IECoreScene.Shader( "DistantLight", "light", {} ),
+
+				IECoreScene.Shader(
+					"PxrDistantLight", "light",
+					expectedLightParameters( {
+						"intensity" : 50000.0,
+						"angleExtent" : 0.53,
+					} )
+				),
+			],
+
+			"distantLight" : [
+
+				IECoreScene.Shader(
+					"DistantLight", "light",
+					{
+						"intensity" : 11.0,
+						"angle" : 2.0,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrDistantLight", "light",
+					expectedLightParameters( {
+						"intensity" : 11.0,
+						"angleExtent" : 2.0,
+					} )
+				)
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -336,6 +369,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "SphereLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 			IECoreScene.Shader( "RectLight", "light", { "width" : 20.0, "height" : 60.0 } ) : imath.M44f().scale( imath.V3f( -20.0, -60.0, 1.0 ) ),
 			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
+			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -502,6 +502,26 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"emissionFocus" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"shaping:focus" : 0.5,
+						"shaping:focusTint" : imath.Color3f( 0.1, 0.2, 0.3 ),
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrRectLight", "light",
+					expectedLightParameters( {
+						"emissionFocus" : 0.5,
+						"emissionFocusTint" : imath.Color3f( 0.1, 0.2, 0.3 ),
+					} )
+				),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -456,6 +456,52 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"sphereLightToSpotLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"coneAngle" : 20.0,
+						"coneSoftness" : 0.5,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotoMetricAndSpot" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "photometric.ies",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True,
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"iesProfile" : "photometric.ies",
+						"iesProfileScale" : 2.0,
+						"iesProfileNormalize" : True,
+						"coneAngle" : 20.0,
+						"coneSoftness" : 0.5,
+					} )
+				),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -268,6 +268,53 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"diskLight" : [
+
+				IECoreScene.Shader(
+					"DiskLight", "light",
+					{
+						"radius" : 2.0,
+					}
+				),
+
+				IECoreScene.Shader( "PxrDiskLight", "light", expectedLightParameters( {} ) )
+
+			],
+
+			"rectLight" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"width" : 20.0,
+						"height" : 60.0,
+						"texture:file" : "test.tex",
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrRectLight", "light",
+					expectedLightParameters( {
+						"lightColorMap" : "test.tex",
+					} )
+				),
+
+			],
+
+			"rectLightNoTexture" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"width" : 20.0,
+						"height" : 60.0,
+					}
+				),
+
+				IECoreScene.Shader( "PxrRectLight", "light", expectedLightParameters( {} ) ),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -287,6 +334,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 		for shader, transform in {
 
 			IECoreScene.Shader( "SphereLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
+			IECoreScene.Shader( "RectLight", "light", { "width" : 20.0, "height" : 60.0 } ) : imath.M44f().scale( imath.V3f( -20.0, -60.0, 1.0 ) ),
+			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -419,6 +419,43 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"sphereLightToPhotometricLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "photometric.ies",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"iesProfile" : "photometric.ies",
+						"iesProfileScale" : 2.0,
+						"iesProfileNormalize" : True,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotometricLightEmptyProfile" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True,
+					}
+				),
+
+				IECoreScene.Shader( "PxrSphereLight", "light", expectedLightParameters( {} ) ),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -52,7 +52,7 @@ namespace
 
 M44f correctiveTransform( const IECoreScene::Shader *lightShader )
 {
-	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" )
+	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" || lightShader->getName() == "DomeLight" )
 	{
 		return M44f().rotate( V3f( -M_PI_2, M_PI_2, 0.0f ) );
 	}

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -80,7 +80,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		LightLinker *m_lightLinker;
 		ConstLightShaderPtr m_lightShader;
 		riley::LightInstanceId m_lightInstance;
-		Imath::M44f m_correctiveTransform;
+		Imath::M44f m_preTransform;
 		/// Used to keep material etc alive as long as we need it.
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -582,6 +582,7 @@ const InternedString g_specularModelTypeParameter( "specularModelType" );
 const InternedString g_specularRoughnessParameter( "specularRoughness" );
 const InternedString g_temperatureParameter( "temperature" );
 const InternedString g_textureFileParameter( "texture:file" );
+const InternedString g_textureFormatParameter( "texture:format" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
@@ -826,6 +827,27 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 
 			const float angle = parameterValue( shader.get(), g_angleParameter, 0.53f );
 			newShader->parameters()[g_angleExtentParameter] = new FloatData( angle );
+		}
+		else if( shader->getName() == "DomeLight" )
+		{
+			newShader = new Shader( "PxrDomeLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+
+			const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
+			if( !textureFile.empty() )
+			{
+				newShader->parameters()[g_lightColorMapParameter] = new StringData( textureFile );
+			}
+
+			const std::string textureFormat = parameterValue( shader.get(), g_textureFormatParameter, std::string() );
+			if( textureFormat != "automatic" )
+			{
+				IECore::msg(
+					IECore::Msg::Warning,
+					"convertUSDShaders",
+					fmt::format( "Unsupported value \"{}\" for DomeLight.format. Only \"automatic\" is supported. Format will be read from texture file.", textureFormat )
+				);
+			}
 		}
 
 		const auto it = g_primVarMap.find( shader->getName() );

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -551,6 +551,9 @@ const InternedString g_glassRoughnessParameter( "glassRoughness" );
 const InternedString g_glowColorParameter( "glowColor" );
 const InternedString g_glowGainParameter( "glowGain" );
 const InternedString g_heightParameter( "height" );
+const InternedString g_iesProfileParameter( "iesProfile" );
+const InternedString g_iesProfileScaleParameter( "iesProfileScale" );
+const InternedString g_iesProfileNormalizeParameter( "iesProfileNormalize" );
 const InternedString g_intensityParameter( "intensity" );
 const InternedString g_lengthParameter( "length" );
 const InternedString g_lightColorParameter( "lightColor" );
@@ -574,6 +577,9 @@ const InternedString g_shadowFalloffParameter( "shadowFalloff" );
 const InternedString g_shadowFalloffUSDParameter( "shadow:falloff" );
 const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
 const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
+const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
+const InternedString g_shapingIesAngleScaleParameter( "shaping:ies:angleScale" );
+const InternedString g_shapingIesNormalizeParameter( "shaping:ies:normalize" );
 const InternedString g_specularParameter( "specular" );
 const InternedString g_specularDoubleSidedParameter( "specularDoubleSided" );
 const InternedString g_specularEdgeColorParameter( "specularEdgeColor" );
@@ -644,6 +650,19 @@ void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHa
 		if( boost::starts_with( name.string(), g_renderManNamespace ) )
 		{
 			shader->parameters()[name.string().substr(g_renderManNamespace.size())] = value;
+		}
+	}
+}
+
+void transferUSDShapingParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
+{
+	if( auto dFile = usdShader->parametersData()->member<StringData>( g_shapingIesFileParameter ) )
+	{
+		if( !dFile->readable().empty() )
+		{
+			shader->parameters()[g_iesProfileParameter] = new StringData( dFile->readable() );
+			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesAngleScaleParameter, shader, g_iesProfileScaleParameter, 0.f );
+			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesNormalizeParameter, shader, g_iesProfileNormalizeParameter, false );
 		}
 	}
 }
@@ -802,6 +821,7 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 		{
 			newShader = new Shader( "PxrSphereLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 
 			if( parameterValue( shader.get(), g_treatAsPointParameter, false ) )
@@ -813,12 +833,14 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 		{
 			newShader = new Shader( "PxrDiskLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 		}
 		else if( shader->getName() == "RectLight" )
 		{
 			newShader = new Shader( "PxrRectLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 
 			const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
@@ -831,6 +853,7 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 		{
 			newShader = new Shader( "PxrDistantLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get(), 50000.f );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 
 			const float angle = parameterValue( shader.get(), g_angleParameter, 0.53f );
@@ -861,6 +884,7 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 		{
 			newShader = new Shader( "PxrCylinderLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDShapingParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 
 			if( parameterValue( shader.get(), g_treatAsLineParameter, false ) )

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -543,6 +543,8 @@ const InternedString g_diffuseParameter( "diffuse" );
 const InternedString g_diffuseColorParameter( "diffuseColor" );
 const InternedString g_diffuseDoubleSidedParameter( "diffuseDoubleSided" );
 const InternedString g_diffuseGainParameter( "diffuseGain") ;
+const InternedString g_emissionFocusParameter( "emissionFocus" );
+const InternedString g_emissionFocusTintParameter( "emissionFocusTint" );
 const InternedString g_enableColorTemperatureParameter( "enableColorTemperature" );
 const InternedString g_enableShadowsParameter( "enableShadows" );
 const InternedString g_enableTemperatureParameter( "enableTemperature" );
@@ -581,6 +583,8 @@ const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
 const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
 const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
 const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
+const InternedString g_shapingFocusParameter( "shaping:focus" );
+const InternedString g_shapingFocusTintParameter( "shaping:focusTint" );
 const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
 const InternedString g_shapingIesAngleScaleParameter( "shaping:ies:angleScale" );
 const InternedString g_shapingIesNormalizeParameter( "shaping:ies:normalize" );
@@ -675,6 +679,13 @@ void transferUSDShapingParameters( ShaderNetwork *network, InternedString shader
 		shader->parameters()[g_coneAngleParameter] = new FloatData( dAngle->readable() );
 		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.f );
 		shader->parameters()[g_coneSoftnessParameter] = new FloatData( softness );
+	}
+
+	if( auto dFocus = usdShader->parametersData()->member<FloatData>( g_shapingFocusParameter ) )
+	{
+		shader->parameters()[g_emissionFocusParameter] = new FloatData( dFocus->readable() );
+		const Color3f tint = parameterValue( usdShader, g_shapingFocusTintParameter, Color3f( 0.f, 0.f, 0.f ) );
+		shader->parameters()[g_emissionFocusTintParameter] = new Color3fData( tint );
 	}
 }
 

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -524,40 +524,65 @@ void transferUSDParameter( ShaderNetwork *network, InternedString shaderHandle, 
 	}
 }
 
+const InternedString g_areaNormalizeParameter( "areaNormalize" );
 const InternedString g_bumpNormalParameter( "bumpNormal" );
 const InternedString g_clearcoatDoubleSidedParameter( "clearcoatDoubleSided" );
 const InternedString g_clearcoatFaceColorParameter( "clearcoatFaceColor" );
 const InternedString g_clearcoatEdgeColorParameter( "clearcoatEdgeColor" );
 const InternedString g_clearcoatRoughnessParameter( "clearcoatRoughness" );
+const InternedString g_colorParameter( "color" );
+const InternedString g_colorTemperatureParameter( "colorTemperature" );
 const InternedString g_defaultFloatParameter( "defaultFloat" );
 const InternedString g_defaultFloat3Parameter( "defaultFloat3" );
 const InternedString g_defaultIntParameter( "defaultInt" );
+const InternedString g_diffuseParameter( "diffuse" );
 const InternedString g_diffuseColorParameter( "diffuseColor" );
 const InternedString g_diffuseDoubleSidedParameter( "diffuseDoubleSided" );
 const InternedString g_diffuseGainParameter( "diffuseGain") ;
+const InternedString g_enableColorTemperatureParameter( "enableColorTemperature" );
+const InternedString g_enableShadowsParameter( "enableShadows" );
+const InternedString g_enableTemperatureParameter( "enableTemperature" );
+const InternedString g_exposureParameter( "exposure" );
 const InternedString g_fallbackParameter( "fallback" );
 const InternedString g_glassIorParameter( "glassIor" );
 const InternedString g_glassRoughnessParameter( "glassRoughness" );
 const InternedString g_glowColorParameter( "glowColor" );
 const InternedString g_glowGainParameter( "glowGain" );
+const InternedString g_intensityParameter( "intensity" );
+const InternedString g_lightColorParameter( "lightColor" );
 const InternedString g_normalParameter( "normal" );
 const InternedString g_normalInParameter( "normalIn" );
+const InternedString g_normalizeParameter( "normalize" );
 const InternedString g_presenceParameter( "presence" );
+const InternedString g_radiusParameter( "radius" );
 const InternedString g_refractionGainParameter( "refractionGain" );
 const InternedString g_resultFParameter( "resultF" );
 const InternedString g_resultIParameter( "resultI" );
 const InternedString g_resultRGBParameter( "resultRGB" );
 const InternedString g_roughSpecularDoubleSidedParameter( "roughSpecularDoubleSided" );
+const InternedString g_shadowColorParameter( "shadowColor" );
+const InternedString g_shadowColorUSDParameter( "shadow:color" );
+const InternedString g_shadowDistanceParameter( "shadowDistance" );
+const InternedString g_shadowDistanceUSDParameter( "shadow:distance" );
+const InternedString g_shadowEnableParameter( "shadow:enable" );
+const InternedString g_shadowFalloffParameter( "shadowFalloff" );
+const InternedString g_shadowFalloffUSDParameter( "shadow:falloff" );
+const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
+const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
+const InternedString g_specularParameter( "specular" );
 const InternedString g_specularDoubleSidedParameter( "specularDoubleSided" );
 const InternedString g_specularEdgeColorParameter( "specularEdgeColor" );
 const InternedString g_specularFaceColorParameter( "specularFaceColor" );
 const InternedString g_specularIorParameter( "specularIor" );
 const InternedString g_specularModelTypeParameter( "specularModelType" );
 const InternedString g_specularRoughnessParameter( "specularRoughness" );
+const InternedString g_temperatureParameter( "temperature" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
 const InternedString g_varnameParameter( "varname" );
+
+const std::string g_renderManNamespace( "ri:" );
 
 const std::vector<InternedString> g_pxrSurfaceParameters = {
 	g_diffuseGainParameter,
@@ -587,6 +612,31 @@ const std::unordered_map<std::string, std::tuple<std::string, InternedString, st
 	{ "UsdPrimvarReader_vector", { "vector", g_defaultFloat3Parameter, V3f( 0.f ) } },
 	{ "UsdPrimvarReader_int", { "int", g_defaultIntParameter, 0 } }
 };
+
+void transferUSDLightParameters( ShaderNetwork *network, InternedString shaderHandle, const Shader *usdShader, Shader *shader )
+{
+	transferUSDParameter( network, shaderHandle, usdShader, g_colorParameter, shader, g_lightColorParameter, Color3f( 1.f, 1.f, 1.f ) );
+	transferUSDParameter( network, shaderHandle, usdShader, g_diffuseParameter, shader, g_diffuseParameter, 1.0f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_exposureParameter, shader, g_exposureParameter, 0.0f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_intensityParameter, shader, g_intensityParameter, 1.0f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_specularParameter, shader, g_specularParameter, 1.0f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_enableColorTemperatureParameter, shader, g_enableTemperatureParameter, false );
+	transferUSDParameter( network, shaderHandle, usdShader, g_colorTemperatureParameter, shader, g_temperatureParameter, 6500.f );
+
+	transferUSDParameter( network, shaderHandle, usdShader, g_shadowEnableParameter, shader, g_enableShadowsParameter, true );
+	transferUSDParameter( network, shaderHandle, usdShader, g_shadowColorUSDParameter, shader, g_shadowColorParameter, Color3f( 0 ) );
+	transferUSDParameter( network, shaderHandle, usdShader, g_shadowDistanceUSDParameter, shader, g_shadowDistanceParameter, -1.f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_shadowFalloffUSDParameter, shader, g_shadowFalloffParameter, -1.f );
+	transferUSDParameter( network, shaderHandle, usdShader, g_shadowFalloffGammaUSDParameter, shader, g_shadowFalloffGammaParameter, 1.f );
+
+	for( const auto &[name, value] : usdShader->parameters() )
+	{
+		if( boost::starts_with( name.string(), g_renderManNamespace ) )
+		{
+			shader->parameters()[name.string().substr(g_renderManNamespace.size())] = value;
+		}
+	}
+}
 
 const InternedString remapOutputParameterName( const InternedString name, const InternedString shaderName )
 {
@@ -738,6 +788,12 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 
 			shaderNetwork->setOutput( { pxrSurfaceHandle, "" } );
 		}
+		else if( shader->getName() == "SphereLight" )
+		{
+			newShader = new Shader( "PxrSphereLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
 		if( it != g_primVarMap.end() )
@@ -762,6 +818,19 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 		}
 	}
 	IECoreScene::ShaderNetworkAlgo::removeUnusedShaders( shaderNetwork );
+}
+
+M44f USDLightTransform( const Shader *lightShader )
+{
+	assert( lightShader );
+
+	if( lightShader->getName() == "SphereLight" )
+	{
+		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
+		return M44f().scale( V3f( radius * 2.f ) );
+	}
+
+	return M44f();
 }
 
 } // namespace IECoreRenderMan::ShaderNetworkAlgo

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -584,6 +584,8 @@ const InternedString g_specularRoughnessParameter( "specularRoughness" );
 const InternedString g_temperatureParameter( "temperature" );
 const InternedString g_textureFileParameter( "texture:file" );
 const InternedString g_textureFormatParameter( "texture:format" );
+const InternedString g_treatAsPointParameter( "treatAsPoint" );
+const InternedString g_treatAsLineParameter( "treatAsLine" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
@@ -801,6 +803,11 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 			newShader = new Shader( "PxrSphereLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+
+			if( parameterValue( shader.get(), g_treatAsPointParameter, false ) )
+			{
+				newShader->parameters()[g_areaNormalizeParameter] = new BoolData( true );
+			}
 		}
 		else if( shader->getName() == "DiskLight" )
 		{
@@ -855,6 +862,11 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 			newShader = new Shader( "PxrCylinderLight", "ri:light" );
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+
+			if( parameterValue( shader.get(), g_treatAsLineParameter, false ) )
+			{
+				newShader->parameters()[g_areaNormalizeParameter] = new BoolData( true );
+			}
 		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
@@ -886,7 +898,15 @@ M44f USDLightTransform( const Shader *lightShader )
 {
 	assert( lightShader );
 
-	if( lightShader->getName() == "SphereLight" || lightShader->getName() == "DiskLight" )
+	if( lightShader->getName() == "SphereLight" )
+	{
+		const float radius = !parameterValue( lightShader, g_treatAsPointParameter, false ) ?
+			parameterValue( lightShader, g_radiusParameter, 1.f ) :
+			0.001f
+		;
+		return M44f().scale( V3f( radius * 2.f ) );
+	}
+	else if( lightShader->getName() == "DiskLight" )
 	{
 		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
 		return M44f().scale( V3f( radius * 2.f ) );
@@ -902,7 +922,10 @@ M44f USDLightTransform( const Shader *lightShader )
 	else if( lightShader->getName() == "CylinderLight" )
 	{
 		const float length = parameterValue( lightShader, g_lengthParameter, 1.f );
-		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
+		const float radius = !parameterValue( lightShader, g_treatAsLineParameter, false ) ?
+			parameterValue( lightShader, g_radiusParameter, 0.5f ) :
+			0.001f
+		;
 
 		return M44f().scale( V3f( length, radius * 2.f, radius * 2.f ) );
 	}

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -552,6 +552,7 @@ const InternedString g_glowColorParameter( "glowColor" );
 const InternedString g_glowGainParameter( "glowGain" );
 const InternedString g_heightParameter( "height" );
 const InternedString g_intensityParameter( "intensity" );
+const InternedString g_lengthParameter( "length" );
 const InternedString g_lightColorParameter( "lightColor" );
 const InternedString g_lightColorMapParameter( "lightColorMap" );
 const InternedString g_normalParameter( "normal" );
@@ -849,6 +850,12 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 				);
 			}
 		}
+		else if( shader->getName() == "CylinderLight" )
+		{
+			newShader = new Shader( "PxrCylinderLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
 		if( it != g_primVarMap.end() )
@@ -891,6 +898,13 @@ M44f USDLightTransform( const Shader *lightShader )
 		// `IECoreRenderMan::Light` takes care of inverting the z axis. We also need
 		// to invert the x and y axes to keep image maps oriented correctly.
 		return M44f().scale( V3f( -width, -height, 1.f ) );
+	}
+	else if( lightShader->getName() == "CylinderLight" )
+	{
+		const float length = parameterValue( lightShader, g_lengthParameter, 1.f );
+		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
+
+		return M44f().scale( V3f( length, radius * 2.f, radius * 2.f ) );
 	}
 
 	return M44f();

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -534,6 +534,8 @@ const InternedString g_clearcoatEdgeColorParameter( "clearcoatEdgeColor" );
 const InternedString g_clearcoatRoughnessParameter( "clearcoatRoughness" );
 const InternedString g_colorParameter( "color" );
 const InternedString g_colorTemperatureParameter( "colorTemperature" );
+const InternedString g_coneAngleParameter( "coneAngle" );
+const InternedString g_coneSoftnessParameter( "coneSoftness" );
 const InternedString g_defaultFloatParameter( "defaultFloat" );
 const InternedString g_defaultFloat3Parameter( "defaultFloat3" );
 const InternedString g_defaultIntParameter( "defaultInt" );
@@ -577,6 +579,8 @@ const InternedString g_shadowFalloffParameter( "shadowFalloff" );
 const InternedString g_shadowFalloffUSDParameter( "shadow:falloff" );
 const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
 const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
+const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
+const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
 const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
 const InternedString g_shapingIesAngleScaleParameter( "shaping:ies:angleScale" );
 const InternedString g_shapingIesNormalizeParameter( "shaping:ies:normalize" );
@@ -664,6 +668,13 @@ void transferUSDShapingParameters( ShaderNetwork *network, InternedString shader
 			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesAngleScaleParameter, shader, g_iesProfileScaleParameter, 0.f );
 			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesNormalizeParameter, shader, g_iesProfileNormalizeParameter, false );
 		}
+	}
+
+	if( auto dAngle = usdShader->parametersData()->member<FloatData>( g_shapingConeAngleParameter ) )
+	{
+		shader->parameters()[g_coneAngleParameter] = new FloatData( dAngle->readable() );
+		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.f );
+		shader->parameters()[g_coneSoftnessParameter] = new FloatData( softness );
 	}
 }
 

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -548,8 +548,10 @@ const InternedString g_glassIorParameter( "glassIor" );
 const InternedString g_glassRoughnessParameter( "glassRoughness" );
 const InternedString g_glowColorParameter( "glowColor" );
 const InternedString g_glowGainParameter( "glowGain" );
+const InternedString g_heightParameter( "height" );
 const InternedString g_intensityParameter( "intensity" );
 const InternedString g_lightColorParameter( "lightColor" );
+const InternedString g_lightColorMapParameter( "lightColorMap" );
 const InternedString g_normalParameter( "normal" );
 const InternedString g_normalInParameter( "normalIn" );
 const InternedString g_normalizeParameter( "normalize" );
@@ -577,10 +579,12 @@ const InternedString g_specularIorParameter( "specularIor" );
 const InternedString g_specularModelTypeParameter( "specularModelType" );
 const InternedString g_specularRoughnessParameter( "specularRoughness" );
 const InternedString g_temperatureParameter( "temperature" );
+const InternedString g_textureFileParameter( "texture:file" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
 const InternedString g_varnameParameter( "varname" );
+const InternedString g_widthParameter( "width" );
 
 const std::string g_renderManNamespace( "ri:" );
 
@@ -794,6 +798,24 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
 		}
+		else if( shader->getName() == "DiskLight" )
+		{
+			newShader = new Shader( "PxrDiskLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+		}
+		else if( shader->getName() == "RectLight" )
+		{
+			newShader = new Shader( "PxrRectLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+
+			const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
+			if( !textureFile.empty() )
+			{
+				newShader->parameters()[g_lightColorMapParameter] = new StringData( textureFile );
+			}
+		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
 		if( it != g_primVarMap.end() )
@@ -824,10 +846,18 @@ M44f USDLightTransform( const Shader *lightShader )
 {
 	assert( lightShader );
 
-	if( lightShader->getName() == "SphereLight" )
+	if( lightShader->getName() == "SphereLight" || lightShader->getName() == "DiskLight" )
 	{
 		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
 		return M44f().scale( V3f( radius * 2.f ) );
+	}
+	else if( lightShader->getName() == "RectLight" )
+	{
+		const float width = parameterValue( lightShader, g_widthParameter, 1.f );
+		const float height = parameterValue( lightShader, g_heightParameter, 1.f );
+		// `IECoreRenderMan::Light` takes care of inverting the z axis. We also need
+		// to invert the x and y axes to keep image maps oriented correctly.
+		return M44f().scale( V3f( -width, -height, 1.f ) );
 	}
 
 	return M44f();

--- a/src/IECoreRenderManModule/IECoreRenderManModule.cpp
+++ b/src/IECoreRenderManModule/IECoreRenderManModule.cpp
@@ -49,4 +49,5 @@ BOOST_PYTHON_MODULE( _IECoreRenderMan )
 	scope shaderNetworkAlgoScope( shaderNetworkAlgoModule );
 
 	def( "convertUSDShaders", &ShaderNetworkAlgo::convertUSDShaders );
+	def( "USDLightTransform", &ShaderNetworkAlgo::USDLightTransform );
 }


### PR DESCRIPTION
This adds support for UsdLux lights to IECoreRenderMan.

I originally was going to build off of https://github.com/GafferHQ/gaffer/pull/6319, but preferred to have it structured as a more straightforward "if this light then set these parameters" for each light. Between that and making sure the test coverage was good, I decided to make a clean start.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
