### PR TITLE
LightEditor, RenderPassEditor, AttributeEditor : Reuse columns

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.2.0)
 =======
 
+Improvements
+------------
+
+- LightEditor, RenderPassEditor, AttributeEditor : Column width adjustments are now preserved when switching tabs.
+
 Fixes
 -----
 

--- a/python/GafferSceneUI/LightEditor.py
+++ b/python/GafferSceneUI/LightEditor.py
@@ -127,6 +127,8 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 			Gaffer.WeakMethod( self.__selectedPathsChanged )
 		)
 
+		self.__columnCache = {}
+
 		self._updateFromSet()
 		self.__transferSelectionFromScriptNode()
 		self.__updateColumns()
@@ -273,9 +275,18 @@ class LightEditor( GafferSceneUI.SceneEditor ) :
 		for rendererKey, sections in self.__columnRegistry.items() :
 			if IECore.StringAlgo.match( attribute, rendererKey ) :
 				section = sections.get( currentSection or None, {} )
-				sectionColumns += [ c( self.settings()["in"], self.settings()["editScope"] ) for c in section.values() ]
+				sectionColumns += [ self.__acquireColumn( c, currentSection ) for c in section.values() ]
 
 		self.__pathListing.setColumns( self.__commonColumns + sectionColumns )
+
+	def __acquireColumn( self, columnCreator, section ) :
+
+		column = self.__columnCache.get( ( columnCreator, section ) )
+		if column is None :
+			column = columnCreator( self.settings()["in"], self.settings()["editScope"] )
+			self.__columnCache[ ( columnCreator, section ) ] = column
+
+		return column
 
 	def __selectedPathsChanged( self, scriptNode ) :
 


### PR DESCRIPTION
Column width adjustments were being lost when switching back to a tab that had previously adjusted columns. PathListingWidget already tracks column width adjustments for each column, but these Editors were creating brand new columns on each call of `__updateColumns()`, so PathListingWidget couldn't associate the old offset with the new column. Now we keep track of the columns created by each instance of the Editor, and reuse them if they already exist.