### PR TITLE
Arnold `LD_DEBUG` Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,16 +160,6 @@ jobs:
       env:
         PYTHONUTF8: 1
 
-    - name: Test
-      # Tests should complete in well under an hour. If they don't it's most likely because
-      # of a hang, in which case we'd like to know more quickly than the default 6hr timeout
-      # allows.
-      timeout-minutes: 60
-      run: |
-        echo "::add-matcher::./.github/workflows/main/problemMatchers/unittest.json"
-        ${{ matrix.testRunner }} ${{ env.GAFFER_BUILD_DIR }}/bin/gaffer test ${{ matrix.testArguments }}
-        echo "::remove-matcher owner=unittest::"
-
     - name: Build and test Arnold extension
       run: |
         import subprocess


### PR DESCRIPTION
This PR is not meant to be merged, it's only meant for checking the output of running Arnold with `LD_DEBUG` environment variable set. We're investigating why it does not crash on CI when it does on workstations.

See https://github.com/GafferHQ/gaffer/pull/6519 for more details.