### PR TITLE
InspectorColumn : Don't accept drags containing NullObject

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Instancer : Fixed potential crash with encapsulated instancers.
+- AttributeEditor, LightEditor, RenderPassEditor : Fixed crash caused by incorrectly intercepting drags being performed by virtual sliders, such as those in the popup cell editors.
 
 1.5.16.0 (relative to 1.5.15.0)
 ========

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -517,7 +517,7 @@ def __dragEnter( column, path, pathListing, event ) :
 	if path is None :
 		return False
 
-	if not isinstance( event.data, IECore.Object ) :
+	if not isinstance( event.data, IECore.Object ) or isinstance( event.data, IECore.NullObject ) :
 		return False
 
 	inspectionContext = path.inspectionContext()


### PR DESCRIPTION
This is the sentinel type used by widgets implementing "private" drags, such as virtual sliders, and shouldn't be accepted by anything else. Accepting it somehow caused complete havoc, whereby we ended up crashing Gaffer on drop.
