### PR TITLE
RenderMan Globals : Work around failure to switch camera

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Fixes
 - HierarchyView : Fixed filtering bug. This could cause the filter to fail to match anything due to being evaluated with the wrong context.
 - PathListingWidget : Fixed parent layout update when column sizes change.
 - Path : Fixed GIL management bug in `children()` binding.
+- RenderMan : Worked around RenderMan bug that prevented edits to the `render:camera` option from working during an interactive render.
 
 API
 ---

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -253,7 +253,19 @@ void Globals::option( const IECore::InternedString &name, const IECore::Object *
 	{
 		if( auto *d = optionCast<const StringData>( value, name ) )
 		{
-			m_cameraOption = d->readable();
+			if( d->readable() != m_cameraOption )
+			{
+				m_cameraOption = d->readable();
+				// Work around Riley bug. We should just be able to change the
+				// camera in our existing render view, which we try to do by
+				// calling `ModifyRenderView()` in `updateRenderView()`. But that
+				// doesn't work, so for now we delete the render view so that it'll
+				// get recreated from scratch instead. The downside of this is
+				// that display drivers are re-opened, which when rendering to a
+				// Catalogue creates a new image. But that's better than not
+				// changing camera at all.
+				deleteRenderView();
+			}
 		}
 	}
 	else if( name == g_frameOption )


### PR DESCRIPTION
It appears that hdPrman works around this by only ever making a single camera, and just changing which source camera it uses to update it from. That could be an option for us too - with more work - but for now we use an easier workaround based on making a new render view. Hopefully one day `Riley::ModifyRenderCamera()` can be fixed to do what it says on the tin, and we can remove the workaround.
