### PR TITLE
Light linking fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,7 +16,9 @@ Fixes
 -----
 
 - Cycles : Fixed light linking in batch renders.
-- RenderMan : Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
+- RenderMan :
+  - Fixed light linking in batch renders.
+  - Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
 - Cryptomatte : Fixed hypothetical inconsistencies if the C++ language locale affects the parsing of JSON files ( probably not an issue in practice, since the JSON in question should just be hexadecimal integers, and no known locale should affect the parsing of integers ).
 
 1.5.12.0 (relative to 1.5.11.0)

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 Fixes
 -----
 
+- Cycles : Fixed light linking in batch renders.
 - RenderMan : Fixed handling of `render:{name}` attributes, such as the `render:displayColor` attribute created by StandardAttributes, and `primvar:{name}` attributes loaded from USD files. These can now be accessed by PxrAttribute shaders as either `user:{name}` or just `{name}`.
 - Cryptomatte : Fixed hypothetical inconsistencies if the C++ language locale affects the parsing of JSON files ( probably not an issue in practice, since the JSON in question should just be hexadecimal integers, and no known locale should affect the parsing of integers ).
 

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1627,5 +1627,18 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 			with GafferTest.TestRunner.PerformanceScope() :
 				s["render"]["task"].execute()
 
+	def _createDiffuseShader( self ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "lambert" )
+		shader["parameters"]["Kd"].setValue( 1 )
+		return shader, shader["parameters"]["Kd_color"], shader["out"]
+
+	def _createPointLight( self ) :
+
+		light = GafferArnold.ArnoldLight()
+		light.loadShader( "point_light" )
+		return light, light["parameters"]["color"]
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/CyclesRenderTest.py
+++ b/python/GafferCyclesTest/CyclesRenderTest.py
@@ -36,11 +36,24 @@
 
 import unittest
 
+import GafferCycles
 import GafferSceneTest
 
 class CyclesRenderTest( GafferSceneTest.RenderTest ) :
 
 	renderer = "Cycles"
+
+	def _createDiffuseShader( self ) :
+
+		shader = GafferCycles.CyclesShader()
+		shader.loadShader( "diffuse_bsdf" )
+		return shader, shader["parameters"]["color"], shader["out"]["BSDF"]
+
+	def _createPointLight( self ) :
+
+		light = GafferCycles.CyclesLight()
+		light.loadShader( "point_light" )
+		return light, light["parameters"]["color"]
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -43,5 +43,10 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 	renderer = "3Delight"
 	sceneDescriptionSuffix = ".nsi"
 
+	@unittest.skip( "No light linking support just yet" )
+	def testLightLinking( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -45,7 +45,7 @@ import Gaffer
 import GafferTest
 import GafferScene
 
-import IECoreRenderMan
+import GafferRenderMan
 import GafferSceneTest
 
 @unittest.skipIf( GafferTest.inCI() and os.name == "nt", "RenderMan cannot get license on Windows.")
@@ -105,6 +105,21 @@ class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 			self.assertAlmostEqual( middlePixel.b, 1, delta = 0.01 )
 			self.assertAlmostEqual( middlePixel.a, 1, delta = 0.01 )
 			self.assertEqual( lowerPixel, imath.Color4f( 0 ) )
+
+	def _createDiffuseShader( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "PxrDiffuse" )
+		return shader, shader["parameters"]["diffuseColor"], shader["out"]
+
+	def _createPointLight( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrSphereLight" )
+		light["attributes"]["ri:visibility:camera"]["enabled"].setValue( True )
+		light["attributes"]["ri:visibility:camera"]["value"].setValue( False )
+
+		return light, light["parameters"]["lightColor"]
 
 	def __colorAtUV( self, image, uv ) :
 

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -109,5 +109,10 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 		self.assertAlmostEqual( imageSampler["color"]["g"].getValue(), 0.666666, delta = 0.001 )
 		self.assertEqual( imageSampler["color"]["b"].getValue(), 0 )
 
+	@unittest.skip( "Light linking not supported" )
+	def testLightLinking( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/IECoreRenderMan/LightLinker.h
+++ b/src/IECoreRenderMan/LightLinker.h
@@ -74,6 +74,7 @@ class LightLinker
 
 		// Returns the value to be used in the `lighting:subset` attribute.
 		const RtUString registerLightLinks( const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
+		void deregisterLightLinks( const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
 
 		// Interface used by Renderer
 		// ==========================
@@ -135,11 +136,15 @@ class LightLinker
 		void updateDirtyLightLinks();
 
 		// Maps from a set of lights to its group name.
-		/// \todo As above, use an unordered container when it becomes available.
-		using LightLinks = std::map<WeakObjectSetPtr, RtUString, std::owner_less<WeakObjectSetPtr>>;
+		struct LightSet
+		{
+			size_t useCount = 0;
+			RtUString groupName;
+		};
+		using LightSets = std::unordered_map<IECoreScenePreview::Renderer::ConstObjectSetPtr, LightSet>;
 		std::mutex m_lightLinksMutex;
-		LightLinks m_lightLinks;
-		size_t m_nextLightLinkGroup;
+		LightSets m_lightSets;
+		size_t m_nextLightGroup;
 		bool m_lightLinksDirty = false;
 
 };

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -78,6 +78,10 @@ Object::~Object()
 		{
 			m_session->riley->DeleteGeometryInstance( riley::GeometryPrototypeId::InvalidId(), m_geometryInstance );
 		}
+		if( m_linkedLights )
+		{
+			m_lightLinker->deregisterLightLinks( m_linkedLights );
+		}
 	}
 }
 
@@ -150,6 +154,11 @@ void Object::link( const IECore::InternedString &type, const IECoreScenePreview:
 	if( type != g_lights )
 	{
 		return;
+	}
+
+	if( m_linkedLights )
+	{
+		m_lightLinker->deregisterLightLinks( m_linkedLights );
 	}
 
 	m_linkedLights = objects;


### PR DESCRIPTION
This fixes a couple of egregious bugs in the light linking support recently added for Cycles and RenderMan. Foolishly I'd only tested it in interactive renders, so it only worked in interactive renders. This fixes it for batch renders, and adds test coverage so that it stays fixed in future.