### PR TITLE
RenderManifest : Add missing include

### DIFF
--- a/src/GafferScene/RenderManifest.cpp
+++ b/src/GafferScene/RenderManifest.cpp
@@ -53,6 +53,7 @@
 #include "boost/property_tree/json_parser.hpp"
 
 #include <regex>
+#include <unordered_map>
 
 using namespace GafferScene;
 


### PR DESCRIPTION
Without this we can't compile with Clang on MacOS.
