### PR TITLE
_InspectorColumn : Only accept drags containing `Data`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Fixes
 - Annotations : Fixed word-wrapping in annotation dialogue.
 - HierarchyView, AttributeEditor, SetEditor : Fixed judder caused by row heights changing during update.
 - RenderPassEditor : Fixed excessive row heights caused by multi-line values in the first row. All rows are now a single line high.
+- AttributeEditor, LightEditor, RenderPassEditor : Fixed bug causing cells to incorrectly appear to accept drags containing a node or plug.
 
 1.5.15.0 (relative to 1.5.14.0)
 ========

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -517,6 +517,9 @@ def __dragEnter( column, path, pathListing, event ) :
 	if path is None :
 		return False
 
+	if not isinstance( event.data, IECore.Object ) :
+		return False
+
 	inspectionContext = path.inspectionContext()
 	if inspectionContext is None :
 		return False


### PR DESCRIPTION
Ran into this while testing the "Source" drag functionality added in #6477.