### PR TITLE
Switch : Use internal connection when switch is disabled

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@ Improvements
   - Improved performance when showing colour values.
   - Added support for showing spline values.
 - GafferUI : Added support for drag and dropping numeric vector data onto numeric vector plugs of compatible types ( For example, dropping a list of ints onto a FloatVectorDataPlug ).
+- Switch : Optimised disabled switches using a direct internal connection, even when the `index` is not constant.
 
 Fixes
 -----

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -238,14 +238,14 @@ class SwitchTest( GafferTest.TestCase ) :
 		script["s"]["in"][1].setInput( script["a2"]["sum"] )
 
 		# Should be using an internal connection for speed
-		self.assertTrue( script["s"]["out"].getInput() is not None )
+		self.assertIsNotNone( script["s"]["out"].getInput() )
 
 		script["expression"] = Gaffer.Expression()
 		script["expression"].setExpression( 'parent["s"]["index"] = int( context.getFrame() )' )
 
 		# Should not be using an internal connection, because the result
 		# varies with context.
-		self.assertTrue( script["s"]["out"].getInput() is None )
+		self.assertIsNone( script["s"]["out"].getInput() )
 
 		with script.context() :
 			script.context().setFrame( 0 )
@@ -257,7 +257,7 @@ class SwitchTest( GafferTest.TestCase ) :
 
 		# Should be using an internal connection for speed now the expression has
 		# been removed.
-		self.assertTrue( script["s"]["out"].getInput() is not None )
+		self.assertIsNotNone( script["s"]["out"].getInput() )
 
 	def testPassThroughWhenIndexConstant( self ) :
 

--- a/python/GafferTest/SwitchTest.py
+++ b/python/GafferTest/SwitchTest.py
@@ -253,6 +253,18 @@ class SwitchTest( GafferTest.TestCase ) :
 			script.context().setFrame( 1 )
 			self.assertEqual( script["s"]["out"].getValue(), 2 )
 
+		# If we disable the node, then it doesn't matter what the index is,
+		# and the expression is irrelevant. So we should be using an
+		# internal connection again.
+
+		script["s"]["enabled"].setValue( False )
+		self.assertIsNotNone( script["s"]["out"].getInput() )
+
+		# Enable it again, and we should be back to computing.
+
+		script["s"]["enabled"].setValue( True )
+		self.assertIsNone( script["s"]["out"].getInput() )
+
 		del script["expression"]
 
 		# Should be using an internal connection for speed now the expression has


### PR DESCRIPTION
Previously we enabled this optimisation only when we could determine that both the `enabled` and `index` plugs had static (non-computed) values. Here we take it one step further : if we can determine that `enabled` has a static value of `false` then we can use the same optimisation even when `index` might be non-static, because the index will never be evaluated.