### PR TITLE
Arnold USD schemas : Add `lens_radius`, `aspect_ratio` and `shadow_density` light parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ Improvements
 - ShaderTweaks : Added support for creating tweaks via drag & drop from the SceneInspector to the `+` button. Dragging a single value creates an unnamed tweak of the right type. Drag a multiple selection containing the name and the value to set the value too.
 - PathListingWidget : Improved update responsiveness by updating visible items before items which are collapsed or scrolled out of view.
 - RenderManAttributes : Re-labelled displacement `Trace` checkbox as `Enabled`, to better match other DCCs.
+- USDLight : Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,9 @@ Improvements
 - ShaderTweaks : Added support for creating tweaks via drag & drop from the SceneInspector to the `+` button. Dragging a single value creates an unnamed tweak of the right type. Drag a multiple selection containing the name and the value to set the value too.
 - PathListingWidget : Improved update responsiveness by updating visible items before items which are collapsed or scrolled out of view.
 - RenderManAttributes : Re-labelled displacement `Trace` checkbox as `Enabled`, to better match other DCCs.
-- USDLight : Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
+- USDLight :
+  - Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
+  - Added Arnold `shadow_density` parameter to the "Shadows" section.
 
 Fixes
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -24,6 +24,7 @@ Improvements
 - USDLight :
   - Added Arnold `lens_radius` and `aspect_ratio` parameters to the "Shaping" section.
   - Added Arnold `shadow_density` parameter to the "Shadows" section.
+  - Renamed DiskLight `arnold:spread` plug label from "Spread" to "Spread (Arnold)".
 
 Fixes
 -----

--- a/python/GafferArnoldTest/USDLightTest.py
+++ b/python/GafferArnoldTest/USDLightTest.py
@@ -60,6 +60,7 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 			( "arnold:indirect", Gaffer.FloatPlug, 1.0 ),
 			( "arnold:volume", Gaffer.FloatPlug, 1.0 ),
 			( "arnold:cast_volumetric_shadows", Gaffer.BoolPlug, True ),
+			( "arnold:shadow_density", Gaffer.FloatPlug, 1.0 ),
 			( "arnold:max_bounces", Gaffer.IntPlug, 999 ),
 		]
 

--- a/python/GafferArnoldTest/USDLightTest.py
+++ b/python/GafferArnoldTest/USDLightTest.py
@@ -102,6 +102,8 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 			[
 				( "arnold:camera", Gaffer.FloatPlug, 0.0 ),
 				( "arnold:transmission", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:lens_radius", Gaffer.FloatPlug, 0.0 ),
+				( "arnold:aspect_ratio", Gaffer.FloatPlug, 1.0 ),
 			]
 		)
 
@@ -123,6 +125,11 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 
 		light = GafferUSD.USDLight()
 
+		spotLightParameters = [
+			"lens_radius",
+			"aspect_ratio"
+		]
+
 		for usdLight, arnoldLight in [
 			( "SphereLight", "point_light" ),
 			( "RectLight", "quad_light" ),
@@ -139,13 +146,15 @@ class USDLightTest( GafferSceneTest.SceneTestCase ) :
 				with IECoreArnold.UniverseBlock( writable = False ) :
 
 					arnoldNode = arnold.AiNodeEntryLookUp( arnoldLight )
+					spotLightNode = arnold.AiNodeEntryLookUp( "spot_light" )
 
 					for plug in light["parameters"].values() :
 
 						if not plug.getName().startswith( "arnold:" ) :
 							continue
 
-						param = arnold.AiNodeEntryLookUpParameter( arnoldNode, plug.getName().replace( "arnold:", "" ) )
+						parameterName = plug.getName().replace( "arnold:", "" )
+						param = arnold.AiNodeEntryLookUpParameter( spotLightNode if parameterName in spotLightParameters else arnoldNode, parameterName )
 						self.assertIsNotNone( param )
 
 						match arnold.AiParamGetType( param ) :

--- a/startup/gui/usd.py
+++ b/startup/gui/usd.py
@@ -51,10 +51,14 @@ Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.texture:format", 
 # because they provide no control over property ordering.
 for i, parameter in enumerate( [
 	"aov", "aov_indirect", "portal_mode", "spread", "roundness", "soft_edge", "camera",
-	"transmission", "sss", "indirect", "volume", "max_bounces", "cast_volumetric_shadows",
-	"samples", "volume_samples", "resolution"
+	"transmission", "sss", "indirect", "volume", "max_bounces", "lens_radius", "aspect_ratio",
+	"cast_volumetric_shadows", "samples", "volume_samples", "resolution"
 ] ) :
 	Gaffer.Metadata.registerValue( GafferUSD.USDLight, f"parameters.arnold:{parameter}", "layout:index", 1000 + i )
+
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters", "layout:activator:coneAngleEnabled", lambda plug : plug["shaping:cone:angle"]["enabled"].getValue() )
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.arnold:lens_radius", "layout:activator", "coneAngleEnabled" )
+Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.arnold:aspect_ratio", "layout:activator", "coneAngleEnabled" )
 
 # Change Cycles ordering.
 for i, parameter in enumerate( [

--- a/startup/gui/usd.py
+++ b/startup/gui/usd.py
@@ -52,7 +52,7 @@ Gaffer.Metadata.registerValue( GafferUSD.USDLight, "parameters.texture:format", 
 for i, parameter in enumerate( [
 	"aov", "aov_indirect", "portal_mode", "spread", "roundness", "soft_edge", "camera",
 	"transmission", "sss", "indirect", "volume", "max_bounces", "lens_radius", "aspect_ratio",
-	"cast_volumetric_shadows", "samples", "volume_samples", "resolution"
+	"cast_volumetric_shadows", "shadow_density", "samples", "volume_samples", "resolution"
 ] ) :
 	Gaffer.Metadata.registerValue( GafferUSD.USDLight, f"parameters.arnold:{parameter}", "layout:index", 1000 + i )
 

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -126,7 +126,7 @@ class "GafferArnoldDiskLightAPI" (
 
 	float inputs:arnold:spread = 1.0 (
 		displayGroup = "Geometry"
-		displayName = "Spread"
+		displayName = "Spread (Arnold)"
 	)
 
 	float inputs:arnold:camera = 0.0 (

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -237,3 +237,25 @@ class "GafferArnoldSkydomeLightAPI" (
 	)
 
 }
+
+class "GafferArnoldSpotLightAPI" (
+	customData = {
+		token[] apiSchemaAutoApplyTo = [ "CylinderLight", "DistantLight", "DiskLight", "SphereLight" ]
+		string apiSchemaType = "singleApply"
+		string className = "GafferArnoldSpotLightAPI"
+	}
+	inherits = </APISchemaBase>
+)
+{
+
+	float inputs:arnold:lens_radius = 0.0 (
+		displayGroup = "Shaping"
+		displayName = "Lens Radius (Arnold)"
+	)
+
+	float inputs:arnold:aspect_ratio = 1.0 (
+		displayGroup = "Shaping"
+		displayName = "Aspect Ratio (Arnold)"
+	)
+
+}

--- a/usdSchemas/GafferArnold.usda
+++ b/usdSchemas/GafferArnold.usda
@@ -80,6 +80,11 @@ class "GafferArnoldLightAPI" (
 		displayName = "Cast Volumetric (Arnold)"
 	)
 
+	float inputs:arnold:shadow_density = 1.0 (
+		displayGroup = "Shadows"
+		displayName = "Shadow Density (Arnold)"
+	)
+
 	int inputs:arnold:max_bounces = 999 (
 		displayGroup = "Refine"
 		displayName = "Max Bounces (Arnold)"


### PR DESCRIPTION
This adds a handful of additional Arnold-specific parameters to USDLight. The Arnold `spot_light` specific parameters have been added to all lights that are able to be translated to an Arnold `spot_light` with an activator to only enable them when `shaping:cone:angle` is in use.