### PR TITLE
Add Initial RenderManifest Support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,8 +19,8 @@ Fixes
 API
 ---
 
-- Gaffer module : Added `environment()` method, returning a dictionary containing all current environment variables. Unlike `os.environ`, this preserves
-  case on Windows.
+- Gaffer module : Added `environment()` method, returning a dictionary containing all current environment variables. Unlike `os.environ`, this preserves case on Windows.
+- GafferScene::RenderManifest : Added class for representing mapping of ids to paths in renders. Supports reading EXR and cryptomatte manifests, and writing EXR manifests.
 
 Breaking Changes
 ----------------

--- a/SConstruct
+++ b/SConstruct
@@ -1100,7 +1100,7 @@ libraries = {
 
 	"GafferScene" : {
 		"envAppends" : {
-			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "osdCPU" ],
+			"LIBS" : [ "Gaffer", "Iex$IMATH_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX", "IECoreImage$CORTEX_LIB_SUFFIX",  "IECoreScene$CORTEX_LIB_SUFFIX", "GafferImage", "GafferDispatch", "osdCPU", "OpenEXR" ],
 		},
 		"pythonEnvAppends" : {
 			"LIBS" : [ "GafferBindings", "GafferScene", "GafferDispatch", "GafferImage", "IECoreScene$CORTEX_LIB_SUFFIX", "IECoreGL$CORTEX_LIB_SUFFIX" ],

--- a/include/GafferScene/InteractiveRender.h
+++ b/include/GafferScene/InteractiveRender.h
@@ -102,6 +102,8 @@ class GAFFERSCENE_API InteractiveRender : public Gaffer::ComputeNode
 
 		void affects( const Gaffer::Plug *input, AffectedPlugsContainer &outputs ) const override;
 
+		std::shared_ptr<const RenderManifest> renderManifest() const;
+
 	protected :
 
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -39,6 +39,7 @@
 #include "GafferScene/ScenePlug.h"
 
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
+#include "GafferScene/RenderManifest.h"
 
 #include "IECoreScene/VisibleRenderable.h"
 
@@ -78,10 +79,14 @@ struct GAFFERSCENE_API RenderOptions
 	bool deformationBlur;
 	Imath::V2f shutter;
 	IECore::ConstStringVectorDataPtr includedPurposes;
+
 	/// Returns true if `includedPurposes` includes the purpose defined by
 	/// `attributes`.
 	bool purposeIncluded( const IECore::CompoundObject *attributes ) const;
 	void outputOptions( IECoreScenePreview::Renderer *renderer, const RenderOptions *previousOptions = nullptr );
+
+	// Returns a manifest file path if it's set, otherwise empty string
+	std::string renderManifestFilePath() const;
 };
 
 /// Creates the directories necessary to receive the outputs defined in globals.
@@ -106,8 +111,8 @@ GAFFERSCENE_API bool transformSamples( const Gaffer::M44fPlug *transformPlug, co
 /// Primitives and Cameras, since other object types cannot be interpolated anyway.
 GAFFERSCENE_API bool objectSamples( const Gaffer::ObjectPlug *objectPlug, const std::vector<float> &sampleTimes, std::vector<IECore::ConstObjectPtr> &samples, IECore::MurmurHash *hash = nullptr );
 
-GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const IECore::CompoundObject *globals, IECoreScenePreview::Renderer *renderer );
-GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const IECore::CompoundObject *globals, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );
+GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, IECoreScenePreview::Renderer *renderer );
+GAFFERSCENE_API void outputOutputs( const ScenePlug *scene, const RenderOptions &renderOptions, const IECore::CompoundObject *previousGlobals, IECoreScenePreview::Renderer *renderer );
 
 /// Utility class to handle all the set computations needed for a render.
 class GAFFERSCENE_API RenderSets : boost::noncopyable
@@ -280,7 +285,10 @@ class GAFFERSCENE_API LightLinks : boost::noncopyable
 GAFFERSCENE_API void outputCameras( const ScenePlug *scene, const RenderOptions &renderOptions, const RenderSets &renderSets, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputLightFilters( const ScenePlug *scene, const RenderOptions &renderOptions, const RenderSets &renderSets, LightLinks *lightLinks, IECoreScenePreview::Renderer *renderer );
 GAFFERSCENE_API void outputLights( const ScenePlug *scene, const RenderOptions &renderOptions, const RenderSets &renderSets, LightLinks *lightLinks, IECoreScenePreview::Renderer *renderer );
-GAFFERSCENE_API void outputObjects( const ScenePlug *scene, const RenderOptions &renderOptions, const RenderSets &renderSets, const LightLinks *lightLinks, IECoreScenePreview::Renderer *renderer, const ScenePlug::ScenePath &root = ScenePlug::ScenePath() );
+
+// If a renderManifest is given, the paths of all objects rendered will be added to it, and renderer->assignID() will
+// be called to assign the generated ids to every object.
+GAFFERSCENE_API void outputObjects( const ScenePlug *scene, const RenderOptions &renderOptions, const RenderSets &renderSets, const LightLinks *lightLinks, IECoreScenePreview::Renderer *renderer, const ScenePlug::ScenePath &root = ScenePlug::ScenePath(), RenderManifest *renderManifest = nullptr );
 
 } // namespace RendererAlgo
 

--- a/include/GafferScene/RenderController.h
+++ b/include/GafferScene/RenderController.h
@@ -41,6 +41,8 @@
 
 #include "Gaffer/Signals.h"
 
+#include "GafferScene/RenderManifest.h"
+
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 #include "GafferScene/Private/RendererAlgo.h"
 
@@ -98,9 +100,11 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 		// ID queries
 		// ==========
 		//
-		// These allow IDs acquired from a standard `uint id` AOV to be mapped
+		// Allow IDs acquired from a standard `uint id` AOV to be mapped
 		// back to the scene paths they came from.
+		std::shared_ptr< const RenderManifest> renderManifest() const;
 
+		// \todo : These functions are all deprecated. Use the functions on renderManifest() instead.
 		std::optional<ScenePlug::ScenePath> pathForID( uint32_t id ) const;
 		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids ) const;
 
@@ -138,12 +142,11 @@ class GAFFERSCENE_API RenderController : public Gaffer::Signals::Trackable
 
 		class SceneGraph;
 		class SceneGraphUpdateTask;
-		class IDMap;
 
 		ConstScenePlugPtr m_scene;
 		Gaffer::ConstContextPtr m_context;
 		IECoreScenePreview::RendererPtr m_renderer;
-		std::unique_ptr<IDMap> m_idMap;
+		std::shared_ptr<RenderManifest> m_renderManifest;
 
 		GafferScene::VisibleSet m_visibleSet;
 		size_t m_minimumExpansionDepth;

--- a/include/GafferScene/RenderManifest.h
+++ b/include/GafferScene/RenderManifest.h
@@ -1,0 +1,135 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "GafferScene/Export.h"
+
+#include "GafferScene/ScenePlug.h"
+
+#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/ordered_index.hpp"
+#include "boost/multi_index_container.hpp"
+#include "boost/noncopyable.hpp"
+
+#include "tbb/spin_rw_mutex.h"
+
+#include <filesystem>
+
+namespace GafferScene
+{
+
+// Maps between scene locations and integer ids.
+class GAFFERSCENE_API RenderManifest : boost::noncopyable
+{
+
+	public :
+
+		RenderManifest();
+
+		// Return the id for the path if it is found in the manifest, otherwise insert
+		// it and return the freshly created id.
+		uint32_t acquireID( const ScenePlug::ScenePath &path );
+
+		// Return the id for the path if it is found in the manifest, otherwise return 0.
+		uint32_t idForPath( const ScenePlug::ScenePath &path ) const;
+
+		// Return the path for the id, if it is found in the manifest.
+		std::optional<ScenePlug::ScenePath> pathForID( uint32_t id ) const;
+
+		// The same functionality as above, except operating on multiple items at once.
+		// More efficient than calling the above functions in a loop.
+		std::vector<uint32_t> acquireIDs( const IECore::PathMatcher &paths );
+		std::vector<uint32_t> idsForPaths( const IECore::PathMatcher &paths ) const;
+		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids ) const;
+
+		// Reset the manifest.
+		void clear();
+
+		// Return the number of id/path pairs in the manifest.
+		size_t size() const;
+
+		// Find a RenderManifest stored in image metadata, according to either a
+		// Gaffer convention ( gaffer:renderManifestFilePath pointing to a sidecar exr file
+		// containing an exr manifest ), or a Cryptomatte convention ( a cryptomatte
+		// metadata entry matching `cryptomatteLayerName`, with JSON text stored
+		// directly in the image metadata, or in a sidecar JSON file ).
+		//
+		// If called repeatedly, will attempt to avoid reloading the manifest if relevant
+		// metadata has not changed.
+		//
+		// In order to get this behaviour, you must not release the shared pointer to the previous manifest you
+		// loaded until after calling this method again ( releasing it to soon would cause it to be evicted from
+		// the cache, and unnecessarily reloaded ).
+		static std::shared_ptr< const RenderManifest > loadFromImageMetadata( const IECore::CompoundData *metadata, const std::string &cryptomatteLayerName );
+
+		// Write the current maninfest to a sidecar EXR file. This file will not contain any image data,
+		// but uses the EXR id manifest format to store this manifest in the header.
+		void writeEXRManifest( const std::filesystem::path &filePath ) const;
+
+	private :
+
+		using PathAndID = std::pair<ScenePlug::ScenePath, uint32_t>;
+		using Map = boost::multi_index::multi_index_container<
+			PathAndID,
+			boost::multi_index::indexed_by<
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<PathAndID, ScenePlug::ScenePath, &PathAndID::first>
+				>,
+				boost::multi_index::ordered_unique<
+					boost::multi_index::member<PathAndID, uint32_t, &PathAndID::second>
+				>
+			>
+		>;
+
+		void loadEXRManifest( const std::filesystem::path &filePath );
+		void loadCryptomatteJSON( std::istream &in );
+
+		// Note: a very rough test indicates that when rendering many cheap locations, resulting in
+		// high contention on this class, using a spin mutex to limit access here is much slower
+		// than giving each thread its own accumulator and then combining them afterwards. The
+		// measured overhead is about 0.4 seconds per million entries, vs 0.1 seconds per million
+		// entries with per thread accumulators. There isn't really a simple way to expose per-thread
+		// accumulators though ... the current thought is that it's worth the 0.3s of overhead to keep
+		// the API simple.
+		using Mutex = tbb::spin_rw_mutex;
+
+		Map m_map;
+		mutable Mutex m_mutex;
+
+};
+
+} // namespace GafferScene

--- a/python/GafferSceneTest/RenderManifestTest.py
+++ b/python/GafferSceneTest/RenderManifestTest.py
@@ -1,0 +1,166 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import pathlib
+import time
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferScene
+import GafferSceneTest
+import GafferImage
+
+class RenderManifestTest( GafferSceneTest.SceneTestCase ) :
+
+	testImagePath = pathlib.Path( __file__ ).parent / "images"
+	testImage = testImagePath / "cryptomatte.exr"
+
+	def test( self ) :
+
+		r = GafferScene.RenderManifest()
+
+		# acquireID can either insert new ids in incremental order, or retrieve existing ids
+		self.assertEqual( r.acquireID( "/a" ), 1 )
+		self.assertEqual( r.acquireID( "/b" ), 2 )
+		self.assertEqual( r.acquireID( "/c" ), 3 )
+		self.assertEqual( r.acquireID( "/long/path/with/many/elements" ), 4 )
+		self.assertEqual( r.acquireID( "/long/path/with/many/elements" ), 4 )
+		self.assertEqual( r.acquireID( "/c" ), 3 )
+		self.assertEqual( r.acquireID( "/b" ), 2 )
+		self.assertEqual( r.acquireID( "/a" ), 1 )
+
+
+		# idForPath can only retrieve existing ids
+		self.assertEqual( r.idForPath( "/a" ), 1 )
+		self.assertEqual( r.idForPath( "/c" ), 3 )
+
+		# Returns 0 for unknown path
+		self.assertEqual( r.idForPath( "/x" ), 0 )
+
+
+		self.assertEqual( r.pathForID( 1 ), "/a" )
+		self.assertEqual( r.pathForID( 3 ), "/c" )
+		self.assertEqual( r.pathForID( 4 ), "/long/path/with/many/elements" )
+
+		# Returns None for unknown path
+		self.assertEqual( r.pathForID( 42 ), None )
+
+		# There are also batch forms that operate on id lists and path matchers
+		self.assertEqual( r.acquireIDs( IECore.PathMatcher( [ "x", "y", "z" ] ) ), [ 5, 6, 7] )
+
+		self.assertEqual( r.pathsForIDs( [ 5, 6, 7] ), IECore.PathMatcher( [ "x", "y", "z" ] ) )
+
+
+		self.assertEqual( r.size(), 7 )
+		r.clear()
+		self.assertEqual( r.size(), 0 )
+
+
+	def testReadCryptomatte( self ):
+
+		imageReader = GafferImage.ImageReader()
+		imageReader["fileName"].setValue( self.testImage )
+
+		# Delete in the in-place manifest, so we know it works to read from the sidecar file
+		m = imageReader["out"].metadata()
+		del m["cryptomatte/f834d0a/manifest"]
+		r = GafferScene.RenderManifest.loadFromImageMetadata( m, "crypto_object" )
+
+		self.assertEqual( r.size(), 92 )
+		self.assertEqual( r.idForPath( "/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_head001_REN" ), 4226998693 )
+		self.assertEqual( r.pathForID( 4226998693 ), "/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_head001_REN" )
+
+		# Delete the manif_file, so we know it works to read from the in-place manifest
+		m = imageReader["out"].metadata()
+		del m["cryptomatte/f834d0a/manif_file"]
+		r = GafferScene.RenderManifest.loadFromImageMetadata( m, "crypto_object" )
+
+		self.assertEqual( r.size(), 92 )
+		self.assertEqual( r.idForPath( "/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_head001_REN" ), 4226998693 )
+		self.assertEqual( r.pathForID( 4226998693 ), "/GAFFERBOT/C_torso_GRP/C_head_GRP/C_head_CPT/C_head001_REN" )
+
+		# We can also load the material cryptomattes
+		r = GafferScene.RenderManifest.loadFromImageMetadata( m, "crypto_material" )
+		self.assertEqual( r.size(), 14 )
+		self.assertEqual( r.idForPath( "shader:ba1b35e0886c8e92a5c5daea71484b84" ), 1650131652 )
+		self.assertEqual( r.pathForID( 1650131652 ), "/shader:ba1b35e0886c8e92a5c5daea71484b84" )
+
+		# If we delete both sources of metadata, we get an exception
+		m = imageReader["out"].metadata()
+		del m["cryptomatte/f834d0a/manif_file"]
+		del m["cryptomatte/f834d0a/manifest"]
+		with self.assertRaisesRegex( IECore.Exception, "No gaffer:renderManifestFilePath metadata or cryptomatte metadata found" ):
+			GafferScene.RenderManifest.loadFromImageMetadata( m, "crypto_object" )
+
+	def testReadWriteEXR( self ):
+		r = GafferScene.RenderManifest()
+		r.acquireID( "/a" )
+		r.acquireID( "/b" )
+		r.acquireID( "/c" )
+		r.acquireID( "/long/path/with/many/elements" )
+
+		filePath = self.temporaryDirectory() / "testManifest.exr"
+
+		r.writeEXRManifest( filePath )
+
+		# Try reading back this manifest
+
+		r2 = GafferScene.RenderManifest.loadFromImageMetadata( IECore.CompoundData( { "gaffer:renderManifestFilePath" : str( filePath ) } ), "" )
+		self.assertEqual( r2.size(), 4 )
+		self.assertEqual( r2.idForPath( "b" ), 2 )
+		self.assertEqual( r2.pathForID( 2 ), "/b" )
+
+		# Update the manifest on disk
+		r.acquireID( "x" )
+
+		# This is such a small manifest that the time to write it could less than the file system's timer
+		# precision, resulting in sporadic failures if both writes get the same mod time, and RenderManifest
+		# thinks it doesn't need to reload because the time stamp hasn't changed. A delay of 0.001s seems
+		# adequate to avoid this - delay by 0.01s to be safe.
+		time.sleep( 0.01 )
+		r.writeEXRManifest( filePath )
+
+		# Make sure we get the update
+		r2 = GafferScene.RenderManifest.loadFromImageMetadata( IECore.CompoundData( { "gaffer:renderManifestFilePath" : str( filePath ) } ), "" )
+		self.assertEqual( r2.size(), 5 )
+		self.assertEqual( r2.idForPath( "x" ), 5 )
+		self.assertEqual( r2.pathForID( 5 ), "/x" )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/src/GafferScene/InteractiveRender.cpp
+++ b/src/GafferScene/InteractiveRender.cpp
@@ -492,6 +492,16 @@ void InteractiveRender::affects( const Plug *input, AffectedPlugsContainer &outp
 	}
 }
 
+std::shared_ptr<const RenderManifest> InteractiveRender::renderManifest() const
+{
+	if( !m_controller )
+	{
+		return nullptr;
+	}
+
+	return m_controller->renderManifest();
+}
+
 void InteractiveRender::hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	ComputeNode::hash( output, context, h );

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -232,67 +232,6 @@ struct ObjectInterfaceHandle : public boost::noncopyable
 
 } // namespace
 
-//////////////////////////////////////////////////////////////////////////
-// Internal implementation details
-//////////////////////////////////////////////////////////////////////////
-
-// Maps between scene locations and integer IDs.
-class RenderController::IDMap
-{
-
-	public :
-
-		uint32_t idForPath( const ScenePlug::ScenePath &path, bool createIfNecessary = false )
-		{
-			Mutex::scoped_lock lock( m_mutex, /* write = */ false );
-			auto it = m_map.find( path );
-			if( it != m_map.end() )
-			{
-				return it->second;
-			}
-
-			if( !createIfNecessary)
-			{
-				return 0;
-			}
-
-			lock.upgrade_to_writer();
-			return m_map.insert( PathAndID( path, m_map.size() + 1 ) ).first->second;
-		}
-
-		std::optional<ScenePlug::ScenePath> pathForID( uint32_t id ) const
-		{
-			Mutex::scoped_lock lock( m_mutex, /* write = */ false );
-			auto &index = m_map.get<1>();
-			auto it = index.find( id );
-			if( it != index.end() )
-			{
-				return it->first;
-			}
-			return std::nullopt;
-		}
-
-	private :
-
-		using PathAndID = std::pair<ScenePlug::ScenePath, uint32_t>;
-		using Map = boost::multi_index::multi_index_container<
-			PathAndID,
-			boost::multi_index::indexed_by<
-				boost::multi_index::ordered_unique<
-					boost::multi_index::member<PathAndID, ScenePlug::ScenePath, &PathAndID::first>
-				>,
-				boost::multi_index::ordered_unique<
-					boost::multi_index::member<PathAndID, uint32_t, &PathAndID::second>
-				>
-			>
-		>;
-		using Mutex = tbb::spin_rw_mutex;
-
-		Map m_map;
-		mutable Mutex m_mutex;
-
-};
-
 // Represents a location in the Gaffer scene as specified to the
 // renderer. We use this to build up a persistent representation of
 // the scene which we can traverse to perform selective updates to
@@ -546,7 +485,7 @@ class RenderController::SceneGraph
 					/// \todo Measure overhead and consider using same IDs everywhere.
 					if( controller->m_renderer->name() != g_openGLRendererName )
 					{
-						m_objectInterface->assignID( controller->m_idMap->idForPath( path, /* createIfNecessary = */ true ) );
+						m_objectInterface->assignID( controller->m_renderManifest->acquireID( path ) );
 					}
 				}
 
@@ -1341,7 +1280,7 @@ class RenderController::SceneGraphUpdateTask : public tbb::task
 
 RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer::ConstContextPtr &context, const IECoreScenePreview::RendererPtr &renderer )
 	:	m_renderer( renderer ),
-		m_idMap( std::make_unique<IDMap>() ),
+		m_renderManifest( std::make_shared<RenderManifest>() ),
 		m_minimumExpansionDepth( 0 ),
 		m_updateRequired( false ),
 		m_updateRequested( false ),
@@ -1625,7 +1564,7 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 		{
 			RenderOptions renderOptions( m_scene.get() );
 			renderOptions.outputOptions( m_renderer.get(), &m_renderOptions );
-			Private::RendererAlgo::outputOutputs( m_scene.get(), renderOptions.globals.get(), m_renderOptions.globals.get(), m_renderer.get() );
+			Private::RendererAlgo::outputOutputs( m_scene.get(), renderOptions, m_renderOptions.globals.get(), m_renderer.get() );
 			if( *renderOptions.globals != *m_renderOptions.globals )
 			{
 				m_changedGlobalComponents |= GlobalsGlobalComponent;
@@ -1807,38 +1746,41 @@ void RenderController::cancelBackgroundTask()
 	}
 }
 
+std::shared_ptr<const RenderManifest> RenderController::renderManifest() const
+{
+	return m_renderManifest;
+}
+
 std::optional<ScenePlug::ScenePath> RenderController::pathForID( uint32_t id ) const
 {
-	return m_idMap->pathForID( id );
+	return m_renderManifest->pathForID( id );
 }
 
 IECore::PathMatcher RenderController::pathsForIDs( const std::vector<uint32_t> &ids ) const
 {
-	IECore::PathMatcher result;
-	for( auto id : ids )
-	{
-		if( auto path = m_idMap->pathForID( id ) )
-		{
-			result.addPath( *path );
-		}
-	}
-	return result;
+	return m_renderManifest->pathsForIDs( ids );
 }
 
 uint32_t RenderController::idForPath( const ScenePlug::ScenePath &path, bool createIfNecessary ) const
 {
-	return m_idMap->idForPath( path, createIfNecessary );
+	if( createIfNecessary )
+	{
+		return m_renderManifest->acquireID( path );
+	}
+	else
+	{
+		return m_renderManifest->idForPath( path );
+	}
 }
 
 std::vector<uint32_t> RenderController::idsForPaths( const IECore::PathMatcher &paths, bool createIfNecessary ) const
 {
-	std::vector<uint32_t> result;
-	for( PathMatcher::Iterator it = paths.begin(), eIt = paths.end(); it != eIt; ++it )
+	if( createIfNecessary )
 	{
-		if( auto id = idForPath( *it, createIfNecessary ) )
-		{
-			result.push_back( id );
-		}
+		return m_renderManifest->acquireIDs( paths );
 	}
-	return result;
+	else
+	{
+		return m_renderManifest->idsForPaths( paths );
+	}
 }

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1306,6 +1306,16 @@ RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer
 
 RenderController::~RenderController()
 {
+	if( m_renderOptions.renderManifestFilePath().size() && m_renderManifest )
+	{
+		// Make sure the directory exists to write the exr manifest to.
+		std::filesystem::create_directories(
+			std::filesystem::path( m_renderOptions.renderManifestFilePath() ).parent_path()
+		);
+
+		renderManifest()->writeEXRManifest( m_renderOptions.renderManifestFilePath() );
+	}
+
 	// Cancel background task before the things it relies
 	// on are destroyed.
 	cancelBackgroundTask();

--- a/src/GafferScene/RenderManifest.cpp
+++ b/src/GafferScene/RenderManifest.cpp
@@ -1,0 +1,493 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferScene/RenderManifest.h"
+
+#include "OpenEXR/ImfChannelList.h"
+#include "OpenEXR/ImfFrameBuffer.h"
+#include "OpenEXR/ImfHeader.h"
+#include "OpenEXR/ImfIDManifest.h"
+#include "OpenEXR/ImfIntAttribute.h"
+#include "OpenEXR/ImfMultiPartInputFile.h"
+#include "OpenEXR/ImfMultiPartOutputFile.h"
+#include "OpenEXR/ImfOutputPart.h"
+#include "OpenEXR/ImfPartType.h"
+#include "OpenEXR/ImfStandardAttributes.h"
+
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "boost/iostreams/stream.hpp"
+#include "boost/property_tree/json_parser.hpp"
+
+#include <regex>
+
+using namespace GafferScene;
+
+namespace
+{
+
+struct CacheKey
+{
+	CacheKey() {};
+	CacheKey( IECore::ConstStringDataPtr loadedFromCryptomatteJSONStringData, std::string loadedFromFilePath, std::filesystem::file_time_type loadedFromFilePathModTime )
+		: loadedFromCryptomatteJSONStringData( loadedFromCryptomatteJSONStringData ), loadedFromFilePath( loadedFromFilePath ), loadedFromFilePathModTime( loadedFromFilePathModTime )
+	{
+	}
+
+	bool operator == ( const CacheKey &other ) const
+	{
+		if( other.loadedFromFilePath != loadedFromFilePath || other.loadedFromFilePathModTime != loadedFromFilePathModTime )
+		{
+			return false;
+		}
+
+		if( bool( other.loadedFromCryptomatteJSONStringData ) != bool( loadedFromCryptomatteJSONStringData ) )
+		{
+			return false;
+		}
+
+		if( ( !other.loadedFromCryptomatteJSONStringData ) && ( !loadedFromCryptomatteJSONStringData ) )
+		{
+			return true;
+		}
+
+		return other.loadedFromCryptomatteJSONStringData->isEqualTo( loadedFromCryptomatteJSONStringData.get() );
+	}
+
+	IECore::ConstStringDataPtr loadedFromCryptomatteJSONStringData;
+	std::string loadedFromFilePath;
+	std::filesystem::file_time_type loadedFromFilePathModTime;
+};
+
+
+struct CacheKeyHasher
+{
+	std::size_t operator()( const CacheKey &key ) const
+	{
+		IECore::MurmurHash h;
+		// Don't want to hash the actual contents of what might be an extremely large string.
+		// StringData's internal lazy-copy-on-write will mean that unmodified copies will share the
+		// same address, so we hash that instead.
+		h.append( reinterpret_cast<uintptr_t>( &key.loadedFromCryptomatteJSONStringData->readable() ) );
+		h.append( key.loadedFromFilePath );
+		h.append( key.loadedFromFilePathModTime.time_since_epoch().count() );
+		return h.h1();
+	}
+};
+
+tbb::spin_rw_mutex g_cacheMutex;
+std::unordered_map< CacheKey, std::weak_ptr< RenderManifest >, CacheKeyHasher > g_cache;
+
+} // namespace
+
+RenderManifest::RenderManifest()
+{
+}
+
+uint32_t RenderManifest::acquireID( const ScenePlug::ScenePath &path )
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+
+	auto it = m_map.find( path );
+	if( it != m_map.end() )
+	{
+		return it->second;
+	}
+
+	lock.upgrade_to_writer();
+	return m_map.insert( PathAndID( path, m_map.size() + 1 ) ).first->second;
+}
+
+uint32_t RenderManifest::idForPath( const ScenePlug::ScenePath &path ) const
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+
+	auto it = m_map.find( path );
+	if( it != m_map.end() )
+	{
+		return it->second;
+	}
+
+	return 0;
+}
+
+std::optional<ScenePlug::ScenePath> RenderManifest::pathForID( uint32_t id ) const
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+
+	auto &index = m_map.get<1>();
+	auto it = index.find( id );
+	if( it != index.end() )
+	{
+		return it->first;
+	}
+	return std::nullopt;
+}
+
+std::vector<uint32_t> RenderManifest::acquireIDs( const IECore::PathMatcher &paths )
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+
+	std::vector<uint32_t> result;
+	for( IECore::PathMatcher::Iterator pathIt = paths.begin(), eIt = paths.end(); pathIt != eIt; ++pathIt )
+	{
+		auto it = m_map.find( *pathIt );
+		if( it != m_map.end() )
+		{
+			result.push_back( it->second );
+		}
+		else
+		{
+			// upgrade_to_writer() is specified to be a no-op if it's already been called.
+			lock.upgrade_to_writer();
+			result.push_back( m_map.insert( PathAndID( *pathIt, m_map.size() + 1 ) ).first->second );
+		}
+	}
+	return result;
+}
+
+std::vector<uint32_t> RenderManifest::idsForPaths( const IECore::PathMatcher &paths ) const
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+	std::vector<uint32_t> result;
+	result.reserve( paths.size() );
+	for( IECore::PathMatcher::Iterator pathIt = paths.begin(), eIt = paths.end(); pathIt != eIt; ++pathIt )
+	{
+		auto it = m_map.find( *pathIt );
+		if( it != m_map.end() )
+		{
+			result.push_back( it->second );
+		}
+	}
+	return result;
+}
+
+IECore::PathMatcher RenderManifest::pathsForIDs( const std::vector<uint32_t> &ids ) const
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+	IECore::PathMatcher result;
+	auto &index = m_map.get<1>();
+	for( auto id : ids )
+	{
+		auto it = index.find( id );
+		if( it != index.end() )
+		{
+			result.addPath( it->first );
+		}
+	}
+	return result;
+}
+
+void RenderManifest::clear()
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ true );
+	m_map.clear();
+}
+
+size_t RenderManifest::size() const
+{
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+	return m_map.size();
+}
+
+std::shared_ptr<const RenderManifest> RenderManifest::loadFromImageMetadata( const IECore::CompoundData *metadata, const std::string &cryptomatteLayerName )
+{
+	std::string sideCarManifestPath;
+	bool isCryptomatte = false;
+	IECore::ConstStringDataPtr cryptoManifestStringData;
+
+	const IECore::StringData *filePathData = metadata->member<IECore::StringData>( "filePath" );
+	const IECore::StringData *manifestFilePathData = metadata->member<IECore::StringData>( "gaffer:renderManifestFilePath" );
+	if( manifestFilePathData )
+	{
+		std::filesystem::path rawManifestPath( manifestFilePathData->readable() );
+		if( rawManifestPath.is_absolute() )
+		{
+			sideCarManifestPath = rawManifestPath.generic_string();
+		}
+		else
+		{
+			if( !filePathData )
+			{
+				throw IECore::Exception( "Can't find \"filePath\" metadata to locate relative manifest path. It should have been set by the ImageReader." );
+			}
+			sideCarManifestPath = ( std::filesystem::path( filePathData->readable() ).parent_path() / rawManifestPath ).generic_string();
+		}
+	}
+
+	// If we couldn't find a manifest using the Gaffer convention, look for a Cryptomatte
+	if( !sideCarManifestPath.size() )
+	{
+		static const std::regex g_cryptoNameRegex( R"((cryptomatte/[^/]{1,7})/name)" );
+
+		for( auto &i : metadata->readable() )
+		{
+			std::smatch match;
+			if( std::regex_match( i.first.string(), match, g_cryptoNameRegex ) )
+			{
+				const IECore::StringData *nameData = IECore::runTimeCast<IECore::StringData>( i.second.get() );
+
+				if( !nameData || nameData->readable() != cryptomatteLayerName )
+				{
+					continue;
+				}
+
+				const std::string metadataPrefix = match.str( 1 );
+
+				// Look for a valid Cryptomatte sidecar json.
+				const IECore::StringData *cryptoManifestPathData = metadata->member<IECore::StringData>(
+					fmt::format( "{}/manif_file", metadataPrefix )
+				);
+
+				if( cryptoManifestPathData )
+				{
+					if( !filePathData )
+					{
+						throw IECore::Exception( "Can't find \"filePath\" metadata to locate relative manifest path. It should have been set by the ImageReader." );
+					}
+
+					sideCarManifestPath = ( std::filesystem::path( filePathData->readable() ).parent_path() / cryptoManifestPathData->readable() ).generic_string();
+					isCryptomatte = true;
+				}
+				else
+				{
+					// Didn't find a sidecar file, look for a manifest stored directly in the header
+					cryptoManifestStringData = metadata->member<IECore::StringData>(
+						fmt::format( "{}/manifest", metadataPrefix )
+					);
+				}
+			}
+		}
+	}
+
+	if( sideCarManifestPath == "" && !cryptoManifestStringData )
+	{
+		throw IECore::Exception( "No gaffer:renderManifestFilePath metadata or cryptomatte metadata found." );
+	}
+
+	if( cryptoManifestStringData )
+	{
+
+		// This copy should never actually result in the string being copied, because we don't modify it.
+		CacheKey cacheKey( cryptoManifestStringData->copy(), "", std::filesystem::file_time_type() );
+
+		Mutex::scoped_lock lock( g_cacheMutex, /* write = */ false );
+		auto existing = g_cache.find( cacheKey );
+		if( existing != g_cache.end() )
+		{
+			std::shared_ptr<RenderManifest> validPointer = existing->second.lock();
+			if( validPointer )
+			{
+				return validPointer;
+			}
+		}
+
+
+		const std::string &cryptoManifestString = cryptoManifestStringData->readable();
+		boost::iostreams::stream<boost::iostreams::array_source> stream( cryptoManifestString.c_str(), cryptoManifestString.size() );
+
+		std::shared_ptr<RenderManifest> result = std::make_shared<RenderManifest>();
+		result->loadCryptomatteJSON( stream );
+
+		lock.upgrade_to_writer();
+		g_cache[ cacheKey ] = result;
+
+		return result;
+
+	}
+
+	std::filesystem::file_time_type currentModTime;
+	try
+	{
+		currentModTime = std::filesystem::last_write_time( sideCarManifestPath );
+	}
+	catch( std::exception &e )
+	{
+		throw IECore::Exception( std::string( "Could not find manifest file : " ) + sideCarManifestPath + " : " + e.what() );
+	}
+
+
+	CacheKey cacheKey( nullptr, sideCarManifestPath, currentModTime );
+
+	Mutex::scoped_lock lock( g_cacheMutex, /* write = */ false );
+	auto existing = g_cache.find( cacheKey );
+	if( existing != g_cache.end() )
+	{
+		std::shared_ptr<RenderManifest> validPointer = existing->second.lock();
+		if( validPointer )
+		{
+			return validPointer;
+		}
+	}
+
+
+	std::shared_ptr<RenderManifest> result = std::make_shared<RenderManifest>();
+	if( !isCryptomatte )
+	{
+		result->loadEXRManifest( sideCarManifestPath.c_str() );
+	}
+	else
+	{
+		std::ifstream stream( sideCarManifestPath.c_str() );
+		result->loadCryptomatteJSON( stream );
+	}
+
+	lock.upgrade_to_writer();
+	g_cache[ cacheKey ] = result;
+
+	return result;
+}
+
+void RenderManifest::loadEXRManifest( const std::filesystem::path &filePath )
+{
+	Imf::MultiPartInputFile exrInput( filePath.generic_string().c_str() );
+	int idManifestPart = -1;
+	for( int part = 0; part < exrInput.parts (); part++ )
+	{
+		if( Imf::hasIDManifest( exrInput.header( part ) ) )
+		{
+			idManifestPart = part;
+			break;
+		}
+	}
+
+	if( idManifestPart == -1 )
+	{
+		throw IECore::Exception( "No manifest found" );
+	}
+
+	const Imf::Header header = exrInput.header( idManifestPart );
+
+	const Imf::CompressedIDManifest& compressedManifest = Imf::idManifest( header );
+	const Imf::IDManifest manifest( compressedManifest );
+	const Imf::IDManifest::ChannelGroupManifest &idManifest = manifest[0];
+
+	for( Imf::IDManifest::ChannelGroupManifest::ConstIterator i = idManifest.begin(); i != idManifest.end(); ++i )
+	{
+		m_map.insert( PathAndID( ScenePlug::stringToPath( i.text()[0] ), i.id() ) );
+	}
+}
+
+void RenderManifest::writeEXRManifest( const std::filesystem::path &filePath ) const
+{
+	Imf::IDManifest::ChannelGroupManifest idManifest;
+	// We're actually using this as a sidecar manifest ... there is no actual id pass in this exr. But if there
+	// were, we would call it "id".
+	idManifest.setChannel( "id" );
+
+	// Each id corresponds to a single string, which is a path
+	idManifest.setComponent( "path" );
+	idManifest.setEncodingScheme( Imf::IDManifest::ID_SCHEME );
+	idManifest.setHashScheme( Imf::IDManifest::NOTHASHED );
+	idManifest.setLifetime( Imf::IDManifest::LIFETIME_FRAME );
+
+	Mutex::scoped_lock lock( m_mutex, /* write = */ false );
+	for( const auto &i : m_map )
+	{
+		idManifest.insert( i.second, ScenePlug::pathToString( i.first ) );
+	}
+
+	std::vector< Imf::Header > headers( 1 );
+
+	Imath::Box2i window( Imath::V2i( 0 ), Imath::V2i( 30, 2 ) );
+
+	headers[0].dataWindow() = window;
+	headers[0].displayWindow() = window;
+	headers[0].setType( Imf::SCANLINEIMAGE );
+	headers[0].channels().insert( "id", Imf::Channel( Imf::FLOAT ) );
+
+	Imf::IDManifest manifestContainer;
+	manifestContainer.add( idManifest );
+	Imf::addIDManifest( headers[0], manifestContainer );
+
+	Imf::MultiPartOutputFile exrOutput( filePath.generic_string().c_str(), headers.data(), 1 );
+
+	float image[93] = {
+		1,1,0,0,0,1,1,0,1,1,0,0,0,1,0,0,1,1,1,0,1,1,1,0,0,1,1,0,1,1,1,
+		1,1,1,0,1,0,1,0,1,0,1,0,0,1,0,0,1,1,0,0,1,1,0,0,0,1,0,0,0,1,0,
+		1,0,1,0,1,0,1,0,1,0,1,0,0,1,0,0,1,0,0,0,1,1,1,0,1,1,0,0,0,1,0
+	};
+	Imf::FrameBuffer outBuf;
+	outBuf.insert (
+		"id",
+		Imf::Slice (
+			Imf::FLOAT,
+			(char*)image,
+			sizeof( float ),
+			sizeof( float ) * 31
+		)
+	);
+
+	Imf::OutputPart outPart( exrOutput, 0 );
+	outPart.setFrameBuffer( outBuf );
+	outPart.writePixels( 3 );
+}
+
+void RenderManifest::loadCryptomatteJSON( std::istream &in )
+{
+	boost::property_tree::ptree pt;
+
+	try
+	{
+		boost::property_tree::read_json( in, pt );
+	}
+	catch( const boost::property_tree::json_parser::json_parser_error &e )
+	{
+		throw IECore::Exception( fmt::format( "Error parsing manifest file: {}", e.what() ) );
+	}
+
+	static const std::regex instanceDataRegex( R"(^instance:[0-9a-f]+$)" );
+
+	std::smatch match;
+	for( auto &it : pt )
+	{
+		// NOTE: exclude locations starting with "instance:" under root
+		if( std::regex_match( it.first, match, instanceDataRegex ) )
+		{
+			continue;
+		}
+
+		const std::string &hashString = it.second.data().c_str();
+		uint32_t hash;
+		auto [_unused, errorCode] = std::from_chars( hashString.data(), hashString.data() + hashString.size(), hash, 16 );
+		if( errorCode != std::errc() )
+		{
+			throw IECore::Exception( fmt::format( "Expected hexadecimal while parsing manifest: {}", hashString ) );
+		}
+
+		m_map.insert( PathAndID( ScenePlug::stringToPath( it.first ), hash ) );
+	}
+}

--- a/src/GafferSceneModule/RenderManifestBinding.cpp
+++ b/src/GafferSceneModule/RenderManifestBinding.cpp
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,65 +36,52 @@
 
 #include "boost/python.hpp"
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IECoreScenePreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
 #include "RenderManifestBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
+
+#include "GafferScene/RenderManifest.h"
 
 using namespace boost::python;
-using namespace GafferSceneModule;
+using namespace Gaffer;
+using namespace GafferScene;
 
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace
 {
 
-	bindIECoreScenePreview(); // Must be declared early since some things depend on Procedural being registered
+// Convert return path to string for Python
+std::optional< std::string > pathForIDWrapper( RenderManifest *renderManifest, uint32_t id )
+{
+	// Return a InternedStringVectorDataPtr or None, since our Python bindings don't know how to
+	// deal with an optional<ScenePlug::ScenePath>
+	auto result = renderManifest->pathForID( id );
+	if( !result )
+	{
+		return std::nullopt;
+	}
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
-	bindRenderManifest();
+	return ScenePlug::pathToString( *result );
+}
+
+std::shared_ptr<RenderManifest> loadFromImageMetadataWrapper( const IECore::CompoundData *metadata, const std::string &cryptomatteLayerName )
+{
+	return std::const_pointer_cast<RenderManifest>( RenderManifest::loadFromImageMetadata( metadata, cryptomatteLayerName ) );
+}
+
+} // namespace
+
+void GafferSceneModule::bindRenderManifest()
+{
+
+	class_<RenderManifest, boost::noncopyable, std::shared_ptr<RenderManifest>>( "RenderManifest" )
+		.def( "acquireID", &RenderManifest::acquireID )
+		.def( "idForPath", &RenderManifest::idForPath )
+		.def( "pathForID", &pathForIDWrapper )
+		.def( "acquireIDs", &RenderManifest::acquireIDs )
+		.def( "pathsForIDs", &RenderManifest::pathsForIDs )
+		.def( "clear", &RenderManifest::clear )
+		.def( "size", &RenderManifest::size )
+		.def( "loadFromImageMetadata", &loadFromImageMetadataWrapper )
+		.staticmethod( "loadFromImageMetadata" )
+		.def( "writeEXRManifest", &RenderManifest::writeEXRManifest )
+	;
 
 }

--- a/src/GafferSceneModule/RenderManifestBinding.h
+++ b/src/GafferSceneModule/RenderManifestBinding.h
@@ -1,7 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
-//  Copyright (c) 2013, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,67 +34,11 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#pragma once
 
-#include "AttributesBinding.h"
-#include "CoreBinding.h"
-#include "EditScopeAlgoBinding.h"
-#include "FilterBinding.h"
-#include "GlobalsBinding.h"
-#include "HierarchyBinding.h"
-#include "IECoreGLPreviewBinding.h"
-#include "IECoreScenePreviewBinding.h"
-#include "IOBinding.h"
-#include "TweaksBinding.h"
-#include "ObjectProcessorBinding.h"
-#include "OptionsBinding.h"
-#include "PrimitiveSamplerBinding.h"
-#include "PrimitiveVariablesBinding.h"
-#include "PrimitivesBinding.h"
-#include "RenderBinding.h"
-#include "RenderControllerBinding.h"
-#include "RenderManifestBinding.h"
-#include "SceneAlgoBinding.h"
-#include "ScenePathBinding.h"
-#include "SetAlgoBinding.h"
-#include "ShaderBinding.h"
-#include "TransformBinding.h"
-#include "QueryBinding.h"
-#include "CryptomatteBinding.h"
-#include "VisibleSetBinding.h"
-
-using namespace boost::python;
-using namespace GafferSceneModule;
-
-BOOST_PYTHON_MODULE( _GafferScene )
+namespace GafferSceneModule
 {
 
-	bindIECoreScenePreview(); // Must be declared early since some things depend on Procedural being registered
+void bindRenderManifest();
 
-	bindCore();
-	bindFilter();
-	bindTransform();
-	bindGlobals();
-	bindOptions();
-	bindAttributes();
-	bindSceneAlgo();
-	bindSetAlgo();
-	bindPrimitives();
-	bindScenePath();
-	bindShader();
-	bindRender();
-	bindRenderController();
-	bindHierarchy();
-	bindObjectProcessor();
-	bindPrimitiveVariables();
-	bindTweaks();
-	bindIO();
-	bindPrimitiveSampler();
-	bindIECoreGLPreview();
-	bindEditScopeAlgo();
-	bindQueries();
-	bindCryptomatte();
-	bindVisibleSet();
-	bindRenderManifest();
-
-}
+} // namespace GafferSceneModule


### PR DESCRIPTION
This contains some of the commits from #6329, with the initial support for the RenderManifest class.

I've added a basic Changes.md entry, and I think addressed all the feedback, with the exception of this discussion: https://github.com/GafferHQ/gaffer/pull/6329#discussion_r2071665212 - I wasn't quite ready to move to a global cache, so I've tried the option that requires the least changes. I'm OK with the global cache if you think it's necessary, but I think my favourite would actually be my first suggestion there - move the logic for picking default ids outside of RenderManifest.