### PR TITLE
Cycles : Improve responsiveness of camera movement in the viewport.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,7 +14,9 @@ Improvements
 - 3Delight, Cycles, OpenGL : Added support for custom EXR metadata, using `header:*` parameters on the output definition.
 - RenderManAttributes, RenderManOptions : Plugs now respect minimum and maximum values specified by RenderMan.
 - RenderManShader : Improved GraphEditor labels for parameter RGB and XYZ components.
-- Cycles : Added support for `layerName` parameter in outputs, to control the naming of channels in EXR outputs.
+- Cycles :
+  - Improved responsiveness for Viewer camera updates when using Cycles as the viewport renderer. One benchmark shows around a 10x improvement in frame rate.
+  - Added support for `layerName` parameter in outputs, to control the naming of channels in EXR outputs.
 - StandardOptions : Added render manifest option.
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 


### PR DESCRIPTION
This fixes a bug I noticed while getting everything updated for Cycles 4.4. It prevents Cycles from doing an unnecessary BVH rebuild when only the camera transform has changed, giving us much faster movement in the viewport. In the benchmark I was testing with I'm seeing ~10x speedup in frame rate.