### PR TITLE
StyleSheet : Conform Editor QTreeView row heights

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,8 @@ Fixes
   - Fixed intermittent bug causing `ERROR : Emitting signal : Bad optional access` when using the undo / redo commands.
 - RotateTool : Fixed bug where objects would rotate around their local Z-axis when using aim at target mode.
 - Annotations : Fixed word-wrapping in annotation dialogue.
+- HierarchyView, AttributeEditor, SetEditor : Fixed judder caused by row heights changing during update.
+- RenderPassEditor : Fixed excessive row heights caused by multi-line values in the first row. All rows are now a single line high.
 
 1.5.15.0 (relative to 1.5.14.0)
 ========

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1301,20 +1301,13 @@ _styleSheet = string.Template(
 		padding-left: 2px;
 	}
 
-	*[gafferClass="GafferSceneUI.HierarchyView"], *[gafferClass="GafferSceneUI.LightEditor"] QTreeView::item {
-		height: 18px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-	}
-
-	*[gafferClass="GafferSceneUI.RenderPassEditor"] QTreeView::item {
-		min-height: 22px;
-		padding-top: 0px;
-		padding-bottom: 0px;
-	}
-
-	*[gafferClass="GafferSceneUI._HistoryWindow"] QTreeView::item {
-		height: 18px;
+	*[gafferClass="GafferSceneUI.HierarchyView"] QTreeView::item,
+	*[gafferClass="GafferSceneUI.LightEditor"] QTreeView::item,
+	*[gafferClass="GafferSceneUI.RenderPassEditor"] QTreeView::item,
+	*[gafferClass="GafferSceneUI.AttributeEditor"] QTreeView::item,
+	*[gafferClass="GafferSceneUI._HistoryWindow"] QTreeView::item,
+	*[gafferClass="GafferSceneUI.SetEditor"] QTreeView::item {
+		height: 20px;
 		padding-top: 0px;
 		padding-bottom: 0px;
 	}


### PR DESCRIPTION
We had a variety of differences here, some of which caused graphical glitches.

- The HierarchyView's selector had omitted the `QTreeView::item` part of the selector. This meant that it wasn't applying, and the row height would change when switching between empty and non-empty scenes.
- The RenderPassEditor used `min-height` rather than `height`, meaning that a multi-line value on the first row would cause _all_ rows to be extra high (because we use `QTreeView.setUniformRowHeights()`).
- The AttributeEditor had no styling, so had all the problems above.
- We had multiple opinions about what the right height was, with 18px being the most miserly and 22px being the most generous.

I've split the difference and made everything be 20px. I do wonder if we shouldn't do this for all PathListingWidgets everywhere, but for now I've contained the change to just the Editors.
