### PR TITLE
InspectorColumn : Improve display of VectorData in InspectionPopupWindow

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Improvements
 - AttributeQuery, ShaderQuery : Global attributes are now queried when `inherit` is enabled and no matching attribute is found at the target location or any of its ancestors.
 - SphereLevelSet : Improved performance when evaluating the bounding box.
 - RenderPassMenu : Added a search menu which displays only the render passes matching the search text. The search menu can be disabled by registering the following metadata in a startup file. `Gaffer.Metadata.registerValue( Gaffer.ScriptNode, "variables.renderPass.value", "renderPassPlugValueWidget:searchable", False )`.
+- RenderPassEditor, AttributeEditor, LightEditor, SceneInspector : Improved presentation of VectorData types in the Inspect popup.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -29,6 +29,7 @@ API
 ---
 
 - ScenePlug : Added optional `withGlobalAttributes` arguments to `fullAttributes()` and `fullAttributesHash()`.
+- VectorDataWidget : Added optional `maximumVisibleRows` argument.
 
 Breaking Changes
 ----------------

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -689,14 +689,24 @@ class __InspectionPopupWindow( GafferUI.PopupWindow ) :
 
 				GafferUI.Label( "<b>Value</b>", parenting = { "index" : ( 0, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top ) } )
 
-				valueLabel = GafferUI.Label(
-					f"{inspection.value()}",
-					parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }
-				)
+				value = inspection.value()
+				## \todo It would be nice to support more widget types here, maybe we could create a common
+				# ValueWidget base class with a `create()` method similar to `PlugValueWidget.create()`?
+				if IECore.DataTraits.isSequenceDataType( value ) :
+					GafferUI.VectorDataWidget(
+						value, editable = False, maximumVisibleRows = 10,
+						parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }
+					)
+				else :
+					valueLabel = GafferUI.Label(
+						f"{value}",
+						parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }
+					)
 
-				valueLabel.buttonPressSignal().connect( lambda widget, event : True )
-				valueLabel.dragBeginSignal().connect( Gaffer.WeakMethod( self.__valueDragBegin ) )
-				valueLabel.dragEndSignal().connect( Gaffer.WeakMethod( self.__valueDragEnd  ))
+					valueLabel.buttonPressSignal().connect( lambda widget, event : True )
+					valueLabel.dragBeginSignal().connect( Gaffer.WeakMethod( self.__valueDragBegin ) )
+					valueLabel.dragEndSignal().connect( Gaffer.WeakMethod( self.__valueDragEnd ) )
+
 				button = GafferUI.Button( image = "duplicate.png", hasFrame = False, toolTip = "Copy Value", parenting = { "index" : ( 2, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) } )
 				button.clickedSignal().connect( Gaffer.WeakMethod( self.__valueCopyClicked ) )
 

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -65,6 +65,9 @@ class VectorDataWidget( GafferUI.Widget ) :
 	# may become visible - before this all rows should be directly visible with no need
 	# for scrolling.
 	#
+	# maximumVisibleRows specifies the maximum number of rows displayed before a vertical
+	# scroll bar becomes visible.
+	#
 	# columnToolTips may be specified as a list of strings to provide a tooltip for
 	# each data. Note that the `column` part of the name is misleading.
 	#
@@ -80,6 +83,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 		header=False,
 		showIndices=True,
 		minimumVisibleRows=8,
+		maximumVisibleRows = None,
 		columnToolTips=None,
 		sizeEditable=True,
 		columnEditability=None,
@@ -94,7 +98,7 @@ class VectorDataWidget( GafferUI.Widget ) :
 
 		# table view
 
-		self.__tableView = _TableView( minimumVisibleRows = minimumVisibleRows )
+		self.__tableView = _TableView( minimumVisibleRows = minimumVisibleRows, maximumVisibleRows = maximumVisibleRows )
 
 		self.__tableView.horizontalHeader().setMinimumSectionSize( 70 )
 

--- a/python/GafferUI/_TableView.py
+++ b/python/GafferUI/_TableView.py
@@ -41,15 +41,16 @@ from Qt import QtWidgets
 # A QTableView derived class with custom size behaviours we want for
 # GafferUI. This is not part of the public API.
 #
-# - Always requests enough space to show all cells if possible.
-# - Optionally refuses to shrink below a certain number of visible rows.
+# - Defaults to requesting enough space to show all cells if possible.
+# - Optionally refuses to shrink or grow beyond a certain number of visible rows.
 class _TableView( QtWidgets.QTableView ) :
 
-	def __init__( self, minimumVisibleRows = 0 ) :
+	def __init__( self, minimumVisibleRows = 0, maximumVisibleRows = None ) :
 
 		QtWidgets.QTableView.__init__( self )
 
 		self.__minimumVisibleRows = minimumVisibleRows
+		self.__maximumVisibleRows = maximumVisibleRows
 		self.horizontalHeader().sectionResized.connect( self.__sizeShouldChange )
 
 	def setModel( self, model ) :
@@ -125,7 +126,12 @@ class _TableView( QtWidgets.QTableView ) :
 		if self.horizontalScrollBarPolicy() != QtCore.Qt.ScrollBarAlwaysOff :
 			w += self.verticalScrollBar().sizeHint().width()
 
-		h = self.verticalHeader().length() + margins.top() + margins.bottom()
+		h = margins.top() + margins.bottom()
+		if self.__maximumVisibleRows is not None and self.__maximumVisibleRows < self.verticalHeader().count() :
+			h += self.verticalHeader().sectionSize( 0 ) * self.__maximumVisibleRows
+		else :
+			h += self.verticalHeader().length()
+
 		if not self.horizontalHeader().isHidden() :
 			h += self.horizontalHeader().sizeHint().height()
 		# allow room for a visible horizontal scrollbar to prevent it overlapping


### PR DESCRIPTION
A quick one to try out an idea to address the current issues displaying large VectorData types in the InspectorColumn's InspectionPopupWindow. This approach uses a VectorDataWidget in a ScrolledContainer to limit the maximum height to 10 rows, as I had trouble limiting the height directly on the VectorDataWidget itself...

<img width="562" height="744" alt="image" src="https://github.com/user-attachments/assets/854bb352-a087-4fe6-9a4b-608014049950" />