### PR TITLE
AnnotationsUI : Restore word wrapping

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
   - Fixed bug where a light would rotate around its local Z-axis during placement.
   - Fixed intermittent bug causing `ERROR : Emitting signal : Bad optional access` when using the undo / redo commands.
 - RotateTool : Fixed bug where objects would rotate around their local Z-axis when using aim at target mode.
+- Annotations : Fixed word-wrapping in annotation dialogue.
 
 1.5.15.0 (relative to 1.5.14.0)
 ========

--- a/python/GafferUI/AnnotationsUI.py
+++ b/python/GafferUI/AnnotationsUI.py
@@ -278,6 +278,7 @@ class __AnnotationsDialogue( GafferUI.Dialogue ) :
 			)
 			self.__textWidget.setHighlighter( _AnnotationsHighlighter( node ) )
 			self.__textWidget.setCompleter( _AnnotationsCompleter( node ) )
+			self.__textWidget.setWrapMode( self.__textWidget.WrapMode.WordOrCharacter )
 			self.__textWidget.textChangedSignal().connect(
 				Gaffer.WeakMethod( self.__updateButtonStatus )
 			)


### PR DESCRIPTION
This was lost in the move to using a CodeWidget in c8e88e6480e7a709ad2dac6daf903f9350d351ec.
