### PR TITLE
3Delight, Cycles, OpenGL : Output `header:*` image metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Improvements
 
 - DeleteAttributes : Optimised case where all attributes are deleted. The input attributes are no longer accessed at all in this case.
 - ShaderAssignment : The `scene:path` context variable is now available in Switches connected directly to the `ShaderAssignment.shader` input. This allows different shaders to be assigned to different locations using a single ShaderAssignment node. Please note that the `scene:path` context variable remains unavailable to the individual shader nodes themselves for performance reasons.
+- 3Delight, Cycles, OpenGL : Added support for custom EXR metadata, using `header:*` parameters on the output definition.
 
 Fixes
 -----

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -822,6 +822,8 @@ IE_CORE_FORWARDDECLARE( OpenGLLightFilter )
 namespace
 {
 
+const std::string g_headerPrefix( "header:" );
+
 class OpenGLRenderer final : public IECoreScenePreview::Renderer
 {
 
@@ -1237,6 +1239,14 @@ class OpenGLRenderer final : public IECoreScenePreview::Renderer
 				{
 					IECore::msg( IECore::Msg::Warning, "IECoreGL::Renderer", fmt::format( "Unsupported data format \"{}\".", data ) );
 					return;
+				}
+
+				for( const auto &[parameterName, parameterValue] : namedOutput.second->parameters() )
+				{
+					if( boost::starts_with( parameterName.string(), g_headerPrefix ) )
+					{
+						image->blindData()->writable()[parameterName.string().substr( g_headerPrefix.size() )] = parameterValue;
+					}
 				}
 
 				const string &type = namedOutput.second->getType();

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -253,6 +253,8 @@ using DelightHandleWeakPtr = std::weak_ptr<DelightHandle>;
 namespace
 {
 
+const std::string g_headerPrefix( "header:" );
+
 class DelightOutput : public IECore::RefCounted
 {
 
@@ -269,7 +271,14 @@ class DelightOutput : public IECore::RefCounted
 			ParameterList driverParams;
 			for( const auto &[parameterName, parameterValue] : output->parameters() )
 			{
-				if( parameterName != "filter" && parameterName != "filterwidth" && parameterName != "scalarformat" && parameterName != "colorprofile" && parameterName != "layername" && parameterName != "layerName" && parameterName != "withalpha" && parameterName != "drawoutlines" )
+				if( boost::starts_with( parameterName.string(), g_headerPrefix ) && output->getType() == "exr" )
+				{
+					const char *prefixedName = driverParams.allocate(
+						"exrheader_" + parameterName.string().substr( g_headerPrefix.size() )
+					);
+					driverParams.add( prefixedName, parameterValue.get() );
+				}
+				else if( parameterName != "filter" && parameterName != "filterwidth" && parameterName != "scalarformat" && parameterName != "colorprofile" && parameterName != "layername" && parameterName != "layerName" && parameterName != "withalpha" && parameterName != "drawoutlines" )
 				{
 					driverParams.add( parameterName.c_str(), parameterValue.get() );
 				}


### PR DESCRIPTION
This brings these backends up to spec with respect to the existing Arnold and RenderMan metadata support, which will be necessary for using them with #6329.