### PR TITLE
HistoryWindow : Show interesting context variables

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - LightEditor, RenderPassEditor, AttributeEditor, SceneInspector : Added context variable columns to the `Show History...` window. These show the values for any context variables which change during the history.
 
+Fixes
+-----
+
+- PathListingWidget : Fixed parent layout update when column sizes change.
+
 1.6.0.0 (relative to 1.5.16.2)
 =======
 

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- LightEditor, RenderPassEditor, AttributeEditor, SceneInspector : Added context variable columns to the `Show History...` window. These show the values for any context variables which change during the history.
+- LightEditor, RenderPassEditor, AttributeEditor, SceneInspector :
+  - Added context variable columns to the `Show History...` window. These show the values for any context variables which change during the history.
+  - Improved default size of `Show History...` window.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+1.6.x.x (relative to 1.6.0.0)
+=======
+
+Improvements
+------------
+
+- LightEditor, RenderPassEditor, AttributeEditor, SceneInspector : Added context variable columns to the `Show History...` window. These show the values for any context variables which change during the history.
+
 1.6.0.0 (relative to 1.5.16.2)
 =======
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -236,6 +236,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 				void propertyNames( std::vector<IECore::InternedString> &names, const IECore::Canceller *canceller = nullptr) const override;
 				IECore::ConstRunTimeTypedPtr property( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override;
+				Gaffer::ConstContextPtr contextProperty( const IECore::InternedString &name, const IECore::Canceller *canceller = nullptr ) const override;
 
 				bool isValid( const IECore::Canceller *canceller = nullptr ) const override;
 				bool isLeaf( const IECore::Canceller *canceller = nullptr ) const override;

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -207,6 +207,7 @@ class _HistoryWindow( GafferUI.Window ) :
 		self.__inspectorColumn.changedSignal().connect( Gaffer.WeakMethod( self.__inspectorColumnChanged ) )
 		self.__inspectionRootPath.pathChangedSignal().connect( Gaffer.WeakMethod( self.__inspectionRootPathChanged ) )
 
+		self.__resizeInUpdateFinished = True
 		self.__updatePath()
 
 	def __updatePath( self ) :
@@ -368,7 +369,14 @@ class _HistoryWindow( GafferUI.Window ) :
 				column = _ContextVariableColumn( variable )
 			columns.append( column )
 
-		pathListing.setColumns( columns )
+		if columns != pathListing.getColumns() :
+			pathListing.setColumns( columns )
+		elif self.__resizeInUpdateFinished :
+			# Once we've completed the first update for all the columns we want,
+			# size the window to fit. We only do this once - after that the user
+			# is in control of the size.
+			self.resizeToFitChild()
+			self.__resizeInUpdateFinished = False
 
 	def __nodeNameChanged( self, node, oldName ) :
 

--- a/python/GafferSceneUI/_HistoryWindow.py
+++ b/python/GafferSceneUI/_HistoryWindow.py
@@ -43,6 +43,25 @@ import GafferSceneUI
 
 from . import _GafferSceneUI
 
+# Hides internal nodes created by the UI (for example, inside
+# `Editor.Settings`).
+class _NodeFilter( Gaffer.PathFilter ) :
+
+	def __init__( self, userData = {} ) :
+
+		Gaffer.PathFilter.__init__( self, userData )
+
+	def _filter( self, paths, canceller ) :
+
+		result = []
+		for path in paths :
+			node = path.property( "history:node", canceller )
+			if node is not None and node.scriptNode() is None :
+				continue
+			result.append( path )
+
+		return result
+
 class _OperationIconColumn( GafferUI.PathColumn ) :
 
 	def __init__( self ) :
@@ -122,6 +141,31 @@ class _ValueColumn( GafferUI.PathColumn ) :
 
 		return self.CellData( "Value" )
 
+class _ContextVariableColumn( GafferUI.PathColumn ) :
+
+	def __init__( self, variable ) :
+
+		GafferUI.PathColumn.__init__( self )
+
+		self.__variable = variable
+
+	def variable( self ) :
+
+		return self.__variable
+
+	def cellData( self, path, canceller = None ) :
+
+		context = path.contextProperty( "history:context", canceller )
+		value = context.get( self.__variable )
+		if value is not None and self.__variable == "scene:path" :
+			value = GafferScene.ScenePlug.pathToString( value )
+
+		return self.CellData( value )
+
+	def headerData( self, canceller = None ) :
+
+		return self.CellData( "${{{}}}".format( self.__variable ) )
+
 class _HistoryWindow( GafferUI.Window ) :
 
 	def __init__( self, inspectorColumn, inspectionRootPath, inspectionPathString, title=None, **kw ) :
@@ -129,8 +173,9 @@ class _HistoryWindow( GafferUI.Window ) :
 		if title is None :
 			title = "History"
 
-		GafferUI.Window.__init__( self, title, **kw )
+		GafferUI.Window.__init__( self, title, borderWidth = 4, **kw )
 
+		self.__nodeFilter = _NodeFilter()
 		self.__inspectorColumn = inspectorColumn
 		self.__inspectionRootPath = inspectionRootPath
 		self.__inspectionPathString = inspectionPathString
@@ -173,6 +218,7 @@ class _HistoryWindow( GafferUI.Window ) :
 			self.close()
 			return
 
+		self.__path.setFilter( self.__nodeFilter )
 		self.__pathListingWidget.setPath( self.__path )
 
 	def __buttonDoubleClick( self, pathListing, event ) :
@@ -272,8 +318,8 @@ class _HistoryWindow( GafferUI.Window ) :
 	def __updateFinished( self, pathListing ) :
 
 		# Note : Now the update is finished, we know our HistoryPath has
-		# computed and cached everything internally. So we can call `children()`
-		# without fear of blocking the UI waiting for it to compute.
+		# computed and cached everything internally. So we can call methods on
+		# it without fear of blocking the UI waiting for it to compute.
 
 		# Close window if there's no longer anything to show.
 
@@ -301,6 +347,28 @@ class _HistoryWindow( GafferUI.Window ) :
 					)
 
 				node = node.parent()
+
+		# Add columns to show any context variables which vary through the
+		# course of the history. Reuse columns where possible because
+		# PathListingWidget is smart enough to reuse cell values in that case.
+
+		currentContextVariableColumns = {
+			c.variable() : c
+			for c in pathListing.getColumns()
+			if isinstance( c, _ContextVariableColumn )
+		}
+
+		columns = [ c for c in pathListing.getColumns() if not isinstance( c, _ContextVariableColumn ) ]
+		for variable in pathListing.getPath().property( "history:varyingContextVariables" ) :
+			if variable.startswith( "__" ) :
+				# Avoid showing private variables like `__sceneInspector:inputIndex`.
+				continue
+			column = currentContextVariableColumns.get( variable )
+			if column is None :
+				column = _ContextVariableColumn( variable )
+			columns.append( column )
+
+		pathListing.setColumns( columns )
 
 	def __nodeNameChanged( self, node, oldName ) :
 

--- a/python/GafferSceneUITest/BasicInspectorTest.py
+++ b/python/GafferSceneUITest/BasicInspectorTest.py
@@ -161,7 +161,7 @@ class BasicInspectorTest( GafferUITest.TestCase ) :
 		children = historyPath.children()
 		self.assertEqual(
 			[ c.property( "history:node" ) for c in children ],
-			[ cube, primitiveVariables, meshTangents ]
+			[ cube, primitiveVariables, meshTangents, group ]
 		)
 
 if __name__ == "__main__":

--- a/python/GafferUI/PathListingWidget.py
+++ b/python/GafferUI/PathListingWidget.py
@@ -1141,6 +1141,7 @@ class _TreeView( QtWidgets.QTreeView ) :
 	def updateColumnWidths( self, columnsChanged = False ) :
 
 		self.__recalculatingColumnWidths = True
+		originalHeaderLength = self.header().length()
 
 		header = self.header()
 		numColumnsToResize = header.count()
@@ -1174,6 +1175,13 @@ class _TreeView( QtWidgets.QTreeView ) :
 			self.__resizeLastColumnToAvailableWidth()
 
 		self.__recalculatingColumnWidths = False
+
+		if self.header().length() != originalHeaderLength :
+			# You might think that `header.geometriesChanged()` would be emitted
+			# for this change in size, but it isn't. So we call `updateGeometry()`
+			# directly ourselves. That triggers a layout update to account for the
+			# fact that our `sizeHint()` will have changed.
+			self.updateGeometry()
 
 	def keyPressEvent( self, event ) :
 

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -828,7 +828,7 @@ ConstRunTimeTypedPtr Inspector::HistoryPath::property( const InternedString &nam
 		}
 	}
 
-	return Path::property( name );
+	return Path::property( name, canceller );
 }
 
 bool Inspector::HistoryPath::isValid( const Canceller *canceller ) const

--- a/src/GafferSceneUI/Inspector.cpp
+++ b/src/GafferSceneUI/Inspector.cpp
@@ -59,12 +59,15 @@ using namespace GafferSceneUI::Private;
 
 using ConstPredecessors = std::vector<const SceneAlgo::History *>;
 
+static InternedString g_contextVariablesPropertyName( "history:contextVariables" );
+static InternedString g_varyingContextVariablesPropertyName( "history:varyingContextVariables" );
 static InternedString g_valuePropertyName( "history:value" );
 static InternedString g_fallbackValuePropertyName( "history:fallbackValue" );
 static InternedString g_operationPropertyName( "history:operation" );
 static InternedString g_sourcePropertyName( "history:source" );
 static InternedString g_editWarningPropertyName( "history:editWarning" );
 static InternedString g_nodePropertyName( "history:node" );
+static InternedString g_contextPropertyName( "history:context" );
 
 //////////////////////////////////////////////////////////////////////////
 // Internal utilities
@@ -617,10 +620,22 @@ struct Inspector::HistoryPath::HistoryProvider
 		return m_historyVector.size();
 	}
 
-	const SceneAlgo::History *historyItem( size_t index, const IECore::Canceller *canceller  )
+	const SceneAlgo::History *historyItem( size_t index, const IECore::Canceller *canceller )
 	{
 		std::call_once( m_initFlag, &HistoryProvider::initHistory, this, canceller );
 		return m_historyVector[index].get();
+	}
+
+	const StringVectorData *contextVariables( const IECore::Canceller *canceller )
+	{
+		std::call_once( m_initFlag, &HistoryProvider::initHistory, this, canceller );
+		return m_contextVariables.get();
+	}
+
+	const StringVectorData *varyingContextVariables( const IECore::Canceller *canceller )
+	{
+		std::call_once( m_initFlag, &HistoryProvider::initHistory, this, canceller );
+		return m_varyingContextVariables.get();
 	}
 
 	private :
@@ -655,6 +670,9 @@ struct Inspector::HistoryPath::HistoryProvider
 
 			std::string editWarning;
 
+			std::unordered_set<InternedString> contextVariables;
+			std::unordered_set<InternedString> varyingContextVariables;
+
 			ConstObjectPtr successorValue;
 			const SceneAlgo::History *successor = nullptr;
 			const SceneAlgo::History *current = history.get();
@@ -665,6 +683,10 @@ struct Inspector::HistoryPath::HistoryProvider
 				{
 					scope.setCanceller( canceller );
 				}
+
+				std::vector<InternedString> currentContextVariables;
+				current->context->names( currentContextVariables );
+				contextVariables.insert( currentContextVariables.begin(), currentContextVariables.end() );
 
 				ConstObjectPtr currentValue = inspector->value( current );
 				if( successor && !endsWith( m_historyVector, successor ) )
@@ -677,6 +699,15 @@ struct Inspector::HistoryPath::HistoryProvider
 						(bool)currentValue != (bool)successorValue ||
 						( currentValue && currentValue->isNotEqualTo( successorValue.get() ) )
 					)
+					{
+						m_historyVector.push_back( successor );
+					}
+				}
+
+				if( successor && *successor->context != *current->context )
+				{
+					addVaryingContextVariables( successor->context.get(), current->context.get(), varyingContextVariables );
+					if( !endsWith( m_historyVector, successor ) )
 					{
 						m_historyVector.push_back( successor );
 					}
@@ -709,6 +740,12 @@ struct Inspector::HistoryPath::HistoryProvider
 			}
 
 			std::reverse( m_historyVector.begin(), m_historyVector.end() );
+			m_contextVariables = new StringVectorData(
+				std::vector<std::string>( contextVariables.begin(), contextVariables.end() )
+			);
+			m_varyingContextVariables = new StringVectorData(
+				std::vector<std::string>( varyingContextVariables.begin(), varyingContextVariables.end() )
+			);
 		}
 
 		static bool endsWith( const std::vector<SceneAlgo::History::ConstPtr> historyVector, const SceneAlgo::History *history )
@@ -716,8 +753,24 @@ struct Inspector::HistoryPath::HistoryProvider
 			return historyVector.size() && historyVector.back() == history;
 		}
 
+		static void addVaryingContextVariables( const Context *context0, const Context *context1, std::unordered_set<InternedString> &variables )
+		{
+			std::vector<InternedString> variableNames;
+			context0->names( variableNames );
+			context1->names( variableNames );
+			for( auto variable : variableNames )
+			{
+				if( context0->variableHash( variable ) != context1->variableHash( variable ) )
+				{
+					variables.insert( variable );
+				}
+			}
+		}
+
 		std::once_flag m_initFlag;
 		std::vector<SceneAlgo::History::ConstPtr> m_historyVector;
+		ConstStringVectorDataPtr m_contextVariables;
+		ConstStringVectorDataPtr m_varyingContextVariables;
 
 };
 
@@ -753,6 +806,13 @@ void Inspector::HistoryPath::propertyNames( std::vector<InternedString> &names, 
 {
 	Path::propertyNames( names );
 
+	if( this->names().empty() )
+	{
+		// Root
+		names.push_back( g_contextVariablesPropertyName );
+		names.push_back( g_varyingContextVariablesPropertyName );
+	}
+
 	if( history( canceller ) )
 	{
 		names.push_back( g_valuePropertyName );
@@ -761,12 +821,21 @@ void Inspector::HistoryPath::propertyNames( std::vector<InternedString> &names, 
 		names.push_back( g_sourcePropertyName );
 		names.push_back( g_editWarningPropertyName );
 		names.push_back( g_nodePropertyName );
+		names.push_back( g_contextPropertyName );
 	}
 }
 
 ConstRunTimeTypedPtr Inspector::HistoryPath::property( const InternedString &name, const Canceller *canceller ) const
 {
-	if(
+	if( name == g_contextVariablesPropertyName )
+	{
+		return names().empty() ? m_historyProvider->contextVariables( canceller ) : nullptr;
+	}
+	else if( name == g_varyingContextVariablesPropertyName )
+	{
+		return names().empty() ? m_historyProvider->varyingContextVariables( canceller ) : nullptr;
+	}
+	else if(
 		name == g_nodePropertyName ||
 		name == g_valuePropertyName ||
 		name == g_fallbackValuePropertyName ||
@@ -829,6 +898,17 @@ ConstRunTimeTypedPtr Inspector::HistoryPath::property( const InternedString &nam
 	}
 
 	return Path::property( name, canceller );
+}
+
+Gaffer::ConstContextPtr Inspector::HistoryPath::contextProperty( const InternedString &name, const Canceller *canceller ) const
+{
+	if( name == g_contextPropertyName )
+	{
+		SceneAlgo::History::ConstPtr h = history( canceller );
+		return h ? h->context : nullptr;
+	}
+
+	return Path::contextProperty( name, canceller );
 }
 
 bool Inspector::HistoryPath::isValid( const Canceller *canceller ) const


### PR DESCRIPTION
This helps folks understand the role of context variables in scene construction, by adding columns for any context variables which vary during the computation of the history. The screenshot below illustrates this for a small example network.

<img width="670" height="299" alt="image" src="https://github.com/user-attachments/assets/2cc90674-3b8e-40d7-8068-2e9248447d6e" />