### PR TITLE
VisualiserTool : Add missing include

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,12 @@
 1.6.x.x (relative to 1.6.0.0a3)
 =======
 
+Fixes
+-----
 
+- VisualiserTool : Fixed "undefined variable FLT_EPSILON" errors [^1].
+
+[^1]: To be omitted from the notes for the final 1.6.0.0 release.
 
 1.6.0.0a3 (relative to 1.6.0.0a2)
 =========

--- a/src/GafferSceneUI/VisualiserTool.cpp
+++ b/src/GafferSceneUI/VisualiserTool.cpp
@@ -83,6 +83,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include <algorithm>
 #include <cassert>
+#include <cfloat>
 #include <limits>
 #include <string>
 


### PR DESCRIPTION
Without it, we see `ERROR : GLWidget : 0(14) : error C1503: undefined variable "FLT_EPSILON"` errors while using the VisualiserTool on Linux.