### PR TITLE
ShaderTweaksUI : Improve plug name sanitisation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
   - PxrSurface, PxrLayerSurface : Moved `utilityPattern` parameter to "Globals" section.
   - Fixed formatting of parameter tooltips, and Node Reference descriptions.
 - RenderManShader : Fixed loading of C++ pattern shaders such as `aaOceanPrmanShader`.
+- ShaderTweaks : Fixed error when selecting an array element to tweak, such as `utilityPattern[0]` in a PxrSurface shader (#6383).
 
 API
 ---

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -322,7 +322,7 @@ class _TweaksFooter( GafferUI.PlugValueWidget ) :
 			plug = Gaffer.TweakPlug( name, plugTypeOrValue() )
 
 		if name :
-			for i in ( ".", ":", ) :
+			for i in ".:[]" :
 				name = name.replace( i, "_" )
 			plug.setName( name )
 


### PR DESCRIPTION
This fixes a problem when trying to tweak `utilityPattern[0]` on a PxrSurface shader.

Fixes #6383.
