### PR TITLE
Add buildGraphics to SConstruct

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Features
 
 - ShuffleOptions : Added a new node for shuffling options in the scene globals (#6412).
 
+Improvements
+------------
+
+- Added `buildGraphics` option to SConstruct to enable building the Gaffer logo and icons separately.
+
 Fixes
 -----
 

--- a/SConstruct
+++ b/SConstruct
@@ -2220,7 +2220,7 @@ def buildQtResourceFile( source, target, env ) :
 if haveInkscape :
 
 	for source in ( "resources/graphics.svg", "resources/GafferLogo.svg", "resources/GafferLogoMini.svg" ) :
-		env.Alias( "build", graphicsCommands( env, source, "$BUILD_DIR/graphics" ) )
+		env.Alias( [ "build", "buildGraphics" ], graphicsCommands( env, source, "$BUILD_DIR/graphics" ) )
 
 	resourceGraphics = set()
 	with open( "python/GafferUI/_StyleSheet.py" ) as styleSheet :


### PR DESCRIPTION
Following up on our Discord convo, here's SConstruct with a `buildGraphics` option added. I tested a bunch and all seems well. The normal build proceeds as expected and using this new option isolates only the logo and icons. Thank you!
