### PR TITLE
Arnold metadata : Tag `standard_volume` as type `volume`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,10 +1,16 @@
 1.x.x.x (relative to 1.6.x.x)
 =======
 
+Improvements
+------------
+
+- ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`. This matches volume assignments imported from USD, and means that Gaffer now exports materials to USD using the same convention.
+
 Breaking Changes
 ----------------
 
 - ValuePlug : Disconnection no longer emits `plugSetSignal()`.
+- ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`.
 
 1.6.x.x (relative to 1.6.0.0)
 =======

--- a/arnoldPlugins/gaffer.mtd
+++ b/arnoldPlugins/gaffer.mtd
@@ -2875,6 +2875,8 @@
 
 [node standard_volume]
 
+	shaderType STRING "volume"
+
 	gaffer.nodeMenu.category STRING "Volume"
 	gaffer.graphEditorLayout.defaultVisibility BOOL false
 

--- a/python/GafferArnoldTest/ArnoldShaderTest.py
+++ b/python/GafferArnoldTest/ArnoldShaderTest.py
@@ -989,5 +989,11 @@ class ArnoldShaderTest( GafferSceneTest.SceneTestCase ) :
 			ignoreBlindData = True
 		)
 
+	def testStandardVolumeType( self ) :
+
+		shader = GafferArnold.ArnoldShader()
+		shader.loadShader( "standard_volume" )
+		self.assertEqual( shader["type"].getValue(), "ai:volume" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This means it gets assigned via an `ai:volume` attribute. Arnold itself doesn't really make any distinction between volume and surface shaders - there is only one shader on any given object - so it hasn't mattered what we assign to in Gaffer. But for interoperability with USD it is much better if we match the expected convention of a `volume` terminal in the material.

Note that we already updated the Arnold backend to support `ai:volume` attributes back in 37b993e0537b442935c03259e0aa2dd71e6ae932, for when they were loaded from USD. Here we're just making them the default for looks authored in Gaffer.

I haven't changed the type of `atmosphere_volume` or `fog`, because I don't think they are intended to be assigned to objects - instead we use those via the ArnoldAtmosphere node, which itself is in charge of the name of the option created. So I don't know if `atmosphere` or `volume` would be the right type, and it would make no practical difference anyway.
