### PR TITLE
Wrapper : Preload libstdc++ when using Arnold on Linux

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
 - ImageReader : Adjusted default `channelInterpretation` heuristics to better match Nuke's behaviour for single-part EXR files with bogus part name metadata (#6527). In this case, the part name is no longer used as the layer name.
 - TweakPlug : Fixed handling of default values for `name`, `enabled` and `mode` child plugs during serialisation and in `createCounterPart()` (#6544) [^1].
 - ShaderTweaks : Fixed errors when `Remove` or `Create` modes are used to tweak a parameter with an input connection. The input connection is now removed.
+- Arnold : Fixed plugin crashes caused by conflicts with Arnold's internal memory allocator [^1].
 
 API
 ---

--- a/SConstruct
+++ b/SConstruct
@@ -1629,15 +1629,6 @@ else :
 
 	libraries["GafferCycles"]["envAppends"]["LIBS"].extend( [ "dl" ] )
 
-	if env["PLATFORM"] == "posix" :
-		# Make sure our Arnold plugin links to `libstdc++` _before_ linking to
-		# `libai`. Otherwise we pick up symbols for `operator delete` and
-		# `operator new` from `libai`, which has its own internal allocator and
-		# exports the symbols from it. If we pick up the Arnold ones then we get
-		# mismatches where we allocate something with the standard allocator and
-		# then try to delete it with the Arnold one.
-		libraries["GafferArnoldPlugin"]["envAppends"]["LIBS"].insert( 0, "stdc++" )
-
 # Optionally add vTune requirements
 
 if os.path.exists( env.subst("$VTUNE_ROOT") ):

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -225,6 +225,15 @@ def setUpArnold() :
 	if "ARNOLD_ADP_OPTIN" not in os.environ and "ARNOLD_ADP_DISABLE" not in os.environ :
 		os.environ["ARNOLD_ADP_DISABLE"] = "1"
 
+	if sys.platform == "linux" :
+		# Preload `libstdc++` before `libai`. Otherwise Arnold plugins can resolve
+		# symbols for `operator delete` and `operator new` from `libai`, which has
+		# its own internal allocator and exports the symbols from it. If plugins
+		# resolve the Arnold symbols then mismatches may occur where they allocate
+		# something with the standard allocator and then try to delete it with the
+		# Arnold one.
+		appendToPath( "libstdc++.so.6", "LD_PRELOAD" )
+
 setUpArnold()
 
 # 3Delight Setup


### PR DESCRIPTION
As John notes in #6519 `libai.so` exports symbols for `operator new` and `operator delete`, implemented using its own internal memory allocator. Arnold plugins can resolve these symbols in preference to the standard ones. This can lead to crashes caused by objects getting allocated with one allocator and deleted by another.

We previously fixed this for our own Arnold plugin in #6519 by linking to `libstdc++` explicitly before `libai`. Though we've recently had reports of other Arnold plugins crashing in Gaffer 1.6 alphas, such as MtoA's xgen_procedural, so this takes a heavier hand and preloads libstdc++.so.6 on Linux when `ARNOLD_ROOT` is defined.