### PR TITLE
HistoryWindow improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -56,6 +56,7 @@ Fixes
   - Fixed potential crashes in `Show History...`.
   - Fixed potential UI lag in `Show History...`.
   - Fixed flickering in history window when scrubbing the timeline.
+- RenderPassEditor : Fixed error when deleting a pass while a history window was open for it.
 
 API
 ---

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -133,7 +133,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 		/// path does defer inspection until its children or properties are
 		/// queried, allowing it to be used with PathListingWidget to perform
 		/// the queries without blocking the UI.
-		Gaffer::PathPtr historyPath();
+		Gaffer::PathPtr historyPath() const;
 
 	protected :
 
@@ -224,7 +224,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 			public :
 
 				HistoryPath(
-					const InspectorPtr inspector,
+					const ConstInspectorPtr &inspector,
 					Gaffer::ConstContextPtr context,
 					const std::string &path = "/",
 					Gaffer::PathFilterPtr filter = nullptr

--- a/include/GafferSceneUI/Private/InspectorColumn.h
+++ b/include/GafferSceneUI/Private/InspectorColumn.h
@@ -66,6 +66,7 @@ class GAFFERSCENEUI_API InspectorColumn : public GafferUI::PathColumn
 
 		GafferSceneUI::Private::ConstInspectorPtr inspector( const Gaffer::Path &path, const IECore::Canceller *canceller = nullptr ) const;
 		GafferSceneUI::Private::Inspector::ResultPtr inspect( const Gaffer::Path &path, const IECore::Canceller *canceller = nullptr ) const;
+		Gaffer::PathPtr historyPath( const Gaffer::Path &path, const IECore::Canceller *canceller = nullptr ) const;
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override;
 		CellData headerData( const IECore::Canceller *canceller ) const override;

--- a/python/GafferSceneUI/AttributeEditor.py
+++ b/python/GafferSceneUI/AttributeEditor.py
@@ -194,7 +194,7 @@ class AttributeEditor( GafferSceneUI.SceneEditor ) :
 		if plug in ( self.settings()["section"], self.settings()["tabGroup"] ) :
 			self.__updateColumns()
 
-	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	@GafferUI.LazyMethod( deferUntilVisible = False, deferUntilPlaybackStops = True )
 	def __lazyUpdateFromContext( self ) :
 
 		self.__pathListing.getPath().setContext( self.context() )

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -234,7 +234,7 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		if plug in ( self.settings()["section"], self.settings()["attribute"] ) :
 			self.__updateColumns()
 
-	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	@GafferUI.LazyMethod( deferUntilVisible = False, deferUntilPlaybackStops = True )
 	def __lazyUpdateFromContext( self ) :
 
 		self.__pathListing.getPath().setContext( self.context() )

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -277,7 +277,7 @@ class RenderPassEditor( GafferSceneUI.SceneEditor ) :
 		elif plug in ( self.settings()["in"], self.settings()["editScope"] ) :
 			self.__updateButtonStatus()
 
-	@GafferUI.LazyMethod( deferUntilPlaybackStops = True )
+	@GafferUI.LazyMethod( deferUntilVisible = False, deferUntilPlaybackStops = True )
 	def __lazyUpdateFromContext( self ) :
 
 		self.__pathListing.getPath().setContext( self.context() )

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -167,6 +167,10 @@ class _HistoryWindow( GafferUI.Window ) :
 		inspectionPath = self.__inspectionRootPath.copy()
 		inspectionPath.setFromString( self.__inspectionPathString )
 		self.__path = self.__inspectorColumn.historyPath( inspectionPath )
+		if self.__path is None :
+			self.close()
+			return
+
 		self.__pathListingWidget.setPath( self.__path )
 
 	def __buttonDoubleClick( self, pathListing, event ) :

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -43,16 +43,13 @@ import GafferSceneUI
 
 class _OperationIconColumn( GafferUI.PathColumn ) :
 
-	def __init__( self, title, property ) :
+	def __init__( self ) :
 
 		GafferUI.PathColumn.__init__( self )
 
-		self.__title = title
-		self.__property = property
-
 	def cellData( self, path, canceller = None ) :
 
-		cellValue = path.property( self.__property, canceller )
+		cellValue = path.property( "history:operation", canceller )
 
 		data = self.CellData()
 
@@ -75,43 +72,36 @@ class _OperationIconColumn( GafferUI.PathColumn ) :
 
 	def headerData( self, canceller = None ) :
 
-		return self.CellData( self.__title )
+		return self.CellData( "Operation" )
 
 class _NodeNameColumn( GafferUI.PathColumn ) :
 
-	def __init__( self, title, property ) :
+	def __init__( self ) :
 
 		GafferUI.PathColumn.__init__( self )
 
-		self.__title = title
-		self.__property = property
-
 	def cellData( self, path, canceller = None ) :
 
-		node = path.property( self.__property, canceller )
+		node = path.property( "history:node", canceller )
 		return self.CellData( node.relativeName( node.scriptNode() ) )
 
 	def headerData( self, canceller = None ) :
 
-		return self.CellData( self.__title )
+		return self.CellData( "Node" )
 
 # \todo This duplicates logic from (in this case) `_GafferSceneUI._LightEditorInspectorColumn`.
 # Refactor to allow calling `_GafferSceneUI.InspectorColumn.cellData()` from `_HistoryWindow` to
 # remove this duplication for columns that customize their value presentation.
 class _ValueColumn( GafferUI.PathColumn ) :
 
-	def __init__( self, title, property, fallbackProperty ) :
+	def __init__( self ) :
 
 		GafferUI.PathColumn.__init__( self )
 
-		self.__title = title
-		self.__property = property
-		self.__fallbackProperty = fallbackProperty
-
 	def cellData( self, path, canceller = None ) :
 
-		cellValue = path.property( self.__property, canceller )
-		fallbackValue = path.property( self.__fallbackProperty, canceller )
+		cellValue = path.property( "history:value", canceller )
+		fallbackValue = path.property( "history:fallbackValue", canceller )
 
 		data = self.CellData()
 
@@ -128,7 +118,7 @@ class _ValueColumn( GafferUI.PathColumn ) :
 
 	def headerData( self, canceller = None ) :
 
-		return self.CellData( self.__title )
+		return self.CellData( "Value" )
 
 class _HistoryWindow( GafferUI.Window ) :
 
@@ -147,9 +137,9 @@ class _HistoryWindow( GafferUI.Window ) :
 			self.__pathListingWidget = GafferUI.PathListingWidget(
 				Gaffer.DictPath( {}, "/" ),
 				columns = (
-					_NodeNameColumn( "Node", "history:node" ),
-					_ValueColumn( "Value", "history:value", "history:fallbackValue" ),
-					_OperationIconColumn( "Operation", "history:operation" ),
+					_NodeNameColumn(),
+					_ValueColumn(),
+					_OperationIconColumn(),
 				),
 				sortable = False,
 				horizontalScrollMode = GafferUI.ScrollMode.Automatic,

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -52,7 +52,7 @@ class _OperationIconColumn( GafferUI.PathColumn ) :
 
 	def cellData( self, path, canceller = None ) :
 
-		cellValue = path.property( self.__property )
+		cellValue = path.property( self.__property, canceller )
 
 		data = self.CellData()
 
@@ -88,7 +88,7 @@ class _NodeNameColumn( GafferUI.PathColumn ) :
 
 	def cellData( self, path, canceller = None ) :
 
-		node = path.property( self.__property )
+		node = path.property( self.__property, canceller )
 		return self.CellData( node.relativeName( node.scriptNode() ) )
 
 	def headerData( self, canceller = None ) :
@@ -110,8 +110,8 @@ class _ValueColumn( GafferUI.PathColumn ) :
 
 	def cellData( self, path, canceller = None ) :
 
-		cellValue = path.property( self.__property )
-		fallbackValue = path.property( self.__fallbackProperty )
+		cellValue = path.property( self.__property, canceller )
+		fallbackValue = path.property( self.__fallbackProperty, canceller )
 
 		data = self.CellData()
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -264,6 +264,14 @@ class _HistoryWindow( GafferUI.Window ) :
 		# computed and cached everything internally. So we can call `children()`
 		# without fear of blocking the UI waiting for it to compute.
 
+		# Close window if there's no longer anything to show.
+
+		if len( self.__path.children() ) == 0 :
+			# History is empty, for example because the scene location no
+			# longer exists.
+			self.close()
+			return
+
 		# Arrange to signal changes for the node name
 		# column if any nodes are renamed.
 
@@ -282,13 +290,6 @@ class _HistoryWindow( GafferUI.Window ) :
 					)
 
 				node = node.parent()
-
-		# Close window if there's no longer anything to show.
-
-		if len( self.__path.children() ) == 0 :
-			# History is empty, for example because the scene location no
-			# longer exists.
-			self.close()
 
 	def __nodeNameChanged( self, node, oldName ) :
 

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -403,6 +403,10 @@ def __contextMenu( column, pathListing, menuDefinition ) :
 		}
 	)
 
+	menuDefinition.append(
+		"EditDivider", { "divider" : True }
+	)
+
 	toggleOnly = isinstance( column, _GafferSceneUI._LightEditorSetMembershipColumn )
 	menuDefinition.append(
 		"Toggle" if toggleOnly else "Edit...",

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -235,8 +235,8 @@ def __selectedSetExpressions( pathListing ) :
 			path.setFromString( pathString )
 			if not (
 				__cellMetadata( column, path, "ui:scene:acceptsSetName" ) or
-				__cellMetadata( column, path, "ui:scene:acceptsSetName" ) or
-				__cellMetadata( column, path, "ui:scene:acceptsSetName" )
+				__cellMetadata( column, path, "ui:scene:acceptsSetNames" ) or
+				__cellMetadata( column, path, "ui:scene:acceptsSetExpression" )
 			) :
 				# We only return set expressions if all selected paths are in
 				# columns that accept set names or set expressions.

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -309,8 +309,9 @@ def __showHistory( pathListing ) :
 			if inspector is None :
 				continue
 			window = _HistoryWindow(
-				inspector,
-				path,
+				column,
+				pathListing.getPath(),
+				pathString,
 				"History : {} : {}".format( pathString, column.headerData().value )
 			)
 			pathListing.ancestor( GafferUI.Window ).addChildWindow( window, removeOnClose = True )

--- a/python/GafferSceneUITest/InspectorColumnTest.py
+++ b/python/GafferSceneUITest/InspectorColumnTest.py
@@ -731,5 +731,18 @@ class InspectorColumnTest( GafferUITest.TestCase ) :
 		path.setFromString( "/inspector2" )
 		self.assertTrue( column.inspector( path ).isSame( inspector2 ) )
 
+	def testHistoryFromPath( self ) :
+
+		self.ignoreMessage( IECore.Msg.Level.Warning, "HistoryPath", "Path evaluated on unexpected thread" )
+
+		plane = GafferScene.Plane()
+		inspector = GafferSceneUI.Private.BasicInspector( plane["out"]["object"], None, lambda objectPlug : objectPlug.getValue().interpolation )
+		column = GafferSceneUI.Private.InspectorColumn( inspector, "label", "help!" )
+		path = GafferScene.ScenePath( plane["out"], Gaffer.Context(), "/plane" )
+
+		historyPath = column.historyPath( path )
+		self.assertEqual( len( historyPath.children() ), 1 )
+		self.assertEqual( historyPath.children()[0].property( "history:node" ), plane )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -587,7 +587,7 @@ void Inspector::editScopeInputChanged( const Gaffer::Plug *plug )
 	}
 }
 
-PathPtr Inspector::historyPath()
+PathPtr Inspector::historyPath() const
 {
 	return new Inspector::HistoryPath( this, new Context( *Context::current() ) );
 }
@@ -604,12 +604,12 @@ PathPtr Inspector::historyPath()
 struct Inspector::HistoryPath::HistoryProvider
 {
 
-	HistoryProvider( const InspectorPtr &inspector, const ConstContextPtr &context )
+	HistoryProvider( const ConstInspectorPtr &inspector, const ConstContextPtr &context )
 		:	inspector( inspector ), m_context( context ), m_constructorThreadId( std::this_thread::get_id() )
 	{
 	}
 
-	const InspectorPtr inspector;
+	const ConstInspectorPtr inspector;
 
 	size_t historySize( const IECore::Canceller *canceller )
 	{
@@ -726,7 +726,7 @@ struct Inspector::HistoryPath::HistoryProvider
 //////////////////////////////////////////////////////////////////////////
 
 Inspector::HistoryPath::HistoryPath(
-	const InspectorPtr inspector,
+	const ConstInspectorPtr &inspector,
 	ConstContextPtr context,
 	const std::string &path,
 	PathFilterPtr filter

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -110,6 +110,24 @@ GafferSceneUI::Private::Inspector::ResultPtr InspectorColumn::inspect( const Gaf
 	return i->inspect();
 }
 
+Gaffer::PathPtr InspectorColumn::historyPath( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
+{
+	ConstInspectorPtr i = inspector( path, canceller );
+	if( !i )
+	{
+		return nullptr;
+	}
+
+	const ContextPtr inspectionContext = path.inspectionContext( canceller );
+	if( !inspectionContext )
+	{
+		return nullptr;
+	}
+
+	Context::Scope scope( inspectionContext.get() );
+	return i->historyPath();
+}
+
 PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
 {
 	CellData result;

--- a/src/GafferSceneUIModule/InspectorColumnBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorColumnBinding.cpp
@@ -65,6 +65,12 @@ Inspector::ResultPtr inspectorColumnInspectBinding( const InspectorColumn &colum
 	return column.inspect( path, canceller );
 }
 
+Gaffer::PathPtr inspectorColumnHistoryPathBinding( const InspectorColumn &column, const Gaffer::Path &path, const IECore::Canceller *canceller )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	return column.historyPath( path, canceller );
+}
+
 } // namespace
 
 void GafferSceneUIModule::bindInspectorColumn()
@@ -99,6 +105,7 @@ void GafferSceneUIModule::bindInspectorColumn()
 		) )
 		.def( "inspector", &inspectorColumnInspectorBinding, ( arg( "path" ), arg( "canceller" ) = object() ) )
 		.def( "inspect", &inspectorColumnInspectBinding, ( arg( "path" ), arg( "canceller" ) = object() ) )
+		.def( "historyPath", &inspectorColumnHistoryPathBinding, ( arg( "path" ), arg( "canceller" ) = object() ) )
 	;
 
 }


### PR DESCRIPTION
This makes further improvements to the HistoryWindow in preparation for its use in a new SceneInspector. The crucial change is to allow it to be used with any Path subclass, but there are a number of other small fixes and improvements as well.