### PR TITLE
IECoreArnold::Renderer : Decouple output filters and drivers

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Improvements
   - Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
   - Added Arnold `shadow_density` parameter to the "Shadows" section.
   - Renamed DiskLight `arnold:spread` plug label from "Spread" to "Spread (Arnold)".
+- Arnold : Reworked output filter handling. Now outputs with different filters can write to the same file (#6574). Also improves tidiness of resulting Arnold scene description.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -25,7 +25,9 @@ Improvements
   - Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
   - Added Arnold `shadow_density` parameter to the "Shadows" section.
   - Renamed DiskLight `arnold:spread` plug label from "Spread" to "Spread (Arnold)".
-- Arnold : Reworked output filter handling. Now outputs with different filters can write to the same file (#6574). Also improves tidiness of resulting Arnold scene description.
+- Arnold :
+  - Reworked output filter handling. Now outputs with different filters can write to the same file (#6574). Also improves tidiness of resulting Arnold scene description.
+  - Allow outputs with layer names and outputs without layer names to be merged to the same file.
 
 Fixes
 -----

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -711,12 +711,12 @@ class RendererTest( GafferTest.TestCase ) :
 			outputs = arnold.AiNodeGetArray( options, "outputs" )
 			outputSet = set( arnold.AiArrayGetStr( outputs, i ) for i in range( 0, arnold.AiArrayGetNumElements( outputs ) ) )
 			self.assertEqual( outputSet, set( [
-				"A RGB ieCoreArnold:filter:testA ieCoreArnold:display:testA",
-				"B RGBA ieCoreArnold:filter:testB ieCoreArnold:display:testB",
-				"C FLOAT ieCoreArnold:filter:testC ieCoreArnold:display:testC",
-				"D INT ieCoreArnold:filter:testD ieCoreArnold:display:testD",
-				"E UINT ieCoreArnold:filter:testE ieCoreArnold:display:testE",
-				"F VECTOR ieCoreArnold:filter:testF ieCoreArnold:display:testF",
+				"A RGB ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testA",
+				"B RGBA ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testB",
+				"C FLOAT ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testC",
+				"D INT ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testD",
+				"E UINT ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testE",
+				"F VECTOR ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testF",
 			] ) )
 
 	def testOutputFilters( self ) :
@@ -753,8 +753,112 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( len( filters ), 1 )
 			f = filters[0]
 
+			self.assertEqual( arnold.AiNodeGetName( f ), 'ieCoreArnold:filter:gaussian_filter1' )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( f ) ), "gaussian_filter" )
 			self.assertEqual( arnold.AiNodeGetFlt( f, "width" ), 3.5 )
+
+	def testOutputFiltersMatching( self ):
+
+		# With matching parameters, we still just get one filter
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.ass" )
+		)
+
+		r.output(
+			"test",
+			IECoreScene.Output(
+				"beauty.exr",
+				"exr",
+				"rgba",
+				{
+					"filter" : "gaussian",
+					"filterwidth" : imath.V2f( 3.5 ),
+				}
+			)
+		)
+
+		r.output(
+			"test2",
+			IECoreScene.Output(
+				"beauty2.exr",
+				"exr",
+				"rgba",
+				{
+					"filter" : "gaussian",
+					"filterwidth" : imath.V2f( 3.5 ),
+				}
+			)
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+			filters = self.__allNodes( universe, type = arnold.AI_NODE_FILTER )
+			# Ignore node created automatically by Arnold itself.
+			filters = [ f for f in filters if arnold.AiNodeGetName( f ) != "_forced_box_filter" ]
+
+			self.assertEqual( len( filters ), 1 )
+			f = filters[0]
+
+			self.assertEqual( arnold.AiNodeGetName( f ), 'ieCoreArnold:filter:gaussian_filter1' )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( f ) ), "gaussian_filter" )
+			self.assertEqual( arnold.AiNodeGetFlt( f, "width" ), 3.5 )
+
+	def testOutputFiltersNotMatching( self ):
+
+		# With mismatched parameters, we get two filters
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.SceneDescription,
+			str( self.temporaryDirectory() / "test.ass" )
+		)
+
+		r.output(
+			"test",
+			IECoreScene.Output(
+				"beauty.exr",
+				"exr",
+				"rgba",
+				{
+					"filter" : "gaussian",
+					"filterwidth" : imath.V2f( 3.5 ),
+				}
+			)
+		)
+
+		r.output(
+			"test2",
+			IECoreScene.Output(
+				"beauty2.exr",
+				"exr",
+				"rgba",
+				{
+					"filter" : "gaussian",
+					"filterwidth" : imath.V2f( 1.5 ),
+				}
+			)
+		)
+
+		r.render()
+		del r
+
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+
+			arnold.AiSceneLoad( universe, str( self.temporaryDirectory() / "test.ass" ), None )
+			filters = self.__allNodes( universe, type = arnold.AI_NODE_FILTER )
+			# Ignore node created automatically by Arnold itself.
+			filters = [ f for f in filters if arnold.AiNodeGetName( f ) != "_forced_box_filter" ]
+
+			self.assertEqual( len( filters ), 2 )
+
+			self.assertEqual( [ arnold.AiNodeGetName( f ) for f in filters ], [ 'ieCoreArnold:filter:gaussian_filter1',  'ieCoreArnold:filter:gaussian_filter2' ] )
+			self.assertEqual( [ arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( f ) ) for f in filters ], [ "gaussian_filter" ] * 2 )
+			self.assertEqual( set( [ arnold.AiNodeGetFlt( f, "width" ) for f in filters ] ), set( [ 3.5, 1.5 ] ) )
 
 	def testOutputLPEs( self ) :
 
@@ -798,8 +902,8 @@ class RendererTest( GafferTest.TestCase ) :
 			self.assertEqual( arnold.AiArrayGetNumElements( outputs ), 2 )
 			outputSet = set( [ arnold.AiArrayGetStr( outputs, 0 ), arnold.AiArrayGetStr( outputs, 1 ) ] )
 			self.assertEqual( outputSet, set( [
-				"ieCoreArnold:lpe:test RGB ieCoreArnold:filter:test ieCoreArnold:display:test",
-				"ieCoreArnold:lpe:testWithAlpha RGBA ieCoreArnold:filter:testWithAlpha ieCoreArnold:display:testWithAlpha"
+				"ieCoreArnold:lpe:test RGB ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:test",
+				"ieCoreArnold:lpe:testWithAlpha RGBA ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testWithAlpha"
 			] ) )
 
 			lpes = arnold.AiNodeGetArray( options, "light_path_expressions" )
@@ -867,7 +971,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"combined2.exr",
 				"exr",
 				"color D",
-				{ "filter" : "catrom" }
+				{ "testParm" : 4, "filter" : "catrom", "filterwidth" : 4 }
 			)
 		)
 
@@ -877,7 +981,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"combined2.exr",
 				"exr",
 				"color E",
-				{ "filter" : "catrom" }
+				{ "testParm" : 4, "filter" : "box" }
 			)
 		)
 
@@ -887,7 +991,7 @@ class RendererTest( GafferTest.TestCase ) :
 				"combined2.exr",
 				"exr",
 				"color F",
-				{ "filter" : "catrom" }
+				{ "testParm" : 4, "filter" : "catrom" }
 			)
 		)
 
@@ -902,30 +1006,31 @@ class RendererTest( GafferTest.TestCase ) :
 			outputs = arnold.AiNodeGetArray( options, "outputs" )
 			outputSet = set( arnold.AiArrayGetStr( outputs, i ) for i in range( 0, arnold.AiArrayGetNumElements( outputs ) ) )
 			self.assertEqual( outputSet, set( [
-				"A RGB ieCoreArnold:filter:testA,testB ieCoreArnold:display:testA,testB",
-				"E RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF",
-				"B RGB ieCoreArnold:filter:testA,testB ieCoreArnold:display:testA,testB",
-				"C RGB ieCoreArnold:filter:testC ieCoreArnold:display:testC",
-				"D RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF",
-				"F RGB ieCoreArnold:filter:testD,testE,testF ieCoreArnold:display:testD,testE,testF"
+				"A RGB ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testA,testB",
+				"B RGB ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testA,testB",
+				"C RGB ieCoreArnold:filter:gaussian_filter1 ieCoreArnold:display:testC",
+				"D RGB ieCoreArnold:filter:catrom_filter1 ieCoreArnold:display:testD,testE,testF",
+				"E RGB ieCoreArnold:filter:box_filter1 ieCoreArnold:display:testD,testE,testF",
+				"F RGB ieCoreArnold:filter:catrom_filter2 ieCoreArnold:display:testD,testE,testF"
 			] ) )
+
 
 			driver1 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testA,testB" )
 			self.assertEqual( arnold.AiNodeGetStr( driver1, "filename" ), "combined.exr" )
 			self.assertEqual( arnold.AiNodeGetInt( driver1, "testParm" ), 2 )
-			filter1 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testA,testB" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter1 ) ), "gaussian_filter" )
 
 			driver2 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testC" )
 			self.assertEqual( arnold.AiNodeGetStr( driver2, "filename" ), "single.exr" )
 			self.assertEqual( arnold.AiNodeGetInt( driver2, "whatever" ), 3 )
-			filter2 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testC" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter2 ) ), "gaussian_filter" )
 
 			driver3 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:display:testD,testE,testF" )
 			self.assertEqual( arnold.AiNodeGetStr( driver3, "filename" ), "combined2.exr" )
-			filter3 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:testD,testE,testF" )
-			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter3 ) ), "catrom_filter" )
+
+			filter1 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:gaussian_filter1" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter1 ) ), "gaussian_filter" )
+
+			filter2 = arnold.AiNodeLookUpByName( universe, "ieCoreArnold:filter:catrom_filter1" )
+			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( filter2 ) ), "catrom_filter" )
 
 	def testMultipleCameras( self ) :
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -4298,6 +4298,39 @@ class RendererTest( GafferTest.TestCase ) :
 			{ "diffuse.{}".format( c ) for c in "RGB" }
 		)
 
+	def testOutputMergeMixedLayerNames( self ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+		)
+
+		fileName = str( self.temporaryDirectory() / "combined.exr" )
+		r.output(
+			"whatABeauty", IECoreScene.Output(
+				fileName, "exr", "rgba",
+				{
+				}
+			)
+		)
+
+		r.output(
+			"diffuseLPE", IECoreScene.Output(
+				fileName, "exr", "lpe C<RD>.*",
+				{
+					"layerName" : "diffuse",
+				}
+			)
+		)
+
+		r.render()
+
+		image = OpenImageIO.ImageBuf( fileName )
+		self.assertEqual(
+			set( image.spec().channelnames ),
+			set( [ "diffuse.{}".format( c ) for c in "RGB" ] + list( "RGBA" ) )
+		)
+
 	def testLightGroupOutputs( self ) :
 
 		r = GafferScene.Private.IECoreScenePreview.Renderer.create(


### PR DESCRIPTION
Equivalent to #6588, but from a branch that can run Arnold CI. Daniel's original description is copied below...

Filters are now stored separately from the driver, instead of having a 1-to-1 relationship. This allows for multiple outputs sharing the same combined driver to have different filters, and also means that separate outputs using separate drivers, but with the same filter, can share the filter, instead of outputting copies of an identical filter.

I've been trying to think of any corner cases where this new approach might go wrong, but it seems to all be OK, and the test coverage is moderately decent.

I should perhaps recount here for the historical record two finer points we discussed offline:
* the new naming convention is just the driver type plus a unique integer. The previous naming convention was based on the output that uses the filter, but usually when you're looking at the name, you're looking at it along side the driver which is also named that way, so the old name didn't really tell you anything.
* this currently does not remove unused filters until the renderer completes. Unused filters would only occur if you're tweaking filter parameters during an interactive render, and having some unused filters around doesn't seem to cause any problems.