### PR TITLE
Arnold Renderer : Avoid deprecated method in Arnold 7.4.3.0

### DIFF
--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -3566,7 +3566,9 @@ class ArnoldGlobals
 			}
 			else if( name == g_statisticsFileNameOptionName )
 			{
+#if ARNOLD_VERSION_NUM < 70403
 				AiStatsSetMode( AI_STATS_MODE_OVERWRITE );
+#endif
 
 				if( value == nullptr )
 				{


### PR DESCRIPTION
From this version onwards, `AiStatsGetMode()` does nothing, and stats are always overwritten. Note that we don't actually make release builds against 7.4.3.0 though - we will continue to build against 7.4.1.0 so that stats are overwritten no matter which 7.4.x version is used at runtime.
