### PR TITLE
Menu : Automatically create shortcuts for keys on the number pad

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -28,6 +28,7 @@ Fixes
 - PathListingWidget : Fixed parent layout update when column sizes change.
 - Path : Fixed GIL management bug in `children()` binding.
 - RenderMan : Worked around RenderMan bug that prevented edits to the `render:camera` option from working during an interactive render.
+- Menu : Fixed bug causing keys pressed on the number pad to not activate keyboard shortcuts, such as the <kbd>Alt</kbd>+<kbd>[1-9]</kbd> shortcuts for assigning focus to a numeric bookmark.
 
 API
 ---


### PR DESCRIPTION
Qt differentiates keys on the keypad by adding the `KeypadModifier` to their keypresses. This means that shortcuts that don't specifically include `KeypadModifier`, such as `"Alt+1"`, would not be triggered by `Alt`+`keypad 1`, while `"Alt+Num+1"` would be triggered by `Alt`+`keypad 1` but not `Alt`+`1`. 

We want keypad keys to be treated the same as regular keys, and not require creators of menu items to remember to create two separate shortcuts, so this PR automatically creates the keypad specific shortcut when necessary.