### PR TITLE
DependencyNodeBinding : Support Python 3.11

### DIFF
--- a/include/GafferBindings/DependencyNodeBinding.inl
+++ b/include/GafferBindings/DependencyNodeBinding.inl
@@ -81,7 +81,7 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString )
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
 	// Install our custom metaclass.
-	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
+	Py_SET_TYPE( this->ptr(), Detail::dependencyNodeMetaclass() );
 }
 
 template<typename T, typename Ptr>
@@ -92,7 +92,7 @@ DependencyNodeClass<T, Ptr>::DependencyNodeClass( const char *docString, boost::
 	this->def( "enabledPlug", &Detail::enabledPlug<T> );
 	this->def( "correspondingInput", &Detail::correspondingInput<T> );
 	// Install our custom metaclass.
-	Py_TYPE( this->ptr() ) = Detail::dependencyNodeMetaclass();
+	Py_SET_TYPE( this->ptr(), Detail::dependencyNodeMetaclass() );
 }
 
 } // namespace GafferBindings

--- a/src/GafferBindings/DependencyNodeBinding.cpp
+++ b/src/GafferBindings/DependencyNodeBinding.cpp
@@ -74,7 +74,7 @@ PyTypeObject *GafferBindings::Detail::dependencyNodeMetaclass()
 		// because it has functionality critical to making the Boost bindings
 		// work. The only thing we're doing is adding `dependencyNodeMetaclassCall`
 		// as the implementation of the `__call__` method.
-		Py_TYPE( &g_dependencyNodeMetaclass ) = &PyType_Type;
+		Py_SET_TYPE( &g_dependencyNodeMetaclass, &PyType_Type );
 		g_dependencyNodeMetaclass.tp_name = "Gaffer.DependencyNodeMetaclass";
 		g_dependencyNodeMetaclass.tp_basicsize = PyType_Type.tp_basicsize,
 		g_dependencyNodeMetaclass.tp_base = boost::python::objects::class_metatype().get();


### PR DESCRIPTION
In Python 3.11 `Py_TYPE()` can no longer be used as an l-value. `Py_SET_TYPE()` was added in Python 3.9 and is the [suggested](https://docs.python.org/3.11/c-api/structures.html#c.Py_TYPE) approach.