### PR TITLE
PlugLayout : Fix bug resolving `layout:index` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -35,6 +35,7 @@ Fixes
   - Fixed potential crash rendering VDB objects.
   - Fixed potential threading-related crashes.
 - RenderPassEditor : Fixed default values displayed for `dl:oversampling` and `dl:quality.shadingsamples` options.
+- PlugLayout : Fixed bug resolving `layout:index` metadata.
 
 API
 ---

--- a/python/GafferUITest/PlugLayoutTest.py
+++ b/python/GafferUITest/PlugLayoutTest.py
@@ -82,6 +82,27 @@ class PlugLayoutTest( GafferUITest.TestCase ) :
 			[ n["user"]["c"], n["user"]["b"], n["user"]["a"] ],
 		)
 
+	def testExplicitIndexWins( self ) :
+
+		n = Gaffer.Node()
+		n["user"]["a"] = Gaffer.IntPlug()
+		n["user"]["b"] = Gaffer.IntPlug()
+		n["user"]["c"] = Gaffer.IntPlug()
+
+		Gaffer.Metadata.registerValue( n["user"]["b"], "layout:index", 0 )
+
+		self.assertEqual(
+			GafferUI.PlugLayout.layoutOrder( n["user"] ),
+			[ n["user"]["b"], n["user"]["a"], n["user"]["c"] ],
+		)
+
+		Gaffer.Metadata.registerValue( n["user"]["a"], "layout:index", -1 )
+
+		self.assertEqual(
+			GafferUI.PlugLayout.layoutOrder( n["user"] ),
+			[ n["user"]["b"], n["user"]["c"], n["user"]["a"] ],
+		)
+
 	class CustomWidget( GafferUI.Widget ) :
 
 		def __init__( self, node ) :


### PR DESCRIPTION
When an explicitly specified index coincided with an implicit index, the first item encountered won. This meant that it was impossible to put a custom widget at index zero without explicitly reordering all plugs to come after it.

The solution here is borrowed from `RenderPassEditor.__orderedColumns`, which faced the same problem.
