### PR TITLE
PathListingWidget : Call `viewport().update()` for Qt 6.5

### DIFF
--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -1057,7 +1057,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 	def setHighlightedIndex( self, index ) :
 
 		self.__highlightedIndex = QtCore.QPersistentModelIndex( index ) if index is not None else None
-		self.update()
+		self.viewport().update()
 
 	def setModel( self, model ) :
 


### PR DESCRIPTION
As with 44af590ef04f662d68671c003e1ee8397a1e74fc, Qt 6.5 requires us to update the viewport widget here instead of the QTreeView directly as all painting operations take place on the viewport for widgets inheriting from QAbstractScrollArea.

https://doc.qt.io/qtforpython-6.5/PySide6/QtWidgets/QAbstractScrollArea.html#detailed-description
