### PR TITLE
Decentralised ClipboardAlgo

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Features
 --------
 
 - ArnoldProcedural : Added a new node for making Arnold `.ass` procedural placeholders.
+- AttributeEditor, LightEditor, RenderPassEditor : Added copy and paste editing. Values from one or more cells can be copied to the clipboard with <kbd>Ctrl</kbd> + <kbd>C</kbd> and pasted with <kbd>Ctrl</kbd> + <kbd>V</kbd> to create or update edits. Values copied from these editors can also be pasted into Spreadsheet cells, and vice versa.
 
 Improvements
 ------------

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,11 @@ Build
 
 - Cortex : Updated to version 10.5.14.0.
 
+API
+---
+
+- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData.
+
 1.5.12.0 (relative to 1.5.11.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,9 @@ Build
 API
 ---
 
-- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
+- PlugAlgo :
+  - Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
+  - Added `setValueOrInsertKeyFromData()`.
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,7 @@ Build
 API
 ---
 
-- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData.
+- PlugAlgo : Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,9 @@ Improvements
 
 - ImageReader : Automatically set "filePath" metadata when reading images, making it easier to determine the path an image was loaded from.
 - Cryptomatte : Improved automatic finding of manifests. Now, if the image's metadata references a sidecar manifest file, but no explicit `manifestDirectory` is specified, it will look in the directory the image was loaded from ( as determined by the "filePath" metadata ). This makes it more likely that cryptomatte files will work automatically.
+- Spreadsheet :
+  - A wider range of types are converted when copy/pasting values between cells, such as BoolData to IntData, FloatData to IntData, etc.
+  - Added support for converting StringData values when pasted or dropped onto a StringVectorData cell. The string array value is formed by splitting the string on spaces.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ API
 - PlugAlgo :
   - Added support in `setValueFromData()` for setting StringPlug values from StringVectorData and StringVectorDataPlugValues from StringData.
   - Added `setValueOrInsertKeyFromData()`.
+- PathListingWidget : Added `visualOrder()`.
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -432,6 +432,7 @@ Toggle cell selection                                | {kbd}`Ctrl` + {{leftClick
 Edit selected cells                                  | {kbd}`Return`<br>or<br>{kbd}`Enter`
 Disable Edit                                         | {kbd}`D`
 Remove Attribute                                     | {kbd}`Delete`
+Copy/Paste selected cells                            | {kbd}`Ctrl` + {kbd}`C`/{kbd}`V`
 
 ## Set Editor ##
 
@@ -451,6 +452,7 @@ Edit selected cells                                  | {kbd}`Return`<br>or<br>{k
 Disable edit                                         | {kbd}`D`
 Toggle a render pass as active                       | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the {{activeRenderPass}} column
 Rename a render pass                                 | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the "Name" column
+Copy/Paste selected cells                            | {kbd}`Ctrl` + {kbd}`C`/{kbd}`V`
 
 ## Color Chooser Color Field ##
 

--- a/include/Gaffer/PlugAlgo.h
+++ b/include/Gaffer/PlugAlgo.h
@@ -109,6 +109,11 @@ GAFFER_API bool setValueFromData( const ValuePlug *plug, ValuePlug *leafPlug, co
 /// If value is provided, then return true if it can be set from Data with this type id
 GAFFER_API bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value = nullptr );
 
+/// Sets the value of an existing plug to the specified data. If the plug has existing
+/// animation then a key will be inserted at `time`.
+/// Returns `true` on success and `false` on failure.
+GAFFER_API bool setValueOrInsertKeyFromData( ValuePlug *plug, float time, const IECore::Data *value );
+
 [[deprecated( "Use `getValueAsData()` instead" )]]
 GAFFER_API IECore::DataPtr extractDataFromPlug( const ValuePlug *plug );
 

--- a/include/GafferUI/PathColumn.h
+++ b/include/GafferUI/PathColumn.h
@@ -303,6 +303,7 @@ class PathListingWidget : public IECore::RefCounted
 		using Selection = std::variant<IECore::PathMatcher, std::vector<IECore::PathMatcher>>;
 		virtual void setSelection( const Selection &selection ) = 0;
 		virtual Selection getSelection() const = 0;
+		virtual std::vector<std::string> visualOrder( const IECore::PathMatcher &paths ) const = 0;
 
 };
 

--- a/python/GafferSceneUITest/InspectorColumnTest.py
+++ b/python/GafferSceneUITest/InspectorColumnTest.py
@@ -36,12 +36,92 @@
 
 import unittest
 
+import IECore
+
+import Gaffer
 import GafferUI
+from GafferUI import _GafferUI
 import GafferUITest
+import GafferScene
 import GafferSceneTest
 import GafferSceneUI
 
 class InspectorColumnTest( GafferUITest.TestCase ) :
+
+	class TestEditor( GafferSceneUI.SceneEditor ) :
+
+		def __init__( self, scriptNode, **kw ) :
+
+			self.__column = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 4, spacing = 4 )
+
+			GafferSceneUI.SceneEditor.__init__( self, self.__column, scriptNode, **kw )
+
+		def addPathListing( self, pathListing ) :
+
+			self.__column.addChild( pathListing )
+
+		def __repr__( self ) :
+
+			return "GafferSceneUITest.InspectorColumnTest.TestEditor( scriptNode )"
+
+	def __testScene( self, script ) :
+
+		script["sphere"] = GafferScene.Sphere()
+
+		script["customAttributes"] = GafferScene.CustomAttributes()
+		script["customAttributes"]["in"].setInput( script["sphere"]["out"] )
+		script["customAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:string", "sphere" ) )
+		script["customAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:int", 100 ) )
+		script["customAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:float", 1.0 ) )
+		script["customAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:bool", False ) )
+		script["customAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:stringVector", IECore.StringVectorData( [ "sphere", "vector" ] ) ) )
+
+		script["cube"] = GafferScene.Cube()
+
+		script["customCubeAttributes"] = GafferScene.CustomAttributes()
+		script["customCubeAttributes"]["in"].setInput( script["cube"]["out"] )
+		script["customCubeAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:string", "cube" ) )
+		script["customCubeAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:int", 200 ) )
+		script["customCubeAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:float", 2.0 ) )
+		script["customCubeAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:bool", True ) )
+		script["customCubeAttributes"]["attributes"].addChild( Gaffer.NameValuePlug( "test:stringVector", IECore.StringVectorData( [ "cube", "vector" ] ) ) )
+
+		script["parent"] = GafferScene.Parent()
+		script["parent"]["in"].setInput( script["customAttributes"]["out"] )
+		script["parent"]["children"][0].setInput( script["customCubeAttributes"]["out"] )
+		script["parent"]["parent"].setValue( "/" )
+
+	def __testSpreadsheet( self ) :
+
+			s = Gaffer.Spreadsheet()
+
+			rowsPlug = s["rows"]
+
+			# N = row number, starting at 1
+			# Rows named 'rowN'
+			# Column 0 - string - 'sN'
+			# Column 1 - int - N
+			# Column 2 - int - 10N - even rows disabled
+			# Column 3 - float - 100N
+			# Column 4 - int - 1000N
+
+			for i, columnPlug in enumerate( (
+				Gaffer.StringPlug(),     # 0
+				Gaffer.IntPlug(),        # 1
+				Gaffer.IntPlug(),        # 2
+				Gaffer.FloatPlug(),      # 3
+				Gaffer.IntPlug(),        # 4
+			) ) :
+				rowsPlug.addColumn( columnPlug, "column%d" % i, adoptEnabledPlug = False )
+
+			for i in range( 1, 11 ) :
+				rowsPlug.addRow()["name"].setValue( "row%d" % i )
+				rowsPlug[i]["cells"][0]["value"].setValue( "s%d" % ( i ) )
+				rowsPlug[i]["cells"][2]["enabled"].setValue( i % 2 )
+				for c in range( 1, 4 ) :
+					rowsPlug[i]["cells"][c]["value"].setValue( i * pow( 10, c - 1 ) )
+
+			return s
 
 	def testInspectorColumnConstructors( self ) :
 
@@ -76,6 +156,551 @@ class InspectorColumnTest( GafferUITest.TestCase ) :
 		self.assertEqual( c.getSizeMode(), GafferUI.PathColumn.SizeMode.Stretch )
 		self.assertEqual( c.headerData().value, "Fancy ( Label )" )
 		self.assertEqual( c.headerData().toolTip, "help!" )
+
+	def testObjectMatrixFromSelection( self ) :
+
+		d = {
+			"a" : 1,
+			"b" : 2,
+			"c" : 3,
+			"d" : 4,
+			"e" : 5
+		}
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			p,
+			columns = [
+				GafferUI.PathListingWidget.defaultNameColumn,
+				GafferUI.PathListingWidget.StandardColumn( "A", "dict:value" )
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		# Select non-contiguous cells in the same column
+
+		s1 = [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/a", "/c", "/e" ] ) ]
+
+		w.setSelection( s1 )
+		self.assertEqual( w.getSelection(), s1 )
+		expected = IECore.ObjectMatrix( 3, 1 )
+		for i, x in enumerate( [ 1, 3, 5 ] ) :
+			expected[i, 0] = IECore.IntData( x )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			expected
+		)
+
+		# Select contiguous cells in the same column
+
+		s2 = [ IECore.PathMatcher( [ "/b", "/c" ] ), IECore.PathMatcher( [] ) ]
+
+		w.setSelection( s2 )
+		self.assertEqual( w.getSelection(), s2 )
+		expected = IECore.ObjectMatrix( 2, 1 )
+		for i, x in enumerate( [ "b", "c" ] ) :
+			expected[i, 0] = IECore.StringData( x )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			expected
+		)
+
+		# Select the same row across both columns
+
+		s3 = [ IECore.PathMatcher( [ "/e" ] ), IECore.PathMatcher( [ "/e" ] ) ]
+		w.setSelection( s3 )
+		self.assertEqual( w.getSelection(), s3 )
+
+		expected = IECore.ObjectMatrix( 1, 2 )
+		expected[0, 0] = IECore.StringData( "e" )
+		expected[0, 1] = IECore.IntData( 5 )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			expected
+		)
+
+		# Select non-contiguous rows
+
+		s4 = [ IECore.PathMatcher( [ "/b", "/d" ] ), IECore.PathMatcher( [ "/b", "/d" ] ) ]
+		w.setSelection( s4 )
+		self.assertEqual( w.getSelection(), s4 )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		data = GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w )
+		self.assertTrue( isinstance( data, IECore.ObjectMatrix ) )
+
+		self.assertEqual( data[ 0, 0 ], IECore.StringData( "b" ) )
+		self.assertEqual( data[ 0, 1 ], IECore.IntData( 2 ) )
+		self.assertEqual( data[ 1, 0 ], IECore.StringData( "d" ) )
+		self.assertEqual( data[ 1, 1 ], IECore.IntData( 4 ) )
+
+		# Select mixed data types, these would end up copied to the same ObjectMatrix column
+
+		s5 = [ IECore.PathMatcher( [ "/a", "/c" ] ), IECore.PathMatcher( [ "/b", "/d" ] ) ]
+		w.setSelection( s5 )
+		self.assertEqual( w.getSelection(), s5 )
+
+		expected = IECore.ObjectMatrix( 4, 1 )
+		expected[0, 0] = IECore.StringData( "a" )
+		expected[1, 0] = IECore.IntData( 2 )
+		expected[2, 0] = IECore.StringData( "c" )
+		expected[3, 0] = IECore.IntData( 4 )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			expected
+		)
+
+		# Select two cells in one row and one cell in another, this is not copyable.
+
+		s6 = [ IECore.PathMatcher( [ "/a" ] ), IECore.PathMatcher( [ "/a", "/d" ] ) ]
+		w.setSelection( s6 )
+		self.assertEqual( w.getSelection(), s6 )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertFalse( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonCopyableReason( w ), "Each row in the selection must contain the same number of cells." )
+
+	def testClipboardPaste( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"]["testScript"] = s
+		self.__testScene( s )
+
+		w = GafferUI.PathListingWidget(
+			GafferScene.ScenePath( s["parent"]["out"], Gaffer.Context(), "/" ),
+			columns = [
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:string" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:int" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:float" ) ),
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		e = InspectorColumnTest.TestEditor( s )
+		e.addPathListing( w )
+
+		# Inconsistent row selection is not copyable
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere", "/cube" ] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertFalse( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonCopyableReason( w ), "Each row in the selection must contain the same number of cells." )
+
+		# Consistent selection is copyable
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere", "/cube" ] ), IECore.PathMatcher( [ "/sphere", "/cube" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonCopyableReason( w ), "" )
+
+		# Test copy single value
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.IntData( 100 )
+		)
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/cube" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.IntData( 200 )
+		)
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.IntData( 100 )
+		)
+
+		# Test copy multiple values
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+		sourceData = GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w )
+		self.assertTrue( isinstance( a.getClipboardContents(), IECore.ObjectMatrix ) )
+		self.assertEqual(
+			a.getClipboardContents(),
+			sourceData
+		)
+
+		w.setSelection( [ IECore.PathMatcher( [ "/cube" ] ), IECore.PathMatcher( [ "/cube" ] ), IECore.PathMatcher( [ "/cube" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canCopySelectedValues( w ) )
+		self.assertNotEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			sourceData
+		)
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			sourceData
+		)
+
+	def testPasteObjectMatrixWithNone( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"]["testScript"] = s
+		self.__testScene( s )
+
+		w = GafferUI.PathListingWidget(
+			GafferScene.ScenePath( s["parent"]["out"], Gaffer.Context(), "/" ),
+			columns = [
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:string" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:int" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:float" ) ),
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		e = InspectorColumnTest.TestEditor( s )
+		e.addPathListing( w )
+
+		# Paste initial values so we can later test that a paste containing None does not overwrite.
+
+		pasteData = IECore.ObjectMatrix( [ [ IECore.StringData( "foo" ), IECore.IntData( 123 ), IECore.FloatData( 123.0 ) ] ] )
+		a.setClipboardContents( pasteData )
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			pasteData
+		)
+
+		# Paste a new ObjectMatrix with None for the middle column. Paste should update the other columns,
+		# but preserve the existing value of the middle column.
+
+		pasteData = IECore.ObjectMatrix( [ [ IECore.StringData( "bar" ), None, IECore.FloatData( 456.0 ) ] ] )
+		a.setClipboardContents( pasteData )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.ObjectMatrix( [ [ IECore.StringData( "bar" ), IECore.IntData( 123 ), IECore.FloatData( 456.0 ) ] ] )
+		)
+
+	def testClipboardValueConversion( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"]["testScript"] = s
+		self.__testScene( s )
+
+		w = GafferUI.PathListingWidget(
+			GafferScene.ScenePath( s["parent"]["out"], Gaffer.Context(), "/" ),
+			columns = [
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:string" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:int" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:float" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:bool" ) ),
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		e = InspectorColumnTest.TestEditor( s )
+		e.addPathListing( w )
+
+		# Test StringData cannot be converted to IntData
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), 'Data of type "StringData" is not compatible.' )
+		self.assertFalse( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		# Test IntData can be converted to FloatData and BoolData
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.ObjectMatrix( [ [ IECore.FloatData( 1.0 ), IECore.BoolData( False ) ] ] )
+		)
+
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.ObjectMatrix( [ [ IECore.FloatData( 100.0 ), IECore.BoolData( True ) ] ] )
+		)
+
+		# Test BoolData can be converted to FloatData and IntData
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/sphere" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.ObjectMatrix( [ [ IECore.IntData( 1 ), IECore.FloatData( 1.0 ) ] ] )
+		)
+
+	def testClipboardStringConversion( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"]["testScript"] = s
+		self.__testScene( s )
+
+		w = GafferUI.PathListingWidget(
+			GafferScene.ScenePath( s["parent"]["out"], Gaffer.Context(), "/" ),
+			columns = [
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:string" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:stringVector" ) ),
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		e = InspectorColumnTest.TestEditor( s )
+		e.addPathListing( w )
+
+		# Test StringData can be converted to StringVectorData
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/cube" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.StringVectorData( [ "cube", "vector" ] )
+		)
+
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.StringVectorData( [ "sphere" ] )
+		)
+
+		# Test StringVectorData can be converted to StringData
+
+		w.setSelection( [ IECore.PathMatcher( [ "" ] ), IECore.PathMatcher( [ "/sphere" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.StringVectorData( [ "sphere", "vector" ] )
+		)
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere" ] ), IECore.PathMatcher( [] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.StringData( "sphere vector" )
+		)
+
+		# Test space separated StringData conversion to StringVectorData
+
+		GafferSceneUI._InspectorColumn._copySelectedValues( w )
+
+		w.setSelection( [ IECore.PathMatcher( [] ), IECore.PathMatcher( [ "/cube" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		self.assertEqual( GafferSceneUI._InspectorColumn._nonPasteableReason( w ), "" )
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+		self.assertEqual(
+			GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w ),
+			IECore.StringVectorData( [ "sphere", "vector" ] )
+		)
+
+	def testCopyFromPathListingWidgetPasteToSpreadsheet( self ) :
+
+		script = Gaffer.ScriptNode()
+		script["s"] = self.__testSpreadsheet()
+
+		rowsPlug = script["s"]["rows"]
+
+		sw = GafferUI.ScriptWindow.acquire( script )
+		r = GafferUI.PlugValueWidget.acquire( rowsPlug )
+		cellsTable = r._RowsPlugValueWidget__cellsTable
+
+		d = {
+			"a" : 101,
+			"b" : 202,
+			"c" : 303,
+			"d" : 404,
+			"e" : 505
+		}
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			p,
+			columns = [
+				GafferUI.PathListingWidget.defaultNameColumn,
+				GafferUI.PathListingWidget.StandardColumn( "A", "dict:value" )
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		w.setSelection( [ IECore.PathMatcher( [ "/a", "/c", "/e" ] ), IECore.PathMatcher( [ "/a", "/c", "/e" ] ) ] )
+
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		data = GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w )
+		self.assertTrue( isinstance( data, IECore.ObjectMatrix ) )
+
+		targetPlugs = [
+			rowsPlug[2]["cells"][0], rowsPlug[2]["cells"][1],
+			rowsPlug[3]["cells"][0], rowsPlug[3]["cells"][1],
+			rowsPlug[4]["cells"][0], rowsPlug[4]["cells"][2]
+		]
+		originalValues = [ x["value"].getValue() for x in targetPlugs ]
+
+		plugMatrix = GafferUI.SpreadsheetUI._ClipboardAlgo.createPlugMatrixFromCells( targetPlugs )
+		self.assertTrue( GafferUI.SpreadsheetUI._ClipboardAlgo.canPasteCells( data, plugMatrix ) )
+		GafferUI.SpreadsheetUI._ClipboardAlgo.pasteCells( data, plugMatrix, 0 )
+
+		pastedValues = [ x["value"].getValue() for x in targetPlugs ]
+		self.assertNotEqual( pastedValues, originalValues )
+		self.assertEqual( pastedValues, [ "a", 101, "c", 303, "e", 505 ] )
+
+		# extend selection to more rows than we copied and paste again
+
+		targetPlugs.extend( [
+			rowsPlug[5]["cells"][0], rowsPlug[5]["cells"][1],
+			rowsPlug[6]["cells"][0], rowsPlug[6]["cells"][1]
+		] )
+
+		plugMatrix = GafferUI.SpreadsheetUI._ClipboardAlgo.createPlugMatrixFromCells( targetPlugs )
+		self.assertTrue( GafferUI.SpreadsheetUI._ClipboardAlgo.canPasteCells( data, plugMatrix ) )
+		GafferUI.SpreadsheetUI._ClipboardAlgo.pasteCells( data, plugMatrix, 0 )
+
+		# pasted values should repeat outside of the copied range
+
+		self.assertEqual( [ x["value"].getValue() for x in targetPlugs ], [ "a", 101, "c", 303, "e", 505, "a", 101, "c", 303 ] )
+
+	def testCopyFromSpreadsheetPasteToPathListingWidget( self ) :
+
+		a = Gaffer.ApplicationRoot()
+		s = Gaffer.ScriptNode()
+		a["scripts"]["testScript"] = s
+		self.__testScene( s )
+
+		w = GafferUI.PathListingWidget(
+			GafferScene.ScenePath( s["parent"]["out"], Gaffer.Context(), "/" ),
+			columns = [
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:string" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:int" ) ),
+				GafferSceneUI.Private.InspectorColumn( GafferSceneUI.Private.AttributeInspector( s["parent"]["out"], None, "test:float" ) ),
+			],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cells,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+
+		e = InspectorColumnTest.TestEditor( s )
+		e.addPathListing( w )
+
+		s["s"] = self.__testSpreadsheet()
+		rowsPlug = s["s"]["rows"]
+
+		sourcePlugs = [
+			rowsPlug[2]["cells"][0], rowsPlug[2]["cells"][1], rowsPlug[2]["cells"][3],
+			rowsPlug[4]["cells"][0], rowsPlug[4]["cells"][1], rowsPlug[4]["cells"][3],
+		]
+		plugMatrix = GafferUI.SpreadsheetUI._ClipboardAlgo.createPlugMatrixFromCells( sourcePlugs )
+		self.assertTrue( GafferUI.SpreadsheetUI._ClipboardAlgo.canCopyPlugs( plugMatrix ) )
+		GafferUI.SpreadsheetUI._ClipboardAlgo.copyPlugs( plugMatrix )
+
+		w.setSelection( [ IECore.PathMatcher( [ "/sphere", "/cube" ] ), IECore.PathMatcher( [ "/sphere", "/cube" ] ), IECore.PathMatcher( [ "/sphere", "/cube" ] ) ] )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		originalValues = GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w )
+
+		self.assertTrue( GafferSceneUI._InspectorColumn._canPasteValues( w ) )
+		GafferSceneUI._InspectorColumn._pasteValues( w )
+
+		valuesAfterPaste = GafferSceneUI._InspectorColumn._dataFromPathListingOrReason( w )
+		self.assertNotEqual( valuesAfterPaste, originalValues )
+		self.assertEqual(
+			valuesAfterPaste,
+			IECore.ObjectMatrix( [
+				[ IECore.StringData( "s2" ), IECore.IntData( 2 ), IECore.FloatData( 200 ) ],
+				[ IECore.StringData( "s4" ), IECore.IntData( 4 ), IECore.FloatData( 400 ) ]
+			] )
+		)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1104,20 +1104,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 				self.assertEqual( plug.getValue(), value )
 				self.assertFalse( plug.isSetToDefault() )
 
-				# Array length 2, can't set
+				# Array length 2, can't set unless setting StringVectorData on StringPlug
 
+				canSetArray = isinstance( data, IECore.StringVectorData ) and plugType == Gaffer.StringPlug
 				data.append( data[0] )
 				plug.setToDefault()
-				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
-				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
-				self.assertTrue( plug.isSetToDefault() )
+				self.assertEqual( Gaffer.PlugAlgo.canSetValueFromData( plug, data ), canSetArray )
+				self.assertEqual( Gaffer.PlugAlgo.setValueFromData( plug, data ), canSetArray )
+				self.assertNotEqual( plug.isSetToDefault(), canSetArray )
 
-				# Array length 0, can't set
+				# Array length 0, can't set unless setting StringVectorData on a StringPlug
 
 				data.resize( 0 )
 				plug.setToDefault()
-				self.assertFalse( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
-				self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+				self.assertEqual( Gaffer.PlugAlgo.canSetValueFromData( plug, data ), canSetArray )
+				self.assertEqual( Gaffer.PlugAlgo.setValueFromData( plug, data ), canSetArray )
 				self.assertTrue( plug.isSetToDefault() )
 
 	def testSetBoxValueFromVectorData( self ) :
@@ -1176,6 +1177,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 					for componentPlug in childPlug :
 						self.assertFalse( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
 				self.assertTrue( plug.isSetToDefault() )
+
+	def testSetStringValueFromStringVectorData( self ) :
+
+		plug = Gaffer.StringPlug()
+
+		for data in [
+			IECore.StringVectorData( [ "a", "b", "c" ] ),
+			IECore.StringVectorData( [ "a" ] ),
+			IECore.StringVectorData()
+		] :
+
+			self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+			self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+			self.assertEqual( plug.getValue(), " ".join( data ) )
+			self.assertEqual( plug.isSetToDefault(), len( data ) == 0 )
 
 	def testDependsOnCompute( self ) :
 

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -1193,6 +1193,21 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 			self.assertEqual( plug.getValue(), " ".join( data ) )
 			self.assertEqual( plug.isSetToDefault(), len( data ) == 0 )
 
+	def testSetStringVectorValueFromStringData( self ) :
+
+		plug = Gaffer.StringVectorDataPlug()
+
+		for data in [
+			IECore.StringData( "a b c" ),
+			IECore.StringData( "a" ),
+			IECore.StringData()
+		] :
+
+			self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+			self.assertTrue( Gaffer.PlugAlgo.setValueFromData( plug, data ) )
+			self.assertEqual( plug.getValue(), IECore.StringVectorData( data.value.split() ) )
+			self.assertEqual( plug.isSetToDefault(), data.value == "" )
+
 	def testDependsOnCompute( self ) :
 
 		add = GafferTest.AddNode()

--- a/python/GafferTest/PlugAlgoTest.py
+++ b/python/GafferTest/PlugAlgoTest.py
@@ -848,6 +848,54 @@ class PlugAlgoTest( GafferTest.TestCase ) :
 			IECore.V2iData( imath.V2i( 1.0 ) )
 		)
 
+	def testSetValueOrInsertKeyFromData( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = Gaffer.Node()
+
+		for data in [
+			IECore.HalfData( 2.5 ),
+			IECore.FloatData( 0.25 ),
+			IECore.DoubleData( 25.5 ),
+			IECore.CharData( "a" ),
+			IECore.UCharData( 11 ),
+			IECore.ShortData( -101 ),
+			IECore.UShortData( 102 ),
+			IECore.UIntData( 405 ),
+			IECore.Int64Data( -1001 ),
+			IECore.UInt64Data( 1002 ),
+			IECore.BoolData( True )
+		] :
+
+			for plugType in [
+				Gaffer.IntPlug,
+				Gaffer.FloatPlug,
+				Gaffer.BoolPlug,
+			] :
+
+				with self.subTest( data = data, plugType = plugType ) :
+
+					plug = plugType()
+					s["n"].addChild( plug )
+
+					self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+
+					self.assertTrue( Gaffer.PlugAlgo.setValueOrInsertKeyFromData( plug, 1002, data ) )
+					self.assertFalse( Gaffer.Animation.isAnimated( plug ) )
+
+					value = ord( data.value ) if isinstance( data, IECore.CharData ) else data.value
+					self.assertEqual( plug.getValue(), plugType.ValueType( value ) )
+
+					curve = Gaffer.Animation.acquire( plug )
+					curve.addKey( Gaffer.Animation.Key( 0, 1001 ) )
+					self.assertFalse( curve.hasKey( 1002 ) )
+					self.assertTrue( Gaffer.PlugAlgo.canSetValueFromData( plug, data ) )
+
+					self.assertTrue( Gaffer.PlugAlgo.setValueOrInsertKeyFromData( plug, 1002, data ) )
+					self.assertTrue( curve.hasKey( 1002 ) )
+					self.assertEqual( curve.getKey( 1002 ).getValue(), Gaffer.FloatPlug.ValueType( value ) )
+
 	def testCanSetPlugFromValue( self ) :
 		compatiblePlugs = [
 			Gaffer.BoolPlug(),

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -394,6 +394,9 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		return selection
 
+	def visualOrder( self, paths ) :
+
+		return _GafferUI._pathListingWidgetVisualOrder( GafferUI._qtAddress( self._qtWidget() ), paths )
 
 	## \deprecated
 	def getSelectedPaths( self ) :

--- a/python/GafferUI/SpreadsheetUI/_PlugTableView.py
+++ b/python/GafferUI/SpreadsheetUI/_PlugTableView.py
@@ -924,7 +924,7 @@ class _PlugTableView( GafferUI.Widget ) :
 			) )
 
 		clipboard = self.__getClipboard()
-		pasteRowsPluralSuffix = "" if _ClipboardAlgo.isValueMatrix( clipboard ) and len( clipboard ) == 1 else "s"
+		pasteRowsPluralSuffix = "" if isinstance( clipboard, IECore.ObjectMatrix ) and clipboard.numRows() == 1 else "s"
 
 		canChangeEnabledState, currentEnabledState = self.__canChangeRowEnabledState( rowPlugs )
 		enabledPlugs = [ row["enabled"] for row in rowPlugs ]
@@ -1034,23 +1034,13 @@ class _PlugTableView( GafferUI.Widget ) :
 		appRoot = self._qtWidget().model().rowsPlug().ancestor( Gaffer.ApplicationRoot )
 		return appRoot.getClipboardContents()
 
-	def __setClipboard( self, data ) :
-
-		appRoot = self._qtWidget().model().rowsPlug().ancestor( Gaffer.ApplicationRoot )
-		return appRoot.setClipboardContents( data )
-
 	def __copyCells( self ) :
 
-		selection = self.selectedPlugs()
-		plugMatrix = _ClipboardAlgo.createPlugMatrixFromCells( selection )
-
+		plugMatrix = _ClipboardAlgo.createPlugMatrixFromCells( self.selectedPlugs() )
 		if not plugMatrix or not _ClipboardAlgo.canCopyPlugs( plugMatrix ) :
 			return
 
-		with self.ancestor( GafferUI.PlugValueWidget ).context() :
-			clipboardData = _ClipboardAlgo.valueMatrix( plugMatrix )
-
-		self.__setClipboard( clipboardData )
+		_ClipboardAlgo.copyPlugs( plugMatrix )
 
 	def __pasteCells( self ) :
 
@@ -1069,9 +1059,7 @@ class _PlugTableView( GafferUI.Widget ) :
 		rowPlugs = _PlugTableView.__orderedRowsPlugs( self.selectedPlugs() )
 
 		with self.ancestor( GafferUI.PlugValueWidget ).context() :
-			clipboardData = _ClipboardAlgo.copyRows( rowPlugs )
-
-		self.__setClipboard( clipboardData )
+			_ClipboardAlgo.copyRows( rowPlugs )
 
 	def __pasteRows( self ) :
 

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -329,6 +329,46 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		w.setSelection( [ s31, s12 ] )
 		self.assertEqual( w.getSelection(), [ s31, s12 ] )
 
+	def testVisualOrder( self ) :
+
+		d = {}
+		for i in range( 0, 10 ) :
+			dd = {}
+			for j in range( 0, 10 ) :
+				dd[str(j)] = j
+			d[str(i)] = dd
+
+		p = Gaffer.DictPath( d, "/" )
+
+		w = GafferUI.PathListingWidget(
+			path = p,
+			columns = [
+				GafferUI.PathListingWidget.defaultNameColumn,
+				GafferUI.PathListingWidget.StandardColumn( "Value", "dict:value" )
+			],
+			sortable = True,
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Rows,
+			displayMode = GafferUI.PathListingWidget.DisplayMode.Tree
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( w._qtWidget() ) )
+
+		s = IECore.PathMatcher( [ "/1", "/2", "/9", "/2/5", "/2/1" ] )
+		w.setSelection( s, scrollToFirst = False )
+		self.assertEqual( w.getSelection(), s )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+
+		w._qtWidget().header().setSortIndicator( 0, QtCore.Qt.AscendingOrder )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.visualOrder( s ), [ "/1", "/2", "/2/1", "/2/5", "/9" ] )
+
+		w._qtWidget().header().setSortIndicator( 0, QtCore.Qt.DescendingOrder )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.visualOrder( s ), [ "/9", "/2", "/2/5", "/2/1", "/1" ] )
+
+		w._qtWidget().header().setSortIndicator( 1, QtCore.Qt.AscendingOrder )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
+		self.assertEqual( w.visualOrder( s ), [ "/1", "/2", "/2/1", "/2/5", "/9" ] )
+
 	def testRowSelectionScrolling( self ) :
 
 		d = {}

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -56,6 +56,7 @@
 #include "IECore/DataAlgo.h"
 #include "IECore/SplineData.h"
 
+#include "boost/algorithm/string/join.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
 
@@ -761,12 +762,8 @@ bool setStringPlugValue( StringPlug *plug, const Data *value )
 			return true;
 		case IECore::StringVectorDataTypeId : {
 			const auto *data = static_cast<const StringVectorData *>( value );
-			if( data->readable().size() == 1 )
-			{
-				plug->setValue( data->readable()[0] );
-				return true;
-			}
-			return false;
+			plug->setValue( boost::algorithm::join( data->readable(), " " ) );
+			return true;
 		}
 		case IECore::InternedStringVectorDataTypeId : {
 			const auto *data = static_cast<const InternedStringVectorData *>( value );
@@ -1047,8 +1044,8 @@ bool canSetStringPlugValue( const Data *value )
 	{
 		case IECore::StringDataTypeId:
 		case IECore::InternedStringDataTypeId:
-			return true;
 		case IECore::StringVectorDataTypeId:
+			return true;
 		case IECore::InternedStringVectorDataTypeId:
 			return IECore::size( value ) == 1;
 		default:

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -56,9 +56,11 @@
 #include "IECore/DataAlgo.h"
 #include "IECore/SplineData.h"
 
+#include "boost/algorithm/string/classification.hpp"
 #include "boost/algorithm/string/join.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
+#include "boost/algorithm/string/split.hpp"
 
 #include "fmt/format.h"
 
@@ -750,6 +752,22 @@ bool setTypedDataPlugValue( PlugType *plug, const Data *value )
 	return false;
 }
 
+bool setStringVectorDataPlugValue( StringVectorDataPlug *plug, const Data *value )
+{
+	if( value->typeId() == IECore::StringDataTypeId )
+	{
+		const auto *data = static_cast<const StringData *>( value );
+		IECore::StringVectorDataPtr result = new IECore::StringVectorData;
+		if( !data->readable().empty() )
+		{
+			boost::split( result->writable(), data->readable(), boost::is_any_of( " " ) );
+		}
+		plug->setValue( result );
+		return true;
+	}
+	return setTypedDataPlugValue( plug, value );
+}
+
 bool setStringPlugValue( StringPlug *plug, const Data *value )
 {
 	switch( value->typeId() )
@@ -1034,6 +1052,21 @@ bool canSetTypedDataPlugValue( const Data *value )
 	return false;
 }
 
+bool canSetStringVectorDataPlugValue( const Data *value )
+{
+	if( !value )
+	{
+		return true;  // Data type not specified, so it could be a match
+	}
+
+	if( value->typeId() == IECore::StringDataTypeId )
+	{
+		return true;
+	}
+
+	return canSetTypedDataPlugValue<StringVectorDataPlug>( value );
+}
+
 bool canSetStringPlugValue( const Data *value )
 {
 	if( !value )
@@ -1142,7 +1175,7 @@ bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value )
 		case Gaffer::StringPlugTypeId:
 			return canSetStringPlugValue( value );
 		case Gaffer::StringVectorDataPlugTypeId:
-			return canSetTypedDataPlugValue<StringVectorDataPlug>( value );
+			return canSetStringVectorDataPlugValue( value );
 		case Gaffer::InternedStringVectorDataPlugTypeId:
 			return canSetTypedDataPlugValue<InternedStringVectorDataPlug>( value );
 		case Gaffer::Color3fPlugTypeId:
@@ -1218,7 +1251,7 @@ bool setValueFromData( ValuePlug *plug, const IECore::Data *value )
 		case Gaffer::StringPlugTypeId:
 			return setStringPlugValue( static_cast<StringPlug *>( plug ), value );
 		case Gaffer::StringVectorDataPlugTypeId:
-			return setTypedDataPlugValue( static_cast<StringVectorDataPlug *>( plug ), value );
+			return setStringVectorDataPlugValue( static_cast<StringVectorDataPlug *>( plug ), value );
 		case Gaffer::InternedStringVectorDataPlugTypeId:
 			return setTypedDataPlugValue( static_cast<InternedStringVectorDataPlug *>( plug ), value );
 		case Gaffer::Color3fPlugTypeId:

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -37,6 +37,7 @@
 
 #include "Gaffer/PlugAlgo.h"
 
+#include "Gaffer/Animation.h"
 #include "Gaffer/Box.h"
 #include "Gaffer/CompoundNumericPlug.h"
 #include "Gaffer/ComputeNode.h"
@@ -1368,6 +1369,62 @@ bool setValueFromData( const ValuePlug *plug, ValuePlug *leafPlug, const IECore:
 
 	return setValueFromData( leafPlug, value );
 
+}
+
+bool setValueOrInsertKeyFromData( ValuePlug *plug, float time, const IECore::Data *value )
+{
+	if( Animation::isAnimated( plug ) )
+	{
+		// convert input data to a float value for a keyframe
+		float keyValue = 0.0f;
+		switch( value->typeId() )
+		{
+			case HalfDataTypeId :
+				keyValue = static_cast<const HalfData *>( value )->readable();
+				break;
+			case FloatDataTypeId :
+				keyValue = static_cast<const FloatData *>( value )->readable();
+				break;
+			case DoubleDataTypeId :
+				keyValue = static_cast<const DoubleData *>( value )->readable();
+				break;
+			case CharDataTypeId :
+				keyValue = static_cast<const CharData *>( value )->readable();
+				break;
+			case UCharDataTypeId :
+				keyValue = static_cast<const UCharData *>( value )->readable();
+				break;
+			case ShortDataTypeId :
+				keyValue = static_cast<const ShortData *>( value )->readable();
+				break;
+			case UShortDataTypeId :
+				keyValue = static_cast<const UShortData *>( value )->readable();
+				break;
+			case IntDataTypeId :
+				keyValue = static_cast<const IntData *>( value )->readable();
+				break;
+			case UIntDataTypeId :
+				keyValue = static_cast<const UIntData *>( value )->readable();
+				break;
+			case Int64DataTypeId :
+				keyValue = static_cast<const Int64Data *>( value )->readable();
+				break;
+			case UInt64DataTypeId :
+				keyValue = static_cast<const UInt64Data *>( value )->readable();
+				break;
+			case BoolDataTypeId :
+				keyValue = static_cast<const BoolData *>( value )->readable();
+				break;
+			default :
+				return false;
+		}
+
+		Animation::CurvePlug *curve = Animation::acquire( plug );
+		curve->insertKey( time, keyValue );
+		return true;
+	}
+
+	return setValueFromData( plug, value );
 }
 
 }  // namespace PlugAlgo

--- a/src/GafferModule/PlugAlgoBinding.cpp
+++ b/src/GafferModule/PlugAlgoBinding.cpp
@@ -129,6 +129,12 @@ bool canSetValueFromData( const ValuePlug *plug, const IECore::Data *value )
 	return PlugAlgo::canSetValueFromData( plug, value );
 }
 
+bool setValueOrInsertKeyFromData( ValuePlug *plug, float time, const IECore::Data *value )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return PlugAlgo::setValueOrInsertKeyFromData( plug, time, value );
+}
+
 PlugPtr promote( Plug &plug, Plug *parent, const IECore::StringAlgo::MatchPattern &excludeMetadata )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -167,6 +173,7 @@ void GafferModule::bindPlugAlgo()
 	def( "setValueFromData", &setLeafValueFromData );
 	def( "setValueFromData", &setValueFromData );
 	def( "canSetValueFromData", &canSetValueFromData, ( arg( "plug" ), arg( "value" ) = object() ) );
+	def( "setValueOrInsertKeyFromData", &setValueOrInsertKeyFromData );
 
 	def( "canPromote", &PlugAlgo::canPromote, ( arg( "plug" ), arg( "parent" ) = object() ) );
 	def( "promote", &promote, ( arg( "plug" ), arg( "parent" ) = object(), arg( "excludeMetadata" ) = "layout:*" ) );

--- a/src/GafferUIModule/PathColumnBinding.cpp
+++ b/src/GafferUIModule/PathColumnBinding.cpp
@@ -141,6 +141,15 @@ class PathListingWidgetAccessor : public GafferUI::PathListingWidget
 			}
 		}
 
+		std::vector<std::string> visualOrder( const IECore::PathMatcher &paths ) const override
+		{
+			IECorePython::ScopedGILLock gilLock;
+			object pythonResult = m_widget.attr( "visualOrder" )( paths );
+			std::vector<std::string> result;
+			container_utils::extend_container( result, pythonResult );
+			return result;
+		}
+
 	private :
 
 		// A `weakref` for the Python PathListingWidget object. We use a

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -640,6 +640,21 @@ class PathModel : public QAbstractItemModel
 			return m_selection;
 		}
 
+		std::vector<std::string> visualOrder( const IECore::PathMatcher &paths )
+		{
+			std::vector<std::string> result;
+			const auto indices = indicesForPaths( paths );
+			for( auto &i : indices )
+			{
+				if( const auto path = pathForIndex( i ) )
+				{
+					result.push_back( path.get()->string() );
+				}
+			}
+
+			return result;
+		}
+
 		void attachTester()
 		{
 			if( !m_tester )
@@ -2059,6 +2074,21 @@ list getSelection( uint64_t treeViewAddress )
 	return result;
 }
 
+list visualOrder( uint64_t treeViewAddress, const IECore::PathMatcher &paths )
+{
+	QTreeView *treeView = reinterpret_cast<QTreeView *>( treeViewAddress );
+	PathModel *model = dynamic_cast<PathModel *>( treeView->model() );
+
+	list result;
+
+	for( auto &p : model->visualOrder( paths ) )
+	{
+		result.append( p );
+	}
+
+	return result;
+}
+
 void scrollToFirst( uint64_t treeViewAddress, const IECore::PathMatcher &paths )
 {
 	IECorePython::ScopedGILRelease gilRelease;
@@ -2187,6 +2217,7 @@ void GafferUIModule::bindPathListingWidget()
 	def( "_pathListingWidgetGetExpansion", &getExpansion );
 	def( "_pathListingWidgetSetSelection", &setSelection );
 	def( "_pathListingWidgetGetSelection", &getSelection );
+	def( "_pathListingWidgetVisualOrder", &visualOrder );
 	def( "_pathListingWidgetPathForIndex", &pathForIndex );
 	def( "_pathListingWidgetIndexForPath", &indexForPath );
 	def( "_pathListingWidgetPathsForIndexRange", &pathsForIndexRange );


### PR DESCRIPTION
This is the functionality from #6380 with the centralised ClipboardAlgo API removed and the work of transferring values to/from an ObjectMatrix left to the Spreadsheet and InspectorColumn. With ObjectMatrix in place, this does feel like a more reasonable way of handling interoperability between the two worlds without the added complexity of tying their otherwise independent implementations together.

Feedback from #6380 has been addressed where still appropriate, but given the amount of restructuring in this PR it would be worth another review with a fresh set of eyes.