### PR TITLE
Metadata : Add `registerValues()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 
 - Gaffer module : Added `environment()` method, returning a dictionary containing all current environment variables. Unlike `os.environ`, this preserves case on Windows.
 - GafferScene::RenderManifest : Added class for representing mapping of ids to paths in renders. Supports reading EXR and cryptomatte manifests, and writing EXR manifests.
+- Metadata : Added `registerValues()` function that registers multiple metadata entries from a dictionary of string targets.
 
 Breaking Changes
 ----------------

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1410,6 +1410,40 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.targetsWithMetadata( "target*", "k1" ), [ "target1", "targetA" ] )
 		self.assertEqual( Gaffer.Metadata.targetsWithMetadata( "*", "k3" ), [ "target2" ] )
 
+	def testRegisterValues( self ) :
+
+		Gaffer.Metadata.registerValues( {
+
+			"testTarget1" : [
+
+				"description", "testTarget1",
+				"otherValue", 100,
+
+			],
+
+			"testTarget2" : [
+
+				"description",
+				"""
+				multi line
+				description
+				""",
+				"otherValue", IECore.StringVectorData( [ "A", "B", "C" ] )
+
+			]
+
+		} )
+
+		for target in ( "testTarget1", "testTarget2" ) :
+			for key in ( "description", "otherValue" ) :
+				self.addCleanup( Gaffer.Metadata.deregisterValue, target, key )
+
+		self.assertEqual( Gaffer.Metadata.value( "testTarget1", "description" ), "testTarget1" )
+		self.assertEqual( Gaffer.Metadata.value( "testTarget1", "otherValue" ), 100 )
+
+		self.assertEqual( Gaffer.Metadata.value( "testTarget2", "description" ), "multi line\ndescription" )
+		self.assertEqual( Gaffer.Metadata.value( "testTarget2", "otherValue" ), IECore.StringVectorData( [ "A", "B", "C" ] ) )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -187,6 +187,21 @@ void registerValue( IECore::InternedString target, IECore::InternedString key, o
 	Metadata::registerValue( target, key, objectToValueFunction( key, value ) );
 }
 
+void registerValues( dict valuesDict )
+{
+	list items = valuesDict.items();
+	for( size_t i = 0, e = len( items ); i < e; ++i )
+	{
+		InternedString target = extract<InternedString>( items[i][0] );
+		object values = items[i][1];
+		for( size_t vi = 0, ve = len( values ); vi < ve; vi += 2 )
+		{
+			InternedString key = extract<InternedString>( values[vi] );
+			Metadata::registerValue( target, key, objectToValueFunction( key, values[vi+1] ) );
+		}
+	}
+}
+
 object value( IECore::InternedString target, IECore::InternedString key, bool copy )
 {
 	ConstDataPtr d = Metadata::value( target, key );
@@ -401,6 +416,9 @@ void GafferModule::bindMetadata()
 			)
 		)
 		.staticmethod( "registerValue" )
+
+		.def( "registerValues", &registerValues )
+		.staticmethod( "registerValues" )
 
 		.def( "registeredValues", &registeredValues )
 		.def( "registeredValues", &registeredGraphComponentValuesDeprecated,

--- a/startup/GafferScene/arnoldAttributes.py
+++ b/startup/GafferScene/arnoldAttributes.py
@@ -38,567 +38,615 @@ import IECore
 
 import Gaffer
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:camera", "label", "Camera" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:camera", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:camera",
-	"description",
-	"""
-	Whether or not the object is visible to camera
-	rays. To hide an object completely, use the
-	`scene:visible` attribute instead.
-	""",
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow", "label", "Shadow" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:shadow",
-	"description",
-	"""
-	Whether or not the object is visible to shadow
-	rays (whether or not it casts shadows).
-	""",
-)
+	"attribute:ai:visibility:camera" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow_group", "label", "Shadow Group" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow_group", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:shadow_group",
-	"description",
-	"""
-	The lights that cause this object to cast shadows.
-	Accepts a set expression or a space separated list of
-	lights. Use \"defaultLights\" to refer to all lights that
-	contribute to illumination by default.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow_group", "ui:scene:acceptsSetExpression", True )
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to camera
+		rays. To hide an object completely, use the
+		`scene:visible` attribute instead.
+		""",
+		"label", "Camera",
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:diffuse_reflect", "label", "Diffuse Reflection" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:diffuse_reflect", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:diffuse_reflect",
-	"description",
-	"""
-	Whether or not the object is visible in
-	reflected diffuse ( ie. if it casts bounce light )
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:specular_reflect", "label", "Specular Reflection" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:specular_reflect", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:specular_reflect",
-	"description",
-	"""
-	Whether or not the object is visible in
-	reflected specular ( ie. if it is visible in mirrors ).
-	""",
-)
+	"attribute:ai:visibility:shadow" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:diffuse_transmit", "label", "Diffuse Transmission" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:diffuse_transmit", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:diffuse_transmit",
-	"description",
-	"""
-	Whether or not the object is visible in
-	transmitted diffuse ( ie. if it casts light through leaves ).
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to shadow
+		rays (whether or not it casts shadows).
+		""",
+		"label", "Shadow",
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:specular_transmit", "label", "Specular Transmission" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:specular_transmit", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:specular_transmit",
-	"description",
-	"""
-	Whether or not the object is visible in
-	refracted specular ( ie. if it can be seen through glass ).
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:volume", "label", "Volume" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:volume", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:volume",
-	"description",
-	"""
-	Whether or not the object is visible in
-	volume scattering.
-	""",
-)
+	"attribute:ai:visibility:shadow_group" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:subsurface", "label", "Subsurface" )
-Gaffer.Metadata.registerValue( "attribute:ai:visibility:subsurface", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:visibility:subsurface",
-	"description",
-	"""
-	Whether or not the object is visible to subsurface
-	rays.
-	""",
-)
+		"defaultValue", "",
+		"description",
+		"""
+		The lights that cause this object to cast shadows.
+		Accepts a set expression or a space separated list of
+		lights. Use \"defaultLights\" to refer to all lights that
+		contribute to illumination by default.
+		""",
+		"label", "Shadow Group",
+		"ui:scene:acceptsSetExpression", True,
 
-Gaffer.Metadata.registerValue( "attribute:ai:disp_autobump", "label", "Autobump" )
-Gaffer.Metadata.registerValue( "attribute:ai:disp_autobump", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:disp_autobump",
-	"description",
-	"""
-	Automatically turns the details of the displacement map
-	into bump, wherever the mesh is not subdivided enough
-	to properly capture them.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:camera", "label", "Camera" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:camera", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:camera",
-	"description",
-	"""
-	Whether or not the autobump is visible to camera
-	rays.
-	""",
-)
+	"attribute:ai:visibility:diffuse_reflect" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:shadow", "label", "Shadow" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:shadow", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:shadow",
-	"description",
-	"""
-	Whether or not the autobump is visible to shadow
-	rays.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		reflected diffuse ( ie. if it casts bounce light )
+		""",
+		"label", "Diffuse Reflection",
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:diffuse_reflect", "label", "Diffuse Reflection" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:diffuse_reflect", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:diffuse_reflect",
-	"description",
-	"""
-	Whether or not the autobump is visible in
-	reflected diffuse ( ie. if it casts bounce light )
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:specular_reflect", "label", "Specular Reflection" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:specular_reflect", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:specular_reflect",
-	"description",
-	"""
-	Whether or not the autobump is visible in
-	reflected specular ( ie. if it is visible in mirrors ).
-	""",
-)
+	"attribute:ai:visibility:specular_reflect" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:diffuse_transmit", "label", "Diffuse Transmission" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:diffuse_transmit", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:diffuse_transmit",
-	"description",
-	"""
-	Whether or not the autobump is visible in
-	transmitted diffuse ( ie. if it casts light through leaves ).
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		reflected specular ( ie. if it is visible in mirrors ).
+		""",
+		"label", "Specular Reflection",
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:specular_transmit", "label", "Specular Transmission" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:specular_transmit", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:specular_transmit",
-	"description",
-	"""
-	Whether or not the autobump is visible in
-	refracted specular ( ie. if it can be seen through glass ).
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:volume", "label", "Volume" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:volume", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:volume",
-	"description",
-	"""
-	Whether or not the autobump is visible in
-	volume scattering.
-	""",
-)
+	"attribute:ai:visibility:diffuse_transmit" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:subsurface", "label", "Subsurface" )
-Gaffer.Metadata.registerValue( "attribute:ai:autobump_visibility:subsurface", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:autobump_visibility:subsurface",
-	"description",
-	"""
-	Whether or not the autobump is visible to subsurface
-	rays.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		transmitted diffuse ( ie. if it casts light through leaves ).
+		""",
+		"label", "Diffuse Transmission",
 
-Gaffer.Metadata.registerValue( "attribute:ai:transform_type", "label", "Transform Type" )
-Gaffer.Metadata.registerValue( "attribute:ai:transform_type", "defaultValue", IECore.StringData( "rotate_about_center" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:transform_type",
-	"description",
-	"""
-	Choose how transform motion is interpolated. "Linear"
-	produces classic linear vertex motion, "RotateAboutOrigin"
-	produces curved arcs centred on the object's origin, and
-	"RotateAboutCenter", the default, produces curved arcs
-	centred on the object's bounding box middle.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:transform_type", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:ai:transform_type", "presetNames", IECore.StringVectorData( [ "Linear", "RotateAboutOrigin", "RotateAboutCenter" ] ) )
-Gaffer.Metadata.registerValue( "attribute:ai:transform_type", "presetValues", IECore.StringVectorData( [ "linear", "rotate_about_origin", "rotate_about_center" ] ) )
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:matte", "label", "Matte" )
-Gaffer.Metadata.registerValue( "attribute:ai:matte", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:matte",
-	"description",
-	"""
-	Turns the object into a holdout matte.
-	This only affects primary (camera) rays.
-	""",
-)
+	"attribute:ai:visibility:specular_transmit" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:opaque", "label", "Opaque" )
-Gaffer.Metadata.registerValue( "attribute:ai:opaque", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:opaque",
-	"description",
-	"""
-	Flags the object as being opaque.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		refracted specular ( ie. if it can be seen through glass ).
+		""",
+		"label", "Specular Transmission",
 
-Gaffer.Metadata.registerValue( "attribute:ai:receive_shadows", "label", "Receive Shadows" )
-Gaffer.Metadata.registerValue( "attribute:ai:receive_shadows", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:receive_shadows",
-	"description",
-	"""
-	Whether or not the object receives shadows.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:self_shadows", "label", "Self Shadows" )
-Gaffer.Metadata.registerValue( "attribute:ai:self_shadows", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:self_shadows",
-	"description",
-	"""
-	Whether or not the object casts shadows onto itself.
-	""",
-)
+	"attribute:ai:visibility:volume" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:sss_setname", "label", "SSS Set Name" )
-Gaffer.Metadata.registerValue( "attribute:ai:sss_setname", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:sss_setname",
-	"description",
-	"""
-	If given, subsurface will be blended across any other objects which share the same sss set name.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		volume scattering.
+		""",
+		"label", "Volume",
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_iterations", "label", "Iterations" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_iterations", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_iterations",
-	"description",
-	"""
-	The maximum number of subdivision
-	steps to apply when rendering subdivision
-	surface. To set an exact number of
-	subdivisions, set the adaptive error to
-	0 so that the maximum becomes the
-	controlling factor.
+	],
 
-	Use the MeshType node to ensure that a
-	mesh is treated as a subdivision surface
-	in the first place.
-	""",
-)
+	"attribute:ai:visibility:subsurface" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_error", "label", "Adaptive Error" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_error", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_adaptive_error",
-	"description",
-	"""
-	The maximum allowable deviation from the true
-	surface and the subdivided approximation. How
-	the error is measured is determined by the
-	metric below. Note also that the iterations
-	value above provides a hard limit on the maximum
-	number of subdivision steps, so if changing the
-	error setting appears to have no effect,
-	you may need to raise the maximum.
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to subsurface
+		rays.
+		""",
+		"label", "Subsurface",
 
-	> Note : Objects with a non-zero value will not take part in
-	> Gaffer's automatic instancing unless subdivAdaptiveSpace is
-	> set to "object".
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_metric", "label", "Adaptive Metric" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_metric", "defaultValue", IECore.StringData( "auto" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_adaptive_metric",
-	"description",
-	"""
-	The metric used when performing adaptive
-	subdivision as specified by the adaptive error.
-	The flatness metric ensures that the subdivided
-	surface doesn't deviate from the true surface
-	by more than the error, and will tend to
-	increase detail in areas of high curvature. The
-	edge length metric ensures that the edge length
-	of a polygon is never longer than the error,
-	so will tend to subdivide evenly regardless of
-	curvature - this can be useful when applying a
-	displacement shader. The auto metric automatically
-	uses the flatness metric when no displacement
-	shader is applied, and the edge length metric when
-	a displacement shader is applied.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_metric", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_metric", "presetNames", IECore.StringVectorData( [ "Auto", "Edge Length", "Flatness" ] ) )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_metric", "presetValues", IECore.StringVectorData( [ "auto", "edge_length", "flatness" ] ) )
+	"attribute:ai:disp_autobump" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_space", "label", "Adaptive Space" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_space", "defaultValue", IECore.StringData( "raster" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_adaptive_space",
-	"description",
-	"""
-	The space in which the error is measured when
-	performing adaptive subdivision. Raster space means
-	that the subdivision adapts to size on screen,
-	with subdivAdaptiveError being specified in pixels.
-	Object space means that the error is measured in
-	object space units and will not be sensitive to
-	size on screen.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_space", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_space", "presetNames", IECore.StringVectorData( [ "Raster", "Object" ] ) )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_adaptive_space", "presetValues", IECore.StringVectorData( [ "raster", "object" ] ) )
+		"defaultValue", False,
+		"description",
+		"""
+		Automatically turns the details of the displacement map
+		into bump, wherever the mesh is not subdivided enough
+		to properly capture them.
+		""",
+		"label", "Autobump",
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_uv_smoothing", "label", "UV Smoothing" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_uv_smoothing", "defaultValue", IECore.StringData( "pin_corners" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_uv_smoothing",
-	"description",
-	"""
-	Determines how UVs are subdivided.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_uv_smoothing", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_uv_smoothing", "presetNames", IECore.StringVectorData( [ "Pin Corners", "Pin Borders", "Linear", "Smooth" ] ) )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_uv_smoothing", "presetValues", IECore.StringVectorData( [ "pin_corners", "pin_borders", "linear", "smooth" ] ) )
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_smooth_derivs", "label", "Smooth Derivatives" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_smooth_derivs", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_smooth_derivs",
-	"description",
-	"""
-	Computes smooth UV derivatives (dPdu and dPdv) per
-	vertex. This can be needed to remove faceting
-	from anisotropic specular and other shading effects
-	that use the derivatives.
-	""",
-)
+	"attribute:ai:autobump_visibility:camera" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_frustum_ignore", "label", "Ignore Frustum" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdiv_frustum_ignore", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdiv_frustum_ignore",
-	"description",
-	"""
-	Turns off subdivision culling on a per-object basis. This provides
-	finer control on top of the global `subdivFrustumCulling` setting
-	provided by the ArnoldOptions node.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the autobump is visible to camera
+		rays.
+		""",
+		"label", "Camera",
 
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdivide_polygons", "label", "Subdivide Polygons (Linear)" )
-Gaffer.Metadata.registerValue( "attribute:ai:polymesh:subdivide_polygons", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:polymesh:subdivide_polygons",
-	"description",
-	"""
-	Causes polygon meshes to be rendered with Arnold's
-	subdiv_type parameter set to "linear" rather than
-	"none". This can be used to increase detail when
-	using polygons with displacement shaders and/or mesh
-	lights.
+	],
 
-	> Caution : This is not equivalent to converting a polygon
-	> mesh into a subdivision surface. To render with Arnold's
-	> subdiv_type set to "catclark", you must use the MeshType
-	> node to convert polygon meshes into subdivision surfaces.
-	""",
-)
+	"attribute:ai:autobump_visibility:shadow" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:curves:mode", "label", "Mode" )
-Gaffer.Metadata.registerValue( "attribute:ai:curves:mode", "defaultValue", IECore.StringData( "ribbon" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:curves:mode",
-	"description",
-	"""
-	How the curves are rendered. Ribbon mode treats
-	the curves as flat ribbons facing the camera, and is
-	most suited for rendering of thin curves with a
-	dedicated hair shader. Thick mode treats the curves
-	as tubes, and is suited for use with a regular
-	surface shader.
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible to shadow
+		rays.
+		""",
+		"label", "Shadow",
 
-	> Note : To render using Arnold's "oriented" mode, set
-	> mode to "ribbon" and add per-vertex normals to the
-	> curves as a primitive variable named "N".
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:ai:curves:mode", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:ai:curves:mode", "presetNames", IECore.StringVectorData( [ "Ribbon", "Thick" ] ) )
-Gaffer.Metadata.registerValue( "attribute:ai:curves:mode", "presetValues", IECore.StringVectorData( [ "ribbon", "thick" ] ) )
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:curves:min_pixel_width", "label", "Min Pixel Width" )
-Gaffer.Metadata.registerValue( "attribute:ai:curves:min_pixel_width", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:curves:min_pixel_width",
-	"description",
-	"""
-	The minimum thickness of the curves, measured
-	in pixels on the screen. When rendering very thin curves, a
-	large number of AA samples are required
-	to avoid aliasing. In these cases a minimum pixel
-	width may be specified to artificially thicken the curves,
-	meaning that fewer AA samples may be used. The additional width is
-	compensated for automatically by lowering the opacity
-	of the curves.
-	""",
-)
+	"attribute:ai:autobump_visibility:diffuse_reflect" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:points:min_pixel_width", "label", "Min Pixel Width" )
-Gaffer.Metadata.registerValue( "attribute:ai:points:min_pixel_width", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:points:min_pixel_width",
-	"description",
-	"""
-	The minimum width of rendered points primitives, measured in pixels on the screen.
-	When rendering very small points, a large number of AA samples are required to avoid
-	aliasing. In these cases a minimum pixel width may be specified to artificially enlarge
-	the points, meaning that fewer AA samples may be used. The additional size is
-	compensated for automatically by lowering the opacity of the points.
-	""",
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible in
+		reflected diffuse ( ie. if it casts bounce light )
+		""",
+		"label", "Diffuse Reflection",
 
-Gaffer.Metadata.registerValue( "attribute:ai:volume:step_size", "label", "Step Size" )
-Gaffer.Metadata.registerValue( "attribute:ai:volume:step_size", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:volume:step_size",
-	"description",
-	"""
-	Override the step size taken when raymarching volumes.
-	If this value is disabled or zero then value is calculated from the voxel size.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:volume:step_scale", "label", "Step Scale" )
-Gaffer.Metadata.registerValue( "attribute:ai:volume:step_scale", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:volume:step_scale",
-	"description",
-	"""
-	Raymarching step size is calculated using this value
-	multiplied by the volume voxel size or `ai:volume:step_size` if set.
-	""",
-)
+	"attribute:ai:autobump_visibility:specular_reflect" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:shape:step_size", "label", "Shape Step Size" )
-Gaffer.Metadata.registerValue( "attribute:ai:shape:step_size", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:shape:step_size",
-	"description",
-	"""
-	A non-zero value causes an object to be treated
-	as a volume container, and a value of 0 causes
-	an object to be treated as regular geometry.
-	""",
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible in
+		reflected specular ( ie. if it is visible in mirrors ).
+		""",
+		"label", "Specular Reflection",
 
-Gaffer.Metadata.registerValue( "attribute:ai:shape:step_scale", "label", "Shape Step Scale" )
-Gaffer.Metadata.registerValue( "attribute:ai:shape:step_scale", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:shape:step_scale",
-	"description",
-	"""
-	Raymarching step size is calculated using this value
-	multiplied by `ai:shape:step_size`.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:shape:volume_padding", "label", "Padding" )
-Gaffer.Metadata.registerValue( "attribute:ai:shape:volume_padding", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:shape:volume_padding",
-	"description",
-	"""
-	Allows a volume to be displaced outside its bounds. When
-	rendering a mesh as a volume, this enables displacement.
-	""",
-)
+	"attribute:ai:autobump_visibility:diffuse_transmit" : [
 
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_scale", "label", "Velocity Scale" )
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_scale", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:volume:velocity_scale",
-	"description",
-	"""
-	Scales the vector used in VDB motion blur computation.
-	""",
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible in
+		transmitted diffuse ( ie. if it casts light through leaves ).
+		""",
+		"label", "Diffuse Transmission",
 
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_fps", "label", "Velocity FPS" )
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_fps", "defaultValue", IECore.FloatData( 24 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:volume:velocity_scale",
-	"description",
-	"""
-	Sets the frame rate used in VDB motion blur computation.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_outlier_threshold", "label", "Velocity Outlier Threshold" )
-Gaffer.Metadata.registerValue( "attribute:ai:volume:velocity_outlier_threshold", "defaultValue", IECore.FloatData( 0.001 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:volume:velocity_outlier_threshold",
-	"description",
-	"""
-	Sets the outlier threshold used in VDB motion blur computation.
+	"attribute:ai:autobump_visibility:specular_transmit" : [
 
-	When rendering physics simulations resulting velocities are
-	potentially noisy and require some filtering for faster rendering.
-	""",
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible in
+		refracted specular ( ie. if it can be seen through glass ).
+		""",
+		"label", "Specular Transmission",
 
-Gaffer.Metadata.registerValue( "attribute:ai:toon_id", "label", "Toon ID" )
-Gaffer.Metadata.registerValue( "attribute:ai:toon_id", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:ai:toon_id",
-	"description",
-	"""
-	You can select in the toon shader to skip outlines between objects with the same toon id set.
-	""",
-)
+	],
+
+	"attribute:ai:autobump_visibility:volume" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible in
+		volume scattering.
+		""",
+		"label", "Volume",
+
+	],
+
+	"attribute:ai:autobump_visibility:subsurface" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the autobump is visible to subsurface
+		rays.
+		""",
+		"label", "Subsurface",
+
+	],
+
+	"attribute:ai:transform_type" : [
+
+		"defaultValue", "rotate_about_center",
+		"description",
+		"""
+		Choose how transform motion is interpolated. "Linear"
+		produces classic linear vertex motion, "RotateAboutOrigin"
+		produces curved arcs centred on the object's origin, and
+		"RotateAboutCenter", the default, produces curved arcs
+		centred on the object's bounding box middle.
+		""",
+		"label", "Transform Type",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Linear", "RotateAboutOrigin", "RotateAboutCenter" ] ),
+		"presetValues", IECore.StringVectorData( [ "linear", "rotate_about_origin", "rotate_about_center" ] ),
+
+	],
+
+	"attribute:ai:matte" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Turns the object into a holdout matte.
+		This only affects primary (camera) rays.
+		""",
+		"label", "Matte",
+
+	],
+
+	"attribute:ai:opaque" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Flags the object as being opaque.
+		""",
+		"label", "Opaque",
+
+	],
+
+	"attribute:ai:receive_shadows" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object receives shadows.
+		""",
+		"label", "Receive Shadows",
+
+	],
+
+	"attribute:ai:self_shadows" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object casts shadows onto itself.
+		""",
+		"label", "Self Shadows",
+
+	],
+
+	"attribute:ai:sss_setname" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		If given, subsurface will be blended across any other objects which share the same sss set name.
+		""",
+		"label", "SSS Set Name",
+
+	],
+
+	"attribute:ai:polymesh:subdiv_iterations" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The maximum number of subdivision
+		steps to apply when rendering subdivision
+		surface. To set an exact number of
+		subdivisions, set the adaptive error to
+		0 so that the maximum becomes the
+		controlling factor.
+
+		Use the MeshType node to ensure that a
+		mesh is treated as a subdivision surface
+		in the first place.
+		""",
+		"label", "Iterations",
+
+	],
+
+	"attribute:ai:polymesh:subdiv_adaptive_error" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		The maximum allowable deviation from the true
+		surface and the subdivided approximation. How
+		the error is measured is determined by the
+		metric below. Note also that the iterations
+		value above provides a hard limit on the maximum
+		number of subdivision steps, so if changing the
+		error setting appears to have no effect,
+		you may need to raise the maximum.
+
+		> Note : Objects with a non-zero value will not take part in
+		> Gaffer's automatic instancing unless subdivAdaptiveSpace is
+		> set to "object".
+		""",
+		"label", "Adaptive Error",
+
+	],
+
+	"attribute:ai:polymesh:subdiv_adaptive_metric" : [
+
+		"defaultValue", "auto",
+		"description",
+		"""
+		The metric used when performing adaptive
+		subdivision as specified by the adaptive error.
+		The flatness metric ensures that the subdivided
+		surface doesn't deviate from the true surface
+		by more than the error, and will tend to
+		increase detail in areas of high curvature. The
+		edge length metric ensures that the edge length
+		of a polygon is never longer than the error,
+		so will tend to subdivide evenly regardless of
+		curvature - this can be useful when applying a
+		displacement shader. The auto metric automatically
+		uses the flatness metric when no displacement
+		shader is applied, and the edge length metric when
+		a displacement shader is applied.
+		""",
+		"label", "Adaptive Metric",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Auto", "Edge Length", "Flatness" ] ),
+		"presetValues", IECore.StringVectorData( [ "auto", "edge_length", "flatness" ] ),
+
+	],
+
+	"attribute:ai:polymesh:subdiv_adaptive_space" : [
+
+		"defaultValue", "raster",
+		"description",
+		"""
+		The space in which the error is measured when
+		performing adaptive subdivision. Raster space means
+		that the subdivision adapts to size on screen,
+		with subdivAdaptiveError being specified in pixels.
+		Object space means that the error is measured in
+		object space units and will not be sensitive to
+		size on screen.
+		""",
+		"label", "Adaptive Space",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Raster", "Object" ] ),
+		"presetValues", IECore.StringVectorData( [ "raster", "object" ] ),
+
+	],
+
+	"attribute:ai:polymesh:subdiv_uv_smoothing" : [
+
+		"defaultValue", "pin_corners",
+		"description",
+		"""
+		Determines how UVs are subdivided.
+		""",
+		"label", "UV Smoothing",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Pin Corners", "Pin Borders", "Linear", "Smooth" ] ),
+		"presetValues", IECore.StringVectorData( [ "pin_corners", "pin_borders", "linear", "smooth" ] ),
+
+	],
+
+	"attribute:ai:polymesh:subdiv_smooth_derivs" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Computes smooth UV derivatives (dPdu and dPdv) per
+		vertex. This can be needed to remove faceting
+		from anisotropic specular and other shading effects
+		that use the derivatives.
+		""",
+		"label", "Smooth Derivatives",
+
+	],
+
+	"attribute:ai:polymesh:subdiv_frustum_ignore" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Turns off subdivision culling on a per-object basis. This provides
+		finer control on top of the global `subdivFrustumCulling` setting
+		provided by the ArnoldOptions node.
+		""",
+		"label", "Ignore Frustum",
+
+	],
+
+	"attribute:ai:polymesh:subdivide_polygons" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Causes polygon meshes to be rendered with Arnold's
+		subdiv_type parameter set to "linear" rather than
+		"none". This can be used to increase detail when
+		using polygons with displacement shaders and/or mesh
+		lights.
+
+		> Caution : This is not equivalent to converting a polygon
+		> mesh into a subdivision surface. To render with Arnold's
+		> subdiv_type set to "catclark", you must use the MeshType
+		> node to convert polygon meshes into subdivision surfaces.
+		""",
+		"label", "Subdivide Polygons (Linear)",
+
+	],
+
+	"attribute:ai:curves:mode" : [
+
+		"defaultValue", "ribbon",
+		"description",
+		"""
+		How the curves are rendered. Ribbon mode treats
+		the curves as flat ribbons facing the camera, and is
+		most suited for rendering of thin curves with a
+		dedicated hair shader. Thick mode treats the curves
+		as tubes, and is suited for use with a regular
+		surface shader.
+
+		> Note : To render using Arnold's "oriented" mode, set
+		> mode to "ribbon" and add per-vertex normals to the
+		> curves as a primitive variable named "N".
+		""",
+		"label", "Mode",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Ribbon", "Thick" ] ),
+		"presetValues", IECore.StringVectorData( [ "ribbon", "thick" ] ),
+
+	],
+
+	"attribute:ai:curves:min_pixel_width" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		The minimum thickness of the curves, measured
+		in pixels on the screen. When rendering very thin curves, a
+		large number of AA samples are required
+		to avoid aliasing. In these cases a minimum pixel
+		width may be specified to artificially thicken the curves,
+		meaning that fewer AA samples may be used. The additional width is
+		compensated for automatically by lowering the opacity
+		of the curves.
+		""",
+		"label", "Min Pixel Width",
+
+	],
+
+	"attribute:ai:points:min_pixel_width" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		The minimum width of rendered points primitives, measured in pixels on the screen.
+		When rendering very small points, a large number of AA samples are required to avoid
+		aliasing. In these cases a minimum pixel width may be specified to artificially enlarge
+		the points, meaning that fewer AA samples may be used. The additional size is
+		compensated for automatically by lowering the opacity of the points.
+		""",
+		"label", "Min Pixel Width",
+
+	],
+
+	"attribute:ai:volume:step_size" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Override the step size taken when raymarching volumes.
+		If this value is disabled or zero then value is calculated from the voxel size.
+		""",
+		"label", "Step Size",
+
+	],
+
+	"attribute:ai:volume:step_scale" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Raymarching step size is calculated using this value
+		multiplied by the volume voxel size or `ai:volume:step_size` if set.
+		""",
+		"label", "Step Scale",
+
+	],
+
+	"attribute:ai:shape:step_size" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		A non-zero value causes an object to be treated
+		as a volume container, and a value of 0 causes
+		an object to be treated as regular geometry.
+		""",
+		"label", "Shape Step Size",
+
+	],
+
+	"attribute:ai:shape:step_scale" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Raymarching step size is calculated using this value
+		multiplied by `ai:shape:step_size`.
+		""",
+		"label", "Shape Step Scale",
+
+	],
+
+	"attribute:ai:shape:volume_padding" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Allows a volume to be displaced outside its bounds. When
+		rendering a mesh as a volume, this enables displacement.
+		""",
+		"label", "Padding",
+
+	],
+
+	"attribute:ai:volume:velocity_scale" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Scales the vector used in VDB motion blur computation.
+		""",
+		"label", "Velocity Scale",
+
+	],
+
+	"attribute:ai:volume:velocity_fps" : [
+
+		"defaultValue", 24.0,
+		"description",
+		"""
+		Sets the frame rate used in VDB motion blur computation.
+		""",
+		"label", "Velocity FPS",
+
+	],
+
+	"attribute:ai:volume:velocity_outlier_threshold" : [
+
+		"defaultValue", 0.001,
+		"description",
+		"""
+		Sets the outlier threshold used in VDB motion blur computation.
+
+		When rendering physics simulations resulting velocities are
+		potentially noisy and require some filtering for faster rendering.
+		""",
+		"label", "Velocity Outlier Threshold",
+
+	],
+
+	"attribute:ai:toon_id" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		You can select in the toon shader to skip outlines between objects with the same toon id set.
+		""",
+		"label", "Toon ID",
+
+	],
+
+} )

--- a/startup/GafferScene/arnoldOptions.py
+++ b/startup/GafferScene/arnoldOptions.py
@@ -34,204 +34,222 @@
 #
 ##########################################################################
 
-import IECore
 import Gaffer
 
 ## \todo Migrate ArnoldOptions to use this metadata so we have one source of truth.
-Gaffer.Metadata.registerValue( "option:ai:AA_samples", "label", "AA Samples" )
-Gaffer.Metadata.registerValue( "option:ai:AA_samples", "defaultValue", IECore.IntData( 3 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:AA_samples",
-	"description",
-	"""
-	Controls the number of rays per pixel
-	traced from the camera. The more samples,
-	the better the quality of antialiasing,
-	motion blur and depth of field. The actual
-	number of rays per pixel is the square of
-	the AA Samples value - so a value of 3
-	means 9 rays are traced, 4 means 16 rays are
-	traced and so on.
-	"""
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:ai:enable_adaptive_sampling", "label", "Enable Adaptive Sampling" )
-Gaffer.Metadata.registerValue( "option:ai:enable_adaptive_sampling", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:enable_adaptive_sampling",
-	"description",
-	"""
-	If adaptive sampling is enabled, Arnold will
-	take a minimum of ( AA Samples * AA Samples )
-	samples per pixel, and will then take up to
-	( AA Samples Max * AA Samples Max ) samples per
-	pixel, or until the remaining estimated noise
-	gets lower than aaAdaptiveThreshold.
-	"""
-)
+	"option:ai:AA_samples" : [
 
-Gaffer.Metadata.registerValue( "option:ai:AA_samples_max", "label", "AA Samples Max" )
-Gaffer.Metadata.registerValue( "option:ai:AA_samples_max", "defaultValue", IECore.IntData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:AA_samples_max",
-	"description",
-	"""
-	The maximum sampling rate during adaptive
-	sampling. Like AA Samples, this value is
-	squared. So AA Samples Max == 6 means up to
-	36 samples per pixel.
-	"""
-)
+		"defaultValue", 3,
+		"description",
+		"""
+		Controls the number of rays per pixel
+		traced from the camera. The more samples,
+		the better the quality of antialiasing,
+		motion blur and depth of field. The actual
+		number of rays per pixel is the square of
+		the AA Samples value - so a value of 3
+		means 9 rays are traced, 4 means 16 rays are
+		traced and so on.
+		""",
+		"label", "AA Samples",
 
-Gaffer.Metadata.registerValue( "option:ai:AA_adaptive_threshold", "label", "AA Adaptive Threshold" )
-Gaffer.Metadata.registerValue( "option:ai:AA_adaptive_threshold", "defaultValue", IECore.FloatData( 0.05 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:AA_adaptive_threshold",
-	"description",
-	"""
-	How much leftover noise is acceptable when
-	terminating adaptive sampling. Higher values
-	accept more noise, lower values keep rendering
-	longer to achieve smaller amounts of noise.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_samples", "label", "Diffuse Samples" )
-Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_samples", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_diffuse_samples",
-	"description",
-	"""
-	Controls the number of rays traced when
-	computing indirect illumination.
-	"""
-)
+	"option:ai:enable_adaptive_sampling" : [
 
-Gaffer.Metadata.registerValue( "option:ai:GI_specular_samples", "label", "Specular Samples" )
-Gaffer.Metadata.registerValue( "option:ai:GI_specular_samples", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_specular_samples",
-	"description",
-	"""
-	Controls the number of rays traced when
-	computing specular reflections.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		If adaptive sampling is enabled, Arnold will
+		take a minimum of ( AA Samples * AA Samples )
+		samples per pixel, and will then take up to
+		( AA Samples Max * AA Samples Max ) samples per
+		pixel, or until the remaining estimated noise
+		gets lower than aaAdaptiveThreshold.
+		""",
+		"label", "Enable Adaptive Sampling",
 
-Gaffer.Metadata.registerValue( "option:ai:GI_transmission_samples", "label", "Transmission Samples" )
-Gaffer.Metadata.registerValue( "option:ai:GI_transmission_samples", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_transmission_samples",
-	"description",
-	"""
-	Controls the number of rays traced when
-	computing specular refractions.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:ai:GI_sss_samples", "label", "SSS Samples" )
-Gaffer.Metadata.registerValue( "option:ai:GI_sss_samples", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_sss_samples",
-	"description",
-	"""
-	Controls the number of rays traced when
-	computing subsurface scattering.
-	"""
-)
+	"option:ai:AA_samples_max" : [
 
-Gaffer.Metadata.registerValue( "option:ai:GI_volume_samples", "label", "Volume Samples" )
-Gaffer.Metadata.registerValue( "option:ai:GI_volume_samples", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_volume_samples",
-	"description",
-	"""
-	Controls the number of rays traced when
-	computing indirect lighting for volumes.
-	"""
-)
+		"defaultValue", 0,
+		"description",
+		"""
+		The maximum sampling rate during adaptive
+		sampling. Like AA Samples, this value is
+		squared. So AA Samples Max == 6 means up to
+		36 samples per pixel.
+		""",
+		"label", "AA Samples Max",
 
-Gaffer.Metadata.registerValue( "option:ai:light_samples", "label", "Light Samples" )
-Gaffer.Metadata.registerValue( "option:ai:light_samples", "defaultValue", IECore.IntData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:light_samples",
-	"description",
-	"""
-	Specifies a fixed number of light samples to be taken at each
-	shading point. This enables "Global Light Sampling", which provides
-	significantly improved performance for scenes containing large numbers
-	of lights. In this mode, the `samples` setting on each light is ignored,
-	and instead the fixed number of samples is distributed among all the
-	lights according to their contribution at the shading point.
+	],
 
-	A value of `0` disables Global Light Sampling, reverting to the original
-	per-light sampling algorithm.
-	"""
-)
+	"option:ai:AA_adaptive_threshold" : [
 
-Gaffer.Metadata.registerValue( "option:ai:GI_total_depth", "label", "Total Depth" )
-Gaffer.Metadata.registerValue( "option:ai:GI_total_depth", "defaultValue", IECore.IntData( 10 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_total_depth",
-	"description",
-	"""
-	The maximum depth of any ray (Diffuse + Specular +
-	Transmission + Volume).
-	"""
-)
+		"defaultValue", 0.05,
+		"description",
+		"""
+		How much leftover noise is acceptable when
+		terminating adaptive sampling. Higher values
+		accept more noise, lower values keep rendering
+		longer to achieve smaller amounts of noise.
+		""",
+		"label", "AA Adaptive Threshold",
 
-Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_depth", "label", "Diffuse Depth" )
-Gaffer.Metadata.registerValue( "option:ai:GI_diffuse_depth", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_diffuse_depth",
-	"description",
-	"""
-	Controls the number of ray bounces when
-	computing indirect illumination ("bounce light").
-	"""
-)
+	],
 
+	"option:ai:GI_diffuse_samples" : [
 
-Gaffer.Metadata.registerValue( "option:ai:GI_specular_depth", "label", "Specular Depth" )
-Gaffer.Metadata.registerValue( "option:ai:GI_specular_depth", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_specular_depth",
-	"description",
-	"""
-	Controls the number of ray bounces when
-	computing specular reflections.
-	"""
-)
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of rays traced when
+		computing indirect illumination.
+		""",
+		"label", "Diffuse Samples",
 
-Gaffer.Metadata.registerValue( "option:ai:GI_transmission_depth", "label", "Transmission Depth" )
-Gaffer.Metadata.registerValue( "option:ai:GI_transmission_depth", "defaultValue", IECore.IntData( 2 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_transmission_depth",
-	"description",
-	"""
-	Controls the number of ray bounces when
-	computing specular refractions.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:ai:GI_volume_depth", "label", "Volume Depth" )
-Gaffer.Metadata.registerValue( "option:ai:GI_volume_depth", "defaultValue", IECore.IntData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:GI_volume_depth",
-	"description",
-	"""
-	Controls the number of ray bounces when
-	computing indirect lighting on volumes.
-	"""
-)
+	"option:ai:GI_specular_samples" : [
 
-Gaffer.Metadata.registerValue( "option:ai:auto_transparency_depth", "label", "Transparency Depth" )
-Gaffer.Metadata.registerValue( "option:ai:auto_transparency_depth", "defaultValue", IECore.IntData( 10 ) )
-Gaffer.Metadata.registerValue(
-	"option:ai:auto_transparency_depth",
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of rays traced when
+		computing specular reflections.
+		""",
+		"label", "Specular Samples",
+
+	],
+
+	"option:ai:GI_transmission_samples" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of rays traced when
+		computing specular refractions.
+		""",
+		"label", "Transmission Samples",
+
+	],
+
+	"option:ai:GI_sss_samples" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of rays traced when
+		computing subsurface scattering.
+		""",
+		"label", "SSS Samples",
+
+	],
+
+	"option:ai:GI_volume_samples" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of rays traced when
+		computing indirect lighting for volumes.
+		""",
+		"label", "Volume Samples",
+
+	],
+
+	"option:ai:light_samples" : [
+
+		"defaultValue", 0,
+		"description",
+		"""
+		Specifies a fixed number of light samples to be taken at each
+		shading point. This enables "Global Light Sampling", which provides
+		significantly improved performance for scenes containing large numbers
+		of lights. In this mode, the `samples` setting on each light is ignored,
+		and instead the fixed number of samples is distributed among all the
+		lights according to their contribution at the shading point.
+
+		A value of `0` disables Global Light Sampling, reverting to the original
+		per-light sampling algorithm.
+		""",
+		"label", "Light Samples",
+
+	],
+
+	"option:ai:GI_total_depth" : [
+
+		"defaultValue", 10,
+		"description",
+		"""
+		The maximum depth of any ray (Diffuse + Specular +
+		Transmission + Volume).
+		""",
+		"label", "Total Depth",
+
+	],
+
+	"option:ai:GI_diffuse_depth" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of ray bounces when
+		computing indirect illumination ("bounce light").
+		""",
+		"label", "Diffuse Depth",
+
+	],
+
+	"option:ai:GI_specular_depth" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of ray bounces when
+		computing specular reflections.
+		""",
+		"label", "Specular Depth",
+
+	],
+
+	"option:ai:GI_transmission_depth" : [
+
+		"defaultValue", 2,
+		"description",
+		"""
+		Controls the number of ray bounces when
+		computing specular refractions.
+		""",
+		"label", "Transmission Depth",
+
+	],
+
+	"option:ai:GI_volume_depth" : [
+
+		"defaultValue", 0,
+		"description",
+		"""
+		Controls the number of ray bounces when
+		computing indirect lighting on volumes.
+		""",
+		"label", "Volume Depth",
+
+	],
+
+	"option:ai:auto_transparency_depth" : [
+
+	"defaultValue", 10,
 	"description",
 	"""
 	The number of allowable transparent layers - after
 	this the last object will be treated as opaque.
-	"""
-)
+	""",
+	"label", "Transparency Depth",
+
+	]
+
+} )

--- a/startup/GafferScene/cyclesAttributes.py
+++ b/startup/GafferScene/cyclesAttributes.py
@@ -38,291 +38,321 @@ import IECore
 
 import Gaffer
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:camera", "label", "Camera" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:camera", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:camera",
-	"description",
-	"""
-	Whether or not the object is visible to camera
-	rays. To hide an object completely, use the
-	`scene:visible` attribute instead.
-	""",
-)
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:diffuse", "label", "Diffuse" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:diffuse", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:diffuse",
-	"description",
-	"""
-	Whether or not the object is visible to diffuse
-	rays.
-	""",
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:glossy", "label", "Glossy" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:glossy", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:glossy",
-	"description",
-	"""
-	Whether or not the object is visible in
-	glossy rays.
-	""",
-)
+	"attribute:cycles:visibility:camera" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:transmission", "label", "Transmission" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:transmission", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:transmission",
-	"description",
-	"""
-	Whether or not the object is visible in
-	transmission.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to camera
+		rays. To hide an object completely, use the
+		`scene:visible` attribute instead.
+		""",
+		"label", "Camera",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:shadow", "label", "Shadow" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:shadow", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:shadow",
-	"description",
-	"""
-	Whether or not the object is visible to shadow
-	rays - whether it casts shadows or not.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:scatter", "label", "Scatter" )
-Gaffer.Metadata.registerValue( "attribute:cycles:visibility:scatter", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:visibility:scatter",
-	"description",
-	"""
-	Whether or not the object is visible to
-	scatter rays.
-	""",
-)
+	"attribute:cycles:visibility:diffuse" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:use_holdout", "label", "Use Holdout" )
-Gaffer.Metadata.registerValue( "attribute:cycles:use_holdout", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:use_holdout",
-	"description",
-	"""
-	Turns the object into a holdout matte.
-	This only affects primary (camera) rays.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to diffuse
+		rays.
+		""",
+		"label", "Diffuse",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:is_shadow_catcher", "label", "Is Shadow Catcher" )
-Gaffer.Metadata.registerValue( "attribute:cycles:is_shadow_catcher", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:is_shadow_catcher",
-	"description",
-	"""
-	Turns the object into a shadow catcher.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shadow_terminator_shading_offset", "label", "Terminator Shading Offset" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shadow_terminator_shading_offset", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shadow_terminator_shading_offset",
-	"description",
-	"""
-	Push the shadow terminator towards the light to hide artifacts on low poly geometry.
-	""",
-)
+	"attribute:cycles:visibility:glossy" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shadow_terminator_geometry_offset", "label", "Terminator Geometry Offset" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shadow_terminator_geometry_offset", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shadow_terminator_geometry_offset",
-	"description",
-	"""
-	Offset rays from the surface to reduce shadow terminator artifact on low poly geometry. Only affects triangles at grazing angles to light.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		glossy rays.
+		""",
+		"label", "Glossy",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:lightgroup", "label", "Lightgroup" )
-Gaffer.Metadata.registerValue( "attribute:cycles:lightgroup", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:lightgroup",
-	"description",
-	"""
-	Set the lightgroup of an object with emission.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:is_caustics_caster", "label", "Is Caustics Caster" )
-Gaffer.Metadata.registerValue( "attribute:cycles:is_caustics_caster", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:is_caustics_caster",
-	"description",
-	"""
-	Cast Shadow Caustics.
-	""",
-)
+	"attribute:cycles:visibility:transmission" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:is_caustics_receiver", "label", "Is Caustics Receiver" )
-Gaffer.Metadata.registerValue( "attribute:cycles:is_caustics_receiver", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:is_caustics_receiver",
-	"description",
-	"""
-	Receive Shadow Caustics.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		transmission.
+		""",
+		"label", "Transmission",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:max_level", "label", "Max Level" )
-Gaffer.Metadata.registerValue( "attribute:cycles:max_level", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:max_level",
-	"description",
-	"""
-	The max level of subdivision that can be
-	applied.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:dicing_rate", "label", "Dicing Scale" )
-Gaffer.Metadata.registerValue( "attribute:cycles:dicing_rate", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:dicing_rate",
-	"description",
-	"""
-	Multiplier for scene dicing rate.
-	""",
-)
+	"attribute:cycles:visibility:shadow" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_clipping", "label", "Clipping" )
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_clipping", "defaultValue", IECore.FloatData( 0.001 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:volume_clipping",
-	"description",
-	"""
-	Value under which voxels are considered empty space to
-	optimize rendering.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to shadow
+		rays - whether it casts shadows or not.
+		""",
+		"label", "Shadow",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_step_size", "label", "Step Size" )
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_step_size", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:volume_step_size",
-	"description",
-	"""
-	Distance between volume samples. When zero it is automatically
-	estimated based on the voxel size.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_object_space", "label", "Object Space" )
-Gaffer.Metadata.registerValue( "attribute:cycles:volume_object_space", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:volume_object_space",
-	"description",
-	"""
-	Specify volume density and step size in object or world space.
-	By default object space is used, so that the volume opacity and
-	detail remains the same regardless of object scale.
-	""",
-)
+	"attribute:cycles:visibility:scatter" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:asset_name", "label", "Asset Name" )
-Gaffer.Metadata.registerValue( "attribute:cycles:asset_name", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:asset_name",
-	"description",
-	"""
-	Asset name for cryptomatte.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to
+		scatter rays.
+		""",
+		"label", "Scatter",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:emission_sampling_method", "label", "Emission Sampling Method" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:emission_sampling_method", "defaultValue", IECore.StringData( "auto" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:emission_sampling_method",
-	"description",
-	"""
-	Sampling strategy for emissive surfaces.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:emission_sampling_method", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:emission_sampling_method", "presetNames", IECore.StringVectorData( [ "None", "Auto", "Front", "Back", "Front-Back" ] ) )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:emission_sampling_method", "presetValues", IECore.StringVectorData( [ "none", "auto", "front", "back", "front_back" ] ) )
+	],
 
+	"attribute:cycles:use_holdout" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:use_transparent_shadow", "label", "Transparent Shadow" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:use_transparent_shadow", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:use_transparent_shadow",
-	"description",
-	"""
-	Use transparent shadows for this material if it contains a Transparent BSDF,
-	disabling will render faster but not give accurate shadows.
-	""",
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Turns the object into a holdout matte.
+		This only affects primary (camera) rays.
+		""",
+		"label", "Use Holdout",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:heterogeneous_volume", "label", "Heterogeneous Volume" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:heterogeneous_volume", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:heterogeneous_volume",
-	"description",
-	"""
-	Disabling this when using volume rendering, assume volume has the same density
-	everywhere (not using any textures), for faster rendering.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_sampling_method", "label", "Volume Sampling" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_sampling_method", "defaultValue", IECore.StringData( "multiple_importance" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:volume_sampling_method",
-	"description",
-	"""
-	Sampling method to use for volumes.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_sampling_method", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_sampling_method", "presetNames", IECore.StringVectorData( [ "Distance", "Equiangular", "Multiple-Importance" ] ) )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_sampling_method", "presetValues", IECore.StringVectorData( [ "distance", "equiangular", "multiple_importance" ] ) )
+	"attribute:cycles:is_shadow_catcher" : [
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_interpolation_method", "label", "Volume Interpolation" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_interpolation_method", "defaultValue", IECore.StringData( "linear" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:volume_interpolation_method",
-	"description",
-	"""
-	Interpolation method to use for volumes.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_interpolation_method", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_interpolation_method", "presetNames", IECore.StringVectorData( [ "Linear", "Cubic" ] ) )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_interpolation_method", "presetValues", IECore.StringVectorData( [ "linear", "cubic" ] ) )
+		"defaultValue", False,
+		"description",
+		"""
+		Turns the object into a shadow catcher.
+		""",
+		"label", "Is Shadow Catcher",
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_step_rate", "label", "Volume Step Rate" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:volume_step_rate", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:volume_step_rate",
-	"description",
-	"""
-	Scale the distance between volume shader samples when rendering the volume
-	(lower values give more accurate and detailed results, but also increased render time).
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:displacement_method", "label", "Displacement Method" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:displacement_method", "defaultValue", IECore.StringData( "bump" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:cycles:shader:displacement_method",
-	"description",
-	"""
-	Method to use for the displacement.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:displacement_method", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:displacement_method", "presetNames", IECore.StringVectorData( [ "Bump", "True", "Both" ] ) )
-Gaffer.Metadata.registerValue( "attribute:cycles:shader:displacement_method", "presetValues", IECore.StringVectorData( [ "bump", "true", "both" ] ) )
+	"attribute:cycles:shadow_terminator_shading_offset" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Push the shadow terminator towards the light to hide artifacts on low poly geometry.
+		""",
+		"label", "Terminator Shading Offset",
+
+	],
+
+	"attribute:cycles:shadow_terminator_geometry_offset" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Offset rays from the surface to reduce shadow terminator artifact on low poly geometry. Only affects triangles at grazing angles to light.
+		""",
+		"label", "Terminator Geometry Offset",
+
+	],
+
+	"attribute:cycles:lightgroup" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		Set the lightgroup of an object with emission.
+		""",
+		"label", "Lightgroup",
+
+	],
+
+	"attribute:cycles:is_caustics_caster" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Cast Shadow Caustics.
+		""",
+		"label", "Is Caustics Caster",
+
+	],
+
+	"attribute:cycles:is_caustics_receiver" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Receive Shadow Caustics.
+		""",
+		"label", "Is Caustics Receiver",
+
+	],
+
+	"attribute:cycles:max_level" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The max level of subdivision that can be
+		applied.
+		""",
+		"label", "Max Level",
+
+	],
+
+	"attribute:cycles:dicing_rate" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Multiplier for scene dicing rate.
+		""",
+		"label", "Dicing Scale",
+
+	],
+
+	"attribute:cycles:volume_clipping" : [
+
+		"defaultValue", 0.001,
+		"description",
+		"""
+		Value under which voxels are considered empty space to
+		optimize rendering.
+		""",
+		"label", "Clipping",
+
+	],
+
+	"attribute:cycles:volume_step_size" : [
+
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Distance between volume samples. When zero it is automatically
+		estimated based on the voxel size.
+		""",
+		"label", "Step Size",
+
+	],
+
+	"attribute:cycles:volume_object_space" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Specify volume density and step size in object or world space.
+		By default object space is used, so that the volume opacity and
+		detail remains the same regardless of object scale.
+		""",
+		"label", "Object Space",
+
+	],
+
+	"attribute:cycles:asset_name" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		Asset name for cryptomatte.
+		""",
+		"label", "Asset Name",
+
+	],
+
+	"attribute:cycles:shader:emission_sampling_method" : [
+
+		"defaultValue", "auto",
+		"description",
+		"""
+		Sampling strategy for emissive surfaces.
+		""",
+		"label", "Emission Sampling Method",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "None", "Auto", "Front", "Back", "Front-Back" ] ),
+		"presetValues", IECore.StringVectorData( [ "none", "auto", "front", "back", "front_back" ] ),
+
+	],
+
+	"attribute:cycles:shader:use_transparent_shadow" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Use transparent shadows for this material if it contains a Transparent BSDF,
+		disabling will render faster but not give accurate shadows.
+		""",
+		"label", "Transparent Shadow",
+
+	],
+
+	"attribute:cycles:shader:heterogeneous_volume" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Disabling this when using volume rendering, assume volume has the same density
+		everywhere (not using any textures), for faster rendering.
+		""",
+		"label", "Heterogeneous Volume",
+
+	],
+
+	"attribute:cycles:shader:volume_sampling_method" : [
+
+		"defaultValue", "multiple_importance",
+		"description",
+		"""
+		Sampling method to use for volumes.
+		""",
+		"label", "Volume Sampling",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Distance", "Equiangular", "Multiple-Importance" ] ),
+		"presetValues", IECore.StringVectorData( [ "distance", "equiangular", "multiple_importance" ] ),
+
+	],
+
+	"attribute:cycles:shader:volume_interpolation_method" : [
+
+		"defaultValue", "linear",
+		"description",
+		"""
+		Interpolation method to use for volumes.
+		""",
+		"label", "Volume Interpolation",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Linear", "Cubic" ] ),
+		"presetValues", IECore.StringVectorData( [ "linear", "cubic" ] ),
+
+	],
+
+	"attribute:cycles:shader:volume_step_rate" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Scale the distance between volume shader samples when rendering the volume
+		(lower values give more accurate and detailed results, but also increased render time).
+		""",
+		"label", "Volume Step Rate",
+
+	],
+
+	"attribute:cycles:shader:displacement_method" : [
+
+		"defaultValue", "bump",
+		"description",
+		"""
+		Method to use for the displacement.
+		""",
+		"label", "Displacement Method",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Bump", "True", "Both" ] ),
+		"presetValues", IECore.StringVectorData( [ "bump", "true", "both" ] ),
+
+	],
+
+} )

--- a/startup/GafferScene/cyclesOptions.py
+++ b/startup/GafferScene/cyclesOptions.py
@@ -34,120 +34,134 @@
 #
 ##########################################################################
 
-import IECore
 import Gaffer
 
-Gaffer.Metadata.registerValue( "option:cycles:session:samples", "label", "Samples" )
-Gaffer.Metadata.registerValue( "option:cycles:session:samples", "defaultValue", IECore.IntData( 1024 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:session:samples",
-	"description",
-	"""
-	Number of samples to render for each pixel.
-	"""
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:use_adaptive_sampling", "label", "Adaptive Sampling" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:use_adaptive_sampling", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:use_adaptive_sampling",
-	"description",
-	"""
-	Automatically determine the number of samples
-	per pixel based on a variance estimation.
-	"""
-)
+	"option:cycles:session:samples" : [
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:adaptive_threshold", "label", "Adaptive Threshold" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:adaptive_threshold", "defaultValue", IECore.FloatData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:adaptive_threshold",
-	"description",
-	"""
-	Noise level step to stop sampling at, lower values reduce noise the cost of render time.
-	`0` for automatic setting based on number of AA samples.
-	"""
-)
+		"defaultValue", 1024,
+		"description",
+		"""
+		Number of samples to render for each pixel.
+		""",
+		"label", "Samples",
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:use_guiding", "label", "Path Guiding" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:use_guiding", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:use_guiding",
-	"description",
-	"""
-	Use path guiding for sampling paths. Path guiding incrementally
-	learns the light distribution of the scene and guides paths into directions
-	with high direct and indirect light contributions.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:min_bounce", "label", "Min Bounces" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:min_bounce", "defaultValue", IECore.IntData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:min_bounce",
-	"description",
-	"""
-	Minimum number of light bounces. Setting this higher reduces noise in the first bounces,
-	but can also be less efficient for more complex geometry like hair and volumes.
-	"""
-)
+	"option:cycles:integrator:use_adaptive_sampling" : [
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_bounce", "label", "Max Bounces" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:max_bounce",
-	"description",
-	"""
-	Total maximum number of bounces.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Automatically determine the number of samples
+		per pixel based on a variance estimation.
+		""",
+		"label", "Adaptive Sampling",
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_diffuse_bounce", "label", "Diffuse" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_diffuse_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:max_diffuse_bounce",
-	"description",
-	"""
-	Maximum number of diffuse reflection bounces, bounded by total maximum.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_glossy_bounce", "label", "Glossy" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_glossy_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:max_glossy_bounce",
-	"description",
-	"""
-	Maximum number of glossy reflection bounces, bounded by total maximum.
-	"""
-)
+	"option:cycles:integrator:adaptive_threshold" : [
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_transmission_bounce", "label", "Transmission" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_transmission_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:max_transmission_bounce",
-	"description",
-	"""
-	Maximum number of transmission reflection bounces, bounded by total maximum.
-	"""
-)
+		"defaultValue", 0.0,
+		"description",
+		"""
+		Noise level step to stop sampling at, lower values reduce noise the cost of render time.
+		`0` for automatic setting based on number of AA samples.
+		""",
+		"label", "Adaptive Threshold",
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_volume_bounce", "label", "Volume" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:max_volume_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:max_volume_bounce",
-	"description",
-	"""
-	Maximum number of volumetric scattering events.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:cycles:integrator:transparent_max_bounce", "label", "Transparency" )
-Gaffer.Metadata.registerValue( "option:cycles:integrator:transparent_max_bounce", "defaultValue", IECore.IntData( 7 ) )
-Gaffer.Metadata.registerValue(
-	"option:cycles:integrator:transparent_max_bounce",
-	"description",
-	"""
-	Maximum number of transparent bounces.
-	"""
-)
+	"option:cycles:integrator:use_guiding" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Use path guiding for sampling paths. Path guiding incrementally
+		learns the light distribution of the scene and guides paths into directions
+		with high direct and indirect light contributions.
+		""",
+		"label", "Path Guiding",
+
+	],
+
+	"option:cycles:integrator:min_bounce" : [
+
+		"defaultValue", 0,
+		"description",
+		"""
+		Minimum number of light bounces. Setting this higher reduces noise in the first bounces,
+		but can also be less efficient for more complex geometry like hair and volumes.
+		""",
+		"label", "Min Bounces",
+
+	],
+
+	"option:cycles:integrator:max_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Total maximum number of bounces.
+		""",
+		"label", "Max Bounces",
+
+	],
+
+	"option:cycles:integrator:max_diffuse_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Maximum number of diffuse reflection bounces, bounded by total maximum.
+		""",
+		"label", "Diffuse",
+
+	],
+
+	"option:cycles:integrator:max_glossy_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Maximum number of glossy reflection bounces, bounded by total maximum.
+		""",
+		"label", "Glossy",
+
+	],
+
+	"option:cycles:integrator:max_transmission_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Maximum number of transmission reflection bounces, bounded by total maximum.
+		""",
+		"label", "Transmission",
+
+	],
+
+	"option:cycles:integrator:max_volume_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Maximum number of volumetric scattering events.
+		""",
+		"label", "Volume",
+
+	],
+
+	"option:cycles:integrator:transparent_max_bounce" : [
+
+		"defaultValue", 7,
+		"description",
+		"""
+		Maximum number of transparent bounces.
+		""",
+		"label", "Transparency",
+
+	],
+
+} )

--- a/startup/GafferScene/delightAttributes.py
+++ b/startup/GafferScene/delightAttributes.py
@@ -34,95 +34,105 @@
 #
 ##########################################################################
 
-import IECore
-
 import Gaffer
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.camera", "label", "Camera" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.camera", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.camera",
-	"description",
-	"""
-	Whether or not the object is visible to camera
-	rays. To hide an object completely, use the
-	`scene:visible` attribute instead.
-	""",
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.diffuse", "label", "Diffuse" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.diffuse", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.diffuse",
-	"description",
-	"""
-	Whether or not the object is visible to diffuse
-	rays.
-	""",
-)
+	"attribute:dl:visibility.camera" : [
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.hair", "label", "Hair" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.hair", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.hair",
-	"description",
-	"""
-	Whether or not the object is visible to
-	hair rays.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to camera
+		rays. To hide an object completely, use the
+		`scene:visible` attribute instead.
+		""",
+		"label", "Camera",
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.reflection", "label", "Reflection" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.reflection", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.reflection",
-	"description",
-	"""
-	Whether or not the object is visible in
-	reflections.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.refraction", "label", "Refraction" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.refraction", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.refraction",
-	"description",
-	"""
-	Whether or not the object is visible in
-	refractions.
-	""",
-)
+	"attribute:dl:visibility.diffuse" : [
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.shadow", "label", "Shadow" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.shadow", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.shadow",
-	"description",
-	"""
-	Whether or not the object is visible to shadow
-	rays - whether it casts shadows or not.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to diffuse
+		rays.
+		""",
+		"label", "Diffuse",
 
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.specular", "label", "Specular" )
-Gaffer.Metadata.registerValue( "attribute:dl:visibility.specular", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:visibility.specular",
-	"description",
-	"""
-	Whether or not the object is visible to
-	specular rays.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:dl:matte", "label", "Matte" )
-Gaffer.Metadata.registerValue( "attribute:dl:matte", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:dl:matte",
-	"description",
-	"""
-	Turns the object into a holdout matte.
-	This only affects primary (camera) rays.
-	""",
-)
+	"attribute:dl:visibility.hair" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to
+		hair rays.
+		""",
+		"label", "Hair",
+
+	],
+
+	"attribute:dl:visibility.reflection" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		reflections.
+		""",
+		"label", "Reflection",
+
+	],
+
+	"attribute:dl:visibility.refraction" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible in
+		refractions.
+		""",
+		"label", "Refraction",
+
+	],
+
+	"attribute:dl:visibility.shadow" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to shadow
+		rays - whether it casts shadows or not.
+		""",
+		"label", "Shadow",
+
+	],
+
+	"attribute:dl:visibility.specular" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is visible to
+		specular rays.
+		""",
+		"label", "Specular",
+
+	],
+
+	"attribute:dl:matte" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Turns the object into a holdout matte.
+		This only affects primary (camera) rays.
+		""",
+		"label", "Matte",
+
+	],
+
+} )

--- a/startup/GafferScene/delightOptions.py
+++ b/startup/GafferScene/delightOptions.py
@@ -34,98 +34,109 @@
 #
 ##########################################################################
 
-import IECore
 import Gaffer
 
-Gaffer.Metadata.registerValue( "option:dl:oversampling", "label", "Oversampling" )
-Gaffer.Metadata.registerValue( "option:dl:oversampling", "defaultValue", IECore.IntData( 9 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:oversampling",
-	"description",
-	"""
-	The number of camera rays to fire for each pixel of
-	the image. Higher values may be needed to resolve fine
-	geometric detail such as hair, or to reduce noise in
-	heavily motion blurred renders.
-	"""
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:dl:quality.shadingsamples", "label", "Shading Samples" )
-Gaffer.Metadata.registerValue( "option:dl:quality.shadingsamples", "defaultValue", IECore.IntData( 64 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:quality.shadingsamples",
-	"description",
-	"""
-	The number of samples to take when evaluating shading.
-	This is the primary means of improving image quality and
-	reducing shading noise.
-	"""
-)
+	"option:dl:oversampling" : [
 
-Gaffer.Metadata.registerValue( "option:dl:quality.volumesamples", "label", "Volume Samples" )
-Gaffer.Metadata.registerValue( "option:dl:quality.volumesamples", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:quality.volumesamples",
-	"description",
-	"""
-	The number of samples to take when evaluating volumes.
-	"""
-)
+		"defaultValue", 9,
+		"description",
+		"""
+		The number of camera rays to fire for each pixel of
+		the image. Higher values may be needed to resolve fine
+		geometric detail such as hair, or to reduce noise in
+		heavily motion blurred renders.
+		""",
+		"label", "Oversampling",
 
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.diffuse", "label", "Diffuse" )
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.diffuse", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:maximumraydepth.diffuse",
-	"description",
-	"""
-	The maximum bounce depth a diffuse ray can reach. A depth
-	of 1 specifies one additional bounce compared to purely
-	local illumination.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.hair", "label", "Hair" )
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.hair", "defaultValue", IECore.IntData( 4 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:maximumraydepth.hair",
-	"description",
-	"""
-	The maximum bounce depth a hair ray can reach. Note that hair
-	is akin to volumetric primitives and might need elevated ray
-	depth to properly capture the illumination.
-	"""
-)
+	"option:dl:quality.shadingsamples" : [
 
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.reflection", "label", "Reflection" )
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.reflection", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:maximumraydepth.reflection",
-	"description",
-	"""
-	The maximum bounce depth a reflection ray can reach. Setting
-	the reflection depth to 0 will only compute local illumination
-	meaning that only emissive surfaces will appear in the reflections.
-	"""
-)
+		"defaultValue", 64,
+		"description",
+		"""
+		The number of samples to take when evaluating shading.
+		This is the primary means of improving image quality and
+		reducing shading noise.
+		""",
+		"label", "Shading Samples",
 
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.refraction", "label", "Refraction" )
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.refraction", "defaultValue", IECore.IntData( 4 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:maximumraydepth.refraction",
-	"description",
-	"""
-	The maximum bounce depth a refraction ray can reach. A value of 4
-	allows light to shine through a properly modeled object such as a
-	glass.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.volume", "label", "Volume" )
-Gaffer.Metadata.registerValue( "option:dl:maximumraydepth.volume", "defaultValue", IECore.IntData( 0 ) )
-Gaffer.Metadata.registerValue(
-	"option:dl:maximumraydepth.volume",
-	"description",
-	"""
-	The maximum bounce depth a volume ray can reach.
-	"""
-)
+	"option:dl:quality.volumesamples" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The number of samples to take when evaluating volumes.
+		""",
+		"label", "Volume Samples",
+
+	],
+
+	"option:dl:maximumraydepth.diffuse" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The maximum bounce depth a diffuse ray can reach. A depth
+		of 1 specifies one additional bounce compared to purely
+		local illumination.
+		""",
+		"label", "Diffuse",
+
+	],
+
+	"option:dl:maximumraydepth.hair" : [
+
+		"defaultValue", 4,
+		"description",
+		"""
+		The maximum bounce depth a hair ray can reach. Note that hair
+		is akin to volumetric primitives and might need elevated ray
+		depth to properly capture the illumination.
+		""",
+		"label", "Hair",
+
+	],
+
+	"option:dl:maximumraydepth.reflection" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The maximum bounce depth a reflection ray can reach. Setting
+		the reflection depth to 0 will only compute local illumination
+		meaning that only emissive surfaces will appear in the reflections.
+		""",
+		"label", "Reflection",
+
+	],
+
+	"option:dl:maximumraydepth.refraction" : [
+
+		"defaultValue", 4,
+		"description",
+		"""
+		The maximum bounce depth a refraction ray can reach. A value of 4
+		allows light to shine through a properly modeled object such as a
+		glass.
+		""",
+		"label", "Refraction",
+
+	],
+
+	"option:dl:maximumraydepth.volume" : [
+
+		"defaultValue", 0,
+		"description",
+		"""
+		The maximum bounce depth a volume ray can reach.
+		""",
+		"label", "Volume",
+
+	],
+
+} )

--- a/startup/GafferScene/openGLAttributes.py
+++ b/startup/GafferScene/openGLAttributes.py
@@ -40,265 +40,291 @@ import IECore
 
 import Gaffer
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:solid", "label", "Shaded" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:solid", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:solid",
-	"description",
-	"""
-	Whether or not the object is rendered solid, in which
-	case the assigned GLSL shader will be used to perform
-	the shading.
-	"""
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframe", "label", "Wireframe" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframe", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:wireframe",
-	"description",
-	"""
-	Whether or not the object is rendered as a wireframe.
-	Use the `gl:primitive:wireframeColor` and `gl:primitive:wireframeWidth`
-	attributes for finer control of the wireframe appearance.
-	"""
-)
+	"attribute:gl:primitive:solid" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframeColor", "label", "Wireframe Color" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframeColor", "defaultValue", IECore.Color4fData( imath.Color4f( 0.2, 0.2, 0.2, 1.0 ) ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:wireframeColor",
-	"description",
-	"""
-	The colour to use for the wireframe rendering. Only
-	meaningful if wireframe rendering is turned on.
-	"""
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object is rendered solid, in which
+		case the assigned GLSL shader will be used to perform
+		the shading.
+		""",
+		"label", "Shaded",
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframeWidth", "label", "Wireframe Width" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:wireframeWidth", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:wireframeWidth",
-	"description",
-	"""
-	The width in pixels of the wireframe rendering. Only
-	meaningful if wireframe rendering is turned on.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outline", "label", "Outline" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outline", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:outline",
-	"description",
-	"""
-	Whether or not an outline is drawn around the object.
-	Use the `gl:primitive:outlineColor` and `gl:primitive:outlineWidth`
-	attributes for finer control of the outline.
-	"""
-)
+	"attribute:gl:primitive:wireframe" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outlineColor", "label", "Outline Color" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outlineColor", "defaultValue", IECore.Color4fData( imath.Color4f( 0.85, 0.75, 0.45, 1.0 ) ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:outlineColor",
-	"description",
-	"""
-	The colour to use for the outline. Only
-	meaningful if outline rendering is turned on.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the object is rendered as a wireframe.
+		Use the `gl:primitive:wireframeColor` and `gl:primitive:wireframeWidth`
+		attributes for finer control of the wireframe appearance.
+		""",
+		"label", "Wireframe",
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outlineWidth", "label", "Outline Width" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:outlineWidth", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:outlineWidth",
-	"description",
-	"""
-	The width in pixels of the outline. Only
-	meaningful if outline rendering is turned on.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:points", "label", "Points" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:points", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:points",
-	"description",
-	"""
-	Whether or not the individual points (vertices) of the
-	object are drawn. Use the `gl:primitive:pointColor` and
-	`gl:primitive:pointWidth` attributes for finer control
-	of the point rendering.
-	"""
-)
+	"attribute:gl:primitive:wireframeColor" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:pointColor", "label", "Point Color" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:pointColor", "defaultValue", IECore.Color4fData( imath.Color4f( 1 ) ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:pointColor",
-	"description",
-	"""
-	The colour to use for the point rendering. Only
-	meaningful if point rendering is turned on.
-	"""
-)
+		"defaultValue", imath.Color4f( 0.2, 0.2, 0.2, 1.0 ),
+		"description",
+		"""
+		The colour to use for the wireframe rendering. Only
+		meaningful if wireframe rendering is turned on.
+		""",
+		"label", "Wireframe Color",
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:pointWidth", "label", "Point Width" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:pointWidth", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:pointWidth",
-	"description",
-	"""
-	The width in pixels of the points. Only
-	meaningful if point rendering is turned on.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:bound", "label", "Bound" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:bound", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:bound",
-	"description",
-	"""
-	Whether or not the bounding box of the object is drawn.
-	This is in addition to any drawing of unexpanded bounding
-	boxes that the viewer performs. Use the `gl:primitive:boundColor`
-	attribute to change the colour of the bounding box.
-	"""
-)
+	"attribute:gl:primitive:wireframeWidth" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:boundColor", "label", "Bound Color" )
-Gaffer.Metadata.registerValue( "attribute:gl:primitive:boundColor", "defaultValue", IECore.Color4fData( imath.Color4f( 0.36, 0.8, 0.85, 1.0 ) ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:primitive:boundColor",
-	"description",
-	"""
-	The colour to use for the bounding box rendering. Only
-	meaningful if bounding box rendering is turned on.
-	"""
-)
+		"defaultValue", 1.0,
+		"description",
+		"""
+		The width in pixels of the wireframe rendering. Only
+		meaningful if wireframe rendering is turned on.
+		""",
+		"label", "Wireframe Width",
 
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:useGLPoints", "label", "Use GL Points" )
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:useGLPoints", "defaultValue", IECore.StringData( "forGLPoints" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:pointsPrimitive:useGLPoints",
-	"description",
-	"""
-	Points primitives have a render type (set by the PointsType
-	node) which allows them to be rendered as particles, disks,
-	spheres etc. This attribute overrides that type for OpenGL
-	only, allowing a much faster rendering as raw OpenGL points.
-	"""
-)
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:useGLPoints", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:useGLPoints", "presetNames", IECore.StringVectorData( [ "For GL Points", "For Particles And Disks", "For All" ] ) )
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:useGLPoints", "presetValues", IECore.StringVectorData( [ "forGLPoints", "forParticlesAndDisks", "forAll" ] ) )
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:glPointWidth", "label", "GL Point Width" )
-Gaffer.Metadata.registerValue( "attribute:gl:pointsPrimitive:glPointWidth", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:pointsPrimitive:glPointWidth",
-	"description",
-	"""
-	The width in pixels of the GL points rendered when
-	the `gl:pointsPrimitive:useGLPoints` attribute has
-	overridden the point type.
-	"""
-)
+	"attribute:gl:primitive:outline" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:useGLLines", "label", "Use GL Lines" )
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:useGLLines", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:curvesPrimitive:useGLLines",
-	"description",
-	"""
-	Curves primitives are typically rendered as ribbons
-	and as such have an associated width in object space.
-	This attribute overrides that for OpenGL only, allowing
-	a much faster rendering as raw OpenGL lines.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not an outline is drawn around the object.
+		Use the `gl:primitive:outlineColor` and `gl:primitive:outlineWidth`
+		attributes for finer control of the outline.
+		""",
+		"label", "Outline",
 
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:glLineWidth", "label", "GL Line Width" )
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:glLineWidth", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:curvesPrimitive:glLineWidth",
-	"description",
-	"""
-	The width in pixels of the GL lines rendered when
-	the `gl:pointsPrimitive:useGLLines` attribute has
-	overridden the drawing to use lines.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:ignoreBasis", "label", "Ignore Basis" )
-Gaffer.Metadata.registerValue( "attribute:gl:curvesPrimitive:ignoreBasis", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:curvesPrimitive:ignoreBasis",
-	"description",
-	"""
-	Turns off interpolation for cubic curves, just
-	rendering straight lines between the vertices
-	instead.
-	"""
-)
+	"attribute:gl:primitive:outlineColor" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:light:drawingMode", "label", "Light Drawing Mode" )
-Gaffer.Metadata.registerValue( "attribute:gl:light:drawingMode", "defaultValue", IECore.StringData( "texture" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:light:drawingMode",
-	"description",
-	"""
-	Controls how lights are presented in the Viewer.
-	"""
-)
-Gaffer.Metadata.registerValue( "attribute:gl:light:drawingMode", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:gl:light:drawingMode", "presetNames", IECore.StringVectorData( [ "Wireframe", "Color", "Texture" ] ) )
-Gaffer.Metadata.registerValue( "attribute:gl:light:drawingMode", "presetValues", IECore.StringVectorData( [ "wireframe", "color", "texture" ] ) )
+		"defaultValue", imath.Color4f( 0.85, 0.75, 0.45, 1.0 ),
+		"description",
+		"""
+		The colour to use for the outline. Only
+		meaningful if outline rendering is turned on.
+		""",
+		"label", "Outline Color",
 
-Gaffer.Metadata.registerValue( "attribute:gl:light:frustumScale", "label", "Light Frustum Scale" )
-Gaffer.Metadata.registerValue( "attribute:gl:light:frustumScale", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:light:frustumScale",
-	"description",
-	"""
-	Allows light projections to be scaled to better suit the scene.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:frustum", "label", "Frustum" )
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:frustum", "defaultValue", IECore.StringData( "whenSelected" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:visualiser:frustum",
-	"description",
-	"""
-	Controls whether applicable locations draw a representation of
-	their projection or frustum.
-	"""
-)
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:frustum", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:frustum", "presetNames", IECore.StringVectorData( [ "Off", "When Selected", "On" ] ) )
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:frustum", "presetValues", IECore.StringVectorData( [ "off", "whenSelected", "on" ] ) )
+	"attribute:gl:primitive:outlineWidth" : [
 
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:maxTextureResolution", "label", "Max Texture Resolution" )
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:maxTextureResolution", "defaultValue", IECore.IntData( 512 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:visualiser:maxTextureResolution",
-	"description",
-	"""
-	Visualisers that load textures will respect this setting to
-	limit their resolution.
-	"""
-)
+		"defaultValue", 1.0,
+		"description",
+		"""
+		The width in pixels of the outline. Only
+		meaningful if outline rendering is turned on.
+		""",
+		"label", "Outline Width",
 
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:scale", "label", "Scale" )
-Gaffer.Metadata.registerValue( "attribute:gl:visualiser:scale", "defaultValue", IECore.FloatData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gl:visualiser:scale",
-	"description",
-	"""
-	Scales non-geometric visualisations in the viewport to make them
-	easier to work with.
-	"""
-)
+	],
+
+	"attribute:gl:primitive:points" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the individual points (vertices) of the
+		object are drawn. Use the `gl:primitive:pointColor` and
+		`gl:primitive:pointWidth` attributes for finer control
+		of the point rendering.
+		""",
+		"label", "Points",
+
+	],
+
+	"attribute:gl:primitive:pointColor" : [
+
+		"defaultValue", imath.Color4f( 1 ),
+		"description",
+		"""
+		The colour to use for the point rendering. Only
+		meaningful if point rendering is turned on.
+		""",
+		"label", "Point Color",
+
+	],
+
+	"attribute:gl:primitive:pointWidth" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		The width in pixels of the points. Only
+		meaningful if point rendering is turned on.
+		""",
+		"label", "Point Width",
+
+	],
+
+	"attribute:gl:primitive:bound" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not the bounding box of the object is drawn.
+		This is in addition to any drawing of unexpanded bounding
+		boxes that the viewer performs. Use the `gl:primitive:boundColor`
+		attribute to change the colour of the bounding box.
+		""",
+		"label", "Bound",
+
+	],
+
+	"attribute:gl:primitive:boundColor" : [
+
+		"defaultValue", imath.Color4f( 0.36, 0.8, 0.85, 1.0 ),
+		"description",
+		"""
+		The colour to use for the bounding box rendering. Only
+		meaningful if bounding box rendering is turned on.
+		""",
+		"label", "Bound Color",
+
+	],
+
+	"attribute:gl:pointsPrimitive:useGLPoints" : [
+
+		"defaultValue", "forGLPoints",
+		"description",
+		"""
+		Points primitives have a render type (set by the PointsType
+		node) which allows them to be rendered as particles, disks,
+		spheres etc. This attribute overrides that type for OpenGL
+		only, allowing a much faster rendering as raw OpenGL points.
+		""",
+		"label", "Use GL Points",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "For GL Points", "For Particles And Disks", "For All" ] ),
+		"presetValues", IECore.StringVectorData( [ "forGLPoints", "forParticlesAndDisks", "forAll" ] ),
+
+	],
+
+	"attribute:gl:pointsPrimitive:glPointWidth" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		The width in pixels of the GL points rendered when
+		the `gl:pointsPrimitive:useGLPoints` attribute has
+		overridden the point type.
+		""",
+		"label", "GL Point Width",
+
+	],
+
+	"attribute:gl:curvesPrimitive:useGLLines" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Curves primitives are typically rendered as ribbons
+		and as such have an associated width in object space.
+		This attribute overrides that for OpenGL only, allowing
+		a much faster rendering as raw OpenGL lines.
+		""",
+		"label", "Use GL Lines",
+
+	],
+
+	"attribute:gl:curvesPrimitive:glLineWidth" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		The width in pixels of the GL lines rendered when
+		the `gl:pointsPrimitive:useGLLines` attribute has
+		overridden the drawing to use lines.
+		""",
+		"label", "GL Line Width",
+
+	],
+
+	"attribute:gl:curvesPrimitive:ignoreBasis" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Turns off interpolation for cubic curves, just
+		rendering straight lines between the vertices
+		instead.
+		""",
+		"label", "Ignore Basis",
+
+	],
+
+	"attribute:gl:light:drawingMode" : [
+
+		"defaultValue", "texture",
+		"description",
+		"""
+		Controls how lights are presented in the Viewer.
+		""",
+		"label", "Light Drawing Mode",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Wireframe", "Color", "Texture" ] ),
+		"presetValues", IECore.StringVectorData( [ "wireframe", "color", "texture" ] ),
+
+	],
+
+	"attribute:gl:light:frustumScale" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Allows light projections to be scaled to better suit the scene.
+		""",
+		"label", "Light Frustum Scale",
+
+	],
+
+	"attribute:gl:visualiser:frustum" : [
+
+		"defaultValue", "whenSelected",
+		"description",
+		"""
+		Controls whether applicable locations draw a representation of
+		their projection or frustum.
+		""",
+		"label", "Frustum",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Off", "When Selected", "On" ] ),
+		"presetValues", IECore.StringVectorData( [ "off", "whenSelected", "on" ] ),
+
+	],
+
+	"attribute:gl:visualiser:maxTextureResolution" : [
+
+		"defaultValue", 512,
+		"description",
+		"""
+		Visualisers that load textures will respect this setting to
+		limit their resolution.
+		""",
+		"label", "Max Texture Resolution",
+
+	],
+
+	"attribute:gl:visualiser:scale" : [
+
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Scales non-geometric visualisations in the viewport to make them
+		easier to work with.
+		""",
+		"label", "Scale",
+
+	],
+
+} )

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -134,9 +134,17 @@ with IECore.IgnoredExceptions( ImportError ) :
 			label = re.sub( r"[dD]isplacement ?", "", Gaffer.Metadata.value( target, "label" ) )
 		Gaffer.Metadata.registerValue( target, "label", label )
 
-	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "presetNames", IECore.StringVectorData( [ "Object", "World" ] ) )
-	Gaffer.Metadata.registerValue( "attribute:ri:displacementbound:CoordinateSystem", "presetValues", IECore.StringVectorData( [ "object", "world" ] ) )
+	Gaffer.Metadata.registerValues( {
+
+		"attribute:ri:displacementbound:CoordinateSystem" : [
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"presetNames", IECore.StringVectorData( [ "Object", "World" ] ),
+			"presetValues", IECore.StringVectorData( [ "object", "world" ] ),
+
+		],
+
+	} )
 
 	# Register BoolPlugValueWidget for attributes which are actually integers
 	# but would more logically be bools. We can't change their type, because

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -173,72 +173,103 @@ with IECore.IgnoredExceptions( ImportError ) :
 		# they can use a CustomOptions node.
 	] :
 
-		Gaffer.Metadata.registerValue( f"option:ri:{name}", "defaultValue", defaultValue )
-		Gaffer.Metadata.registerValue( f"option:ri:{name}", "description",
-			f"""
-			Defines the contents of the `{lobe}` custom LPE lobe.
+		Gaffer.Metadata.registerValues( {
+
+			f"option:ri:{name}" : [
+
+				"defaultValue", defaultValue,
+				"description",
+				f"""
+				Defines the contents of the `{lobe}` custom LPE lobe.
+				""",
+				"label", lobe,
+				"layout:section", "Custom LPE Lobes",
+
+			]
+
+		} )
+
+	Gaffer.Metadata.registerValues( {
+
+		# Add widgets and presets that are missing from the `.args` file.
+
+		"option:ri:volume:aggregatespace" : [
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"presetNames", IECore.StringVectorData( [ "World", "Camera" ] ),
+			"presetValues", IECore.StringVectorData( [ "world", "camera" ] ),
+
+		],
+
+		# Add options used by GafferRenderMan._InteractiveDenoiserAdaptor. These don't mean
+		# anything to RenderMan, but we still use the "ri:" prefix to keep things consistent
+		# for the end user.
+		## \todo Should we use a different prefix?
+
+		"option:ri:interactiveDenoiser:enabled" : [
+
+			"defaultValue", False,
+			"description",
 			"""
-		)
-		Gaffer.Metadata.registerValue( f"option:ri:{name}", "label", lobe )
-		Gaffer.Metadata.registerValue( f"option:ri:{name}", "layout:section", "Custom LPE Lobes" )
+			Enables interactive denoising using RenderMan's `quicklyNoiseless` display driver. When on, all
+			required denoising AOVs are added to the render automatically.
+			""",
+			"label", "Enabled",
+			"layout:section", "Interactive Denoiser",
 
-	# Add widgets and presets that are missing from the `.args` file.
+		],
 
-	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "presetNames", IECore.StringVectorData( [ "World", "Camera" ] ) )
-	Gaffer.Metadata.registerValue( "option:ri:volume:aggregatespace", "presetValues", IECore.StringVectorData( [ "world", "camera" ] ) )
+		"option:ri:interactiveDenoiser:cheapPass" : [
 
-	# Add options used by GafferRenderMan._InteractiveDenoiserAdaptor. These don't mean
-	# anything to RenderMan, but we still use the "ri:" prefix to keep things consistent
-	# for the end user.
-	## \todo Should we use a different prefix?
+			"defaultValue", True,
+			"description",
+			"""
+			When on, the first pass will use a cheaper (slightly faster but lower
+			quality) heuristic. This can be useful if rendering something that is
+			converging very quickly and you want to prioritize getting a denoised
+			result faster.
+			""",
+			"label", "Cheap First Pass",
+			"layout:section", "Interactive Denoiser",
 
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:enabled", "defaultValue", False )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:enabled", "description",
-		"""
-		Enables interactive denoising using RenderMan's `quicklyNoiseless` display driver. When on, all
-		required denoising AOVs are added to the render automatically.
-		"""
-	)
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:enabled", "label", "Enabled" )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:enabled", "layout:section", "Interactive Denoiser" )
+		],
 
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:cheapPass", "defaultValue", True )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:cheapPass", "description",
-		"""
-		When on, the first pass will use a cheaper (slightly faster but lower
-		quality) heuristic. This can be useful if rendering something that is
-		converging very quickly and you want to prioritize getting a denoised
-		result faster.
-		"""
-	)
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:cheapPass", "label", "Cheap First Pass" )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:cheapPass", "layout:section", "Interactive Denoiser" )
+		"option:ri:interactiveDenoiser:interval" : [
 
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:interval", "defaultValue", 4.0 )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:interval", "description",
-		"""
-		The time interval in between denoise runs (in seconds).
-		"""
-	)
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:interval", "label", "Interval" )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:interval", "layout:section", "Interactive Denoiser" )
+			"defaultValue", 4.0,
+			"description",
+			"""
+			The time interval in between denoise runs (in seconds).
+			""",
+			"label", "Interval",
+			"layout:section", "Interactive Denoiser",
 
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:minSamples", "defaultValue", 2 )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:minSamples", "description",
-		"""
-		The minimum number of average samples per bucket before the interactive denoiser runs for the first time.
-		Changing this preference requires the render to be restarted for this option to be respected.
-		"""
-	)
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:minSamples", "label", "Min Samples" )
-	Gaffer.Metadata.registerValue( "option:ri:interactiveDenoiser:minSamples", "layout:section", "Interactive Denoiser" )
+		],
 
-	# Add an option to allow checkpoint recovery - this is handled by `IECoreRenderMan::Session::Session()`
-	# since it is not an official RenderMan option.
+		"option:ri:interactiveDenoiser:minSamples" : [
 
-	Gaffer.Metadata.registerValue( "option:ri:checkpoint:recover", "label", "Checkpoint Recover" )
-	Gaffer.Metadata.registerValue( "option:ri:checkpoint:recover", "description", "Enables recovery from a checkpoint created by a previous render." )
-	Gaffer.Metadata.registerValue( "option:ri:checkpoint:recover", "defaultValue", 0 )
-	Gaffer.Metadata.registerValue( "option:ri:checkpoint:recover", "layout:section", "Display" )
-	Gaffer.Metadata.registerValue( "option:ri:checkpoint:recover", "plugValueWidget:type", "GafferUI.BoolPlugValueWidget" )
+			"defaultValue", 2,
+			"description",
+			"""
+			The minimum number of average samples per bucket before the interactive denoiser runs for the first time.
+			Changing this preference requires the render to be restarted for this option to be respected.
+			""",
+			"label", "Min Samples",
+			"layout:section", "Interactive Denoiser",
+
+		],
+
+		# Add an option to allow checkpoint recovery - this is handled by `IECoreRenderMan::Session::Session()`
+		# since it is not an official RenderMan option.
+
+		"option:ri:checkpoint:recover" : [
+
+			"defaultValue", 0,
+			"description", "Enables recovery from a checkpoint created by a previous render.",
+			"label", "Checkpoint Recover",
+			"layout:section", "Display",
+			"plugValueWidget:type", "GafferUI.BoolPlugValueWidget",
+
+		],
+
+	} )

--- a/startup/GafferScene/renderPassOptions.py
+++ b/startup/GafferScene/renderPassOptions.py
@@ -34,23 +34,31 @@
 #
 ##########################################################################
 
-import IECore
 import Gaffer
 
-Gaffer.Metadata.registerValue( "option:renderPass:enabled", "label", "Enabled" )
-Gaffer.Metadata.registerValue( "option:renderPass:enabled", "description", "Whether the render pass is enabled for rendering." )
-Gaffer.Metadata.registerValue( "option:renderPass:enabled", "defaultValue", IECore.BoolData( True ) )
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:renderPass:type", "label", "Type" )
-Gaffer.Metadata.registerValue(
-	"option:renderPass:type",
-	"description",
-	"""
-	The type of the render pass. This provides simple setup for renders such as reflection and shadow passes,
-	typically by assigning custom shaders to the objects specified by `Casters` and `Catchers`. Use a RenderPassShaders
-	node to customise the shaders used for this purpose.
+	"option:renderPass:enabled" : [
 
-	> Hint : Render pass types and their behaviours can be customised using the RenderPassTypeAdaptor API.
-	"""
-)
-Gaffer.Metadata.registerValue( "option:renderPass:type", "defaultValue", IECore.StringData( "" ) )
+		"defaultValue", True,
+		"description", "Whether the render pass is enabled for rendering.",
+		"label", "Enabled",
+
+	],
+
+	"option:renderPass:type" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		The type of the render pass. This provides simple setup for renders such as reflection and shadow passes,
+		typically by assigning custom shaders to the objects specified by `Casters` and `Catchers`. Use a RenderPassShaders
+		node to customise the shaders used for this purpose.
+
+		> Hint : Render pass types and their behaviours can be customised using the RenderPassTypeAdaptor API.
+		""",
+		"label", "Type",
+
+	],
+
+} )

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -36,151 +36,164 @@
 
 import imath
 
-import IECore
-
 import Gaffer
 
-Gaffer.Metadata.registerValue( "attribute:scene:visible", "label", "Visible" )
-Gaffer.Metadata.registerValue( "attribute:scene:visible", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:scene:visible",
-	"description",
-	"""
-	Whether or not the object can be seen - invisible objects are
-	not sent to the renderer at all. Typically more fine
-	grained (camera, reflection etc) visibility can be
-	specified using a renderer specific attributes node.
-	Note that making a parent location invisible will
-	always make all the children invisible too, regardless
-	of their visibility settings.
-	""",
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "attribute:doubleSided", "label", "Double Sided" )
-Gaffer.Metadata.registerValue( "attribute:doubleSided", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:doubleSided",
-	"description",
-	"""
-	Whether or not the object can be seen from both sides.
-	Single sided objects appear invisible when seen from
-	the back.
-	""",
-)
+	"attribute:scene:visible" : [
 
-Gaffer.Metadata.registerValue( "attribute:render:displayColor", "label", "Display Color" )
-Gaffer.Metadata.registerValue( "attribute:render:displayColor", "defaultValue", IECore.Color3fData( imath.Color3f( 1 ) ) )
-Gaffer.Metadata.registerValue(
-	"attribute:render:displayColor",
-	"description",
-	"""
-	The default colour used to display the object in the absence
-	of a specific shader assignment. Commonly used to control
-	basic object appearance in the Viewer.
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object can be seen - invisible objects are
+		not sent to the renderer at all. Typically more fine
+		grained (camera, reflection etc) visibility can be
+		specified using a renderer specific attributes node.
+		Note that making a parent location invisible will
+		always make all the children invisible too, regardless
+		of their visibility settings.
+		""",
+		"label", "Visible",
 
-	> Tip : For more detailed control of object appearance in the
-	> Viewer, use OpenGL attributes.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gaffer:transformBlur", "label", "Transform Blur" )
-Gaffer.Metadata.registerValue( "attribute:gaffer:transformBlur", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gaffer:transformBlur",
-	"description",
-	"""
-	Whether or not transformation animation on the object
-	is taken into account in the rendered image. Use the
-	`gaffer:transformBlurSegments` attribute to specify
-	the number of segments used to represent the motion.
-	""",
-)
+	"attribute:doubleSided" : [
 
-Gaffer.Metadata.registerValue( "attribute:gaffer:transformBlurSegments", "label", "Transform Segments" )
-Gaffer.Metadata.registerValue( "attribute:gaffer:transformBlurSegments", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gaffer:transformBlurSegments",
-	"description",
-	"""
-	The number of segments of transform animation to
-	pass to the renderer when Transform Blur is on.
-	""",
-)
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not the object can be seen from both sides.
+		Single sided objects appear invisible when seen from
+		the back.
+		""",
+		"label", "Double Sided",
 
-Gaffer.Metadata.registerValue( "attribute:gaffer:deformationBlur", "label", "Deformation Blur" )
-Gaffer.Metadata.registerValue( "attribute:gaffer:deformationBlur", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gaffer:deformationBlur",
-	"description",
-	"""
-	Whether or not deformation animation on the object
-	is taken into account in the rendered image. Use the
-	`gaffer:deformationBlurSegments` attribute to specify
-	the number of segments used to represent the motion.
-	""",
-)
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gaffer:deformationBlurSegments", "label", "Deformation Segments" )
-Gaffer.Metadata.registerValue( "attribute:gaffer:deformationBlurSegments", "defaultValue", IECore.IntData( 1 ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gaffer:deformationBlurSegments",
-	"description",
-	"""
-	The number of segments of deformation animation to
-	pass to the renderer when Deformation Blur is on.
-	""",
-)
+	"attribute:render:displayColor" : [
 
-Gaffer.Metadata.registerValue( "attribute:light:mute", "label", "Mute" )
-Gaffer.Metadata.registerValue( "attribute:light:mute", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"attribute:light:mute",
-	"description",
-	"""
-	Whether this light is muted.
-	"""
-)
+		"defaultValue", imath.Color3f( 1 ),
+		"description",
+		"""
+		The default colour used to display the object in the absence
+		of a specific shader assignment. Commonly used to control
+		basic object appearance in the Viewer.
 
-Gaffer.Metadata.registerValue( "attribute:linkedLights", "label", "Linked Lights" )
-Gaffer.Metadata.registerValue( "attribute:linkedLights", "defaultValue", "defaultLights" )
-Gaffer.Metadata.registerValue(
-	"attribute:linkedLights",
-	"description",
-	"""
-	The lights to be linked to this object. Accepts a set expression or
-	a space separated list of lights. Use \"defaultLights\" to refer to
-	all lights that contribute to illumination by default.
-	"""
-)
-Gaffer.Metadata.registerValue( "attribute:linkedLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:linkedLights", "ui:scene:acceptsSetExpression", True )
+		> Tip : For more detailed control of object appearance in the
+		> Viewer, use OpenGL attributes.
+		""",
+		"label", "Display Color",
 
-Gaffer.Metadata.registerValue( "attribute:filteredLights", "label", "Filtered Lights" )
-Gaffer.Metadata.registerValue( "attribute:filteredLights", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:filteredLights",
-	"description",
-	"""
-	The lights to be filtered by this light filter. Accepts a
-	set expression or a space separated list of lights.
-	Use \"defaultLights\" to refer to all lights that
-	contribute to illumination by default.
-	"""
-)
-Gaffer.Metadata.registerValue( "attribute:filteredLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:filteredLights", "ui:scene:acceptsSetExpression", True )
+	],
 
-Gaffer.Metadata.registerValue( "attribute:gaffer:automaticInstancing", "label", "Automatic Instancing" )
-Gaffer.Metadata.registerValue( "attribute:gaffer:automaticInstancing", "defaultValue", IECore.BoolData( True ) )
-Gaffer.Metadata.registerValue(
-	"attribute:gaffer:automaticInstancing",
-	"description",
-	"""
-	By default, if Gaffer sees two objects are identical, it will pass them
-	to the renderer only once, saving a lot of memory. You can set this to
-	false to disable that, losing the memory savings. This can be useful
-	in certain cases like using world space displacement and wanting multiple
-	copies to displace differently. Disabling is currently only supported by
-	the Arnold render backend.
-	""",
-)
+	"attribute:gaffer:transformBlur" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not transformation animation on the object
+		is taken into account in the rendered image. Use the
+		`gaffer:transformBlurSegments` attribute to specify
+		the number of segments used to represent the motion.
+		""",
+		"label", "Transform Blur",
+
+	],
+
+	"attribute:gaffer:transformBlurSegments" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The number of segments of transform animation to
+		pass to the renderer when Transform Blur is on.
+		""",
+		"label", "Transform Segments",
+
+	],
+
+	"attribute:gaffer:deformationBlur" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		Whether or not deformation animation on the object
+		is taken into account in the rendered image. Use the
+		`gaffer:deformationBlurSegments` attribute to specify
+		the number of segments used to represent the motion.
+		""",
+		"label", "Deformation Blur",
+
+	],
+
+	"attribute:gaffer:deformationBlurSegments" : [
+
+		"defaultValue", 1,
+		"description",
+		"""
+		The number of segments of deformation animation to
+		pass to the renderer when Deformation Blur is on.
+		""",
+		"label", "Deformation Segments",
+
+	],
+
+	"attribute:light:mute" : [
+
+		"defaultValue", False,
+		"description",
+		"""
+		Whether this light is muted.
+		""",
+		"label", "Mute",
+
+	],
+
+	"attribute:linkedLights" : [
+
+		"defaultValue", "defaultLights",
+		"description",
+		"""
+		The lights to be linked to this object. Accepts a set expression or
+		a space separated list of lights. Use \"defaultLights\" to refer to
+		all lights that contribute to illumination by default.
+		""",
+		"label", "Linked Lights",
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True
+
+	],
+
+	"attribute:filteredLights" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		The lights to be filtered by this light filter. Accepts a
+		set expression or a space separated list of lights.
+		Use \"defaultLights\" to refer to all lights that
+		contribute to illumination by default.
+		""",
+		"label", "Filtered Lights",
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"attribute:gaffer:automaticInstancing" : [
+
+		"defaultValue", True,
+		"description",
+		"""
+		By default, if Gaffer sees two objects are identical, it will pass them
+		to the renderer only once, saving a lot of memory. You can set this to
+		false to disable that, losing the memory savings. This can be useful
+		in certain cases like using world space displacement and wanting multiple
+		copies to displace differently. Disabling is currently only supported by
+		the Arnold render backend.
+		""",
+		"label", "Automatic Instancing",
+
+	],
+
+} )

--- a/startup/GafferScene/standardOptions.py
+++ b/startup/GafferScene/standardOptions.py
@@ -36,186 +36,203 @@
 
 import imath
 
-import IECore
 import Gaffer
 
-Gaffer.Metadata.registerValue( "option:render:camera", "label", "Camera" )
-Gaffer.Metadata.registerValue( "option:render:camera", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:camera",
-	"description",
-	"""
-	The primary camera to be used for rendering. If this
-	is not specified, then a default orthographic camera
-	positioned at the origin is used.
-	"""
-)
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:render:resolution", "label", "Resolution" )
-Gaffer.Metadata.registerValue( "option:render:resolution", "defaultValue", IECore.V2iData( imath.V2i( 1024, 778 ) ) )
-Gaffer.Metadata.registerValue(
-	"option:render:resolution",
-	"description",
-	"""
-	The resolution of the image to be rendered.
-	"""
-)
+	"option:render:camera" : [
 
-Gaffer.Metadata.registerValue( "option:render:resolutionMultiplier", "label", "Resolution Multiplier" )
-Gaffer.Metadata.registerValue( "option:render:resolutionMultiplier", "defaultValue", IECore.FloatData( 1.0 ) )
-Gaffer.Metadata.registerValue(
-	"option:render:resolutionMultiplier",
-	"description",
-	"""
-	Multiplies the resolution of the render by this amount.
-	"""
-)
+		"defaultValue", "",
+		"description",
+		"""
+		The primary camera to be used for rendering. If this
+		is not specified, then a default orthographic camera
+		positioned at the origin is used.
+		""",
+		"label", "Camera",
 
-Gaffer.Metadata.registerValue( "option:render:deformationBlur", "label", "Deformation Blur" )
-Gaffer.Metadata.registerValue( "option:render:deformationBlur", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"option:render:deformationBlur",
-	"description",
-	"""
-	Whether or not deformation motion is taken into
-	account in the rendered image. To specify the
-	number of deformation segments to use for each
-	object in the scene, use a StandardAttributes
-	node with appropriate filters.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:render:transformBlur", "label", "Transform Blur" )
-Gaffer.Metadata.registerValue( "option:render:transformBlur", "defaultValue", IECore.BoolData( False ) )
-Gaffer.Metadata.registerValue(
-	"option:render:transformBlur",
-	"description",
-	"""
-	Whether or not transform motion is taken into
-	account in the rendered image. To specify the
-	number of transform segments to use for each
-	object in the scene, use a StandardAttributes
-	node with appropriate filters.
-	"""
-)
+	"option:render:resolution" : [
 
-Gaffer.Metadata.registerValue( "option:render:shutter", "label", "Shutter" )
-Gaffer.Metadata.registerValue( "option:render:shutter", "defaultValue", IECore.V2fData( imath.V2f( -0.25, 0.25 ) ) )
-Gaffer.Metadata.registerValue(
-	"option:render:shutter",
-	"description",
-	"""
-	The interval over which the camera shutter is open. Measured
-	in frames, and specified relative to the frame being rendered.
-	"""
-)
+		"defaultValue", imath.V2i( 1024, 778 ),
+		"description",
+		"""
+		The resolution of the image to be rendered.
+		""",
+		"label", "Resolution",
 
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "label", "Renderer" )
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "defaultValue", "" )
-Gaffer.Metadata.registerValue(
-	"option:render:defaultRenderer",
-	"description",
-	"""
-	Specifies the default renderer to be used by the Render and
-	InteractiveRender nodes.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:render:inclusions", "label", "Inclusions" )
-Gaffer.Metadata.registerValue( "option:render:inclusions", "defaultValue", IECore.StringData( "/" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:inclusions",
-	"description",
-	"""
-	A set expression that limits the objects included in the render to only those matched
-	and their descendants. Objects not matched by the set expression will be pruned from
-	the scene. Cameras are included by default and do not need to be specified here.
-	"""
-)
+	"option:render:resolutionMultiplier" : [
 
-Gaffer.Metadata.registerValue( "option:render:exclusions", "label", "Exclusions" )
-Gaffer.Metadata.registerValue( "option:render:exclusions", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:exclusions",
-	"description",
-	"""
-	A set expression that excludes the matched objects from the render. Exclusions
-	affect both `inclusions` and `additionalLights` and cause the matching objects and
-	their descendants to be pruned from the scene.
-	"""
-)
+		"defaultValue", 1.0,
+		"description",
+		"""
+		Multiplies the resolution of the render by this amount.
+		""",
+		"label", "Resolution Multiplier",
 
-Gaffer.Metadata.registerValue( "option:render:additionalLights", "label", "Additional Lights" )
-Gaffer.Metadata.registerValue( "option:render:additionalLights", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:additionalLights",
-	"description",
-	"""
-	A set expression that specifies additional lights to be included in the render.
-	This differs from `inclusions` as only lights and light filters will be matched
-	by this set expression.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "label", "Camera Inclusions / Catchers" )
-Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "defaultValue", IECore.StringData( "/" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:cameraInclusions",
-	"description",
-	"""
-	A set expression that limits the objects visible to camera rays to only those matched
-	and their descendants. Camera visibility attributes authored in the scene take
-	precedence over this option.
+	"option:render:deformationBlur" : [
 
-	For shadow, reflection and reflectionAlpha pass types, this specifies objects that
-	catch shadows or reflections.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not deformation motion is taken into
+		account in the rendered image. To specify the
+		number of deformation segments to use for each
+		object in the scene, use a StandardAttributes
+		node with appropriate filters.
+		""",
+		"label", "Deformation Blur",
 
-Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "label", "Camera Exclusions / Casters" )
-Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:cameraExclusions",
-	"description",
-	"""
-	A set expression that excludes the matched objects and their descendants from camera
-	ray visibility. Camera visibility attributes authored in the scene take precedence
-	over this option.
+	],
 
-	Typically, this is used to exclude descendants of locations in `cameraInclusions`,
-	as locations not specified in `cameraInclusions` already default to being excluded
-	from camera ray visibility.
+	"option:render:transformBlur" : [
 
-	For shadow, reflection and reflectionAlpha pass types, this specifies objects that
-	cast shadows or reflections. Shadow or reflection visibility attributes authored
-	in the scene take precedence over this option.
-	"""
-)
+		"defaultValue", False,
+		"description",
+		"""
+		Whether or not transform motion is taken into
+		account in the rendered image. To specify the
+		number of transform segments to use for each
+		object in the scene, use a StandardAttributes
+		node with appropriate filters.
+		""",
+		"label", "Transform Blur",
 
-Gaffer.Metadata.registerValue( "option:render:matteInclusions", "label", "Matte Inclusions" )
-Gaffer.Metadata.registerValue( "option:render:matteInclusions", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:matteInclusions",
-	"description",
-	"""
-	A set expression that specifies objects that should be treated as matte (holdout)
-	objects along with their descendants. Matte attributes authored in the scene take
-	precedence over this option.
-	"""
-)
+	],
 
-Gaffer.Metadata.registerValue( "option:render:matteExclusions", "label", "Matte Exclusions" )
-Gaffer.Metadata.registerValue( "option:render:matteExclusions", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"option:render:matteExclusions",
-	"description",
-	"""
-	A set expression that excludes the matched objects and their descendants from being
-	treated as matte (holdout) objects. Matte attributes authored in the scene take
-	precedence over this option.
+	"option:render:shutter" : [
 
-	Typically, this is used to exclude descendants of locations in `matteInclusions`,
-	as locations not specified in `matteInclusions` already default to not being
-	treated as matte objects.
-	"""
-)
+		"defaultValue", imath.V2f( -0.25, 0.25 ),
+		"description",
+		"""
+		The interval over which the camera shutter is open. Measured
+		in frames, and specified relative to the frame being rendered.
+		""",
+		"label", "Shutter",
+
+	],
+
+	"option:render:defaultRenderer" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		Specifies the default renderer to be used by the Render and
+		InteractiveRender nodes.
+		""",
+		"label", "Renderer",
+
+	],
+
+	"option:render:inclusions" : [
+
+		"defaultValue", "/",
+		"description",
+		"""
+		A set expression that limits the objects included in the render to only those matched
+		and their descendants. Objects not matched by the set expression will be pruned from
+		the scene. Cameras are included by default and do not need to be specified here.
+		""",
+		"label", "Inclusions",
+
+	],
+
+	"option:render:exclusions" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		A set expression that excludes the matched objects from the render. Exclusions
+		affect both `inclusions` and `additionalLights` and cause the matching objects and
+		their descendants to be pruned from the scene.
+		""",
+		"label", "Exclusions",
+
+	],
+
+	"option:render:additionalLights" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		A set expression that specifies additional lights to be included in the render.
+		This differs from `inclusions` as only lights and light filters will be matched
+		by this set expression.
+		""",
+		"label", "Additional Lights",
+
+	],
+
+	"option:render:cameraInclusions" : [
+
+		"defaultValue", "/",
+		"description",
+		"""
+		A set expression that limits the objects visible to camera rays to only those matched
+		and their descendants. Camera visibility attributes authored in the scene take
+		precedence over this option.
+
+		For shadow, reflection and reflectionAlpha pass types, this specifies objects that
+		catch shadows or reflections.
+		""",
+		"label", "Camera Inclusions / Catchers",
+
+	],
+
+	"option:render:cameraExclusions" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		A set expression that excludes the matched objects and their descendants from camera
+		ray visibility. Camera visibility attributes authored in the scene take precedence
+		over this option.
+
+		Typically, this is used to exclude descendants of locations in `cameraInclusions`,
+		as locations not specified in `cameraInclusions` already default to being excluded
+		from camera ray visibility.
+
+		For shadow, reflection and reflectionAlpha pass types, this specifies objects that
+		cast shadows or reflections. Shadow or reflection visibility attributes authored
+		in the scene take precedence over this option.
+		""",
+		"label", "Camera Exclusions / Casters",
+
+	],
+
+	"option:render:matteInclusions" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		A set expression that specifies objects that should be treated as matte (holdout)
+		objects along with their descendants. Matte attributes authored in the scene take
+		precedence over this option.
+		""",
+		"label", "Matte Inclusions",
+
+	],
+
+	"option:render:matteExclusions" : [
+
+		"defaultValue", "",
+		"description",
+		"""
+		A set expression that excludes the matched objects and their descendants from being
+		treated as matte (holdout) objects. Matte attributes authored in the scene take
+		precedence over this option.
+
+		Typically, this is used to exclude descendants of locations in `matteInclusions`,
+		as locations not specified in `matteInclusions` already default to not being
+		treated as matte objects.
+		""",
+		"label", "Matte Exclusions",
+
+	],
+
+} )

--- a/startup/GafferScene/usdAttributes.py
+++ b/startup/GafferScene/usdAttributes.py
@@ -40,35 +40,41 @@ import Gaffer
 
 import pxr.Kind
 
-Gaffer.Metadata.registerValue( "attribute:usd:kind", "label", "Kind" )
-Gaffer.Metadata.registerValue( "attribute:usd:kind", "defaultValue", IECore.StringData( "" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:usd:kind",
-	"description",
-	"""
-	Specifies the kind of a location to be any
-	of the values from USD's kind registry. See
-	the USD documentation for more details.
+Gaffer.Metadata.registerValues( {
 
-	> Note : Gaffer doesn't assign any intrinsic
-	> meaning to USD's kind.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:usd:kind", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:usd:kind", "presetNames", IECore.StringVectorData( [ IECore.CamelCase.toSpaced( k ) for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ] ) )
-Gaffer.Metadata.registerValue( "attribute:usd:kind", "presetValues", IECore.StringVectorData( k for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ) )
+	"attribute:usd:kind" : [
 
-Gaffer.Metadata.registerValue( "attribute:usd:purpose", "label", "Purpose" )
-Gaffer.Metadata.registerValue( "attribute:usd:purpose", "defaultValue", IECore.StringData( "default" ) )
-Gaffer.Metadata.registerValue(
-	"attribute:usd:purpose",
-	"description",
-	"""
-	Specifies the purpose of a location to be
-	`default`, `render`, `proxy` or `guide`. See
-	the USD documentation for more details.
-	""",
-)
-Gaffer.Metadata.registerValue( "attribute:usd:purpose", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "attribute:usd:purpose", "presetNames", IECore.StringVectorData( [ "Default", "Render", "Proxy", "Guide" ] ) )
-Gaffer.Metadata.registerValue( "attribute:usd:purpose", "presetValues", IECore.StringVectorData( [ "default", "render", "proxy", "guide" ] ) )
+		"defaultValue", "",
+		"description",
+		"""
+		Specifies the kind of a location to be any
+		of the values from USD's kind registry. See
+		the USD documentation for more details.
+
+		> Note : Gaffer doesn't assign any intrinsic
+		> meaning to USD's kind.
+		""",
+		"label", "Kind",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ IECore.CamelCase.toSpaced( k ) for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ] ),
+		"presetValues", IECore.StringVectorData( k for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ),
+
+	],
+
+	"attribute:usd:purpose" : [
+
+		"defaultValue", "default",
+		"description",
+		"""
+		Specifies the purpose of a location to be
+		`default`, `render`, `proxy` or `guide`. See
+		the USD documentation for more details.
+		""",
+		"label", "Purpose",
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetNames", IECore.StringVectorData( [ "Default", "Render", "Proxy", "Guide" ] ),
+		"presetValues", IECore.StringVectorData( [ "default", "render", "proxy", "guide" ] ),
+
+	],
+
+} )

--- a/startup/GafferSceneUI/renderPassOptions.py
+++ b/startup/GafferSceneUI/renderPassOptions.py
@@ -37,11 +37,19 @@
 import Gaffer
 import GafferSceneUI
 
-Gaffer.Metadata.registerValue( "option:renderPass:type", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:renderPass:type", "presetsPlugValueWidget:allowCustom", True )
-Gaffer.Metadata.registerValue( "option:renderPass:type", "preset:Standard", "" )
-## \todo As part of the future great metadata reckoning, it would make more sense for renderPassTypePresetNames to be defined as
-# part of this global metadata rather than by GafferSceneUI.RenderPassTypeAdaptorUI and then called here. This would also allow
-# the registrations in this file to be combined with those in `startup/GafferScene/renderPassOptions.py`.
-Gaffer.Metadata.registerValue( "option:renderPass:type", "presetNames", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetNames )
-Gaffer.Metadata.registerValue( "option:renderPass:type", "presetValues", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetValues )
+Gaffer.Metadata.registerValues( {
+
+	"option:renderPass:type" : [
+
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"presetsPlugValueWidget:allowCustom", True,
+		"preset:Standard", "",
+		## \todo As part of the future great metadata reckoning, it would make more sense for renderPassTypePresetNames to be defined as
+		# part of this global metadata rather than by GafferSceneUI.RenderPassTypeAdaptorUI and then called here. This would also allow
+		# the registrations in this file to be combined with those in `startup/GafferScene/renderPassOptions.py`.
+		"presetNames", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetNames,
+		"presetValues", GafferSceneUI.RenderPassTypeAdaptorUI.renderPassTypePresetValues,
+
+	],
+
+} )

--- a/startup/GafferSceneUI/standardOptions.py
+++ b/startup/GafferSceneUI/standardOptions.py
@@ -37,31 +37,67 @@
 import Gaffer
 import GafferSceneUI
 
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "plugValueWidget:type", "GafferUI.PresetsPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "preset:None", "" )
-## \todo As part of the future great metadata reckoning, it would make more sense for rendererPresetNames to be defined as
-# part of this global metadata rather than by GafferSceneUI.RenderUI and then called here. This would also allow the registrations
-# in this file to be combined with those in `startup/GafferScene/standardOptions.py`.
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "presetNames", GafferSceneUI.RenderUI.rendererPresetNames )
-Gaffer.Metadata.registerValue( "option:render:defaultRenderer", "presetValues", GafferSceneUI.RenderUI.rendererPresetNames )
+Gaffer.Metadata.registerValues( {
 
-Gaffer.Metadata.registerValue( "option:render:inclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:inclusions", "ui:scene:acceptsSetExpression", True )
+	"option:render:defaultRenderer" : [
 
-Gaffer.Metadata.registerValue( "option:render:exclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:exclusions", "ui:scene:acceptsSetExpression", True )
+		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+		"preset:None", "",
+		## \todo As part of the future great metadata reckoning, it would make more sense for rendererPresetNames to be defined as
+		# part of this global metadata rather than by GafferSceneUI.RenderUI and then called here. This would also allow the registrations
+		# in this file to be combined with those in `startup/GafferScene/standardOptions.py`.
+		"presetNames", GafferSceneUI.RenderUI.rendererPresetNames,
+		"presetValues", GafferSceneUI.RenderUI.rendererPresetNames,
 
-Gaffer.Metadata.registerValue( "option:render:additionalLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:additionalLights", "ui:scene:acceptsSetExpression", True )
+	],
 
-Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:cameraInclusions", "ui:scene:acceptsSetExpression", True )
+	"option:render:inclusions" : [
 
-Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:cameraExclusions", "ui:scene:acceptsSetExpression", True )
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
 
-Gaffer.Metadata.registerValue( "option:render:matteInclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:matteInclusions", "ui:scene:acceptsSetExpression", True )
+	],
 
-Gaffer.Metadata.registerValue( "option:render:matteExclusions", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
-Gaffer.Metadata.registerValue( "option:render:matteExclusions", "ui:scene:acceptsSetExpression", True )
+	"option:render:exclusions" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"option:render:additionalLights" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"option:render:cameraInclusions" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"option:render:cameraExclusions" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"option:render:matteInclusions" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+	"option:render:matteExclusions" : [
+
+		"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+		"ui:scene:acceptsSetExpression", True,
+
+	],
+
+} )


### PR DESCRIPTION
In preparation for the Great Metadata Unification of 2025, this adds `Gaffer.Metadata.registerValues()` which can register multiple metadata entries from a dictionary of the form:

```
{
	"stringTarget" : [

		"key1", "value1",
		"key2", "value2",

	],

	"anotherStringTarget" : [

		...
```

This also adjusts our existing config files containing metadata registrations for options and attributes to use this new registration method, which improves their legibility and gives us a better starting point for any modifications required when we begin using them to populate the various Attributes and Options nodes...