### PR TITLE
GraphComponentBinding : Add support for aliasing children

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,11 @@ Build
 - SConstruct : Added `GAFFER_COMMAND` option to control the command to be called during install.
 - Cortex : Updated to version 10.5.15.1.
 
+API
+---
+
+- GraphComponent : Added support for `compatibility:childAlias:{aliasName}` metadata, which specifies the name of a child to be accessed via the alias `{aliasName}`. The Python methods `getChild()`, `__getitem__`, `__delitem__`, and `__contains__` now fall back to using aliases when a direct match is not found. This metadata can be registered to maintain compatibility when renaming plugs.
+
 1.5.15.0 (relative to 1.5.14.0)
 ========
 

--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - RenderPassEditor : Fixed excessive row heights caused by multi-line values in the first row. All rows are now a single line high.
 - AttributeEditor, LightEditor, RenderPassEditor : Fixed bug causing cells to incorrectly appear to accept drags containing a node or plug.
 - SceneReader : Fixed reading of bounds from USD prims with `extentsHint` and `model` kind but without UsdGeomModelAPI applied.
+- ArnoldAttributes, ArnoldOptions, CyclesAttributes, CyclesOptions, DelightAttributes, DelightOptions, OpenGLAttributes, StandardAttributes, StandardOptions, USDAttributes : Fixed loading of nodes saved from Gaffer 1.6.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -31,7 +31,7 @@ Build
 API
 ---
 
-- GraphComponent : Added support for `compatibility:childAlias:{aliasName}` metadata, which specifies the name of a child to be accessed via the alias `{aliasName}`. The Python methods `getChild()`, `__getitem__`, `__delitem__`, and `__contains__` now fall back to using aliases when a direct match is not found. This metadata can be registered to maintain compatibility when renaming plugs.
+- GraphComponent : Added support for `compatibility:childAlias:{aliasName}` metadata, which specifies the name of a child to be accessed via the alias `{aliasName}`. The Python methods `getChild()`, `descendant()`, `__getitem__`, `__delitem__`, and `__contains__` now fall back to using aliases when a direct match is not found. This metadata can be registered to maintain compatibility when renaming plugs.
 
 1.5.15.0 (relative to 1.5.14.0)
 ========

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -1236,6 +1236,7 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertTrue( g.getChild( "c2alias" ).isSame( c2 ) )
 		self.assertTrue( g["c2alias"].isSame( c2 ) )
 		self.assertTrue( g["c2alias"]["gc1"].isSame( gc1 ) )
+		self.assertTrue( g.descendant( "c2alias.gc1" ).isSame( gc1 ) )
 
 		self.assertIn( "c1alias", g )
 		self.assertIn( "c2alias", g )
@@ -1243,10 +1244,14 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertNotIn( "c2alias", g.children() )
 
 		self.assertIsNone( g["c2"].getChild( "gc1alias") )
+		self.assertIsNone( g.descendant( "c2.gc1alias" ) )
 		Gaffer.Metadata.registerValue( g["c2"], "compatibility:childAlias:gc1alias", "gc1" )
 		self.assertTrue( g["c2"].getChild( "gc1alias" ).isSame( gc1 ) )
 		self.assertTrue( g["c2alias"]["gc1alias"].isSame( gc1 ) )
 		self.assertTrue( g["c2alias"].getChild( "gc1alias" ).isSame( gc1 ) )
+		self.assertTrue( g.descendant( "c2.gc1alias" ).isSame( gc1 ) )
+		self.assertTrue( g.descendant( "c2alias.gc1" ).isSame( gc1 ) )
+		self.assertTrue( g.descendant( "c2alias.gc1alias" ).isSame( gc1 ) )
 
 		self.assertIn( "gc1alias", g["c2"] )
 		self.assertIn( "gc1alias", g["c2alias"] )

--- a/python/GafferTest/GraphComponentTest.py
+++ b/python/GafferTest/GraphComponentTest.py
@@ -1207,5 +1207,63 @@ class GraphComponentTest( GafferTest.TestCase ) :
 		self.assertTrue( p.getChild( "test:a:b" ).isSame( g ) )
 		self.assertTrue( p.descendant( "test:a:b" ).isSame( g ) )
 
+	def testChildAliasMetadata( self ) :
+
+		g = Gaffer.Node()
+		c1 = Gaffer.Plug()
+		c2 = Gaffer.Plug()
+		gc1 = Gaffer.Plug()
+		g["c1"] = c1
+		g["c2"] = c2
+		g["c2"]["gc1"] = gc1
+
+		self.assertIsNone( g.getChild( "c1alias" ) )
+		self.assertIsNone( g.getChild( "c2alias" ) )
+		self.assertNotIn( "c1alias", g )
+		self.assertNotIn( "c2alias", g )
+
+		Gaffer.Metadata.registerValue( g, "compatibility:childAlias:c1alias", "c1" )
+		self.assertTrue( g.getChild( "c1alias" ).isSame( c1 ) )
+		self.assertTrue( g["c1alias"].isSame( c1 ) )
+		self.assertIsNone( g.getChild( "c2alias" ) )
+
+		self.assertIn( "c1alias", g )
+		self.assertNotIn( "c1alias", g.children() )
+		self.assertNotIn( "c2alias", g )
+
+		Gaffer.Metadata.registerValue( g, "compatibility:childAlias:c2alias", "c2" )
+		self.assertTrue( g.getChild( "c1alias" ).isSame( c1 ) )
+		self.assertTrue( g.getChild( "c2alias" ).isSame( c2 ) )
+		self.assertTrue( g["c2alias"].isSame( c2 ) )
+		self.assertTrue( g["c2alias"]["gc1"].isSame( gc1 ) )
+
+		self.assertIn( "c1alias", g )
+		self.assertIn( "c2alias", g )
+		self.assertNotIn( "c1alias", g.children() )
+		self.assertNotIn( "c2alias", g.children() )
+
+		self.assertIsNone( g["c2"].getChild( "gc1alias") )
+		Gaffer.Metadata.registerValue( g["c2"], "compatibility:childAlias:gc1alias", "gc1" )
+		self.assertTrue( g["c2"].getChild( "gc1alias" ).isSame( gc1 ) )
+		self.assertTrue( g["c2alias"]["gc1alias"].isSame( gc1 ) )
+		self.assertTrue( g["c2alias"].getChild( "gc1alias" ).isSame( gc1 ) )
+
+		self.assertIn( "gc1alias", g["c2"] )
+		self.assertIn( "gc1alias", g["c2alias"] )
+		self.assertNotIn( "gc1alias", g["c2"].children() )
+		self.assertNotIn( "gc1alias", g["c2alias"].children() )
+
+		del g["c1alias"]
+		self.assertNotIn( "c1alias", g )
+		self.assertNotIn( "c1", g )
+		self.assertIsNone( g.getChild( "c1alias" ) )
+		self.assertIsNone( g.getChild( "c1" ) )
+
+		del g["c2"]["gc1"]
+		self.assertNotIn( "gc1alias", g["c2"] )
+		self.assertNotIn( "gc1", g["c2"] )
+		self.assertIsNone( g["c2"].getChild( "gc1alias" ) )
+		self.assertIsNone( g["c2"].getChild( "gc1" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/GraphComponentBinding.cpp
+++ b/src/GafferModule/GraphComponentBinding.cpp
@@ -168,7 +168,24 @@ GraphComponentPtr getChild( GraphComponent &g, const IECore::InternedString &n )
 
 GraphComponentPtr descendant( GraphComponent &g, const std::string &n )
 {
-	return g.descendant( n );
+	if( !n.size() )
+	{
+		return nullptr;
+	}
+
+	using Tokenizer = boost::tokenizer<boost::char_separator<char> >;
+	Tokenizer tokens( n, boost::char_separator<char>( "." ) );
+	GraphComponentPtr result = &g;
+	for( const auto &token : tokens )
+	{
+		result = getChild( *result, token );
+		if( !result )
+		{
+			return nullptr;
+		}
+	}
+
+	return result;
 }
 
 void throwKeyError( const GraphComponent &g, const IECore::InternedString &n )

--- a/startup/GafferArnold/arnoldAttributesCompatibility.py
+++ b/startup/GafferArnold/arnoldAttributesCompatibility.py
@@ -1,0 +1,89 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferArnold
+
+__aliases = {
+	"ai:visibility:camera" : "cameraVisibility",
+	"ai:visibility:shadow" : "shadowVisibility",
+	"ai:visibility:shadow_group" : "shadowGroup",
+	"ai:visibility:diffuse_reflect" : "diffuseReflectionVisibility",
+	"ai:visibility:specular_reflect" : "specularReflectionVisibility",
+	"ai:visibility:diffuse_transmit" : "diffuseTransmissionVisibility",
+	"ai:visibility:specular_transmit" : "specularTransmissionVisibility",
+	"ai:visibility:volume" : "volumeVisibility",
+	"ai:visibility:subsurface" : "subsurfaceVisibility",
+	"ai:disp_autobump" : "autoBump",
+	"ai:autobump_visibility:camera" : "cameraAutoBumpVisibility",
+	"ai:autobump_visibility:shadow" : "shadowAutoBumpVisibility",
+	"ai:autobump_visibility:diffuse_reflect" : "diffuseReflectionAutoBumpVisibility",
+	"ai:autobump_visibility:specular_reflect" : "specularReflectionAutoBumpVisibility",
+	"ai:autobump_visibility:diffuse_transmit" : "diffuseTransmissionAutoBumpVisibility",
+	"ai:autobump_visibility:specular_transmit" : "specularTransmissionAutoBumpVisibility",
+	"ai:autobump_visibility:volume" : "volumeAutoBumpVisibility",
+	"ai:autobump_visibility:subsurface" : "subsurfaceAutoBumpVisibility",
+	"ai:transform_type" : "transformType",
+	"ai:matte" : "matte",
+	"ai:opaque" : "opaque",
+	"ai:receive_shadows" : "receiveShadows",
+	"ai:self_shadows" : "selfShadows",
+	"ai:sss_setname" : "sssSetName",
+	"ai:polymesh:subdiv_iterations" : "subdivIterations",
+	"ai:polymesh:subdiv_adaptive_error" : "subdivAdaptiveError",
+	"ai:polymesh:subdiv_adaptive_metric" : "subdivAdaptiveMetric",
+	"ai:polymesh:subdiv_adaptive_space" : "subdivAdaptiveSpace",
+	"ai:polymesh:subdiv_uv_smoothing" : "subdivUVSmoothing",
+	"ai:polymesh:subdiv_smooth_derivs" : "subdivSmoothDerivs",
+	"ai:polymesh:subdiv_frustum_ignore" : "subdivFrustumIgnore",
+	"ai:polymesh:subdivide_polygons" : "subdividePolygons",
+	"ai:curves:mode" : "curvesMode",
+	"ai:curves:min_pixel_width" : "curvesMinPixelWidth",
+	"ai:points:min_pixel_width" : "pointsMinPixelWidth",
+	"ai:volume:step_size" : "volumeStepSize",
+	"ai:volume:step_scale" : "volumeStepScale",
+	"ai:shape:step_size" : "shapeStepSize",
+	"ai:shape:step_scale" : "shapeStepScale",
+	"ai:shape:volume_padding" : "volumePadding",
+	"ai:volume:velocity_scale" : "velocityScale",
+	"ai:volume:velocity_fps" : "velocityFPS",
+	"ai:volume:velocity_outlier_threshold" : "velocityOutlierThreshold",
+	"ai:toon_id" : "toonId",
+}
+
+# Provide compatibility for ArnoldAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldAttributes, "attributes", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferArnold/arnoldOptionsCompatibility.py
+++ b/startup/GafferArnold/arnoldOptionsCompatibility.py
@@ -1,0 +1,134 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferArnold
+
+__aliases = {
+	"ai:bucket_size" : "bucketSize",
+	"ai:bucket_scanning" : "bucketScanning",
+	"ai:parallel_node_init" : "parallelNodeInit",
+	"ai:threads" : "threads",
+	"ai:AA_samples" : "aaSamples",
+	"ai:GI_diffuse_samples" : "giDiffuseSamples",
+	"ai:GI_specular_samples" : "giSpecularSamples",
+	"ai:GI_transmission_samples" : "giTransmissionSamples",
+	"ai:GI_sss_samples" : "giSSSSamples",
+	"ai:GI_volume_samples" : "giVolumeSamples",
+	"ai:light_samples" : "lightSamples",
+	"ai:AA_seed" : "aaSeed",
+	"ai:AA_sample_clamp" : "aaSampleClamp",
+	"ai:AA_sample_clamp_affects_aovs" : "aaSampleClampAffectsAOVs",
+	"ai:indirect_sample_clamp" : "indirectSampleClamp",
+	"ai:low_light_threshold" : "lowLightThreshold",
+	"ai:enable_adaptive_sampling" : "enableAdaptiveSampling",
+	"ai:AA_samples_max" : "aaSamplesMax",
+	"ai:AA_adaptive_threshold" : "aaAdaptiveThreshold",
+	"ai:enable_progressive_render" : "enableProgressiveRender",
+	"ai:progressive_min_AA_samples" : "progressiveMinAASamples",
+	"ai:GI_total_depth" : "giTotalDepth",
+	"ai:GI_diffuse_depth" : "giDiffuseDepth",
+	"ai:GI_specular_depth" : "giSpecularDepth",
+	"ai:GI_transmission_depth" : "giTransmissionDepth",
+	"ai:GI_volume_depth" : "giVolumeDepth",
+	"ai:auto_transparency_depth" : "autoTransparencyDepth",
+	"ai:max_subdivisions" : "maxSubdivisions",
+	"ai:subdiv_dicing_camera" : "subdivDicingCamera",
+	"ai:subdiv_frustum_culling" : "subdivFrustumCulling",
+	"ai:subdiv_frustum_padding" : "subdivFrustumPadding",
+	"ai:texture_max_memory_MB" : "textureMaxMemoryMB",
+	"ai:texture_per_file_stats" : "texturePerFileStats",
+	"ai:texture_max_sharpen" : "textureMaxSharpen",
+	"ai:texture_use_existing_tx" : "textureUseExistingTx",
+	"ai:texture_auto_generate_tx" : "textureAutoGenerateTx",
+	"ai:texture_auto_tx_path" : "textureAutoTxPath",
+	"ai:ignore_textures" : "ignoreTextures",
+	"ai:ignore_shaders" : "ignoreShaders",
+	"ai:ignore_atmosphere" : "ignoreAtmosphere",
+	"ai:ignore_lights" : "ignoreLights",
+	"ai:ignore_shadows" : "ignoreShadows",
+	"ai:ignore_subdivision" : "ignoreSubdivision",
+	"ai:ignore_displacement" : "ignoreDisplacement",
+	"ai:ignore_bump" : "ignoreBump",
+	"ai:ignore_sss" : "ignoreSSS",
+	"ai:ignore_imagers" : "ignoreImagers",
+	"ai:texture_searchpath" : "textureSearchPath",
+	"ai:procedural_searchpath" : "proceduralSearchPath",
+	"ai:plugin_searchpath" : "pluginSearchPath",
+	"ai:abort_on_error" : "abortOnError",
+	"ai:error_color_bad_texture" : "errorColorBadTexture",
+	"ai:error_color_bad_pixel" : "errorColorBadPixel",
+	"ai:error_color_bad_shader" : "errorColorBadShader",
+	"ai:log:filename" : "logFileName",
+	"ai:log:max_warnings" : "logMaxWarnings",
+	"ai:log:info" : "logInfo",
+	"ai:log:warnings" : "logWarnings",
+	"ai:log:errors" : "logErrors",
+	"ai:log:debug" : "logDebug",
+	"ai:log:ass_parse" : "logAssParse",
+	"ai:log:plugins" : "logPlugins",
+	"ai:log:progress" : "logProgress",
+	"ai:log:nan" : "logNAN",
+	"ai:log:timestamp" : "logTimestamp",
+	"ai:log:stats" : "logStats",
+	"ai:log:backtrace" : "logBacktrace",
+	"ai:log:memory" : "logMemory",
+	"ai:log:color" : "logColor",
+	"ai:console:info" : "consoleInfo",
+	"ai:console:warnings" : "consoleWarnings",
+	"ai:console:errors" : "consoleErrors",
+	"ai:console:debug" : "consoleDebug",
+	"ai:console:ass_parse" : "consoleAssParse",
+	"ai:console:plugins" : "consolePlugins",
+	"ai:console:progress" : "consoleProgress",
+	"ai:console:nan" : "consoleNAN",
+	"ai:console:timestamp" : "consoleTimestamp",
+	"ai:console:stats" : "consoleStats",
+	"ai:console:backtrace" : "consoleBacktrace",
+	"ai:console:memory" : "consoleMemory",
+	"ai:console:color" : "consoleColor",
+	"ai:statisticsFileName" : "statisticsFileName",
+	"ai:profileFileName" : "profileFileName",
+	"ai:reportFileName" : "reportFileName",
+	"ai:abort_on_license_fail" : "abortOnLicenseFail",
+	"ai:skip_license_check" : "skipLicenseCheck",
+	"ai:render_device" : "renderDevice",
+	"ai:gpu_max_texture_resolution" : "gpuMaxTextureResolution",
+}
+
+# Provide compatibility for ArnoldOptions plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferArnold.ArnoldOptions, "options", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferCycles/cyclesAttributesCompatibility.py
+++ b/startup/GafferCycles/cyclesAttributesCompatibility.py
@@ -1,0 +1,73 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferCycles
+
+__aliases = {
+	"cycles:visibility:camera" : "cameraVisibility",
+	"cycles:visibility:diffuse" : "diffuseVisibility",
+	"cycles:visibility:glossy" : "glossyVisibility",
+	"cycles:visibility:transmission" : "transmissionVisibility",
+	"cycles:visibility:shadow" : "shadowVisibility",
+	"cycles:visibility:scatter" : "scatterVisibility",
+	"cycles:use_holdout" : "useHoldout",
+	"cycles:is_shadow_catcher" : "isShadowCatcher",
+	"cycles:shadow_terminator_shading_offset" : "shadowTerminatorShadingOffset",
+	"cycles:shadow_terminator_geometry_offset" : "shadowTerminatorGeometryOffset",
+	"cycles:is_caustics_caster" : "isCausticsCaster",
+	"cycles:is_caustics_receiver" : "isCausticsReceiver",
+	"cycles:max_level" : "maxLevel",
+	"cycles:dicing_rate" : "dicingScale",
+	"cycles:lightgroup" : "lightGroup",
+	"cycles:volume_clipping" : "volumeClipping",
+	"cycles:volume_step_size" : "volumeStepSize",
+	"cycles:volume_object_space" : "volumeObjectSpace",
+	"cycles:volume_velocity_scale" : "volumeVelocityScale",
+	"cycles:volume_precision" : "volumePrecision",
+	"cycles:asset_name" : "assetName",
+	"cycles:shader:emission_sampling_method" : "emissionSamplingMethod",
+	"cycles:shader:use_transparent_shadow" : "useTransparentShadow",
+	"cycles:shader:heterogeneous_volume" : "heterogeneousVolume",
+	"cycles:shader:volume_sampling_method" : "volumeSamplingMethod",
+	"cycles:shader:volume_interpolation_method" : "volumeInterpolationMethod",
+	"cycles:shader:volume_step_rate" : "volumeStepRate",
+	"cycles:shader:displacement_method" : "displacementMethod",
+}
+
+# Provide compatibility for CyclesAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesAttributes, "attributes", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferCycles/cyclesOptionsCompatibility.py
+++ b/startup/GafferCycles/cyclesOptionsCompatibility.py
@@ -1,0 +1,119 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferCycles
+
+__aliases = {
+	"cycles:log_level" : "logLevel",
+	"cycles:device" : "device",
+	"cycles:shadingsystem" : "shadingSystem",
+	"cycles:session:samples" : "samples",
+	"cycles:session:pixel_size" : "pixelSize",
+	"cycles:session:threads" : "numThreads",
+	"cycles:session:time_limit" : "timeLimit",
+	"cycles:session:use_profiling" : "useProfiling",
+	"cycles:session:use_auto_tile" : "useAutoTile",
+	"cycles:session:tile_size" : "tileSize",
+	"cycles:scene:bvh_layout" : "bvhLayout",
+	"cycles:scene:use_bvh_spatial_split" : "useBvhSpatialSplit",
+	"cycles:scene:use_bvh_unaligned_nodes" : "useBvhUnalignedNodes",
+	"cycles:scene:num_bvh_time_steps" : "numBvhTimeSteps",
+	"cycles:scene:hair_subdivisions" : "hairSubdivisions",
+	"cycles:scene:hair_shape" : "hairShape",
+	"cycles:scene:texture_limit" : "textureLimit",
+	"cycles:integrator:min_bounce" : "minBounce",
+	"cycles:integrator:max_bounce" : "maxBounce",
+	"cycles:integrator:max_diffuse_bounce" : "maxDiffuseBounce",
+	"cycles:integrator:max_glossy_bounce" : "maxGlossyBounce",
+	"cycles:integrator:max_transmission_bounce" : "maxTransmissionBounce",
+	"cycles:integrator:max_volume_bounce" : "maxVolumeBounce",
+	"cycles:integrator:transparent_min_bounce" : "transparentMinBounce",
+	"cycles:integrator:transparent_max_bounce" : "transparentMaxBounce",
+	"cycles:integrator:ao_bounces" : "aoBounces",
+	"cycles:integrator:ao_factor" : "aoFactor",
+	"cycles:integrator:ao_distance" : "aoDistance",
+	"cycles:integrator:volume_max_steps" : "volumeMaxSteps",
+	"cycles:integrator:volume_step_rate" : "volumeStepRate",
+	"cycles:integrator:caustics_reflective" : "causticsReflective",
+	"cycles:integrator:caustics_refractive" : "causticsRefractive",
+	"cycles:integrator:filter_glossy" : "filterGlossy",
+	"cycles:integrator:seed" : "seed",
+	"cycles:integrator:sample_clamp_direct" : "sampleClampDirect",
+	"cycles:integrator:sample_clamp_indirect" : "sampleClampIndirect",
+	"cycles:integrator:start_sample" : "startSample",
+	"cycles:integrator:use_light_tree" : "useLightTree",
+	"cycles:integrator:light_sampling_threshold" : "lightSamplingThreshold",
+	"cycles:integrator:use_adaptive_sampling" : "useAdaptiveSampling",
+	"cycles:integrator:adaptive_threshold" : "adaptiveThreshold",
+	"cycles:integrator:adaptive_min_samples" : "adaptiveMinSamples",
+	"cycles:integrator:denoiser_type" : "denoiserType",
+	"cycles:denoise_device" : "denoiseDevice",
+	"cycles:integrator:denoise_start_sample" : "denoiseStartSample",
+	"cycles:integrator:use_denoise_pass_albedo" : "useDenoisePassAlbedo",
+	"cycles:integrator:use_denoise_pass_normal" : "useDenoisePassNormal",
+	"cycles:integrator:denoiser_prefilter" : "denoiserPrefilter",
+	"cycles:integrator:use_guiding" : "useGuiding",
+	"cycles:integrator:use_surface_guiding" : "useSurfaceGuiding",
+	"cycles:integrator:use_volume_guiding" : "useVolumeGuiding",
+	"cycles:integrator:guiding_training_samples" : "guidingTrainingSamples",
+	"cycles:background:use_shader" : "bgUseShader",
+	"cycles:background:visibility:camera" : "bgCameraVisibility",
+	"cycles:background:visibility:diffuse" : "bgDiffuseVisibility",
+	"cycles:background:visibility:glossy" : "bgGlossyVisibility",
+	"cycles:background:visibility:transmission" : "bgTransmissionVisibility",
+	"cycles:background:visibility:shadow" : "bgShadowVisibility",
+	"cycles:background:visibility:scatter" : "bgScatterVisibility",
+	"cycles:background:transparent" : "bgTransparent",
+	"cycles:background:transparent_glass" : "bgTransparentGlass",
+	"cycles:background:transparent_roughness_threshold" : "bgTransparentRoughnessThreshold",
+	"cycles:background:volume_step_size" : "volumeStepSize",
+	"cycles:film:exposure" : "exposure",
+	"cycles:film:pass_alpha_threshold" : "passAlphaThreshold",
+	"cycles:film:display_pass" : "displayPass",
+	"cycles:film:show_active_pixels" : "showActivePixels",
+	"cycles:film:filter_type" : "filterType",
+	"cycles:film:filter_width" : "filterWidth",
+	"cycles:film:mist_start" : "mistStart",
+	"cycles:film:mist_depth" : "mistDepth",
+	"cycles:film:mist_falloff" : "mistFalloff",
+	"cycles:film:cryptomatte_depth" : "cryptomatteDepth",
+	"cycles:dicing_camera" : "dicingCamera",
+}
+
+# Provide compatibility for CyclesOptions plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferCycles.CyclesOptions, "options", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferDelight/delightAttributesCompatibility.py
+++ b/startup/GafferDelight/delightAttributesCompatibility.py
@@ -1,0 +1,53 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferDelight
+
+__aliases = {
+	"dl:visibility_camera" : "cameraVisibility",
+	"dl:visibility_diffuse" : "diffuseVisibility",
+	"dl:visibility_hair" : "hairVisibility",
+	"dl:visibility_reflection" : "reflectionVisibility",
+	"dl:visibility_refraction" : "refractionVisibility",
+	"dl:visibility_shadow" : "shadowVisibility",
+	"dl:visibility_specular" : "specularVisibility",
+	"dl:matte" : "matte",
+}
+
+# Provide compatibility for DelightAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferDelight.DelightAttributes, "attributes", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferDelight/delightOptionsCompatibility.py
+++ b/startup/GafferDelight/delightOptionsCompatibility.py
@@ -1,0 +1,75 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferDelight
+
+__aliases = {
+	"dl:bucketorder" : "bucketOrder",
+	"dl:numberofthreads" : "numberOfThreads",
+	"dl:renderatlowpriority" : "renderAtLowPriority",
+	"dl:oversampling" : "oversampling",
+	"dl:quality_shadingsamples" : "shadingSamples",
+	"dl:quality_volumesamples" : "volumeSamples",
+	"dl:clampindirect" : "clampIndirect",
+	"dl:importancesamplefilter" : "importanceSampleFilter",
+	"dl:show_displacement" : "showDisplacement",
+	"dl:show_osl_subsurface" : "showSubsurface",
+	"dl:show_atmosphere" : "showAtmosphere",
+	"dl:show_multiplescattering" : "showMultipleScattering",
+	"dl:statistics_progress" : "showProgress",
+	"dl:statistics_filename" : "statisticsFileName",
+	"dl:maximumraydepth_diffuse" : "maximumRayDepthDiffuse",
+	"dl:maximumraydepth_hair" : "maximumRayDepthHair",
+	"dl:maximumraydepth_reflection" : "maximumRayDepthReflection",
+	"dl:maximumraydepth_refraction" : "maximumRayDepthRefraction",
+	"dl:maximumraydepth_volume" : "maximumRayDepthVolume",
+	"dl:maximumraylength_diffuse" : "maximumRayLengthDiffuse",
+	"dl:maximumraylength_hair" : "maximumRayLengthHair",
+	"dl:maximumraylength_reflection" : "maximumRayLengthReflection",
+	"dl:maximumraylength_refraction" : "maximumRayLengthRefraction",
+	"dl:maximumraylength_specular" : "maximumRayLengthSpecular",
+	"dl:maximumraylength_volume" : "maximumRayLengthVolume",
+	"dl:texturememory" : "textureMemory",
+	"dl:networkcache_size" : "networkCacheSize",
+	"dl:networkcache_directory" : "networkCacheDirectory",
+	"dl:license_server" : "licenseServer",
+	"dl:license_wait" : "licenseWait",
+}
+
+# Provide compatibility for DelightOptions plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferDelight.DelightOptions, "options", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferScene/openGLAttributesCompatibility.py
+++ b/startup/GafferScene/openGLAttributesCompatibility.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+__aliases = {
+	"gl:primitive:solid" : "primitiveSolid",
+	"gl:primitive:wireframe" : "primitiveWireframe",
+	"gl:primitive:wireframeColor" : "primitiveWireframeColor",
+	"gl:primitive:wireframeWidth" : "primitiveWireframeWidth",
+	"gl:primitive:outline" : "primitiveOutline",
+	"gl:primitive:outlineColor" : "primitiveOutlineColor",
+	"gl:primitive:outlineWidth" : "primitiveOutlineWidth",
+	"gl:primitive:points" : "primitivePoint",
+	"gl:primitive:pointColor" : "primitivePointColor",
+	"gl:primitive:pointWidth" : "primitivePointWidth",
+	"gl:primitive:bound" : "primitiveBound",
+	"gl:primitive:boundColor" : "primitiveBoundColor",
+	"gl:pointsPrimitive:useGLPoints" : "pointsPrimitiveUseGLPoints",
+	"gl:pointsPrimitive:glPointWidth" : "pointsPrimitiveGLPointWidth",
+	"gl:curvesPrimitive:useGLLines" : "curvesPrimitiveUseGLLines",
+	"gl:curvesPrimitive:glLineWidth" : "curvesPrimitiveGLLineWidth",
+	"gl:curvesPrimitive:ignoreBasis" : "curvesPrimitiveIgnoreBasis",
+	"gl:visualiser:scale" : "visualiserScale",
+	"gl:visualiser:maxTextureResolution" : "visualiserMaxTextureResolution",
+	"gl:visualiser:frustum" : "visualiserFrustum",
+	"gl:light:drawingMode" : "lightDrawingMode",
+	"gl:light:frustumScale" : "lightFrustumScale",
+}
+
+# Provide compatibility for OpenGLAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferScene.OpenGLAttributes, "attributes", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferScene/standardAttributesCompatibility.py
+++ b/startup/GafferScene/standardAttributesCompatibility.py
@@ -1,0 +1,52 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+__aliases = {
+	"scene:visible" : "visibility",
+	"render:displayColor" : "displayColor",
+	"gaffer:transformBlur" : "transformBlur",
+	"gaffer:transformBlurSegments" : "transformBlurSegments",
+	"gaffer:deformationBlur" : "deformationBlur",
+	"gaffer:deformationBlurSegments" : "deformationBlurSegments",
+	"gaffer:automaticInstancing" : "automaticInstancing",
+}
+
+# Provide compatibility for StandardAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferScene.StandardAttributes, "attributes", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferScene/standardOptionsCompatibility.py
+++ b/startup/GafferScene/standardOptionsCompatibility.py
@@ -1,0 +1,66 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferScene
+
+__aliases = {
+	"render:camera" : "renderCamera",
+	"render:filmFit" : "filmFit",
+	"render:resolution" : "renderResolution",
+	"render:pixelAspectRatio" : "pixelAspectRatio",
+	"render:resolutionMultiplier" : "resolutionMultiplier",
+	"render:cropWindow" : "renderCropWindow",
+	"render:overscan" : "overscan",
+	"render:overscanTop" : "overscanTop",
+	"render:overscanBottom" : "overscanBottom",
+	"render:overscanLeft" : "overscanLeft",
+	"render:overscanRight" : "overscanRight",
+	"render:depthOfField" : "depthOfField",
+	"render:defaultRenderer" : "defaultRenderer",
+	"render:includedPurposes" : "includedPurposes",
+	"render:inclusions" : "inclusions",
+	"render:exclusions" : "exclusions",
+	"render:additionalLights" : "additionalLights",
+	"render:transformBlur" : "transformBlur",
+	"render:deformationBlur" : "deformationBlur",
+	"render:shutter" : "shutter",
+	"render:performanceMonitor" : "performanceMonitor",
+}
+
+# Provide compatibility for StandardOptions plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferScene.StandardOptions, "options", f"compatibility:childAlias:{k}", v )

--- a/startup/GafferUSD/usdAttributesCompatibility.py
+++ b/startup/GafferUSD/usdAttributesCompatibility.py
@@ -1,0 +1,47 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import GafferUSD
+
+__aliases = {
+	"usd:purpose" : "purpose",
+	"usd:kind" : "kind",
+}
+
+# Provide compatibility for USDAttributes plugs renamed in Gaffer 1.6
+for k, v in __aliases.items() :
+	Gaffer.Metadata.registerValue( GafferUSD.USDAttributes, "attributes", f"compatibility:childAlias:{k}", v )


### PR DESCRIPTION
This introduces `compatibility:childAlias:<aliasName>` metadata to provide a method for creating aliases to children of a GraphComponent by allowing calls to `getChild( name )` in Python to fall back to returning a child matching the value of `compatibility:childAlias:name` metadata registered to the GraphComponent when a child matching `name` isn't found.

`descendant()` has been reimplemented in GraphComponentBinding using the internal `getChild()`, plus `__getItem__` and `__contains__` are updated so they all have access to the aliases.

The immediate motivation here is to provide forwards compatibility in Gaffer 1.5 for the plugs renamed in Gaffer 1.6 as part of the great metadata unification of 2025. Existing configs providing compatibility for other renamed plugs by overriding `__getItem__` could also be replaced with childAlias metadata registrations, some examples of those can found in [this](https://github.com/murraystevenson/gaffer/commit/ebb48a631170cda18cbab69933418d40c377572a) commit which may end up in a later PR targeted to `main`.

When merging this forwards to `main`, we'll need to make sure that 6d8d79d is not included, and we can later update the existing compatibility configs from the great metadata unification on `main` providing backwards compatibility with the Gaffer 1.5 plug names to use this new metadata.