### PR TITLE
LocaliseAttributes / AttributeQuery / AttributeTweaks : Inherit global attributes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,7 +27,7 @@ Improvements
   - Added `render:cameraInclusions`, `render:cameraExclusions`, `render:matteInclusions`, and `render:matteExclusions` options.
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 - PathListingWidget : Improved formatting of Box and Matrix values.
-- LocaliseAttributes : Added support for localising global attributes.
+- LocaliseAttributes : Added support for localising global attributes, controlled by the new `includeGlobalAttributes` plug.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -66,6 +66,7 @@ API
 - SceneAlgo :
   - `applyCameraGlobals()` now always applies the `render:overscan[Top/Bottom/Left/Right]` options to the camera if they exist in the scene globals.
   - `applyCameraGlobals()` now applies the `render:depthOfField` option to the `depthOfField` camera parameter. The `fStop` camera parameter is no longer overridden to `0.0` when the `render:depthOfField` option is `False` or not specified.
+- ScenePlug : Added optional `withGlobalAttributes` arguments to `fullAttributes()` and `fullAttributesHash()`.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Improvements
   - Added `render:cameraInclusions`, `render:cameraExclusions`, `render:matteInclusions`, and `render:matteExclusions` options.
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 - PathListingWidget : Improved formatting of Box and Matrix values.
+- LocaliseAttributes : Added support for localising global attributes.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ Improvements
 - PathListingWidget : Improved formatting of Box and Matrix values.
 - LocaliseAttributes : Added support for localising global attributes, controlled by the new `includeGlobalAttributes` plug.
 - AttributeTweaks : Added support for localising global attributes when `localise` is enabled.
+- AttributeQuery : Added support for querying global attributes when `inherit` is enabled.
 
 Fixes
 -----
@@ -93,6 +94,7 @@ Breaking Changes
 - ContextAlgo : Removed deprecated API. Use ScriptNodeAlgo instead, which has been available from Gaffer 1.4.13.0 onwards.
 - ScriptNodeAlgo : Reimplemented using Metadata rather than Context variables for storage. Use the ScriptNodeAlgo API instead of attempting direct access to `ui:*` context variables.
 - AttributeTweaks : Tweaks with `localise` enabled and a mode of `CreateIfMissing` will now not create an attribute if it is missing from the scene hierarchy, but exists in the globals.
+- AttributeQuery : Queries with `inherit` enabled will now return a result when querying an attribute that does not exist in the scene hierarchy, but does exist in the globals.
 
 Build
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Improvements
 - CyclesMeshLight : Improved presentation of `cameraVisibility` and `lightGroup` plugs in the Node Editor.
 - PathListingWidget : Improved formatting of Box and Matrix values.
 - LocaliseAttributes : Added support for localising global attributes, controlled by the new `includeGlobalAttributes` plug.
+- AttributeTweaks : Added support for localising global attributes when `localise` is enabled.
 
 Fixes
 -----
@@ -91,6 +92,7 @@ Breaking Changes
 - OSLObject, OSLImage, Expression : Removed support for file-based pointclouds.
 - ContextAlgo : Removed deprecated API. Use ScriptNodeAlgo instead, which has been available from Gaffer 1.4.13.0 onwards.
 - ScriptNodeAlgo : Reimplemented using Metadata rather than Context variables for storage. Use the ScriptNodeAlgo API instead of attempting direct access to `ui:*` context variables.
+- AttributeTweaks : Tweaks with `localise` enabled and a mode of `CreateIfMissing` will now not create an attribute if it is missing from the scene hierarchy, but exists in the globals.
 
 Build
 -----

--- a/include/GafferScene/LocaliseAttributes.h
+++ b/include/GafferScene/LocaliseAttributes.h
@@ -56,6 +56,9 @@ class GAFFERSCENE_API LocaliseAttributes : public AttributeProcessor
 		Gaffer::StringPlug *attributesPlug();
 		const Gaffer::StringPlug *attributesPlug() const;
 
+		Gaffer::BoolPlug *includeGlobalAttributesPlug();
+		const Gaffer::BoolPlug *includeGlobalAttributesPlug() const;
+
 	protected :
 
 		bool affectsProcessedAttributes( const Gaffer::Plug *input ) const override;

--- a/include/GafferScene/ScenePlug.h
+++ b/include/GafferScene/ScenePlug.h
@@ -225,7 +225,8 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		/// Returns just the attributes set at the specific scene path.
 		IECore::ConstCompoundObjectPtr attributes( const ScenePath &scenePath ) const;
 		/// Returns the full set of inherited attributes at the specified scene path.
-		IECore::CompoundObjectPtr fullAttributes( const ScenePath &scenePath ) const;
+		/// Attributes are inherited from the globals when `withGlobalAttributes` is true.
+		IECore::CompoundObjectPtr fullAttributes( const ScenePath &scenePath, bool withGlobalAttributes = false ) const;
 		IECore::ConstObjectPtr object( const ScenePath &scenePath ) const;
 		IECore::ConstInternedStringVectorDataPtr childNames( const ScenePath &scenePath ) const;
 		/// Returns true if the specified location exists.
@@ -249,7 +250,7 @@ class GAFFERSCENE_API ScenePlug : public Gaffer::ValuePlug
 		IECore::MurmurHash transformHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash fullTransformHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash attributesHash( const ScenePath &scenePath ) const;
-		IECore::MurmurHash fullAttributesHash( const ScenePath &scenePath ) const;
+		IECore::MurmurHash fullAttributesHash( const ScenePath &scenePath, bool withGlobalAttributes = false ) const;
 		IECore::MurmurHash objectHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash childNamesHash( const ScenePath &scenePath ) const;
 		IECore::MurmurHash childBoundsHash( const ScenePath &scenePath ) const;

--- a/python/GafferSceneTest/LocaliseAttributesTest.py
+++ b/python/GafferSceneTest/LocaliseAttributesTest.py
@@ -124,6 +124,11 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 		)
 		self.assertEqual(
 			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
+			localiseAttributes["in"].fullAttributes( "/outerGroup/innerGroup/plane" )
+		)
+		localiseAttributes["includeGlobalAttributes"].setValue( True )
+		self.assertEqual(
+			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
 			localiseAttributes["in"].fullAttributes( "/outerGroup/innerGroup/plane", withGlobalAttributes = True )
 		)
 
@@ -169,6 +174,15 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+		localiseAttributes["includeGlobalAttributes"].setValue( False )
+		self.assertEqual(
+			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
+			IECore.CompoundObject( {
+				"a" : IECore.StringData( "planeA" ),
+				"c" : IECore.StringData( "outerGroupC" ),
+			} )
+		)
+
 	def testDirtyPropagation( self ) :
 
 		globalAttributes = GafferScene.StandardAttributes()
@@ -180,6 +194,14 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 
 		cs = GafferTest.CapturingSlot( localiseAttributes.plugDirtiedSignal() )
 
+		globalAttributes["attributes"]["doubleSided"]["enabled"].setValue( True )
+		self.assertNotIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
+
+		localiseAttributes["includeGlobalAttributes"].setValue( True )
+		self.assertIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
+
+		globalAttributes["attributes"]["doubleSided"]["enabled"].setValue( False )
+		del cs[:]
 		globalAttributes["attributes"]["doubleSided"]["enabled"].setValue( True )
 		self.assertIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
 

--- a/python/GafferSceneTest/LocaliseAttributesTest.py
+++ b/python/GafferSceneTest/LocaliseAttributesTest.py
@@ -74,8 +74,14 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 		outerGroupFilter = GafferScene.PathFilter()
 		outerGroupFilter["paths"].setValue( IECore.StringVectorData( [ "/outerGroup" ] ) )
 
+		globalAttributes = GafferScene.CustomAttributes()
+		globalAttributes["in"].setInput( outerGroup["out"] )
+		globalAttributes["global"].setValue( True )
+		globalAttributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "globalA" ) )
+		globalAttributes["attributes"].addChild( Gaffer.NameValuePlug( "d", "globalD" ) )
+
 		planeAttributes = GafferScene.CustomAttributes()
-		planeAttributes["in"].setInput( outerGroup["out"] )
+		planeAttributes["in"].setInput( globalAttributes["out"] )
 		planeAttributes["filter"].setInput( planeFilter["out"] )
 		planeAttributes["attributes"].addChild( Gaffer.NameValuePlug( "a", "planeA" ) )
 
@@ -118,7 +124,7 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 		)
 		self.assertEqual(
 			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
-			localiseAttributes["in"].fullAttributes( "/outerGroup/innerGroup/plane" )
+			localiseAttributes["in"].fullAttributes( "/outerGroup/innerGroup/plane", withGlobalAttributes = True )
 		)
 
 		# Localise a subset of the attributes.
@@ -143,14 +149,41 @@ class LocaliseAttributesTest( GafferSceneTest.SceneTestCase ) :
 			} )
 		)
 
+		localiseAttributes["attributes"].setValue( "c d" )
+		self.assertEqual(
+			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
+			IECore.CompoundObject( {
+				"a" : IECore.StringData( "planeA" ),
+				"c" : IECore.StringData( "outerGroupC" ),
+				"d" : IECore.StringData( "globalD" ),
+			} )
+		)
+
+		globalAttributes["attributes"]["NameValuePlug1"]["value"].setValue( "anotherGlobalD" )
+		self.assertEqual(
+			localiseAttributes["out"].attributes( "/outerGroup/innerGroup/plane" ),
+			IECore.CompoundObject( {
+				"a" : IECore.StringData( "planeA" ),
+				"c" : IECore.StringData( "outerGroupC" ),
+				"d" : IECore.StringData( "anotherGlobalD" ),
+			} )
+		)
+
 	def testDirtyPropagation( self ) :
 
+		globalAttributes = GafferScene.StandardAttributes()
+		globalAttributes["global"].setValue( True )
 		standardAttributes = GafferScene.StandardAttributes()
+		standardAttributes["in"].setInput( globalAttributes["out"] )
 		localiseAttributes = GafferScene.LocaliseAttributes()
 		localiseAttributes["in"].setInput( standardAttributes["out"] )
 
 		cs = GafferTest.CapturingSlot( localiseAttributes.plugDirtiedSignal() )
 
+		globalAttributes["attributes"]["doubleSided"]["enabled"].setValue( True )
+		self.assertIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
+
+		del cs[:]
 		standardAttributes["attributes"]["scene:visible"]["enabled"].setValue( True )
 		self.assertIn( localiseAttributes["out"]["attributes"], { x[0] for x in cs } )
 

--- a/python/GafferSceneTest/ScenePlugTest.py
+++ b/python/GafferSceneTest/ScenePlugTest.py
@@ -105,6 +105,11 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 		n = GafferSceneTest.CompoundObjectSource()
 		n["in"].setValue(
 			IECore.CompoundObject( {
+				"globals" : {
+					"attribute:a" : IECore.StringData( "aGlobal" ),
+					"attribute:d" : IECore.StringData( "dGlobal" ),
+					"attribute:e" : IECore.StringData( "eGlobal" ),
+				},
 				"children" : {
 					"group" : {
 						"attributes" : {
@@ -116,6 +121,7 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 								"attributes" : {
 									"b" : IECore.StringData( "bOverride" ),
 									"c" : IECore.StringData( "c" ),
+									"d" : IECore.StringData( "d" ),
 								 },
 							}
 						}
@@ -133,12 +139,44 @@ class ScenePlugTest( GafferSceneTest.SceneTestCase ) :
 		)
 
 		self.assertEqual(
+			n["out"].fullAttributes( "/group", withGlobalAttributes = True ),
+			IECore.CompoundObject( {
+				"a" : IECore.StringData( "a" ),
+				"b" : IECore.StringData( "b" ),
+				"d" : IECore.StringData( "dGlobal" ),
+				"e" : IECore.StringData( "eGlobal" ),
+			} )
+		)
+
+		self.assertNotEqual(
+			n["out"].fullAttributesHash( "/group" ),
+			n["out"].fullAttributesHash( "/group", withGlobalAttributes = True )
+		)
+
+		self.assertEqual(
 			n["out"].fullAttributes( "/group/ball" ),
 			IECore.CompoundObject( {
 				"a" : IECore.StringData( "a" ),
 				"b" : IECore.StringData( "bOverride" ),
 				"c" : IECore.StringData( "c" ),
+				"d" : IECore.StringData( "d" ),
 			} )
+		)
+
+		self.assertEqual(
+			n["out"].fullAttributes( "/group/ball", withGlobalAttributes = True ),
+			IECore.CompoundObject( {
+				"a" : IECore.StringData( "a" ),
+				"b" : IECore.StringData( "bOverride" ),
+				"c" : IECore.StringData( "c" ),
+				"d" : IECore.StringData( "d" ),
+				"e" : IECore.StringData( "eGlobal" ),
+			} )
+		)
+
+		self.assertNotEqual(
+			n["out"].fullAttributesHash( "/group/ball" ),
+			n["out"].fullAttributesHash( "/group/ball", withGlobalAttributes = True )
 		)
 
 	def testCreateCounterpart( self ) :

--- a/python/GafferSceneUI/AttributeQueryUI.py
+++ b/python/GafferSceneUI/AttributeQueryUI.py
@@ -132,7 +132,8 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Should inherited attributes or be considered or not.
+			Should inherited attributes or be considered or not. Attributes are
+			inherited from ancestors or from the scene globals.
 			""",
 
 			"nodule:type", ""

--- a/python/GafferSceneUI/AttributeTweaksUI.py
+++ b/python/GafferSceneUI/AttributeTweaksUI.py
@@ -97,10 +97,10 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Turn on to allow location-specific tweaks to be made to inherited
-			attributes. Attributes will be localised to locations matching the
-			node's filter prior to tweaking. The original inherited attributes
-			will remain untouched.
+			Turn on to allow location-specific tweaks to be made to attributes
+			inherited from ancestors or the scene globals. Attributes will be
+			localised to locations matching the node's filter prior to tweaking.
+			The original inherited attributes will remain untouched.
 			"""
 
 		],

--- a/python/GafferSceneUI/LocaliseAttributesUI.py
+++ b/python/GafferSceneUI/LocaliseAttributesUI.py
@@ -59,6 +59,19 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"includeGlobalAttributes" : [
+
+			"description",
+			"""
+			When enabled, global attributes matching the names in
+			`attributes` will be localised if an equivalent local
+			or inherited attribute is not found.
+			""",
+
+			"userDefault", True,
+
+		],
+
 	}
 
 )

--- a/src/GafferScene/AttributeQuery.cpp
+++ b/src/GafferScene/AttributeQuery.cpp
@@ -259,7 +259,8 @@ void AttributeQuery::affects( const Gaffer::Plug* const input, AffectedPlugsCont
 		( input == locationPlug() ) ||
 		( input == attributePlug() ) ||
 		( input == scenePlug()->existsPlug() ) ||
-		( input == scenePlug()->attributesPlug() ) )
+		( input == scenePlug()->attributesPlug() ) ||
+		( input == scenePlug()->globalsPlug() && !inheritPlug()->isSetToDefault() ) )
 	{
 		outputs.push_back( internalObjectPlug() );
 	}
@@ -300,7 +301,7 @@ void AttributeQuery::hash( const Gaffer::ValuePlug* const output, const Gaffer::
 			if( splug->exists( path ) )
 			{
 				h.append( ( inheritPlug()->getValue() )
-					? splug->fullAttributesHash( path )
+					? splug->fullAttributesHash( path, /* withGlobalAttributes = */ true )
 					: splug->attributesHash( path ) );
 				attributePlug()->hash( h );
 			}
@@ -347,7 +348,7 @@ void AttributeQuery::compute( Gaffer::ValuePlug* const output, const Gaffer::Con
 				if( ! name.empty() )
 				{
 					const IECore::ConstCompoundObjectPtr cobj = ( inheritPlug()->getValue() )
-						? boost::static_pointer_cast< const IECore::CompoundObject >( splug->fullAttributes( path ) )
+						? boost::static_pointer_cast< const IECore::CompoundObject >( splug->fullAttributes( path, /* withGlobalAttributes = */ true ) )
 						: ( splug->attributes( path ) );
 					assert( cobj );
 

--- a/src/GafferScene/AttributeTweaks.cpp
+++ b/src/GafferScene/AttributeTweaks.cpp
@@ -103,7 +103,8 @@ bool AttributeTweaks::affectsProcessedAttributes( const Gaffer::Plug *input) con
 		AttributeProcessor::affectsProcessedAttributes( input ) ||
 		tweaksPlug()->isAncestorOf( input ) ||
 		input == localisePlug() ||
-		input == ignoreMissingPlug()
+		input == ignoreMissingPlug() ||
+		( input == inPlug()->globalsPlug() && !localisePlug()->isSetToDefault() )
 	;
 }
 
@@ -120,7 +121,7 @@ void AttributeTweaks::hashProcessedAttributes( const ScenePath &path, const Gaff
 
 		if( localisePlug()->getValue() )
 		{
-			h.append( inPlug()->fullAttributesHash( path ) );
+			h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ true ) );
 		}
 
 		ignoreMissingPlug()->hash( h );
@@ -149,7 +150,7 @@ IECore::ConstCompoundObjectPtr AttributeTweaks::computeProcessedAttributes( cons
 	ConstCompoundObjectPtr fullAttributes;
 	if( localisePlug()->getValue() )
 	{
-		fullAttributes = inPlug()->fullAttributes( path );
+		fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ true );
 		source = fullAttributes.get();
 	}
 

--- a/src/GafferScene/LocaliseAttributes.cpp
+++ b/src/GafferScene/LocaliseAttributes.cpp
@@ -70,14 +70,15 @@ bool LocaliseAttributes::affectsProcessedAttributes( const Gaffer::Plug *input )
 {
 	return
 		AttributeProcessor::affectsProcessedAttributes( input ) ||
-		input == attributesPlug()
+		input == attributesPlug() ||
+		input == inPlug()->globalsPlug()
 	;
 }
 
 void LocaliseAttributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	AttributeProcessor::hashProcessedAttributes( path, context, h );
-	h.append( inPlug()->fullAttributesHash( path ) );
+	h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ true ) );
 	attributesPlug()->hash( h );
 }
 
@@ -92,7 +93,7 @@ IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( c
 	CompoundObjectPtr result = new CompoundObject;
 	result->members() = inputAttributes->members();
 
-	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path );
+	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ true );
 	for( const auto &attribute : fullAttributes->members() )
 	{
 		if( StringAlgo::matchMultiple( attribute.first, attributes ) )

--- a/src/GafferScene/LocaliseAttributes.cpp
+++ b/src/GafferScene/LocaliseAttributes.cpp
@@ -50,6 +50,7 @@ LocaliseAttributes::LocaliseAttributes( const std::string &name )
 {
 	storeIndexOfNextChild( g_firstPlugIndex );
 	addChild( new StringPlug( "attributes", Plug::In, "*" ) );
+	addChild( new BoolPlug( "includeGlobalAttributes", Plug::In, false ) );
 }
 
 LocaliseAttributes::~LocaliseAttributes()
@@ -66,19 +67,31 @@ const Gaffer::StringPlug *LocaliseAttributes::attributesPlug() const
 	return getChild<StringPlug>( g_firstPlugIndex );
 }
 
+Gaffer::BoolPlug *LocaliseAttributes::includeGlobalAttributesPlug()
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
+const Gaffer::BoolPlug *LocaliseAttributes::includeGlobalAttributesPlug() const
+{
+	return getChild<BoolPlug>( g_firstPlugIndex + 1 );
+}
+
 bool LocaliseAttributes::affectsProcessedAttributes( const Gaffer::Plug *input ) const
 {
 	return
 		AttributeProcessor::affectsProcessedAttributes( input ) ||
 		input == attributesPlug() ||
-		input == inPlug()->globalsPlug()
+		input == includeGlobalAttributesPlug() ||
+		( input == inPlug()->globalsPlug() && !includeGlobalAttributesPlug()->isSetToDefault() )
 	;
 }
 
 void LocaliseAttributes::hashProcessedAttributes( const ScenePath &path, const Gaffer::Context *context, IECore::MurmurHash &h ) const
 {
 	AttributeProcessor::hashProcessedAttributes( path, context, h );
-	h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ true ) );
+	h.append( inPlug()->fullAttributesHash( path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() ) );
+	includeGlobalAttributesPlug()->hash( h );
 	attributesPlug()->hash( h );
 }
 
@@ -93,7 +106,7 @@ IECore::ConstCompoundObjectPtr LocaliseAttributes::computeProcessedAttributes( c
 	CompoundObjectPtr result = new CompoundObject;
 	result->members() = inputAttributes->members();
 
-	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ true );
+	ConstCompoundObjectPtr fullAttributes = inPlug()->fullAttributes( path, /* withGlobalAttributes = */ includeGlobalAttributesPlug()->getValue() );
 	for( const auto &attribute : fullAttributes->members() )
 	{
 		if( StringAlgo::matchMultiple( attribute.first, attributes ) )

--- a/src/GafferScene/ScenePlug.cpp
+++ b/src/GafferScene/ScenePlug.cpp
@@ -45,8 +45,17 @@
 #include "IECore/NullObject.h"
 #include "IECore/StringAlgo.h"
 
+#include "boost/algorithm/string/predicate.hpp"
+
 using namespace Gaffer;
 using namespace GafferScene;
+
+namespace
+{
+
+const std::string g_attributePrefix( "attribute:" );
+
+} // namespace
 
 GAFFER_PLUG_DEFINE_TYPE( ScenePlug );
 
@@ -430,7 +439,7 @@ IECore::ConstCompoundObjectPtr ScenePlug::attributes( const ScenePath &scenePath
 	return attributesPlug()->getValue();
 }
 
-IECore::CompoundObjectPtr ScenePlug::fullAttributes( const ScenePath &scenePath ) const
+IECore::CompoundObjectPtr ScenePlug::fullAttributes( const ScenePath &scenePath, bool withGlobalAttributes ) const
 {
 	PathScope pathScope( Context::current() );
 
@@ -450,6 +459,21 @@ IECore::CompoundObjectPtr ScenePlug::fullAttributes( const ScenePath &scenePath 
 			}
 		}
 		path.pop_back();
+	}
+
+	if( withGlobalAttributes )
+	{
+		for( const auto &g : globals()->members() )
+		{
+			if( boost::starts_with( g.first.string(), g_attributePrefix ) )
+			{
+				const std::string attributeName = g.first.string().substr( g_attributePrefix.size() );
+				if( resultMembers.find( attributeName ) == resultMembers.end() )
+				{
+					resultMembers.insert( { attributeName, g.second } );
+				}
+			}
+		}
 	}
 
 	return result;
@@ -519,7 +543,7 @@ IECore::MurmurHash ScenePlug::attributesHash( const ScenePath &scenePath ) const
 	return attributesPlug()->hash();
 }
 
-IECore::MurmurHash ScenePlug::fullAttributesHash( const ScenePath &scenePath ) const
+IECore::MurmurHash ScenePlug::fullAttributesHash( const ScenePath &scenePath, bool withGlobalAttributes ) const
 {
 	PathScope pathScope( Context::current() );
 
@@ -530,6 +554,18 @@ IECore::MurmurHash ScenePlug::fullAttributesHash( const ScenePath &scenePath ) c
 		pathScope.setPath( &path );
 		attributesPlug()->hash( result );
 		path.pop_back();
+	}
+
+	if( withGlobalAttributes )
+	{
+		for( const auto &g : globals()->members() )
+		{
+			if( boost::starts_with( g.first.string(), g_attributePrefix ) )
+			{
+				result.append( g.first.value() );
+				g.second->hash( result );
+			}
+		}
 	}
 
 	return result;

--- a/src/GafferSceneModule/CoreBinding.cpp
+++ b/src/GafferSceneModule/CoreBinding.cpp
@@ -208,10 +208,10 @@ IECore::CompoundObjectPtr attributesWrapper( const ScenePlug &plug, const SceneP
 	return copy ? a->copy() : boost::const_pointer_cast<IECore::CompoundObject>( a );
 }
 
-IECore::CompoundObjectPtr fullAttributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+IECore::CompoundObjectPtr fullAttributesWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool withGlobalAttributes )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	return plug.fullAttributes( scenePath );
+	return plug.fullAttributes( scenePath, withGlobalAttributes );
 }
 
 IECore::CompoundObjectPtr globalsWrapper( const ScenePlug &plug, bool copy )
@@ -271,10 +271,10 @@ IECore::MurmurHash attributesHashWrapper( const ScenePlug &plug, const ScenePlug
 	return plug.attributesHash( scenePath );
 }
 
-IECore::MurmurHash fullAttributesHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath )
+IECore::MurmurHash fullAttributesHashWrapper( const ScenePlug &plug, const ScenePlug::ScenePath &scenePath, bool withGlobalAttributes )
 {
 	IECorePython::ScopedGILRelease gilRelease;
-	return plug.fullAttributesHash( scenePath );
+	return plug.fullAttributesHash( scenePath, withGlobalAttributes );
 }
 
 IECore::MurmurHash globalsHashWrapper( const ScenePlug &plug )
@@ -406,7 +406,7 @@ void GafferSceneModule::bindCore()
 		.def( "object", &objectWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "childNames", &childNamesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "attributes", &attributesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
-		.def( "fullAttributes", &fullAttributesWrapper )
+		.def( "fullAttributes", &fullAttributesWrapper, ( boost::python::arg_( "plug" ), boost::python::arg_( "scenePath" ), boost::python::arg_( "withGlobalAttributes" ) = false ) )
 		.def( "globals", &globalsWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "setNames", &setNamesWrapper, ( boost::python::arg_( "_copy" ) = true ) )
 		.def( "set", &setWrapper, ( boost::python::arg_( "_copy" ) = true ) )
@@ -417,7 +417,7 @@ void GafferSceneModule::bindCore()
 		.def( "objectHash", &objectHashWrapper )
 		.def( "childNamesHash", &childNamesHashWrapper )
 		.def( "attributesHash", &attributesHashWrapper )
-		.def( "fullAttributesHash", &fullAttributesHashWrapper )
+		.def( "fullAttributesHash", &fullAttributesHashWrapper, ( ( boost::python::arg_( "plug" ), boost::python::arg_( "scenePath" ), boost::python::arg_( "withGlobalAttributes" ) = false ) ) )
 		.def( "globalsHash", &globalsHashWrapper )
 		.def( "setNamesHash", &setNamesHashWrapper )
 		.def( "setHash", &setHashWrapper )


### PR DESCRIPTION
This adds support for inheriting/localising global attributes in LocaliseAttributes, AttributeQuery and AttributeTweaks. After a bit of dliberation, I've made this behaviour optional for LocaliseAttributes via a new `includeGlobalAttributes` plug that defaults off for backwards compatibility, but is userDefaulted on for newly created nodes. This additional complexity seems reasonable for LocaliseAttributes, as it's already quite a simple node, and with this plug, LocaliseAttributes could be used in concert with AttributeQuery/AttributeTweaks/SubTree/etc in more complex cases where you require a very specific flavour of localisation.

This PR does introduce two breaking changes of behaviour, an AttributeQuery with `inherit` enabled will now return a result when querying an attribute that doesn't exist in the scene hierarchy but does exist in the globals, and AttributeTweaks would now not create an attribute in `CreateIfMissing` mode if `localise` was enabled and there was a global attribute of the same name. These may be edge-case enough that we don't need to go to great lengths to provide a compatibility mode, or overly complicate the nodes. I've reached out to a few users to gauge their opinions...

Future work would be to include a `useFallback` plug on AttributeQuery to allow the query to return the registered default value as a fallback, and changing the `exists` plug to a `source` plug similar to what we've added to CameraQuery. ShaderQuery & ShaderTweaks would also benefit from this new behaviour if we plan to add a `global` plug to ShaderAssignment, though LocaliseAttributes would help with this in the meantime.