### PR TITLE
Instance ID Picking

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@ Improvements
   - Improved formatting of Box and Matrix values.
   - Improved performance when showing colour values.
   - Added support for showing spline values.
+- GafferUI : Added support for drag and dropping numeric vector data onto numeric vector plugs of compatible types ( For example, dropping a list of ints onto a FloatVectorDataPlug ).
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,9 @@ Features
 --------
 
 - Arnold : Added multi-layer EXR support. All outputs with the same filename are now written to the same file via a single output driver.
-- ImageSelectionTool : Added new tool that allows selecting scene paths based on an image. Works with both Catalogue images and images on disk. Has two requirements : an `id` AOV (added using the `ID` preset on an `Outputs` node), and a render manifest (added using StandardOptions > Render Manifest > File Path ).
+- ImageSelectionTool :
+  - Added new tool that allows selecting scene paths based on an image. Works with both Catalogue images and images on disk. Has two requirements : an `id` AOV (added using the `ID` preset on an `Outputs` node), and a render manifest (added using StandardOptions > Render Manifest > File Path ).
+  - Also supports picking instance IDs, using an `instanceID` aov. Supported when rendering an instancer that is encapsulated ( USD instancers rendered to Arnold are encapsulated by default ).
 - ColorInspectorTool : Moved the Viewer's colour inspectors into a dedicated tool, selected from the toolbar on the left.
 - OSLObject : Added the ability to use `pointcloud_search()` and `pointcloud_get()` to query geometry from arbitrary scene locations.
 - CameraQuery : Added a new node to query camera parameters (#6431).

--- a/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/CapturingRenderer.h
@@ -122,6 +122,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				int numLinkEdits( const IECore::InternedString &type ) const;
 
 				uint32_t id() const;
+				uint32_t instanceID() const;
 
 				/// Renderer interface
 				/// ==================
@@ -131,6 +132,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				bool attributes( const AttributesInterface *attributes ) override;
 				void link( const IECore::InternedString &type, const ConstObjectSetPtr &objects ) override;
 				void assignID( uint32_t id ) override;
+				void assignInstanceID( uint32_t instanceID ) override;
 
 			private :
 
@@ -148,6 +150,7 @@ class GAFFERSCENE_API CapturingRenderer : public Renderer
 				int m_numAttributeEdits;
 				std::unordered_map<IECore::InternedString, std::pair<ConstObjectSetPtr, int>> m_capturedLinks;
 				uint32_t m_id;
+				uint32_t m_instanceID;
 
 		};
 

--- a/include/GafferScene/Private/IECoreScenePreview/Renderer.h
+++ b/include/GafferScene/Private/IECoreScenePreview/Renderer.h
@@ -214,6 +214,8 @@ class GAFFERSCENE_API Renderer : public IECore::RefCounted
 				/// AOV that can be referenced via `output()`.
 				virtual void assignID( uint32_t id ) = 0;
 
+				virtual void assignInstanceID( uint32_t id ) = 0;
+
 			protected :
 
 				~ObjectInterface() override;

--- a/include/GafferScene/Private/RendererAlgo.h
+++ b/include/GafferScene/Private/RendererAlgo.h
@@ -94,6 +94,9 @@ GAFFERSCENE_API void createOutputDirectories( const IECore::CompoundObject *glob
 // Returns whether the globals contain an Output that references the data `float id`
 GAFFERSCENE_API bool hasIDOutput( const IECore::CompoundObject *globals );
 
+// Returns whether the globals contain an Output that references the data `float instanceID`
+GAFFERSCENE_API bool hasInstanceIDOutput( const IECore::CompoundObject *globals );
+
 // Returns a manifest file path if it's set in the globals, otherwise empty string
 GAFFERSCENE_API std::string renderManifestFilePath( const IECore::CompoundObject *globals );
 

--- a/include/GafferSceneUI/Private/ImageSelectionTool.h
+++ b/include/GafferSceneUI/Private/ImageSelectionTool.h
@@ -70,6 +70,9 @@ class GAFFERSCENEUI_API ImageSelectionTool : public GafferUI::Tool
 
 		GAFFER_NODE_DECLARE_TYPE( GafferSceneUI::ImageSelectionTool, ImageSelectionToolTypeId, GafferUI::Tool );
 
+		Gaffer::StringPlug *selectModePlug();
+		const Gaffer::StringPlug *selectModePlug() const;
+
 	private :
 
 		IE_CORE_FORWARDDECLARE( Rectangle );
@@ -82,13 +85,15 @@ class GAFFERSCENEUI_API ImageSelectionTool : public GafferUI::Tool
 
 		GafferImageUI::ImageGadget *imageGadget();
 
+		void updateRenderManifest();
+
 		void plugDirtied( const Gaffer::Plug *plug );
 
 		IECore::PathMatcher pathsForIDs( const std::vector<uint32_t> &ids );
 		void idsForPaths( const IECore::PathMatcher &paths, std::vector<uint32_t> &result );
 
-		uint32_t pixelID( const Imath::V2i &pixel );
-		std::unordered_set<uint32_t> rectIDs( const Imath::Box2i &rect );
+		std::optional<uint32_t> pixelID( const Imath::V2i &pixel, bool instance );
+		std::unordered_set<uint32_t> rectIDs( const Imath::Box2i &rect, bool instance );
 
 		void selectedPathsChanged();
 

--- a/python/GafferCyclesTest/CyclesRenderTest.py
+++ b/python/GafferCyclesTest/CyclesRenderTest.py
@@ -80,5 +80,10 @@ class CyclesRenderTest( GafferSceneTest.RenderTest ) :
 
 		return options
 
+	@unittest.skip( "Instance IDs only work with encapsulated instancers. We don't have encapsulation support yet in our Cycles backend" )
+	def testInstanceIDOutput( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -53,5 +53,10 @@ class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "Instance IDs only work with encapsulated instancers. We don't have encapsulation support yet in our 3Delight backend" )
+	def testInstanceIDOutput( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferRenderManTest/RenderManRenderTest.py
+++ b/python/GafferRenderManTest/RenderManRenderTest.py
@@ -141,5 +141,10 @@ class RenderManRenderTest( GafferSceneTest.RenderTest ) :
 
 		return imath.Color4f( image["R"][i], image["G"][i], image["B"][i], image["A"][i] if "A" in image.keys() else 0.0 )
 
+	@unittest.skip( "Instance IDs only work with encapsulated instancers. We don't have encapsulation support yet in our RenderMan backend" )
+	def testInstanceIDOutput( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CapturingRendererTest.py
@@ -83,13 +83,16 @@ class CapturingRendererTest( GafferTest.TestCase ) :
 		self.assertEqual( o.numAttributeEdits(), 1 )
 		self.assertEqual( o.numLinkEdits( "lights" ), 0 )
 		self.assertEqual( o.id(), 0 )
+		self.assertEqual( o.instanceID(), 0 )
 
 		o.attributes( attributes2 )
 		self.assertEqual( o.capturedAttributes(), attributes2 )
 		self.assertEqual( o.numAttributeEdits(), 2 )
 
 		o.assignID( 10 )
+		o.assignInstanceID( 7 )
 		self.assertEqual( o.id(), 10 )
+		self.assertEqual( o.instanceID(), 7 )
 
 		l1 = renderer.light( "l1", IECore.NullObject(), attributes1 )
 		l2 = renderer.light( "l2", IECore.NullObject(), attributes1 )

--- a/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
+++ b/python/GafferSceneTest/IECoreScenePreviewTest/CompoundRendererTest.py
@@ -71,11 +71,14 @@ class CompoundRendererTest( GafferTest.TestCase ) :
 			self.assertEqual( o.capturedSampleTimes(), [] )
 			self.assertEqual( o.capturedAttributes().attributes(), coreAttributes1 )
 			self.assertEqual( o.id(), 0 )
+			self.assertEqual( o.instanceID(), 0 )
 
 		compoundObject.assignID( 1 )
+		compoundObject.assignInstanceID( 7 )
 		for r in renderers :
 			o = r.capturedObject( "o" )
 			self.assertEqual( o.id(), 1 )
+			self.assertEqual( o.instanceID(), 7 )
 
 		# Attribute edits
 

--- a/python/GafferSceneUI/ImageSelectionToolUI.py
+++ b/python/GafferSceneUI/ImageSelectionToolUI.py
@@ -46,6 +46,18 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
+	Tool for selecting objects based on image data. Requires an `id` image layer
+	from a Gaffer render, with gaffer:renderManifestFilePath metadata, or an
+	ObjectID cryptomatte, or an `instanceID` image layer for selecting numerical
+	ids of instances within an encapsulated instancer.
+
+	Supports the same interactions as the 3D scene selection tool:
+
+	- Click or drag to set selection
+	- Shift-click or shift-drag to add to selection
+	- Drag and drop selected objects
+		- Drag to Python Editor to get their names
+		- Drag to PathFilter or Set node to add/remove their paths
 	""",
 
 	"viewer:shortCut", "Q",

--- a/python/GafferSceneUI/ImageSelectionToolUI.py
+++ b/python/GafferSceneUI/ImageSelectionToolUI.py
@@ -46,10 +46,11 @@ Gaffer.Metadata.registerNode(
 
 	"description",
 	"""
-	Tool for selecting objects based on image data. Requires an `id` image layer
-	from a Gaffer render, with gaffer:renderManifestFilePath metadata, or an
-	ObjectID cryptomatte, or an `instanceID` image layer for selecting numerical
-	ids of instances within an encapsulated instancer.
+	Tool for selecting objects based on image data.  Requires one of the following :
+
+	- An `id` image layer with associated render manifest (enabled using the StandardOptions node).
+	- An ObjectID Cryptomatte image.
+	- An `instanceID` image layer.
 
 	Supports the same interactions as the 3D scene selection tool:
 
@@ -69,8 +70,11 @@ Gaffer.Metadata.registerNode(
 	"toolbarLayout:customWidget:SelectionWidget:widgetType", "GafferSceneUI.ImageSelectionToolUI._StatusWidget",
 	"toolbarLayout:customWidget:SelectionWidget:section", "Bottom",
 
-	# So our widget doesn't center, add a stretchy spacer to the right
-	"toolbarLayout:customWidget:RightSpacer:widgetType", "GafferSceneUI.ImageSelectionToolUI._RightSpacer",
+	"toolbarLayout:customWidget:LeftSpacer:widgetType", "GafferSceneUI.ImageSelectionToolUI._ToolOverlayInsetSpacer",
+	"toolbarLayout:customWidget:LeftSpacer:section", "Bottom",
+	"toolbarLayout:customWidget:LeftSpacer:index", 0,
+
+	"toolbarLayout:customWidget:RightSpacer:widgetType", "GafferSceneUI.ImageSelectionToolUI._ToolOverlayInsetSpacer",
 	"toolbarLayout:customWidget:RightSpacer:section", "Bottom",
 	"toolbarLayout:customWidget:RightSpacer:index", -1,
 
@@ -82,36 +86,55 @@ Gaffer.Metadata.registerNode(
 
 		],
 
+		"selectMode" : [
+
+			"description",
+			"""
+			The standard mode selects locations based on an `id` layer with a corresponding manifest.
+			`Instance` mode instead picks instance ids based on an `instanceID` layer ( this will only
+			contain information for encapsulated instancers, which don't pass multiple locations to the
+			renderer, but do set up special instance id information ).
+			""",
+
+			"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
+			"preset:Standard", "standard",
+			"preset:Instance", "instance",
+
+			"label", "Select",
+
+			"toolbarLayout:section", "Bottom",
+			"toolbarLayout:width", 80,
+
+		],
+
 	}
 
 )
 
-class _RightSpacer( GafferUI.Spacer ) :
+class _ToolOverlayInsetSpacer( GafferUI.Spacer ) :
 
 	def __init__( self, imageView, **kw ) :
 
-		GafferUI.Spacer.__init__( self, size = imath.V2i( 0, 0 ) )
+		GafferUI.Spacer.__init__( self, size = imath.V2i( 40, 0 ), maximumSize = imath.V2i( 40, 0 ) )
 
-class _StatusWidget( GafferUI.ListContainer ) :
+class _StatusWidget( GafferUI.Frame ) :
 
 	def __init__( self, tool, **kw ) :
 
-		GafferUI.ListContainer.__init__( self, **kw )
+		GafferUI.Frame.__init__( self, borderWidth = 0, **kw )
 
 		self.__tool = tool
 
 		with self :
-			with GafferUI.Frame( borderWidth = 4 ) as self.__frame:
-				with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal ) :
+			with GafferUI.ListContainer( orientation = GafferUI.ListContainer.Orientation.Horizontal, borderWidth = 0 ) :
 
-					self.__infoIcon = GafferUI.Image( "infoSmall.png" )
-					self.__errorIcon = GafferUI.Image( "errorSmall.png" )
-					self.__warningIcon = GafferUI.Image( "warningSmall.png" )
-					GafferUI.Spacer( size = imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
-					self.__label = GafferUI.Label( "" )
-					self.__label.setTextSelectable( True )
-
-		self.__frame._qtWidget().setObjectName( "gafferImageSelectionStatus" )
+				self.__infoIcon = GafferUI.Image( "infoSmall.png" )
+				self.__errorIcon = GafferUI.Image( "errorSmall.png" )
+				self.__warningIcon = GafferUI.Image( "warningSmall.png" )
+				GafferUI.Spacer( size = imath.V2i( 4 ), maximumSize = imath.V2i( 4 ) )
+				self.__label = GafferUI.Label( "" )
+				self.__label.setTextSelectable( True )
+				GafferUI.Spacer( size = imath.V2i( 0 ) )
 
 		self.__tool.statusChangedSignal().connect( Gaffer.WeakMethod( self.__update, fallbackResult = None ) )
 
@@ -130,18 +153,17 @@ class _StatusWidget( GafferUI.ListContainer ) :
 			return
 
 		status = self.__tool.status()
-		self.__frame.setVisible( bool(status) )
 
 		state, _, message = status.partition( ":" )
 
 		self.__label.setText( message )
 
 		info = warn = error = False
-		if state == "error" :
+		if state == "error":
 			error = True
-		elif state == "warning" :
+		elif state == "warning":
 			warn = True
-		else :
+		else:
 			info = True
 
 		self.__infoIcon.setVisible( info )

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -1519,11 +1519,11 @@ _styleSheet = string.Template(
 	}
 
 	#gafferColorInspector,
-	#gafferImageSelectionStatus,
 	*[gafferClass="GafferSceneUI.TransformToolUI._SelectionWidget"],
 	*[gafferClass="GafferSceneUI.CropWindowToolUI._StatusWidget"],
 	*[gafferClass="GafferSceneUI.TransformToolUI._TargetTipWidget"] > QFrame,
 	*[gafferClass="GafferSceneUI.InteractiveRenderUI._ViewRenderControlUI"] > QFrame,
+	*[gafferClass="GafferSceneUI.ImageSelectionToolUI._StatusWidget"],
 	*[gafferClass="GafferSceneUI._SceneViewInspector"] > QFrame
 	{
 		background: rgba( 42, 42, 42, 240 );
@@ -1570,8 +1570,7 @@ _styleSheet = string.Template(
 		margin-right: auto;
 	}
 
-	#gafferColorInspector,
-	#gafferImageSelectionStatus
+	#gafferColorInspector
 	{
 		margin-left: $toolOverlayInset;
 		margin-right: $toolOverlayInset;

--- a/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/Renderer.cpp
@@ -1937,6 +1937,11 @@ class CyclesObject : public IECoreScenePreview::Renderer::ObjectInterface
 			m_object->set_pass_id( id );
 		}
 
+		void assignInstanceID( uint32_t id ) override
+		{
+			// Instance IDs not needed in Cycles, because encapsulated instancers aren't supported.
+		}
+
 	private :
 
 		ccl::Scene *m_scene;
@@ -2013,6 +2018,10 @@ class CyclesLight : public IECoreScenePreview::Renderer::ObjectInterface
 		void assignID( uint32_t id ) override
 		{
 			/// \todo Implement me
+		}
+
+		void assignInstanceID( uint32_t instanceID ) override
+		{
 		}
 
 		// Used by LightLinker
@@ -2201,6 +2210,10 @@ class CyclesCamera : public IECoreScenePreview::Renderer::ObjectInterface
 		}
 
 		void assignID( uint32_t id ) override
+		{
+		}
+
+		void assignInstanceID( uint32_t instanceID ) override
 		{
 		}
 

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -187,12 +187,16 @@ std::string channelNameFromEXR( std::string view, std::string part, std::string 
 	// But if useHeuristics is on, try to figure out which of the dozen incorrect interpretations of the EXR spec
 	// this might adhere to.
 
-	if( channel == "cortexId.v" )
+	// Specific workaround for ID outputs from 3Delight. 3Delight doesn't
+	// support a custom `layerName`, despite it being part of the NSI spec,
+	// so we need to apply the desired name here.
+	if( channel == "cortexID.v" )
 	{
-		// Specific workaround for ID outputs from 3Delight. 3Delight doesn't
-		// support a custom `layerName`, despite it being part of the NSI spec,
-		// so we need to apply the desired name here.
 		return "id";
+	}
+	else if( channel == "cortexInstanceID.v" )
+	{
+		return "instanceID";
 	}
 
 	std::vector< std::string > layerTokens;

--- a/src/GafferScene/Catalogue.cpp
+++ b/src/GafferScene/Catalogue.cpp
@@ -634,8 +634,8 @@ class Catalogue::InternalImage : public ImageNode
 					m_writer->fileNamePlug()->setValue( filePath );
 
 					// Set up a spreadsheet that will set the data type to full 32 bit floats when storing the
-					// "id" channel. We are currently using integers bitcast to floats for ids ... converting
-					// these to 16 bit floats completely destroys the data.
+					// "id" or "instanceID" channel. We are currently using integers bitcast to floats for ids
+					// ... converting these to 16 bit floats completely destroys the data.
 					StringPlug *dataTypePlug = m_writer->fileFormatSettingsPlug( "openexr" )->getChild<StringPlug>( "dataType" );
 
 					Gaffer::SpreadsheetPtr spreadsheet = new Gaffer::Spreadsheet();
@@ -643,8 +643,9 @@ class Catalogue::InternalImage : public ImageNode
 					spreadsheet->selectorPlug()->setValue( "${imageWriter:channelName}" );
 					spreadsheet->rowsPlug()->addColumn( new Gaffer::StringPlug( "dataType", Gaffer::Plug::Direction::In, "half" ) );
 					Spreadsheet::RowPlug *row = spreadsheet->rowsPlug()->addRow();
-					row->namePlug()->setValue( "id" );
+					row->namePlug()->setValue( "id instanceID" );
 					row->cellsPlug()->getChild<Spreadsheet::CellPlug>(0)->valuePlug<StringPlug>()->setValue( "float" );
+
 					dataTypePlug->setInput( spreadsheet->outPlug()->getChild<Plug>( 0 ) );
 
 					if( renderManifest )

--- a/src/GafferScene/IECoreGLPreview/Renderer.cpp
+++ b/src/GafferScene/IECoreGLPreview/Renderer.cpp
@@ -545,6 +545,12 @@ class OpenGLObject : public IECoreScenePreview::Renderer::ObjectInterface
 			/// consider dropping the custom OpenGL one.
 		}
 
+		void assignInstanceID( uint32_t instanceID ) override
+		{
+			// The GL renderer doesn't support encapsulated instancers, so we have no
+			// need for instance ids.
+		}
+
 		Box3f transformedBound() const
 		{
 			Box3f b;

--- a/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CapturingRenderer.cpp
@@ -238,7 +238,7 @@ bool CapturingRenderer::CapturedAttributes::unrenderableAttributeValue( const Ca
 //////////////////////////////////////////////////////////////////////////
 
 CapturingRenderer::CapturedObject::CapturedObject( CapturingRenderer *renderer, const std::string &name, const std::vector<const IECore::Object *> &samples, const std::vector<float> &times )
-	:	m_renderer( renderer ), m_name( name ), m_capturedSamples( samples.begin(), samples.end() ), m_capturedSampleTimes( times ), m_numAttributeEdits( 0 ), m_id( 0 )
+	:	m_renderer( renderer ), m_name( name ), m_capturedSamples( samples.begin(), samples.end() ), m_capturedSampleTimes( times ), m_numAttributeEdits( 0 ), m_id( 0 ), m_instanceID( 0 )
 {
 }
 
@@ -324,6 +324,11 @@ uint32_t CapturingRenderer::CapturedObject::id() const
 	return m_id;
 }
 
+uint32_t CapturingRenderer::CapturedObject::instanceID() const
+{
+	return m_instanceID;
+}
+
 void CapturingRenderer::CapturedObject::transform( const Imath::M44f &transform )
 {
 	m_renderer->checkPaused();
@@ -371,4 +376,10 @@ void CapturingRenderer::CapturedObject::assignID( uint32_t id )
 {
 	m_renderer->checkPaused();
 	m_id = id;
+}
+
+void CapturingRenderer::CapturedObject::assignInstanceID( uint32_t instanceID )
+{
+	m_renderer->checkPaused();
+	m_instanceID = instanceID;
 }

--- a/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
+++ b/src/GafferScene/IECoreScenePreview/CompoundRenderer.cpp
@@ -216,6 +216,17 @@ struct CompoundObjectInterface : public IECoreScenePreview::Renderer::ObjectInte
 		}
 	}
 
+	void assignInstanceID( uint32_t instanceID ) override
+	{
+		for( auto &o : objects )
+		{
+			if( o )
+			{
+				o->assignInstanceID( instanceID );
+			}
+		}
+	}
+
 	/// See comment for CompoundAttributesInterface::attributes.
 	std::array<IECoreScenePreview::Renderer::ObjectInterfacePtr, 2> objects;
 

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -3240,6 +3240,8 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 
 	const GafferScene::Private::RendererAlgo::RenderOptions renderOpts = renderOptions();
 
+	const bool needsInstanceIDs = GafferScene::Private::RendererAlgo::hasInstanceIDOutput( renderOpts.globals.get() );
+
 	// This is a bit of a weird convention for using a const variable with an initialization that doesn't
 	// fit in one line ... not sure how I feel about it. In this case, it's crucial that sampleTimes is
 	// const, because it is used from multiple threads simultaneously.
@@ -3476,6 +3478,14 @@ void Instancer::InstancerCapsule::render( IECoreScenePreview::Renderer *renderer
 					}
 
 					objectInterface->transform( pointTransforms, sampleTimes );
+				}
+
+				if( needsInstanceIDs )
+				{
+					// We add one here so that we can distinguish between the background and an id of 0.
+					// Anything that uses these ids will need to subtract this off ( currently just
+					// ImageSelectionTool ).
+					objectInterface->assignInstanceID( pointIndex + 1 );
 				}
 
 			}

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -292,6 +292,29 @@ bool hasIDOutput( const IECore::CompoundObject *globals )
 	return false;
 }
 
+bool hasInstanceIDOutput( const IECore::CompoundObject *globals )
+{
+	static const std::string outputPrefix( "output:" );
+	static const std::string instanceIDData( "float instanceID" );
+	CompoundObject::ObjectMap::const_iterator it, eIt;
+	for( it = globals->members().begin(), eIt = globals->members().end(); it != eIt; ++it )
+	{
+		if( !boost::starts_with( it->first.string(), outputPrefix ) )
+		{
+			continue;
+		}
+		if( const Output *output = runTimeCast<Output>( it->second.get() ) )
+		{
+			if( output->getData() == instanceIDData )
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 std::string renderManifestFilePath( const IECore::CompoundObject *globals )
 {
 	const StringData *renderManifestFilePathData = globals->member<StringData>( g_renderManifestFilePathOptionName );

--- a/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
+++ b/src/GafferSceneModule/IECoreScenePreviewBinding.cpp
@@ -427,6 +427,7 @@ void GafferSceneModule::bindIECoreScenePreview()
 			.def( "attributes", &Renderer::ObjectInterface::attributes )
 			.def( "link", &objectInterfaceLink )
 			.def( "assignID", &Renderer::ObjectInterface::assignID )
+			.def( "assignInstanceID", &Renderer::ObjectInterface::assignInstanceID )
 		;
 	}
 
@@ -547,6 +548,7 @@ void GafferSceneModule::bindIECoreScenePreview()
 		.def( "numAttributeEdits", &CapturingRenderer::CapturedObject::numAttributeEdits )
 		.def( "numLinkEdits", &CapturingRenderer::CapturedObject::numLinkEdits )
 		.def( "id", &CapturingRenderer::CapturedObject::id )
+		.def( "instanceID", &CapturingRenderer::CapturedObject::instanceID )
 	;
 
 	{

--- a/src/IECoreDelight/Renderer.cpp
+++ b/src/IECoreDelight/Renderer.cpp
@@ -368,10 +368,14 @@ class DelightOutput : public IECore::RefCounted
 				variableName = "z";
 				variableSource = "builtin";
 			}
-
-			if( variableName == "id" )
+			else if( variableName == "id" )
 			{
-				variableName = "cortexId";
+				variableName = "cortexID";
+				variableSource = "attribute";
+			}
+			else if( variableName == "instanceID" )
+			{
+				variableName = "cortexInstanceID";
 				variableSource = "attribute";
 			}
 
@@ -1149,6 +1153,27 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 
 		void assignID( uint32_t id ) override
 		{
+			assignIDInternal( id, "cortexID" );
+		}
+
+		void assignInstanceID( uint32_t instanceID ) override
+		{
+			// This isn't actually used yet, but it will be ready to go if we add support for encapsulation
+			// to our 3delight backend so we need to deal with encapsulated instancers.
+			assignIDInternal( instanceID, "cortexInstanceID" );
+		}
+
+	protected :
+
+		const DelightHandle m_transformHandle;
+		// We keep a reference to the instance and attributes so that they
+		// remain alive for at least as long as the object does.
+		ConstDelightAttributesPtr m_attributes;
+
+	private :
+
+		void assignIDInternal( uint32_t id, const char *attrName )
+		{
 			if( !m_idAttributesHandle )
 			{
 				m_idAttributesHandle = DelightHandle(
@@ -1162,7 +1187,7 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 				);
 			}
 			NSIParam_t param = {
-				"cortexId",
+				attrName,
 				&id,
 				// Deliberately declaring as `float` even though it is an
 				// integer. This lets us render the full range of integer values
@@ -1175,15 +1200,6 @@ class DelightObject: public IECoreScenePreview::Renderer::ObjectInterface
 			};
 			NSISetAttribute( m_idAttributesHandle.context(), m_idAttributesHandle.name(), 1, &param );
 		}
-
-	protected :
-
-		const DelightHandle m_transformHandle;
-		// We keep a reference to the instance and attributes so that they
-		// remain alive for at least as long as the object does.
-		ConstDelightAttributesPtr m_attributes;
-
-	private :
 
 		DelightHandleSharedPtr m_instance;
 		DelightHandle m_idAttributesHandle;

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -177,6 +177,10 @@ void Camera::assignID( uint32_t id )
 {
 }
 
+void Camera::assignInstanceID( uint32_t id )
+{
+}
+
 void Camera::transformInternal( std::vector<Imath::M44f> samples, const std::vector<float> &times )
 {
 	for( auto &m : samples )

--- a/src/IECoreRenderMan/Camera.h
+++ b/src/IECoreRenderMan/Camera.h
@@ -56,6 +56,7 @@ class Camera :  public IECoreScenePreview::Renderer::ObjectInterface
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;
+		void assignInstanceID( uint32_t id ) override;
 
 	private :
 

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -305,6 +305,10 @@ void Light::assignID( uint32_t id )
 {
 }
 
+void Light::assignInstanceID( uint32_t id )
+{
+}
+
 void Light::updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &lightFilterShader )
 {
 	if( m_lightInstance == riley::LightInstanceId::InvalidId() )

--- a/src/IECoreRenderMan/Light.h
+++ b/src/IECoreRenderMan/Light.h
@@ -65,6 +65,7 @@ class Light : public IECoreScenePreview::Renderer::ObjectInterface
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;
+		void assignInstanceID( uint32_t id ) override;
 
 		// Interface used by LightLinker
 		// =============================

--- a/src/IECoreRenderMan/LightFilter.cpp
+++ b/src/IECoreRenderMan/LightFilter.cpp
@@ -151,3 +151,7 @@ void LightFilter::link( const IECore::InternedString &type, const IECoreScenePre
 void LightFilter::assignID( uint32_t id )
 {
 }
+
+void LightFilter::assignInstanceID( uint32_t id )
+{
+}

--- a/src/IECoreRenderMan/LightFilter.h
+++ b/src/IECoreRenderMan/LightFilter.h
@@ -63,6 +63,7 @@ class LightFilter : public IECoreScenePreview::Renderer::ObjectInterface
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;
+		void assignInstanceID( uint32_t id ) override;
 
 		// Interface used by Light and LightLinker
 		// =======================================

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -201,3 +201,8 @@ void Object::assignID( uint32_t id )
 	m_extraAttributes.SetInteger( Rix::k_identifier_id, id );
 	attributes( m_attributes.get() );
 }
+
+void Object::assignInstanceID( uint32_t id )
+{
+	// \todo : This will be needed once our RenderMan backend supports encapsulated instancers
+}

--- a/src/IECoreRenderMan/Object.h
+++ b/src/IECoreRenderMan/Object.h
@@ -64,6 +64,7 @@ class Object : public IECoreScenePreview::Renderer::ObjectInterface
 		bool attributes( const IECoreScenePreview::Renderer::AttributesInterface *attributes ) override;
 		void link( const IECore::InternedString &type, const IECoreScenePreview::Renderer::ConstObjectSetPtr &objects ) override;
 		void assignID( uint32_t id ) override;
+		void assignInstanceID( uint32_t id ) override;
 
 	private :
 

--- a/startup/gui/outputs.py
+++ b/startup/gui/outputs.py
@@ -106,6 +106,38 @@ GafferScene.Outputs.registerOutput(
 	)
 )
 
+GafferScene.Outputs.registerOutput(
+	"Interactive/InstanceID",
+	IECoreScene.Output(
+		"instanceID",
+		"ieDisplay",
+		"float instanceID",
+		{
+			"catalogue:imageName" : "Image",
+			"driverType" : "ClientDisplayDriver",
+			"displayHost" : "localhost",
+			"displayPort" : "${image:catalogue:port}",
+			"remoteDisplayType" : "GafferScene::GafferDisplayDriver",
+			"filter" : "closest",
+			"layerName" : "instanceID",
+			"updateInteractively" : True,
+		}
+	)
+)
+
+GafferScene.Outputs.registerOutput(
+	"Batch/InstanceID",
+	IECoreScene.Output(
+		"${project:rootDirectory}/renders/${script:name}/${renderPass}/instanceID/instanceID.####.exr",
+		"exr",
+		"float instanceID",
+		{
+			"filter" : "closest",
+			"layerName" : "instanceID",
+		}
+	)
+)
+
 Gaffer.Metadata.registerValue( GafferScene.StandardOptions, "options.render:manifestFilePath.value", "userDefault", "${project:rootDirectory}/renders/${script:name}/${renderPass}/renderManifest/renderManifest.####.exr" )
 
 # Add standard AOVs as they are defined in the aiStandard and alSurface shaders


### PR DESCRIPTION
This initial implementation of image picking for instance ids should be ready for review.

On the renderer side, it's a bit weird because we want this to theoretically work across all renderers, but only Arnold actually supports encapsulated instancers.

I'm also not quite fully sure how we communicate to users that this new mode is only used for instance ids for encapsulated instancers, and it won't show any information on non-encapsulated renders ( this behaviour seems correct, but might not immediately be intuitive ).

Other than that, the main ugly bit is that we need to handle 0 ids here - I haven't squashed the two fix commits that implement this yet, because I'm not sure yet we've got the right approach. I've tried to make the offset-by-one feel like part of the bitcast translation from a float ... but we don't want this toggle to impact ImageGadget, so ImageGadget does the bitcast without an offset, and we instead offset the ids being passed in ... which works, but feels inconsistent. From this point of view, it would be better if we just passed in floats to match with, and ImageGadget didn't know that ids were integers ( it just go a list of floats to match with ) - but I think I moved away from that because doing floating point comparisons on the GPU left us vulnerable to floating point comparison weirdness.

The idea of always including an offset-by-one as part of our int->float conversion is kind of attractive to me still? I think your argument against it was that you didn't like preserving zeros for the main id pass because RenderManifest::acquireID never returns 0, so it's not necessary to preserve zeros for the main id pass?