### PR TITLE
IECoreRenderMan : UsdLux support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - GafferML :
   - Added support for custom ONNX ops via the `GAFFERML_CUSTOM_OPS_LIBRARIES` environment variable. This should contain a comma-separated list of full paths to libraries containing custom ops.
   - Added support for string tensors.
+- RenderMan : Added support for USDLux lights.
 
 1.5.13.0 (relative to 1.5.12.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -77,6 +77,7 @@ Fixes
   - Fixed compatibility with ShaderTweakProxy.
 - ShaderTweaks : Fixed error when selecting an array element to tweak, such as `utilityPattern[0]` in a PxrSurface shader (#6383).
 - CompoundVectorParameterValueWidget : Fixed being unable to edit certain parameters when there were too many, by adding a horizontal scroll bar.
+- RenderMan Light : Fixed orientation of color maps on `PxrRectLight`.
 
 API
 ---

--- a/include/IECoreRenderMan/ShaderNetworkAlgo.h
+++ b/include/IECoreRenderMan/ShaderNetworkAlgo.h
@@ -53,9 +53,12 @@ std::vector<riley::ShadingNode> convert( const IECoreScene::ShaderNetwork *netwo
 /// host to do this combining.
 IECoreScene::ConstShaderNetworkPtr combineLightFilters( const std::vector<const IECoreScene::ShaderNetwork *> networks );
 
-/// Converts any UsdPreviewSurface shaders into native RenderMan shaders. This conversion
+/// Converts any UsdPreviewSurface and UsdLux shaders into native RenderMan shaders. This conversion
 /// is performed automatically by `preprocessedNetwork()` and is mainly just exposed for the unit
 /// tests.
 IECORERENDERMAN_API void convertUSDShaders( IECoreScene::ShaderNetwork *shaderNetwork );
+
+/// Returns the matrix needed to transform a Pxr*Light to match a UsdLux shader.
+IECORERENDERMAN_API Imath::M44f usdLightTransform( const IECoreScene::Shader *lightShader );
 
 } // namespace IECoreRenderMan::ShaderNetworkAlgo

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -315,6 +315,39 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"distantLightDefault" : [
+
+				IECoreScene.Shader( "DistantLight", "light", {} ),
+
+				IECoreScene.Shader(
+					"PxrDistantLight", "light",
+					expectedLightParameters( {
+						"intensity" : 50000.0,
+						"angleExtent" : 0.53,
+					} )
+				),
+			],
+
+			"distantLight" : [
+
+				IECoreScene.Shader(
+					"DistantLight", "light",
+					{
+						"intensity" : 11.0,
+						"angle" : 2.0,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrDistantLight", "light",
+					expectedLightParameters( {
+						"intensity" : 11.0,
+						"angleExtent" : 2.0,
+					} )
+				)
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -336,6 +369,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "SphereLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 			IECoreScene.Shader( "RectLight", "light", { "width" : 20.0, "height" : 60.0 } ) : imath.M44f().scale( imath.V3f( 20.0, 60.0, 1.0 ) ),
 			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
+			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -368,6 +368,22 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 				),
 			],
 
+			"cylinderLight" : [
+
+				IECoreScene.Shader(
+					"CylinderLight", "light",
+					{
+						"length" : 2.0,
+						"radius" : 4.0,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrCylinderLight", "light",
+					expectedLightParameters( {} )
+				)
+			]
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -391,6 +407,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
+			IECoreScene.Shader( "CylinderLight", "light", { "length" : 2.0, "radius" : 4.0 } ) : imath.M44f().scale( imath.V3f( 2.0, 8.0, 8.0 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -268,6 +268,53 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"diskLight" : [
+
+				IECoreScene.Shader(
+					"DiskLight", "light",
+					{
+						"radius" : 2.0,
+					}
+				),
+
+				IECoreScene.Shader( "PxrDiskLight", "light", expectedLightParameters( {} ) )
+
+			],
+
+			"rectLight" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"width" : 20.0,
+						"height" : 60.0,
+						"texture:file" : "test.tex",
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrRectLight", "light",
+					expectedLightParameters( {
+						"lightColorMap" : "test.tex",
+					} )
+				),
+
+			],
+
+			"rectLightNoTexture" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"width" : 20.0,
+						"height" : 60.0,
+					}
+				),
+
+				IECoreScene.Shader( "PxrRectLight", "light", expectedLightParameters( {} ) ),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -287,6 +334,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 		for shader, transform in {
 
 			IECoreScene.Shader( "SphereLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
+			IECoreScene.Shader( "RectLight", "light", { "width" : 20.0, "height" : 60.0 } ) : imath.M44f().scale( imath.V3f( 20.0, 60.0, 1.0 ) ),
+			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -348,6 +348,26 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"domeLight" : [
+
+				IECoreScene.Shader(
+					"DomeLight", "light",
+					{
+						"texture:file" : "test.tex",
+						"texture:format" : "automatic",
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrDomeLight", "light",
+					{
+						k : v for k, v in expectedLightParameters( {
+							"lightColorMap" : "test.tex"
+						} ).items() if k != "areaNormalize"
+					}
+				),
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 
@@ -370,6 +390,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "RectLight", "light", { "width" : 20.0, "height" : 60.0 } ) : imath.M44f().scale( imath.V3f( 20.0, 60.0, 1.0 ) ),
 			IECoreScene.Shader( "DiskLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
+			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
 
 		}.items() :
 			with self.subTest() :
@@ -379,6 +400,29 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 					transform,
 					"Testing {}".format( shader.name )
 				)
+
+	def testDomeLightNotAutomatic( self ) :
+
+		shaderNetwork = IECoreScene.ShaderNetwork(
+			shaders = {
+				"light" : IECoreScene.Shader(
+					"DomeLight", "light",
+					{
+						"texture:format" : "latlong",
+					}
+				)
+			},
+			output = "light",
+		)
+
+		with IECore.CapturingMessageHandler() as mh :
+			IECoreRenderMan.ShaderNetworkAlgo.convertUSDShaders( shaderNetwork )
+			self.assertEqual( len( mh.messages ), 1 )
+			self.assertEqual( mh.messages[0].level, mh.Level.Warning )
+			self.assertEqual(
+				mh.messages[0].message,
+				"Unsupported value \"latlong\" for DomeLight.format. Only \"automatic\" is supported. Format will be read from texture file."
+			)
 
 	def __assertShadersEqual( self, shader1, shader2, message = None ) :
 

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -457,6 +457,52 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"sphereLightToSpotLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"coneAngle" : 20.0,
+						"coneSoftness" : 0.5,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotoMetricAndSpot" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "photometric.ies",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True,
+						"shaping:cone:angle" : 20.0,
+						"shaping:cone:softness" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"iesProfile" : "photometric.ies",
+						"iesProfileScale" : 2.0,
+						"iesProfileNormalize" : True,
+						"coneAngle" : 20.0,
+						"coneSoftness" : 0.5,
+					} )
+				),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -167,6 +167,146 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 				self.assertEqual( network.input( ( "previewSurface", surfaceIn ) ), ( "reader", readerOut ) )
 
+	def testConvertUSDLights( self ) :
+
+		def expectedLightParameters( parameters ) :
+
+			# Start with defaults
+			result = {
+				"intensity" : 1.0,
+				"exposure" : 0.0,
+				"lightColor" : imath.Color3f( 1.0, 1.0, 1.0 ),
+				"diffuse" : 1.0,
+				"specular" : 1.0,
+				"areaNormalize" : False,  # Common to all lights except DomeLight
+				"enableTemperature" : False,
+				"temperature" : 6500.0,
+				"enableShadows" : True,
+				"shadowColor" : imath.Color3f( 0.0, 0.0, 0.0 ),
+				"shadowDistance" : -1.0,
+				"shadowFalloff" : -1.0,
+				"shadowFalloffGamma" : 1.0,
+			}
+			result.update( parameters )
+			return result
+
+		for testName, shaders in {
+
+			# Basic SphereLight -> point_light conversion, testing default values
+
+			"defaultParameters" : [
+
+				IECoreScene.Shader( "SphereLight", "light", {} ),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {} )
+				)
+
+			],
+
+			# Basic SphereLight -> PxrSphereLight conversion
+
+			"sphereLightToPointLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"intensity" : 2.5,
+						"exposure" : 1.1,
+						"color" : imath.Color3f( 1, 2, 3 ),
+						"diffuse" : 0.5,
+						"specular" : 0.75,
+						"radius" : 0.5,
+						"normalize" : True,
+						"enableColorTemperature" : True,
+						"colorTemperature" : 5500.0,
+						"ri:light:thinShadow" : False,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"intensity" : 2.5,
+						"exposure" : 1.1,
+						"lightColor" : imath.Color3f( 1, 2, 3 ),
+						"diffuse" : 0.5,
+						"specular" : 0.75,
+						"areaNormalize" : True,
+						"enableTemperature" : True,
+						"temperature" : 5500.0,
+						"thinShadow" : False,
+					} )
+				),
+
+			],
+
+			"shadowAPI" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shadow:enable" : False,
+						"shadow:color" : imath.V3f( 1.0, 0.0, 0.0 ),
+						"shadow:distance" : 2.0,
+						"shadow:falloff" : 3.0,
+						"shadow:falloffGamma" : 0.5,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"enableShadows" : False,
+						"shadowColor" : imath.Color3f( 1.0, 0.0, 0.0 ),
+						"shadowDistance" : 2.0,
+						"shadowFalloff" : 3.0,
+						"shadowFalloffGamma" : 0.5,
+					} )
+				),
+
+			],
+
+		}.items() :
+			with self.subTest( testName = testName ) :
+
+				network = IECoreScene.ShaderNetwork(
+					shaders = {
+						"light" : shaders[0],
+					},
+					output = "light"
+				)
+
+				IECoreRenderMan.ShaderNetworkAlgo.convertUSDShaders( network )
+
+				self.__assertShadersEqual( network.getShader( "light" ), shaders[1], "Testing {}".format( testName ) )
+
+	def testUSDLightTransform( self ) :
+
+		for shader, transform in {
+
+			IECoreScene.Shader( "SphereLight", "light", { "radius" : 2.0 } ) : imath.M44f().scale( imath.V3f( 4.0 ) ),
+
+		}.items() :
+			with self.subTest() :
+
+				self.assertEqual(
+					IECoreRenderMan.ShaderNetworkAlgo.usdLightTransform( shader ),
+					transform,
+					"Testing {}".format( shader.name )
+				)
+
+	def __assertShadersEqual( self, shader1, shader2, message = None ) :
+
+		self.assertEqual( shader1.name, shader2.name, message )
+		self.assertEqual( shader1.parameters.keys(), shader2.parameters.keys(), message )
+		for k in shader1.parameters.keys() :
+			self.assertEqual(
+				shader1.parameters[k], shader2.parameters[k],
+				"{}(Parameter = {})".format( message or "", k )
+			)
+
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -382,7 +382,43 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 					"PxrCylinderLight", "light",
 					expectedLightParameters( {} )
 				)
-			]
+			],
+
+			"treatAsPoint" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"treatAsPoint" : True,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"areaNormalize" : True,
+					} )
+				),
+
+			],
+
+			"treatAsLine" : [
+
+				IECoreScene.Shader(
+					"CylinderLight", "light",
+					{
+						"treatAsLine" : True,
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrCylinderLight", "light",
+					expectedLightParameters( {
+						"areaNormalize" : True,
+					} )
+				),
+
+			],
 
 		}.items() :
 			with self.subTest( testName = testName ) :
@@ -408,6 +444,8 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			IECoreScene.Shader( "DistantLight", "light", { "angle" : 2.0 } ) : imath.M44f(),
 			IECoreScene.Shader( "DomeLight", "light", {} ) : imath.M44f(),
 			IECoreScene.Shader( "CylinderLight", "light", { "length" : 2.0, "radius" : 4.0 } ) : imath.M44f().scale( imath.V3f( 2.0, 8.0, 8.0 ) ),
+			IECoreScene.Shader( "SphereLight", "light", { "treatAsPoint" : True } ) : imath.M44f().scale( imath.V3f( 0.002 ) ),
+			IECoreScene.Shader( "CylinderLight", "light", { "treatAsLine" : True } ) : imath.M44f().scale( imath.V3f( 1.0, 0.002, 0.002 ) ),
 
 		}.items() :
 			with self.subTest() :

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -503,6 +503,26 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"emissionFocus" : [
+
+				IECoreScene.Shader(
+					"RectLight", "light",
+					{
+						"shaping:focus" : 0.5,
+						"shaping:focusTint" : imath.Color3f( 0.1, 0.2, 0.3 ),
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrRectLight", "light",
+					expectedLightParameters( {
+						"emissionFocus" : 0.5,
+						"emissionFocusTint" : imath.Color3f( 0.1, 0.2, 0.3 ),
+					} )
+				),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
+++ b/python/IECoreRenderManTest/ShaderNetworkAlgoTest.py
@@ -420,6 +420,43 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 			],
 
+			"sphereLightToPhotometricLight" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "photometric.ies",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True
+					}
+				),
+
+				IECoreScene.Shader(
+					"PxrSphereLight", "light",
+					expectedLightParameters( {
+						"iesProfile" : "photometric.ies",
+						"iesProfileScale" : 2.0,
+						"iesProfileNormalize" : True,
+					} )
+				),
+
+			],
+
+			"sphereLightToPhotometricLightEmptyProfile" : [
+
+				IECoreScene.Shader(
+					"SphereLight", "light",
+					{
+						"shaping:ies:file" : "",
+						"shaping:ies:angleScale" : 2.0,
+						"shaping:ies:normalize" : True,
+					}
+				),
+
+				IECoreScene.Shader( "PxrSphereLight", "light", expectedLightParameters( {} ) ),
+
+			],
+
 		}.items() :
 			with self.subTest( testName = testName ) :
 

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -36,7 +36,10 @@
 
 #include "Light.h"
 
+#include "IECore/SimpleTypedData.h"
+
 #include "IECoreRenderMan/ShaderNetworkAlgo.h"
+
 #include "LightFilter.h"
 #include "Transform.h"
 
@@ -44,24 +47,14 @@
 
 using namespace std;
 using namespace Imath;
+using namespace IECore;
 using namespace IECoreRenderMan;
 
 namespace
 {
 
-M44f correctiveTransform( const Attributes *attributes )
+M44f correctiveTransform( const IECoreScene::Shader *lightShader )
 {
-	if( !attributes->lightShader() )
-	{
-		return M44f();
-	}
-
-	const IECoreScene::Shader *lightShader = attributes->lightShader()->outputShader();
-	if( !lightShader )
-	{
-		return M44f();
-	}
-
 	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" )
 	{
 		return M44f().rotate( V3f( -M_PI_2, M_PI_2, 0.0f ) );
@@ -78,11 +71,28 @@ M44f correctiveTransform( const Attributes *attributes )
 
 const IECore::InternedString g_lightFilters( "lightFilters" );
 
+M44f preTransform( const Attributes *attributes )
+{
+	if( !attributes->lightShader() )
+	{
+		return M44f();
+	}
+
+	const IECoreScene::Shader *lightShader = attributes->lightShader()->outputShader();
+
+	if( !lightShader )
+	{
+		return M44f();
+	}
+
+	return IECoreRenderMan::ShaderNetworkAlgo::usdLightTransform( lightShader ) * correctiveTransform( lightShader );
+}
+
 } // namespace
 
 Light::Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, MaterialCache *materialCache, LightLinker *lightLinker, Session *session )
 	:	m_materialCache( materialCache ), m_session( session ), m_lightLinker( lightLinker ),
-		m_lightInstance( riley::LightInstanceId::InvalidId() ), m_correctiveTransform( correctiveTransform( attributes ) ),
+		m_lightInstance( riley::LightInstanceId::InvalidId() ), m_preTransform( preTransform( attributes ) ),
 		m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
 
 {
@@ -124,7 +134,7 @@ void Light::transform( const Imath::M44f &transform )
 		return;
 	}
 
-	const M44f correctedTransform = m_correctiveTransform * transform;
+	const M44f correctedTransform = m_preTransform * transform;
 	StaticTransform staticTransform( correctedTransform );
 
 	const riley::LightInstanceResult result = m_session->modifyLightInstance(
@@ -152,7 +162,7 @@ void Light::transform( const std::vector<Imath::M44f> &samples, const std::vecto
 	vector<Imath::M44f> correctedSamples = samples;
 	for( auto &m : correctedSamples )
 	{
-		m = m_correctiveTransform * m;
+		m = m_preTransform * m;
 	}
 	AnimatedTransform animatedTransform( correctedSamples, times );
 
@@ -174,10 +184,13 @@ void Light::transform( const std::vector<Imath::M44f> &samples, const std::vecto
 bool Light::attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes )
 {
 	auto renderManAttributes = static_cast<const Attributes *>( attributes );
-	if( correctiveTransform( renderManAttributes ) != m_correctiveTransform )
+	if( preTransform( renderManAttributes ) != m_preTransform )
 	{
-		// This can only happen when the light type changes, which is pretty unlikely.
-		// We don't know the light's transform, so just request that it be recreated.
+		// This can happen when the light type changes, which is pretty unlikely, or
+		// geometry related changes, which are common. We don't know the light's
+		// transform, so just request that it be recreated.
+		/// \todo Would there be a performance benefit to RenderMan if we don't recreate
+		/// the light with each geometry edit?
 		return false;
 	}
 

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -55,7 +55,7 @@ namespace
 
 M44f correctiveTransform( const IECoreScene::Shader *lightShader )
 {
-	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" )
+	if( lightShader->getName() == "PxrDomeLight" || lightShader->getName() == "PxrEnvDayLight" || lightShader->getName() == "DomeLight" )
 	{
 		return M44f().rotate( V3f( -M_PI_2, M_PI_2, 0.0f ) );
 	}

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -65,7 +65,7 @@ M44f correctiveTransform( const IECoreScene::Shader *lightShader )
 	}
 	else
 	{
-		return M44f().scale( V3f( 1, 1, -1 ) );
+		return M44f().scale( V3f( -1 ) );
 	}
 }
 

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -81,7 +81,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		LightLinker *m_lightLinker;
 		ConstLightShaderPtr m_lightShader;
 		riley::LightInstanceId m_lightInstance;
-		Imath::M44f m_correctiveTransform;
+		Imath::M44f m_preTransform;
 		/// Used to keep material etc alive as long as we need it.
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -582,6 +582,7 @@ const InternedString g_specularModelTypeParameter( "specularModelType" );
 const InternedString g_specularRoughnessParameter( "specularRoughness" );
 const InternedString g_temperatureParameter( "temperature" );
 const InternedString g_textureFileParameter( "texture:file" );
+const InternedString g_textureFormatParameter( "texture:format" );
 const InternedString g_typeParameter( "type" );
 const InternedString g_usdPrimvarReaderIntShaderName( "UsdPrimvarReader_int" );
 const InternedString g_usdPrimvarReaderFloatShaderName( "UsdPrimvarReader_float" );
@@ -826,6 +827,27 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 
 			const float angle = parameterValue( shader.get(), g_angleParameter, 0.53f );
 			newShader->parameters()[g_angleExtentParameter] = new FloatData( angle );
+		}
+		else if( shader->getName() == "DomeLight" )
+		{
+			newShader = new Shader( "PxrDomeLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+
+			const std::string textureFile = parameterValue( shader.get(), g_textureFileParameter, std::string() );
+			if( !textureFile.empty() )
+			{
+				newShader->parameters()[g_lightColorMapParameter] = new StringData( textureFile );
+			}
+
+			const std::string textureFormat = parameterValue( shader.get(), g_textureFormatParameter, std::string() );
+			if( textureFormat != "automatic" )
+			{
+				IECore::msg(
+					IECore::Msg::Warning,
+					"convertUSDShaders",
+					fmt::format( "Unsupported value \"{}\" for DomeLight.format. Only \"automatic\" is supported. Format will be read from texture file.", textureFormat )
+				);
+			}
 		}
 
 		const auto it = g_primVarMap.find( shader->getName() );

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -543,6 +543,8 @@ const InternedString g_diffuseParameter( "diffuse" );
 const InternedString g_diffuseColorParameter( "diffuseColor" );
 const InternedString g_diffuseDoubleSidedParameter( "diffuseDoubleSided" );
 const InternedString g_diffuseGainParameter( "diffuseGain") ;
+const InternedString g_emissionFocusParameter( "emissionFocus" );
+const InternedString g_emissionFocusTintParameter( "emissionFocusTint" );
 const InternedString g_enableColorTemperatureParameter( "enableColorTemperature" );
 const InternedString g_enableShadowsParameter( "enableShadows" );
 const InternedString g_enableTemperatureParameter( "enableTemperature" );
@@ -581,6 +583,8 @@ const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
 const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
 const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
 const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
+const InternedString g_shapingFocusParameter( "shaping:focus" );
+const InternedString g_shapingFocusTintParameter( "shaping:focusTint" );
 const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
 const InternedString g_shapingIesAngleScaleParameter( "shaping:ies:angleScale" );
 const InternedString g_shapingIesNormalizeParameter( "shaping:ies:normalize" );
@@ -675,6 +679,13 @@ void transferUSDShapingParameters( ShaderNetwork *network, InternedString shader
 		shader->parameters()[g_coneAngleParameter] = new FloatData( dAngle->readable() );
 		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.f );
 		shader->parameters()[g_coneSoftnessParameter] = new FloatData( softness );
+	}
+
+	if( auto dFocus = usdShader->parametersData()->member<FloatData>( g_shapingFocusParameter ) )
+	{
+		shader->parameters()[g_emissionFocusParameter] = new FloatData( dFocus->readable() );
+		const Color3f tint = parameterValue( usdShader, g_shapingFocusTintParameter, Color3f( 0.f, 0.f, 0.f ) );
+		shader->parameters()[g_emissionFocusTintParameter] = new Color3fData( tint );
 	}
 }
 

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -534,6 +534,8 @@ const InternedString g_clearcoatEdgeColorParameter( "clearcoatEdgeColor" );
 const InternedString g_clearcoatRoughnessParameter( "clearcoatRoughness" );
 const InternedString g_colorParameter( "color" );
 const InternedString g_colorTemperatureParameter( "colorTemperature" );
+const InternedString g_coneAngleParameter( "coneAngle" );
+const InternedString g_coneSoftnessParameter( "coneSoftness" );
 const InternedString g_defaultFloatParameter( "defaultFloat" );
 const InternedString g_defaultFloat3Parameter( "defaultFloat3" );
 const InternedString g_defaultIntParameter( "defaultInt" );
@@ -577,6 +579,8 @@ const InternedString g_shadowFalloffParameter( "shadowFalloff" );
 const InternedString g_shadowFalloffUSDParameter( "shadow:falloff" );
 const InternedString g_shadowFalloffGammaParameter( "shadowFalloffGamma");
 const InternedString g_shadowFalloffGammaUSDParameter( "shadow:falloffGamma" );
+const InternedString g_shapingConeAngleParameter( "shaping:cone:angle" );
+const InternedString g_shapingConeSoftnessParameter( "shaping:cone:softness" );
 const InternedString g_shapingIesFileParameter( "shaping:ies:file" );
 const InternedString g_shapingIesAngleScaleParameter( "shaping:ies:angleScale" );
 const InternedString g_shapingIesNormalizeParameter( "shaping:ies:normalize" );
@@ -664,6 +668,13 @@ void transferUSDShapingParameters( ShaderNetwork *network, InternedString shader
 			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesAngleScaleParameter, shader, g_iesProfileScaleParameter, 0.f );
 			transferUSDParameter( network, shaderHandle, usdShader, g_shapingIesNormalizeParameter, shader, g_iesProfileNormalizeParameter, false );
 		}
+	}
+
+	if( auto dAngle = usdShader->parametersData()->member<FloatData>( g_shapingConeAngleParameter ) )
+	{
+		shader->parameters()[g_coneAngleParameter] = new FloatData( dAngle->readable() );
+		const float softness = parameterValue( usdShader, g_shapingConeSoftnessParameter, 0.f );
+		shader->parameters()[g_coneSoftnessParameter] = new FloatData( softness );
 	}
 }
 

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -552,6 +552,7 @@ const InternedString g_glowColorParameter( "glowColor" );
 const InternedString g_glowGainParameter( "glowGain" );
 const InternedString g_heightParameter( "height" );
 const InternedString g_intensityParameter( "intensity" );
+const InternedString g_lengthParameter( "length" );
 const InternedString g_lightColorParameter( "lightColor" );
 const InternedString g_lightColorMapParameter( "lightColorMap" );
 const InternedString g_normalParameter( "normal" );
@@ -849,6 +850,12 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 				);
 			}
 		}
+		else if( shader->getName() == "CylinderLight" )
+		{
+			newShader = new Shader( "PxrCylinderLight", "ri:light" );
+			transferUSDLightParameters( shaderNetwork, handle, shader.get(), newShader.get() );
+			transferUSDParameter( shaderNetwork, handle, shader.get(), g_normalizeParameter, newShader.get(), g_areaNormalizeParameter, false );
+		}
 
 		const auto it = g_primVarMap.find( shader->getName() );
 		if( it != g_primVarMap.end() )
@@ -889,6 +896,13 @@ M44f usdLightTransform( const Shader *lightShader )
 		const float width = parameterValue( lightShader, g_widthParameter, 1.f );
 		const float height = parameterValue( lightShader, g_heightParameter, 1.f );
 		return M44f().scale( V3f( width, height, 1.f ) );
+	}
+	else if( lightShader->getName() == "CylinderLight" )
+	{
+		const float length = parameterValue( lightShader, g_lengthParameter, 1.f );
+		const float radius = parameterValue( lightShader, g_radiusParameter, 0.5f );
+
+		return M44f().scale( V3f( length, radius * 2.f, radius * 2.f ) );
 	}
 
 	return M44f();

--- a/src/IECoreRenderManModule/IECoreRenderManModule.cpp
+++ b/src/IECoreRenderManModule/IECoreRenderManModule.cpp
@@ -49,4 +49,5 @@ BOOST_PYTHON_MODULE( _IECoreRenderMan )
 	scope shaderNetworkAlgoScope( shaderNetworkAlgoModule );
 
 	def( "convertUSDShaders", &ShaderNetworkAlgo::convertUSDShaders );
+	def( "usdLightTransform", &ShaderNetworkAlgo::usdLightTransform );
 }


### PR DESCRIPTION
This adds support for UsdLux lights to IECoreRenderMan.

I originally was going to build off of https://github.com/GafferHQ/gaffer/pull/6319, but preferred to have it structured as a more straightforward "if this light then set these parameters" for each light. Between that and making sure the test coverage was good, I decided to make a clean start.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
