### PR TITLE
Arnold plugin : Fix conflict with Arnold's internal allocator

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,10 +6,17 @@ Improvements
 
 - Arnold : Improved readability of shader node names as they appear in statistics and `.ass` files. They are now formatted as `shader:{handle}:{uniqueId}` where `{handle}` is the Gaffer node name of the assigned shader, or if loaded from USD, the prim name.
 
+Fixes
+-----
+
+- Arnold : Fixed crashes caused by conflicts with Arnold's internal memory allocator [^1].
+
 Breaking Changes
 ----------------
 
 - Arnold : Changed the naming of shader nodes in the generated Arnold scene.
+
+[^1]: To be omitted from the notes for the final 1.6.0.0 release.
 
 1.6.0.0a1 (relative to 1.5.16.1)
 =========

--- a/SConstruct
+++ b/SConstruct
@@ -1629,6 +1629,15 @@ else :
 
 	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl" ] )
 
+	if env["PLATFORM"] == "posix" :
+		# Make sure our Arnold plugin links to `libstdc++` _before_ linking to
+		# `libai`. Otherwise we pick up symbols for `operator delete` and
+		# `operator new` from `libai`, which has its own internal allocator and
+		# exports the symbols from it. If we pick up the Arnold ones then we get
+		# mismatches where we allocate something with the standard allocator and
+		# then try to delete it with the Arnold one.
+		libraries["GafferArnoldPlugin"]["envAppends"]["LIBS"].insert( 0, "stdc++" )
+
 # Optionally add vTune requirements
 
 if os.path.exists( env.subst("$VTUNE_ROOT") ):


### PR DESCRIPTION
`libai.so` exports symbols for `operator new` and `operator delete`, implemented using its own internal memory allocator. Our `Gaffer.so` plugin with the output driver in it was binding to these symbols in preference to the standard ones. This lead to crashes caused by objects getting allocated with one allocator (an object created in IECore for example) and deleted by another (when the plugin disposed of the object).

This problem only came to light when we updated from GafferHQ/dependencies `10.0.0a1` to `10.0.0a2`, with the relevant change being an upgrade to OpenImageIO 3. This contained the following change, which meant we were no longer loading the `osl.imageio` plugin :

https://github.com/AcademySoftwareFoundation/OpenImageIO/pull/4245

Why would that be relevant? Because OpenImageIO loads all its plugins with `RTLD_GLOBAL` and was therefore was putting `libstdc++` in the global symbol table, ahead of `libai` in the search order. With the plugin no longer loading, that was no longer happening and the problem was revealed.

This could be fixed by using `OPENIMAGEIO_PLUGIN_PATH` to get `osl.imageio` loading again. But we don't use the plugin anyway, and it pollutes the global symbol table with a huuuuge amount of stuff in addition to `libstdc++`, and we'd be better off without that. So instead we fix by linking our plugin to `libstdc++` explicitly, making sure it comes before `libai.so` in the link order.

See also https://github.com/GafferHQ/dependencies/pull/284 where I remove the `osl.imageio` from our dependencies entirely.
