### PR TITLE
OSLExpressionEngine : Fix errors accessing plugs named with `:`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - RenderMan : Added missing attribute handlers for float, string, InternedString, Color3f and V3f array attributes. In particular, this fixes the export of `render:displayColor` attributes loaded from USD.
+- Expression : Fixed error when creating OSL expressions for plugs with `:` characters in their name.
 
 1.5.14.0 (relative to 1.5.13.0)
 ========

--- a/python/GafferOSLTest/OSLExpressionEngineTest.py
+++ b/python/GafferOSLTest/OSLExpressionEngineTest.py
@@ -888,5 +888,18 @@ class OSLExpressionEngineTest( GafferOSLTest.OSLTestCase ) :
 		with self.assertRaisesRegex( RuntimeError, "expression:1: error: 'undefinedVariable' was not declared in this scope" ) :
 			s["expression"].setExpression( "parent.node.op1 = undefinedVariable;", "OSL" )
 
+	def testColonInPlugNames( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["n"] = Gaffer.Node()
+		s["n"]["user"]["test:i"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["test:o"] = Gaffer.IntPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( "parent.n.user.test:o = parent.n.user.test:i + 1;", "OSL" )
+
+		s["n"]["user"]["test:i"].setValue( 1 )
+		self.assertEqual( s["n"]["user"]["test:o"].getValue(), 2 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferOSL/OSLExpressionEngine.cpp
+++ b/src/GafferOSL/OSLExpressionEngine.cpp
@@ -692,7 +692,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 		static void findPlugPaths( const string &expression, vector<string> &inPaths, vector<string> &outPaths )
 		{
 			std::set<string> visited;
-			const regex plugPathRegex( "(parent\\.[A-Za-z_0-9\\.]+)[ \t]*(=*)" );
+			const regex plugPathRegex( "(parent\\.[A-Za-z_0-9\\.:]+)[ \t]*(=*)" );
 			for( sregex_iterator it = make_regex_iterator( expression, plugPathRegex ); it != sregex_iterator(); ++it )
 			{
 				string plugPath( (*it)[1].str().substr( 7 ) );
@@ -838,6 +838,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 						parameter = "_" + parameter;
 					}
 					replace_all( parameter, ".", "_" );
+					replace_all( parameter, ":", "__" );
 					replacements.push_back( { prefix + inPlugPaths[i], parameter } );
 					inParameters.push_back( ustring( parameter ) );
 				}
@@ -850,6 +851,7 @@ class OSLExpressionEngine : public Gaffer::Expression::Engine
 						parameter = "_" + parameter;
 					}
 					replace_all( parameter, ".", "_" );
+					replace_all( parameter, ":", "__" );
 					replacements.push_back( { prefix + outPlugPaths[i], parameter } );
 					outParameters.push_back( ustring( parameter ) );
 				}


### PR DESCRIPTION
Noticed this in the process of transitioning the ArnoldOptions and ArnoldAttributes nodes to being defined from our option and attribute metadata registrations. The existing OSL expressions in `arnoldViewerSettings.gfr` were not happy with the new plug names.