### PR TITLE
Editors : Maintain scroll position on tab change

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.16.0)
 =======
 
+Improvements
+------------
 
+- RenderPassEditor, AttributeEditor, LightEditor : The vertical scroll position is now maintained when changing sections.
 
 1.5.16.0 (relative to 1.5.15.0)
 ========

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -167,6 +167,7 @@ class PathListingWidget( GafferUI.Widget ) :
 		self.__dragBeginIndex = None
 		self.__currentDragIndex = None
 		self.__path = None
+		self.__verticalScrollPosition = None
 
 		self.setDisplayMode( displayMode )
 		self.setPath( path )
@@ -327,6 +328,10 @@ class PathListingWidget( GafferUI.Widget ) :
 
 		if columns == self.getColumns() :
 			return
+
+		vScrollBar = self._qtWidget().verticalScrollBar()
+		if vScrollBar is not None :
+			self.__verticalScrollPosition = vScrollBar.value()
 
 		_GafferUI._pathListingWidgetSetColumns( GafferUI._qtAddress( self._qtWidget() ), columns )
 		self._qtWidget().updateColumnWidths()
@@ -586,6 +591,11 @@ class PathListingWidget( GafferUI.Widget ) :
 		self.__expansionChangedSignal( self )
 
 	def __updateFinished( self ) :
+
+		vScrollBar = self._qtWidget().verticalScrollBar()
+		if vScrollBar is not None and self.__verticalScrollPosition is not None :
+			vScrollBar.setValue( self.__verticalScrollPosition )
+		self.__verticalScrollPosition = None
 
 		self.__updateFinishedSignal( self )
 


### PR DESCRIPTION
This keeps the vertical scroll position consistent when switching sections in the LightEditor, AttributeEditor and RenderPassEditor.

I had hoped to keep this contained within the `LightEditor.__updateColumns()` method, but it looks like that's not possible with the current `PathListingWidget` implementation. When we set the columns in the c++ `PathListingWidgetBinding`, we reset the `m_rootItem` at https://github.com/GafferHQ/gaffer/blob/27a9120131ccff681c4697df6c1483e76a7e23ad/src/GafferUIModule/PathListingWidgetBinding.cpp#L588
I haven't tracked exactly where, but `m_rootItem` is eventually updated in the background. That means we can't just update the scroll position immediately after `setColumns()` call in `LightEditor.__updateColumns()`. It looks like the next chance `PathListingWidget` clients get to see the populated list, and therefore the scroll possibilities, is in the `PathListingWidget.updateFinished()` signal which I'm using here.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
