### PR TITLE
BasicInspector : Add class to simplify creation of minimal inspectors

### DIFF
--- a/include/GafferSceneUI/Private/BasicInspector.inl
+++ b/include/GafferSceneUI/Private/BasicInspector.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012, John Haddon. All rights reserved.
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -36,39 +36,24 @@
 
 #pragma once
 
-namespace GafferSceneUI
+namespace GafferSceneUI::Private
 {
 
-enum TypeId
+template<typename PlugType, typename ValueFunctionType>
+BasicInspector::BasicInspector(
+	PlugType *plug, const Gaffer::PlugPtr &editScope,
+	const ValueFunctionType &&valueFunction,
+	const std::string &type, const std::string &name
+)
+	: 	Inspector( type, name, editScope ), m_plug( plug )
 {
-	SceneViewTypeId = 121000,
-	SceneGadgetTypeId = 121001,
-	SelectionToolTypeId = 121002,
-	CropWindowToolTypeId = 121003,
-	ShaderViewTypeId = 121004,
-	ShaderNodeGadgetTypeId = 121005,
-	TransformToolTypeId = 121006,
-	TranslateToolTypeId = 121007,
-	ScaleToolTypeId = 121008,
-	RotateToolTypeId = 121009,
-	CameraToolTypeId = 121010,
-	UVViewTypeId = 121011,
-	UVSceneTypeId = 121012,
-	HistoryPathTypeId = 121013,
-	SetPathTypeId = 121014,
-	LightToolTypeId = 121015,
-	LightPositionToolTypeId = 121016,
-	RenderPassPathTypeId = 121017,
-	VisualiserToolTypeId = 121018,
-	ImageSelectionToolTypeId = 121019,
-	InspectorTypeId = 121020,
-	OptionInspectorTypeId = 121021,
-	AttributeInspectorTypeId = 121022,
-	ParameterInspectorTypeId = 121023,
-	SetMembershipInspectorTypeId = 121024,
-	BasicInspectorTypeId = 121025,
+	// Wrapper downcasts the plug to the correct type, removing the
+	// need to do that manually in the supplied lambda.
+	m_valueFunction = [f = valueFunction] ( const Gaffer::Plug *p ) {
+		// Cast is safe because `m_plug` was initialised with `PlugType`.
+		return f( static_cast<const PlugType *>( p ) );
+	};
+	init();
+}
 
-	LastTypeId = 121199
-};
-
-} // namespace GafferSceneUI
+} // namespace GafferSceneUI::Private

--- a/python/GafferSceneUITest/BasicInspectorTest.py
+++ b/python/GafferSceneUITest/BasicInspectorTest.py
@@ -1,0 +1,134 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+import Gaffer
+import GafferTest
+import GafferUITest
+import GafferScene
+import GafferSceneUI
+
+class BasicInspectorTest( GafferUITest.TestCase ) :
+
+	def testName( self ) :
+
+		sphere = GafferScene.SceneNode()
+
+		inspector = GafferSceneUI.Private.BasicInspector( sphere["out"]["object"], None, lambda plug : None, name = "MyName" )
+		self.assertEqual( inspector.name(), "MyName" )
+
+	def testPlugMustBeChildOfScene( self ) :
+
+		sphere = GafferScene.Sphere()
+		add = GafferTest.AddNode()
+
+		for plug in ( sphere["out"], add["sum"] ) :
+			with self.assertRaisesRegex( Exception, 'Plug "{}" is not a child of a ScenePlug'.format( plug.fullName() ) ) :
+				GafferSceneUI.Private.BasicInspector( plug, None, lambda plug : None )
+
+	def testDirtiedSignal( self ) :
+
+		sphere = GafferScene.Sphere()
+		inspector = GafferSceneUI.Private.BasicInspector( sphere["out"]["object"], None, lambda plug : None, name = "MyName" )
+		cs = GafferTest.CapturingSlot( inspector.dirtiedSignal() )
+
+		sphere["radius"].setValue( 2 )
+		self.assertEqual( len( cs ), 1 )
+
+		sphere["transform"]["translate"]["x"].setValue( 1 )
+		self.assertEqual( len( cs ), 1 )
+
+	@staticmethod
+	def __inspect( plug, valueFunction, path = None, editScope = None ) :
+
+		editScopePlug = Gaffer.Plug()
+		editScopePlug.setInput( editScope["enabled"] if editScope is not None else None )
+		inspector = GafferSceneUI.Private.BasicInspector(
+			plug, editScopePlug, valueFunction
+		)
+		with Gaffer.Context() as context :
+			if path is not None :
+				context["scene:path"] = GafferScene.ScenePlug.stringToPath( path )
+			return inspector.inspect()
+
+	def testInspectObject( self ) :
+
+		sphere = GafferScene.Sphere()
+		inspection = self.__inspect( sphere["out"]["object"], lambda objectPlug : objectPlug.getValue(), path = "/sphere" )
+
+		self.assertEqual( inspection.value(), sphere["out"].object( "/sphere" ) )
+		self.assertIsNone( inspection.source() )
+		self.assertEqual( inspection.sourceType(), inspection.SourceType.Other )
+		self.assertEqual( inspection.fallbackDescription(), "" )
+		self.assertFalse( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "No editable source found in history." )
+		self.assertRaises( RuntimeError, inspection.acquireEdit )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "No editable source found in history." )
+		self.assertRaises( RuntimeError, inspection.disableEdit )
+		self.assertFalse( inspection.canEdit( inspection.value() ) )
+		self.assertRaises( RuntimeError, inspection.edit, inspection.value() )
+
+	def testInspectNonExistentObject( self ) :
+
+		sphere = GafferScene.Sphere()
+		inspection = self.__inspect( sphere["out"]["object"], lambda objectPlug : objectPlug["ifThisLambdaIsCalledItWillError"].getValue(), path = "/iDoNotExist" )
+		self.assertIsNone( inspection )
+
+	def testInspectGlobals( self ) :
+
+		options = GafferScene.CustomOptions()
+		options["options"].addChild( Gaffer.NameValuePlug( "test", 10 ) )
+		inspection = self.__inspect( options["out"]["globals"], lambda globalsPlug : globalsPlug.getValue() )
+
+		self.assertEqual( inspection.value(), options["out"].globals() )
+		self.assertIsNone( inspection.source() )
+		self.assertEqual( inspection.sourceType(), inspection.SourceType.Other )
+		self.assertEqual( inspection.fallbackDescription(), "" )
+		self.assertFalse( inspection.editable() )
+		self.assertEqual( inspection.nonEditableReason(), "No editable source found in history." )
+		self.assertRaises( RuntimeError, inspection.acquireEdit )
+		self.assertFalse( inspection.canDisableEdit() )
+		self.assertEqual( inspection.nonDisableableReason(), "No editable source found in history." )
+		self.assertRaises( RuntimeError, inspection.disableEdit )
+		self.assertFalse( inspection.canEdit( inspection.value() ) )
+		self.assertRaises( RuntimeError, inspection.edit, inspection.value() )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferSceneUITest/__init__.py
+++ b/python/GafferSceneUITest/__init__.py
@@ -67,6 +67,7 @@ from .InspectorColumnTest import InspectorColumnTest
 from .ScriptNodeAlgoTest import ScriptNodeAlgoTest
 from .AttributeEditorTest import AttributeEditorTest
 from .CatalogueUITest import CatalogueUITest
+from .BasicInspectorTest import BasicInspectorTest
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/BasicInspector.cpp
+++ b/src/GafferSceneUI/BasicInspector.cpp
@@ -1,0 +1,168 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "GafferSceneUI/Private/BasicInspector.h"
+
+#include "Gaffer/ParallelAlgo.h"
+#include "Gaffer/Private/IECorePreview/LRUCache.h"
+
+using namespace boost::placeholders;
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Gaffer;
+using namespace GafferScene;
+using namespace GafferSceneUI::Private;
+
+
+//////////////////////////////////////////////////////////////////////////
+// History cache for BasicInspector
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+// This uses the same strategy that ValuePlug uses for the hash cache,
+// using `plug->dirtyCount()` to invalidate previous cache entries when
+// a plug is dirtied.
+struct HistoryCacheKey
+{
+	HistoryCacheKey() {};
+	HistoryCacheKey( const ValuePlug *plug )
+		:	plug( plug ), contextHash( Context::current()->hash() ), dirtyCount( plug->dirtyCount() )
+	{
+	}
+
+	bool operator==( const HistoryCacheKey &rhs ) const
+	{
+		return
+			plug == rhs.plug &&
+			contextHash == rhs.contextHash &&
+			dirtyCount == rhs.dirtyCount
+		;
+	}
+
+	const ValuePlug *plug;
+	IECore::MurmurHash contextHash;
+	uint64_t dirtyCount;
+};
+
+size_t hash_value( const HistoryCacheKey &key )
+{
+	size_t result = 0;
+	boost::hash_combine( result, key.plug );
+	boost::hash_combine( result, key.contextHash );
+	boost::hash_combine( result, key.dirtyCount );
+	return result;
+}
+
+using HistoryCache = IECorePreview::LRUCache<HistoryCacheKey, SceneAlgo::History::ConstPtr>;
+
+HistoryCache g_historyCache(
+	// Getter
+	[] ( const HistoryCacheKey &key, size_t &cost, const IECore::Canceller *canceller ) {
+		assert( canceller == Context::current()->canceller() );
+		cost = 1;
+		const ScenePlug::ScenePath *path = Context::current()->getIfExists<ScenePlug::ScenePath>( ScenePlug::scenePathContextName );
+		return path ? SceneAlgo::history( key.plug, *path ) : SceneAlgo::history( key.plug );
+	},
+	// Max cost
+	1000,
+	// Removal callback
+	[] ( const HistoryCacheKey &key, const SceneAlgo::History::ConstPtr &history ) {
+		// Histories contain PlugPtrs, which could potentially be the sole
+		// owners. Destroying plugs can trigger dirty propagation, so as a
+		// precaution we destroy the history on the UI thread, where this would
+		// be OK.
+		ParallelAlgo::callOnUIThread(
+			[history] () {}
+		);
+	}
+
+);
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////
+// BasicInspector
+//////////////////////////////////////////////////////////////////////////
+
+IE_CORE_DEFINERUNTIMETYPED( BasicInspector )
+
+BasicInspector::~BasicInspector()
+{
+}
+
+void BasicInspector::init()
+{
+	if( !m_plug->parent<ScenePlug>() )
+	{
+		throw IECore::Exception( fmt::format( "Plug \"{}\" is not a child of a ScenePlug", m_plug->fullName() ) );
+	}
+
+	m_plug->node()->plugDirtiedSignal().connect(
+		boost::bind( &BasicInspector::plugDirtied, this, ::_1 )
+	);
+}
+
+GafferScene::SceneAlgo::History::ConstPtr BasicInspector::history() const
+{
+	const auto scenePlug = m_plug->parent<ScenePlug>();
+	if( m_plug != scenePlug->globalsPlug() && m_plug != scenePlug->setNamesPlug() && m_plug != scenePlug->setPlug() )
+	{
+		if( !scenePlug->existsPlug()->getValue() )
+		{
+			return nullptr;
+		}
+	}
+	return g_historyCache.get( HistoryCacheKey( m_plug.get() ), Context::current()->canceller() );
+}
+
+IECore::ConstObjectPtr BasicInspector::value( const GafferScene::SceneAlgo::History *history ) const
+{
+	/// \todo We want this to be cancellable, but the API currently doesn't allow that.
+	/// Perhaps the Inspector base class should always scope `history->context` and an
+	/// appropriate canceller for us before calling `value()`?
+	Context::Scope scope( history->context.get() );
+	return m_valueFunction( history->scene->getChild<ValuePlug>( m_plug->getName() ) );
+}
+
+void BasicInspector::plugDirtied( Gaffer::Plug *plug )
+{
+	if( plug == m_plug )
+	{
+		dirtiedSignal()( this );
+	}
+}


### PR DESCRIPTION
This will be used in an upcoming SceneInspector rewrite, where we'll need a lot of different inspector types, but won't want to be writing fully-featured inspectors for each one, at least initially.

At this point, `Inspector::historyPath()` doesn't do anything useful because it skips everything where `Inspector::source()` is null. That will be addressed in a future commit.
