### PR TITLE
SceneTestCase : Remove `assertBoxes[Almost]Equal()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -38,6 +38,7 @@ Breaking Changes
 - OpenGLAttributes :
   - Attribute plugs have been renamed to match the name of their attribute (e.g. `attributes.primitiveWireframeColor` is now `attributes.gl:primitive:wireframeColor`). A compatibility config has been provided to allow OpenGLAttributes nodes to be loaded from scripts saved in earlier Gaffer versions.
   - The default values of the attribute plugs authoring the `gl:primitive:bound`, `gl:primitive:outline`, `gl:primitive:points`, `gl:primitive:pointColor`, `gl:primitive:wireframe`, and `gl:primitive:wireframeColor` attributes have changed to match the default behaviour of the OpenGL renderer. Scripts loaded from previous Gaffer versions with these plugs enabled and set to the default value will see a difference in OpenGL renders.
+- SceneTestCase : Removed `assertBoxesEqual()` and `assertBoxesAlmostEqual()` methods.
 
 1.5.x.x (relative to 1.5.14.0)
 =======

--- a/python/GafferSceneTest/SceneTestCase.py
+++ b/python/GafferSceneTest/SceneTestCase.py
@@ -350,22 +350,6 @@ class SceneTestCase( GafferImageTest.ImageTestCase ) :
 			for setName in scenePlug1.setNames() :
 				self.assertNotEqual( scenePlug1.setHash( setName ), scenePlug2.setHash( setName ) )
 
-	def assertBoxesEqual( self, box1, box2 ) :
-
-		for n in "min", "max" :
-			v1 = getattr( box1, n )
-			v2 = getattr( box1, n )
-			for i in range( 0, 3 ) :
-				self.assertEqual( v1[i], v2[i] )
-
-	def assertBoxesAlmostEqual( self, box1, box2, places ) :
-
-		for n in "min", "max" :
-			v1 = getattr( box1, n )()
-			v2 = getattr( box1, n )()
-			for i in range( 0, 3 ) :
-				self.assertAlmostEqual( v1[i], v2[i], places )
-
 	def assertParallelGetValueComputesObjectOnce( self, scene, path ) :
 
 		with Gaffer.PerformanceMonitor() as pm :


### PR DESCRIPTION
Both functions were broken, and both were fortunately unused.
