### PR TITLE
SceneInspector : Support custom option/attribute categories

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,13 @@ Fixes
 
 - CyclesShader : Moved the `principled_bsdf.diffuse_roughness` parameter to a new "Diffuse" section in the Node Editor [^1].
 
+API
+---
+
+- SceneInspector :
+  - Added `registerAttributeCategory()` and `deregisterAttributeCategory()` methods.
+  - Added `registerOptionCategory()` and `deregisterOptionCategory()` methods.
+
 Breaking Changes
 ----------------
 

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -290,6 +290,11 @@ GafferUI.Editor.registerType( "SceneInspector", SceneInspector )
 # InspectorTree isn't public API. Expose the `registerInspectors()` function on SceneInspector
 # itself to make it available to extension authors.
 SceneInspector.registerInspectors = _GafferSceneUI._SceneInspector.InspectorTree.registerInspectors
+# Likewise expose functions for registering custom categories.
+SceneInspector.registerAttributeCategory = _GafferSceneUI._SceneInspector.registerAttributeCategory
+SceneInspector.deregisterAttributeCategory = _GafferSceneUI._SceneInspector.deregisterAttributeCategory
+SceneInspector.registerOptionCategory = _GafferSceneUI._SceneInspector.registerOptionCategory
+SceneInspector.deregisterOptionCategory = _GafferSceneUI._SceneInspector.deregisterOptionCategory
 
 ##########################################################################
 # Settings metadata

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -710,7 +710,7 @@ vector<InternedString> alphabeticallySortedKeys( const T &container )
 	return result;
 }
 
-const boost::container::flat_map<string, InternedString> g_attributeCategories = {
+boost::container::flat_map<string, InternedString> g_attributeCategories = {
 	{ "ai:*", "Arnold" },
 	{ "dl:*", "3Delight" },
 	{ "cycles:*", "Cycles" },
@@ -725,6 +725,26 @@ const boost::container::flat_map<string, InternedString> g_attributeCategories =
 		"Standard"
 	}
 };
+
+void registerAttributeCategory( InternedString category, const IECore::StringAlgo::MatchPattern &pattern )
+{
+	g_attributeCategories.insert( { pattern, category } );
+}
+
+void deregisterAttributeCategory( InternedString category )
+{
+	for( auto it = g_attributeCategories.begin(); it != g_attributeCategories.end(); )
+	{
+		if( it->second == category )
+		{
+			it = g_attributeCategories.erase( it );
+		}
+		else
+		{
+			it++;
+		}
+	}
+}
 
 const InternedString g_other( "Other" );
 
@@ -1348,7 +1368,7 @@ const InspectorTree::Registration g_subdivisionInspectionRegistration( { "Locati
 // Option Inspectors
 // =================
 
-const boost::container::flat_map<string, InternedString> g_optionCategories = {
+boost::container::flat_map<string, InternedString> g_optionCategories = {
 	{ "ai:*", "Arnold" },
 	{ "dl:*", "3Delight" },
 	{ "cycles:*", "Cycles" },
@@ -1358,6 +1378,26 @@ const boost::container::flat_map<string, InternedString> g_optionCategories = {
 	{ "user:*", "User" },
 	{ "render:* sampleMotion", "Standard" },
 };
+
+void registerOptionCategory( InternedString category, const IECore::StringAlgo::MatchPattern &pattern )
+{
+	g_optionCategories.insert( { pattern, category } );
+}
+
+void deregisterOptionCategory( InternedString category )
+{
+	for( auto it = g_optionCategories.begin(); it != g_optionCategories.end(); )
+	{
+		if( it->second == category )
+		{
+			it = g_optionCategories.erase( it );
+		}
+		else
+		{
+			it++;
+		}
+	}
+}
 
 const std::string g_optionPrefix( "option:" );
 const std::string g_attributePrefix( "attribute:" );
@@ -1700,5 +1740,11 @@ void GafferSceneUIModule::bindSceneInspector()
 			.value( "B", InspectorDiffColumn::DiffContext::B )
 		;
 	}
+
+	def( "registerAttributeCategory", &registerAttributeCategory, ( boost::python::arg( "category" ), boost::python::arg( "pattern" ) ) );
+	def( "deregisterAttributeCategory", &deregisterAttributeCategory, ( boost::python::arg( "category" ) ) );
+
+	def( "registerOptionCategory", &registerOptionCategory, ( boost::python::arg( "category" ), boost::python::arg( "category" ) ) );
+	def( "deregisterOptionCategory", &deregisterOptionCategory, ( boost::python::arg( "category" ) ) );
 
 }

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -710,21 +710,7 @@ vector<InternedString> alphabeticallySortedKeys( const T &container )
 	return result;
 }
 
-boost::container::flat_map<string, InternedString> g_attributeCategories = {
-	{ "ai:*", "Arnold" },
-	{ "dl:*", "3Delight" },
-	{ "cycles:*", "Cycles" },
-	{ "ri:*", "RenderMan" },
-	{ "gl:*", "OpenGL" },
-	{ "usd:*", "USD" },
-	{ "user:*", "User" },
-	{
-		"scene:visible doubleSided render:* gaffer:* "
-		"linkedLights shadowedLights filteredLights "
-		"surface displacement volume light",
-		"Standard"
-	}
-};
+boost::container::flat_map<string, InternedString> g_attributeCategories;
 
 void registerAttributeCategory( InternedString category, const IECore::StringAlgo::MatchPattern &pattern )
 {
@@ -1368,16 +1354,7 @@ const InspectorTree::Registration g_subdivisionInspectionRegistration( { "Locati
 // Option Inspectors
 // =================
 
-boost::container::flat_map<string, InternedString> g_optionCategories = {
-	{ "ai:*", "Arnold" },
-	{ "dl:*", "3Delight" },
-	{ "cycles:*", "Cycles" },
-	{ "ri:*", "RenderMan" },
-	{ "gl:*", "OpenGL" },
-	{ "usd:*", "USD" },
-	{ "user:*", "User" },
-	{ "render:* sampleMotion", "Standard" },
-};
+boost::container::flat_map<string, InternedString> g_optionCategories;
 
 void registerOptionCategory( InternedString category, const IECore::StringAlgo::MatchPattern &pattern )
 {

--- a/startup/gui/sceneInspector.py
+++ b/startup/gui/sceneInspector.py
@@ -1,0 +1,67 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import GafferSceneUI
+
+## \todo Investigate alternatives to these manual registrations. Perhaps we could register
+# category metadata for each attribute/option and use it directly in the SceneInspector instead?
+
+for category, pattern in {
+	"Arnold" : "ai:*",
+	"3Delight" : "dl:*",
+	"Cycles" : "cycles:*",
+	"RenderMan" : "ri:*",
+	"OpenGL" : "gl:*",
+	"USD" : "usd:*",
+	"User" : "user:*",
+	"Standard" :
+		"scene:visible doubleSided render:* gaffer:* "
+		"linkedLights shadowedLights filteredLights "
+		"surface displacement volume light",
+}.items() :
+	GafferSceneUI.SceneInspector.registerAttributeCategory( category, pattern )
+
+for category, pattern in {
+	"Arnold" : "ai:*",
+	"3Delight" : "dl:*",
+	"Cycles" : "cycles:*",
+	"RenderMan" : "ri:*",
+	"OpenGL" : "gl:*",
+	"USD" : "usd:*",
+	"User" : "user:*",
+	"Standard" : "render:* sampleMotion",
+}.items() :
+	GafferSceneUI.SceneInspector.registerOptionCategory( category, pattern )


### PR DESCRIPTION
We thought we wanted this to allow folks to do things like putting all `ie:` prefixed attributes in their own "Image Engine" category in the SceneInspector. But having written it as presented in this PR, I think it is the wrong approach.

What I now want to do instead is to continue the great metadata unification by registering `"attribute:<name>", "category"` metadata for each attribute, and using that automatically in the SceneInspector to produce the category subdivisions. Then at some point the AttributeEditor could do the same, and we'd have a single source of truth for all this stuff and the editors couldn't be configured to contradict each other. What do you think? If it sounds OK, then I'll ditch this PR and open another one with the metadata approach.

The only counterargument I can come up with is if people want to show the same attribute in multiple subsections. This does actually happen at Cinesite at present, where an additional SceneInspector section shows only shader attributes, while they are still available in the main section. If we want that, then I was going to continue the work on this PR to allow multiple categories to include the same attribute. Mind you, the same could be achieved using additional metadata, or StringVectorData metadata instead of StringData. And I'm not sure showing the same thing in two places is really a good idea anyway - it might confuse people as to the identity of the thing. I think I'd rather add advanced filtering like a "Show Only Shaders" checkbox instead.