### PR TITLE
SphereLevelSet : Add more efficient overrides for `hash/computeBound()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Improvements
 - LocaliseAttributes : Added support for localising global attributes, controlled by the new `includeGlobalAttributes` plug.
 - AttributeTweaks, ShaderTweaks : Global attributes are now localised when `localise` is enabled and no matching attribute is found at the target location or any of its ancestors.
 - AttributeQuery, ShaderQuery : Global attributes are now queried when `inherit` is enabled and no matching attribute is found at the target location or any of its ancestors.
+- SphereLevelSet : Improved performance when evaluating the bounding box.
 
 Fixes
 -----

--- a/include/GafferVDB/SphereLevelSet.h
+++ b/include/GafferVDB/SphereLevelSet.h
@@ -76,6 +76,15 @@ class GAFFERVDB_API SphereLevelSet : public GafferScene::ObjectSource
 
 	protected :
 
+		// The ObjectSource base class does implement these bound methods for
+		// us, but only by computing the source object and taking its bound.
+		// Since that can be expensive for a high resolution voxel grid, we
+		// reimplement to provide an efficient version.
+		/// \todo Should the base class provide some facility for making this
+		/// easier, so we don't need to account for the transform?
+		void hashBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent, IECore::MurmurHash &h ) const override;
+		Imath::Box3f computeBound( const SceneNode::ScenePath &path, const Gaffer::Context *context, const GafferScene::ScenePlug *parent ) const override;
+
 		void hashSource( const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		IECore::ConstObjectPtr computeSource( const Gaffer::Context *context ) const override;
 


### PR DESCRIPTION
This fixes `SphereLevelSetTest.testBounds` which I broke when I merged e6cbd98b8e31b3f22ace606575eab54c9d8f5e36. That exposed a bug in `VDBObject::bound()` whereby it relied on metadata to provide the bound, when in fact the metadata is entirely optional. The VDBObject bug hasn't been a problem for any of our other VDB nodes because they compute Gaffer bounds efficiently rather than making them depend on the voxel grid. While we do have a fix for the VDBObject bug (see https://github.com/ImageEngine/cortex/pull/1423/), it seems worthwhile to have a more efficient implementation for SphereLevelSet anyway.
