### PR TITLE
OSL : Fix documentation links

### DIFF
--- a/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
+++ b/doc/source/WorkingWithTheNodeGraph/TutorialUsingTheOSLCodeNode/index.md
@@ -64,7 +64,7 @@ OSL resources
 
 This short tutorial has only scratched the surface of what can be done with Open Shading Language. The following resources are a good place to learn more :
 
-- The [language specification](https://github.com/imageworks/OpenShadingLanguage/blob/master/src/doc/osl-languagespec.pdf) (also available from _Help_ > _Open Shading Language_ > _Language Reference_)
+- The [language specification](https://open-shading-language.readthedocs.io)
 - The [OSL mailing list](https://groups.google.com/forum/#!forum/osl-dev)
 
 [1]: https://github.com/imageworks/OpenShadingLanguage

--- a/startup/gui/menus.py
+++ b/startup/gui/menus.py
@@ -491,12 +491,10 @@ if moduleSearchPath.find( "GafferOSL" ) :
 	nodeMenu.append( "/OSL/Image", GafferOSL.OSLImage, searchText = "OSLImage" )
 	nodeMenu.append( "/OSL/Object", GafferOSL.OSLObject, searchText = "OSLObject" )
 
-	oslDocs = os.path.expandvars( "$GAFFER_ROOT/doc/osl-languagespec.pdf" )
 	scriptWindowMenu.append(
 		"/Help/Open Shading Language/Language Reference",
 		{
-			"active" : os.path.exists( oslDocs ),
-			"command" : functools.partial( GafferUI.showURL, oslDocs ),
+			"command" : functools.partial( GafferUI.showURL, "https://open-shading-language.readthedocs.io" ),
 		}
 	)
 


### PR DESCRIPTION
As of 1.14, OSL no longer generates PDF documentation. So we point folks at the web version instead.
