### PR TITLE
Support light linking for RenderMan and Cycles

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 - AttributeEditor : Improved widgets used for editing `linkedLights` and `filteredLights` attributes.
+- Viewer : Improved light linking performance.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Added light linking support.
+- Cycles : Added light linking support.
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - Cycles : Added light linking support.
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
+- AttributeEditor : Improved widgets used for editing `linkedLights` and `filteredLights` attributes.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- RenderMan : Added light linking support.
 - VisualiserTool : Added new visualisation for orientation (Quatf) data.
 - PrimitiveInspector : Changed column order for quaternions to match Imath's conventions.
 

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -115,7 +115,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				const std::vector<float> &capturedTransformTimes() const;
 
 				const CapturedAttributes *capturedAttributes() const;
-				std::vector< IECore::InternedString > capturedLinkTypes() const;
+				std::vector<IECore::InternedString> capturedLinkTypes() const;
 				const ObjectSet *capturedLinks( const IECore::InternedString &type ) const;
 
 				int numAttributeEdits() const;

--- a/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
+++ b/python/GafferCyclesTest/InteractiveCyclesRenderTest.py
@@ -107,16 +107,6 @@ class InteractiveCyclesRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		pass
 
-	@unittest.skip( "Light linking not supported" )
-	def testLightLinking( self ) :
-
-		pass
-
-	@unittest.skip( "Light linking not supported" )
-	def testHideLinkedLight( self ) :
-
-		pass
-
 	def _createConstantShader( self ) :
 
 		shader = GafferCycles.CyclesShader()

--- a/python/GafferCyclesTest/RenderPassAdaptorTest.py
+++ b/python/GafferCyclesTest/RenderPassAdaptorTest.py
@@ -49,11 +49,6 @@ class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
 	shadowColor = imath.Color4f( 0 )
 	litColor = imath.Color4f( 1, 1, 1, 0 )
 
-	@unittest.skip( "Light linking not supported" )
-	def testReflectionCasterLightLinks( self ) :
-
-		pass
-
 	def _createDistantLight( self ) :
 
 		light = GafferCycles.CyclesLight()

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -49,15 +49,16 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "3Delight"
 
-	# Disable this test for now as we don't have light linking support in
-	# 3Delight, yet.
 	@unittest.skip( "No light linking support just yet" )
-	def testLightLinking( self ) :
+	def testBasicLightLinking( self ) :
 
 		pass
 
-	# Disable this test for now as we don't have light linking support in
-	# 3Delight, yet.
+	@unittest.skip( "No light linking support just yet" )
+	def testLinkedLightsAttributes( self ) :
+
+		pass
+
 	@unittest.skip( "No light linking support just yet" )
 	def testHideLinkedLight( self ) :
 

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -82,6 +82,8 @@ class InteractiveRenderManRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		light = GafferRenderMan.RenderManLight()
 		light.loadShader( "PxrSphereLight" )
+		light["attributes"]["ri:visibility:camera"]["enabled"].setValue( True )
+		light["attributes"]["ri:visibility:camera"]["value"].setValue( False )
 
 		return light, light["parameters"]["lightColor"]
 

--- a/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
+++ b/python/GafferRenderManTest/InteractiveRenderManRenderTest.py
@@ -49,16 +49,6 @@ class InteractiveRenderManRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 	renderer = "RenderMan"
 
-	@unittest.skip( "Feature not supported yet" )
-	def testHideLinkedLight( self ) :
-
-		pass
-
-	@unittest.skip( "Feature not supported yet" )
-	def testLightLinking( self ) :
-
-		pass
-
 	@unittest.skip( "Crop window doesn't change data window" )
 	def testEditCropWindow( self ) :
 

--- a/python/GafferRenderManTest/RenderPassAdaptorTest.py
+++ b/python/GafferRenderManTest/RenderPassAdaptorTest.py
@@ -52,12 +52,6 @@ class RenderPassAdaptorTest( GafferSceneTest.RenderPassAdaptorTest ) :
 	shadowColor = imath.Color4f( 1, 1, 1, 0 )
 	litColor = imath.Color4f( 0 )
 
-	## \todo Remove once light linking is supported.
-	@unittest.skip( "Light linking not supported yet" )
-	def testReflectionCasterLightLinks( self ) :
-
-		pass
-
 	def _createDistantLight( self ) :
 
 		light = GafferRenderMan.RenderManLight()

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -282,9 +282,9 @@ const CapturingRenderer::CapturedAttributes *CapturingRenderer::CapturedObject::
 	return m_capturedAttributes.get();
 }
 
-std::vector< IECore::InternedString > CapturingRenderer::CapturedObject::capturedLinkTypes() const
+std::vector<IECore::InternedString> CapturingRenderer::CapturedObject::capturedLinkTypes() const
 {
-	std::vector< IECore::InternedString > result;
+	std::vector<IECore::InternedString> result;
 	for( const auto &i : m_capturedLinks )
 	{
 		result.push_back( i.first );

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -70,6 +70,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		// =============================
 
 		void updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &lightFilterShader );
+		void updateGroupingMemberships( RtUString memberships );
 
 	private :
 
@@ -85,6 +86,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.
 		ConstGeometryPrototypePtr m_geometryPrototype;
+		RtParamList m_extraAttributes;
 		IECoreScene::ConstShaderNetworkPtr m_lightFilterShader;
 		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedFilters;
 

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -47,11 +47,12 @@ namespace
 {
 
 const riley::CoordinateSystemList g_emptyCoordinateSystems = { 0, nullptr };
+const IECore::InternedString g_lights( "lights" );
 
 } // namespace
 
-Object::Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session )
-	:	m_session( session ), m_geometryInstance( riley::GeometryInstanceId::InvalidId() ), m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
+Object::Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session )
+	:	m_session( session ), m_lightLinker( lightLinker ), m_geometryInstance( riley::GeometryInstanceId::InvalidId() ), m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
 {
 	m_extraAttributes.SetString( Rix::k_identifier_name, RtUString( name.c_str() ) );
 
@@ -146,6 +147,21 @@ bool Object::attributes( const IECoreScenePreview::Renderer::AttributesInterface
 
 void Object::link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects )
 {
+	if( type != g_lights )
+	{
+		return;
+	}
+
+	m_linkedLights = objects;
+
+	RtUString lightingSubset;
+	if( objects )
+	{
+		lightingSubset = m_lightLinker->registerLightLinks( objects );
+	}
+
+	m_extraAttributes.SetString( Rix::k_lighting_subset, lightingSubset );
+	attributes( m_attributes.get() );
 }
 
 void Object::assignID( uint32_t id )

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -38,6 +38,7 @@
 
 #include "Attributes.h"
 #include "GeometryPrototypeCache.h"
+#include "LightLinker.h"
 #include "Session.h"
 
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
@@ -50,7 +51,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 
 	public :
 
-		Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, const Session *session );
+		Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session );
 		~Object();
 
 		/// \todo RenderMan volumes seem to reject attempts to transform them
@@ -67,12 +68,14 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 	private :
 
 		const Session *m_session;
+		LightLinker *m_lightLinker;
 		riley::GeometryInstanceId m_geometryInstance;
 		/// Used to keep material etc alive as long as we need it.
 		ConstAttributesPtr m_attributes;
 		/// Used to keep geometry prototype alive as long as we need it.
 		ConstGeometryPrototypePtr m_geometryPrototype;
 		RtParamList m_extraAttributes;
+		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedLights;
 
 };
 

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -184,7 +184,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_session );
+			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_lightLinker.get(), m_session );
 		}
 
 		ObjectInterfacePtr object( const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const AttributesInterface *attributes ) override
@@ -199,7 +199,7 @@ class RenderManRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_session );
+			return new IECoreRenderMan::Object( name, geometryPrototype, typedAttributes, m_lightLinker.get(), m_session );
 		}
 
 		void render() override

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -152,6 +152,7 @@ Gaffer.Metadata.registerValue(
 	all lights that contribute to illumination by default.
 	"""
 )
+Gaffer.Metadata.registerValue( "attribute:linkedLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
 Gaffer.Metadata.registerValue( "attribute:linkedLights", "ui:scene:acceptsSetExpression", True )
 
 Gaffer.Metadata.registerValue( "attribute:filteredLights", "label", "Filtered Lights" )
@@ -166,6 +167,7 @@ Gaffer.Metadata.registerValue(
 	contribute to illumination by default.
 	"""
 )
+Gaffer.Metadata.registerValue( "attribute:filteredLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
 Gaffer.Metadata.registerValue( "attribute:filteredLights", "ui:scene:acceptsSetExpression", True )
 
 Gaffer.Metadata.registerValue( "attribute:gaffer:automaticInstancing", "label", "Automatic Instancing" )


### PR DESCRIPTION
This adds light linking support to both the RenderMan and Cycles renderer backends, and improves the existing light linking test coverage a bit too.

For Cycles, I've taken what I think is a simpler approach than the one in the existing PR #5604. I'm using just the data provided officially to `ObjectInterface::link()` while the old PR was separately also relying on the `linkedLights` string attribute passed to `ObjectInterface::attributes()`. Better to just use the official data I think, since my view is that the attribute is being "leaked", and possibly shouldn't even be provided to the renderer in future.

PR #5604 also supported shadow linking, but  "borrowed" Arnold's `ai:visibility:shadow_group` attribute for that purpose. I think that would be far too confusing of a user experience so I've left shadow linking as future work. But I'm hopeful that it can be implemented for both renderers with a similar level of simplicity as in this PR.