### PR TITLE
Standard ID output

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - ShaderAssignment : The `scene:path` context variable is now available in Switches connected directly to the `ShaderAssignment.shader` input. This allows different shaders to be assigned to different locations using a single ShaderAssignment node. Please note that the `scene:path` context variable remains unavailable to the individual shader nodes themselves for performance reasons.
 - 3Delight, Cycles, OpenGL : Added support for custom EXR metadata, using `header:*` parameters on the output definition.
 - RenderManAttributes, RenderManOptions : Plugs now respect minimum and maximum values specified by RenderMan.
+- Cycles : Added support for `layerName` parameter in outputs, to control the naming of channels in EXR outputs.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - 3Delight, Cycles, OpenGL : Added support for custom EXR metadata, using `header:*` parameters on the output definition.
 - RenderManAttributes, RenderManOptions : Plugs now respect minimum and maximum values specified by RenderMan.
 - Cycles : Added support for `layerName` parameter in outputs, to control the naming of channels in EXR outputs.
+- StandardOptions : Added render manifest option.
 
 Fixes
 -----

--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -119,5 +119,10 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "ID output not supported" )
+	def testIDOutput( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUI/StandardOptionsUI.py
+++ b/python/GafferSceneUI/StandardOptionsUI.py
@@ -518,6 +518,20 @@ plugsMetadata = {
 
 	],
 
+	"options.renderManifestFilePath" : [
+
+		"description",
+		"""
+		Specifies a file to write a manifest to. If a render outputs both a
+		manifest and an ID AOV, the Image Selection Tool may be used to select
+		objects in the rendered image.
+		""",
+
+		"layout:section", "Render Manifest",
+		"label", "File Path",
+
+	],
+
 	# Statistics plugs
 
 	"options.performanceMonitor" : [

--- a/python/IECoreRenderManTest/RendererTest.py
+++ b/python/IECoreRenderManTest/RendererTest.py
@@ -2151,6 +2151,25 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertEqual( len( messageHandler.messages ), 1 )
 		self.assertEqual( messageHandler.messages[0].message, "R56049 Incremental rendering recovery succeeded; resuming render at checkpoint 2." )
 
+	def testAssignID( self ) :
+
+		with IECoreRenderManTest.RileyCapture() as capture :
+
+			renderer = GafferScene.Private.IECoreScenePreview.Renderer.create(
+				"RenderMan",
+				GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch
+			)
+
+			object = renderer.object( "/sphere", IECoreScene.SpherePrimitive( 1 ), renderer.attributes( IECore.CompoundObject() ) )
+			object.assignID( 1 )
+
+			del renderer
+
+		self.__assertParameterEqual(
+			next( x for x in capture.json if x["method"] == "ModifyGeometryInstance" )["attributes"]["params"],
+			"identifier:id", [ 1 ]
+		)
+
 	def __assertParameterEqual( self, paramList, name, data ) :
 
 		p = next( x for x in paramList if x["info"]["name"] == name )

--- a/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
@@ -275,6 +275,18 @@ void OIIOOutputDriver::write_render_tile( const Tile &tile )
 				return;
 			}
 
+			if( layer.name == "id" )
+			{
+				// Cycles renders IDs as float values, but Gaffer's expects them to
+				// be integers, type-punned into a float for storage.
+				for( auto &p : pixels )
+				{
+					/// \todo Use `std::bit_cast` when C++20 is available to us.
+					const uint32_t id = p;
+					memcpy( &p, &id, sizeof( p ) );
+				}
+			}
+
 			imageData = &pixels[0];
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
@@ -218,9 +218,24 @@ void OIIOOutputDriver::write_render_tile( const Tile &tile )
 		}
 		else
 		{
-			for( int i = 0; i < layer.numChannels; ++i )
+			/// \todo This logic should be shared with IEDisplayOutputDriver.
+			std::string layerName;
+			if( auto d = layer.metadata->member<IECore::StringData>( "layerName" ) )
 			{
-				spec.channelnames.push_back( g_channels[i] );
+				layerName = d->readable();
+			}
+			if( layer.numChannels == 1 )
+			{
+				spec.channelnames.push_back( layerName.size() ? layerName : layer.name );
+			}
+			else
+			{
+				for( int i = 0; i < layer.numChannels; ++i )
+				{
+					spec.channelnames.push_back(
+						fmt::format( "{}{}{}", layerName, layerName.size() ? "." : "", g_channels[i] )
+					);
+				}
 			}
 		}
 		spec.full_x = m_displayWindow.min.x;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -319,7 +319,7 @@ class CyclesOutput : public IECore::RefCounted
 					p["type"] = new StringData( "depth" );
 					passType = "depth";
 				}
-				else if( tokens[0] == "uint" && tokens[1] == "id" )
+				else if( tokens[0] == "float" && tokens[1] == "id" )
 				{
 					m_data = tokens[1];
 					p["name"] = new StringData( tokens[1] );

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -185,7 +185,16 @@ std::string channelNameFromEXR( std::string view, std::string part, std::string 
 	}
 
 	// But if useHeuristics is on, try to figure out which of the dozen incorrect interpretations of the EXR spec
-	// this might adhere to
+	// this might adhere to.
+
+	if( channel == "cortexId.v" )
+	{
+		// Specific workaround for ID outputs from 3Delight. 3Delight doesn't
+		// support a custom `layerName`, despite it being part of the NSI spec,
+		// so we need to apply the desired name here.
+		return "id";
+	}
+
 	std::vector< std::string > layerTokens;
 	bool partUnderscoreSplit = false;
 	string baseName;

--- a/src/GafferScene/StandardOptions.cpp
+++ b/src/GafferScene/StandardOptions.cpp
@@ -83,6 +83,11 @@ StandardOptions::StandardOptions( const std::string &name )
 	options->addChild( new Gaffer::NameValuePlug( "render:shutter", new IECore::V2fData( Imath::V2f( -0.25, 0.25 ) ), false, "shutter" ) );
 	options->addChild( new Gaffer::NameValuePlug( "sampleMotion", new IECore::BoolData( true ), false, "sampleMotion" ) );
 
+	// ID Manifest
+
+	options->addChild( new Gaffer::NameValuePlug( "render:renderManifestFilePath", new IECore::StringData( "" ), false, "renderManifestFilePath" ) );
+
+
 	// Statistics
 
 	options->addChild( new Gaffer::NameValuePlug( "render:performanceMonitor", new IECore::BoolData( false ), false, "performanceMonitor" ) );

--- a/src/GafferSceneUI/OutputBuffer.cpp
+++ b/src/GafferSceneUI/OutputBuffer.cpp
@@ -202,7 +202,10 @@ OutputBuffer::OutputBuffer( IECoreScenePreview::Renderer *renderer )
 			// approximation of depth at the centre of the pixel, which is important
 			// for accuracy in `SceneGadget::objectAt()`.
 			OutputDefinition( "depth", "float Z", "box" ),
-			OutputDefinition( "id", "uint id", "closest" ),
+			// The `IECoreImage::DisplayDriver` API only supports floats, and several
+			// renderers have deficiencies in rendering integer AOVs. So we declare
+			// `id` as a float AOV, and pass type-punned integers through it.
+			OutputDefinition( "id", "float id", "closest" ),
 		}
 	)
 	{

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -2574,10 +2574,12 @@ class ArnoldObjectBase : public IECoreScenePreview::Renderer::ObjectInterface
 				/// it for some reason.
 				if(
 					AiNodeLookUpUserParameter( node, g_cortexIDArnoldString ) ||
-					AiNodeDeclare( node, g_cortexIDArnoldString, "constant UINT" )
+					AiNodeDeclare( node, g_cortexIDArnoldString, "constant FLOAT" )
 				)
 				{
-					AiNodeSetUInt( node, g_cortexIDArnoldString, id );
+					float bitcastID;
+					memcpy( &bitcastID, &id, 4 );
+					AiNodeSetFlt( node, g_cortexIDArnoldString, bitcastID );
 				}
 			}
 		}
@@ -4296,11 +4298,11 @@ class ArnoldGlobals
 				IECoreScene::ShaderNetworkPtr network = new IECoreScene::ShaderNetwork;
 				network->addShader(
 					"userData",
-					new IECoreScene::Shader( "user_data_int", "ai:shader", { { "attribute", new IECore::StringData( "cortex:id" ) } } )
+					new IECoreScene::Shader( "user_data_float", "ai:shader", { { "attribute", new IECore::StringData( "cortex:id" ) } } )
 				);
 				network->addShader(
 					"aovWrite",
-					new IECoreScene::Shader( "aov_write_int", "ai:shader", { { "aov_name", new IECore::StringData( "id" ) } })
+					new IECoreScene::Shader( "aov_write_float", "ai:shader", { { "aov_name", new IECore::StringData( "id" ) } })
 				);
 				network->addConnection( { { "userData", "" }, { "aovWrite", "aov_input" } } );
 				network->setOutput( { "aovWrite", "" } );

--- a/src/IECoreDelight/Display.cpp
+++ b/src/IECoreDelight/Display.cpp
@@ -314,29 +314,7 @@ PtDspyError imageData( PtDspyImageHandle image, int xMin, int xMaxPlusOne, int y
 	{
 		try
 		{
-			if( dd->channelNames().size() == 1 && dd->channelNames()[0] == "id" )
-			{
-				// ID output for doing interactive selection (see `GafferSceneUI::OutputBuffer`).
-				// We want to have declared this output with an integer `scalarformat` to match the
-				// integer `cortexId` attribute created by `ObjectInterface::assignID()`, but we
-				// can't because 3Delight thinks it's quantizing a float into an integer and throws
-				// away everything outside `0-1` (see DelightOutput). So, we instead get floats
-				// from 3Delight and convert to integers here.
-				vector<uint32_t> intData( bufferSize );
-				for( int i = 0; i < bufferSize; ++i )
-				{
-					intData[i] = ((const float *)data)[i];
-				}
-				// Then, in a second hack that applies to all renderers/drivers,
-				// we have to pretend that the integers are floats to get them
-				// across the `IECoreImage::DisplayDriver` boundary, which only
-				// supports floats.
-				dd->imageData( box, (const float *)intData.data(), bufferSize );
-			}
-			else
-			{
-				dd->imageData( box, (const float *)data, bufferSize );
-			}
+			dd->imageData( box, (const float *)data, bufferSize );
 		}
 		catch( std::exception &e )
 		{

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -372,12 +372,6 @@ class DelightOutput : public IECore::RefCounted
 			{
 				variableName = "cortexId";
 				variableSource = "attribute";
-				/// \todo We really want to use something like "uint32" here (as
-				/// provided by the code above), but that maps the `0.0 - 1.0`
-				/// range into the integer range, whereas we want a direct
-				/// mapping. So we render as float and deal with it in
-				/// Display.cpp.
-				scalarFormat = "float";
 			}
 
 			layerName = parameter<string>( output->parameters(), "layerName", layerName );
@@ -1169,7 +1163,12 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 			NSIParam_t param = {
 				"cortexId",
 				&id,
-				NSITypeInteger,
+				// Deliberately declaring as `float` even though it is an
+				// integer. This lets us render the full range of integer values
+				// out of a float AOV through type-punning. 3Delight does have
+				// integer AOVs, but they are broken, and don't preserve integer
+				// input values.
+				NSITypeFloat,
 				0, 1, // array length, count
 				0 // flags
 			};

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -347,6 +347,18 @@ void Globals::output( const IECore::InternedString &name, const Output *output )
 	if( output )
 	{
 		OutputPtr copy = output->copy();
+
+		// Conform "standard" ID output defined by Gaffer's OutputBuffer class
+		// (used in the raytraced viewport).
+		if( copy->getData() == "float id" && parameter<string>( copy->parameters(), "filter", "" ) == "closest" )
+		{
+			copy->setData( "int id" );
+			copy->parameters()["accumulationRule"] = new StringData( "zmin" );
+			copy->parameters().erase( "filter" );
+		}
+
+		// Warn for parameters that we don't support, but which folks might
+		// accidentally set.
 		for( const auto &n : g_rejectedOutputFilterParameters )
 		{
 			if( copy->parameters().erase( n ) )

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -198,4 +198,6 @@ void Object::link( const IECore::InternedString &type, const IECoreScenePreview:
 
 void Object::assignID( uint32_t id )
 {
+	m_extraAttributes.SetInteger( Rix::k_identifier_id, id );
+	attributes( m_attributes.get() );
 }

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -44,8 +44,7 @@ import Gaffer
 import GafferScene
 import GafferImage
 
-# Add standard beauty output that should be supported by
-# all renderers.
+# Add standard beauty and ID outputs that should be supported by all renderers.
 
 GafferScene.Outputs.registerOutput(
 	"Interactive/Beauty",
@@ -75,6 +74,39 @@ GafferScene.Outputs.registerOutput(
 		}
 	)
 )
+
+GafferScene.Outputs.registerOutput(
+	"Interactive/ID",
+	IECoreScene.Output(
+		"id",
+		"ieDisplay",
+		"float id",
+		{
+			"catalogue:imageName" : "Image",
+			"driverType" : "ClientDisplayDriver",
+			"displayHost" : "localhost",
+			"displayPort" : "${image:catalogue:port}",
+			"remoteDisplayType" : "GafferImage::GafferDisplayDriver",
+			"filter" : "closest",
+			"layerName" : "id",
+		}
+	)
+)
+
+GafferScene.Outputs.registerOutput(
+	"Batch/ID",
+	IECoreScene.Output(
+		"${project:rootDirectory}/renders/${script:name}/${renderPass}/id/id.####.exr",
+		"exr",
+		"float id",
+		{
+			"filter" : "closest",
+			"layerName" : "id",
+		}
+	)
+)
+
+Gaffer.Metadata.registerValue( GafferScene.StandardOptions, "options.renderManifestFilePath.value", "userDefault", "${project:rootDirectory}/renders/${script:name}/${renderPass}/renderManifest/renderManifest.####.exr" )
 
 # Add standard AOVs as they are defined in the aiStandard and alSurface shaders
 


### PR DESCRIPTION
This builds on top of #6421 to add a standardised ID output from all our supported renderers, to be used with the ImageSelectionTool from #6329. Test coverage is provided by a new generic test in `GafferSceneTest.RenderTest` that runs for all renderers. The ugliest bit is the OpenImageIOReader workaround for 3Delight channel naming - I have made enquiries as to whether `layername` really is unimplemented in 3Delight or I've just missed something, and will report back when I have a response.