### PR TITLE
Fixes courtesy of Clang

### DIFF
--- a/include/Gaffer/Context.inl
+++ b/include/Gaffer/Context.inl
@@ -226,17 +226,22 @@ inline const Context::Value &Context::internalGet( const IECore::InternedString 
 		throw IECore::Exception( fmt::format( "Context has no variable named \"{}\"", name.value() ) );
 	}
 
-#ifndef NDEBUG
-	result->validate( name );
-#endif
-
 	return *result;
 }
 
 inline const Context::Value *Context::internalGetIfExists( const IECore::InternedString &name ) const
 {
 	Map::const_iterator it = m_map.find( name );
-	return it != m_map.end() ? &it->second : nullptr;
+	if( it == m_map.end() )
+	{
+		return nullptr;
+	}
+
+#ifndef NDEBUG
+	it->second.validate( name );
+#endif
+
+	return &it->second;
 }
 
 template<typename T>
@@ -250,7 +255,7 @@ const T &Context::get( const IECore::InternedString &name, const T &defaultValue
 {
 	if( const Value *value = internalGetIfExists( name ) )
 	{
-		return internalGet( name ).value<T>();
+		return value->value<T>();
 	}
 	return defaultValue;
 }

--- a/include/GafferVDB/VolumeScatter.h
+++ b/include/GafferVDB/VolumeScatter.h
@@ -54,7 +54,7 @@ class GAFFERVDB_API VolumeScatter : public GafferScene::BranchCreator
 	public :
 
 		VolumeScatter(const std::string &name = defaultName<VolumeScatter>() );
-		~VolumeScatter();
+		~VolumeScatter() override;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferVDB::VolumeScatter, VolumeScatterTypeId, GafferScene::BranchCreator );
 

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -123,7 +123,7 @@ private:
 	/// Implement to extend curve to specified key
 	virtual void extend( CurvePlug& curve, Animation::Direction direction, KeyPtr key ) const;
 
-	typedef std::vector< ConstExtrapolatorPtr > Container;
+	using Container = std::vector<ConstExtrapolatorPtr>;
 	static const Container& get();
 
 	Animation::Extrapolation m_extrapolation;

--- a/src/Gaffer/Animation.cpp
+++ b/src/Gaffer/Animation.cpp
@@ -3056,7 +3056,7 @@ const char* Animation::toString( const Animation::Extrapolation extrapolation )
 			return "CycleFlip";
 		default:
 			assert( 0 );
-			return 0;
+			return nullptr;
 	}
 }
 

--- a/src/Gaffer/ThreadMonitor.cpp
+++ b/src/Gaffer/ThreadMonitor.cpp
@@ -44,7 +44,7 @@ using namespace Gaffer;
 namespace
 {
 
-static std::atomic<int> g_threadIdCounter = 0;
+std::atomic<int> g_threadIdCounter = 0;
 ThreadMonitor::ProcessesPerThread g_emptyStatistics;
 
 } // namespace

--- a/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/GeometryAlgo.cpp
@@ -88,7 +88,7 @@ struct Converters
 
 };
 
-typedef std::unordered_map<IECore::TypeId, Converters> Registry;
+using Registry = std::unordered_map<IECore::TypeId, Converters>;
 
 Registry &registry()
 {

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -151,7 +151,7 @@ bool nullNodeDeleter( ccl::Node *node )
 
 // Helper to swap the node to delete to the front of the vector, then pop off
 template<typename T, typename U>
-static void removeNodesInSet( const ccl::set<T *> &nodesSet, tbb::concurrent_vector<U> &nodesArray )
+void removeNodesInSet( const ccl::set<T *> &nodesSet, tbb::concurrent_vector<U> &nodesArray )
 {
 	size_t newSize = nodesArray.size();
 

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -136,11 +136,11 @@ using SharedCObjectPtr = std::shared_ptr<ccl::Object>;
 using SharedCLightPtr = std::shared_ptr<ccl::Light>;
 using SharedCGeometryPtr = std::shared_ptr<ccl::Geometry>;
 // Need to defer shader assignments to the scene lock
-typedef std::pair<ccl::Node*, ccl::array<ccl::Node*>> ShaderAssignPair;
+using ShaderAssignPair = std::pair<ccl::Node *, ccl::array<ccl::Node *>>;
 // Defer adding the created nodes to the scene lock
 using NodesCreated = tbb::concurrent_vector<ccl::Node *>;
 // Defer creation of volumes to the scene lock
-typedef std::tuple<const IECoreVDB::VDBObject*, ccl::Volume*, int> VolumeToConvert;
+using VolumeToConvert = std::tuple<const IECoreVDB::VDBObject *, ccl::Volume *, int>;
 
 // The shared pointer never deletes, we leave that up to Cycles to do the final delete
 using NodeDeleter = bool (*)( ccl::Node * );
@@ -373,7 +373,7 @@ class CyclesOutput : public IECore::RefCounted
 
 IE_CORE_DECLAREPTR( CyclesOutput )
 
-typedef std::map<IECore::InternedString, CyclesOutputPtr> OutputMap;
+using OutputMap = std::map<IECore::InternedString, CyclesOutputPtr>;
 
 } // namespace
 
@@ -802,7 +802,7 @@ class ShaderCache : public IECore::RefCounted
 
 		ccl::Scene *m_scene;
 		int m_numDefaultShaders;
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, CyclesShaderPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, CyclesShaderPtr>;
 		Cache m_cache;
 		CyclesShaderPtr m_defaultSurface;
 		// Need to assign shaders in a deferred manner
@@ -1450,7 +1450,7 @@ class AttributesCache : public IECore::RefCounted
 
 		ShaderCachePtr m_shaderCache;
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, CyclesAttributesPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, CyclesAttributesPtr>;
 		Cache m_cache;
 
 };
@@ -1811,7 +1811,7 @@ class InstanceCache : public IECore::RefCounted
 		ccl::Scene *m_scene;
 		using Objects = tbb::concurrent_vector<SharedCObjectPtr>;
 		Objects m_objects;
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, SharedCGeometryPtr> Geometry;
+		using Geometry = tbb::concurrent_hash_map<IECore::MurmurHash, SharedCGeometryPtr>;
 		Geometry m_geometry;
 		using UniqueGeometry = tbb::concurrent_vector<SharedCGeometryPtr>;
 		UniqueGeometry m_uniqueGeometry;
@@ -1978,7 +1978,7 @@ class CameraCache : public IECore::RefCounted
 
 	private :
 
-		typedef tbb::concurrent_hash_map<IECore::MurmurHash, SharedCCameraPtr> Cache;
+		using Cache = tbb::concurrent_hash_map<IECore::MurmurHash, SharedCCameraPtr>;
 		Cache m_cache;
 
 };
@@ -3880,7 +3880,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 		OutputMap m_outputs;
 
 		// Cameras (Cycles can only know of one camera at a time)
-		typedef tbb::concurrent_unordered_map<std::string, IECoreScene::ConstCameraPtr> CameraMap;
+		using CameraMap = tbb::concurrent_unordered_map<std::string, IECoreScene::ConstCameraPtr>;
 		CameraMap m_cameras;
 
 		// Registration with factory

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -92,7 +92,7 @@ std::string shaderCacheGetter( const std::string &shaderName, size_t &cost )
 	}
 }
 
-typedef IECore::LRUCache<std::string, std::string> ShaderSearchPathCache;
+using ShaderSearchPathCache = IECore::LRUCache<std::string, std::string>;
 ShaderSearchPathCache g_shaderSearchPathCache( shaderCacheGetter, 10000 );
 
 ccl::SocketType::Type getSocketType( const std::string &name )
@@ -108,7 +108,7 @@ ccl::SocketType::Type getSocketType( const std::string &name )
 	return ccl::SocketType::Type::UNDEFINED;
 }
 
-typedef boost::unordered_map<ShaderNetwork::Parameter, ccl::ShaderNode *> ShaderMap;
+using ShaderMap = boost::unordered_map<ShaderNetwork::Parameter, ccl::ShaderNode *>;
 
 ccl::ShaderNode *convertWalk( const ShaderNetwork::Parameter &outputParameter, const IECoreScene::ShaderNetwork *shaderNetwork, const std::string &namePrefix, ccl::ShaderManager *shaderManager, ccl::ShaderGraph *shaderGraph, ShaderMap &converted )
 {

--- a/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/ShaderNetworkAlgo.cpp
@@ -309,7 +309,7 @@ T parameterValue( const IECore::CompoundDataMap &parameters, const IECore::Inter
 	return defaultValue;
 }
 
-static const bool g_useLegacyLights = []() -> bool {
+const bool g_useLegacyLights = []() -> bool {
 	const char *c = getenv( "GAFFERCYCLES_USE_LEGACY_LIGHTS" );
 	if( !c )
 	{

--- a/src/GafferImageUI/OpenColorIOAlgo.cpp
+++ b/src/GafferImageUI/OpenColorIOAlgo.cpp
@@ -134,7 +134,7 @@ void AllocateTexture2D(
 	}
 }
 
-static const std::string g_vertexSource = R"(
+const std::string g_vertexSource = R"(
 #version 120
 
 #if __VERSION__ <= 120
@@ -154,7 +154,7 @@ void main()
 
 )";
 
-static const std::string g_fragmentSource = R"(
+const std::string g_fragmentSource = R"(
 #version 120
 
 <OCIODisplay>

--- a/src/GafferModule/SplinePlugBinding.cpp
+++ b/src/GafferModule/SplinePlugBinding.cpp
@@ -84,7 +84,7 @@ std::string splineDefinitionRepr( object x )
 }
 
 template<typename T>
-static T *splineDefinitionConstruct( object o, const SplineDefinitionInterpolation &interpolation )
+T *splineDefinitionConstruct( object o, const SplineDefinitionInterpolation &interpolation )
 {
 	typename T::PointContainer points;
 	int s = extract<int>( o.attr( "__len__" )() );
@@ -106,7 +106,7 @@ static T *splineDefinitionConstruct( object o, const SplineDefinitionInterpolati
 }
 
 template<typename T>
-static boost::python::tuple splineDefinitionPoints( const T &s )
+boost::python::tuple splineDefinitionPoints( const T &s )
 {
 	boost::python::list p;
 	typename T::PointContainer::const_iterator it;

--- a/src/GafferOSL/ShadingEngine.cpp
+++ b/src/GafferOSL/ShadingEngine.cpp
@@ -103,7 +103,7 @@ namespace
 
 // Initialised by first call to `shadingSystem()`. Declared here because
 // it affects the conversion routines.
-static int g_shadingSystemBatchSize = 0;
+int g_shadingSystemBatchSize = 0;
 
 template<typename T>
 struct TypeDescFromType
@@ -1332,7 +1332,7 @@ void declareParameters( const CompoundDataMap &parameters, ShadingSystem *shadin
 }
 
 template <typename T>
-static T uniformValue( const IECore::CompoundData *points, const char *name )
+T uniformValue( const IECore::CompoundData *points, const char *name )
 {
 	using DataType = TypedData<T>;
 	const DataType *d = points->member<DataType>( name );
@@ -1347,7 +1347,7 @@ static T uniformValue( const IECore::CompoundData *points, const char *name )
 }
 
 template<typename T>
-static const T *varyingValue( const IECore::CompoundData *points, const char *name )
+const T *varyingValue( const IECore::CompoundData *points, const char *name )
 {
 	using DataType = TypedData<vector<T> >;
 	const DataType *d = points->member<DataType>( name );

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -95,7 +95,7 @@ namespace
 {
 
 using ParameterSet = unordered_set<string>;
-static const unordered_map<string, ParameterSet> g_omittedParameters = {
+const unordered_map<string, ParameterSet> g_omittedParameters = {
 	{
 		"PxrPortalLight",
 		{

--- a/src/GafferRenderMan/RenderManShader.cpp
+++ b/src/GafferRenderMan/RenderManShader.cpp
@@ -146,7 +146,7 @@ bool isVStruct( const boost::property_tree::ptree &parameter )
 template<typename PlugType>
 PlugPtr acquireNumericParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, Plug *candidatePlug )
 {
-	typedef typename PlugType::ValueType ValueType;
+	using ValueType = typename PlugType::ValueType;
 
 	const ValueType defaultValue = parameter.get( "<xmlattr>.default", ValueType( 0 ) );
 	const ValueType minValue = parameter.get( "<xmlattr>.min", numeric_limits<ValueType>::lowest() );
@@ -169,8 +169,8 @@ PlugPtr acquireNumericParameter( const boost::property_tree::ptree &parameter, I
 template<typename T>
 T parseCompoundNumericValue( const string &s )
 {
-	typedef typename T::BaseType BaseType;
-	typedef boost::tokenizer<boost::char_separator<char> > Tokenizer;
+	using BaseType = typename T::BaseType;
+	using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 	T result( 0 );
 	unsigned int i = 0;
@@ -189,8 +189,8 @@ T parseCompoundNumericValue( const string &s )
 template<typename PlugType>
 PlugPtr acquireCompoundNumericParameter( const boost::property_tree::ptree &parameter, IECore::InternedString name, Plug::Direction direction, IECore::GeometricData::Interpretation interpretation, Plug *candidatePlug )
 {
-	typedef typename PlugType::ValueType ValueType;
-	typedef typename ValueType::BaseType BaseType;
+	using ValueType = typename PlugType::ValueType;
+	using BaseType = typename ValueType::BaseType;
 
 	const ValueType defaultValue = parseCompoundNumericValue<ValueType>( parameter.get( "<xmlattr>.default", "0 0 0" ) );
 

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -861,8 +861,8 @@ const Gaffer::GraphComponent *GafferScene::EditScopeAlgo::attributeEditReadOnlyR
 namespace
 {
 
-static int g_addSetColumnIndex = 0;
-static int g_removeSetColumnIndex = 1;
+int g_addSetColumnIndex = 0;
+int g_removeSetColumnIndex = 1;
 
 SceneProcessorPtr setMembershipProcessor()
 {

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -122,7 +122,7 @@ struct CompoundAttributesInterface : public IECoreScenePreview::Renderer::Attrib
 struct CompoundObjectInterface : public IECoreScenePreview::Renderer::ObjectInterface
 {
 
-	~CompoundObjectInterface()
+	~CompoundObjectInterface() override
 	{
 		if( m_links.empty() )
 		{

--- a/src/GafferScene/IECoreScenePreview/MeshAlgoTessellate.cpp
+++ b/src/GafferScene/IECoreScenePreview/MeshAlgoTessellate.cpp
@@ -558,8 +558,8 @@ struct MutexWriteGuard
 	tbb::spin_rw_mutex::scoped_lock m_guard;
 };
 
-typedef OSDB::SurfaceFactoryCacheThreaded< tbb::spin_rw_mutex, MutexReadGuard, MutexWriteGuard > SurfaceFactoryCache;
-typedef OSDB::RefinerSurfaceFactory< SurfaceFactoryCache > SurfaceFactory;
+using SurfaceFactoryCache = OSDB::SurfaceFactoryCacheThreaded<tbb::spin_rw_mutex, MutexReadGuard, MutexWriteGuard>;
+using SurfaceFactory = OSDB::RefinerSurfaceFactory<SurfaceFactoryCache>;
 
 
 // In order to output a watertight mesh, we need to share output vertices and edges where the input vertices
@@ -1325,7 +1325,7 @@ MeshPrimitivePtr MeshAlgo::tessellateMesh(
 
 	// The TopologyDescriptor is how we pass all our mesh topology to OpenSubdiv
 
-	typedef OSDF::TopologyDescriptor Descriptor;
+	using Descriptor = OSDF::TopologyDescriptor;
 	Descriptor desc;
 
 	std::vector<int> creaseIdsBuffer;

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -3198,7 +3198,7 @@ struct Prototype : public IECore::RefCounted
 	std::vector<M44f> m_transforms;
 };
 
-typedef boost::intrusive_ptr< const Prototype > ConstPrototypePtr;
+using ConstPrototypePtr = boost::intrusive_ptr<const Prototype>;
 
 struct PrototypeCacheGetterKey
 {

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -249,8 +249,8 @@ InternedString g_transformBlurSegmentsAttributeName( "gaffer:transformBlurSegmen
 InternedString g_deformationBlurAttributeName( "gaffer:deformationBlur" );
 InternedString g_deformationBlurSegmentsAttributeName( "gaffer:deformationBlurSegments" );
 
-static BoolDataPtr g_true = new BoolData( true );
-static BoolDataPtr g_false = new BoolData( false );
+BoolDataPtr g_true = new BoolData( true );
+BoolDataPtr g_false = new BoolData( false );
 
 } // namespace
 

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -48,7 +48,7 @@
 
 #include "tbb/enumerable_thread_specific.h"
 
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 using namespace boost::placeholders;

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -730,7 +730,7 @@ class VisualiserGadget : public Gadget
 				GLuint buffer = 0u;
 				glGenBuffers( 1, &buffer );
 				glBindBuffer( GL_UNIFORM_BUFFER, buffer );
-				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockColorShader ), 0, GL_DYNAMIC_DRAW );
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockColorShader ), nullptr, GL_DYNAMIC_DRAW );
 				m_colorUniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
 			}
 
@@ -1132,7 +1132,7 @@ class VisualiserGadget : public Gadget
 				GLuint buffer = 0u;
 				glGenBuffers( 1, &buffer );
 				glBindBuffer( GL_UNIFORM_BUFFER, buffer );
-				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockVertexLabelShader ), 0, GL_DYNAMIC_DRAW );
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockVertexLabelShader ), nullptr, GL_DYNAMIC_DRAW );
 				glBindBuffer( GL_UNIFORM_BUFFER, uniformBinding );
 				m_vertexLabelUniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
 			}
@@ -1375,7 +1375,7 @@ class VisualiserGadget : public Gadget
 
 				if( m_vertexLabelStorageCapacity < storageCapacity )
 				{
-					glBufferData( GL_SHADER_STORAGE_BUFFER, storageSize, 0, GL_DYNAMIC_DRAW );
+					glBufferData( GL_SHADER_STORAGE_BUFFER, storageSize, nullptr, GL_DYNAMIC_DRAW );
 					m_vertexLabelStorageCapacity = storageCapacity;
 				}
 
@@ -1653,7 +1653,7 @@ class VisualiserGadget : public Gadget
 				GLuint buffer = 0u;
 				glGenBuffers( 1, &buffer );
 				glBindBuffer( GL_UNIFORM_BUFFER, buffer );
-				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockVectorShader ), 0, GL_DYNAMIC_DRAW );
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockVectorShader ), nullptr, GL_DYNAMIC_DRAW );
 				m_vectorUniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
 			}
 
@@ -1913,7 +1913,7 @@ class VisualiserGadget : public Gadget
 				GLuint buffer = 0u;
 				glGenBuffers( 1, &buffer );
 				glBindBuffer( GL_UNIFORM_BUFFER, buffer );
-				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockOrientationShader ), 0, GL_DYNAMIC_DRAW );
+				glBufferData( GL_UNIFORM_BUFFER, sizeof( UniformBlockOrientationShader ), nullptr, GL_DYNAMIC_DRAW );
 				m_orientationUniformBuffer.reset( new IECoreGL::Buffer( buffer ) );
 			}
 

--- a/src/GafferUI/Pointer.cpp
+++ b/src/GafferUI/Pointer.cpp
@@ -43,10 +43,10 @@ using namespace GafferUI;
 namespace
 {
 
-static ConstPointerPtr g_current;
+ConstPointerPtr g_current;
 
 using Registry = std::map<std::string, ConstPointerPtr>;
-static Registry &registry()
+Registry &registry()
 {
 	static Registry r;
 	if( !r.size() )

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -1269,7 +1269,7 @@ class DelightLight : public DelightObject
 						m_transformHandle.context(),
 						m_lightGeometry->name(), "",
 						m_transformHandle.name(), "objects",
-						0, 0
+						0, nullptr
 					);
 
 					m_lightGeometryType = geometryType;

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -200,10 +200,10 @@ IECoreScene::ConstShaderNetworkPtr g_facingRatio = []() {
 IECoreScene::ConstShaderNetworkPtr g_black = []() {
 
 	ShaderNetworkPtr result = new ShaderNetwork;
-	const InternedString facingRatioHandle = result->addShader(
+	const InternedString blackHandle = result->addShader(
 		"black", new Shader( "PxrBlack" )
 	);
-	result->setOutput( { "black", "out" } );
+	result->setOutput( { blackHandle, "out" } );
 
 	return result;
 

--- a/src/IECoreRenderMan/Attributes.h
+++ b/src/IECoreRenderMan/Attributes.h
@@ -49,7 +49,7 @@ class Attributes : public IECoreScenePreview::Renderer::AttributesInterface
 	public :
 
 		Attributes( const IECore::CompoundObject *attributes, MaterialCache *materialCache );
-		~Attributes();
+		~Attributes() override;
 
 		/// Returns a hash of everything in `prototypeParamList()`, to be
 		/// used by GeometryPrototypeCache when automaticaly deduplicating

--- a/src/IECoreRenderMan/Camera.h
+++ b/src/IECoreRenderMan/Camera.h
@@ -49,7 +49,7 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 	public :
 
 		Camera( const std::string &name, const IECoreScene::Camera *camera, Session *session );
-		~Camera();
+		~Camera() override;
 
 		void transform( const Imath::M44f &transform ) override;
 		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override;

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -55,7 +55,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 	public :
 
 		Light( const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, MaterialCache *materialCache, LightLinker *lightLinker, Session *session );
-		~Light();
+		~Light() override;
 
 		// ObjectInterface overrides
 		// =========================

--- a/src/IECoreRenderMan/LightFilter.h
+++ b/src/IECoreRenderMan/LightFilter.h
@@ -53,7 +53,7 @@ class LightFilter : public IECoreScenePreview::Renderer::ObjectInterface
 	public :
 
 		LightFilter( const std::string &name, const Attributes *attributes, Session *session, LightLinker *lightLinker );
-		~LightFilter();
+		~LightFilter() override;
 
 		// ObjectInterface overrides
 		// =========================

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -52,7 +52,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 	public :
 
 		Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session );
-		~Object();
+		~Object() override;
 
 		/// \todo RenderMan volumes seem to reject attempts to transform them
 		/// after creation, althought we get lucky and the first one works

--- a/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
+++ b/src/IECoreRenderMan/ShaderNetworkAlgo.cpp
@@ -924,7 +924,7 @@ void convertUSDShaders( ShaderNetwork *shaderNetwork )
 			newShader->parameters()[g_typeParameter] = new StringData( typeName );
 			transferUSDParameter( shaderNetwork, handle, shader.get(), g_varnameParameter, newShader.get(), g_varnameParameter, string() );
 			std::visit(
-				[&shaderNetwork, &handle, &shader, &newShader, &defaultParameter]( auto &&v )
+				[&shaderNetwork, &handle=handle, &shader=shader, &newShader, &defaultParameter=defaultParameter]( auto &&v )
 				{
 					transferUSDParameter( shaderNetwork, handle, shader.get(), g_fallbackParameter, newShader.get(), defaultParameter, v );
 				},


### PR DESCRIPTION
This fixes a few errors when compiling with clang, and then uses `clang-tidy` to re-apply all the checks we've used in the past. A few new things have crept in since last we ran it.

@danieldresser-ie, I've put you down to review partly to spread the load, but also because I'd like your eyes on https://github.com/GafferHQ/gaffer/commit/c52bbbbddc51f2dcd3ac59e0d8cefbffa1d35f46 in particular. I think it's fine, but it's very central so worth a close look. One thing we've lost is the call to `validate()` in debug builds - I could move that from `internalGet()` to `internalGetIfExists()` if we wanted to have it called for both.