### PR TITLE
ImageReader : ColorSpace should affect all layers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - PathListingWidget : Columns set to automatically stretch now equally share available space when a PathListingWidget's columns are updated via `setColumns()`.
 - CyclesShader : Moved the `principled_bsdf.diffuse_roughness` parameter to a new "Diffuse" section in the Node Editor [^1].
 - ContextQuery : Removed `Create Context Query...` menu item from plugs where it was not relevant.
+- ImageReader : If you specify a color space, it now affects all RGB layers ( previously it affected RGB, but not someLayerName.RGB )
 
 API
 ---

--- a/python/GafferImageTest/ImageReaderTest.py
+++ b/python/GafferImageTest/ImageReaderTest.py
@@ -127,6 +127,33 @@ class ImageReaderTest( GafferImageTest.ImageTestCase ) :
 
 		self.assertImagesEqual( colorSpace["out"], exrReader["out"], ignoreMetadata = True, maxDifference = 0.000001 )
 
+	def testColorSpaceOverrideOnLayers( self ) :
+
+		layersFileName = GafferImageTest.ImageTestCase.imagesPath() / "channelTestSinglePart.exr"
+
+		# Default reader assumes that image is already in `scene_linear`
+		# space, so no transform is applied during loading.
+		exrReader = GafferImage.ImageReader()
+		exrReader["fileName"].setValue( layersFileName )
+
+		# Override reader requires a transform from sRGB primaries to
+		# ACEScg primaries (the primaries for `scene_linear`).
+		overrideReader = GafferImage.ImageReader()
+		overrideReader["fileName"].setValue( layersFileName )
+		overrideReader["colorSpace"].setValue( "Linear Rec.709 (sRGB)" )
+
+		# Transform back manually and we should end up with the default
+		# image.
+		colorSpace = GafferImage.ColorSpace()
+		colorSpace["in"].setInput( overrideReader["out"] )
+		colorSpace["inputSpace"].setValue( "scene_linear" )
+		colorSpace["outputSpace"].setValue( "Linear Rec.709 (sRGB)" )
+
+		# We expect the reader to apply the transform to all layers
+		colorSpace["channels"].setValue( "*" )
+
+		self.assertImagesEqual( colorSpace["out"], exrReader["out"], ignoreMetadata = True, maxDifference = 0.000001 )
+
 	def testJpgRead( self ) :
 
 		exrReader = GafferImage.ImageReader()

--- a/src/GafferImage/ImageReader.cpp
+++ b/src/GafferImage/ImageReader.cpp
@@ -167,6 +167,7 @@ ImageReader::ImageReader( const std::string &name )
 	colorSpace->inPlug()->setInput( oiioReader->outPlug() );
 	colorSpace->inputSpacePlug()->setInput( intermediateColorSpacePlug() );
 	colorSpace->processUnpremultipliedPlug()->setValue( true );
+	colorSpace->channelsPlug()->setValue( "*" );
 	intermediateImagePlug()->setInput( colorSpace->outPlug() );
 
 	availableFramesPlug()->setInput( oiioReader->availableFramesPlug() );


### PR DESCRIPTION
As per discussion here: https://github.com/GafferHQ/gaffer/issues/6524

The ColorSpace node in ImageReader should have a channel mask of "*" so it affects all layers. ColorSpace already handles ignoring channels that are not colours.
