### PR TITLE
Fix ImageSelectionTool Crash

### DIFF
--- a/src/GafferImage/Checkerboard.cpp
+++ b/src/GafferImage/Checkerboard.cpp
@@ -269,6 +269,10 @@ void Checkerboard::hashChannelData( const GafferImage::ImagePlug *output, const 
 	h.append( channelName );
 
 	const int channelIndex = ImageAlgo::colorIndex( channelName );
+	if( channelIndex == -1 )
+	{
+		throw IECore::Exception( "Evaluated with invalid channel name: \"" + channelName + "\". This indicates a bug in a downstream node." );
+	}
 	colorAPlug()->getChild( channelIndex )->hash( h );
 	colorBPlug()->getChild( channelIndex )->hash( h );
 
@@ -279,6 +283,10 @@ void Checkerboard::hashChannelData( const GafferImage::ImagePlug *output, const 
 IECore::ConstFloatVectorDataPtr Checkerboard::computeChannelData( const std::string &channelName, const Imath::V2i &tileOrigin, const Gaffer::Context *context, const ImagePlug *parent ) const
 {
 	const int channelIndex = ImageAlgo::colorIndex( context->get<std::string>( ImagePlug::channelNameContextName ) );
+	if( channelIndex == -1 )
+	{
+		throw IECore::Exception( "Evaluated with invalid channel name: \"" + channelName + "\". This indicates a bug in a downstream node." );
+	}
 
 	const float valueA = colorAPlug()->getChild( channelIndex )->getValue();
 	const float valueB = colorBPlug()->getChild( channelIndex )->getValue();

--- a/src/GafferSceneUI/ImageSelectionTool.cpp
+++ b/src/GafferSceneUI/ImageSelectionTool.cpp
@@ -341,7 +341,15 @@ uint32_t ImageSelectionTool::pixelID( const Imath::V2i &pixel )
 	}
 
 	Context::Scope scopedContext( view()->context() );
-	GafferImage::Sampler sampler( imagePlug(), idChannelName( imagePlug()->channelNames()->readable() ), Box2i( pixel, pixel + V2i( 1 ) ) );
+
+	std::string chanName = idChannelName( imagePlug()->channelNames()->readable() );
+
+	if( !chanName.size() )
+	{
+		return 0;
+	}
+
+	GafferImage::Sampler sampler( imagePlug(), chanName, Box2i( pixel, pixel + V2i( 1 ) ) );
 	float floatID = sampler.sample( pixel.x, pixel.y );
 	uint32_t id;
 	memcpy( &id, &floatID, 4 );
@@ -361,8 +369,14 @@ std::unordered_set<uint32_t> ImageSelectionTool::rectIDs( const Imath::Box2i &re
 
 	const auto [ wipeEnabled, wipePosition, wipeDirection ] = effectiveWipePlane( imageGadget() );
 
+	std::string chanName = idChannelName( imagePlug()->channelNames()->readable() );
 
-	GafferImage::Sampler sampler( imagePlug(), idChannelName( imagePlug()->channelNames()->readable() ), validRect );
+	if( !chanName.size() )
+	{
+		return result;
+	}
+
+	GafferImage::Sampler sampler( imagePlug(), chanName, validRect );
 
 	float prevValue = sampler.sample( validRect.min.x, validRect.min.y );
 	uint32_t prevID;


### PR DESCRIPTION
This was a silly oversight of failing to handle the case where `idChannelName()` returned empty string, which caused a crash when viewing an image with no id channel.

While I was at it, I modified Checkerboard so that triggering this undefined behaviour now throws a helpful exception, instead of crashing.