### PR TITLE
ModuleTest : Remove RenderMan from `GAFFER_EXTENSION_PATHS`

### DIFF
--- a/python/GafferRenderManTest/ModuleTest.py
+++ b/python/GafferRenderManTest/ModuleTest.py
@@ -54,7 +54,7 @@ class ModuleTest( GafferTest.TestCase ) :
 		# check that we can still load the GUI configs cleanly.
 
 		env = Gaffer.environment()
-		for var in ( "RMANTREE", "PYTHONPATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "GAFFER_STARTUP_PATHS" ) :
+		for var in ( "RMANTREE", "PYTHONPATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "GAFFER_STARTUP_PATHS", "GAFFER_EXTENSION_PATHS" ) :
 			env.pop( var, None )
 
 		try :


### PR DESCRIPTION
We were getting test failures on Windows because `GafferRenderMan` was successfully importing even though `RMANTREE` was not set. Windows was satisfied enough to load the module with what was setup in the wrapper's `setUp3rdPartyExtensions()` with `GAFFER_EXTENSION_PATHS` inherited from the test process. We remove the entry in `GAFFER_EXTENSION_PATHS` to keep that module from loading.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
