### PR TITLE
Wrapper : Remove `GAFFERRENDERMAN_FEATURE_PREVIEW` check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,6 @@ jobs:
     env:
       ARNOLD_LICENSE_ORDER: none # Don't waste time looking for a license that doesn't exist
       ARNOLD_FORCE_ABORT_ON_LICENSE_FAIL: 0 # And don't abort because the license isn't found
-      GAFFERRENDERMAN_FEATURE_PREVIEW: 1
       GAFFER_BUILD_DIR: "./build"
       GAFFER_CACHE_DIR: "./sconsCache"
 

--- a/.github/workflows/main/sconsOptions
+++ b/.github/workflows/main/sconsOptions
@@ -39,7 +39,7 @@ import sys
 import glob
 import subprocess
 
-ENV_VARS_TO_IMPORT = "PATH GAFFERRENDERMAN_FEATURE_PREVIEW"
+ENV_VARS_TO_IMPORT = "PATH"
 
 BUILD_CACHEDIR = os.environ["GAFFER_CACHE_DIR"]
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.0.0a3)
 =======
 
+Improvements
+------------
+
+- RenderMan : Removed the `GAFFERRENDERMAN_FEATURE_PREVIEW` environment variable. The RenderMan extension is now automatically enabled any time the `RMANTREE` environment variable is present. While the RenderMan extension is not yet feature complete, it is considered to be mature enough for general use.
+
 Fixes
 -----
 

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -267,7 +267,7 @@ def setUpRenderMan() :
 
 	# Determine RenderMan version.
 
-	if not os.environ.get( "RMANTREE" ) or os.environ.get( "GAFFERRENDERMAN_FEATURE_PREVIEW", "0" ) != "1" :
+	if not os.environ.get( "RMANTREE" ) :
 		return
 
 	rmanTree = pathlib.Path( os.environ["RMANTREE"] )


### PR DESCRIPTION
Although the RenderMan extension isn't fully feature complete, it is mature enough to remove the gating for Gaffer 1.6.
