### PR TITLE
ContextQueryUI : Don't create queries for unsupported plug types

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - RenderMan : Added dedicated viewport visualisers for RenderMan lights.
 
+Fixes
+-----
+
+- ContextQuery : Removed `Create Context Query...` menu item from plugs where it was not relevant.
+
 Breaking Changes
 ----------------
 

--- a/python/GafferUI/ContextQueryUI.py
+++ b/python/GafferUI/ContextQueryUI.py
@@ -419,7 +419,7 @@ def __plugPopupMenu( menuDefinition, plugValueWidget ) :
 
 	# For ValuePlug in general, we offer the option to drive them with ContextQuery
 	plug = plugValueWidget.getPlug()
-	if not isinstance( plug, Gaffer.ValuePlug ) :
+	if not isinstance( plug, Gaffer.ValuePlug ) or not Gaffer.PlugAlgo.canSetValueFromData( plug ) :
 		return
 
 	node = plug.node()


### PR DESCRIPTION
Better to never make the node than to make a node which doesn't work. In the case of NameValuePlugs, the created node sortof almost kindof worked, but in a confusing way where dependency tracking was broken. That could maybe be fixed in the node itself, but there's not really any point because there's no associated data type that could be used for such a context variable anyway.
