### PR TITLE
SceneInspector : Expose Inspection class to Python

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,11 @@ Fixes
 
 - VisualiserTool : Fixed "undefined variable FLT_EPSILON" errors [^1].
 
+Breaking Changes
+----------------
+
+- SceneInspector : Custom inspectors implemented in Python must now return a list of Inspector objects rather than a dictionary [^1].
+
 [^1]: To be omitted from the notes for the final 1.6.0.0 release.
 
 1.6.0.0a3 (relative to 1.6.0.0a2)

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -300,9 +300,10 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 
 GafferUI.Editor.registerType( "SceneInspector", SceneInspector )
 
-# InspectorTree isn't public API. Expose the `registerInspectors()` function on SceneInspector
-# itself to make it available to extension authors.
+# InspectorTree isn't public API. Expose the `registerInspectors()` function and the `Inspection` class
+# on SceneInspector itself to make them available to extension authors.
 SceneInspector.registerInspectors = _GafferSceneUI._SceneInspector.InspectorTree.registerInspectors
+SceneInspector.Inspection = _GafferSceneUI._SceneInspector.InspectorTree.Inspection
 
 ##########################################################################
 # Settings metadata

--- a/python/GafferVDBUI/VDBInspector.py
+++ b/python/GafferVDBUI/VDBInspector.py
@@ -51,7 +51,7 @@ def __gridMaxValue( objectPlug, gridName ) :
 
 def __vdbInspectors( scene, editScope ) :
 
-	result = {}
+	result = []
 
 	vdb = scene["object"].getValue()
 	if not isinstance( vdb, IECoreVDB.VDBObject ) :
@@ -67,15 +67,40 @@ def __vdbInspectors( scene, editScope ) :
 		# We can't register the inspectors from C++, because no C++ API for doing that has
 		# been exposed yet.
 
-		result[f"Grids/{gridName}/Value Type"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridValueType, gridName = gridName ) )
-		result[f"Grids/{gridName}/Min Value"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( __gridMinValue, gridName = gridName ) )
-		result[f"Grids/{gridName}/Max Value"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( __gridMaxValue, gridName = gridName ) )
-		result[f"Grids/{gridName}/Active Voxels"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridActiveVoxels, gridName = gridName ) )
-		result[f"Grids/{gridName}/Voxel Bound"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridVoxelBound, gridName = gridName ) )
-		result[f"Grids/{gridName}/Memory Usage"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridMemoryUsage, gridName = gridName ) )
+		result.extend( [
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Value Type",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridValueType, gridName = gridName ) )
+			),
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Min Value",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( __gridMinValue, gridName = gridName ) )
+			),
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Max Value",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( __gridMaxValue, gridName = gridName ) )
+			),
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Active Voxels",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridActiveVoxels, gridName = gridName ) )
+			),
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Voxel Bound",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridVoxelBound, gridName = gridName ) )
+			),
+			GafferSceneUI.SceneInspector.Inspection(
+				f"Grids/{gridName}/Memory Usage",
+				GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridMemoryUsage, gridName = gridName ) )
+			),
+		] )
 
 		for key in sorted( _GafferVDBUI._gridMetadataNames( scene["object"], gridName ) ) :
-			result[f"Grids/{gridName}/Metadata/{key}"] = GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridMetadata, gridName = gridName, metadataName = key ) )
+			result.append(
+				GafferSceneUI.SceneInspector.Inspection(
+					f"Grids/{gridName}/Metadata/{key}",
+					GafferSceneUI.Private.BasicInspector( scene["object"], editScope, functools.partial( _GafferVDBUI._gridMetadata, gridName = gridName, metadataName = key ) )
+				)
+			)
 
 	return result
 


### PR DESCRIPTION
Python extensions now return a list of Inspections instead of a dictionary mapping from path to Inspector. This is a more direct match to the C++ API, and will allow us to extend the Inspection class with additional fields in future.
