### PR TITLE
SceneGadget : Isolate TBB tasks used to compute bounds

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - TweakPlug : Fixed handling of default values for `name`, `enabled` and `mode` child plugs during serialisation and in `createCounterPart()` (#6544).
+- Viewer : Fixed hangs when using the raytraced viewport.
 
 API
 ---

--- a/src/GafferSceneUI/SceneGadget.cpp
+++ b/src/GafferSceneUI/SceneGadget.cpp
@@ -98,14 +98,18 @@ Box3f sceneBound( const ScenePlug *scene, const PathMatcher *include, const Path
 		}
 	};
 
-	if( include )
-	{
-		SceneAlgo::filteredParallelTraverse( scene, *include, f );
-	}
-	else
-	{
-		SceneAlgo::parallelTraverse( scene, f );
-	}
+	tbb::this_task_arena::isolate(
+		[&] () {
+			if( include )
+			{
+				SceneAlgo::filteredParallelTraverse( scene, *include, f );
+			}
+			else
+			{
+				SceneAlgo::parallelTraverse( scene, f );
+			}
+		}
+	);
 
 	return threadBounds.combine(
 		[] ( const Box3f b1, const Box3f b2 ) {


### PR DESCRIPTION
Reminder : task stealing means that any TBB construct is essentially a `goto anywhere`. In this case, we were running a `parallel_for()` to compute bounds on the UI thread, and it was stealing a task enqueued by a completely unrelated BackgroundTask. This meant 2 things :

1. In the best case we were pulling arbitrary background work onto the UI thread, extending the length of time the user had to wait for the result they actually cared about.
2. In the worst case, we could deadlock. BackgroundTasks expect to run in the background, and often use `ParallelAlgo::callOnUIThread()` to transport the results back onto the UI thread and clean up the BackgroundTask. But if the task is actually running on the UI thread, then `callOnUIThread()` executes immediately, causing BackgroundTask to try to clean itself up while still running. Since `~BackgroundTask` calls `wait()`, this deadlocks.

Really, we should not ever be doing this amount of work on the UI thread anyway, and should be computing bounds asynchronously. But for now, isolating the work gives us a quick fix for the deadlock, ensuring we don't steal any unrelated tasks.
