### PR TITLE
VectorDataWidget : Avoid deprecated QMouseEvent constructor

### DIFF
--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -784,6 +784,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 		qEvent = QtGui.QMouseEvent(
 			QtCore.QEvent.MouseButtonPress,
 			point,
+			self.__tableView.viewport().mapToGlobal( point ),
 			QtCore.Qt.LeftButton,
 			QtCore.Qt.LeftButton,
 			QtCore.Qt.NoModifier


### PR DESCRIPTION
This was giving us the following warning :

```
VectorDataWidget.py:784: DeprecationWarning: Function: 'QMouseEvent.QMouseEvent(QEvent.Type type, const QPointF & localPos, Qt.MouseButton button, QFlags<Qt.MouseButton> buttons, QFlags<Qt.KeyboardModifier> modifiers, const QPointingDevice * device)' is marked as deprecated, please check the documentation for more information.
```
