### PR TITLE
SConstruct : Add GAFFER_COMMAND option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,11 @@ Fixes
 - RenderPassEditor : Fixed excessive row heights caused by multi-line values in the first row. All rows are now a single line high.
 - AttributeEditor, LightEditor, RenderPassEditor : Fixed bug causing cells to incorrectly appear to accept drags containing a node or plug.
 
+Build
+-----
+
+- SConstruct : Added `GAFFER_COMMAND` option to control the command to be called during install.
+
 1.5.15.0 (relative to 1.5.14.0)
 ========
 


### PR DESCRIPTION
This change allows us to change the command to be called as part of the gaffer build that executes gaffer itself (after the binary has been copied to the build location) to generate docs and extensions.

At IE, we need it in order to run the command for builds targeting dccs like houdini.

Specifically, at the moment, we need to be able to set `LD_PRELOAD` only for those calls, but not for every call being made during build.

This mechanism allows for that, while also potentially enabling more extensive changes in the future, if necessary.

Feel free to suggest a different approach though, if you don't like this one, as well as a different name for the option.

I don't have an easy way to test the changes with the regular gaffer build, so I'm counting on the CIs to make sure that I'm not breaking anything if the option is not used.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
