### PR TITLE
Remove Some Use Of Deprecated IECoreImage

### DIFF
--- a/python/GafferArnoldTest/ArnoldRenderTest.py
+++ b/python/GafferArnoldTest/ArnoldRenderTest.py
@@ -45,7 +45,6 @@ import arnold
 import imath
 
 import IECore
-import IECoreImage
 import IECoreScene
 import IECoreArnold
 

--- a/python/GafferImageTest/ImageSamplerTest.py
+++ b/python/GafferImageTest/ImageSamplerTest.py
@@ -38,7 +38,6 @@ import imath
 import math
 
 import IECore
-import IECoreImage
 
 import Gaffer
 import GafferTest

--- a/python/GafferImageTest/ImageTestCase.py
+++ b/python/GafferImageTest/ImageTestCase.py
@@ -39,7 +39,6 @@ import os
 import pathlib
 
 import IECore
-import IECoreImage
 
 import Gaffer
 import GafferTest

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -49,7 +49,6 @@ import inspect
 import OpenImageIO
 
 import IECore
-import IECoreImage
 
 import Gaffer
 import GafferTest
@@ -553,7 +552,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 			# reference images were written with an older OIIO that mistakenly read/writes
 			# this metadata. Note non-OIIO apps like RV do not read this metadata.
 			# See https://github.com/OpenImageIO/oiio/pull/2521 for an explanation
-			ignoreDataWindow = ext in ( "tif", "tiff" ) and hasattr( IECoreImage, "OpenImageIOAlgo" ) and IECoreImage.OpenImageIOAlgo.version() >= 20206
+			ignoreDataWindow = ext in ( "tif", "tiff" ) and OpenImageIO.VERSION >= 20206
 
 			if not removeAlpha:
 				self.assertImagesEqual( expectedOutput["out"], writerOutput["out"], maxDifference = maxError, ignoreMetadata = True, ignoreDataWindow = ignoreDataWindow )
@@ -825,7 +824,7 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		# reference images were written with an older OIIO that mistakenly read/writes
 		# this metadata. Note non-OIIO apps like RV do not read this metadata.
 		# See https://github.com/OpenImageIO/oiio/pull/2521 for an explanation
-		ignoreDataWindow = ext in ( "tif", "tiff" ) and hasattr( IECoreImage, "OpenImageIOAlgo" ) and IECoreImage.OpenImageIOAlgo.version() >= 20206
+		ignoreDataWindow = ext in ( "tif", "tiff" ) and OpenImageIO.VERSION >= 20206
 
 		self.assertImagesEqual( misledWriter["in"], misledReader["out"], ignoreMetadata = True, ignoreDataWindow = ignoreDataWindow )
 		self.assertImagesEqual( misledReader["out"], regularReader["out"], ignoreMetadata = True, ignoreDataWindow = ignoreDataWindow )

--- a/python/IECoreArnoldTest/MeshAlgoTest.py
+++ b/python/IECoreArnoldTest/MeshAlgoTest.py
@@ -41,7 +41,6 @@ import imath
 
 import IECore
 import IECoreScene
-import IECoreImage
 import IECoreArnold
 
 class MeshAlgoTest( unittest.TestCase ) :


### PR DESCRIPTION
Following on from my previous commit where I was asked not to copy code in IECoreArnoldTest::RendererTest that used IECoreImage, I've now gone back and removed the deprecated usage from the existing code.

While I was at it, I did a quick skim for similar usage elsewhere, and found a similar use in ImageWriterTest that was easy to fix. Also several files that are import IECoreImage, but don't appear to be using it in any way ... unless you know how these are being used, it appears safe to remove them as well.