### PR TITLE
RenderMan config : Re-label dislacement `Trace` as `Enabled`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Improved default size of `Show History...` window.
 - SceneInspector, LightEditor, Viewer : Shader parameters with input connections now show the connection source name instead of the plug value. The input shader can be selected via the context menu.
 - Layout menu : Sorted the editor creation items alphabetically.
+- RenderManAttributes : Re-labelled displacement `Trace` checkbox as `Enabled`, to better match other DCCs.
 
 Fixes
 -----

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -128,10 +128,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 	] :
 		target = f"attribute:ri:{attribute}"
 		Gaffer.Metadata.registerValue( target, "layout:section", "Displacement" )
-		if attribute == "trace:displacements" :
-			label = "Trace"
-		else :
-			label = re.sub( r"[dD]isplacement ?", "", Gaffer.Metadata.value( target, "label" ) )
+		label = re.sub( r" ?[dD]isplacement ?", "", Gaffer.Metadata.value( target, "label" ) )
 		Gaffer.Metadata.registerValue( target, "label", label )
 
 	Gaffer.Metadata.registerValues( {


### PR DESCRIPTION
This brings it into line with the `.Args` file and (most) other DCCs.
