### PR TITLE
OpDialogue : Resize on show to ensure dialogue is the correct size

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
   - Fixed bug where a light would rotate around its local Z-axis during placement.
   - Fixed intermittent bug causing `ERROR : Emitting signal : Bad optional access` when using the undo / redo commands.
 - RotateTool : Fixed bug where objects would rotate around their local Z-axis when using aim at target mode.
+- Op Dialogue : Fixed Op dialogue was not opening with the correct size based on it's child widgets.
 
 1.5.15.0 (relative to 1.5.14.0)
 ========

--- a/python/GafferCortexUI/OpDialogue.py
+++ b/python/GafferCortexUI/OpDialogue.py
@@ -41,6 +41,8 @@ import threading
 import traceback
 import imath
 
+from Qt import QtCore
+
 import IECore
 
 import Gaffer
@@ -119,6 +121,8 @@ class OpDialogue( GafferUI.Dialogue ) :
 			title = IECore.CamelCase.toSpaced( opInstance.typeName() )
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )
+
+		self._qtWidget().installEventFilter( _opDialogueEventFilter )
 
 		# decide what we'll do after execution.
 
@@ -500,3 +504,22 @@ class OpDialogue( GafferUI.Dialogue ) :
 
 		for child in graphComponent.children() :
 			self.__setUserDefaults( child )
+
+class _OpDialogueEventFilter( QtCore.QObject ) :
+
+	def __init__( self ) :
+
+		QtCore.QObject.__init__( self )
+
+	def eventFilter( self, qObject, qEvent ) :
+		type = qEvent.type()
+
+		if type == QtCore.QEvent.Show :
+			widget = GafferUI.Widget._owner( qObject )
+			widget.resizeToFitChild()
+			return True
+
+		return False
+
+# this single instance is used by all op dialogue widgets
+_opDialogueEventFilter = _OpDialogueEventFilter()


### PR DESCRIPTION
This ensures the Op Dialogue is correctly sized based on it's child widgets when it is shown.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.