### PR TITLE
MultiLineTextWidget : Clear selection on focus loss

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - RenderMan : Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
+- MultiLineTextWidget : Fixed bug causing text selection highlighting to persist after the widget has lost focus.
 
 1.5.12.0 (relative to 1.5.11.0)
 ========

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -587,6 +587,11 @@ class _PlainTextEdit( QtWidgets.QPlainTextEdit ) :
 		if widget is not None :
 			widget._emitEditingFinished()
 
+		if event.reason() != QtCore.Qt.PopupFocusReason :
+			cursor = self.textCursor()
+			cursor.clearSelection()
+			self.setTextCursor( cursor )
+
 		QtWidgets.QPlainTextEdit.focusOutEvent( self, event )
 
 	def paintEvent( self, event ) :


### PR DESCRIPTION
Noticed this while prototyping alternate widgets for editing light links, and now I see it everywhere...

![image](https://github.com/user-attachments/assets/2a949bfb-6842-4550-be01-4a4f3343da6f)

We don't clear selection for events with a reason of `QtCore.Qt.PopupFocusReason` to ensure selection is maintained while focus is lost to a popup menu.
