### PR TITLE
RenderMan : Translate `render:{name}` attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.12.0)
 =======
 
+Fixes
+-----
 
+- RenderMan : Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -497,53 +497,60 @@ class RendererTest( GafferTest.TestCase ) :
 
 		self.assertFalse( OpenImageIO.ImageBufAlgo.compare( image1, image2, failthresh = 0, warnthresh=0 ).error )
 
-	def testUserAttribute( self ) :
+	def testUserAttributes( self ) :
 
-		renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
-			"RenderMan",
-			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
-		)
+		for attributeName, lookupName in [
+			( "render:displayColor", "displayColor" ),
+			( "user:myColor", "user:myColor" ),
+		] :
 
-		fileName = str( self.temporaryDirectory() / "test.exr" )
-		renderer.output(
-			"test",
-			IECoreScene.Output(
-				fileName,
-				"exr",
-				"rgba",
-				{
-				},
-			)
-		)
+			with self.subTest( attributeName = attributeName, lookupName = lookupName ) :
 
-		renderer.object(
-			"sphere",
-			IECoreScene.SpherePrimitive(),
-			renderer.attributes( IECore.CompoundObject( {
-				"ri:surface" : IECoreScene.ShaderNetwork(
-					shaders = {
-						"attribute" : IECoreScene.Shader(
-							"PxrAttribute", "osl:shader", {
-								"varname" : "user:myColor",
-								"type" : "color",
-							}
+				renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+					"RenderMan",
+					GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+				)
+
+				fileName = str( self.temporaryDirectory() / "test.exr" )
+				renderer.output(
+					"test",
+					IECoreScene.Output(
+						fileName,
+						"exr",
+						"rgba",
+						{
+						},
+					)
+				)
+
+				renderer.object(
+					"sphere",
+					IECoreScene.SpherePrimitive(),
+					renderer.attributes( IECore.CompoundObject( {
+						"ri:surface" : IECoreScene.ShaderNetwork(
+							shaders = {
+								"attribute" : IECoreScene.Shader(
+									"PxrAttribute", "osl:shader", {
+										"varname" : lookupName,
+										"type" : "color",
+									}
+								),
+								"output" : IECoreScene.Shader( "PxrConstant", "ri:surface" ),
+							},
+							connections = [
+								( ( "attribute", "resultRGB" ), ( "output", "emitColor" ) )
+							],
+							output = "output",
 						),
-						"output" : IECoreScene.Shader( "PxrConstant", "ri:surface" ),
-					},
-					connections = [
-						( ( "attribute", "resultRGB" ), ( "output", "emitColor" ) )
-					],
-					output = "output",
-				),
-				"user:myColor" : IECore.Color3fData( imath.Color3f( 1, 0.5, 0.25 ) ),
-			} ) )
-		).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
+						attributeName : IECore.Color3fData( imath.Color3f( 1, 0.5, 0.25 ) ),
+					} ) )
+				).transform( imath.M44f().translate( imath.V3f( 0, 0, -3 ) ) )
 
-		renderer.render()
-		del renderer
+				renderer.render()
+				del renderer
 
-		image = OpenImageIO.ImageBuf( fileName )
-		self.assertEqual( image.getpixel( 320, 240, 0 ), ( 1.0, 0.5, 0.25, 1.0 ) )
+				image = OpenImageIO.ImageBuf( fileName )
+				self.assertEqual( image.getpixel( 320, 240, 0 ), ( 1.0, 0.5, 0.25, 1.0 ) )
 
 	def testArrayConnections( self ) :
 

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -209,6 +209,9 @@ IECoreScene::ConstShaderNetworkPtr g_black = []() {
 
 } ();
 
+const std::string g_renderAttributePrefix( "render:" );
+const std::string g_userAttributePrefix( "user:" );
+
 } // namespace
 
 Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache *materialCache )
@@ -274,9 +277,16 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 			int sides = attributeCast<bool>( value.get(), name, true ) ? 2 : 1;
 			m_instanceAttributes.SetInteger( Rix::k_Ri_Sides, sides );
 		}
-		else if( boost::starts_with( name.c_str(), "user:" ) )
+		else if( boost::starts_with( name.string(), g_userAttributePrefix ) )
 		{
 			ParamListAlgo::convertParameter( RtUString( name.c_str() ), data, m_instanceAttributes );
+		}
+		else if( boost::starts_with( name.string(), g_renderAttributePrefix ) )
+		{
+			const string withUserPrefix = g_userAttributePrefix + ( name.c_str() + g_renderAttributePrefix.size() );
+			ParamListAlgo::convertParameter(
+				RtUString( withUserPrefix.c_str() ), data, m_instanceAttributes
+			);
 		}
 
 		if( !boost::starts_with( name.c_str(), g_renderManPrefix.c_str() ) )


### PR DESCRIPTION
These need to be given a `user:` prefix to be readable from shaders. But internally (not sure if in the renderer or the shader), RenderMan supports lookup both as `user:{name}` and just `{name}`.

