### PR TITLE
IECoreCycles object lifetime refactoring

### DIFF
--- a/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
+++ b/include/GafferCycles/IECoreCyclesPreview/GeometryAlgo.h
@@ -48,7 +48,6 @@
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "scene/geometry.h"
 #include "scene/volume.h"
-// Currently only VDBs need scene to get to the image manager
 #include "scene/scene.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
@@ -59,10 +58,10 @@ namespace GeometryAlgo
 {
 
 /// Converts the specified `IECore::Object` into `ccl::Geometry`.
-IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene = nullptr );
+IECORECYCLES_API ccl::Geometry *convert( const IECore::Object *object, const std::string &nodeName, ccl::Scene *scene );
 /// As above, but converting a moving object. If no motion converter
 /// is available, the first sample is converted instead.
-IECORECYCLES_API ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene = nullptr );
+IECORECYCLES_API ccl::Geometry *convert( const std::vector<const IECore::Object *> &samples, const std::vector<float> &times, const int frame, const std::string &nodeName, ccl::Scene *scene );
 
 /// Converts a primitive variable to a `ccl::Attribute` inside of a `ccl::AttributeSet`.
 IECORECYCLES_API void convertPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, ccl::AttributeSet &attributes, ccl::AttributeElement attributeElement );

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1792,9 +1792,9 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 
 	public :
 
-		CyclesObject( ccl::Session *session, const SharedGeometryPtr &geometry, const std::string &name, const float frame, LightLinker *lightLinker, NodeDeleter *nodeDeleter )
-			:	m_session( session ),
-				m_object( SceneAlgo::createNodeWithLock<ccl::Object>( m_session->scene ), NodeDeleter::ObjectDeleter( nodeDeleter ) ),
+		CyclesObject( ccl::Scene *scene, const SharedGeometryPtr &geometry, const std::string &name, const float frame, LightLinker *lightLinker, NodeDeleter *nodeDeleter )
+			:	m_scene( scene ),
+				m_object( SceneAlgo::createNodeWithLock<ccl::Object>( scene ), NodeDeleter::ObjectDeleter( nodeDeleter ) ),
 				m_geometry( geometry ), m_frame( frame ), m_attributes( nullptr ), m_lightLinker( lightLinker )
 		{
 			m_object->name = ccl::ustring( name.c_str() );
@@ -1879,7 +1879,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 
 			m_object->set_motion( motion );
 
-			m_object->tag_update( m_session->scene );
+			m_object->tag_update( m_scene );
 		}
 
 		void transform( const std::vector<Imath::M44f> &samples, const std::vector<float> &times ) override
@@ -1899,7 +1899,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 					motion[i] = m_object->get_tfm();
 					m_object->set_motion( motion );
 				}
-				m_object->tag_update( m_session->scene );
+				m_object->tag_update( m_scene );
 				return;
 			}
 
@@ -1908,7 +1908,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 			if( numSamples == 1 )
 			{
 				m_object->set_tfm( SocketAlgo::setTransform( samples.front() ) );
-				m_object->tag_update( m_session->scene );
+				m_object->tag_update( m_scene );
 				return;
 			}
 
@@ -1998,7 +1998,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 				}
 			}
 
-			m_object->tag_update( m_session->scene );
+			m_object->tag_update( m_scene );
 		}
 
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override
@@ -2007,7 +2007,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 			if( cyclesAttributes->applyObject( m_object.get(), m_attributes.get() ) )
 			{
 				m_attributes = cyclesAttributes;
-				m_object->tag_update( m_session->scene );
+				m_object->tag_update( m_scene );
 				return true;
 			}
 
@@ -2021,7 +2021,7 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 
 	private :
 
-		ccl::Session *m_session;
+		ccl::Scene *m_scene;
 		using UniqueObjectPtr = std::unique_ptr<ccl::Object, NodeDeleter::ObjectDeleter>;
 		UniqueObjectPtr m_object;
 		SharedGeometryPtr m_geometry;
@@ -2734,7 +2734,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			ObjectInterfacePtr result = new CyclesObject( m_session.get(), geometry, name, frame(), &m_lightLinker, m_nodeDeleter.get() );
+			ObjectInterfacePtr result = new CyclesObject( m_scene, geometry, name, frame(), &m_lightLinker, m_nodeDeleter.get() );
 			result->attributes( attributes );
 			return result;
 		}
@@ -2759,7 +2759,7 @@ class CyclesRenderer final : public IECoreScenePreview::Renderer
 				return nullptr;
 			}
 
-			ObjectInterfacePtr result = new CyclesObject( m_session.get(), geometry, name, frame(), &m_lightLinker, m_nodeDeleter.get() );
+			ObjectInterfacePtr result = new CyclesObject( m_scene, geometry, name, frame(), &m_lightLinker, m_nodeDeleter.get() );
 			result->attributes( attributes );
 			return result;
 		}

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -127,8 +127,6 @@ using namespace IECoreCycles;
 namespace
 {
 
-using CIntegratorPtr = std::unique_ptr<ccl::Integrator>;
-using CBackgroundPtr = std::unique_ptr<ccl::Background>;
 using CFilmPtr = std::unique_ptr<ccl::Film>;
 using SharedCObjectPtr = std::shared_ptr<ccl::Object>;
 using SharedCGeometryPtr = std::shared_ptr<ccl::Geometry>;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1748,12 +1748,6 @@ class InstanceCache : public IECore::RefCounted
 			m_scene->delete_nodes( toEraseGeos, m_scene );
 		}
 
-		void nodesCreated( NodesCreated &objects, NodesCreated &geometry )
-		{
-			objectsCreated( objects );
-			geometryCreated( geometry );
-		}
-
 	private :
 
 		SharedCGeometryPtr convert( const IECore::Object *object, const CyclesAttributes *attributes, const std::string &nodeName )
@@ -1848,35 +1842,6 @@ class InstanceCache : public IECore::RefCounted
 				}
 				m_scene->object_manager->tag_update( m_scene, ccl::GeometryManager::GEOMETRY_ADDED );
 				nodes.clear();
-			}
-		}
-
-		void objectsCreated( NodesCreated &nodes ) const
-		{
-			for( Objects::const_iterator it = m_objects.begin(), eIt = m_objects.end(); it != eIt; ++it )
-			{
-				if( it->get() )
-				{
-					nodes.push_back( it->get() );
-				}
-			}
-		}
-
-		void geometryCreated( NodesCreated &nodes ) const
-		{
-			for( UniqueGeometry::const_iterator it = m_uniqueGeometry.begin(), eIt = m_uniqueGeometry.end(); it != eIt; ++it )
-			{
-				if( it->get() )
-				{
-					nodes.push_back( it->get() );
-				}
-			}
-			for( Geometry::const_iterator it = m_geometry.begin(), eIt = m_geometry.end(); it != eIt; ++it )
-			{
-				if( it->second )
-				{
-					nodes.push_back( it->second.get() );
-				}
 			}
 		}
 

--- a/src/GafferCycles/IECoreCyclesPreview/SceneAlgo.h
+++ b/src/GafferCycles/IECoreCyclesPreview/SceneAlgo.h
@@ -1,0 +1,53 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "scene/scene.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
+namespace IECoreCycles::SceneAlgo
+{
+
+template<typename T, typename... Args> T *createNodeWithLock( ccl::Scene *scene, Args &&...args )
+{
+	// `Scene::create_node()` adds the new node to the relevant list
+	// (`lights`, `geometry` etc) in the Scene, so we need the lock
+	// to make that addition thread-safe.
+	std::scoped_lock lock( scene->mutex );
+	return scene->create_node<T>( std::forward<Args>( args )... );
+}
+
+} // IECoreCycles::SceneAlgo

--- a/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/SphereAlgo.cpp
@@ -35,6 +35,8 @@
 #include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
+#include "SceneAlgo.h"
+
 #include "IECoreScene/SpherePrimitive.h"
 
 #include "IECore/Interpolator.h"
@@ -72,11 +74,11 @@ void warnIfUnsupported( const IECoreScene::SpherePrimitive *sphere )
 	}
 }
 
-ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere )
+ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere, ccl::Scene *scene )
 {
 	assert( sphere->typeId() == IECoreScene::SpherePrimitive::staticTypeId() );
 	warnIfUnsupported( sphere );
-	ccl::PointCloud *pointcloud = new ccl::PointCloud();
+	ccl::PointCloud *pointcloud = SceneAlgo::createNodeWithLock<ccl::PointCloud>( scene );
 
 	//pointcloud->set_point_style( ccl::POINT_CLOUD_POINT_SPHERE );
 	pointcloud->reserve( 1 );
@@ -101,14 +103,14 @@ ccl::PointCloud *convertCommon( const IECoreScene::SpherePrimitive *sphere )
 
 ccl::Geometry *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Geometry *result = convertCommon( sphere );
+	ccl::Geometry *result = convertCommon( sphere, scene );
 	result->name = ccl::ustring( nodeName.c_str() );
 	return result;
 }
 
 ccl::Geometry *convert( const vector<const IECoreScene::SpherePrimitive *> &samples, const std::vector<float> &times, const int frameIdx, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Geometry *result = convertCommon( samples.front() );
+	ccl::Geometry *result = convertCommon( samples.front(), scene );
 	result->name = ccl::ustring( nodeName.c_str() );
 	return result;
 }

--- a/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/VDBAlgo.cpp
@@ -35,6 +35,8 @@
 #include "GafferCycles/IECoreCyclesPreview/GeometryAlgo.h"
 #include "GafferCycles/IECoreCyclesPreview/SocketAlgo.h"
 
+#include "SceneAlgo.h"
+
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "openvdb/openvdb.h"
 IECORE_POP_DEFAULT_VISIBILITY
@@ -60,7 +62,7 @@ namespace
 
 ccl::Geometry *convert( const IECoreVDB::VDBObject *vdbObject, const std::string &nodeName, ccl::Scene *scene )
 {
-	ccl::Volume *volume = new ccl::Volume();
+	ccl::Volume *volume = SceneAlgo::createNodeWithLock<ccl::Volume>( scene );
 	volume->name = ccl::ustring( nodeName.c_str() );
 	return volume;
 }


### PR DESCRIPTION
For reasons unknown, IECoreCycles was avoiding the standard `ccl::Scene::create_node()` method of creating nodes, and doing its own more convoluted thing instead. This refactors that so we use `create_node()` as intended for `Light`, `Object` and `Geometry` nodes. It also clarifies the process used to delete such objects, and tidies up a few bits of related code. All in all it knocks ~250 lines of code off of Renderer.cpp. This puts us in a better place to start adapting to the changes in the Cycles 4.4 API.