### PR TITLE
ShaderAssignment : Move GlobalScope to ShaderPlug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Improvements
 ------------
 
 - DeleteAttributes : Optimised case where all attributes are deleted. The input attributes are no longer accessed at all in this case.
+- ShaderAssignment : The `scene:path` context variable is now available in Switches connected directly to the `ShaderAssignment.shader` input. This allows different shaders to be assigned to different locations using a single ShaderAssignment node. Please note that the `scene:path` context variable remains unavailable to the individual shader nodes themselves for performance reasons.
 
 Fixes
 -----

--- a/src/GafferScene/ShaderAssignment.cpp
+++ b/src/GafferScene/ShaderAssignment.cpp
@@ -100,14 +100,12 @@ bool ShaderAssignment::affectsProcessedAttributes( const Gaffer::Plug *input ) c
 void ShaderAssignment::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	AttributeProcessor::hashProcessedAttributes( path, context, h );
-	ScenePlug::GlobalScope globalScope( context );
 	h.append( shaderPlug()->attributesHash() );
 	labelPlug()->hash( h );
 }
 
 IECore::ConstCompoundObjectPtr ShaderAssignment::computeProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, const IECore::CompoundObject *inputAttributes ) const
 {
-	ScenePlug::GlobalScope globalScope( context );
 	ConstCompoundObjectPtr attributes = shaderPlug()->attributes();
 
 	if( attributes->members().empty() )

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -36,6 +36,7 @@
 
 #include "GafferScene/ShaderPlug.h"
 
+#include "GafferScene/ScenePlug.h"
 #include "GafferScene/Shader.h"
 
 #include "Gaffer/BoxIO.h"
@@ -234,9 +235,8 @@ struct ShaderPlug::ShaderContext
 {
 
 	ConstContextPtr context;
-	std::optional<Context::Scope> scope;
+	std::optional<ScenePlug::GlobalScope> scope;
 	std::string outputParameter;
-	std::optional<Context::EditableScope> editableScope;
 
 };
 
@@ -333,16 +333,12 @@ const Gaffer::Plug *ShaderPlug::shaderOutPlug( ShaderContext &shaderContext ) co
 		return nullptr;
 	}
 
+	shaderContext.context = context;
+	shaderContext.scope.emplace( context.get() );
 	if( source != shaderOutPlug )
 	{
-		shaderContext.editableScope.emplace( context.get() );
 		shaderContext.outputParameter = source->relativeName( shaderOutPlug );
-		shaderContext.editableScope->set( Shader::g_outputParameterContextName, &shaderContext.outputParameter );
-	}
-	else if( context != Context::current() )
-	{
-		shaderContext.context = context;
-		shaderContext.scope.emplace( context.get() );
+		shaderContext.scope->set( Shader::g_outputParameterContextName, &shaderContext.outputParameter );
 	}
 
 	return source;


### PR DESCRIPTION
This means we instantiate the GlobalScope only after using `contextSensitiveSource()` to traverse through switches to find the input shader. That allows a user to use `${scene:path}` to control the switch, assigning different shaders to different locations.

This isn't completely side-effect-free, as the `${scene:path}` deletion now applies to all ShaderPlug clients, not just ShaderAssignment. Examples of edge-case behaviour changes include :

- Light parameters can no longer contain `${scene:path}` to receive the name of location created by the Light node.
- The input to an OSLImage node can no longer use `${scene:path}`, should the OSLImage be used by a GafferScene node.

I haven't thought of any good reason to want to do either of those things, so would definitely be happy to accept the changes in return for the benefit of switchable assignments. But it seems open for debate whether the likelihood of unexpected consequences warrants this going in the next major rather than minor version. Opinions welcome.
