### PR TITLE
OIIO clients : Avoid `TypeDesc::<Type>` aliases

### DIFF
--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -101,19 +101,19 @@ ccl::TypeDesc typeFromGeometricDataInterpretation( IECore::GeometricData::Interp
 	switch( dataType )
 	{
 		case GeometricData::Numeric :
-			return ccl::TypeDesc::TypeVector;
+			return ccl::TypeVector;
 		case GeometricData::Point :
-			return ccl::TypeDesc::TypePoint;
+			return ccl::TypePoint;
 		case GeometricData::Normal :
-			return ccl::TypeDesc::TypeNormal;
+			return ccl::TypeNormal;
 		case GeometricData::Vector :
-			return ccl::TypeDesc::TypeVector;
+			return ccl::TypeVector;
 		case GeometricData::Color :
-			return ccl::TypeDesc::TypeColor;
+			return ccl::TypeColor;
 		case GeometricData::UV :
-			return ccl::TypeDesc::TypePoint;
+			return ccl::TypePoint;
 		default :
-			return ccl::TypeDesc::TypeVector;
+			return ccl::TypeVector;
 	}
 }
 
@@ -272,7 +272,7 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 		// Simple int-based data. Cycles doesn't support int attributes, so we promote to the equivalent float types.
 
 		case IntDataTypeId :
-			attr = convertTypedPrimitiveVariable<IntData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeFloat, attributeElement );
+			attr = convertTypedPrimitiveVariable<IntData>( name, primitiveVariable, attributes, ccl::TypeFloat, attributeElement );
 			break;
 		case V2iDataTypeId :
 			attr = convertTypedPrimitiveVariable<V2iData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
@@ -290,7 +290,7 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 		// Vectors of int-based data. Cycles doesn't support int attributes, so we promote to the equivalent float types.
 
 		case IntVectorDataTypeId :
-			attr = convertTypedPrimitiveVariable<IntVectorData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeFloat, attributeElement );
+			attr = convertTypedPrimitiveVariable<IntVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat, attributeElement );
 			break;
 		case V2iVectorDataTypeId :
 			attr = convertTypedPrimitiveVariable<V2iVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
@@ -308,7 +308,7 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 		// Simple float-based data.
 
 		case FloatDataTypeId :
-			attr = convertTypedPrimitiveVariable<FloatData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeFloat, attributeElement );
+			attr = convertTypedPrimitiveVariable<FloatData>( name, primitiveVariable, attributes, ccl::TypeFloat, attributeElement );
 			break;
 		case V2fDataTypeId :
 			attr = convertTypedPrimitiveVariable<V2fData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
@@ -323,13 +323,13 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 			);
 			break;
 		case Color3fDataTypeId :
-			attr = convertTypedPrimitiveVariable<Color3fData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeColor, attributeElement );
+			attr = convertTypedPrimitiveVariable<Color3fData>( name, primitiveVariable, attributes, ccl::TypeColor, attributeElement );
 			break;
 
 		// Vectors of float-based data.
 
 		case FloatVectorDataTypeId :
-			attr = convertTypedPrimitiveVariable<FloatVectorData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeFloat, attributeElement );
+			attr = convertTypedPrimitiveVariable<FloatVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat, attributeElement );
 			break;
 		case V2fVectorDataTypeId :
 			attr = convertTypedPrimitiveVariable<V2fVectorData>( name, primitiveVariable, attributes, ccl::TypeFloat2, attributeElement );
@@ -344,7 +344,7 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 			);
 			break;
 		case Color3fVectorDataTypeId :
-			attr = convertTypedPrimitiveVariable<Color3fVectorData>( name, primitiveVariable, attributes, ccl::TypeDesc::TypeColor, attributeElement );
+			attr = convertTypedPrimitiveVariable<Color3fVectorData>( name, primitiveVariable, attributes, ccl::TypeColor, attributeElement );
 			break;
 		default :
 			msg(
@@ -369,11 +369,11 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	/// use `convertPrimitiveVariable()` for most data, instead of having
 	/// custom code paths for `P`, `uv` etc?
 
-	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX && attr->type == ccl::TypeDesc::TypeNormal )
+	if( name == "N" && attr->element == ccl::ATTR_ELEMENT_VERTEX && attr->type == ccl::TypeNormal )
 	{
 		attr->std = ccl::ATTR_STD_VERTEX_NORMAL;
 	}
-	else if( name == "N" && attr->element == ccl::ATTR_ELEMENT_FACE && attr->type == ccl::TypeDesc::TypeNormal )
+	else if( name == "N" && attr->element == ccl::ATTR_ELEMENT_FACE && attr->type == ccl::TypeNormal )
 	{
 		attr->std = ccl::ATTR_STD_FACE_NORMAL;
 		attr->name = ccl::Attribute::standard_name( attr->std ); // Cycles calls this `Ng`.
@@ -382,11 +382,11 @@ void convertPrimitiveVariable( const std::string &name, const IECoreScene::Primi
 	{
 		attr->std = ccl::ATTR_STD_UV;
 	}
-	else if( name == "uv.tangent_sign" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeFloat )
+	else if( name == "uv.tangent_sign" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeFloat )
 	{
 		attr->std = ccl::ATTR_STD_UV_TANGENT_SIGN;
 	}
-	else if( name == "uv.tangent" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeDesc::TypeVector )
+	else if( name == "uv.tangent" && attr->element == ccl::ATTR_ELEMENT_CORNER && attr->type == ccl::TypeVector )
 	{
 		attr->std = ccl::ATTR_STD_UV_TANGENT;
 	}
@@ -443,35 +443,35 @@ void convertVoxelGrids( const IECoreVDB::VDBObject *vdbObject, ccl::Volume *volu
 			openvdb::GridBase::ConstPtr grid = vdbObject->findGrid( gridName );
 			if( grid->isType<openvdb::BoolGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeInt;
+				ctype = ccl::TypeInt;
 			}
 			else if( grid->isType<openvdb::DoubleGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeFloat;
+				ctype = ccl::TypeFloat;
 			}
 			else if( grid->isType<openvdb::FloatGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeFloat;
+				ctype = ccl::TypeFloat;
 			}
 			else if( grid->isType<openvdb::Int32Grid>() )
 			{
-				ctype = ccl::TypeDesc::TypeInt;
+				ctype = ccl::TypeInt;
 			}
 			else if( grid->isType<openvdb::Int64Grid>() )
 			{
-				ctype = ccl::TypeDesc::TypeInt;
+				ctype = ccl::TypeInt;
 			}
 			else if( grid->isType<openvdb::Vec3DGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeVector;
+				ctype = ccl::TypeVector;
 			}
 			else if( grid->isType<openvdb::Vec3IGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeVector;
+				ctype = ccl::TypeVector;
 			}
 			else if( grid->isType<openvdb::Vec3SGrid>() )
 			{
-				ctype = ccl::TypeDesc::TypeVector;
+				ctype = ccl::TypeVector;
 			}
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SocketAlgo.cpp
@@ -525,34 +525,34 @@ ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore:
 			{
 				const BoolData *data = static_cast<const BoolData *>( value );
 				float result = static_cast<float>( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat, 1, &result );
 			}
 			break;
 		case IntDataTypeId :
 			{
 				const IntData *data = static_cast<const IntData *>( value );
 				float result = static_cast<float>( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat, 1, &result );
 			}
 			break;
 		case UIntDataTypeId :
 			{
 				const UIntData *data = static_cast<const UIntData *>( value );
 				float result = static_cast<float>( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat, 1, &result );
 			}
 			break;
 		case DoubleDataTypeId :
 			{
 				const DoubleData *data = static_cast<const DoubleData *>( value );
 				float result = static_cast<float>( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat, 1, &result );
 			}
 			break;
 		case FloatDataTypeId :
 			{
 				const FloatData *data = static_cast<const FloatData *>( value );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat, 1, &data->readable() );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat, 1, &data->readable() );
 			}
 			break;
 		case Color3fDataTypeId :
@@ -589,7 +589,7 @@ ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore:
 				// Need to pad to float4 to prevent an assert in Cycles debug mode
 				const V3f vec = data->readable();
 				const ccl::float4 result = ccl::make_float4( vec[0], vec[1], vec[2], 1.0f );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat4, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat4, 1, &result );
 			}
 			break;
 		case V3iDataTypeId :
@@ -598,7 +598,7 @@ ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore:
 				// Need to pad to float4 to prevent an assert in Cycles debug mode
 				const V3i vec = data->readable();
 				const ccl::float4 result = ccl::make_float4( (float)vec[0], (float)vec[1], (float)vec[2], 1.0f );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeFloat4, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeFloat4, 1, &result );
 			}
 			break;
 		case QuatfDataTypeId :
@@ -612,14 +612,14 @@ ccl::ParamValue setParamValue( const IECore::InternedString &name, const IECore:
 			{
 				const M44fData *data = static_cast<const M44fData *>( value );
 				const ccl::Transform result = setTransform( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeMatrix, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeMatrix, 1, &result );
 			}
 			break;
 		case M44dDataTypeId :
 			{
 				const M44dData *data = static_cast<const M44dData *>( value );
 				const ccl::Transform result = setTransform( data->readable() );
-				return ccl::ParamValue( name.string(), ccl::TypeDesc::TypeMatrix, 1, &result );
+				return ccl::ParamValue( name.string(), ccl::TypeMatrix, 1, &result );
 			}
 			break;
 		default :

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -453,25 +453,25 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 			{
 				const TypeDesc type = s->symbol_typedesc( *it );
 				const void *storage = s->symbol_address( *shadingContext, *it );
-				if( type == TypeDesc::TypeFloat )
+				if( type == OIIO::TypeFloat )
 				{
 					result->members().push_back( new FloatData( *(const float *)storage ) );
 				}
-				else if( type == TypeDesc::TypeInt )
+				else if( type == OIIO::TypeInt )
 				{
 					result->members().push_back( new IntData( *(const int *)storage ) );
 				}
-				else if( type == TypeDesc::TypeColor )
+				else if( type == OIIO::TypeColor )
 				{
 					const float *f = (const float *)storage;
 					result->members().push_back( new Color3fData( Color3f( f[0], f[1], f[2] ) ) );
 				}
-				else if( type == TypeDesc::TypeVector )
+				else if( type == OIIO::TypeVector )
 				{
 					const float *f = (const float *)storage;
 					result->members().push_back( new V3fData( V3f( f[0], f[1], f[2] ) ) );
 				}
-				else if( type == TypeDesc::TypeMatrix )
+				else if( type == OIIO::TypeMatrix )
 				{
 					const float *f = (const float *)storage;
 					result->members().push_back( new M44fData( M44f(
@@ -481,7 +481,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 						f[12], f[13], f[14], f[15]
 					) ) );
 				}
-				else if( type == TypeDesc::TypeString )
+				else if( type == OIIO::TypeString )
 				{
 					result->members().push_back( new StringData( *(const char **)storage ) );
 				}

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -969,7 +969,7 @@ bool findGafferSplineParameters( const OSLQuery &query, const OSLQuery::Paramete
 	}
 
 	basisParameter = query.getparam( nameWithoutSuffix + "Basis" );
-	if( !basisParameter || basisParameter->type != TypeDesc::TypeString )
+	if( !basisParameter || basisParameter->type != OIIO::TypeString )
 	{
 		return false;
 	}

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -92,7 +92,7 @@ using namespace GafferOSL;
 
 // keyword matrix parameter macro. reference: OSL/genclosure.h
 #define CLOSURE_MATRIX_KEYPARAM(st, fld, key) \
-	{ TypeDesc::TypeMatrix44, (int)reckless_offsetof(st, fld), key, fieldsize(st, fld) }
+	{ OIIO::TypeMatrix44, (int)reckless_offsetof(st, fld), key, fieldsize(st, fld) }
 
 //////////////////////////////////////////////////////////////////////////
 // Conversion utilities
@@ -1142,7 +1142,7 @@ class ShadingResults
 				char *dst = static_cast<char *>( debugResult.basePointer );
 				dst += pointIndex * debugResult.type.elementsize();
 				ShadingSystem::convert_value(
-					dst, debugResult.type, &value, TypeDesc::TypeMatrix44
+					dst, debugResult.type, &value, OIIO::TypeMatrix44
 				);
 			}
 			else if( parameters->type == g_stringType )
@@ -1161,7 +1161,7 @@ class ShadingResults
 					dst,
 					debugResult.type,
 					&value,
-					debugResult.type.aggregate == TypeDesc::SCALAR ? TypeDesc::TypeFloat : TypeDesc::TypeColor
+					debugResult.type.aggregate == TypeDesc::SCALAR ? OIIO::TypeFloat : OIIO::TypeColor
 				);
 			}
 		}
@@ -1180,7 +1180,7 @@ class ShadingResults
 			{
 				return TypeDesc( TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::NORMAL );
 			}
-			return type != ustring() ? TypeDesc( type.c_str() ) : TypeDesc::TypeColor;
+			return type != ustring() ? TypeDesc( type.c_str() ) : OIIO::TypeColor;
 		}
 
 		CompoundDataPtr m_results;


### PR DESCRIPTION
These are removed in OIIO 3.0, and the alternatives that are directly in the OIIO namespace are already available in OIIO 2.0.
