### PR TITLE
ParameterInspector Shader Connections

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Removed the `GAFFERRENDERMAN_FEATURE_PREVIEW` environment variable. The RenderMan extension is now automatically enabled any time the `RMANTREE` environment variable is present. While the RenderMan extension is not yet feature complete, it is considered to be mature enough for general use.
-- SceneInspector, LightEditor : Shader parameters with input connections now show the connection source name instead of the plug value. Parameters in the SceneInspector allow framing the input shader via the context menu.
+- SceneInspector, LightEditor, SceneViewInspector, HistoryWindow and InspectionPopup : Shader parameters with input connections now show the connection source name instead of the plug value. Parameters in the SceneInspector allow framing the input shader via the context menu.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Removed the `GAFFERRENDERMAN_FEATURE_PREVIEW` environment variable. The RenderMan extension is now automatically enabled any time the `RMANTREE` environment variable is present. While the RenderMan extension is not yet feature complete, it is considered to be mature enough for general use.
+- SceneInspector, LightEditor : Shader parameters with input connections now show the connection source name instead of the plug value.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@ Improvements
 ------------
 
 - RenderMan : Removed the `GAFFERRENDERMAN_FEATURE_PREVIEW` environment variable. The RenderMan extension is now automatically enabled any time the `RMANTREE` environment variable is present. While the RenderMan extension is not yet feature complete, it is considered to be mature enough for general use.
-- SceneInspector, LightEditor : Shader parameters with input connections now show the connection source name instead of the plug value.
+- SceneInspector, LightEditor : Shader parameters with input connections now show the connection source name instead of the plug value. Parameters in the SceneInspector allow framing the input shader via the context menu.
 
 Fixes
 -----

--- a/include/GafferSceneUI/Private/ParameterInspector.h
+++ b/include/GafferSceneUI/Private/ParameterInspector.h
@@ -61,6 +61,10 @@ class GAFFERSCENEUI_API ParameterInspector : public AttributeInspector
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( GafferSceneUI::Private::ParameterInspector, ParameterInspectorTypeId, AttributeInspector );
 
+		/// Returns the equivalent `Parameter` given an `object` as returned from `value()` or an
+		/// empty `Parameter` if the input cannot be converted.
+		static IECoreScene::ShaderNetwork::Parameter connectionSource( const IECore::Object *object );
+
 	protected :
 
 		GafferScene::SceneAlgo::History::ConstPtr history() const override;

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -36,6 +36,9 @@
 
 import imath
 
+import IECore
+import IECoreScene
+
 import Gaffer
 import GafferUI
 import GafferScene
@@ -107,14 +110,21 @@ class _ValueColumn( GafferUI.PathColumn ) :
 
 		data = self.CellData()
 
+		connectionSource = IECoreScene.ShaderNetwork.Parameter()
 		if cellValue is not None :
-			data.value = cellValue
+			connectionSource = GafferSceneUI.Private.ParameterInspector.connectionSource( cellValue ) if (
+				isinstance( cellValue, IECore.Object ) ) else IECoreScene.ShaderNetwork.Parameter()
+			data.value = cellValue if not connectionSource else IECore.StringData( connectionSource.shader + "." + connectionSource.name )
 		elif fallbackValue is not None :
-			data.value = fallbackValue
+			connectionSource = GafferSceneUI.Private.ParameterInspector.connectionSource( fallbackValue ) if (
+				isinstance( fallbackValue, IECore.Object ) ) else IECoreScene.ShaderNetwork.Parameter()
+			data.value = fallbackValue if not connectionSource else IECore.StringData( connectionSource.shader + "." + connectionSource.name )
 			data.foreground = imath.Color4f( 0.64, 0.64, 0.64, 1.0 )
 
 		if isinstance( data.value, ( imath.Color3f, imath.Color4f ) ) :
 			data.icon = data.value
+		elif connectionSource :
+			data.icon = IECore.StringData( "SceneInspectorShaderConnection.png" )
 
 		return data
 

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -698,6 +698,9 @@ class __InspectionPopupWindow( GafferUI.PopupWindow ) :
 						parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }
 					)
 				else :
+					connectionSource = GafferSceneUI.Private.ParameterInspector.connectionSource( value )
+					if connectionSource :
+						value = connectionSource.shader + "." + connectionSource.name
 					valueLabel = GafferUI.Label(
 						f"{value}",
 						parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -701,11 +701,15 @@ class __InspectionPopupWindow( GafferUI.PopupWindow ) :
 					connectionSource = GafferSceneUI.Private.ParameterInspector.connectionSource( value )
 					if connectionSource :
 						value = connectionSource.shader + "." + connectionSource.name
-					valueLabel = GafferUI.Label(
-						f"{value}",
+					with GafferUI.ListContainer(
+						GafferUI.ListContainer.Orientation.Horizontal,
+						spacing = 4,
 						parenting = { "index" : ( 1, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.None_, GafferUI.VerticalAlignment.Top ) }
-					)
+					) :
+						connectionIcon = GafferUI.Image( "SceneInspectorShaderConnection.png" )
+						valueLabel = GafferUI.Label( f"{value}" )
 
+					connectionIcon.setVisible( connectionSource )
 					valueLabel.buttonPressSignal().connect( lambda widget, event : True )
 					valueLabel.dragBeginSignal().connect( Gaffer.WeakMethod( self.__valueDragBegin ) )
 					valueLabel.dragEndSignal().connect( Gaffer.WeakMethod( self.__valueDragEnd ) )

--- a/python/GafferSceneUI/_SceneViewInspector.py
+++ b/python/GafferSceneUI/_SceneViewInspector.py
@@ -524,6 +524,8 @@ class _ValueWidget( GafferUI.Widget ) :
 			)
 		elif isinstance( value, ( imath.V3f, imath.V2f, imath.V3i, imath.V2i ) ) :
 			return " ".join( GafferUI.NumericWidget.valueToString( x ) for x in value )
+		elif isinstance( value, IECore.Object ) and ( source := GafferSceneUI.Private.ParameterInspector.connectionSource( value ) ) :
+			return source.shader + "." + source.name
 		elif value is None :
 			return ""
 		else :

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -1338,6 +1338,137 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 					editWarning = "Edits to TestShader may affect other locations in the scene."
 				)
 
+	def testShaderNetworkParameterInput( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["add"] = GafferScene.Shader()
+		s["add"]["out"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out )
+
+		s["multiOut"] = GafferScene.Shader()
+		s["multiOut"]["out"] = Gaffer.Plug( direction = Gaffer.Plug.Direction.Out )
+		s["multiOut"]["out"]["a"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out )
+		s["multiOut"]["out"]["b"] = Gaffer.FloatPlug( direction = Gaffer.Plug.Direction.Out )
+
+		s["srf"] = GafferScene.Shader()
+		s["srf"]["type"].setValue( "test:surface" )
+		s["srf"]["parameters"]["a"] = Gaffer.Color3fPlug()
+		s["srf"]["parameters"]["a"].setInput( s["add"]["out"] )
+		s["srf"]["parameters"]["b"] = Gaffer.Color3fPlug()
+		s["srf"]["parameters"]["b"].setInput( s["multiOut"]["out"]["a"] )
+		s["srf"]["parameters"]["c"] = Gaffer.FloatPlug()
+		s["srf"]["parameters"]["c"].setInput( s["multiOut"]["out"]["b"] )
+		s["srf"]["out"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out )
+
+		s["cube"] = GafferScene.Cube()
+
+		s["assign"] = GafferScene.ShaderAssignment()
+		s["assign"]["in"].setInput( s["cube"]["out"] )
+		s["assign"]["shader"].setInput( s["srf"]["out"] )
+
+		inspection = self.__inspect( s["assign"]["out"], "/cube", ( "srf", "a" ), attribute = "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "add" ), "shaderConnection:parameter" : IECore.InternedStringData( "out" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["a"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = False,
+			nonEditableReason = "srf.parameters.a has a non-settable input."
+		)
+
+		inspection = self.__inspect( s["assign"]["out"], "/cube", ( "srf", "b" ), attribute = "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "multiOut" ), "shaderConnection:parameter" : IECore.InternedStringData( "a" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["b"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = False,
+			nonEditableReason = "srf.parameters.b has a non-settable input."
+		)
+
+		inspection = self.__inspect( s["assign"]["out"], "/cube", "c", attribute = "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "multiOut" ), "shaderConnection:parameter" : IECore.InternedStringData( "b" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["c"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Other,
+			editable = False,
+			nonEditableReason = "srf.parameters.c has a non-settable input."
+		)
+
+		s["editScope"] = Gaffer.EditScope()
+		s["editScope"].setup( s["assign"]["out"] )
+		s["editScope"]["in"].setInput( s["assign"]["out"] )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", ( "srf", "a" ), s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "add" ), "shaderConnection:parameter" : IECore.InternedStringData( "out" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["a"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Upstream,
+			editable = True,
+		)
+
+		edit = inspection.acquireEdit()
+		edit["enabled"].setValue( True )
+		edit["value"].setValue( imath.Color3f( 1, 2, 3 ) )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", ( "srf", "a" ), s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value().value, imath.Color3f( 1, 2, 3 ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", ( "srf", "b" ), s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "multiOut" ), "shaderConnection:parameter" : IECore.InternedStringData( "a" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["b"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Upstream,
+			editable = True,
+		)
+
+		edit = inspection.acquireEdit()
+		edit["enabled"].setValue( True )
+		edit["value"].setValue( imath.Color3f( 4, 5, 6 ) )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", ( "srf", "b" ), s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value().value, imath.Color3f( 4, 5, 6 ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", "c", s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value(), IECore.CompoundData( { "shaderConnection:shader" : IECore.InternedStringData( "multiOut" ), "shaderConnection:parameter" : IECore.InternedStringData( "b" ) } ) )
+		self.__assertExpectedResult(
+			inspection,
+			source = s["srf"]["parameters"]["c"],
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.Upstream,
+			editable = True,
+		)
+
+		edit = inspection.acquireEdit()
+		edit["enabled"].setValue( True )
+		edit["value"].setValue( 2.0 )
+
+		inspection = self.__inspect( s["editScope"]["out"], "/cube", "c", s["editScope"], "test:surface" )
+		self.assertEqual( inspection.value().value, 2.0 )
+		self.__assertExpectedResult(
+			inspection,
+			source = edit,
+			sourceType = GafferSceneUI.Private.Inspector.Result.SourceType.EditScope,
+			editable = True,
+			edit = edit
+		)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -1469,6 +1469,32 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 			edit = edit
 		)
 
+	def testParameter( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["add"] = GafferScene.Shader()
+		s["add"]["out"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out )
+
+		s["srf"] = GafferScene.Shader()
+		s["srf"]["type"].setValue( "test:surface" )
+		s["srf"]["parameters"]["a"] = Gaffer.Color3fPlug()
+		s["srf"]["parameters"]["a"].setInput( s["add"]["out"] )
+		s["srf"]["parameters"]["b"] = Gaffer.Color3fPlug()
+		s["srf"]["out"] = Gaffer.Color3fPlug( direction = Gaffer.Plug.Direction.Out )
+
+		s["cube"] = GafferScene.Cube()
+
+		s["assign"] = GafferScene.ShaderAssignment()
+		s["assign"]["in"].setInput( s["cube"]["out"] )
+		s["assign"]["shader"].setInput( s["srf"]["out"] )
+
+		inspection = self.__inspect( s["assign"]["out"], "/cube", ( "srf", "a" ), attribute = "test:surface" )
+		self.assertEqual( GafferSceneUI.Private.ParameterInspector.connectionSource( inspection.value() ), ( "add", "out" ) )
+
+		inspection = self.__inspect( s["assign"]["out"], "/cube", ( "srf", "b" ), attribute = "test:surface" )
+		self.assertEqual( GafferSceneUI.Private.ParameterInspector.connectionSource( inspection.value() ), ( "", "" ) )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/resources/graphics.py
+++ b/resources/graphics.py
@@ -492,6 +492,7 @@
 				"locationPinnedOff",
 				"sceneInspectorCompareOn",
 				"sceneInspectorCompareOff",
+				"SceneInspectorShaderConnection",
 			]
 		},
 

--- a/resources/graphics.svg
+++ b/resources/graphics.svg
@@ -101,7 +101,7 @@
     </linearGradient>
     <linearGradient
        id="boundsTemplate"
-       gradientTransform="matrix(1.4488738,0,0,1.25,1185.8825,5337.4915)"
+       gradientTransform="matrix(1.4488738,0,0,1.25,1285.8825,5285.1293)"
        inkscape:swatch="solid">
       <stop
          style="stop-color:#ff0101;stop-opacity:0.0787037;"
@@ -3734,38 +3734,59 @@
          style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.787426;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
          inkscape:label="colorPlugValueWidgetSlidersOn" />
     </g>
-    <rect
-       inkscape:label="locationPinnedOn"
-       style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       width="16"
-       height="16"
-       x="30"
-       y="3002"
-       id="locationPinnedOn" />
-    <rect
-       id="locationPinnedOff"
-       y="3002"
-       x="50"
-       height="16"
-       width="16"
-       style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="locationPinnedOff" />
-    <rect
-       id="sceneInspectorCompareOff"
-       y="3002"
-       x="69"
-       height="16"
-       width="18"
-       style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.633865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
-    <rect
-       id="sceneInspectorCompareOn"
-       y="3002"
-       x="89"
-       height="16"
-       width="18"
-       style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.633865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="" />
+    <g
+       id="g3888"
+       inkscape:label="SceneInspector">
+      <rect
+         inkscape:label="locationPinnedOn"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         width="16"
+         height="16"
+         x="30"
+         y="3002"
+         id="locationPinnedOn" />
+      <rect
+         id="locationPinnedOff"
+         y="3002"
+         x="50"
+         height="16"
+         width="16"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="locationPinnedOff" />
+      <rect
+         id="rect2527"
+         y="3054.3621"
+         x="10"
+         height="16"
+         width="16"
+         style="display:inline;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="sizeGuide"
+         transform="translate(0,-52.362183)" />
+      <rect
+         id="sceneInspectorCompareOff"
+         y="3002"
+         x="69"
+         height="16"
+         width="18"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.633865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="sceneInspectorCompareOff" />
+      <rect
+         id="sceneInspectorCompareOn"
+         y="3002"
+         x="89"
+         height="16"
+         width="18"
+         style="display:inline;opacity:0.1;fill:none;fill-opacity:1;stroke:none;stroke-width:0.633865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="sceneInspectorCompareOn" />
+      <rect
+         id="SceneInspectorShaderConnection"
+         y="3001.9998"
+         x="110"
+         height="16"
+         width="16"
+         style="display:inline;fill:none;fill-opacity:1;stroke:none;stroke-width:0.59716535;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="SceneInspectorShaderConnection" />
+    </g>
   </g>
   <g
      inkscape:label="Artwork"
@@ -10889,145 +10910,152 @@
        width="11.273009"
        id="rect4131"
        style="display:inline;fill:none;fill-opacity:0.992157;stroke:#f1c816;stroke-width:1.00001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157" />
-    <rect
-       id="rect2527"
-       y="3054.3621"
-       x="10"
-       height="16"
-       width="16"
-       style="display:inline;fill:url(#boundsTemplate);fill-opacity:1;stroke:none;stroke-width:0.597614;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:markers stroke fill"
-       inkscape:label="sizeGuide" />
     <g
-       style="clip-rule:evenodd;display:inline;fill:url(#foreground);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
-       transform="matrix(0.74882855,0,0,0.74882855,-697.72881,2796.3443)"
-       id="sdfsf-7"
-       inkscape:label="">
+       id="g3916"
+       inkscape:label="SceneInspector">
       <g
-         id="g1179-5"
-         transform="rotate(-45,1063.0797,502.31281)"
-         style="fill:url(#foreground)">
-        <path
-           id="path1177-3"
-           style="fill:url(#foreground);stroke:url(#focusMenuBorder);stroke-width:1.33542;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
-           inkscape:connector-curvature="0" />
+         style="clip-rule:evenodd;display:inline;fill:url(#foreground);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5"
+         transform="matrix(0.74882855,0,0,0.74882855,-697.72881,2796.3443)"
+         id="sdfsf-7"
+         inkscape:label="">
+        <g
+           id="g1179-5"
+           transform="rotate(-45,1063.0797,502.31281)"
+           style="fill:url(#foreground)">
+          <path
+             id="path1177-3"
+             style="fill:url(#foreground);stroke:url(#focusMenuBorder);stroke-width:1.33542;stroke-miterlimit:1.5;stroke-dasharray:none"
+             d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g1183-5"
+           transform="rotate(-45,1063.0911,503.72257)"
+           style="fill:url(#foreground)">
+          <path
+             id="path1181-6"
+             style="fill:none;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
+             d="m 1108.5,339 v 7"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g1187-2"
+           transform="rotate(-45,1058.8981,494.14549)"
+           style="fill:url(#foreground)">
+          <path
+             id="path1185-9"
+             style="fill:none;fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
+             d="m 1108.5,339 v 7"
+             inkscape:connector-curvature="0" />
+        </g>
       </g>
       <g
-         id="g1183-5"
-         transform="rotate(-45,1063.0911,503.72257)"
-         style="fill:url(#foreground)">
-        <path
-           id="path1181-6"
-           style="fill:none;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
+         style="clip-rule:evenodd;display:inline;fill:url(#linearGradient80003);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;fill-opacity:1"
+         transform="matrix(0.74882855,0,0,0.74882855,-677.72881,2796.3443)"
+         id="g4712"
+         inkscape:label="">
+        <g
+           id="g4702"
+           transform="rotate(-45,1063.0797,502.31281)"
+           style="fill:url(#linearGradient80003);fill-opacity:1">
+          <path
+             id="path4700"
+             style="fill:url(#linearGradient80003);stroke:url(#focusMenuBorder);stroke-width:1.33542;stroke-miterlimit:1.5;stroke-dasharray:none;fill-opacity:1"
+             d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4706"
+           transform="rotate(-45,1063.0911,503.72257)"
+           style="fill:url(#linearGradient80003);fill-opacity:1">
+          <path
+             id="path4704"
+             style="fill:url(#linearGradient80003);stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none;fill-opacity:1"
+             d="m 1108.5,339 v 7"
+             inkscape:connector-curvature="0" />
+        </g>
+        <g
+           id="g4710"
+           transform="rotate(-45,1058.8981,494.14549)"
+           style="fill:url(#linearGradient80003);fill-opacity:1">
+          <path
+             id="path4708"
+             style="fill:url(#linearGradient80003);fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
+             d="m 1108.5,339 v 7"
+             inkscape:connector-curvature="0" />
+        </g>
       </g>
       <g
-         id="g1187-2"
-         transform="rotate(-45,1058.8981,494.14549)"
-         style="fill:url(#foreground)">
+         aria-label="A"
+         transform="matrix(0.99204714,0,0,1.0932357,-1.915421,-170.82757)"
+         id="text2183-6-2"
+         style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#787878;fill-opacity:1;stroke-width:0.349234px">
         <path
-           id="path1185-9"
-           style="fill:none;fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
-      </g>
-    </g>
-    <g
-       style="clip-rule:evenodd;display:inline;fill:url(#linearGradient80003);fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;fill-opacity:1"
-       transform="matrix(0.74882855,0,0,0.74882855,-677.72881,2796.3443)"
-       id="g4712"
-       inkscape:label="">
-      <g
-         id="g4702"
-         transform="rotate(-45,1063.0797,502.31281)"
-         style="fill:url(#linearGradient80003);fill-opacity:1">
-        <path
-           id="path4700"
-           style="fill:url(#linearGradient80003);stroke:url(#focusMenuBorder);stroke-width:1.33542;stroke-miterlimit:1.5;stroke-dasharray:none;fill-opacity:1"
-           d="m 1099.5,342.135 1,-1.613 h 5 V 336 c 0.97,-1.378 1.01,-1.482 2,0 v 2 l 8,1 v -2 h 2 v 9 l -2,0.27 v -2.31 l -8,1.04 v 2 c -0.91,1.591 -1.3,1.384 -2,0 v -4.478 h -5 z"
-           inkscape:connector-curvature="0" />
+           d="m 75.865954,2957.3747 c 0.23748,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726409,2.9336 l 0.209541,0.8382 h -1.913808 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751972 l 0.544807,2.1652 h 2.179226 l -2.835788,-9.108 h -2.458615 z"
+           id="path20356"
+           style="fill:#787878;fill-opacity:1" />
       </g>
       <g
-         id="g4706"
-         transform="rotate(-45,1063.0911,503.72257)"
-         style="fill:url(#linearGradient80003);fill-opacity:1">
+         aria-label="B"
+         transform="matrix(0.98608244,0,0,1.0998485,-2.1470217,-170.82757)"
+         id="text2187-8-0"
+         style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#787878;fill-opacity:1;stroke-width:0.349399px">
         <path
-           id="path4704"
-           style="fill:url(#linearGradient80003);stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none;fill-opacity:1"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
+           d="m 82.292334,2944.2346 h 3.326288 c 1.970616,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.684824,-1.9007 -1.984592,-2.1383 v -0.056 c 1.076152,-0.2795 1.565312,-1.16 1.565312,-1.9706 0,-1.747 -1.453504,-2.2641 -3.340264,-2.2641 h -3.060744 z m 2.054472,-5.4506 v -2.0545 h 0.922416 c 0.964344,0 1.411576,0.2656 1.411576,0.9364 0,0.6988 -0.41928,1.1181 -1.425552,1.1181 z m 0,3.8434 v -2.362 h 1.104104 c 1.132056,0 1.649168,0.3355 1.649168,1.1321 0,0.8246 -0.531088,1.2299 -1.649168,1.2299 z"
+           id="path20351"
+           style="fill:#787878;fill-opacity:1" />
       </g>
       <g
-         id="g4710"
-         transform="rotate(-45,1058.8981,494.14549)"
-         style="fill:url(#linearGradient80003);fill-opacity:1">
+         aria-label="A"
+         transform="matrix(0.99204715,0,0,1.0932357,-2.461978,-170.82757)"
+         id="g96421"
+         style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
         <path
-           id="path4708"
-           style="fill:url(#linearGradient80003);fill-opacity:1;stroke:url(#focusMenuBorder);stroke-width:1.00156;stroke-miterlimit:1.5;stroke-dasharray:none"
-           d="m 1108.5,339 v 7"
-           inkscape:connector-curvature="0" />
+           d="m 96.57722,2957.3747 c 0.237479,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726408,2.9336 l 0.209541,0.8382 h -1.913807 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751971 l 0.544807,2.1652 h 2.179225 l -2.835787,-9.108 h -2.458614 z"
+           id="path96419"
+           style="fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
       </g>
-    </g>
-    <g
-       aria-label="A"
-       transform="matrix(0.99204714,0,0,1.0932357,-1.915421,-170.82757)"
-       id="text2183-6-2"
-       style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#787878;fill-opacity:1;stroke-width:0.349234px">
+      <g
+         aria-label="B"
+         transform="matrix(0.98608245,0,0,1.0998485,-2.693579,-170.82757)"
+         id="g96425"
+         style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+        <path
+           d="m 103.12888,2944.2346 h 3.32629 c 1.97062,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.68482,-1.9007 -1.98459,-2.1383 v -0.056 c 1.07615,-0.2795 1.56531,-1.16 1.56531,-1.9706 0,-1.747 -1.4535,-2.2641 -3.34026,-2.2641 h -3.06075 z m 2.05447,-5.4506 v -2.0545 h 0.92242 c 0.96434,0 1.41158,0.2656 1.41158,0.9364 0,0.6988 -0.41928,1.1181 -1.42556,1.1181 z m 0,3.8434 v -2.362 h 1.10411 c 1.13205,0 1.64917,0.3355 1.64917,1.1321 0,0.8246 -0.53109,1.2299 -1.64917,1.2299 z"
+           id="path96423"
+           style="fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         aria-label="A"
+         transform="matrix(0.99204714,0,0,1.0932357,18.084579,-170.82757)"
+         id="g96429"
+         style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke-width:0.349234px">
+        <path
+           d="m 75.865954,2957.3747 c 0.23748,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726409,2.9336 l 0.209541,0.8382 h -1.913808 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751972 l 0.544807,2.1652 h 2.179226 l -2.835788,-9.108 h -2.458615 z"
+           id="path96427"
+           style="fill:#e0e0e0;fill-opacity:1" />
+      </g>
+      <g
+         aria-label="B"
+         transform="matrix(0.98608244,0,0,1.0998485,17.852978,-170.82757)"
+         id="g96433"
+         style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke-width:0.349399px">
+        <path
+           d="m 82.292334,2944.2346 h 3.326288 c 1.970616,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.684824,-1.9007 -1.984592,-2.1383 v -0.056 c 1.076152,-0.2795 1.565312,-1.16 1.565312,-1.9706 0,-1.747 -1.453504,-2.2641 -3.340264,-2.2641 h -3.060744 z m 2.054472,-5.4506 v -2.0545 h 0.922416 c 0.964344,0 1.411576,0.2656 1.411576,0.9364 0,0.6988 -0.41928,1.1181 -1.425552,1.1181 z m 0,3.8434 v -2.362 h 1.104104 c 1.132056,0 1.649168,0.3355 1.649168,1.1321 0,0.8246 -0.531088,1.2299 -1.649168,1.2299 z"
+           id="path96431"
+           style="fill:#e0e0e0;fill-opacity:1" />
+      </g>
       <path
-         d="m 75.865954,2957.3747 c 0.23748,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726409,2.9336 l 0.209541,0.8382 h -1.913808 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751972 l 0.544807,2.1652 h 2.179226 l -2.835788,-9.108 h -2.458615 z"
-         id="path20356"
-         style="fill:#787878;fill-opacity:1" />
-    </g>
-    <g
-       aria-label="B"
-       transform="matrix(0.98608244,0,0,1.0998485,-2.1470217,-170.82757)"
-       id="text2187-8-0"
-       style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#787878;fill-opacity:1;stroke-width:0.349399px">
-      <path
-         d="m 82.292334,2944.2346 h 3.326288 c 1.970616,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.684824,-1.9007 -1.984592,-2.1383 v -0.056 c 1.076152,-0.2795 1.565312,-1.16 1.565312,-1.9706 0,-1.747 -1.453504,-2.2641 -3.340264,-2.2641 h -3.060744 z m 2.054472,-5.4506 v -2.0545 h 0.922416 c 0.964344,0 1.411576,0.2656 1.411576,0.9364 0,0.6988 -0.41928,1.1181 -1.425552,1.1181 z m 0,3.8434 v -2.362 h 1.104104 c 1.132056,0 1.649168,0.3355 1.649168,1.1321 0,0.8246 -0.531088,1.2299 -1.649168,1.2299 z"
-         id="path20351"
-         style="fill:#787878;fill-opacity:1" />
-    </g>
-    <g
-       aria-label="A"
-       transform="matrix(0.99204715,0,0,1.0932357,-2.461978,-170.82757)"
-       id="g96421"
-       style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <path
-         d="m 96.57722,2957.3747 c 0.237479,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726408,2.9336 l 0.209541,0.8382 h -1.913807 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751971 l 0.544807,2.1652 h 2.179225 l -2.835787,-9.108 h -2.458614 z"
-         id="path96419"
-         style="fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       aria-label="B"
-       transform="matrix(0.98608245,0,0,1.0998485,-2.693579,-170.82757)"
-       id="g96425"
-       style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
-      <path
-         d="m 103.12888,2944.2346 h 3.32629 c 1.97062,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.68482,-1.9007 -1.98459,-2.1383 v -0.056 c 1.07615,-0.2795 1.56531,-1.16 1.56531,-1.9706 0,-1.747 -1.4535,-2.2641 -3.34026,-2.2641 h -3.06075 z m 2.05447,-5.4506 v -2.0545 h 0.92242 c 0.96434,0 1.41158,0.2656 1.41158,0.9364 0,0.6988 -0.41928,1.1181 -1.42556,1.1181 z m 0,3.8434 v -2.362 h 1.10411 c 1.13205,0 1.64917,0.3355 1.64917,1.1321 0,0.8246 -0.53109,1.2299 -1.64917,1.2299 z"
-         id="path96423"
-         style="fill:#272727;fill-opacity:1;stroke:#272727;stroke-width:1.92047;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-    <g
-       aria-label="A"
-       transform="matrix(0.99204714,0,0,1.0932357,18.084579,-170.82757)"
-       id="g96429"
-       style="font-weight:bold;font-size:13.9694px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke-width:0.349234px">
-      <path
-         d="m 75.865954,2957.3747 c 0.23748,-0.908 0.488929,-1.9697 0.712439,-2.9336 h 0.05588 c 0.209541,0.9639 0.488929,2.0256 0.726409,2.9336 l 0.209541,0.8382 h -1.913808 z m -3.282809,4.6099 h 2.09541 l 0.558776,-2.1652 h 2.751972 l 0.544807,2.1652 h 2.179226 l -2.835788,-9.108 h -2.458615 z"
-         id="path96427"
-         style="fill:#e0e0e0;fill-opacity:1" />
-    </g>
-    <g
-       aria-label="B"
-       transform="matrix(0.98608244,0,0,1.0998485,17.852978,-170.82757)"
-       id="g96433"
-       style="font-weight:bold;font-size:13.976px;font-family:'Source Code Pro';-inkscape-font-specification:'Source Code Pro Bold';letter-spacing:0px;word-spacing:0px;opacity:1;fill:#e0e0e0;fill-opacity:1;stroke-width:0.349399px">
-      <path
-         d="m 82.292334,2944.2346 h 3.326288 c 1.970616,0 3.494,-0.8246 3.494,-2.6834 0,-1.2159 -0.684824,-1.9007 -1.984592,-2.1383 v -0.056 c 1.076152,-0.2795 1.565312,-1.16 1.565312,-1.9706 0,-1.747 -1.453504,-2.2641 -3.340264,-2.2641 h -3.060744 z m 2.054472,-5.4506 v -2.0545 h 0.922416 c 0.964344,0 1.411576,0.2656 1.411576,0.9364 0,0.6988 -0.41928,1.1181 -1.425552,1.1181 z m 0,3.8434 v -2.362 h 1.104104 c 1.132056,0 1.649168,0.3355 1.649168,1.1321 0,0.8246 -0.531088,1.2299 -1.649168,1.2299 z"
-         id="path96431"
-         style="fill:#e0e0e0;fill-opacity:1" />
+         id="rect4470"
+         style="fill:#e0e0e0;fill-opacity:1;stroke:#3d3d3d;stroke-width:2;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+         d="m 122,3058.3622 h -8 v 7 h -4 v 2 h 6 v -7 h 6 z"
+         sodipodi:nodetypes="ccccccccc" />
+      <circle
+         style="display:inline;fill:#e0e0e0;fill-opacity:1;stroke:#3d3d3d;stroke-width:2;stroke-dasharray:none;stroke-dashoffset:1.10173;stroke-opacity:1;paint-order:stroke fill markers;stop-color:#000000"
+         id="path4970"
+         cx="122"
+         cy="3059.3623"
+         r="2.5" />
     </g>
   </g>
 </svg>

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -35,6 +35,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GafferSceneUI/Private/InspectorColumn.h"
+#include "GafferSceneUI/Private/ParameterInspector.h"
 
 #include "GafferUI/PathColumn.h"
 
@@ -163,7 +164,12 @@ PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const 
 		return result;
 	}
 
-	if( const auto shaderNetwork = runTimeCast<const IECoreScene::ShaderNetwork>( inspectorResult->value() ) )
+	IECoreScene::ShaderNetwork::Parameter connectionSource = ParameterInspector::connectionSource( inspectorResult->value() );
+	if( connectionSource )
+	{
+		result.value = new StringData( connectionSource.shader.string() + "." + connectionSource.name.string() );
+	}
+	else if( const auto shaderNetwork = runTimeCast<const IECoreScene::ShaderNetwork>( inspectorResult->value() ) )
 	{
 		/// \todo We don't really want InspectorColumn to know about scene types.
 		/// If this comes up again, consider adding a registry of converters instead

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -63,6 +63,7 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 };
 const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
 const ConstStringDataPtr g_missingOutputShader = new StringData( "Missing output shader" );
+const StringDataPtr g_shaderConnectionIcon = new StringData( "SceneInspectorShaderConnection.png" );
 
 }  // namespace
 
@@ -168,6 +169,7 @@ PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const 
 	if( connectionSource )
 	{
 		result.value = new StringData( connectionSource.shader.string() + "." + connectionSource.name.string() );
+		result.icon = g_shaderConnectionIcon;
 	}
 	else if( const auto shaderNetwork = runTimeCast<const IECoreScene::ShaderNetwork>( inspectorResult->value() ) )
 	{

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -102,6 +102,24 @@ ParameterInspector::ParameterInspector(
 
 }
 
+ShaderNetwork::Parameter ParameterInspector::connectionSource( const Object *object )
+{
+	if( auto data = runTimeCast<const CompoundData>( object ) )
+	{
+		if( data->readable().size() == 2 )
+		{
+			const auto shaderName = data->member<InternedStringData>( "shaderConnection:shader" );
+			const auto parameterName = data->member<InternedStringData>( "shaderConnection:parameter" );
+
+			if( shaderName && parameterName )
+			{
+				return ShaderNetwork::Parameter( shaderName->readable(), parameterName->readable() );
+			}
+		}
+	}
+	return ShaderNetwork::Parameter();
+}
+
 GafferScene::SceneAlgo::History::ConstPtr ParameterInspector::history() const
 {
 	// Computing histories is expensive, and there's no point doing it

--- a/src/GafferSceneUI/ParameterInspector.cpp
+++ b/src/GafferSceneUI/ParameterInspector.cpp
@@ -70,6 +70,15 @@ IECore::ConstObjectPtr parameterData( const Object *attribute, const ShaderNetwo
 		return nullptr;
 	}
 
+	const ShaderNetwork::Parameter input = parameter.shader.string().empty() ? shaderNetwork->input( { shaderNetwork->getOutput().shader, parameter.name } ) : shaderNetwork->input( parameter );
+	if( input )
+	{
+		return new CompoundData( {
+			{ InternedString( "shaderConnection:shader" ), new InternedStringData( input.shader ) },
+			{ InternedString( "shaderConnection:parameter" ), new InternedStringData( input.name ) }
+		} );
+	}
+
 	const IECoreScene::Shader *shader = parameter.shader.string().empty() ? shaderNetwork->outputShader() : shaderNetwork->getShader( parameter.shader );
 	if( !shader )
 	{

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -206,6 +206,8 @@ void GafferSceneUIModule::bindInspector()
 				( arg( "scene" ), arg( "attribute" ), arg( "parameter" ), arg( "inheritAttributes" ) = false )
 			)
 		)
+		.def( "connectionSource", &ParameterInspector::connectionSource )
+		.staticmethod( "connectionSource" )
 	;
 
 	RunTimeTypedClass<SetMembershipInspector>( "SetMembershipInspector" )


### PR DESCRIPTION
This shows the input to shader parameters that have connections, rather than the underlying plug value. `ParameterInspector` now returns a `CompoundData` object for parameters with inputs and has a static method for converting that to a `ShaderNetwork::Parameter`, when possible. (There is no `Object` derived data type for `ShaderNetwork::Parameter`, so we're storing the equivalent data in `CompoundData`)

The user interface shows this as a `shader.name` string with an accompanying icon to indicate it's a connection rather than a string. The Scene Inspector, since it shows the other shaders in the network, allows framing the source shader via a context menu item.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
