### PR TITLE
PathListingWidget : Preserve model data in `setColumns()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,7 +10,12 @@ Fixes
 -----
 
 - Arnold : Fixed crashes caused by conflicts with Arnold's internal memory allocator [^1].
-- PathListingWidget : Fixed ordering of `selectionChangedSignal()` emission from `setColumns()` call. It is now emitted when `getColumns()` returns the new columns, not the old ones.
+- PathListingWidget :
+  - Fixed ordering of `selectionChangedSignal()` emission from `setColumns()` call. It is now emitted when `getColumns()` returns the new columns, not the old ones.
+  - Fixed unwanted vertical scrolling caused by `setColumns()`.
+- LightEditor, RenderPassEditor, AttributeEditor :
+  - Fixed unwanted vertical scrolling when switching tabs.
+  - Fixed flickering when switching tabs.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Arnold : Fixed crashes caused by conflicts with Arnold's internal memory allocator [^1].
+- PathListingWidget : Fixed ordering of `selectionChangedSignal()` emission from `setColumns()` call. It is now emitted when `getColumns()` returns the new columns, not the old ones.
 
 Breaking Changes
 ----------------

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -1050,8 +1050,6 @@ class _TreeView( QtWidgets.QTreeView ) :
 		# offsets to the ideal sizes made by the user
 		self.__columnWidthAdjustments = collections.defaultdict( int )
 
-		self.__currentEventModifiers = QtCore.Qt.NoModifier
-
 		self.__highlightedIndex = None
 
 	def setHighlightedIndex( self, index ) :

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -735,6 +735,24 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		self.assertEqual( widget.getSelection(), [ IECore.PathMatcher(), IECore.PathMatcher( [ "/1" ] ) ] )
 		self.assertEqual( columnsWhenSelectionChanged, widget.getColumns() )
 
+	def testSetColumnsMaintainsVerticalScroll( self ) :
+
+		path = Gaffer.DictPath(
+			{ str( x ) : x  for x in range( 0, 1000 ) },
+			"/"
+		)
+
+		widget = GafferUI.PathListingWidget( path )
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( widget._qtWidget() ) )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( widget._qtWidget().model() ) )
+
+		widget.scrollToPath( path.children()[-1] )
+		scroll = widget._qtWidget().verticalScrollBar().value()
+		self.assertNotEqual( scroll, 0 )
+
+		widget.setColumns( [ widget.defaultNameColumn, widget.StandardColumn( "Value", "dict:value" ) ] )
+		self.assertEqual( widget._qtWidget().verticalScrollBar().value(), scroll )
+
 	def testSortable( self ) :
 
 		w = GafferUI.PathListingWidget( Gaffer.DictPath( {}, "/" ) )

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -712,6 +712,29 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( w._qtWidget().model() ) )
 		self.assertEqual( len( updates ), 0 )
 
+	def testSetColumnsSignalsSelectionChangeInValidState( self ) :
+
+		widget = GafferUI.PathListingWidget(
+			Gaffer.DictPath( { "1" : 1 }, "/" ),
+			columns = [ GafferUI.PathListingWidget.defaultNameColumn ],
+			selectionMode = GafferUI.PathListingWidget.SelectionMode.Cell
+		)
+		_GafferUI._pathListingWidgetAttachTester( GafferUI._qtAddress( widget._qtWidget() ) )
+		_GafferUI._pathModelWaitForPendingUpdates( GafferUI._qtAddress( widget._qtWidget().model() ) )
+		widget.setSelection( [ IECore.PathMatcher( [ "/1" ] ) ] )
+
+		columnsWhenSelectionChanged = None
+		def selectionChanged( widget ) :
+
+			nonlocal columnsWhenSelectionChanged
+			columnsWhenSelectionChanged = widget.getColumns()
+
+		widget.selectionChangedSignal().connect( selectionChanged )
+		widget.setColumns( [ widget.StandardColumn( "Value", "dict:value" ), widget.defaultNameColumn ] )
+
+		self.assertEqual( widget.getSelection(), [ IECore.PathMatcher(), IECore.PathMatcher( [ "/1" ] ) ] )
+		self.assertEqual( columnsWhenSelectionChanged, widget.getColumns() )
+
 	def testSortable( self ) :
 
 		w = GafferUI.PathListingWidget( Gaffer.DictPath( {}, "/" ) )

--- a/python/GafferUITest/PathListingWidgetTest.py
+++ b/python/GafferUITest/PathListingWidgetTest.py
@@ -1592,6 +1592,38 @@ class PathListingWidgetTest( GafferUITest.TestCase ) :
 			self.assertEqual( widget._qtWidget().header().sectionSize( 1 ), columnWidth )
 			self.assertEqual( widget._qtWidget().header().sectionSize( 2 ), widget._qtWidget().viewport().width() - ( columnWidth * 2 ) )
 
+	def testColumnWidthsWhenRemovingLastColumn( self ) :
+
+		for sizeMode in ( GafferUI.PathColumn.SizeMode.Stretch, GafferUI.PathColumn.SizeMode.Interactive ) :
+
+			with self.subTest( sizeMode = sizeMode ) :
+
+				with GafferUI.Window() as window :
+					widget = GafferUI.PathListingWidget(
+						path = Gaffer.DictPath( {}, "/" ),
+						displayMode = GafferUI.PathListingWidget.DisplayMode.List,
+						columns = [
+							GafferUI.PathListingWidget.StandardColumn( "Test", "test" ),
+							GafferUI.PathListingWidget.StandardColumn( "Test", "test", sizeMode = sizeMode ),
+							GafferUI.PathListingWidget.StandardColumn( "Test", "test", sizeMode = sizeMode )
+						]
+					)
+
+				window._qtWidget().resize( 512, 384 )
+				window.setVisible( True )
+
+				self.waitForIdle( 1000 )
+				self.assertAlmostEqual(
+					widget._qtWidget().header().length(),
+					widget._qtWidget().viewport().width(),
+					## \todo We should not need this delta. Fix `_TreeView.__resizeStretchColumns` to
+					# remove numerical imprecision.
+					delta = 1
+				)
+
+				widget.setColumns( widget.getColumns()[:-1] )
+				self.assertEqual( widget._qtWidget().header().length(), widget._qtWidget().viewport().width() )
+
 	def testColumnSizeSurvivesStylesheetUpdate( self ) :
 
 		for visible in ( False, True ) :

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -563,9 +563,7 @@ class PathModel : public QAbstractItemModel
 
 			beginResetModel();
 
-			m_columnChangedConnections.clear();
-
-			// Keep track of selections that are common between the current and incoming columns
+			// Remap selections from old columns to new columns.
 			Selection newSelection( columns.size(), IECore::PathMatcher() );
 			for( size_t i = 0; i < columns.size(); ++i )
 			{
@@ -575,9 +573,10 @@ class PathModel : public QAbstractItemModel
 					newSelection[i] = m_selection[ it - m_columns.begin() ];
 				}
 			}
-			setSelection( newSelection );
 
+			// Update columns and our connections to them.
 			m_columns = columns;
+			m_columnChangedConnections.clear();
 			for( const auto &c : m_columns )
 			{
 				m_columnChangedConnections.push_back(
@@ -590,6 +589,10 @@ class PathModel : public QAbstractItemModel
 			m_headerDataState = State::Unrequested;
 
 			endResetModel();
+
+			// Update selection. We do this last so observers see our
+			// final state in `selectionChangedSignal()`.
+			setSelection( newSelection, /* scrollToFirst = */ false );
 		}
 
 		const std::vector<GafferUI::PathColumnPtr> &getColumns() const

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -931,6 +931,7 @@ class PathModel : public QAbstractItemModel
 
 		void expansionChanged();
 		void selectionChanged();
+		void headerUpdateFinished();
 		void updateFinished();
 
 		///////////////////////////////////////////////////////////////////
@@ -1137,6 +1138,14 @@ class PathModel : public QAbstractItemModel
 					{
 						const IECore::Canceller *canceller = Context::current()->canceller();
 						updateHeaderData( canceller );
+						queueEdit(
+							[this] () {
+								if( !m_blockUpdateFinished )
+								{
+									headerUpdateFinished();
+								}
+							}
+						);
 						m_rootItem->updateWalk( this, workingPath.get(), expandedPaths, canceller );
 						queueEdit(
 							[this] () {


### PR DESCRIPTION
Our original `setColumns()` implementation blew away the entire model and rebuild it from scratch, which had several downsides :

- The QTreeView would reset the vertical scroll to the origin. So when users switched tabs in the LightEditor for example, they would also lose their position in the hierarchy.
- We'd get a lot of flicker and column resizing as we rebuilt the model, including for columns which were completely unchanged (e.g. `Name` and `Mute` and `Solo` in the LightEditor).

#6506 attempts to work around the first problem by restoring the scroll position later on, but it causes additional flicker and isn't robust in the face of slow updates - it might restore the old scroll position after the user has already scrolled somewhere else.

In this PR I've taken the alternative approach of retaining as much information as possible in `setColumns()`, so we don't reset the model at all. This fixes both the scrolling issue and also removes a bunch of irritating flicker. It's a much more complex approach, and far more error prone in implementation, but I believe it is the right approach for the long term. I don't consider it suitable for a 1.5.x release though, due to the higher likelihood of short term bugs.

