### PR TITLE
CodeWidget : Allow ":" in PythonCompleter completions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ Fixes
 
 - RenderMan : Added missing attribute handlers for float, string, InternedString, Color3f and V3f array attributes. In particular, this fixes the export of `render:displayColor` attributes loaded from USD.
 - Expression : Fixed error when creating OSL expressions for plugs with `:` characters in their name.
+- PythonEditor : Fixed completions menu not appearing after typing `:` in a partial plug or node name or a dictionary key.
 
 1.5.14.0 (relative to 1.5.13.0)
 ========

--- a/python/GafferUI/CodeWidget.py
+++ b/python/GafferUI/CodeWidget.py
@@ -559,9 +559,11 @@ class PythonCompleter( Completer ) :
 		optionalWord = r"[a-zA-Z0-9_]*"
 		getAttr = r"\.{word}".format( word = word )
 		partialGetAttr = r"\.{optionalWord}".format( optionalWord = optionalWord )
-		quotedWord = r"""(?:'{word}'|"{word}")""".format( word = word )
-		getItem = r"\[{quotedWord}\]".format( quotedWord = quotedWord )
-		partialGetItem = r"\[(?:['\"]{optionalWord})?".format( optionalWord = optionalWord )
+		item = r"[a-zA-Z0-9_:]+"
+		optionalItem = r"[a-zA-Z0-9_:]*"
+		quotedItem = r"""(?:'{item}'|"{item}")""".format( item = item )
+		getItem = r"\[{quotedItem}\]".format( quotedItem = quotedItem )
+		partialGetItem = r"\[(?:['\"]{optionalItem})?".format( optionalItem = optionalItem )
 		path = r"{searchPrefix}({word}(?:{getAttr}|{getItem})*)({partialGetAttr}|{partialGetItem})$".format(
 			searchPrefix = self.__searchPrefix, word = word, getAttr = getAttr, getItem = getItem,
 			partialGetAttr = partialGetAttr, partialGetItem = partialGetItem


### PR DESCRIPTION
`:` characters could be in plug or node names, as well as dictionary keys.