### PR TITLE
CI : Update to GafferHQ/dependencies 10.0.0a1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
         name: [
           linux-gcc11,
           linux-debug-gcc11,
+          linux-gcc11-platform23,
           windows,
         ]
 
@@ -59,6 +60,20 @@ jobs:
             # limit. In practice this compresses down to 4-500Mb.
             sconsCacheMegabytes: 2500
             jobs: 4
+
+          - name: linux-gcc11-platform23
+            os: ubuntu-24.04
+            buildType: RELEASE
+            publish: false
+            containerImage: ghcr.io/gafferhq/build/build:3.2.0
+            # GitHub container builds run as root. This causes failures for tests that
+            # assert that filesystem permissions are respected, because root doesn't
+            # respect permissions. So we run the final test suite as a dedicated
+            # test user rather than as root.
+            testRunner: sudo -E -u testUser
+            sconsCacheMegabytes: 400
+            jobs: 4
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.14.1/cortex-10.5.14.1-linux-gcc11.tar.gz
 
           - name: windows
             os: windows-2022

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
             testArguments: -excludedCategories performance
             sconsCacheMegabytes: 800
             jobs: 4
+            dependenciesURL: https://github.com/ImageEngine/cortex/releases/download/10.5.14.1/cortex-10.5.14.1-windows.zip
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main/installDependencies.py
+++ b/.github/workflows/main/installDependencies.py
@@ -49,7 +49,7 @@ else :
 
 # Determine default archive URL.
 
-defaultURL = "https://github.com/ImageEngine/cortex/releases/download/10.5.14.0/cortex-10.5.14.0-{platform}{buildEnvironment}.{extension}"
+defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/10.0.0a1/gafferDependencies-10.0.0a1-{platform}{buildEnvironment}.{extension}"
 
 # Parse command line arguments.
 


### PR DESCRIPTION
This starts moving us towards building Gaffer 1.6 with VFX Platform 2024 dependencies (the Qt 6.5 update still outstanding).