### PR TITLE
SceneInspector : Show inherited shader parameters

### DIFF
--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -69,7 +69,7 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 		Gaffer::ValuePlugPtr source( const GafferScene::SceneAlgo::History *history, std::string &editWarning ) const override;
 		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *scope, const GafferScene::SceneAlgo::History *history ) const override;
 
-		bool attributeExists() const;
+		bool attributeExists( const bool inheritAttributes ) const;
 
 	private :
 

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -55,7 +55,8 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 
 		ParameterInspector(
 			const GafferScene::ScenePlugPtr &scene, const Gaffer::PlugPtr &editScope,
-			IECore::InternedString attribute, const IECoreScene::ShaderNetwork::Parameter &parameter
+			IECore::InternedString attribute, const IECoreScene::ShaderNetwork::Parameter &parameter,
+			const bool inheritAttributes = false
 		);
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::Private::ParameterInspector, ParameterInspectorTypeId, AttributeInspector );
@@ -72,6 +73,7 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 		AcquireEditFunctionOrFailure acquireEditFunction( Gaffer::EditScope *editScope, const GafferScene::SceneAlgo::History *history ) const override;
 
 		const IECoreScene::ShaderNetwork::Parameter m_parameter;
+		const bool m_inheritAttributes;
 
 };
 

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -202,8 +202,8 @@ void GafferSceneUIModule::bindInspector()
 
 	RunTimeTypedClass<ParameterInspector>( "ParameterInspector" )
 		.def(
-			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString, const ShaderNetwork::Parameter &>(
-				( arg( "scene" ), arg( "attribute" ), arg( "parameter" ) )
+			init<const ScenePlugPtr &, const PlugPtr &, IECore::InternedString, const ShaderNetwork::Parameter &, const bool>(
+				( arg( "scene" ), arg( "attribute" ), arg( "parameter" ), arg( "inheritAttributes" ) = false )
 			)
 		)
 	;

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -779,7 +779,7 @@ void addShaderInspections( InspectorTree::Inspections &inspections, const vector
 			inspections.push_back( {
 				parameterPath,
 				new GafferSceneUI::Private::ParameterInspector(
-					scene, editScope, attributeName, { shaderHandle, parameterName }
+					scene, editScope, attributeName, { shaderHandle, parameterName }, /* inheritAttributes = */ true
 				)
 			} );
 		}


### PR DESCRIPTION
This adds display of shader parameters from inherited shaders in the Scene Inspector.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
