### PR TITLE
PlugPopup : Select text in MultiLineTextWidget

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - Spreadsheet :
   - A wider range of types are converted when copy/pasting values between cells, such as BoolData to IntData, FloatData to IntData, etc.
   - Added support for converting StringData values when pasted or dropped onto a StringVectorData cell. The string array value is formed by splitting the string on spaces.
+- AttributeEditor, LightEditor, RenderPassEditor, Spreadsheet : The current text is selected automatically when editing popup multi-line text fields.
 
 Fixes
 -----

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -154,10 +154,10 @@ class PlugPopup( GafferUI.PopupWindow ) :
 
 		textWidget = self.__firstTextWidget( self.__plugValueWidget )
 		if textWidget is not None :
+			textWidget.setSelection( 0, len( textWidget.getText() ) )
 			if isinstance( textWidget, GafferUI.TextWidget ) :
 				textWidget.grabFocus()
-				textWidget.setSelection( 0, len( textWidget.getText() ) )
-			else :
+			else : # MultiLineTextWidget
 				textWidget.setFocussed( True )
 			textWidget._qtWidget().activateWindow()
 


### PR DESCRIPTION
When we first made PlugPopup, MultiLineTextWidget didn't have a `setSelection()` method, but it does now. Using it removes an editing step when using the popup editors in RenderPassEditor, AttributeEditor and Spreadsheet etc. This matches the existing behaviour we had for single-line text fields.

The original code was a little unclear, but I have verified that in all cases `__firstTextWidget` either returns a TextWidget or MultiLineTextWidget, and have clarified that with a comment on the `else` block.
