### PR TITLE
Shader : Record top-level connections between struct parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,7 +15,9 @@ Fixes
   - PxrCookieLightFilter : Added button for reloading the map.
   - PxrSurface, PxrLayerSurface : Moved `utilityPattern` parameter to "Globals" section.
   - Fixed formatting of parameter tooltips, and Node Reference descriptions.
-- RenderManShader : Fixed loading of C++ pattern shaders such as `aaOceanPrmanShader`.
+- RenderManShader :
+  - Fixed export of struct connections to USD, including connections to `PxrTexture.manifold`.
+  - Fixed loading of C++ pattern shaders such as `aaOceanPrmanShader`.
 - ShaderTweaks : Fixed error when selecting an array element to tweak, such as `utilityPattern[0]` in a PxrSurface shader (#6383).
 - CompoundVectorParameterValueWidget : Fixed being unable to edit certain parameters when there were too many, by adding a horizontal scroll bar.
 

--- a/src/GafferScene/Shader.cpp
+++ b/src/GafferScene/Shader.cpp
@@ -453,6 +453,10 @@ class Shader::NetworkBuilder
 		{
 			if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
 			{
+				if( !parameter->parent<Node>() )
+				{
+					hashParameter( parameter, h );
+				}
 				// Compound parameter - recurse
 				for( Plug::InputIterator it( parameter ); !it.done(); ++it )
 				{
@@ -478,6 +482,15 @@ class Shader::NetworkBuilder
 		{
 			if( !isLeafParameter( parameter ) || parameter->parent<Node>() )
 			{
+				if( !parameter->parent<Node>() )
+				{
+					// Needed to add top-level connections between OSL struct parameters.
+					/// \todo Refactor recursion so this happens more naturally, and so that
+					/// we don't redundantly store the connections between each field
+					/// of the struct as well.
+					addParameter( parameter, parameterName, shader, connections );
+				}
+
 				// Compound parameter - recurse
 				for( Plug::InputIterator it( parameter ); !it.done(); ++it )
 				{


### PR DESCRIPTION
This fixes problems exporting RenderMan texture manifold connections to USD. Allow me to explain...

We represent `struct` parameters in OSLShader using a parent ValuePlug with a child plug for each struct field. This allows individual values and connections to be authored for each field. When we translate this to a ShaderNetwork, we represent it with multiple values/connections in the form `{structName}.{fieldName}`. I believe this is what OSL intended : it is a close for match for how `oslquery` reports structs, and for how `OSL::ShadingSystem` receives struct parameters. It offers maximum flexibility in the way structs are used.

The Pxr OSL shaders use structs in a couple of places, with the primary use being a `struct Manifold` used for passing texture placements between shaders. It doesn't seem like the fields for these structs are intended to be authored individually - you just need to make a single top-level connection between a manifold and a texture. But the Riley API accepts the individual connections/values that we supply for each field, and all is well in GafferRenderMan. It seems that the RenderMan API supports the OSL conception of structs, and you could use them for more than just connections if you wanted in your own shaders.

But USD has a different conception of struct parameters. Both `SdrOslParserPlugin` and `RmanOslParserPlugin` ignore struct fields entirely, populating the shader registry with a single `token`-typed attribute for each struct input or output. Furthermore, the naming restrictions on attributes prevent the creation of a `{structName}.{fieldName}` attribute. So attempts to export our ShaderNetworks to USD resulted in a lot of warnings about invalid attribute names, and the total loss of the struct connections and values.

We could have "fixed" this by inventing our own mapping to USD attributes, most likely `{structName}:{fieldName}`, but that wouldn't help with interoperability with other DCCs. So instead we make an additional top-level connection in the ShaderNetwork, which naturally gets exported to a `token` attribute by IECoreUSD, in the form dictated by SdrOslParserPlugin. We still lose the individual field values, but since those aren't needed for the Pxr shaders, we get sufficient round-tripping to render the manifold connections correctly on return to Gaffer.

The additional call to `addParameter()` that I've used to do this is not particularly elegant. That function was intended to be called when `addParameterWalk()` "bottoms out" at a leaf parameter but we are now calling it at intermediate levels in the recursion. Nevertheless the new call does exactly what we want - it adds a connection, without adding a value. I've also kept all the remaining field-level connections and values, since I don't want to change behaviour any more than necessary for this bugfix. I'm not very clued up on how folks are using structs in OSL shaders in Gaffer, so don't want to change more than necessary.

A more elegant approach is possible though, and I have one in progress at https://github.com/johnhaddon/gaffer/tree/shaderNetworkBuilderRefactor. This removes a bunch of special-cases from the recursion, fixing a few other subtle bugs in the process. It is also a net reduction in the amount of code in `Shader.cpp` which is usually a good sign. And it doesn't make redundant connections for each of the struct fields (the top-level connection is sufficient). But I feel that it is too big and too risky of a refactor to include at this stage of the Gaffer 1.5 lifecycle. I think it would be good to finish it off and include it in 1.6 instead.
