### PR TITLE
More Image Picking Fixes

### DIFF
--- a/include/GafferSceneUI/Private/ImageSelectionTool.h
+++ b/include/GafferSceneUI/Private/ImageSelectionTool.h
@@ -82,13 +82,10 @@ class GAFFERSCENEUI_API ImageSelectionTool : public GafferUI::Tool
 
 		GafferImageUI::ImageGadget *imageGadget();
 
-		void setStatus( const std::string &message, bool error );
-		void setErrorMessage( const std::string &message );
-
 		void plugDirtied( const Gaffer::Plug *plug );
 
-		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids, std::string &message );
-		void idsForPaths( const IECore::PathMatcher &paths, std::vector<uint32_t> &result, std::string &message );
+		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids );
+		void idsForPaths( const IECore::PathMatcher &paths, std::vector<uint32_t> &result );
 
 		uint32_t pixelID( const Imath::V2i &pixel );
 		std::unordered_set<uint32_t> rectIDs( const Imath::Box2i &rect );
@@ -96,8 +93,6 @@ class GAFFERSCENEUI_API ImageSelectionTool : public GafferUI::Tool
 		void selectedPathsChanged();
 
 		void updateSelectedIDs();
-
-		void updateRenderManifest( std::string &message );
 
 		void preRender();
 
@@ -120,7 +115,8 @@ class GAFFERSCENEUI_API ImageSelectionTool : public GafferUI::Tool
 		std::shared_ptr<const GafferScene::RenderManifest> m_renderManifest;
 		bool m_manifestDirty;
 
-		std::string m_status;
+		std::string m_manifestError;
+		std::string m_infoStatus;
 		StatusChangedSignal m_statusChangedSignal;
 
 		std::vector<uint32_t> m_selectedIDs;

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -589,11 +589,12 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			script["parent"]["children"].next().setInput( sphere["out"] )
 
 		imagePath = self.temporaryDirectory() / "test.exr"
+		beautyPath = self.temporaryDirectory() / "beauty.exr"
 		script["outputs"] = GafferScene.Outputs()
 		script["outputs"].addOutput(
 			"beauty",
 			IECoreScene.Output(
-				( self.temporaryDirectory() / "beauty.exr" ).as_posix(),
+				beautyPath.as_posix(),
 				"exr",
 				"rgba"
 			)
@@ -622,6 +623,10 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			self.assertEqual( len( mh.messages ), 1 )
 			self.assertEqual( mh.messages[0].message, 'Found render:manifestFilePath option, but the render manifest is not enabled because there is no ID output' )
 
+		reader = GafferImage.ImageReader()
+		reader["fileName"].setValue( beautyPath )
+		self.assertNotIn( "gaffer:renderManifestFilePath", reader["out"].metadata() )
+
 		script["outputs"].addOutput(
 			"id",
 			IECoreScene.Output(
@@ -637,9 +642,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 
 		script["render"]["task"].execute()
 
-		reader = GafferImage.ImageReader()
 		reader["fileName"].setValue( imagePath )
-
 		manifest = GafferScene.RenderManifest.loadFromImageMetadata( reader["out"].metadata(), "" )
 
 		sampler = GafferImage.ImageSampler()

--- a/python/GafferSceneUI/ImageSelectionToolUI.py
+++ b/python/GafferSceneUI/ImageSelectionToolUI.py
@@ -97,6 +97,7 @@ class _StatusWidget( GafferUI.ListContainer ) :
 					self.__warningIcon = GafferUI.Image( "warningSmall.png" )
 					GafferUI.Spacer( size = imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
 					self.__label = GafferUI.Label( "" )
+					self.__label.setTextSelectable( True )
 
 		self.__frame._qtWidget().setObjectName( "gafferImageSelectionStatus" )
 

--- a/src/GafferImageUI/ImageGadget.cpp
+++ b/src/GafferImageUI/ImageGadget.cpp
@@ -1070,7 +1070,20 @@ Imath::V2f ImageGadget::pixelAt( const IECore::LineSegment3f &lineInGadgetSpace 
 		return V2f( 0 );
 	}
 
-	return V2f( i.x / format().getPixelAspect(), i.y );
+	Format f;
+	try
+	{
+		f = format();
+	}
+	catch( ... )
+	{
+		// Clients wouldn't necessarily expect pixelAt to throw - if the input image is invalid, there
+		// should be other indications in the UI, so it's probably safe to silently return a default pixel
+		// here.
+		return V2f( 0 );
+	}
+
+	return V2f( i.x / f.getPixelAspect(), i.y );
 }
 
 void ImageGadget::setWipeEnabled( bool enabled )

--- a/src/GafferScene/RenderManifest.cpp
+++ b/src/GafferScene/RenderManifest.cpp
@@ -297,9 +297,9 @@ std::shared_ptr<const RenderManifest> RenderManifest::loadFromImageMetadata( con
 	{
 		currentModTime = std::filesystem::last_write_time( sideCarManifestPath );
 	}
-	catch( std::exception &e )
+	catch( ... )
 	{
-		throw IECore::Exception( std::string( "Could not find manifest file : " ) + sideCarManifestPath + " : " + e.what() );
+		throw IECore::Exception( std::string( "Could not open manifest file : " ) + sideCarManifestPath );
 	}
 
 	FileCacheKey cacheKey( sideCarManifestPath, currentModTime );


### PR DESCRIPTION
Building on top of #6483, this addresses the outstanding requests from the end of #6329.

The only significant reshuffle is `ImageSelectionTool : Don't wait for manifest to be used before error`, which moves updating the render manifest to whenever the image metadata changes, instead of being triggered by something that uses the manifest. This simplifies things for now ( though it will need to get complicated in a different way if we want to do it properly on a background thread ).

The other changes are pretty direct ways of addressing the feedback on #6329.