### PR TITLE
GafferScene : Add forward compat for Catalogue moving to GafferScene

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Fixes
 - PythonEditor : Fixed completions menu not appearing after typing `:` in a partial plug or node name or a dictionary key.
 - Animation : Fixed "Jump To" actions in plug context menu.
 - Edit Menu : Disabled "Rename" menu item when the selection is read-only.
+- Catalogue : Added forwards compatibility for Catalogues saved from Gaffer 1.6.
 
 Build
 -----

--- a/python/GafferSceneTest/SceneNodeTest.py
+++ b/python/GafferSceneTest/SceneNodeTest.py
@@ -98,7 +98,8 @@ class SceneNodeTest( GafferSceneTest.SceneTestCase ) :
 				"PathMatcherData", "Gaffer::PathMatcherDataPlug", "Gaffer::Switch",
 				"Gaffer::ContextVariables", "Gaffer::DeleteContextVariables", "Gaffer::TimeWarp",
 				"Gaffer::Loop", "GafferScene::ShaderTweaks", "Gaffer::TweakPlug",
-				"Gaffer::TweaksPlug",
+				"Gaffer::TweaksPlug", "GafferImage::Catalogue", "GafferImage::CatalogueSelect",
+				"GafferImage::Display"
 			}
 		)
 

--- a/startup/GafferScene/catalogueForwardCompatibility.py
+++ b/startup/GafferScene/catalogueForwardCompatibility.py
@@ -1,0 +1,43 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferScene
+import GafferImage
+
+GafferScene.Catalogue = GafferImage.Catalogue
+GafferScene.CatalogueSelect = GafferImage.CatalogueSelect
+GafferScene.Display = GafferImage.Display
+


### PR DESCRIPTION
This is a very basic forward compatibility config to make Gaffer 1.6 catalogues open in Gaffer 1.5.

We don't need to do any of the weird property deferred loading from the backwards compatibility config, because GafferScene already depends on GafferImage.