### PR TITLE
Instancer : Fix data lifetime bug

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.x.x (relative to 1.5.16.0)
 =======
 
+Fixes
+-----
 
+- Instancer : Fixed potential crash with encapsulated instancers.
 
 1.5.16.0 (relative to 1.5.15.0)
 ========

--- a/src/GafferScene/Instancer.cpp
+++ b/src/GafferScene/Instancer.cpp
@@ -2341,7 +2341,8 @@ void Instancer::compute( Gaffer::ValuePlug *output, const Gaffer::Context *conte
 				taskGroupContext
 			);
 
-			const auto &prototypeSetNames = prototypesPlug()->setNames()->readable();
+			ConstInternedStringVectorDataPtr prototypeSetNamesData = prototypesPlug()->setNames();
+			const auto &prototypeSetNames = prototypeSetNamesData->readable();
 			const IECore::MurmurHash prototypeSetsHash = tbb::parallel_reduce(
 				tbb::blocked_range<size_t>( 0, prototypeSetNames.size() ),
 				IECore::MurmurHash( 0, 0 ),


### PR DESCRIPTION
The `setNames()` call returns a reference counted Ptr that we are required to hold onto as long as we use the data. But we were not holding onto it, so we could end up accessing data that had been deleted already.
