### PR TITLE
IECoreCycles : Fix default camera resolution and projection

### DIFF
--- a/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
+++ b/python/GafferCyclesTest/IECoreCyclesPreviewTest/RendererTest.py
@@ -947,8 +947,8 @@ class RendererTest( GafferTest.TestCase ) :
 		self.assertTrue( isinstance( image, IECoreImage.ImagePrimitive ) )
 
 		center = self.__colorAtUV( image, imath.V2f( 0.5, 0.5 ) )
-		left = self.__colorAtUV( image, imath.V2f( 0.3, 0.5 ) )
-		right = self.__colorAtUV( image, imath.V2f( 0.7, 0.5 ) )
+		left = self.__colorAtUV( image, imath.V2f( 0.15, 0.5 ) )
+		right = self.__colorAtUV( image, imath.V2f( 0.85, 0.5 ) )
 
 		# Everything should have solid alpha.
 
@@ -961,9 +961,9 @@ class RendererTest( GafferTest.TestCase ) :
 		if smoothingExpected :
 			# Center normal faces straight at us
 			self.assertGreater( center[0], 0.95 )
-			# Outer normals actually face slightly away
-			self.assertLess( left[0], 0 )
-			self.assertLess( right[0], 0 )
+			# Outer normals are close to perpendicular.
+			self.assertLess( left[0], 0.015 )
+			self.assertLess( right[0], 0.015 )
 		else :
 			# Everything faces towards and to the side of us.
 			self.assertGreater( center[0], 0.4 )

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -2829,14 +2829,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				m_lightLinker( renderType )
 
 		{
-			IECoreScene::CameraPtr camera = new IECoreScene::Camera();
-			/// \todo Remove, and use default parameter values. The
-			/// values here are to match a historical bug in Cycles.
-			camera->setResolution( V2i( 1024, 512 ) );
-			camera->setProjection( "perspective" );
-			camera->setFocalLengthFromFieldOfView( 80.0f );
-			CyclesCameraPtr defaultCamera = new CyclesCamera( camera );
-			m_cameras["ieCoreCycles:defaultCamera"] = defaultCamera;
+			m_cameras["ieCoreCycles:defaultCamera"] =  new CyclesCamera( new IECoreScene::Camera() );
 		}
 
 		~CyclesRenderer() override


### PR DESCRIPTION
Follow up to #6442, with one final fix to bring the default camera in line with other renderer backends.