### PR TITLE
HistoryPath refactor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -45,7 +45,9 @@ Fixes
 - ScriptNodeAlgo : Stopped polluting the ScriptNode context with `ui:*` variables. Warnings are now emitted by the UI if anything else causes similar pollution.
 - Checkerboard : Fixed crash when evaluated for non-existent channel name.
 - PathListingWidget : Prevented emission of `updateFinishedSignal()` when a new update is pending anyway.
-- LightEditor, RenderPassEditor, AttributeEditor : Fixed missing history entries when two edits have the same source plug.
+- LightEditor, RenderPassEditor, AttributeEditor :
+  - Fixed missing history entries when two edits have the same source plug.
+  - Fixed potential crashes in `Show History...`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -48,6 +48,7 @@ Fixes
 - LightEditor, RenderPassEditor, AttributeEditor :
   - Fixed missing history entries when two edits have the same source plug.
   - Fixed potential crashes in `Show History...`.
+  - Fixed potential UI lag in `Show History...`.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -45,6 +45,7 @@ Fixes
 - ScriptNodeAlgo : Stopped polluting the ScriptNode context with `ui:*` variables. Warnings are now emitted by the UI if anything else causes similar pollution.
 - Checkerboard : Fixed crash when evaluated for non-existent channel name.
 - PathListingWidget : Prevented emission of `updateFinishedSignal()` when a new update is pending anyway.
+- LightEditor, RenderPassEditor, AttributeEditor : Fixed missing history entries when two edits have the same source plug.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -49,6 +49,7 @@ Fixes
   - Fixed missing history entries when two edits have the same source plug.
   - Fixed potential crashes in `Show History...`.
   - Fixed potential UI lag in `Show History...`.
+  - Fixed flickering in history window when scrubbing the timeline.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -44,6 +44,7 @@ Fixes
 - PlugLayout : Fixed bug resolving `layout:index` metadata.
 - ScriptNodeAlgo : Stopped polluting the ScriptNode context with `ui:*` variables. Warnings are now emitted by the UI if anything else causes similar pollution.
 - Checkerboard : Fixed crash when evaluated for non-existent channel name.
+- PathListingWidget : Prevented emission of `updateFinishedSignal()` when a new update is pending anyway.
 
 API
 ---

--- a/include/GafferSceneUI/Private/BasicInspector.inl
+++ b/include/GafferSceneUI/Private/BasicInspector.inl
@@ -45,7 +45,7 @@ BasicInspector::BasicInspector(
 	const ValueFunctionType &&valueFunction,
 	const std::string &type, const std::string &name
 )
-	: 	Inspector( type, name, editScope ), m_plug( plug )
+	: 	Inspector( plug, type, name, editScope ), m_plug( plug )
 {
 	// Wrapper downcasts the plug to the correct type, removing the
 	// need to do that manually in the supplied lambda.

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -258,7 +258,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 					Gaffer::PathFilterPtr filter = nullptr
 				);
 
-				const GafferScene::SceneAlgo::History *history() const;
+				const GafferScene::SceneAlgo::History *history( const IECore::Canceller *canceller ) const;
 				HistoryProviderPtr m_historyProvider;
 
 		};

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -99,7 +99,6 @@ IE_CORE_FORWARDDECLARE( Inspector );
 ///   This has additional requirements such as knowing the `transformSpace` that a node
 ///   works in. We think this information can be stored in a dedicated TransformHistory
 ///   class provided by SceneAlgo, avoiding any need to specialise Inspector::Result.
-
 class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::Signals::Trackable
 {
 
@@ -202,8 +201,6 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 		/// edit `plug` to set `value`. Called with `history->context` as the
 		/// current context.
 		virtual EditFunction editFunction( const GafferScene::SceneAlgo::History *history ) const;
-
-	protected :
 
 		Gaffer::EditScope *targetEditScope() const;
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -243,41 +243,26 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 			private :
 
-				// Index history entries using :
-				// 1. The hash of the ScenePlug address and the context. This uniquely
-				//    identifies the history item.
-				// 2. Random access for maintaining the order of the history.
-				struct PlugHistoryEntry
-				{
-					std::string hashString;
-					GafferScene::SceneAlgo::History::ConstPtr history;
-				};
-				using PlugMap = boost::multi_index::multi_index_container<
-					PlugHistoryEntry,
-					boost::multi_index::indexed_by<
-						boost::multi_index::hashed_unique<
-							boost::multi_index::member<PlugHistoryEntry, std::string, &PlugHistoryEntry::hashString>
-						>,
-						boost::multi_index::random_access<>
-					>
-				>;
+				using HistoryVector = std::vector<GafferScene::SceneAlgo::History::ConstPtr>;
+				using HistoryVectorConstPtr = std::shared_ptr<const HistoryVector>;
 
 				// Private constructor for creating children and copies. We reuse the
-				// acceleration structure `plugMap` to avoid computing history more than once.
+				// history vector to avoid computing history more than once.
 				HistoryPath(
 					const InspectorPtr inspector,
 					Gaffer::ConstContextPtr context,
-					PlugMap plugMap,
+					const HistoryVectorConstPtr &historyVector,
 					const std::string &path = "/",
 					Gaffer::PathFilterPtr filter = nullptr
 				);
 
-				void updatePlugMap() const;
+				GafferScene::SceneAlgo::History::ConstPtr history() const;
+				void updateHistoryVector() const;
 
 				const InspectorPtr m_inspector;
 				Gaffer::ConstContextPtr m_context;
 
-				mutable PlugMap m_plugMap;
+				mutable HistoryVectorConstPtr m_historyVector;
 
 		};
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -244,9 +244,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 			private :
 
 				// Index history entries using :
-				// 1. The hash of the source plug pointer and the context. A plug could have
-				// multiple values affecting the history in different contexts, making the
-				// plug alone insufficient for uniqueness.
+				// 1. The hash of the ScenePlug address and the context. This uniquely
+				//    identifies the history item.
 				// 2. Random access for maintaining the order of the history.
 				struct PlugHistoryEntry
 				{

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -139,7 +139,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 		/// Protected constructor for use by derived classes. The `name` argument
 		/// will be returned verbatim by the `name()` method.
-		Inspector( const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
+		Inspector( const Gaffer::ConstPlugPtr &target, const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
 
 		/// Methods to be implemented in derived classes
 		/// ============================================
@@ -241,6 +241,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 				bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override;
 				Gaffer::PathPtr copy() const override;
 
+				const Gaffer::Plug *cancellationSubject() const override;
+
 			protected :
 
 				void doChildren( std::vector<Gaffer::PathPtr> &children, const IECore::Canceller *canceller = nullptr ) const override;
@@ -263,6 +265,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 		};
 
+		const Gaffer::ConstPlugPtr m_target;
 		const std::string m_type;
 		const std::string m_name;
 		const Gaffer::PlugPtr m_editScope;

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -69,7 +69,7 @@ class _OperationIconColumn( GafferUI.PathColumn ) :
 			Gaffer.TweakPlug.Mode.ListAppend : "listAppendSmall.png",
 			Gaffer.TweakPlug.Mode.ListPrepend : "listPrependSmall.png",
 			Gaffer.TweakPlug.Mode.ListRemove : "listRemoveSmall.png",
-		}.get( cellValue, "errorSmall.png" )
+		}.get( cellValue )
 
 		return data
 
@@ -225,13 +225,14 @@ class _HistoryWindow( GafferUI.Window ) :
 			not isinstance( self.__inspector, GafferSceneUI.Private.SetMembershipInspector )
 		) :
 			editPlug = selectedPath.property( "history:source" )
-			self.__popup = GafferUI.PlugPopup(
-				[ editPlug ], warning = selectedPath.property( "history:editWarning" )
-			)
-			if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
-				self.__popup.plugValueWidget().setNameVisible( False )
+			if editPlug is not None :
+				self.__popup = GafferUI.PlugPopup(
+					[ editPlug ], warning = selectedPath.property( "history:editWarning" )
+				)
+				if isinstance( self.__popup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :
+					self.__popup.plugValueWidget().setNameVisible( False )
 
-			self.__popup.popup( parent = self )
+				self.__popup.popup( parent = self )
 
 	def __dragBegin( self, pathListing, event ) :
 
@@ -241,13 +242,13 @@ class _HistoryWindow( GafferUI.Window ) :
 
 		if selectedColumn == self.__nameColumnIndex :
 			GafferUI.Pointer.setCurrent( "nodes" )
-
 			return selectedPath.property( "history:node" )
 
 		elif selectedColumn == self.__operationColumnIndex :
-			GafferUI.Pointer.setCurrent( "values" )
-
-			return selectedPath.property( "history:operation" )
+			operation = selectedPath.property( "history:operation" )
+			if operation is not None :
+				GafferUI.Pointer.setCurrent( "values" )
+				return operation
 
 		# Value column works by default
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -270,7 +270,7 @@ class _HistoryWindow( GafferUI.Window ) :
 
 	def __inspectorDirtied( self, inspector ) :
 
-		self.__path._emitPathChanged()
+		self.__updatePath()
 
 	def __contextChanged( self, contextTracker ) :
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -279,24 +279,24 @@ class _HistoryWindow( GafferUI.Window ) :
 
 	def __updateFinished( self, pathListing ) :
 
-		self.__nodeNameChangedSignals = []
+		self.__nodeNameChangedSignals = {}
 
 		for path in self.__path.children() :
-			node = path.property( "history:node" )
 
 			# The node and all of its parents up to the script node
 			# contribute to the path name.
 
+			node = path.property( "history:node" )
 			while node is not None and not isinstance( node, Gaffer.ScriptNode ) :
-				self.__nodeNameChangedSignals.append(
-					node.nameChangedSignal().connect(
+				if node not in self.__nodeNameChangedSignals :
+					self.__nodeNameChangedSignals[node] = node.nameChangedSignal().connect(
 						Gaffer.WeakMethod( self.__nodeNameChanged ),
 						scoped = True
 					)
-				)
 
 				node = node.parent()
 
 	def __nodeNameChanged( self, node, oldName ) :
 
-		self.__path._emitPathChanged()
+		nameColumn = self.__pathListingWidget.getColumns()[0]
+		nameColumn.changedSignal()( nameColumn )

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -514,5 +514,23 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		historyPathEdited[0] += "foo"
 		self.assertIsNone( historyPathEdited.property( "history:node" ) )
 
+	def testInspectionIsDeferred( self ) :
+
+		monitor = Gaffer.PerformanceMonitor()
+
+		light = GafferSceneTest.TestLight()
+		inspector = self.__inspector( light["out"], "exposure" )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/light" )
+			with monitor :
+				historyPath = inspector.historyPath()
+
+		self.assertEqual( len( monitor.allStatistics() ), 0 )
+
+		with monitor :
+			historyPath.children()
+
+		self.assertGreaterEqual( len( monitor.allStatistics() ), 1 )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -532,5 +532,28 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 
 		self.assertGreaterEqual( len( monitor.allStatistics() ), 1 )
 
+	def testCancellation( self ) :
+
+		light = GafferSceneTest.TestLight()
+		inspector = self.__inspector( light["out"], "exposure" )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/light" )
+			historyPath = inspector.historyPath()
+
+		canceller = IECore.Canceller()
+		canceller.cancel()
+
+		with self.assertRaises( IECore.Cancelled ) :
+			historyPath.children( canceller )
+
+		historyPath.append( "0" )
+
+		light["parameters"]["exposure"].setValue( 1 )
+		with self.assertRaises( IECore.Cancelled ) :
+			historyPath.propertyNames( canceller )
+
+		with self.assertRaises( IECore.Cancelled ) :
+			historyPath.property( "history:source", canceller )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -35,13 +35,10 @@
 ##########################################################################
 
 import unittest
-import threading
-import imath
 
 import IECore
 
 import Gaffer
-import GafferTest
 import GafferScene
 import GafferSceneUI
 import GafferSceneTest

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -493,5 +493,26 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertFalse( historyPathEdited.isValid() )
 		self.assertFalse( historyPathEdited.isLeaf() )
 
+	def testNoPropertiesOnNonLeafPaths( self ) :
+
+		light = GafferSceneTest.TestLight()
+		inspector = self.__inspector( light["out"], "exposure" )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/light" )
+			historyPath = inspector.historyPath()
+
+		self.assertIsNone( historyPath.property( "history:node" ) )
+
+		historyPath = historyPath.children()[0]
+		self.assertIsNotNone( historyPath.property( "history:node" ) )
+
+		historyPathDeeper = historyPath.copy()
+		historyPathDeeper.append( "foo" )
+		self.assertIsNone( historyPathDeeper.property( "history:node" ) )
+
+		historyPathEdited = historyPath.copy()
+		historyPathEdited[0] += "foo"
+		self.assertIsNone( historyPathEdited.property( "history:node" ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -468,5 +468,30 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		self.assertEqual( c[1].property( "history:source" ), s["openGLAttributes"]["attributes"]["gl:visualiser:maxTextureResolution"] )
 		self.assertEqual( c[1].property( "history:editWarning" ), "Edits to \"gl:visualiser:maxTextureResolution\" may affect other locations in the scene." )
 
+	def testIsLeafAndIsValid( self ) :
+
+		light = GafferSceneTest.TestLight()
+		inspector = self.__inspector( light["out"], "exposure" )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/light" )
+			historyPath = inspector.historyPath()
+
+		self.assertTrue( historyPath.isValid() )
+		self.assertFalse( historyPath.isLeaf() )
+
+		historyPath = historyPath.children()[0]
+		self.assertTrue( historyPath.isValid() )
+		self.assertTrue( historyPath.isLeaf() )
+
+		historyPathDeeper = historyPath.copy()
+		historyPathDeeper.append( "foo" )
+		self.assertFalse( historyPathDeeper.isValid() )
+		self.assertFalse( historyPathDeeper.isLeaf() )
+
+		historyPathEdited = historyPath.copy()
+		historyPathEdited[0] += "foo"
+		self.assertFalse( historyPathEdited.isValid() )
+		self.assertFalse( historyPathEdited.isLeaf() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -58,6 +58,13 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 
 		return inspector
 
+	def setUp( self ) :
+
+		GafferSceneTest.SceneTestCase.setUp( self )
+		# Ignore messages intended to catch bad usage by the UI. It's fine
+		# to be testing on the main thread.
+		self.ignoreMessage( IECore.Msg.Level.Warning, "HistoryPath", "Path evaluated on unexpected thread" )
+
 	def test( self ) :
 
 		s = Gaffer.ScriptNode()

--- a/python/GafferSceneUITest/HistoryPathTest.py
+++ b/python/GafferSceneUITest/HistoryPathTest.py
@@ -605,5 +605,20 @@ class HistoryPathTest( GafferSceneTest.SceneTestCase ) :
 		backgroundTask.wait()
 		self.assertEqual( backgroundTask.status(), backgroundTask.Status.Cancelled )
 
+	def testSceneReader( self ) :
+
+		reader = GafferScene.SceneReader()
+		reader["fileName"].setValue( "${GAFFER_ROOT}/python/GafferSceneTest/usdFiles/sphereLight.usda" )
+
+		inspector = self.__inspector( reader["out"], "exposure" )
+		with Gaffer.Context() as context :
+			context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/SpotLight23" )
+			historyPath = inspector.historyPath()
+
+		self.assertEqual(
+			[ c.property( "history:node" ) for c in historyPath.children() ],
+			[ reader ]
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/AttributeInspector.cpp
+++ b/src/GafferSceneUI/AttributeInspector.cpp
@@ -218,7 +218,7 @@ AttributeInspector::AttributeInspector(
 	const std::string &name,
 	const std::string &type
 ) :
-Inspector( type, name == "" ? attribute.string() : name, editScope ),
+Inspector( scene, type, name == "" ? attribute.string() : name, editScope ),
 m_scene( scene ),
 m_attribute( attribute )
 {

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -717,12 +717,12 @@ bool Inspector::HistoryPath::isValid( const Canceller *canceller ) const
 	{
 		return true;
 	}
-	return m_plugMap.find( names()[0].string() ) != m_plugMap.end();
+	return names().size() == 1 && m_plugMap.count( names()[0].string() );
 }
 
 bool Inspector::HistoryPath::isLeaf( const Canceller *canceller ) const
 {
-	return isValid() && names().size() > 0;
+	return isValid() && names().size() == 1;
 }
 
 PathPtr Inspector::HistoryPath::copy() const

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -252,8 +252,8 @@ void edit( Gaffer::ValuePlug *plug, const IECore::Object *value )
 
 IE_CORE_DEFINERUNTIMETYPED( Inspector )
 
-Inspector::Inspector( const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope )
-	:	m_type( type ), m_name( name ), m_editScope( editScope )
+Inspector::Inspector( const Gaffer::ConstPlugPtr &target, const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope )
+	:	m_target( target ), m_type( type ), m_name( name ), m_editScope( editScope )
 {
 	if( editScope && editScope->node() )
 	{
@@ -804,6 +804,11 @@ bool Inspector::HistoryPath::isLeaf( const Canceller *canceller ) const
 PathPtr Inspector::HistoryPath::copy() const
 {
 	return new Inspector::HistoryPath( m_historyProvider, string(), const_cast<PathFilter *>( getFilter() ) );
+}
+
+const Gaffer::Plug *Inspector::HistoryPath::cancellationSubject() const
+{
+	return m_historyProvider->inspector->m_target.get();
 }
 
 void Inspector::HistoryPath::doChildren( std::vector<PathPtr> &children, const Canceller *canceller) const

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -781,11 +781,10 @@ void Inspector::HistoryPath::updatePlugMap() const
 	{
 		Context::Scope currentScope( history->context.get() );
 
-		if( ValuePlugPtr immediateSource = m_inspector->source( history.get(), editWarning ) )
+		if( m_inspector->source( history.get(), editWarning ) )
 		{
-			ValuePlugPtr source = runTimeCast<ValuePlug>( spreadsheetAwareSource( immediateSource.get() ) );
 			MurmurHash h;
-			h.append( (uintptr_t)source.get() );
+			h.append( (uintptr_t)history->scene.get() );
 			h.append( history->context->hash() );
 			m_plugMap.insert( { h.toString(), history } );
 		}

--- a/src/GafferSceneUI/OptionInspector.cpp
+++ b/src/GafferSceneUI/OptionInspector.cpp
@@ -190,7 +190,7 @@ OptionInspector::OptionInspector(
 	const Gaffer::PlugPtr &editScope,
 	IECore::InternedString option
 ) :
-Inspector( "option", option.string(), editScope ),
+Inspector( scene, "option", option.string(), editScope ),
 m_scene( scene ),
 m_option( option )
 {

--- a/src/GafferSceneUI/SetMembershipInspector.cpp
+++ b/src/GafferSceneUI/SetMembershipInspector.cpp
@@ -234,7 +234,7 @@ SetMembershipInspector::SetMembershipInspector(
 	const Gaffer::PlugPtr &editScope,
 	IECore::InternedString setName
 ) :
-Inspector( "setMembership", setName.string(), editScope ),
+Inspector( scene, "setMembership", setName.string(), editScope ),
 m_scene( scene ),
 m_setName( setName )
 {

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -500,7 +500,8 @@ class PathModel : public QAbstractItemModel
 				m_sortColumn( -1 ),
 				m_sortOrder( Qt::AscendingOrder ),
 				m_modifyingTreeViewExpansion( false ),
-				m_updateScheduled( false )
+				m_updateScheduled( false ),
+				m_blockUpdateFinished( false )
 		{
 			connect( parent, &QTreeView::expanded, this, &PathModel::treeViewExpanded );
 			connect( parent, &QTreeView::collapsed, this, &PathModel::treeViewCollapsed );
@@ -1036,7 +1037,10 @@ class PathModel : public QAbstractItemModel
 						queueEdit(
 							[this] () {
 								finaliseRecursiveExpansion();
-								updateFinished();
+								if( !m_blockUpdateFinished )
+								{
+									updateFinished();
+								}
 							}
 						);
 					}
@@ -1092,6 +1096,7 @@ class PathModel : public QAbstractItemModel
 
 			if( flushPendingEdits )
 			{
+				Private::ScopedAssignment blockUpdateFinished( m_blockUpdateFinished, true );
 				QCoreApplication::sendPostedEvents( this, EditEvent::staticType() );
 			}
 		}
@@ -1934,6 +1939,7 @@ class PathModel : public QAbstractItemModel
 
 		std::unique_ptr<Gaffer::BackgroundTask> m_updateTask;
 		bool m_updateScheduled;
+		bool m_blockUpdateFinished;
 
 };
 


### PR DESCRIPTION
This started out as an innocent little effort to get the HistoryPath working with BasicInspectors in the upcoming SceneInspector revamp - see https://github.com/GafferHQ/gaffer/commit/546b8b066cb13755c93e0d8956e3320fb3c080a7. But it quickly got more involved...

Representing the history as a Path was always a tricky ask, with the intended payoff being that we'd then get lots of good functionality for free by combining it with a PathListingWidget for display. Primary in that was a desire to push all computation into cancellable background tasks so the history window never blocked the UI. But upon closer inspection it turned out that we weren't getting what we thought we were. HistoryPath wasn't actually cancellable, the way we used it was sometimes triggering computes on the UI thread, and we had thread-safety issues too. So the rest of this PR refactors HistoryPath step by step to fix all that, adding a bunch of additional test coverage along the way.