### PR TITLE
ShaderPlug : Accept connections from RenderMan BXDFPlug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 -----
 
 - RenderMan : Added missing attribute handlers for float, string, InternedString, Color3f and V3f array attributes. In particular, this fixes the export of `render:displayColor` attributes loaded from USD.
+- RenderManShader : Fixed failure to load connections made via Dots and other intermediate nodes.
 - Expression : Fixed error when creating OSL expressions for plugs with `:` characters in their name.
 - PythonEditor : Fixed completions menu not appearing after typing `:` in a partial plug or node name or a dictionary key.
 - Animation : Fixed "Jump To" actions in plug context menu.

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -269,5 +269,25 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		proxy.loadShader( "ri:PxrConstant" )
 		self.assertIn( "bxdf_out", proxy["out"] )
 
+	def testDot( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["shaderAssignment"] = GafferScene.ShaderAssignment()
+
+		script["shader"] = GafferRenderMan.RenderManShader()
+		script["shader"].loadShader( "PxrSurface" )
+
+		script["dot"] = Gaffer.Dot()
+		script["dot"].setup( script["shader"]["out"]["bxdf_out"] )
+		script["dot"]["in"].setInput( script["shader"]["out"]["bxdf_out"] )
+
+		script["shaderAssignment"]["shader"].setInput( script["dot"]["out"] )
+
+		script2 = Gaffer.ScriptNode()
+		script2.execute( script.serialise() )
+		self.assertTrue( script["shaderAssignment"]["shader"].getInput().isSame( script["dot"]["out"] ) )
+		self.assertTrue( script["shaderAssignment"]["shader"].source().isSame( script["shader"]["out"]["bxdf_out"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferScene/ShaderPlug.cpp
+++ b/src/GafferScene/ShaderPlug.cpp
@@ -99,10 +99,14 @@ bool isParameterType( const Plug *plug )
 		case BoolPlugTypeId :
 			return true;
 		default :
-			// Use typeName query to avoid hard dependency on
-			// GafferOSL. It may be that we should move ClosurePlug
-			// to GafferScene anyway.
-			return plug->isInstanceOf( "GafferOSL::ClosurePlug" );
+			// Use `typeName()` query to avoid hard dependency on GafferOSL and
+			// GafferRenderMan. It may be that we should move ClosurePlug to
+			// GafferScene anyway, and give it an additional property to say what
+			// type of closure it is.
+			return
+				plug->isInstanceOf( "GafferOSL::ClosurePlug" ) ||
+				plug->isInstanceOf( "GafferRenderMan::BXDFPlug" )
+			;
 	}
 }
 


### PR DESCRIPTION
We were failing to recreate the connection on loading, with an error of this form :

```
IECore.Exception: Line 20 : IECore.Exception: Plug "ScriptNode.shaderAssignment.shader" rejects input "ScriptNode.dot.out".
```

Taking a cheap-and-cheerful approach to fixing for now, but I think the fix described in the comment is probably a better longer-term approach when we can break ABI.
