### PR TITLE
RenderManShader : Register with ShaderTweakProxy

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Fixes
 - RenderManShader :
   - Fixed export of struct connections to USD, including connections to `PxrTexture.manifold`.
   - Fixed loading of C++ pattern shaders such as `aaOceanPrmanShader`.
+  - Fixed compatibility with ShaderTweakProxy.
 - ShaderTweaks : Fixed error when selecting an array element to tweak, such as `utilityPattern[0]` in a PxrSurface shader (#6383).
 - CompoundVectorParameterValueWidget : Fixed being unable to edit certain parameters when there were too many, by adding a horizontal scroll bar.
 

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -263,5 +263,11 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		network = sceneReader["out"].attributes( "/plane" )["ri:surface"]
 		self.assertEqual( network.input( ( "texture", "manifold" ) ), ( "manifold", "result" ) )
 
+	def testShaderTweakProxy( self ) :
+
+		proxy = GafferScene.ShaderTweakProxy()
+		proxy.loadShader( "ri:PxrConstant" )
+		self.assertIn( "bxdf_out", proxy["out"] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -38,6 +38,8 @@
 
 #include "GafferRenderMan/BXDFPlug.h"
 
+#include "GafferScene/ShaderTweakProxy.h"
+
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/NumericPlug.h"
 #include "Gaffer/PlugAlgo.h"
@@ -77,6 +79,13 @@ RenderManShader::RenderManShader( const std::string &name )
 RenderManShader::~RenderManShader()
 {
 }
+
+namespace
+{
+
+ShaderTweakProxy::ShaderLoaderDescription<RenderManShader> g_shaderTweakProxyRegistration( "ri" );
+
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////
 // Shader-specific overrides


### PR DESCRIPTION
This allows ShaderTweakProxy to reference RenderMan C++ shaders. I'm not sure how useful this is since most of the things you'd want to proxy are OSL pattern shaders, but it's worth having for completeness.
