### PR TITLE
Cycles, RenderMan : Support shadow linking

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ Fixes
 
 - RenderManLight : Fixed orientation of color maps on `PxrRectLight`.
 
+API
+---
+
+- TestCase : Added `assertEqualWithAbsError()` method.
+
 1.5.13.0 (relative to 1.5.12.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -9,7 +9,9 @@ Improvements
   - Added support for custom ONNX ops via the `GAFFERML_CUSTOM_OPS_LIBRARIES` environment variable. This should contain a comma-separated list of full paths to libraries containing custom ops.
   - Added support for string tensors.
 - Cycles : Added support for shadow linking.
-- RenderMan : Added support for USDLux lights.
+- RenderMan :
+  - Added support for shadow linking.
+  - Added support for USDLux lights.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - GafferML :
   - Added support for custom ONNX ops via the `GAFFERML_CUSTOM_OPS_LIBRARIES` environment variable. This should contain a comma-separated list of full paths to libraries containing custom ops.
   - Added support for string tensors.
+- Cycles : Added support for shadow linking.
 - RenderMan : Added support for USDLux lights.
 
 Fixes

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,7 @@
 Improvements
 ------------
 
-- StandardAttributes : Added `shadowedLights` attribute to specify shadow linking.
+- StandardAttributes : Added `shadowedLights` attribute to specify shadow linking. This supercedes the Arnold-specific `shadowGroup` attribute on the ArnoldAttributes node.
 - GafferML :
   - Added support for custom ONNX ops via the `GAFFERML_CUSTOM_OPS_LIBRARIES` environment variable. This should contain a comma-separated list of full paths to libraries containing custom ops.
   - Added support for string tensors.

--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- StandardAttributes : Added `shadowedLights` attribute to specify shadow linking.
 - GafferML :
   - Added support for custom ONNX ops via the `GAFFERML_CUSTOM_OPS_LIBRARIES` environment variable. This should contain a comma-separated list of full paths to libraries containing custom ops.
   - Added support for string tensors.

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -169,7 +169,7 @@ class GAFFERSCENE_API LightLinks : boost::noncopyable
 
 	public :
 
-		LightLinks();
+		LightLinks( const IECoreScenePreview::Renderer *renderer );
 
 		/// Registration functions
 		/// ======================
@@ -231,6 +231,10 @@ class GAFFERSCENE_API LightLinks : boost::noncopyable
 		IECoreScenePreview::Renderer::ConstObjectSetPtr linkedLights( const std::string &linkedLightsExpression, const ScenePlug *scene ) const;
 		void outputLightFilterLinks( const std::string &lightName, IECoreScenePreview::Renderer::ObjectInterface *light ) const;
 		void clearLightLinks();
+
+		/// \todo Remove. This just provides temporary backwards compatibility for
+		/// Arnold.
+		const IECore::InternedString *m_shadowedLightsFallbackAttributeName;
 
 		/// Storage for lights. This maps from the light name to the light itself.
 		using LightMap = tbb::concurrent_hash_map<std::string, IECoreScenePreview::Renderer::ObjectInterfacePtr>;

--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -1640,5 +1640,26 @@ class ArnoldRenderTest( GafferSceneTest.RenderTest ) :
 		light.loadShader( "point_light" )
 		return light, light["parameters"]["color"]
 
+	def _createDistantLight( self ) :
+
+		light = GafferArnold.ArnoldLight()
+		light.loadShader( "distant_light" )
+		return light, light["parameters"]["color"]
+
+	def _cameraVisibilityAttribute( self ) :
+
+		return "ai:visibility:camera"
+
+	def _createOptions( self ) :
+
+		# Stop unwanted bounce light throwing off the shadow linking test
+
+		options = GafferArnold.ArnoldOptions()
+
+		options["options"]["giTotalDepth"]["enabled"].setValue( True )
+		options["options"]["giTotalDepth"]["value"].setValue( 0 )
+
+		return options
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferArnoldUI/ArnoldAttributesUI.py
+++ b/python/GafferArnoldUI/ArnoldAttributesUI.py
@@ -249,9 +249,9 @@ Gaffer.Metadata.registerNode(
 			"description",
 			"""
 			The lights that cause this object to cast shadows.
-			Accepts a set expression or a space separated list of
-			lights. Use \"defaultLights\" to refer to all lights that
-			contribute to illumination by default.
+
+			> Caution : This attribute has been superceded and will be removed. Use
+			> StandardAttributes to set the `shadowedLights` attribute instead.
 			""",
 
 			"layout:section", "Visibility",

--- a/python/GafferCyclesTest/CyclesRenderTest.py
+++ b/python/GafferCyclesTest/CyclesRenderTest.py
@@ -55,5 +55,30 @@ class CyclesRenderTest( GafferSceneTest.RenderTest ) :
 		light.loadShader( "point_light" )
 		return light, light["parameters"]["color"]
 
+	def _createDistantLight( self ) :
+
+		light = GafferCycles.CyclesLight()
+		light.loadShader( "distant_light" )
+		return light, light["parameters"]["color"]
+
+	def _cameraVisibilityAttribute( self ) :
+
+		return "cycles:visibility:camera"
+
+	def _createOptions( self ) :
+
+		# Options that speed up the render, which can otherwise take
+		# longer than we might want.
+
+		options = GafferCycles.CyclesOptions()
+
+		options["options"]["maxBounce"]["enabled"].setValue( True )
+		options["options"]["maxBounce"]["value"].setValue( 0 )
+
+		options["options"]["samples"]["enabled"].setValue( True )
+		options["options"]["samples"]["value"].setValue( 8 )
+
+		return options
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -1102,11 +1102,7 @@ class RendererTest( GafferTest.TestCase ) :
 				expectedColor = imath.Color4f( expectedColor, expectedColor, expectedColor, 1 )
 
 			color = self.__colorAtUV( image, uv )
-			if maxDifference :
-				for i in range( 0, 4 ) :
-					self.assertAlmostEqual( color[i], expectedColor[i], delta = maxDifference )
-			else :
-				self.assertEqual( color, expectedColor )
+			self.assertEqualWithAbsError( color, expectedColor, maxDifference )
 
 	def testMeshPrimitiveVariableInterpolation( self ) :
 

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -48,5 +48,10 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "No shadow linking support just yet" )
+	def testShadowLinking( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/InteractiveDelightRenderTest.py
+++ b/python/GafferDelightTest/InteractiveDelightRenderTest.py
@@ -64,6 +64,12 @@ class InteractiveDelightRenderTest( GafferSceneTest.InteractiveRenderTest ) :
 
 		pass
 
+
+	@unittest.skip( "No shadow linking support just yet" )
+	def testShadowLinking( self ) :
+
+		pass
+
 	@unittest.skip( "Need to be able to close old driver _after_ opening new one" )
 	def testEditCropWindow( self ) :
 

--- a/python/GafferImageTest/MergeTest.py
+++ b/python/GafferImageTest/MergeTest.py
@@ -375,27 +375,24 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 
 		self.longMessage = True
 		for operation, expected in [
-			( GafferImage.Merge.Operation.Add, ( 1.1, 0.5, 0.4, 0.6 ) ),
-			( GafferImage.Merge.Operation.Atop, ( 0.48, 0.28, 0.28, 0.4 ) ),
-			( GafferImage.Merge.Operation.Divide, ( 10, 1.5, 1/3.0, 0.5 ) ),
-			( GafferImage.Merge.Operation.In, ( 0.4, 0.12, 0.04, 0.08 ) ),
-			( GafferImage.Merge.Operation.Out, ( 0.6, 0.18, 0.06, 0.12 ) ),
-			( GafferImage.Merge.Operation.Mask, ( 0.02, 0.04, 0.06, 0.08 ) ),
-			( GafferImage.Merge.Operation.Matte, ( 0.28, 0.22, 0.26, 0.36 ) ),
-			( GafferImage.Merge.Operation.Multiply, ( 0.1, 0.06, 0.03, 0.08 ) ),
-			( GafferImage.Merge.Operation.Over, ( 1.08, 0.46, 0.34, 0.52 ) ),
-			( GafferImage.Merge.Operation.Subtract, ( 0.9, 0.1, -0.2, -0.2 ) ),
-			( GafferImage.Merge.Operation.Difference, ( 0.9, 0.1, 0.2, 0.2 ) ),
-			( GafferImage.Merge.Operation.Under, ( 0.7, 0.38, 0.36, 0.52 ) ),
-			( GafferImage.Merge.Operation.Min, ( 0.1, 0.2, 0.1, 0.2 ) ),
-			( GafferImage.Merge.Operation.Max, ( 1, 0.3, 0.3, 0.4 ) )
+			( GafferImage.Merge.Operation.Add, imath.Color4f( 1.1, 0.5, 0.4, 0.6 ) ),
+			( GafferImage.Merge.Operation.Atop, imath.Color4f( 0.48, 0.28, 0.28, 0.4 ) ),
+			( GafferImage.Merge.Operation.Divide, imath.Color4f( 10, 1.5, 1/3.0, 0.5 ) ),
+			( GafferImage.Merge.Operation.In, imath.Color4f( 0.4, 0.12, 0.04, 0.08 ) ),
+			( GafferImage.Merge.Operation.Out, imath.Color4f( 0.6, 0.18, 0.06, 0.12 ) ),
+			( GafferImage.Merge.Operation.Mask, imath.Color4f( 0.02, 0.04, 0.06, 0.08 ) ),
+			( GafferImage.Merge.Operation.Matte, imath.Color4f( 0.28, 0.22, 0.26, 0.36 ) ),
+			( GafferImage.Merge.Operation.Multiply, imath.Color4f( 0.1, 0.06, 0.03, 0.08 ) ),
+			( GafferImage.Merge.Operation.Over, imath.Color4f( 1.08, 0.46, 0.34, 0.52 ) ),
+			( GafferImage.Merge.Operation.Subtract, imath.Color4f( 0.9, 0.1, -0.2, -0.2 ) ),
+			( GafferImage.Merge.Operation.Difference, imath.Color4f( 0.9, 0.1, 0.2, 0.2 ) ),
+			( GafferImage.Merge.Operation.Under, imath.Color4f( 0.7, 0.38, 0.36, 0.52 ) ),
+			( GafferImage.Merge.Operation.Min, imath.Color4f( 0.1, 0.2, 0.1, 0.2 ) ),
+			( GafferImage.Merge.Operation.Max, imath.Color4f( 1, 0.3, 0.3, 0.4 ) )
 		] :
 
 			merge["operation"].setValue( operation )
-			self.assertAlmostEqual( sampler["color"]["r"].getValue(), expected[0], msg=operation )
-			self.assertAlmostEqual( sampler["color"]["g"].getValue(), expected[1], msg=operation )
-			self.assertAlmostEqual( sampler["color"]["b"].getValue(), expected[2], msg=operation )
-			self.assertAlmostEqual( sampler["color"]["a"].getValue(), expected[3], msg=operation )
+			self.assertEqualWithAbsError( sampler["color"].getValue(), expected, error = 1e6, message = operation )
 
 	def testDifferenceExceptionalValues( self ) :
 
@@ -482,10 +479,7 @@ class MergeTest( GafferImageTest.ImageTestCase ) :
 		sampler["image"].setInput( merge["out"] )
 		sampler["pixel"].setValue( imath.V2f( 10 ) )
 
-		self.assertAlmostEqual( sampler["color"]["r"].getValue(), 0.0 + 1.0 )
-		self.assertAlmostEqual( sampler["color"]["g"].getValue(), 0.2 + 0.0 )
-		self.assertAlmostEqual( sampler["color"]["b"].getValue(), 0.3 + 0.1 )
-		self.assertAlmostEqual( sampler["color"]["a"].getValue(), 0.4 + 0.2 )
+		self.assertEqualWithAbsError( sampler["color"].getValue(), imath.Color4f( 0.0 + 1.0, 0.2 + 0.0, 0.3 + 0.1, 0.4 + 0.2 ), 1e6 )
 
 	def testNonFlatThrows( self ) :
 

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -121,6 +121,16 @@ class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 
 		return light, light["parameters"]["lightColor"]
 
+	def _createDistantLight( self ) :
+
+		light = GafferRenderMan.RenderManLight()
+		light.loadShader( "PxrDistantLight" )
+		return light, light["parameters"]["lightColor"]
+
+	def _cameraVisibilityAttribute( self ) :
+
+		return "ri:visibility:camera"
+
 	def __colorAtUV( self, image, uv ) :
 
 		dimensions = image.dataWindow.size() + imath.V2i( 1 )

--- a/python/GafferSceneTest/CapsuleTest.py
+++ b/python/GafferSceneTest/CapsuleTest.py
@@ -103,7 +103,9 @@ class CapsuleTest( GafferSceneTest.SceneTestCase ) :
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 		)
 		GafferScene.Private.RendererAlgo.outputObjects(
-			encapsulate["out"], GafferScene.Private.RendererAlgo.RenderOptions( encapsulate["out"] ), GafferScene.Private.RendererAlgo.RenderSets( encapsulate["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+			encapsulate["out"], GafferScene.Private.RendererAlgo.RenderOptions( encapsulate["out"] ),
+			GafferScene.Private.RendererAlgo.RenderSets( encapsulate["out"] ),
+			GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 			renderer
 		)
 

--- a/python/GafferSceneTest/MeshTangentsTest.py
+++ b/python/GafferSceneTest/MeshTangentsTest.py
@@ -108,10 +108,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 1, 0, 0 ), 0.000001 )
 
 		for v in vTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 0, 1, 0 ), 0.000001 )
 
 	def testModeFirstEdge( self ) :
 
@@ -136,10 +136,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( biTangent.data ), 3 )
 
 		for v, v1 in zip( tangent.data, [ imath.V3f( 1, 0, 0 ), imath.V3f( -1, 0, 0 ), imath.V3f( 1, -1, 0 ).normalized() ] ) :
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 		for v, v1 in zip( biTangent.data, [ imath.V3f( 0, -1, 0 ), imath.V3f( 0, 1, 0 ), imath.V3f( -1, -1, 0 ).normalized() ] ) :
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 	def testModeTwoEdges( self ) :
 
@@ -164,10 +164,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( biTangent.data ), 3 )
 
 		for v, v1 in zip( tangent.data, [x.normalized() for x in [ imath.V3f( 1, 1, 0 ), imath.V3f( -2, 1, 0 ), imath.V3f( 1, -2, 0 ) ] ] ):
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 		for v, v1 in zip( tangent.data, [x.normalized() for x in [ imath.V3f( 1, 1, 0 ), imath.V3f( -2, 1, 0 ), imath.V3f( 1, -2, 0 ) ] ] ):
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 	def testModeCentroid( self ) :
 
@@ -192,11 +192,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( biTangent.data ), 3 )
 
 		for v, v1 in zip( tangent.data, [x.normalized() for x in [ imath.V3f( 1, 1, 0 ), imath.V3f( -2, 1, 0 ), imath.V3f( 1, -2, 0 ) ] ] ):
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 		for v, v1 in zip( tangent.data, [x.normalized() for x in [ imath.V3f( 1, 1, 0 ), imath.V3f( -2, 1, 0 ), imath.V3f( 1, -2, 0 ) ] ] ):
-			self.assertTrue( v.equalWithAbsError( v1, 0.000001 ) )
-
+			self.assertEqualWithAbsError( v, v1, 0.000001 )
 
 	def testCanRenameOutputTangents( self ) :
 
@@ -221,10 +220,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 1, 0, 0 ), 0.000001 )
 
 		for v in vTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 0, 1, 0 ), 0.000001 )
 
 	def testCanUseSecondUVSet( self ) :
 
@@ -249,12 +248,12 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 0, 1, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 0, 1, 0 ), 0.000001 )
 
 		# really I'd expect the naive answer to the vTangent to be IECore.V3f( 1, 0, 0 )
 		# but the code forces the triple of n, uT, vT to flip the direction of vT if we don't have a correctly handed set of basis vectors
 		for v in vTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( -1, 0, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( -1, 0, 0 ), 0.000001 )
 
 	def testCanUsePref( self ) :
 
@@ -279,11 +278,10 @@ class MeshTangentsTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( len( vTangent.data ), 3 )
 
 		for v in uTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 0, -1, 0 ), 0.000001 ) )
+			self.assertEqualWithAbsError( v, imath.V3f( 0, -1, 0 ), 0.000001 )
 
 		for v in vTangent.data :
-			self.assertTrue( v.equalWithAbsError( imath.V3f( 1, 0, 0 ), 0.000001 ) )
-
+			self.assertEqualWithAbsError( v, imath.V3f( 1, 0, 0 ), 0.000001 )
 
 	def testHandedness( self ) :
 

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -114,5 +114,10 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "Shadow linking not supported" )
+	def testShadowLinking( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/RenderAdaptorTest.py
+++ b/python/GafferSceneTest/RenderAdaptorTest.py
@@ -480,7 +480,9 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				testAdaptors["out"], GafferScene.Private.RendererAlgo.RenderOptions( testAdaptors["out"] ), GafferScene.Private.RendererAlgo.RenderSets( testAdaptors["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+				testAdaptors["out"], GafferScene.Private.RendererAlgo.RenderOptions( testAdaptors["out"] ),
+				GafferScene.Private.RendererAlgo.RenderSets( testAdaptors["out"] ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 
@@ -618,7 +620,9 @@ class RenderAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				testAdaptors["out"], GafferScene.Private.RendererAlgo.RenderOptions( testAdaptors["out"] ), GafferScene.Private.RendererAlgo.RenderSets( testAdaptors["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+				testAdaptors["out"], GafferScene.Private.RendererAlgo.RenderOptions( testAdaptors["out"] ),
+				GafferScene.Private.RendererAlgo.RenderSets( testAdaptors["out"] ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 

--- a/python/GafferSceneTest/RenderPassTypeAdaptorTest.py
+++ b/python/GafferSceneTest/RenderPassTypeAdaptorTest.py
@@ -281,7 +281,9 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ), GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ),
+				GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 
@@ -500,7 +502,9 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ), GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ),
+				GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 
@@ -762,7 +766,9 @@ class RenderPassTypeAdaptorTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ), GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+				processor["out"], GafferScene.Private.RendererAlgo.RenderOptions( processor["out"] ),
+				GafferScene.Private.RendererAlgo.RenderSets( processor["out"] ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 

--- a/python/GafferSceneTest/RendererAlgoTest.py
+++ b/python/GafferSceneTest/RendererAlgoTest.py
@@ -320,13 +320,14 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		# Output the lights to the renderer
 
-		renderOptions = GafferScene.Private.RendererAlgo.RenderOptions( soloSet["out"] )
-		renderSets = GafferScene.Private.RendererAlgo.RenderSets( soloSet["out"] )
-		lightLinks = GafferScene.Private.RendererAlgo.LightLinks()
-
 		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer(
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 		)
+
+		renderOptions = GafferScene.Private.RendererAlgo.RenderOptions( soloSet["out"] )
+		renderSets = GafferScene.Private.RendererAlgo.RenderSets( soloSet["out"] )
+		lightLinks = GafferScene.Private.RendererAlgo.LightLinks( renderer )
+
 		GafferScene.Private.RendererAlgo.outputLights( soloSet["out"], renderOptions, renderSets, lightLinks, renderer )
 
 		# Check that the output is correct
@@ -451,13 +452,14 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 
 		# Output the lights to the renderer
 
-		renderOptions = GafferScene.Private.RendererAlgo.RenderOptions( muteAttributes["out"] )
-		renderSets = GafferScene.Private.RendererAlgo.RenderSets( muteAttributes["out"] )
-		lightLinks = GafferScene.Private.RendererAlgo.LightLinks()
-
 		renderer = GafferScene.Private.IECoreScenePreview.CapturingRenderer(
 			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 		)
+
+		renderOptions = GafferScene.Private.RendererAlgo.RenderOptions( muteAttributes["out"] )
+		renderSets = GafferScene.Private.RendererAlgo.RenderSets( muteAttributes["out"] )
+		lightLinks = GafferScene.Private.RendererAlgo.LightLinks( renderer )
+
 		GafferScene.Private.RendererAlgo.outputLights( muteAttributes["out"], renderOptions, renderSets, lightLinks, renderer )
 
 		# Check that the output is correct
@@ -654,7 +656,8 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
-				group["out"], renderOptions, GafferScene.Private.RendererAlgo.RenderSets( scene ), GafferScene.Private.RendererAlgo.LightLinks(),
+				group["out"], renderOptions, GafferScene.Private.RendererAlgo.RenderSets( scene ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 
@@ -798,7 +801,8 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 			)
 			GafferScene.Private.RendererAlgo.outputObjects(
 				scene, GafferScene.Private.RendererAlgo.RenderOptions( scene ),
-				GafferScene.Private.RendererAlgo.RenderSets( scene ), GafferScene.Private.RendererAlgo.LightLinks(),
+				GafferScene.Private.RendererAlgo.RenderSets( scene ),
+				GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 				renderer
 			)
 
@@ -902,7 +906,8 @@ class RendererAlgoTest( GafferSceneTest.SceneTestCase ) :
 				)
 				GafferScene.Private.RendererAlgo.outputObjects(
 					standardOptions["out"], GafferScene.Private.RendererAlgo.RenderOptions( standardOptions["out"] ),
-					GafferScene.Private.RendererAlgo.RenderSets( standardOptions["out"] ), GafferScene.Private.RendererAlgo.LightLinks(),
+					GafferScene.Private.RendererAlgo.RenderSets( standardOptions["out"] ),
+					GafferScene.Private.RendererAlgo.LightLinks( renderer ),
 					renderer
 				)
 

--- a/python/GafferSceneUI/StandardAttributesUI.py
+++ b/python/GafferSceneUI/StandardAttributesUI.py
@@ -239,6 +239,26 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"attributes.shadowedLights" : [
+
+			"description",
+			"""
+			The lights that cast shadows from this object. Accepts a set
+			expression or a space separated list of lights.
+			""",
+
+			"layout:section", "Light Linking",
+			"label", "Shadowed Lights",
+
+		],
+
+		"attributes.shadowedLights.value" : [
+
+			"ui:scene:acceptsSetExpression", True,
+			"plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget",
+
+		],
+
 		"attributes.filteredLights" : [
 
 			"description",

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -227,7 +227,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertEqualWithAbsError( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 1 ), error = 0.01 )
+		self.assertEqualWithAbsError( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 1 ), error = 0.01 )
 
 		renderer.option(
 			"ri:integrator",
@@ -249,7 +249,7 @@ class RendererTest( GafferTest.TestCase ) :
 		time.sleep( 1 )
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "myLovelySphere" )
-		self.__assertEqualWithAbsError( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0, 0.514107, 0, 1 ), error = 0.01 )
+		self.assertEqualWithAbsError( self.__colorAtUV( image, imath.V2i( 0.5 ) ), imath.Color4f( 0, 0.514107, 0, 1 ), error = 0.01 )
 
 		del object
 		del renderer
@@ -1561,7 +1561,7 @@ class RendererTest( GafferTest.TestCase ) :
 		# No light filter yet. Sphere should appear white.
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
 
 		# Add a green light filter. Sphere should appear green.
 
@@ -1589,7 +1589,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 1, 0 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 1, 0 ), 0.1 )
 
 		# Edit light filter tint. Sphere should update.
 
@@ -1600,7 +1600,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 0, 1 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 0, 1 ), 0.1 )
 
 		# Edit light, and make sure filter is still applied.
 
@@ -1610,7 +1610,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 0, 2 ), 0.2 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0, 0, 2 ), 0.2 )
 
 		# Remove light filter and check render is unfiltered.
 
@@ -1621,7 +1621,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 2 ), 0.2 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 2 ), 0.2 )
 
 		# Remove light and check render is black.
 
@@ -1632,7 +1632,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
 
 		# Clean up.
 
@@ -1716,8 +1716,8 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.68, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.68, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
 
 		# Move rod to right hand side of plane, and check expected result.
 
@@ -1727,8 +1727,8 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.68, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 1 ), 0.1 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.68, 0.5 ) ), imath.Color3f( 0 ), 0.1 )
 
 		# Clean up.
 
@@ -1820,7 +1820,7 @@ class RendererTest( GafferTest.TestCase ) :
 		# `0.5 * 0.5 == 0.25`
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.25 ), 0.05 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.25 ), 0.05 )
 
 		# `min( 0.75, 0.5 ) == 0.5`
 
@@ -1832,7 +1832,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.5 ), 0.05 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.5 ), 0.05 )
 
 		# The results from different groups are multiplied together
 		# so this is also `0.5 * 0.5 == 0.25`.
@@ -1845,7 +1845,7 @@ class RendererTest( GafferTest.TestCase ) :
 		renderer.pause()
 
 		image = IECoreImage.ImageDisplayDriver.storedImage( "lightFilterTest" )
-		self.__assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.25 ), 0.05 )
+		self.assertEqualWithAbsError( self.__color3AtUV( image, imath.V2f( 0.5, 0.5 ) ), imath.Color3f( 0.25 ), 0.05 )
 
 		# Clean up.
 
@@ -2162,20 +2162,6 @@ class RendererTest( GafferTest.TestCase ) :
 
 		c = self.__colorAtUV( image, uv )
 		return imath.Color3f( c.r, c.g, c.b )
-
-	def __assertEqualWithAbsError( self, x, y, error ) :
-
-		if isinstance( x, imath.Color4f ) :
-			equal = True
-			for i in range( 0, 4 ) :
-				equal = equal and math.fabs( x[i] - y[i] ) <= error
-		else :
-			equal = x.equalWithAbsError( y, error )
-
-		if not equal :
-			raise self.failureException(
-				f"{x} != {y} with error of {error}"
-			)
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/Render.cpp
+++ b/src/GafferScene/Render.cpp
@@ -372,7 +372,7 @@ void Render::executeInternal( bool flushCaches ) const
 		// Using nested scope so that we free the memory used by `renderSets`
 		// and `lightLinks` before we call `render()`.
 		GafferScene::Private::RendererAlgo::RenderSets renderSets( adaptedInPlug() );
-		GafferScene::Private::RendererAlgo::LightLinks lightLinks;
+		GafferScene::Private::RendererAlgo::LightLinks lightLinks( renderer.get() );
 
 		if( renderer->name().string() == "RenderMan" )
 		{

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1358,7 +1358,7 @@ RenderController::RenderController( const ConstScenePlugPtr &scene, const Gaffer
 	{
 		// We avoid light linking overhead for the GL renderer,
 		// because we know it doesn't support it.
-		m_lightLinks = std::make_unique<LightLinks>();
+		m_lightLinks = std::make_unique<LightLinks>( m_renderer.get() );
 	}
 
 	setScene( scene );

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -835,9 +835,11 @@ namespace
 IECore::InternedString g_linkedLightsAttributeName( "linkedLights" );
 IECore::InternedString g_filteredLightsAttributeName( "filteredLights" );
 IECore::InternedString g_defaultLightsSetName( "defaultLights" );
+IECore::InternedString g_shadowedLightsAttributeName( "shadowedLights" );
 IECore::InternedString g_shadowGroupAttributeName( "ai:visibility:shadow_group" );
 IECore::InternedString g_lights( "lights" );
 IECore::InternedString g_lightFilters( "lightFilters" );
+const std::string g_shadowedLightsDefaultValue( "__lights" );
 
 } // namespace
 
@@ -850,8 +852,9 @@ namespace Private
 namespace RendererAlgo
 {
 
-LightLinks::LightLinks()
-	:	m_lightLinksDirty( true ), m_lightFilterLinksDirty( true )
+LightLinks::LightLinks( const IECoreScenePreview::Renderer *renderer )
+	:	m_shadowedLightsFallbackAttributeName( renderer->name() == "Arnold" ? &g_shadowGroupAttributeName : nullptr ),
+		m_lightLinksDirty( true ), m_lightFilterLinksDirty( true )
 {
 }
 
@@ -1012,18 +1015,19 @@ std::string LightLinks::filteredLightsExpression( const IECore::CompoundObject *
 void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::CompoundObject *attributes, IECoreScenePreview::Renderer::ObjectInterface *object, IECore::MurmurHash *hash ) const
 {
 	const StringData *linkedLightsExpressionData = attributes->member<StringData>( g_linkedLightsAttributeName );
-	/// This is Arnold-specific. We could consider making it a standard,
-	/// or if we find we need to support other renderer-specific attributes, we
-	/// could add a mechanism for registering them.
-	const StringData *linkedShadowsExpressionData = attributes->member<StringData>( g_shadowGroupAttributeName );
+	const StringData *shadowedLightsExpressionData = attributes->member<StringData>( g_shadowedLightsAttributeName );
+	if( !shadowedLightsExpressionData && m_shadowedLightsFallbackAttributeName )
+	{
+		shadowedLightsExpressionData = attributes->member<StringData>( *m_shadowedLightsFallbackAttributeName );
+	}
 	const std::string linkedLightsExpression = linkedLightsExpressionData ? linkedLightsExpressionData->readable() : "defaultLights";
-	const std::string linkedShadowsExpression = linkedShadowsExpressionData ? linkedShadowsExpressionData->readable() : "__lights";
+	const std::string &shadowedLightsExpression = shadowedLightsExpressionData ? shadowedLightsExpressionData->readable() : g_shadowedLightsDefaultValue;
 
 	if( hash )
 	{
 		IECore::MurmurHash h;
 		h.append( linkedLightsExpression );
-		h.append( linkedShadowsExpression );
+		h.append( shadowedLightsExpression );
 		if( !m_lightLinksDirty && *hash == h )
 		{
 			// We're only being called because the attributes have changed as a whole, but the
@@ -1038,8 +1042,8 @@ void LightLinks::outputLightLinks( const ScenePlug *scene, const IECore::Compoun
 
 	IECoreScenePreview::Renderer::ConstObjectSetPtr objectSet = linkedLights( linkedLightsExpression, scene );
 	object->link( g_lights, objectSet );
-	objectSet = linkedLights( linkedShadowsExpression, scene );
-	object->link( g_shadowGroupAttributeName, objectSet );
+	objectSet = linkedLights( shadowedLightsExpression, scene );
+	object->link( g_shadowedLightsAttributeName, objectSet );
 }
 
 IECoreScenePreview::Renderer::ConstObjectSetPtr LightLinks::linkedLights( const std::string &linkedLightsExpression, const ScenePlug *scene ) const

--- a/src/GafferScene/StandardAttributes.cpp
+++ b/src/GafferScene/StandardAttributes.cpp
@@ -67,6 +67,7 @@ StandardAttributes::StandardAttributes( const std::string &name )
 
 	/// \todo The default value is wrong - it should be "defaultLights".
 	attributes->addChild( new Gaffer::NameValuePlug( "linkedLights", new IECore::StringData( "" ), false, "linkedLights" ) );
+	attributes->addChild( new Gaffer::NameValuePlug( "shadowedLights", new IECore::StringData( "__lights" ), false, "shadowedLights" ) );
 
 	// light filter linking
 

--- a/src/GafferSceneModule/RenderBinding.cpp
+++ b/src/GafferSceneModule/RenderBinding.cpp
@@ -227,8 +227,8 @@ void GafferSceneModule::bindRender()
 			class_<GafferScene::Private::RendererAlgo::RenderSets, boost::noncopyable>( "RenderSets" )
 				.def( init<const ScenePlug *>() )
 			;
-			class_<GafferScene::Private::RendererAlgo::LightLinks, boost::noncopyable>( "LightLinks" )
-				.def( init<>() )
+			class_<GafferScene::Private::RendererAlgo::LightLinks, boost::noncopyable>( "LightLinks", no_init )
+				.def( init<const IECoreScenePreview::Renderer *>() )
 			;
 
 			def( "outputCameras", &outputCamerasWrapper );

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -947,6 +947,7 @@ IECore::InternedString g_automaticInstancingAttributeName( "gaffer:automaticInst
 IECore::InternedString g_muteLightAttributeName( "light:mute" );
 
 IECore::InternedString g_cameraVisibilityAttributeName( "ai:visibility:camera" );
+IECore::InternedString g_shadowedLights( "shadowedLights" );
 IECore::InternedString g_shadowVisibilityAttributeName( "ai:visibility:shadow" );
 IECore::InternedString g_shadowGroup( "ai:visibility:shadow_group" );
 IECore::InternedString g_diffuseReflectVisibilityAttributeName( "ai:visibility:diffuse_reflect" );
@@ -2919,7 +2920,7 @@ class ArnoldObject : public ArnoldObjectBase
 				groupParameterName = g_lightGroupArnoldString;
 				useParameterName = g_useLightGroupArnoldString;
 			}
-			else if( type == g_shadowGroup )
+			else if( type == g_shadowedLights || type == g_shadowGroup ) /// \todo Remove backwards compatibility for `g_shadowGroup`.
 			{
 				groupParameterName = g_shadowGroupArnoldString;
 				useParameterName = g_useShadowGroupArnoldString;

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -69,8 +69,6 @@ M44f correctiveTransform( const IECoreScene::Shader *lightShader )
 	}
 }
 
-const IECore::InternedString g_lightFilters( "lightFilters" );
-
 M44f preTransform( const Attributes *attributes )
 {
 	if( !attributes->lightShader() )
@@ -88,12 +86,15 @@ M44f preTransform( const Attributes *attributes )
 	return IECoreRenderMan::ShaderNetworkAlgo::usdLightTransform( lightShader ) * correctiveTransform( lightShader );
 }
 
+const IECore::InternedString g_lightFilters( "lightFilters" );
+const RtUString g_defaultShadowGroup( "defaultShadowGroup" );
+
 } // namespace
 
 Light::Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, MaterialCache *materialCache, LightLinker *lightLinker, Session *session )
 	:	m_materialCache( materialCache ), m_session( session ), m_lightLinker( lightLinker ),
 		m_lightInstance( riley::LightInstanceId::InvalidId() ), m_preTransform( preTransform( attributes ) ),
-		m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
+		m_attributes( attributes ), m_geometryPrototype( geometryPrototype ), m_shadowSubset( g_defaultShadowGroup )
 
 {
 	updateLightShader( attributes );
@@ -324,7 +325,7 @@ void Light::updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &l
 	);
 }
 
-void Light::updateGroupingMemberships( RtUString memberships )
+void Light::updateLinking( RtUString memberships, RtUString shadowSubset )
 {
 	m_extraAttributes.SetString( Rix::k_grouping_membership, memberships );
 
@@ -340,10 +341,18 @@ void Light::updateGroupingMemberships( RtUString memberships )
 	}
 	allAttributes.Update( m_extraAttributes );
 
+	const riley::LightShaderId *newLightShader = nullptr;
+	if( m_shadowSubset != shadowSubset )
+	{
+		m_shadowSubset = shadowSubset;
+		updateLightShader( m_attributes.get() );
+		newLightShader = &m_lightShader->id();
+	}
+
 	const riley::LightInstanceResult result = m_session->modifyLightInstance(
 		m_lightInstance,
 		/* material = */ nullptr,
-		/* light shader = */ nullptr,
+		newLightShader,
 		/* coordinateSystems = */ nullptr,
 		/* xform = */ nullptr,
 		&allAttributes
@@ -359,7 +368,7 @@ void Light::updateLightShader( const Attributes *attributes )
 {
 	if( attributes->lightShader() )
 	{
-		m_lightShader = m_materialCache->getLightShader( attributes->lightShader(), m_lightFilterShader.get() );
+		m_lightShader = m_materialCache->getLightShader( attributes->lightShader(), m_lightFilterShader.get(), m_shadowSubset );
 	}
 	else
 	{

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -70,7 +70,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		// =============================
 
 		void updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &lightFilterShader );
-		void updateGroupingMemberships( RtUString memberships );
+		void updateLinking( RtUString memberships, RtUString shadowSubset );
 
 	private :
 
@@ -89,6 +89,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		RtParamList m_extraAttributes;
 		IECoreScene::ConstShaderNetworkPtr m_lightFilterShader;
 		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedFilters;
+		RtUString m_shadowSubset;
 
 };
 

--- a/src/IECoreRenderMan/LightLinker.h
+++ b/src/IECoreRenderMan/LightLinker.h
@@ -61,6 +61,8 @@ class LightLinker
 
 	public :
 
+		LightLinker();
+
 		// Interface used by Light, LightFilter and ObjectInterface
 		// ========================================================
 		//
@@ -72,9 +74,18 @@ class LightLinker
 		void deregisterFilterLinks( Light *light, const IECoreScenePreview::Renderer::ConstObjectSetPtr &lightFilters );
 		void dirtyLightFilter( const LightFilter *lightFilter );
 
-		// Returns the value to be used in the `lighting:subset` attribute.
-		const RtUString registerLightLinks( const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
-		void deregisterLightLinks( const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
+		enum class SetType
+		{
+			Light = 0,
+			Shadow = 1
+		};
+
+		// Returns an attribute to be added to the registering object :
+		//
+		// - SetType::Light : Return value is for the `lighting:subset` attribute.
+		// - SetType::Shadow : Return value is to be included in the `grouping:membership` attribute.
+		const RtUString registerLightSet( SetType setType, const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
+		void deregisterLightSet( SetType setType, const IECoreScenePreview::Renderer::ConstObjectSetPtr &lights );
 
 		// Interface used by Renderer
 		// ==========================
@@ -141,10 +152,18 @@ class LightLinker
 			size_t useCount = 0;
 			RtUString groupName;
 		};
-		using LightSets = std::unordered_map<IECoreScenePreview::Renderer::ConstObjectSetPtr, LightSet>;
-		std::mutex m_lightLinksMutex;
+
+		struct LightSets
+		{
+			using Map = std::unordered_map<IECoreScenePreview::Renderer::ConstObjectSetPtr, LightSet>;
+			Map map;
+			std::string groupNamePrefix;
+			size_t nextGroupIndex = 0;
+		};
+
+		std::mutex m_lightAndShadowSetsMutex;
 		LightSets m_lightSets;
-		size_t m_nextLightGroup;
+		LightSets m_shadowSets;
 		bool m_lightLinksDirty = false;
 
 };

--- a/src/IECoreRenderMan/MaterialCache.h
+++ b/src/IECoreRenderMan/MaterialCache.h
@@ -65,7 +65,7 @@ class MaterialCache
 		// Can be called concurrently with other calls to `get()`
 		ConstMaterialPtr getMaterial( const IECoreScene::ShaderNetwork *network );
 		ConstDisplacementPtr getDisplacement( const IECoreScene::ShaderNetwork *network );
-		ConstLightShaderPtr getLightShader( const IECoreScene::ShaderNetwork *network, const IECoreScene::ShaderNetwork *lightFilter );
+		ConstLightShaderPtr getLightShader( const IECoreScene::ShaderNetwork *network, const IECoreScene::ShaderNetwork *lightFilter, RtUString shadowSubset );
 
 		// Must not be called concurrently with anything.
 		void clearUnused();

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -76,6 +76,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 		ConstGeometryPrototypePtr m_geometryPrototype;
 		RtParamList m_extraAttributes;
 		IECoreScenePreview::Renderer::ConstObjectSetPtr m_linkedLights;
+		IECoreScenePreview::Renderer::ConstObjectSetPtr m_shadowedLights;
 
 };
 

--- a/startup/GafferScene/arnoldAttributes.py
+++ b/startup/GafferScene/arnoldAttributes.py
@@ -68,9 +68,9 @@ Gaffer.Metadata.registerValue(
 	"description",
 	"""
 	The lights that cause this object to cast shadows.
-	Accepts a set expression or a space separated list of
-	lights. Use \"defaultLights\" to refer to all lights that
-	contribute to illumination by default.
+
+	> Caution : This attribute has been superceded and will be removed. Use
+	> the standard `shadowedLights` attribute instead.
 	""",
 )
 Gaffer.Metadata.registerValue( "attribute:ai:visibility:shadow_group", "ui:scene:acceptsSetExpression", True )

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -155,6 +155,19 @@ Gaffer.Metadata.registerValue(
 Gaffer.Metadata.registerValue( "attribute:linkedLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
 Gaffer.Metadata.registerValue( "attribute:linkedLights", "ui:scene:acceptsSetExpression", True )
 
+Gaffer.Metadata.registerValue( "attribute:shadowedLights", "label", "Shadowed Lights" )
+Gaffer.Metadata.registerValue( "attribute:shadowedLights", "defaultValue", "__lights" )
+Gaffer.Metadata.registerValue(
+	"attribute:shadowedLights",
+	"description",
+	"""
+	The lights that cast shadows from this object. Accepts a set
+	expression or a space separated list of lights.
+	"""
+)
+Gaffer.Metadata.registerValue( "attribute:shadowedLights", "plugValueWidget:type", "GafferSceneUI.SetExpressionPlugValueWidget" )
+Gaffer.Metadata.registerValue( "attribute:shadowedLights", "ui:scene:acceptsSetExpression", True )
+
 Gaffer.Metadata.registerValue( "attribute:filteredLights", "label", "Filtered Lights" )
 Gaffer.Metadata.registerValue( "attribute:filteredLights", "defaultValue", IECore.StringData( "" ) )
 Gaffer.Metadata.registerValue(

--- a/startup/gui/attributeEditor.py
+++ b/startup/gui/attributeEditor.py
@@ -57,6 +57,7 @@ GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:deformation
 GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:deformationBlurSegments", "Motion Blur" )
 
 GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "linkedLights", "Light Linking" )
+GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "shadowedLights", "Light Linking" )
 GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "filteredLights", "Light Linking" )
 
 GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:automaticInstancing", "Instancing" )


### PR DESCRIPTION
This generalises our Arnold shadow linking to use a new standard `shadowedLights` attribute, and then adds support for shadow linking in Cycles and RenderMan using that attribute. The `shadowedLights` attribute is applied to objects to specify which lights they block; this this is the _opposite_ of USD's approach, but we're sticking with it for now for the following reasons :

- It's backwards-compatible with Arnold's `ai:visibility:shadow_group` attribute. This provides a simple upgrade path for Arnold users, and folks who might be transferring assets from Arnold to RenderMan (or Cycles).
- It's consistent with the way `linkedLights` currently works.

Longer term, we're probably due a reckoning where we align our linking with USD's, but we can't do that in the 1.5.x timeframe anyway, as it would be a breaking change.