### PR TITLE
Picking Prerequisites

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.5.x.x (relative to 1.5.12.0)
 =======
 
+Improvements
+------------
+
+- ImageReader : Automatically set "filePath" metadata when reading images, making it easier to determine the path an image was loaded from.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - RenderMan : Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
+- Cryptomatte : Fixed hypothetical inconsistencies if the C++ language locale affects the parsing of JSON files ( probably not an issue in practice, since the JSON in question should just be hexadecimal integers, and no known locale should affect the parsing of integers ).
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - ImageReader : Automatically set "filePath" metadata when reading images, making it easier to determine the path an image was loaded from.
+- Cryptomatte : Improved automatic finding of manifests. Now, if the image's metadata references a sidecar manifest file, but no explicit `manifestDirectory` is specified, it will look in the directory the image was loaded from ( as determined by the "filePath" metadata ). This makes it more likely that cryptomatte files will work automatically.
 
 Fixes
 -----

--- a/include/GafferOSL/OSLImage.h
+++ b/include/GafferOSL/OSLImage.h
@@ -129,4 +129,6 @@ class GAFFEROSL_API OSLImage : public GafferImage::ImageProcessor
 
 };
 
+IE_CORE_DECLAREPTR( OSLImage )
+
 } // namespace GafferOSL

--- a/include/GafferOSL/OSLObject.h
+++ b/include/GafferOSL/OSLObject.h
@@ -111,4 +111,6 @@ class GAFFEROSL_API OSLObject : public GafferScene::Deformer
 
 };
 
+IE_CORE_DECLAREPTR( OSLObject )
+
 } // namespace GafferOSL

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -1026,7 +1026,7 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 		expectedReader["fileName"].setValue( self.imagesPath() / "rgb.100x100.exr" )
 
 		with IECore.CapturingMessageHandler() as mh :
-			self.assertImagesEqual( reader["out"], expectedReader["out"], metadataBlacklist = [ "DateTime" ] )
+			self.assertImagesEqual( reader["out"], expectedReader["out"], metadataBlacklist = [ "DateTime", "filePath" ] )
 
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertIn( 'Ignoring invalid "multiView" attribute', mh.messages[0].message )

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -533,7 +533,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			for metaName in expectedMetadata.keys() :
 				if metaName in metadataToIgnore :
 					continue
-				if metaName in ( "fileFormat", "dataType" ) :
+				if metaName in ( "filePath", "fileFormat", "dataType" ) :
 					# These are added on automatically by the ImageReader, and
 					# we can't expect them to be the same when converting between
 					# image formats.
@@ -831,6 +831,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		expectedMetadata["Artist"] = IECore.StringData( os.environ.get("USER") or os.environ["USERNAME"] ) #Linux or windows
 		expectedMetadata["DocumentName"] = IECore.StringData( "untitled" )
 		expectedMetadata["fileFormat"] = regularReaderMetadata["fileFormat"]
+		expectedMetadata["filePath"] = IECore.StringData( regularReaderMetadata["filePath"].value.replace( "regularMetadata", "misleadingMetadata" ) )
 		expectedMetadata["dataType"] = regularReaderMetadata["dataType"]
 
 		self.__addExpectedIPTCMetadata( regularReaderMetadata, expectedMetadata )
@@ -859,6 +860,8 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			if metaName == "DateTime" :
 				dateTimeDiff = datetime.datetime.strptime( str( regularReaderMetadata[metaName] ), "%Y:%m:%d %H:%M:%S" ) - datetime.datetime.strptime( str( misledReaderMetadata[metaName] ), "%Y:%m:%d %H:%M:%S" )
 				self.assertLessEqual( abs( dateTimeDiff ), datetime.timedelta( seconds=1 ) )
+			elif metaName == "filePath" :
+				pass # The file paths are different
 			else :
 				self.assertEqual( regularReaderMetadata[metaName], misledReaderMetadata[metaName], "Metadata does not match for key \"{}\" : {}".format(metaName, ext) )
 

--- a/python/GafferImageTest/OpenImageIOReaderTest.py
+++ b/python/GafferImageTest/OpenImageIOReaderTest.py
@@ -104,6 +104,7 @@ class OpenImageIOReaderTest( GafferImageTest.ImageTestCase ) :
 			"screenWindowWidth" : IECore.FloatData( 1 ),
 			"fileFormat" : IECore.StringData( "openexr" ),
 			"dataType" : IECore.StringData( "float" ),
+			"filePath" : IECore.StringData( self.fileName.resolve().as_posix() ),
 		} )
 
 		self.assertEqual( n["out"]["metadata"].getValue(), expectedMetadata )

--- a/python/GafferSceneTest/CryptomatteTest.py
+++ b/python/GafferSceneTest/CryptomatteTest.py
@@ -187,11 +187,19 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		c = GafferScene.Cryptomatte()
 		c["in"].setInput( d["out"] )
 		c["manifestSource"].setValue( GafferScene.Cryptomatte.ManifestSource.Metadata )
+
+		# With no manifest directory specified, we automatically infer it from the filePath
+
+		self.compareValues( c, ["crypto_object", "crypto_material"] )
+
+		# Or we can set it explicitly
 		c["manifestDirectory"].setValue( self.testImage.parent )
 
 		self.compareValues( c, ["crypto_object", "crypto_material"] )
 
+		# If there is no manifestDirectory or filePath specified, we get an exception
 		c["manifestDirectory"].setValue( "" )
+		d["names"].setValue( "cryptomatte/*/manifest filePath" )
 
 		with self.assertRaisesRegex( Gaffer.ProcessException, r'No manifest directory provided.' ) as raised :
 			self.compareValues( c, ["crypto_object"] )

--- a/python/GafferSceneTest/CryptomatteTest.py
+++ b/python/GafferSceneTest/CryptomatteTest.py
@@ -57,7 +57,18 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 
 	def testCryptomatteHash( self ) :
 
-		manifest = {
+
+		i = GafferImage.ImageMetadata()
+		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/conversion", "uint32_to_float32" ) )
+		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/hash", "MurmurHash3_32" ) )
+		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/name", "crypto_object" ) )
+		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/manifest", json.dumps( {} ) ) )
+
+		c = GafferScene.Cryptomatte()
+		c["in"].setInput( i["out"] )
+		c["layer"].setValue( "crypto_object" )
+
+		expectedValues = {
 			"hello": 6.0705627102400005616e-17,
 			"cube": -4.08461912519e+15,
 			"sphere": 2.79018604383e+15,
@@ -65,20 +76,9 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 			"/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_head001_REN": -2.5222249091461295e+36,
 			"shader:b0d1fe5b982bcae64d6329033cbadc70": 876260905451520.0,
 		}
-
-		i = GafferImage.ImageMetadata()
-		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/conversion", "uint32_to_float32" ) )
-		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/hash", "MurmurHash3_32" ) )
-		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/name", "crypto_object" ) )
-		i["metadata"].addChild( Gaffer.NameValuePlug( "cryptomatte/f834d0a/manifest", json.dumps( manifest ) ) )
-
-		c = GafferScene.Cryptomatte()
-		c["in"].setInput( i["out"] )
-		c["layer"].setValue( "crypto_object" )
-
-		for name in sorted( manifest.keys() ) :
+		for name in sorted( expectedValues.keys() ) :
 			c["matteNames"].setValue( IECore.StringVectorData( [name] ) )
-			self.assertEqual( IECore.FloatData( manifest[name] ), IECore.FloatData( c["__matteValues"].getValue()[0] ) )
+			self.assertEqual( IECore.FloatData( expectedValues[name] ), IECore.FloatData( c["__matteValues"].getValue()[0] ) )
 
 	def compareValues( self, c, layers ) :
 

--- a/python/GafferSceneTest/CryptomatteTest.py
+++ b/python/GafferSceneTest/CryptomatteTest.py
@@ -93,8 +93,9 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		if "crypto_object" in layers :
 			c["layer"].setValue( "crypto_object" )
 			m = c["__manifest"].getValue()
+			self.assertEqual( m['4030791963'], IECore.StringData( "/cow" ) )
+			self.assertEqual( m['2678692000'], IECore.StringData( "/cow1" ) )
 
-			self.assertTrue( IECore.StringData( "/cow" ) in m.values() )
 			self.assertEqual( cowSampler["color"].getValue()[3], 0.0 )
 			self.assertEqual( cow1Sampler["color"].getValue()[3], 0.0 )
 
@@ -113,8 +114,9 @@ class CryptomatteTest( GafferSceneTest.SceneTestCase ) :
 		if "crypto_material" in layers :
 			c["layer"].setValue( "crypto_material" )
 			m = c["__manifest"].getValue()
+			self.assertEqual( m['2757339133'], IECore.StringData( "shader:db33c6a440a2dcf4a92383d8ae16c33a" ) )
+			self.assertEqual( m['1481063705'], IECore.StringData( "shader:b0d1fe5b982bcae64d6329033cbadc70" ) )
 
-			self.assertTrue( IECore.StringData( "shader:db33c6a440a2dcf4a92383d8ae16c33a" ) in m.values() )
 			self.assertEqual( cowSampler["color"].getValue()[3], 0.0 )
 			self.assertEqual( cow1Sampler["color"].getValue()[3], 0.0 )
 

--- a/python/GafferSceneUI/CropWindowToolUI.py
+++ b/python/GafferSceneUI/CropWindowToolUI.py
@@ -135,7 +135,6 @@ class _StatusWidget( GafferUI.Frame ) :
 			return
 
 		status = self.__tool.status()
-		self.setVisible( bool(status) )
 
 		state, _, message = status.partition( ":" )
 

--- a/python/GafferSceneUI/CryptomatteUI.py
+++ b/python/GafferSceneUI/CryptomatteUI.py
@@ -213,6 +213,10 @@ Gaffer.Metadata.registerNode(
 			If a `manif_file` metadata entry exists for the selected Cryptomatte
 			layer, it will be appended to this directory. The manifest is read from
 			the file at the resulting path.
+
+			If this is not specified, the directory will be inferred from the
+			image's `filePath` metadata.
+
 			""",
 
 			"plugValueWidget:type", "GafferUI.FileSystemPathPlugValueWidget",

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1273,6 +1273,7 @@ ImageSpec createImageSpec( const ImageWriter *node, const ImageOutput *out, cons
 	metadata->writable().erase( "oiio:Gamma" );
 	metadata->writable().erase( "oiio:UnassociatedAlpha" );
 	metadata->writable().erase( "fileFormat" );
+	metadata->writable().erase( "filePath" );
 	// Including fileValid is technically redundant here - it is usually a BoolData, and
 	// IECoreImage::OpenImageIOAlgo::DataView fails to support bools. But we keep this erase()
 	// for a hypothetical future where bools might be supported.

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -119,9 +119,6 @@ class TileShader
 		TileShader()
 		{
 
-			std::string colorTransformCode;
-			OCIO_NAMESPACE::GpuShaderDescRcPtr shaderDesc;
-
 			// Build and compile GLSL shader
 			std::string combinedFragmentCode;
 			if( glslVersion() >= 330 )
@@ -130,7 +127,7 @@ class TileShader
 				// define it correctly in the same way as the OpenGL shader preprocessing would.
 				combinedFragmentCode = "#version 330 compatibility\n #define __VERSION__ 330\n\n";
 			}
-			combinedFragmentCode += colorTransformCode + fragmentSource();
+			combinedFragmentCode += fragmentSource();
 
 			m_shader = ShaderLoader::defaultShaderLoader()->create( vertexSource(), "", combinedFragmentCode );
 

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -167,8 +167,6 @@ IECore::CompoundDataPtr propertyTreeToCompoundData( const boost::property_tree::
 	IECore::CompoundDataPtr resultData = new IECore::CompoundData();
 	CompoundDataMap &result = resultData->writable();
 
-	uint32_t hash;
-
 	for( auto &it : pt )
 	{
 		// NOTE: exclude locations starting with "instance:" under root
@@ -177,7 +175,16 @@ IECore::CompoundDataPtr propertyTreeToCompoundData( const boost::property_tree::
 			continue;
 		}
 
-		std::sscanf( it.second.data().c_str(), "%x", &hash );
+		const std::string &hashString = it.second.data().c_str();
+
+		uint32_t hash = 0;
+
+		auto [_unused, errorCode] = std::from_chars( hashString.data(), hashString.data() + hashString.size(), hash, 16 );
+
+		if( errorCode != std::errc() )
+		{
+			throw IECore::Exception( fmt::format( "Expected hexadecimal while parsing manifest: {}", hashString ) );
+		}
 
 		result[hash] = new StringData( it.first );
 	}

--- a/src/GafferScene/Cryptomatte.cpp
+++ b/src/GafferScene/Cryptomatte.cpp
@@ -175,7 +175,7 @@ IECore::CompoundDataPtr propertyTreeToCompoundData( const boost::property_tree::
 			continue;
 		}
 
-		const std::string &hashString = it.second.data().c_str();
+		const std::string &hashString = it.second.data();
 
 		uint32_t hash = 0;
 
@@ -183,7 +183,7 @@ IECore::CompoundDataPtr propertyTreeToCompoundData( const boost::property_tree::
 
 		if( errorCode != std::errc() )
 		{
-			throw IECore::Exception( fmt::format( "Expected hexadecimal while parsing manifest: {}", hashString ) );
+			throw IECore::Exception( fmt::format( "Expected hexadecimal while parsing manifest: \"{}\"", hashString ) );
 		}
 
 		result[hash] = new StringData( it.first );
@@ -240,7 +240,7 @@ IECore::CompoundDataPtr parseManifestFromSidecarFile( const std::string &manifes
 	return propertyTreeToCompoundData( pt );
 }
 
-IECore::CompoundDataPtr parseManifestFromMetadataAndSidecar( const std::string &metadataKey, ConstCompoundDataPtr metadata, const std::string &manifestDirectory )
+IECore::CompoundDataPtr parseManifestFromMetadataAndSidecar( const std::string &metadataKey, ConstCompoundDataPtr metadata, std::string manifestDirectory )
 {
 	if( metadata->readable().find( metadataKey ) == metadata->readable().end() )
 	{
@@ -249,9 +249,15 @@ IECore::CompoundDataPtr parseManifestFromMetadataAndSidecar( const std::string &
 
 	if( manifestDirectory == "" )
 	{
-		throw IECore::Exception( "No manifest directory provided. A directory is required to locate the manifest." );
+		const StringData *filePathData = metadata->member<StringData>( "filePath" );
+		if( !filePathData )
+		{
+			throw IECore::Exception( "No manifest directory provided, and no `filePath` metadata that would allow inferring the directory. A directory is required to locate the manifest." );
+		}
+		manifestDirectory = std::filesystem::path( filePathData->readable() ).parent_path().generic_string();
 	}
-	else if( !std::filesystem::is_directory( manifestDirectory ) )
+
+	if( !std::filesystem::is_directory( manifestDirectory ) )
 	{
 		throw IECore::Exception( fmt::format( "Manifest directory not found: {}", manifestDirectory ) );
 	}


### PR DESCRIPTION
As discussed in #6329, the actual feature of image based picking is going to be deferred to 1.6.

This PR is just the first half of commits from that PR: things that are already nice to have, and that won't cause any issues in 1.5.

I've added Changelog entries for anything that seems user visible. `Cryptomatte : Prefer from_chars to sscanf` is kind of on the border of that - it seems very unlikely it would result in any user visible difference, but it could affect which error you get from parsing an invalid JSON, so I figured I should mention it.