### PR TITLE
Option/Attribute "category" metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@ API
 
 - ScenePlug : Added optional `withGlobalAttributes` arguments to `fullAttributes()` and `fullAttributesHash()`.
 - VectorDataWidget : Added optional `maximumVisibleRows` argument.
+- Metadata : Added per-target signals for string targets, available via the `valueChangedSignal( target )` method. The old all-target `valueChangedSignal()` method is now deprecated.
 
 Breaking Changes
 ----------------

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,9 @@ Fixes
 - CyclesShader : Moved the `principled_bsdf.diffuse_roughness` parameter to a new "Diffuse" section in the Node Editor [^1].
 - ContextQuery : Removed `Create Context Query...` menu item from plugs where it was not relevant.
 - Menu : Executing a non-searchable menu item from a searchable menu no longer causes it to appear as the last used action in the menu's search field.
+- AttributeEditor :
+  - Added missing Cycles volume attributes.
+  - Renamed OpenGL "Shading" section to "Drawing", to match the NodeEditor.
 
 API
 ---

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -168,11 +168,12 @@ class GAFFER_API Metadata
 			InstanceDeregistration
 		};
 
-		using ValueChangedSignal = Signals::Signal<void ( IECore::InternedString target, IECore::InternedString key ), Signals::CatchingCombiner<void>>;
+		using ValueChangedSignal = Signals::Signal<void ( IECore::InternedString target, IECore::InternedString key, ValueChangedReason reason ), Signals::CatchingCombiner<void>>;
 		using NodeValueChangedSignal = Signals::Signal<void ( Node *node, IECore::InternedString key, ValueChangedReason reason ), Signals::CatchingCombiner<void>>;
 		using PlugValueChangedSignal = Signals::Signal<void ( Plug *plug, IECore::InternedString key, ValueChangedReason reason ), Signals::CatchingCombiner<void>>;
 
-		static ValueChangedSignal &valueChangedSignal();
+		/// Returns a signal that will be emitted when metadata has changed for `target`.
+		static ValueChangedSignal &valueChangedSignal( IECore::InternedString target );
 		/// Returns a signal that will be emitted when metadata has changed for `node`.
 		static NodeValueChangedSignal &nodeValueChangedSignal( Node *node );
 		/// Returns a signal that will be emitted when metadata has changed for any plug on `node`.
@@ -181,13 +182,16 @@ class GAFFER_API Metadata
 		/// Legacy signals
 		/// ==============
 		///
-		/// These signals are emitted when metadata is changed on _any_ node or
-		/// plug. Their usage leads to performance bottlenecks whereby all observers
+		/// These signals are emitted when metadata is changed on _any_ target.
+		/// Their usage leads to performance bottlenecks whereby all observers
 		/// are triggered by all edits. They will be removed in future.
 
+		using LegacyValueChangedSignal = Signals::Signal<void ( IECore::InternedString target, IECore::InternedString key ), Signals::CatchingCombiner<void>>;
 		using LegacyNodeValueChangedSignal = Signals::Signal<void ( IECore::TypeId nodeTypeId, IECore::InternedString key, Gaffer::Node *node ), Signals::CatchingCombiner<void>>;
 		using LegacyPlugValueChangedSignal = Signals::Signal<void ( IECore::TypeId typeId, const IECore::StringAlgo::MatchPattern &plugPath, IECore::InternedString key, Gaffer::Plug *plug ), Signals::CatchingCombiner<void>>;
 
+		/// \deprecated
+		static LegacyValueChangedSignal &valueChangedSignal();
 		/// Deprecated, but currently necessary for tracking inherited
 		/// changes to read-only metadata.
 		/// \deprecated

--- a/python/GafferSceneUI/AttributeEditor.py
+++ b/python/GafferSceneUI/AttributeEditor.py
@@ -380,6 +380,8 @@ class _SectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 						self._qtWidget().addTab( section or "Main" )
 					if "All" not in sections.keys() and len( sections.keys() ) > 1 :
 						self._qtWidget().addTab( "All" )
+
+			self._qtWidget().setVisible( self._qtWidget().count() > 1 )
 		finally :
 			self.__ignoreCurrentChanged = False
 

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1059,14 +1059,19 @@ class MetadataTest( GafferTest.TestCase ) :
 
 	def testOverwriteNonNodeMetadata( self ) :
 
-		cs = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal() )
+		legacyCS = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal() )
+		cs = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "testTarget" ) )
 
 		Gaffer.Metadata.registerValue( "testTarget", "testInt", 1 )
+		self.assertEqual( len( legacyCS ), 1 )
 		self.assertEqual( len( cs ), 1 )
+		self.assertEqual( cs[0], ( "testTarget", "testInt", Gaffer.Metadata.ValueChangedReason.StaticRegistration ) )
 		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testInt" ), 1 )
 
 		Gaffer.Metadata.registerValue( "testTarget", "testInt", 2 )
+		self.assertEqual( len( legacyCS ), 2 )
 		self.assertEqual( len( cs ), 2 )
+		self.assertEqual( cs[1], ( "testTarget", "testInt", Gaffer.Metadata.ValueChangedReason.StaticRegistration ) )
 		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testInt" ), 2 )
 
 	def testDeregisterNonNodeMetadata( self ) :
@@ -1074,16 +1079,22 @@ class MetadataTest( GafferTest.TestCase ) :
 		Gaffer.Metadata.registerValue( "testTarget", "testInt", 1 )
 		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testInt" ), 1 )
 
-		cs = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal() )
+		legacyCS = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal() )
+		cs = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "testTarget" ) )
+
 		Gaffer.Metadata.deregisterValue( "testTarget", "testInt" )
+		self.assertEqual( len( legacyCS ), 1 )
 		self.assertEqual( len( cs ), 1 )
-		self.assertEqual( cs[0], ( "testTarget", "testInt" ) )
+		self.assertEqual( legacyCS[0], ( "testTarget", "testInt" ) )
+		self.assertEqual( cs[0], ( "testTarget", "testInt", Gaffer.Metadata.ValueChangedReason.StaticDeregistration ) )
 		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testInt" ), None )
 
 		Gaffer.Metadata.deregisterValue( "testTarget", "nonExistentKey" )
+		self.assertEqual( len( legacyCS ), 1 )
 		self.assertEqual( len( cs ), 1 )
 
 		Gaffer.Metadata.deregisterValue( "nonExistentTarget", "testInt" )
+		self.assertEqual( len( legacyCS ), 1 )
 		self.assertEqual( len( cs ), 1 )
 
 	def testSerialisationQuoting( self ) :
@@ -1474,6 +1485,50 @@ class MetadataTest( GafferTest.TestCase ) :
 		# registration.
 		Gaffer.Metadata.registerValue( "target1", "key1", "value2" )
 		self.assertEqual( Gaffer.Metadata.value( "target1", "key1" ), "value2" )
+
+	def testPerTargetSignals( self ) :
+
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target1", "key1" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target2", "key1" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target3", "key1" )
+
+		cs1 = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "target1" ) )
+		cs2 = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "target2" ) )
+
+		Gaffer.Metadata.registerValue( "target1", "key1", "value1" )
+		self.assertEqual( len( cs1 ), 1 )
+		self.assertEqual( cs1[0], ( "target1", "key1", Gaffer.Metadata.ValueChangedReason.StaticRegistration ) )
+		self.assertEqual( len( cs2 ), 0 )
+
+		Gaffer.Metadata.registerValue( "target2", "key1", "value1" )
+		self.assertEqual( len( cs1 ), 1 )
+		self.assertEqual( len( cs2 ), 1 )
+		self.assertEqual( cs2[0], ( "target2", "key1", Gaffer.Metadata.ValueChangedReason.StaticRegistration ) )
+
+		Gaffer.Metadata.registerValue( "target3", "key1", "value1" )
+		self.assertEqual( len( cs1 ), 1 )
+		self.assertEqual( len( cs2 ), 1 )
+
+	def testWildcardTargetChangeSignalling( self ) :
+
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "foo*", "key" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "bar*", "key" )
+
+		cs1 = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "foo1" ) )
+		cs2 = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "foo2" ) )
+		cs3 = GafferTest.CapturingSlot( Gaffer.Metadata.valueChangedSignal( "bar3" ) )
+
+		Gaffer.Metadata.registerValue( "foo*", "key", "value" )
+
+		self.assertEqual( len( cs1 ), 1 )
+		self.assertEqual( len( cs2 ), 1 )
+		self.assertEqual( len( cs3 ), 0 )
+
+		Gaffer.Metadata.registerValue( "bar*", "key", "value" )
+
+		self.assertEqual( len( cs1 ), 1 )
+		self.assertEqual( len( cs2 ), 1 )
+		self.assertEqual( len( cs3 ), 1 )
 
 	def tearDown( self ) :
 

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1447,6 +1447,34 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( Gaffer.Metadata.value( "testTarget2", "description" ), "multi line\ndescription" )
 		self.assertEqual( Gaffer.Metadata.value( "testTarget2", "otherValue" ), IECore.StringVectorData( [ "A", "B", "C" ] ) )
 
+	def testWildcardTargets( self ) :
+
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target*", "key1" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target1", "key1" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, "target1", "key2" )
+
+		self.assertIsNone( Gaffer.Metadata.value( "target1", "key1" ) )
+
+		Gaffer.Metadata.registerValue( "target*", "key1", "value1" )
+		self.assertEqual( Gaffer.Metadata.value( "target1", "key1" ), "value1" )
+
+		# Because the registration is against wildcards, it doesn't create a
+		# concrete target that can be queried by `targetsWithMetadata`.
+		self.assertEqual( Gaffer.Metadata.targetsWithMetadata( "*", "key1" ), [] )
+		# But as soon as a concrete target exists (for any key), then the
+		# wildcard registrations will be considered for it.
+		Gaffer.Metadata.registerValue( "target1", "key2", "value2" )
+		self.assertEqual( Gaffer.Metadata.targetsWithMetadata( "*", "key1" ), [ "target1" ] )
+		# And if the concrete target is removed, then the `targetsWithMetadata()`
+		# will once again be empty.
+		Gaffer.Metadata.deregisterValue( "target1", "key2" )
+		self.assertEqual( Gaffer.Metadata.targetsWithMetadata( "*", "key1" ), [] )
+
+		# A concrete registration takes precedence over a wildcard
+		# registration.
+		Gaffer.Metadata.registerValue( "target1", "key1", "value2" )
+		self.assertEqual( Gaffer.Metadata.value( "target1", "key1" ), "value2" )
+
 	def tearDown( self ) :
 
 		GafferTest.TestCase.tearDown( self )

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -68,8 +68,41 @@ using namespace Gaffer;
 namespace
 {
 
-// Signals
-// =======
+// Signals for string targets
+// ==========================
+
+using StringSignalsMap = std::unordered_map<InternedString, Metadata::ValueChangedSignal>;
+StringSignalsMap &stringSignalsMap()
+{
+	static StringSignalsMap *g_stringSignalsMap = new StringSignalsMap;
+	return *g_stringSignalsMap;
+}
+
+void emitValueChangedSignals( InternedString target, InternedString key, Metadata::ValueChangedReason reason )
+{
+	StringSignalsMap &m = stringSignalsMap();
+	if( StringAlgo::hasWildcards( target.c_str() ) )
+	{
+		for( auto &[t, signal] : m )
+		{
+			if( StringAlgo::matchMultiple( t.string(), target.string() ) )
+			{
+				signal( t, key, reason );
+			}
+		}
+	}
+	else
+	{
+		auto it = m.find( target );
+		if( it != m.end() )
+		{
+			it->second( target, key, reason );
+		}
+	}
+}
+
+// Signals for Node/Plug targets
+// =============================
 //
 // We store all our signals in a map indexed by `Node *`. Although we do not
 // allow concurrent edits to a node graph, we do allow different node graphs to
@@ -526,9 +559,8 @@ void Metadata::registerValue( IECore::InternedString target, IECore::InternedStr
 		values->replace( keyIt.first, namedValue );
 	}
 
-	/// \todo This doesn't make much sense when the target is wildcarded. Would
-	/// we be better off matching the node/plug signals and providing a signal
-	/// per target?
+	emitValueChangedSignals( target, key, ValueChangedReason::StaticRegistration );
+	// Legacy signal receives target directly, even if it contains wildcards.
 	valueChangedSignal()( target, key );
 }
 
@@ -557,6 +589,8 @@ void Metadata::deregisterValue( IECore::InternedString target, IECore::InternedS
 		m.erase( mIt );
 	}
 
+	emitValueChangedSignals( target, key, ValueChangedReason::StaticDeregistration );
+	// Legacy signal receives target directly, even if it contains wildcards.
 	valueChangedSignal()( target, key );
 }
 
@@ -1002,10 +1036,9 @@ IECore::ConstDataPtr Metadata::valueInternal( const GraphComponent *target, IECo
 	return Metadata::valueInternal( target, key, registrationTypes( instanceOnly ) );
 }
 
-Metadata::ValueChangedSignal &Metadata::valueChangedSignal()
+Metadata::ValueChangedSignal &Metadata::valueChangedSignal( InternedString target )
 {
-	static ValueChangedSignal *s = new ValueChangedSignal;
-	return *s;
+	return stringSignalsMap()[target];
 }
 
 Metadata::NodeValueChangedSignal &Metadata::nodeValueChangedSignal( Node *node )
@@ -1016,6 +1049,12 @@ Metadata::NodeValueChangedSignal &Metadata::nodeValueChangedSignal( Node *node )
 Metadata::PlugValueChangedSignal &Metadata::plugValueChangedSignal( Node *node )
 {
 	return nodeSignals( node, /* createIfMissing = */ true )->plugSignal;
+}
+
+Metadata::LegacyValueChangedSignal &Metadata::valueChangedSignal()
+{
+	static LegacyValueChangedSignal *s = new LegacyValueChangedSignal;
+	return *s;
 }
 
 Metadata::LegacyNodeValueChangedSignal &Metadata::nodeValueChangedSignal()

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -235,6 +235,14 @@ MetadataMap &metadataMap()
 	return *g_m;
 }
 
+using WildcardMetadataMap = std::unordered_map<InternedString, Values>;
+
+WildcardMetadataMap &wildcardMetadataMap()
+{
+	static auto g_m = new WildcardMetadataMap;
+	return *g_m;
+}
+
 // Value storage for type-based targets
 // ====================================
 
@@ -491,25 +499,36 @@ void Metadata::registerValue( IECore::InternedString target, IECore::InternedStr
 
 void Metadata::registerValue( IECore::InternedString target, IECore::InternedString key, ValueFunction value )
 {
-	auto &targetMap = metadataMap();
-
-	auto targetIt = targetMap.find( target );
-	if( targetIt == targetMap.end() )
+	Values *values = nullptr;
+	if( StringAlgo::hasWildcards( target.c_str() ) )
 	{
-		targetIt = targetMap.insert( NamedValues( target, Values() ) ).first;
+		values = &wildcardMetadataMap()[target];
 	}
+	else
+	{
+		auto &targetMap = metadataMap();
 
-	// Cast is safe because we don't use `second` as a key in the `multi_index_container`,
-	// so we can modify it without affecting indexing.
-	Values &values = const_cast<Values &>( targetIt->second );
+		auto targetIt = targetMap.find( target );
+		if( targetIt == targetMap.end() )
+		{
+			targetIt = targetMap.insert( NamedValues( target, Values() ) ).first;
+		}
+
+		// Cast is safe because we don't use `second` as a key in the `multi_index_container`,
+		// so we can modify it without affecting indexing.
+		values = const_cast<Values *>( &targetIt->second );
+	}
 
 	const NamedValue namedValue( key, value );
-	auto keyIt = values.insert( namedValue );
+	auto keyIt = values->insert( namedValue );
 	if( !keyIt.second )
 	{
-		values.replace( keyIt.first, namedValue );
+		values->replace( keyIt.first, namedValue );
 	}
 
+	/// \todo This doesn't make much sense when the target is wildcarded. Would
+	/// we be better off matching the node/plug signals and providing a signal
+	/// per target?
 	valueChangedSignal()( target, key );
 }
 
@@ -533,6 +552,11 @@ void Metadata::deregisterValue( IECore::InternedString target, IECore::InternedS
 	}
 
 	values.erase( vIt );
+	if( values.empty() )
+	{
+		m.erase( mIt );
+	}
+
 	valueChangedSignal()( target, key );
 }
 
@@ -556,16 +580,29 @@ IECore::ConstDataPtr Metadata::valueInternal( IECore::InternedString target, IEC
 {
 	const MetadataMap &m = metadataMap();
 	MetadataMap::const_iterator it = m.find( target );
-	if( it == m.end() )
+	if( it != m.end() )
 	{
-		return nullptr;
+		Values::const_iterator vIt = it->second.find( key );
+		if( vIt != it->second.end() )
+		{
+			return vIt->second();
+		}
 	}
 
-	Values::const_iterator vIt = it->second.find( key );
-	if( vIt != it->second.end() )
+	for( const auto &[pattern, values] : wildcardMetadataMap() )
 	{
-		return vIt->second();
+		if( !IECore::StringAlgo::matchMultiple( target.string(), pattern ) )
+		{
+			continue;
+		}
+
+		Values::const_iterator vIt = values.find( key );
+		if( vIt != values.end() )
+		{
+			return vIt->second();
+		}
 	}
+
 	return nullptr;
 }
 
@@ -573,13 +610,33 @@ std::vector<IECore::InternedString> Metadata::targetsWithMetadata( const IECore:
 {
 	vector<InternedString> result;
 	const auto &orderedIndex = metadataMap().get<1>();
+	const auto &wildcardMap = wildcardMetadataMap();
+
 	for( const auto &[target, values] : orderedIndex )
 	{
 		if( !StringAlgo::matchMultiple( target.c_str(), targetPattern ) )
 		{
 			continue;
 		}
-		if( values.find( key ) != values.end() )
+
+		bool hasMetadata = values.find( key ) != values.end();
+		if( !hasMetadata )
+		{
+			for( const auto &[pattern, wildcardValues] : wildcardMap )
+			{
+				if(
+					StringAlgo::matchMultiple( target.string(), pattern ) &&
+					wildcardValues.find( key ) != wildcardValues.end()
+
+				)
+				{
+					hasMetadata = true;
+					break;
+				}
+			}
+		}
+
+		if( hasMetadata )
 		{
 			result.push_back( target );
 		}

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -268,9 +268,9 @@ void registerPlugValue( IECore::TypeId nodeTypeId, const char *plugPath, IECore:
 struct ValueChangedSlotCaller
 {
 
-	void operator()( boost::python::object slot, IECore::InternedString target, IECore::InternedString key )
+	void operator()( boost::python::object slot, IECore::InternedString target, IECore::InternedString key, Metadata::ValueChangedReason reason )
 	{
-		slot( target.c_str(), key.c_str() );
+		slot( target.c_str(), key.c_str(), reason );
 	}
 
 	void operator()( boost::python::object slot, Node *node, IECore::InternedString key, Metadata::ValueChangedReason reason )
@@ -281,6 +281,11 @@ struct ValueChangedSlotCaller
 	void operator()( boost::python::object slot, Plug *plug, IECore::InternedString key, Metadata::ValueChangedReason reason )
 	{
 		slot( PlugPtr( plug ), key.c_str(), reason );
+	}
+
+	void operator()( boost::python::object slot, IECore::InternedString target, IECore::InternedString key )
+	{
+		slot( target.c_str(), key.c_str() );
 	}
 
 	void operator()( boost::python::object slot, IECore::TypeId nodeTypeId, IECore::InternedString key, Node *node )
@@ -400,6 +405,7 @@ void GafferModule::bindMetadata()
 		SignalClass<Metadata::ValueChangedSignal, DefaultSignalCaller<Metadata::ValueChangedSignal>, ValueChangedSlotCaller>( "ValueChangedSignal" );
 		SignalClass<Metadata::NodeValueChangedSignal, DefaultSignalCaller<Metadata::NodeValueChangedSignal>, ValueChangedSlotCaller>( "NodeValueChangedSignal" );
 		SignalClass<Metadata::PlugValueChangedSignal, DefaultSignalCaller<Metadata::PlugValueChangedSignal>, ValueChangedSlotCaller>( "PlugValueChangedSignal" );
+		SignalClass<Metadata::LegacyValueChangedSignal, DefaultSignalCaller<Metadata::LegacyValueChangedSignal>, ValueChangedSlotCaller>( "LegacyValueChangedSignal" );
 		SignalClass<Metadata::LegacyNodeValueChangedSignal, DefaultSignalCaller<Metadata::LegacyNodeValueChangedSignal>, ValueChangedSlotCaller>( "LegacyNodeValueChangedSignal" );
 		SignalClass<Metadata::LegacyPlugValueChangedSignal, DefaultSignalCaller<Metadata::LegacyPlugValueChangedSignal>, ValueChangedSlotCaller>( "LegacyPlugValueChangedSignal" );
 	}
@@ -469,7 +475,8 @@ void GafferModule::bindMetadata()
 		.def( "registerNode", boost::python::raw_function( &registerNode, 1 ) )
 		.staticmethod( "registerNode" )
 
-		.def( "valueChangedSignal", &Metadata::valueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "valueChangedSignal", (Metadata::LegacyValueChangedSignal &(*)() )&Metadata::valueChangedSignal, return_value_policy<reference_existing_object>() )
+		.def( "valueChangedSignal", (Metadata::ValueChangedSignal &(*)( InternedString ) )&Metadata::valueChangedSignal, return_value_policy<reference_existing_object>() )
 		.staticmethod( "valueChangedSignal" )
 
 		.def( "nodeValueChangedSignal", (Metadata::LegacyNodeValueChangedSignal &(*)() )&Metadata::nodeValueChangedSignal, return_value_policy<reference_existing_object>() )

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -1407,7 +1407,7 @@ InspectorTree::Inspections globalAttributesInspectionProvider( ScenePlug *scene,
 			continue;
 		}
 
-		string optionName = name.string().substr( g_attributePrefix.size() );
+		string attributeName = name.string().substr( g_attributePrefix.size() );
 		InternedString category = g_other;
 		for( const auto &[pattern, matchingCategory] : g_attributeCategories )
 		{
@@ -1418,7 +1418,7 @@ InspectorTree::Inspections globalAttributesInspectionProvider( ScenePlug *scene,
 			}
 		}
 		result.push_back( {
-			{ category, optionName },
+			{ category, attributeName },
 			new GafferSceneUI::Private::BasicInspector(
 				scene->globalsPlug(), editScope,
 				[ name = name ] ( const CompoundObjectPlug *globalsPlug ) {

--- a/src/GafferUIModule/PathListingWidgetBinding.cpp
+++ b/src/GafferUIModule/PathListingWidgetBinding.cpp
@@ -218,7 +218,7 @@ QString toString( T v, typename std::enable_if<std::is_floating_point_v<T> || st
 }
 
 template<typename T>
-QString toString( T v, typename std::enable_if<std::is_integral_v<T>>::type *enabler = nullptr )
+QString toString( T v, typename std::enable_if<std::is_integral_v<T> || std::is_same_v<T, std::vector<bool>::const_reference>>::type *enabler = nullptr )
 {
 	return QString::number( v );
 }

--- a/startup/GafferScene/arnoldAttributes.py
+++ b/startup/GafferScene/arnoldAttributes.py
@@ -714,3 +714,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:ai:*", "category", "Arnold" )

--- a/startup/GafferScene/arnoldOptions.py
+++ b/startup/GafferScene/arnoldOptions.py
@@ -1020,3 +1020,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "option:ai:*", "category", "Arnold" )

--- a/startup/GafferScene/cyclesAttributes.py
+++ b/startup/GafferScene/cyclesAttributes.py
@@ -414,3 +414,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:cycles:*", "category", "Cycles" )

--- a/startup/GafferScene/cyclesOptions.py
+++ b/startup/GafferScene/cyclesOptions.py
@@ -1045,3 +1045,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "option:cycles:*", "category", "Cycles" )

--- a/startup/GafferScene/delightAttributes.py
+++ b/startup/GafferScene/delightAttributes.py
@@ -144,3 +144,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:dl:*", "category", "3Delight" )

--- a/startup/GafferScene/delightOptions.py
+++ b/startup/GafferScene/delightOptions.py
@@ -468,3 +468,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "option:dl:*", "category", "3Delight" )

--- a/startup/GafferScene/openGLAttributes.py
+++ b/startup/GafferScene/openGLAttributes.py
@@ -363,3 +363,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:gl:*", "category", "OpenGL" )

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -161,3 +161,5 @@ with IECore.IgnoredExceptions( ImportError ) :
 		"displacementbound:offscreen",
 	] :
 		Gaffer.Metadata.registerValue( f"attribute:ri:{attribute}", "plugValueWidget:type", "GafferUI.BoolPlugValueWidget" )
+
+Gaffer.Metadata.registerValue( "attribute:ri:*", "category", "RenderMan" )

--- a/startup/GafferScene/renderManOptions.py
+++ b/startup/GafferScene/renderManOptions.py
@@ -273,3 +273,5 @@ with IECore.IgnoredExceptions( ImportError ) :
 		],
 
 	} )
+
+Gaffer.Metadata.registerValue( "option:ri:*", "category", "RenderMan" )

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -163,6 +163,7 @@ Gaffer.Metadata.registerValues( {
 		""",
 		"category", "Standard",
 		"label", "Mute",
+		"layout:section", "Light",
 
 	],
 

--- a/startup/GafferScene/standardAttributes.py
+++ b/startup/GafferScene/standardAttributes.py
@@ -53,6 +53,7 @@ Gaffer.Metadata.registerValues( {
 		always make all the children invisible too, regardless
 		of their visibility settings.
 		""",
+		"category", "Standard",
 		"label", "Visible",
 		"layout:section", "Attributes",
 
@@ -67,6 +68,7 @@ Gaffer.Metadata.registerValues( {
 		Single sided objects appear invisible when seen from
 		the back.
 		""",
+		"category", "Standard",
 		"label", "Double Sided",
 		"layout:section", "Attributes",
 
@@ -84,6 +86,7 @@ Gaffer.Metadata.registerValues( {
 		> Tip : For more detailed control of object appearance in the
 		> Viewer, use OpenGL attributes.
 		""",
+		"category", "Standard",
 		"label", "Display Color",
 		"layout:section", "Attributes",
 
@@ -99,6 +102,7 @@ Gaffer.Metadata.registerValues( {
 		`gaffer:transformBlurSegments` attribute to specify
 		the number of segments used to represent the motion.
 		""",
+		"category", "Standard",
 		"label", "Transform Blur",
 		"layout:section", "Motion Blur",
 
@@ -113,6 +117,7 @@ Gaffer.Metadata.registerValues( {
 		The number of segments of transform animation to
 		pass to the renderer when Transform Blur is on.
 		""",
+		"category", "Standard",
 		"label", "Transform Segments",
 		"layout:section", "Motion Blur",
 
@@ -128,6 +133,7 @@ Gaffer.Metadata.registerValues( {
 		`gaffer:deformationBlurSegments` attribute to specify
 		the number of segments used to represent the motion.
 		""",
+		"category", "Standard",
 		"label", "Deformation Blur",
 		"layout:section", "Motion Blur",
 
@@ -142,6 +148,7 @@ Gaffer.Metadata.registerValues( {
 		The number of segments of deformation animation to
 		pass to the renderer when Deformation Blur is on.
 		""",
+		"category", "Standard",
 		"label", "Deformation Segments",
 		"layout:section", "Motion Blur",
 
@@ -154,6 +161,7 @@ Gaffer.Metadata.registerValues( {
 		"""
 		Whether this light is muted.
 		""",
+		"category", "Standard",
 		"label", "Mute",
 
 	],
@@ -183,6 +191,7 @@ Gaffer.Metadata.registerValues( {
 		> Info : Lights can be added to sets either by using the `sets` plug
 		> on the light node itself, or by using a separate Set node.
 		""",
+		"category", "Standard",
 		"label", "Linked Lights",
 		"layout:section", "Light Linking",
 
@@ -199,6 +208,7 @@ Gaffer.Metadata.registerValues( {
 		The lights that cast shadows from this object. Accepts a set
 		expression or a space separated list of lights.
 		""",
+		"category", "Standard",
 		"label", "Shadowed Lights",
 		"layout:section", "Light Linking",
 
@@ -217,6 +227,7 @@ Gaffer.Metadata.registerValues( {
 		Use \"defaultLights\" to refer to all lights that
 		contribute to illumination by default.
 		""",
+		"category", "Standard",
 		"label", "Filtered Lights",
 		"layout:section", "Light Linking",
 
@@ -237,9 +248,12 @@ Gaffer.Metadata.registerValues( {
 		copies to displace differently. Disabling is currently only supported by
 		the Arnold and RenderMan renderer backends.
 		""",
+		"category", "Standard",
 		"label", "Automatic Instancing",
 		"layout:section", "Instancing",
 
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:user:*", "category", "User" )

--- a/startup/GafferScene/standardOptions.py
+++ b/startup/GafferScene/standardOptions.py
@@ -540,3 +540,6 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "option:render:* option:sampleMotion option:renderPass:*", "category", "Standard" )
+Gaffer.Metadata.registerValue( "option:user:*", "category", "User" )

--- a/startup/GafferScene/usdAttributes.py
+++ b/startup/GafferScene/usdAttributes.py
@@ -89,3 +89,5 @@ Gaffer.Metadata.registerValues( {
 	],
 
 } )
+
+Gaffer.Metadata.registerValue( "attribute:usd:*", "category", "USD" )

--- a/startup/gui/attributeEditor.py
+++ b/startup/gui/attributeEditor.py
@@ -41,192 +41,51 @@ import IECore
 import Gaffer
 import GafferSceneUI
 
-## \todo Investigate alternatives to these manual registrations, perhaps we could register
-# "Section" metadata for each attribute and use it here and in the Node Editor UI?
+# Register attribute columns for all attributes we have metadata for.
+## \todo Potentially the AttributeEditor should just do this itself automatically.
+
+for target in Gaffer.Metadata.targetsWithMetadata( "attribute:*", "defaultValue" ) :
+
+	category = Gaffer.Metadata.value( target, "category" )
+	if not category :
+		continue
+
+	section = Gaffer.Metadata.value( target, "layout:section" )
+	if section :
+		# AttributeEditor doesn't support nested sections, so just take
+		# the top-level section.
+		section = section.partition( "." )[0]
+
+	GafferSceneUI.AttributeEditor.registerAttribute(
+		category, target[10:], section, Gaffer.Metadata.value( target, "label" )
+	)
+
+# Register `tabGroup` presets to allow the user to switch between the categories.
+## \todo Potentially the AttributeEditor should just do this itself automatically.
+# For now the manual registration is somewhat useful in that it allows us to avoid
+# exposing renderers that aren't available.
+## \todo Consider renaming the `tabGroup` plug to `category`.
 
 Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:Standard", "Standard" )
 Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "userDefault", "Standard" )
 
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "scene:visible", "Attributes" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "render:displayColor", "Attributes" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "doubleSided", "Attributes" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:transformBlur", "Motion Blur" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:transformBlurSegments", "Motion Blur" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:deformationBlur", "Motion Blur" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:deformationBlurSegments", "Motion Blur" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "linkedLights", "Light Linking" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "shadowedLights", "Light Linking" )
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "filteredLights", "Light Linking" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "gaffer:automaticInstancing", "Instancing" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "Standard", "light:mute", "Light" )
-
 Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:USD", "USD" )
 
-GafferSceneUI.AttributeEditor.registerAttribute( "USD", "usd:kind", "Attributes" )
-GafferSceneUI.AttributeEditor.registerAttribute( "USD", "usd:purpose", "Attributes" )
-
 with IECore.IgnoredExceptions( ImportError ) :
-
-	# This import appears unused, but it is intentional; it prevents us from
-	# registering when Arnold isn't available.
 	import GafferArnold
-
 	Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:Arnold", "Arnold" )
 
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:camera", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:shadow", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:shadow_group", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:diffuse_reflect", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:specular_reflect", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:diffuse_transmit", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:specular_transmit", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:volume", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:visibility:subsurface", "Visibility" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:disp_autobump", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:camera", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:shadow", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:diffuse_reflect", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:specular_reflect", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:diffuse_transmit", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:specular_transmit", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:volume", "Displacement" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:autobump_visibility:subsurface", "Displacement" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:transform_type", "Transform" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:matte", "Shading" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:opaque", "Shading" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:receive_shadows", "Shading" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:self_shadows", "Shading" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:sss_setname", "Shading" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_iterations", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_adaptive_error", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_adaptive_metric", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_adaptive_space", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_uv_smoothing", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_smooth_derivs", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdiv_frustum_ignore", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:polymesh:subdivide_polygons", "Subdivision" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:curves:mode", "Curves" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:curves:min_pixel_width", "Curves" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:points:min_pixel_width", "Points" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:volume:step_size", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:volume:step_scale", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:shape:step_size", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:shape:step_scale", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:shape:volume_padding", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:volume:velocity_scale", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:volume:velocity_fps", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:volume:velocity_outlier_threshold", "Volume" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Arnold", "ai:toon_id", "Toon" )
-
 if os.environ.get( "CYCLES_ROOT" ) and os.environ.get( "GAFFERCYCLES_HIDE_UI", "" ) != "1" :
-
 	Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:Cycles", "Cycles" )
 
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:camera", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:diffuse", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:glossy", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:transmission", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:shadow", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:visibility:scatter", "Visibility" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:use_holdout", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:is_shadow_catcher", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shadow_terminator_shading_offset", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shadow_terminator_geometry_offset", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:is_caustics_caster", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:is_caustics_receiver", "Rendering" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:lightgroup", "Rendering" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:max_level", "Subdivision" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:dicing_rate", "Subdivision" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:volume_clipping", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:volume_step_size", "Volume" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:volume_object_space", "Volume" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:asset_name", "Object" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:emission_sampling_method", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:use_transparent_shadow", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:heterogeneous_volume", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:volume_sampling_method", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:volume_interpolation_method", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:volume_step_rate", "Shader" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "Cycles", "cycles:shader:displacement_method", "Shader" )
-
 with IECore.IgnoredExceptions( ImportError ) :
-
-	# This import appears unused, but it is intentional; it prevents us from
-	# registering when 3Delight isn't available.
 	import GafferDelight
-
 	Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:3Delight", "3Delight" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.camera", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.diffuse", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.hair", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.reflection", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.refraction", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.shadow", "Visibility" )
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:visibility.specular", "Visibility" )
-
-	GafferSceneUI.AttributeEditor.registerAttribute( "3Delight", "dl:matte", "Shading" )
 
 if os.environ.get( "GAFFERRENDERMAN_HIDE_UI", "" ) != "1" :
 
 	with IECore.IgnoredExceptions( ImportError ) :
-
-		# This import appears unused, but it is intentional; it prevents us from
-		# registering when RenderMan isn't available.
 		import GafferRenderMan
-
 		Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:RenderMan", "RenderMan" )
 
-		# Register all options we have metadata for.
-		## \todo We should probably do things this way for the other renderers too. The
-		# AttributeEditor could just read the metadata itself then, and we wouldn't
-		# need `registerAttribute()` at all.
-		for target in Gaffer.Metadata.targetsWithMetadata( "attribute:ri:*", "defaultValue" ) :
-			GafferSceneUI.AttributeEditor.registerAttribute(
-				"RenderMan", target[10:], Gaffer.Metadata.value( target, "layout:section" ), Gaffer.Metadata.value( target, "label" )
-			)
-
 Gaffer.Metadata.registerValue( GafferSceneUI.AttributeEditor.Settings, "tabGroup", "preset:OpenGL", "OpenGL" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:solid", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:wireframe", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:wireframeColor", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:wireframeWidth", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:outline", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:outlineColor", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:outlineWidth", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:points", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:pointColor", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:pointWidth", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:bound", "Shading" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:primitive:boundColor", "Shading" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:pointsPrimitive:useGLPoints", "Points" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:pointsPrimitive:glPointWidth", "Points" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:curvesPrimitive:useGLLines", "Curves" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:curvesPrimitive:glLineWidth", "Curves" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:curvesPrimitive:ignoreBasis", "Curves" )
-
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:visualiser:scale", "Visualisers" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:visualiser:maxTextureResolution", "Visualisers" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:visualiser:frustum", "Visualisers" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:light:frustumScale", "Visualisers" )
-GafferSceneUI.AttributeEditor.registerAttribute( "OpenGL", "gl:light:drawingMode", "Visualisers" )


### PR DESCRIPTION
This replaces the hardcoded attribute/option categories from the SceneInspector with customisable metadata registrations made by `startup/GafferScene`. It also updates the AttributeEditor configuration to use the categories, removing a bunch of duplication. This will allow studios to more easily customise both editor layouts for site-specific options and attributes. 