### PR TITLE
PlugPopup : Allow holding `Shift` to prevent popup closing on activation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Improvements
 - Animation :
   - Added plug context menu actions for color, vector and box plugs.
   - Plug context menu actions are now available on widgets that edit multiple plugs. This enables the animation of multiple cells at once in the LightEditor, RenderPassEditor, AttributeEditor and Spreadsheet UI.
+- Attribute Editor, Light Editor, Render Pass Editor, Spreadsheet : Added <kbd>Shift</kbd> + <kbd>Enter</kbd> and <kbd>Shift</kbd> + <kbd>Ctrl</kbd> + <kbd>Enter</kbd> shortcuts to commit an edit without closing the popup editor window.
 
 Fixes
 -----

--- a/doc/source/Interface/ControlsAndShortcuts/index.md
+++ b/doc/source/Interface/ControlsAndShortcuts/index.md
@@ -430,6 +430,7 @@ Move cell selection                                  | {kbd}`↑`, {kbd}`↓`, {
 Extend cell selection                                | {kbd}`Shift` + {{leftClick}}<br>or<br>{kbd}`Shift` + {kbd}`↑`, {kbd}`↓`, {kbd}`←`, {kbd}`→`
 Toggle cell selection                                | {kbd}`Ctrl` + {{leftClick}}<br>or<br>{kbd}`Ctrl` + {kbd}`↑`, {kbd}`↓`, {kbd}`←`, {kbd}`→`
 Edit selected cells                                  | {kbd}`Return`<br>or<br>{kbd}`Enter`
+Commit edit without closing popup                    | {kbd}`Shift` + {kbd}`Return`<br>or<br>{kbd}`Ctrl` + {kbd}`Shift` + {kbd}`Return`
 Disable Edit                                         | {kbd}`D`
 Remove Attribute                                     | {kbd}`Delete`
 Copy/Paste selected cells                            | {kbd}`Ctrl` + {kbd}`C`/{kbd}`V`
@@ -449,6 +450,7 @@ Move cell selection                                  | {kbd}`↑`, {kbd}`↓`, {
 Extend cell selection                                | {kbd}`Shift` + {{leftClick}}<br>or<br>{kbd}`Shift` + {kbd}`↑`, {kbd}`↓`, {kbd}`←`, {kbd}`→`
 Toggle cell selection                                | {kbd}`Ctrl` + {{leftClick}}<br>or<br>{kbd}`Ctrl` + {kbd}`↑`, {kbd}`↓`, {kbd}`←`, {kbd}`→`
 Edit selected cells                                  | {kbd}`Return`<br>or<br>{kbd}`Enter`
+Commit edit without closing popup                    | {kbd}`Shift` + {kbd}`Return`<br>or<br>{kbd}`Ctrl` + {kbd}`Shift` + {kbd}`Return`
 Disable edit                                         | {kbd}`D`
 Toggle a render pass as active                       | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the {{activeRenderPass}} column
 Rename a render pass                                 | {kbd}`Return` or {{leftClick}} {{leftClick}} a cell within the "Name" column

--- a/python/GafferUI/MultiLineTextWidget.py
+++ b/python/GafferUI/MultiLineTextWidget.py
@@ -358,7 +358,7 @@ class MultiLineTextWidget( GafferUI.Widget ) :
 
 		assert( widget is self )
 
-		if event.key=="Enter" or ( event.key=="Return" and event.modifiers==event.Modifiers.Control ) :
+		if event.key=="Enter" or ( event.key=="Return" and event.modifiers & event.Modifiers.Control ) :
 			self.__activatedSignal( self )
 			self._emitEditingFinished()
 			return True

--- a/python/GafferUI/PlugPopup.py
+++ b/python/GafferUI/PlugPopup.py
@@ -192,6 +192,11 @@ class PlugPopup( GafferUI.PopupWindow ) :
 
 	def __activated( self, unused ) :
 
+		if GafferUI.Widget.currentModifiers() & GafferUI.ModifiableEvent.Modifiers.Shift :
+			# Do not close while Shift is held, so Shift+Return can
+			# be used to commit an edit without closing the popup.
+			return
+
 		self.close()
 
 	@classmethod

--- a/python/GafferUI/TextWidget.py
+++ b/python/GafferUI/TextWidget.py
@@ -238,7 +238,7 @@ class TextWidget( GafferUI.Widget ) :
 			return self.__activatedSignal
 		except :
 			self.__activatedSignal = GafferUI.WidgetSignal()
-			self._qtWidget().returnPressed.connect( Gaffer.WeakMethod( self.__returnPressed ) )
+			self.keyPressSignal().connect( Gaffer.WeakMethod( self.__activationKeyPress ) )
 
 		return self.__activatedSignal
 
@@ -280,10 +280,6 @@ class TextWidget( GafferUI.Widget ) :
 
 		self.__textChangedSignal( self )
 
-	def __returnPressed( self ) :
-
-		self.__activatedSignal( self )
-
 	def __editingFinished( self ) :
 
 		self.__editingFinishedSignal( self )
@@ -291,6 +287,17 @@ class TextWidget( GafferUI.Widget ) :
 	def __selectionChanged( self ) :
 
 		self.__selectionChangedSignal( self )
+
+	def __activationKeyPress( self, widget, event ) :
+
+		assert( widget is self )
+
+		if event.key in ( "Enter", "Return" ) :
+			self.__activatedSignal( self )
+			self.editingFinishedSignal()( self )
+			return True
+
+		return False
 
 	def __keyPress( self, widget, event ) :
 


### PR DESCRIPTION
This allows `Shift` + `Enter` and `Shift` + `Ctrl` + `Enter` to commit an edit and not close the PlugPopup. This is useful in situations where you want to keep the popup open to more easily test a range of values before committing to a final value.