### PR TITLE
Reduce usage of legacy Cortex functionality

### DIFF
--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -634,15 +634,21 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		w["task"].execute()
 
 		self.assertTrue( testFile.exists() )
-		i = IECore.Reader.create( str( testFile ) ).read()
+		imageInput = OpenImageIO.ImageInput.open( str( testFile ) )
+		roi = imageInput.spec().roi
+		imageInput.close()
 
-		# Cortex uses the EXR convention, which differs
+		oiioDisplayWindow = imath.Box2i(
+			imath.V2i( roi.xbegin, roi.ybegin ), imath.V2i( roi.xend - 1, roi.yend - 1 )
+		)
+
+		# OIIO uses the EXR convention, which differs
 		# from Gaffer's, so we use the conversion methods to
 		# check that the image windows are as expected.
 
 		self.assertEqual(
 			format.toEXRSpace( format.getDisplayWindow() ),
-			i.displayWindow
+			oiioDisplayWindow
 		)
 
 	def testHash( self ) :

--- a/python/GafferUITest/WidgetAlgoTest.py
+++ b/python/GafferUITest/WidgetAlgoTest.py
@@ -34,14 +34,12 @@
 #
 ##########################################################################
 
-import os
 import unittest
 import weakref
 import imath
 import math
 
-import IECore
-import IECoreImage
+import OpenImageIO
 
 import GafferUI
 import GafferUITest
@@ -61,8 +59,6 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 
 		GafferUI.WidgetAlgo.grab( b, str( self.temporaryDirectory() / "grab.png" ) )
 
-		i = IECore.Reader.create( str( self.temporaryDirectory() / "grab.png" ) ).read()
-
 		## \todo Should we have an official method for getting
 		# physical pixel size like this? Or should `grab()` downsize
 		# to return an image with the logical pixel size?
@@ -75,7 +71,10 @@ class WidgetAlgoTest( GafferUITest.TestCase ) :
 			expectedSize *= screen.devicePixelRatio()
 			expectedSize = imath.V2f( math.ceil( expectedSize.x ), math.ceil( expectedSize.y ) )
 
-		self.assertEqual( imath.V2f( i.displayWindow.size() ) + imath.V2f( 1 ), expectedSize )
+		imageInput = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "grab.png" ) )
+		imageSpec = imageInput.spec()
+		imageInput.close()
+		self.assertEqual( imath.V2f( imageSpec.width, imageSpec.height ), expectedSize )
 
 	def testGrabWithEventLoopRunning( self ) :
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -970,14 +970,22 @@ class RendererTest( GafferTest.TestCase ) :
 		if hasattr( IECoreImage, "OpenImageIOAlgo" ) and IECoreImage.OpenImageIOAlgo.version() >= 20206 :
 			worldToCameraKey = "worldToCamera"
 
-		for i in range( 3 ):
-			image = IECoreImage.ImageReader( str( self.temporaryDirectory() / f"beauty{i}.exr" ) ).read()
-			self.assertEqual( image.blindData()[worldToCameraKey].value,
-				imath.M44f( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, -i, 0, 0, 1 ) )
+		for i in range( 3 ) :
+			imageInput = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / f"beauty{i}.exr" ) )
+			imageSpec = imageInput.spec()
+			imageInput.close()
+			self.assertEqual(
+				imageSpec[worldToCameraKey],
+				( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, -i, 0, 0, 1 )
+			)
 
-		image = IECoreImage.ImageReader( str( self.temporaryDirectory() / "diffuse2.exr" ) ).read()
-		self.assertEqual( image.blindData()[worldToCameraKey].value,
-			imath.M44f( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, -2, 0, 0, 1 ) )
+		imageInput = OpenImageIO.ImageInput.open( str( self.temporaryDirectory() / "diffuse2.exr" ) )
+		imageSpec = imageInput.spec()
+		imageInput.close()
+		self.assertEqual(
+			imageSpec[worldToCameraKey],
+			( 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, -1, 0, -2, 0, 0, 1 )
+		)
 
 	def testCameraMesh( self ) :
 

--- a/src/GafferUI/ImageGadget.cpp
+++ b/src/GafferUI/ImageGadget.cpp
@@ -43,8 +43,6 @@
 #include "IECoreGL/TextureLoader.h"
 #include "IECoreGL/ToGLTextureConverter.h"
 
-#include "IECoreImage/ImageReader.h"
-
 #include "IECore/Exception.h"
 #include "IECore/SearchPath.h"
 

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -36,8 +36,6 @@
 
 #include "GafferUI/Pointer.h"
 
-#include "IECore/CachedReader.h"
-
 #include "fmt/format.h"
 
 using namespace GafferUI;


### PR DESCRIPTION
Inside Cortex there is a much slimmer set of libraries trying to get out. But Gaffer still has a few dependencies on legacy features that we'd like to remove. This PR whittles away some of that, noodling us a tiny bit closer to a less bloated future. Here I've focussed on users of `IECore.*Reader`, of which there are still a few remaining even after this PR. If anyone would like to chip in with tidying of their own, that would be great :)