### PR TITLE
ShaderTweaks, ShaderQuery : Add "Arnold Volume" `shader` preset

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
   - Improved default size of `Show History...` window.
 - SceneInspector, LightEditor, Viewer : Shader parameters with input connections now show the connection source name instead of the plug value. The input shader can be selected via the context menu.
 - Layout menu : Sorted the editor creation items alphabetically.
+- ShaderTweaks, ShaderQuery : Added `Arnold Volume` preset for the `shader` plug.
 
 Fixes
 -----

--- a/startup/gui/shaderPresets.py
+++ b/startup/gui/shaderPresets.py
@@ -54,6 +54,7 @@ with IECore.IgnoredExceptions( ImportError ) :
 
 		( "Arnold Surface", "ai:surface" ),
 		( "Arnold Displacement", "ai:disp_map" ),
+		( "Arnold Volume", "ai:volume" ),
 		( "Arnold Light", "ai:light" ),
 		( "Arnold Gobo", "ai:lightFilter:gobo" ),
 		( "Arnold Decay", "ai:lightFilter:light_decay" ),


### PR DESCRIPTION
This is needed to easily tweak or query volume shaders loaded from USD files, and assigned via ShaderAssignment in Gaffer 1.7 (once #6586 is merged).

