### PR TITLE
RenderPassMenu : Add search field

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Improvements
 - AttributeTweaks, ShaderTweaks : Global attributes are now localised when `localise` is enabled and no matching attribute is found at the target location or any of its ancestors.
 - AttributeQuery, ShaderQuery : Global attributes are now queried when `inherit` is enabled and no matching attribute is found at the target location or any of its ancestors.
 - SphereLevelSet : Improved performance when evaluating the bounding box.
+- RenderPassMenu : Added a search menu which displays only the render passes matching the search text. The search menu can be disabled by registering the following metadata in a startup file. `Gaffer.Metadata.registerValue( Gaffer.ScriptNode, "variables.renderPass.value", "renderPassPlugValueWidget:searchable", False )`.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -22,6 +22,7 @@ Fixes
 - PathListingWidget : Columns set to automatically stretch now equally share available space when a PathListingWidget's columns are updated via `setColumns()`.
 - CyclesShader : Moved the `principled_bsdf.diffuse_roughness` parameter to a new "Diffuse" section in the Node Editor [^1].
 - ContextQuery : Removed `Create Context Query...` menu item from plugs where it was not relevant.
+- Menu : Executing a non-searchable menu item from a searchable menu no longer causes it to appear as the last used action in the menu's search field.
 
 API
 ---

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -1104,9 +1104,10 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 				GafferUI.Label( "Render Pass" )
 			self.__busyWidget = GafferUI.BusyWidget( size = 18 )
 			self.__busyWidget.setVisible( False )
+			searchable = Gaffer.Metadata.value( plug, "renderPassPlugValueWidget:searchable" )
 			self.__menuButton = GafferUI.MenuButton(
 				"",
-				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ) ),
+				menu = GafferUI.Menu( Gaffer.WeakMethod( self.__menuDefinition ), searchable = searchable if searchable is not None else True ),
 				highlightOnOver = False
 			)
 
@@ -1208,9 +1209,9 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 		renderPasses = self.__renderPasses.get( "enabled", [] ) if self.__hideDisabled else self.__renderPasses.get( "all", [] )
 
 		if self.__renderPasses is None :
-			result.append( "/Refresh", { "command" : Gaffer.WeakMethod( self.__refreshMenu ) } )
+			result.append( "/Refresh", { "command" : Gaffer.WeakMethod( self.__refreshMenu ), "searchable" : False } )
 		elif len( renderPasses ) == 0 :
-			result.append( "/No Render Passes Available", { "active" : False } )
+			result.append( "/No Render Passes Available", { "active" : False, "searchable" : False } )
 		else :
 			groupingFn = GafferSceneUI.RenderPassEditor.pathGroupingFunction()
 			prefixes = IECore.PathMatcher()
@@ -1253,7 +1254,8 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 			{
 				"checkBox" : self.__displayGrouped,
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setDisplayGrouped ) ),
-				"description" : "Toggle grouped display of render passes."
+				"description" : "Toggle grouped display of render passes.",
+				"searchable" : False
 			}
 		)
 
@@ -1262,7 +1264,8 @@ class _RenderPassPlugValueWidget( GafferUI.PlugValueWidget ) :
 			{
 				"checkBox" : self.__hideDisabled,
 				"command" : functools.partial( Gaffer.WeakMethod( self.__setHideDisabled ) ),
-				"description" : "Hide render passes disabled for rendering."
+				"description" : "Hide render passes disabled for rendering.",
+				"searchable" : False
 			}
 		)
 

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -400,7 +400,7 @@ class Menu( GafferUI.Widget ) :
 			else :
 				signal = qtAction.triggered[bool]
 
-			if self.__searchable :
+			if self.__searchable and getattr( item, "searchable", True ) :
 				signal.connect( IECore.curry( Gaffer.WeakMethod( self.__menuActionTriggered ), qtAction ) )
 
 			signal.connect( IECore.curry( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -401,7 +401,7 @@ class Menu( GafferUI.Widget ) :
 				signal = qtAction.triggered[bool]
 
 			if self.__searchable and getattr( item, "searchable", True ) :
-				signal.connect( functools.partial( Gaffer.WeakMethod( self.__menuActionTriggered ), qtAction ) )
+				signal.connect( functools.partial( Gaffer.WeakMethod( self.__searchableActionTriggered ), qtAction ) )
 
 			signal.connect( functools.partial( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )
 
@@ -653,7 +653,7 @@ class Menu( GafferUI.Widget ) :
 		if self.__searchMenu and self.__searchMenu.defaultAction() :
 			self.__searchMenu.defaultAction().trigger()
 
-	def __menuActionTriggered( self, action, checked ) :
+	def __searchableActionTriggered( self, action, checked ) :
 
 		if self.__lastAction is not None :
 			self.__lastAction.deleteLater()

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -307,7 +307,7 @@ class Menu( GafferUI.Widget ) :
 					qtMenu.addMenu( subMenu )
 
 					subMenu.__definition = definition.reRooted( "/" + name + "/" )
-					subMenu.aboutToShow.connect( IECore.curry( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
+					subMenu.aboutToShow.connect( functools.partial( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
 					if recurse :
 						self.__build( subMenu, recurse, forShortCuts=forShortCuts )
 
@@ -337,7 +337,7 @@ class Menu( GafferUI.Widget ) :
 						qtMenu.addMenu( subMenu )
 
 						subMenu.__definition = item.subMenu
-						subMenu.aboutToShow.connect( IECore.curry( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
+						subMenu.aboutToShow.connect( functools.partial( Gaffer.WeakMethod( self.__build ), weakref.ref( subMenu ) ) )
 						if recurse :
 							self.__build( subMenu, recurse, forShortCuts=forShortCuts )
 
@@ -401,9 +401,9 @@ class Menu( GafferUI.Widget ) :
 				signal = qtAction.triggered[bool]
 
 			if self.__searchable and getattr( item, "searchable", True ) :
-				signal.connect( IECore.curry( Gaffer.WeakMethod( self.__menuActionTriggered ), qtAction ) )
+				signal.connect( functools.partial( Gaffer.WeakMethod( self.__menuActionTriggered ), qtAction ) )
 
-			signal.connect( IECore.curry( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )
+			signal.connect( functools.partial( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )
 
 		active = self.__evaluateItemValue( item.active )
 		qtAction.setEnabled( active )

--- a/python/GafferUI/Menu.py
+++ b/python/GafferUI/Menu.py
@@ -401,6 +401,8 @@ class Menu( GafferUI.Widget ) :
 				signal = qtAction.triggered[bool]
 
 			if self.__searchable and getattr( item, "searchable", True ) :
+				## \todo Investigate why we don't use `weakref.ref( qtAction )` like in the connection below,
+				# and standardise on one approach or the other.
 				signal.connect( functools.partial( Gaffer.WeakMethod( self.__searchableActionTriggered ), qtAction ) )
 
 			signal.connect( functools.partial( Gaffer.WeakMethod( self.__actionTriggered ), weakref.ref( qtAction ) ) )


### PR DESCRIPTION
This makes the Render Pass Menu searchable, which can aid in navigation of the menu in scenes with large numbers of render passes.

<img width="398" height="431" alt="renderPassMenuSearch" src="https://github.com/user-attachments/assets/b6f523c7-52be-4875-ad1c-c7b661276353" />