### PR TITLE
OpenGLRenderTest : Skip `testInstanceIDOutput`

### DIFF
--- a/python/GafferSceneTest/OpenGLRenderTest.py
+++ b/python/GafferSceneTest/OpenGLRenderTest.py
@@ -124,5 +124,10 @@ class OpenGLRenderTest( GafferSceneTest.RenderTest ) :
 
 		pass
 
+	@unittest.skip( "Instance ID output not supported" )
+	def testInstanceIDOutput( self ) :
+
+		pass
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
ID outputs aren't currently supported by the OpenGL renderer. This had gone unnoticed because we don't run the OpenGL tests on CI..
