### PR TITLE
CI : Install Windows Inkscape from Chocolatey

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,8 +99,7 @@ jobs:
       run: |
         python -m pip install scons
         python -m pip install sphinx==4.3.1 sphinx_rtd_theme==1.0.0 myst-parser==0.15.2 docutils==0.17.1 sphinxcontrib-applehelp==1.0.2 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.0 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-serializinghtml==1.1.5 sphinxcontrib-qthelp==1.0.3
-        Invoke-WebRequest -Uri "https://inkscape.org/gallery/item/37363/inkscape-1.2.2_2022-12-09_732a01da63-x64.exe" -OutFile "inkscape.exe"
-        Start-Process .\inkscape.exe /S -NoNewWindow -Wait
+        choco install inkscape --version 1.2.2 -y
       shell: pwsh
       if: runner.os == 'Windows'
 


### PR DESCRIPTION
We've been having fairly frequent `403 : Forbidden` errors when downloading directly from the Inkscape site. From what I can tell, the Chocolatey package is sourced from it's own repository and hopefully it will be more reliable.

I _think_ this is a trustworthy source, I verified the hashes of the more recent 1.4 version of Inkscape to the corresponding Chocolatey package. But the package for Inkscape 1.2.2 has a binary from a few days before the official release (perhaps they did a quick patch release that didn't get picked up by Chocolatey).

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
