### PR TITLE
VisualiserTool : Uniform visualisers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -23,7 +23,7 @@ Improvements
   - Added `render:cameraInclusions`, `render:cameraExclusions`, `render:matteInclusions`, and `render:matteExclusions` options.
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 - PathListingWidget : Improved formatting of Box and Matrix values.
-- VisualiserTool : Added visualisation of labels for uniform primitive variables and face indices.
+- VisualiserTool : Added visualisation of labels for uniform primitive variables, face indices and curve indices.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -23,6 +23,7 @@ Improvements
   - Added `render:cameraInclusions`, `render:cameraExclusions`, `render:matteInclusions`, and `render:matteExclusions` options.
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 - PathListingWidget : Improved formatting of Box and Matrix values.
+- VisualiserTool : Added visualisation of labels for uniform primitive variables and face indices.
 
 Fixes
 -----

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -206,7 +206,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 	__primitiveVariablePrefix = "primitiveVariable:"
 	__primitiveVariablePrefixSize = len( __primitiveVariablePrefix )
 	__vertexIndexDataName = "vertex:index"
-	__faceIndexDataName = "face:index"
+	__uniformIndexDataName = "uniform:index"
 
 	def __init__( self, plug, **kw ) :
 
@@ -223,7 +223,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 		if singleValue is not None :
 			if singleValue == self.__vertexIndexDataName :
 				text = "Vertex Index"
-			elif singleValue == self.__faceIndexDataName :
+			elif singleValue == self.__uniformIndexDataName :
 				text = "Face Index"
 			else :
 				text = self.__primitiveVariableFromDataName( singleValue )
@@ -302,10 +302,10 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 			}
 		)
 		menuDefinition.append(
-			"/Face Index",
+			"/Face or Curve Index",
 			{
-				"command" : functools.partial( Gaffer.WeakMethod( self.__setDataName), self.__faceIndexDataName ),
-				"checkBox" : self.getPlug().getValue() == self.__faceIndexDataName,
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setDataName), self.__uniformIndexDataName ),
+				"checkBox" : self.getPlug().getValue() == self.__uniformIndexDataName,
 			}
 		)
 

--- a/python/GafferSceneUI/VisualiserToolUI.py
+++ b/python/GafferSceneUI/VisualiserToolUI.py
@@ -206,6 +206,7 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 	__primitiveVariablePrefix = "primitiveVariable:"
 	__primitiveVariablePrefixSize = len( __primitiveVariablePrefix )
 	__vertexIndexDataName = "vertex:index"
+	__faceIndexDataName = "face:index"
 
 	def __init__( self, plug, **kw ) :
 
@@ -220,7 +221,12 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 		singleValue = sole( values )
 		text = "None"
 		if singleValue is not None :
-			text = "Vertex Index" if singleValue == self.__vertexIndexDataName else self.__primitiveVariableFromDataName( singleValue )
+			if singleValue == self.__vertexIndexDataName :
+				text = "Vertex Index"
+			elif singleValue == self.__faceIndexDataName :
+				text = "Face Index"
+			else :
+				text = self.__primitiveVariableFromDataName( singleValue )
 
 		self.__menuButton.setText( text )
 
@@ -293,6 +299,13 @@ class _DataNameChooser( GafferUI.PlugValueWidget ) :
 			{
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setDataName ), self.__vertexIndexDataName ),
 				"checkBox" : self.getPlug().getValue() == self.__vertexIndexDataName,
+			}
+		)
+		menuDefinition.append(
+			"/Face Index",
+			{
+				"command" : functools.partial( Gaffer.WeakMethod( self.__setDataName), self.__faceIndexDataName ),
+				"checkBox" : self.getPlug().getValue() == self.__faceIndexDataName,
 			}
 		)
 

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -604,10 +604,7 @@ class VisualiserGadget : public Gadget
 		explicit VisualiserGadget( const VisualiserTool &tool, const std::string &name = defaultName<VisualiserGadget>() ) :
 			Gadget( name ),
 			m_tool( &tool ),
-			m_colorShader(),
-			m_colorUniformBuffer(),
-			m_vertexLabelShader(),
-			m_vertexLabelUniformBuffer(),
+			m_vertexLabelStorageCapacity( 0 ),
 			m_cursorVertexValue()
 		{
 		}

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -267,7 +267,10 @@ std::string const g_vertexLabelShaderVertSource
 
 	"void main()\n"
 	"{\n"
-	"   gl_Position = vec4( ps, 1.0 ) * uniforms.o2c;\n"
+	"   vec4 p = vec4( ps, 1.0 ) * uniforms.o2c;\n"
+	"   p.z -= 0.001;\n"
+
+	"   gl_Position = p;\n"
 	"   outputs.vertexId = uint( gl_VertexID );\n"
 	"}\n"
 );


### PR DESCRIPTION
This adds support for visualising uniform primitive variable labels, face indices and curve indices to the VisualiserTool.

If we're happy enough with the placement of the uniform labels, does it make sense to replace the `__uniformPScene` plug from `VisualiserTool` and replace uses of it with the new `uniformPPrimitive()` private method?

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
