### PR TITLE
Menu : Fix laggy search behaviour in Qt 6

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -32,6 +32,7 @@ Fixes
 - LightEditor, RenderPassEditor, AttributeEditor :
   - Fixed unwanted vertical scrolling when switching tabs.
   - Fixed flickering when switching tabs.
+- Node menu : Fixed laggy search behaviour [^1].
 
 API
 ---

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -277,6 +277,12 @@ class Menu( GafferUI.Widget ) :
 			else :
 				definition = definition()
 
+		# We'll be replacing all existing submenus so flag to Qt that they're
+		# available for deletion. Otherwise they and their children are kept
+		# alive until their parent Menu is deleted.
+		for menu in qtMenu.findChildren( QtWidgets.QMenu ) :
+			menu.deleteLater()
+
 		qtMenu.clear()
 
 		needsBottomSpacer = False
@@ -639,9 +645,13 @@ class Menu( GafferUI.Widget ) :
 
 	def __menuActionTriggered( self, action, checked ) :
 
-		self.__lastAction = action if action.objectName() != "GafferUI.Menu.__searchWidget" else None
 		if self.__lastAction is not None :
-			self.__searchMenu.addAction( self.__lastAction )
+			self.__lastAction.deleteLater()
+
+		# Store the last triggered action as a new action built from the original.
+		# We do this as the triggered action will often be parented to a submenu
+		# that will be deleted the next time we build the menu.
+		self.__lastAction = self.__buildAction( action.item, action.text(), self._qtWidget() ) if action.objectName() != "GafferUI.Menu.__searchWidget" else None
 
 		self._qtWidget().hide()
 


### PR DESCRIPTION
With the recent update to Qt 6.5, searching for nodes in Gaffer's Node menu has felt especially laggy. After a bit of investigation it appears that the time spent creating connections to QActions in Qt 6 scales with the number of QActions in existence, and we were inadvertently accumulating lots of QActions through our rebuilding of menus. Specifically, old submenus were not being cleaned up and the QActions from their menu items would accumulate. We now expressly flag to Qt that old submenus can be deleted when we replace them in a menu rebuild. 

Additionally, the menu search behaviour was creating new actions for every update of the search results menu, often creating the same action multiple times while a search was being refined. This would cause longer searches to feel laggy as the overall number of actions increased with each keypress, we now cache and reuse these within a search.