### PR TITLE
IECoreRenderMan : Load `libprman` at runtime

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1451,8 +1451,6 @@ libraries = {
 			"CPPDEFINES" : [ "RMAN_RIX_NO_WARN_DEPRECATED" ],
 			"LIBS" : [
 				"Iex$OPENEXR_LIB_SUFFIX", "Gaffer", "GafferDispatch", "GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX",
-				"prman" if env["PLATFORM"] != "win32" else "libprman",
-				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
 			],
 			"LIBPATH" : [ "$RENDERMAN_ROOT/lib" ],
 		},

--- a/SConstruct
+++ b/SConstruct
@@ -1407,7 +1407,7 @@ libraries = {
 			"LIBS" : [
 				"GafferScene", "IECoreScene$CORTEX_LIB_SUFFIX",
 				"IECoreVDB$CORTEX_LIB_SUFFIX",
-				"prman" if env["PLATFORM"] != "win32" else "libprman",
+				"loadprman",
 				"pxrcore" if env["PLATFORM"] != "win32" else "libpxrcore",
 				"oslquery$OSL_LIB_SUFFIX",
 				"OpenImageIO_Util$OIIO_LIB_SUFFIX",

--- a/src/IECoreRenderMan/Attributes.cpp
+++ b/src/IECoreRenderMan/Attributes.cpp
@@ -37,12 +37,11 @@
 #include "Attributes.h"
 
 #include "ParamListAlgo.h"
+#include "Strings.h"
 
 #include "IECoreScene/ShaderNetwork.h"
 
 #include "IECore/SimpleTypedData.h"
-
-#include "RixPredefinedStrings.hpp"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/predicate.hpp"
@@ -270,12 +269,12 @@ Attributes::Attributes( const IECore::CompoundObject *attributes, MaterialCache 
 
 		if( name == g_lightMuteAttributeName )
 		{
-			ParamListAlgo::convertParameter( Rix::k_lighting_mute, data, m_instanceAttributes );
+			ParamListAlgo::convertParameter( strings().k_lighting_mute, data, m_instanceAttributes );
 		}
 		else if( name == g_doubleSidedAttributeName )
 		{
 			int sides = attributeCast<bool>( value.get(), name, true ) ? 2 : 1;
-			m_instanceAttributes.SetInteger( Rix::k_Ri_Sides, sides );
+			m_instanceAttributes.SetInteger( strings().k_Ri_Sides, sides );
 		}
 		else if( boost::starts_with( name.string(), g_userAttributePrefix ) )
 		{

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -37,9 +37,8 @@
 #include "Camera.h"
 
 #include "ParamListAlgo.h"
+#include "Strings.h"
 #include "Transform.h"
-
-#include "RixPredefinedStrings.hpp"
 
 #include "boost/algorithm/string/predicate.hpp"
 
@@ -67,12 +66,12 @@ Camera::Camera( const std::string &name, const IECoreScene::Camera *camera, Sess
 	// Parameters
 
 	RtParamList cameraParamList;
-	cameraParamList.SetFloat( Rix::k_nearClip, camera->getClippingPlanes()[0] );
-	cameraParamList.SetFloat( Rix::k_farClip, camera->getClippingPlanes()[1] );
+	cameraParamList.SetFloat( strings().k_nearClip, camera->getClippingPlanes()[0] );
+	cameraParamList.SetFloat( strings().k_farClip, camera->getClippingPlanes()[1] );
 
 	const Box2f frustum = camera->frustum();
 	array<float, 4> screenWindow = { frustum.min.x, frustum.max.x, frustum.min.y, frustum.max.y };
-	cameraParamList.SetFloatArray( Rix::k_Ri_ScreenWindow, screenWindow.data(), screenWindow.size() );
+	cameraParamList.SetFloatArray( strings().k_Ri_ScreenWindow, screenWindow.data(), screenWindow.size() );
 
 	// Projection shader
 
@@ -118,8 +117,8 @@ Camera::Camera( const std::string &name, const IECoreScene::Camera *camera, Sess
 	RtParamList options;
 
 	const Imath::V2i resolution = camera->renderResolution();
-	options.SetIntegerArray( Rix::k_Ri_FormatResolution, resolution.getValue(), 2 );
-	options.SetFloat( Rix::k_Ri_FormatPixelAspectRatio, camera->getPixelAspectRatio() );
+	options.SetIntegerArray( strings().k_Ri_FormatResolution, resolution.getValue(), 2 );
+	options.SetFloat( strings().k_Ri_FormatPixelAspectRatio, camera->getPixelAspectRatio() );
 
 	Box2f cropWindow = camera->getCropWindow();
 	if( cropWindow.isEmpty() )
@@ -129,7 +128,7 @@ Camera::Camera( const std::string &name, const IECoreScene::Camera *camera, Sess
 		cropWindow = Box2f( V2f( 0 ), V2f( 1 ) );
 	}
 	float renderManCropWindow[4] = { cropWindow.min.x, cropWindow.max.x, cropWindow.min.y, cropWindow.max.y };
-	options.SetFloatArray( Rix::k_Ri_CropWindow, renderManCropWindow, 4 );
+	options.SetFloatArray( strings().k_Ri_CropWindow, renderManCropWindow, 4 );
 
 	// Camera
 

--- a/src/IECoreRenderMan/CurvesAlgo.cpp
+++ b/src/IECoreRenderMan/CurvesAlgo.cpp
@@ -35,10 +35,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GeometryAlgo.h"
+#include "Strings.h"
 
 #include "IECoreScene/CurvesPrimitive.h"
-
-#include "RixPredefinedStrings.hpp"
 
 using namespace IECore;
 using namespace IECoreScene;
@@ -59,25 +58,25 @@ void convertCurvesTopology( const IECoreScene::CurvesPrimitive *curves, RtPrimVa
 	if( curves->basis().standardBasis() == StandardCubicBasis::Unknown )
 	{
 		IECore::msg( IECore::Msg::Warning, messageContext, "Unsupported CubicBasis" );
-		primVars.SetString( Rix::k_Ri_type, Rix::k_linear );
+		primVars.SetString( strings().k_Ri_type, strings().k_linear );
 	}
 	else if( curves->basis().standardBasis() == StandardCubicBasis::Linear )
 	{
-		primVars.SetString( Rix::k_Ri_type, Rix::k_linear );
+		primVars.SetString( strings().k_Ri_type, strings().k_linear );
 	}
 	else
 	{
-		primVars.SetString( Rix::k_Ri_type, Rix::k_cubic );
+		primVars.SetString( strings().k_Ri_type, strings().k_cubic );
 		switch( curves->basis().standardBasis() )
 		{
 			case StandardCubicBasis::Bezier :
-				primVars.SetString( Rix::k_Ri_Basis, Rix::k_bezier );
+				primVars.SetString( strings().k_Ri_Basis, strings().k_bezier );
 				break;
 			case StandardCubicBasis::BSpline :
-				primVars.SetString( Rix::k_Ri_Basis, Rix::k_bspline );
+				primVars.SetString( strings().k_Ri_Basis, strings().k_bspline );
 				break;
 			case StandardCubicBasis::CatmullRom :
-				primVars.SetString( Rix::k_Ri_Basis, Rix::k_catmullrom );
+				primVars.SetString( strings().k_Ri_Basis, strings().k_catmullrom );
 				break;
 			default :
 				// Should have dealt with Unknown and Linear above
@@ -85,22 +84,22 @@ void convertCurvesTopology( const IECoreScene::CurvesPrimitive *curves, RtPrimVa
 		}
 	}
 
-	primVars.SetString( Rix::k_Ri_wrap, curves->periodic() ? Rix::k_periodic : Rix::k_nonperiodic );
-	primVars.SetIntegerDetail( Rix::k_Ri_nvertices, curves->verticesPerCurve()->readable().data(), RtDetailType::k_uniform );
+	primVars.SetString( strings().k_Ri_wrap, curves->periodic() ? strings().k_periodic : strings().k_nonperiodic );
+	primVars.SetIntegerDetail( strings().k_Ri_nvertices, curves->verticesPerCurve()->readable().data(), RtDetailType::k_uniform );
 }
 
 RtUString convertStaticCurves( const IECoreScene::CurvesPrimitive *curves, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	convertCurvesTopology( curves, primVars, messageContext );
 	GeometryAlgo::convertPrimitiveVariables( curves, primVars, messageContext );
-	return Rix::k_Ri_Curves;
+	return strings().k_Ri_Curves;
 }
 
 RtUString convertAnimatedCurves( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	convertCurvesTopology( samples[0], primVars, messageContext );
 	GeometryAlgo::convertPrimitiveVariables( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
-	return Rix::k_Ri_Curves;
+	return strings().k_Ri_Curves;
 }
 
 GeometryAlgo::ConverterDescription<CurvesPrimitive> g_curvesConverterDescription( convertStaticCurves, convertAnimatedCurves );

--- a/src/IECoreRenderMan/Globals.cpp
+++ b/src/IECoreRenderMan/Globals.cpp
@@ -36,14 +36,13 @@
 
 #include "Globals.h"
 #include "ParamListAlgo.h"
+#include "Strings.h"
 #include "Transform.h"
 
 #include "IECoreRenderMan/ShaderNetworkAlgo.h"
 
 #include "IECore/SimpleTypedData.h"
 #include "IECore/StringAlgo.h"
-
-#include "RixPredefinedStrings.hpp"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/predicate.hpp"
@@ -70,7 +69,7 @@ const IECore::InternedString g_pixelFilterNameOption( "ri:Ri:PixelFilterName" );
 const IECore::InternedString g_pixelFilterWidthOption( "ri:Ri:PixelFilterWidth" );
 const IECore::InternedString g_pixelVarianceOption( "ri:Ri:PixelVariance" );
 
-const RtUString g_defaultPixelFilter = Rix::k_gaussian;
+const RtUString g_defaultPixelFilter = strings().k_gaussian;
 riley::FilterSize g_defaultPixelFilterSize = { 2, 2 };
 float g_defaultPixelVariance = 0.015;
 
@@ -168,7 +167,7 @@ Globals::Globals( IECoreScenePreview::Renderer::RenderType renderType, const IEC
 	if( char *p = getenv( "RMAN_DISPLAYS_PATH" ) )
 	{
 		string searchPath = string( p ) + ":@";
-		m_options.SetString( Rix::k_searchpath_display, RtUString( searchPath.c_str() ) );
+		m_options.SetString( strings().k_searchpath_display, RtUString( searchPath.c_str() ) );
 	}
 
 	if( char *p = getenv( "OSL_SHADER_PATHS" ) )
@@ -177,13 +176,13 @@ Globals::Globals( IECoreScenePreview::Renderer::RenderType renderType, const IEC
 		// Convert Windows ';' path entry separator to ':' as `RMAN_SHADERPATH` expects
 		std::replace( searchPath.begin(), searchPath.end(), ';', ':' );
 		searchPath += ":@";
-		m_options.SetString( Rix::k_searchpath_shader, RtUString( searchPath.c_str() ) );
+		m_options.SetString( strings().k_searchpath_shader, RtUString( searchPath.c_str() ) );
 	}
 
 	if( renderType == IECoreScenePreview::Renderer::Interactive )
 	{
-		m_options.SetInteger( Rix::k_hider_incremental, 1 );
-		m_options.SetString( Rix::k_bucket_order, RtUString( "circle" ) );
+		m_options.SetInteger( strings().k_hider_incremental, 1 );
+		m_options.SetString( strings().k_bucket_order, RtUString( "circle" ) );
 	}
 
 	for( const auto &[name, value] : g_lpeLobeDefaults )
@@ -561,7 +560,7 @@ void Globals::updateRenderView()
 	}
 
 	riley::Extent extent = { 640, 480, 0 };
-	if( auto *resolution = camera.options.GetIntegerArray( Rix::k_Ri_FormatResolution, 2 ) )
+	if( auto *resolution = camera.options.GetIntegerArray( strings().k_Ri_FormatResolution, 2 ) )
 	{
 		extent.x = resolution[0];
 		extent.y = resolution[1];
@@ -846,7 +845,7 @@ const std::vector<riley::RenderOutputId> &Globals::acquireRenderOutputs( const I
 		result.push_back(
 			m_session->riley->CreateRenderOutput(
 				riley::UserId(),
-				RtUString( "a" ), riley::RenderOutputType::k_Float, Rix::k_a,
+				RtUString( "a" ), riley::RenderOutputType::k_Float, strings().k_a,
 				accumulationRule, m_pixelFilter, m_pixelFilterSize, relativePixelVariance,
 				RtParamList()
 			)

--- a/src/IECoreRenderMan/Light.cpp
+++ b/src/IECoreRenderMan/Light.cpp
@@ -41,9 +41,8 @@
 #include "IECoreRenderMan/ShaderNetworkAlgo.h"
 
 #include "LightFilter.h"
+#include "Strings.h"
 #include "Transform.h"
-
-#include "RixPredefinedStrings.hpp"
 
 using namespace std;
 using namespace Imath;
@@ -355,7 +354,7 @@ void Light::updateLightFilterShader( const IECoreScene::ConstShaderNetworkPtr &l
 
 void Light::updateLinking( RtUString memberships, RtUString shadowSubset )
 {
-	m_extraAttributes.SetString( Rix::k_grouping_membership, memberships );
+	m_extraAttributes.SetString( strings().k_grouping_membership, memberships );
 
 	if( m_lightInstance == riley::LightInstanceId::InvalidId() )
 	{

--- a/src/IECoreRenderMan/MeshAlgo.cpp
+++ b/src/IECoreRenderMan/MeshAlgo.cpp
@@ -36,9 +36,9 @@
 
 #include "GeometryAlgo.h"
 
-#include "IECoreScene/MeshPrimitive.h"
+#include "Strings.h"
 
-#include "RixPredefinedStrings.hpp"
+#include "IECoreScene/MeshPrimitive.h"
 
 #include "fmt/format.h"
 
@@ -129,25 +129,25 @@ RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVar
 		mesh->variableSize( PrimitiveVariable::FaceVarying )
 	);
 
-	primVars.SetIntegerDetail( Rix::k_Ri_nvertices, mesh->verticesPerFace()->readable().data(), RtDetailType::k_uniform );
-	primVars.SetIntegerDetail( Rix::k_Ri_vertices, mesh->vertexIds()->readable().data(), RtDetailType::k_facevarying );
+	primVars.SetIntegerDetail( strings().k_Ri_nvertices, mesh->verticesPerFace()->readable().data(), RtDetailType::k_uniform );
+	primVars.SetIntegerDetail( strings().k_Ri_vertices, mesh->vertexIds()->readable().data(), RtDetailType::k_facevarying );
 
-	RtUString geometryType = Rix::k_Ri_PolygonMesh;
+	RtUString geometryType = strings().k_Ri_PolygonMesh;
 	if( mesh->interpolation() != MeshPrimitive::interpolationLinear.string() )
 	{
-		geometryType = Rix::k_Ri_SubdivisionMesh;
+		geometryType = strings().k_Ri_SubdivisionMesh;
 		if( mesh->interpolation() == MeshPrimitive::interpolationCatmullClark.string() )
 		{
-			primVars.SetString( Rix::k_Ri_scheme, Rix::k_catmullclark );
+			primVars.SetString( strings().k_Ri_scheme, strings().k_catmullclark );
 		}
 		else if( mesh->interpolation() == MeshPrimitive::interpolationLoop.string() )
 		{
-			primVars.SetString( Rix::k_Ri_scheme, Rix::k_loop );
+			primVars.SetString( strings().k_Ri_scheme, strings().k_loop );
 		}
 		else
 		{
 			msg( Msg::Error, messageContext, fmt::format( "Unknown mesh interpolation \"{}\"", mesh->interpolation() ) );
-			primVars.SetString( Rix::k_Ri_scheme, Rix::k_catmullclark );
+			primVars.SetString( strings().k_Ri_scheme, strings().k_catmullclark );
 		}
 
 		vector<RtUString> tagNames;
@@ -159,7 +159,7 @@ RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVar
 
 		for( int creaseLength : mesh->creaseLengths()->readable() )
 		{
-			tagNames.push_back( Rix::k_crease );
+			tagNames.push_back( strings().k_crease );
 			tagArgCounts.push_back( creaseLength ); // integer argument count
 			tagArgCounts.push_back( 1 ); // float argument count
 			tagArgCounts.push_back( 0 ); // string argument count
@@ -172,7 +172,7 @@ RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVar
 
 		if( mesh->cornerIds()->readable().size() )
 		{
-			tagNames.push_back( Rix::k_corner );
+			tagNames.push_back( strings().k_corner );
 			tagArgCounts.push_back( mesh->cornerIds()->readable().size() ); // integer argument count
 			tagArgCounts.push_back( mesh->cornerIds()->readable().size() ); // float argument count
 			tagArgCounts.push_back( 0 ); // string argument count
@@ -182,24 +182,24 @@ RtUString convertMeshTopology( const IECoreScene::MeshPrimitive *mesh, RtPrimVar
 
 		// Interpolation rules
 
-		tagNames.push_back( Rix::k_interpolateboundary );
+		tagNames.push_back( strings().k_interpolateboundary );
 		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
 		tagIntArgs.push_back( interpolateBoundary( mesh, messageContext ) );
 
-		tagNames.push_back( Rix::k_facevaryinginterpolateboundary );
+		tagNames.push_back( strings().k_facevaryinginterpolateboundary );
 		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
 		tagIntArgs.push_back( faceVaryingInterpolateBoundary( mesh, messageContext ) );
 
-		tagNames.push_back( Rix::k_smoothtriangles );
+		tagNames.push_back( strings().k_smoothtriangles );
 		tagArgCounts.insert( tagArgCounts.end(), { 1, 0, 0 } );
 		tagIntArgs.push_back( smoothTriangles( mesh, messageContext ) );
 
 		// Pseudo-primvars to hold the tags
 
-		primVars.SetStringArray( Rix::k_Ri_subdivtags, tagNames.data(), tagNames.size() );
-		primVars.SetIntegerArray( Rix::k_Ri_subdivtagnargs, tagArgCounts.data(), tagArgCounts.size() );
-		primVars.SetFloatArray( Rix::k_Ri_subdivtagfloatargs, tagFloatArgs.data(), tagFloatArgs.size() );
-		primVars.SetIntegerArray( Rix::k_Ri_subdivtagintargs, tagIntArgs.data(), tagIntArgs.size() );
+		primVars.SetStringArray( strings().k_Ri_subdivtags, tagNames.data(), tagNames.size() );
+		primVars.SetIntegerArray( strings().k_Ri_subdivtagnargs, tagArgCounts.data(), tagArgCounts.size() );
+		primVars.SetFloatArray( strings().k_Ri_subdivtagfloatargs, tagFloatArgs.data(), tagFloatArgs.size() );
+		primVars.SetIntegerArray( strings().k_Ri_subdivtagintargs, tagIntArgs.data(), tagIntArgs.size() );
 	}
 
 	return geometryType;

--- a/src/IECoreRenderMan/Object.cpp
+++ b/src/IECoreRenderMan/Object.cpp
@@ -36,9 +36,8 @@
 
 #include "Object.h"
 
+#include "Strings.h"
 #include "Transform.h"
-
-#include "RixPredefinedStrings.hpp"
 
 using namespace std;
 using namespace IECoreRenderMan;
@@ -56,7 +55,7 @@ const RtUString g_defaultShadowGroup( "defaultShadowGroup" );
 Object::Object( const std::string &name, const ConstGeometryPrototypePtr &geometryPrototype, const Attributes *attributes, LightLinker *lightLinker, const Session *session )
 	:	m_session( session ), m_lightLinker( lightLinker ), m_geometryInstance( riley::GeometryInstanceId::InvalidId() ), m_attributes( attributes ), m_geometryPrototype( geometryPrototype )
 {
-	m_extraAttributes.SetString( Rix::k_identifier_name, RtUString( name.c_str() ) );
+	m_extraAttributes.SetString( strings().k_identifier_name, RtUString( name.c_str() ) );
 
 	RtParamList allAttributes = m_attributes->instanceAttributes();
 	allAttributes.Update( m_extraAttributes );
@@ -166,13 +165,13 @@ void Object::link( const IECore::InternedString &type, const IECoreScenePreview:
 	{
 		setMemberData = &m_linkedLights;
 		setType = LightLinker::SetType::Light;
-		attributeName = Rix::k_lighting_subset;
+		attributeName = strings().k_lighting_subset;
 	}
 	else if( type == g_shadowedLights )
 	{
 		setMemberData = &m_shadowedLights;
 		setType = LightLinker::SetType::Shadow;
-		attributeName = Rix::k_grouping_membership;
+		attributeName = strings().k_grouping_membership;
 		defaultAttributeValue = g_defaultShadowGroup;
 	}
 	else
@@ -198,7 +197,7 @@ void Object::link( const IECore::InternedString &type, const IECoreScenePreview:
 
 void Object::assignID( uint32_t id )
 {
-	m_extraAttributes.SetInteger( Rix::k_identifier_id, id );
+	m_extraAttributes.SetInteger( strings().k_identifier_id, id );
 	attributes( m_attributes.get() );
 }
 

--- a/src/IECoreRenderMan/PointsAlgo.cpp
+++ b/src/IECoreRenderMan/PointsAlgo.cpp
@@ -35,10 +35,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GeometryAlgo.h"
+#include "Strings.h"
 
 #include "IECoreScene/PointsPrimitive.h"
-
-#include "RixPredefinedStrings.hpp"
 
 using namespace IECoreScene;
 using namespace IECoreRenderMan;
@@ -60,14 +59,14 @@ RtUString convertStaticPoints( const IECoreScene::PointsPrimitive *points, RtPri
 {
 	convertPointsTopology( points, primVars );
 	GeometryAlgo::convertPrimitiveVariables( points, primVars, messageContext );
-	return Rix::k_Ri_Points;
+	return strings().k_Ri_Points;
 }
 
 RtUString convertAnimatedPoints( const std::vector<const IECoreScene::PointsPrimitive *> &samples, const std::vector<float> &sampleTimes, RtPrimVarList &primVars, const std::string &messageContext )
 {
 	convertPointsTopology( samples[0], primVars );
 	GeometryAlgo::convertPrimitiveVariables( reinterpret_cast<const std::vector<const IECoreScene::Primitive *> &>( samples ), sampleTimes, primVars, messageContext );
-	return Rix::k_Ri_Points;
+	return strings().k_Ri_Points;
 }
 
 GeometryAlgo::ConverterDescription<PointsPrimitive> g_pointsConverterDescription( convertStaticPoints, convertAnimatedPoints );

--- a/src/IECoreRenderMan/Renderer.cpp
+++ b/src/IECoreRenderMan/Renderer.cpp
@@ -56,7 +56,6 @@
 #include "IECore/SimpleTypedData.h"
 
 #include "Riley.h"
-#include "RixPredefinedStrings.hpp"
 
 #include "boost/algorithm/string/predicate.hpp"
 

--- a/src/IECoreRenderMan/Session.cpp
+++ b/src/IECoreRenderMan/Session.cpp
@@ -35,10 +35,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "Session.h"
+#include "Strings.h"
 
 #include "Imath/ImathMatrixAlgo.h"
 
-#include "RixPredefinedStrings.hpp"
+#include "RiEntrypoints.h"
 #include "XcptErrorCodes.h"
 
 #include "fmt/format.h"
@@ -136,11 +137,14 @@ struct Session::ExceptionHandler : public RixXcpt::XcptHandler
 };
 
 Session::Session( IECoreScenePreview::Renderer::RenderType renderType, const RtParamList &options, const IECore::MessageHandlerPtr &messageHandler )
-	:	riley( nullptr ), renderType( renderType ), m_portalsDirty( false )
+	:	riley( nullptr ), renderType( renderType ),
+		m_context( RixGetContextViaRMANTREE() ),
+		m_riCtl( (RixRiCtl *)m_context->GetRixInterface( k_RixRiCtl ) ),
+		m_portalsDirty( false )
 {
 	// `argv[0]==""` prevents RenderMan doing its own signal handling.
 	vector<const char *> args = { "" };
-	PRManSystemBegin( args.size(), args.data() );
+	m_riCtl->PRManSystemBegin( args.size(), args.data() );
 
 	args.clear(); // PRManRenderBegin() doesn't want `argv[0]` as above.
 	int32_t recover = 0;
@@ -156,16 +160,16 @@ Session::Session( IECoreScenePreview::Renderer::RenderType renderType, const RtP
 		args.push_back( "1" );
 	}
 
-	PRManRenderBegin( args.size(), args.data() );
+	m_riCtl->PRManRenderBegin( args.size(), args.data() );
 
 	if( messageHandler )
 	{
 		m_exceptionHandler = std::make_unique<ExceptionHandler>( messageHandler );
-		auto rixXcpt = (RixXcpt *)RixGetContext()->GetRixInterface( k_RixXcpt );
+		auto rixXcpt = (RixXcpt *)m_context->GetRixInterface( k_RixXcpt );
 		rixXcpt->Register( m_exceptionHandler.get() );
 	}
 
-	auto rileyManager = (RixRileyManager *)RixGetContext()->GetRixInterface( k_RixRileyManager );
+	auto rileyManager = (RixRileyManager *)m_context->GetRixInterface( k_RixRileyManager );
 	/// \todo What is the `rileyVariant` argument for? XPU?
 	riley = rileyManager->CreateRiley( RtUString(), RtParamList() );
 
@@ -174,17 +178,17 @@ Session::Session( IECoreScenePreview::Renderer::RenderType renderType, const RtP
 
 Session::~Session()
 {
-	auto rileyManager = (RixRileyManager *)RixGetContext()->GetRixInterface( k_RixRileyManager );
+	auto rileyManager = (RixRileyManager *)m_context->GetRixInterface( k_RixRileyManager );
 	rileyManager->DestroyRiley( riley );
 
 	if( m_exceptionHandler )
 	{
-		auto rixXcpt = (RixXcpt *)RixGetContext()->GetRixInterface( k_RixXcpt );
+		auto rixXcpt = (RixXcpt *)m_context->GetRixInterface( k_RixXcpt );
 		rixXcpt->Unregister( m_exceptionHandler.get() );
 	}
 
-	PRManRenderEnd();
-	PRManSystemEnd();
+	m_riCtl->PRManRenderEnd();
+	m_riCtl->PRManSystemEnd();
 }
 
 riley::CameraId Session::createCamera( RtUString name, const riley::ShadingNode &projection, const riley::Transform &transform, const RtParamList &properties, const RtParamList &options )
@@ -389,7 +393,7 @@ void Session::updatePortals()
 	// Link the lights appropriately.
 
 	RtParamList mutedAttributes;
-	mutedAttributes.SetInteger( Rix::k_lighting_mute, 1 );
+	mutedAttributes.SetInteger( strings().k_lighting_mute, 1 );
 
 	for( const auto &[id, info] : m_domeAndPortalLights )
 	{

--- a/src/IECoreRenderMan/Session.h
+++ b/src/IECoreRenderMan/Session.h
@@ -39,6 +39,7 @@
 #include "GafferScene/Private/IECoreScenePreview/Renderer.h"
 
 #include "Riley.h"
+#include "RixRiCtl.h"
 
 #include "boost/multi_index/member.hpp"
 #include "boost/multi_index/ordered_index.hpp"
@@ -122,6 +123,9 @@ struct Session
 	void updatePortals();
 
 	private :
+
+		RixContext *m_context;
+		RixRiCtl *m_riCtl;
 
 		struct ExceptionHandler;
 		std::unique_ptr<ExceptionHandler> m_exceptionHandler;

--- a/src/IECoreRenderMan/Strings.cpp
+++ b/src/IECoreRenderMan/Strings.cpp
@@ -34,42 +34,16 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GeometryAlgo.h"
-
 #include "Strings.h"
 
-#include "IECoreScene/SpherePrimitive.h"
-
-using namespace IECoreScene;
-using namespace IECoreRenderMan;
-
-namespace
+const RiPredefinedStrings &IECoreRenderMan::strings()
 {
-
-RtUString convertStaticSphere( const IECoreScene::SpherePrimitive *sphere, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	primVars.SetDetail(
-		sphere->variableSize( PrimitiveVariable::Uniform ),
-		sphere->variableSize( PrimitiveVariable::Vertex ),
-		sphere->variableSize( PrimitiveVariable::Varying ),
-		sphere->variableSize( PrimitiveVariable::FaceVarying )
-	);
-
-	GeometryAlgo::convertPrimitiveVariables( sphere, primVars );
-
-	const float radius = sphere->radius();
-	const float zMin = sphere->zMin();
-	const float zMax = sphere->zMax();
-	const float thetaMax = sphere->thetaMax();
-
-	primVars.SetFloatDetail( strings().k_Ri_radius, &radius, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_zmin, &zMin, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_zmax, &zMax, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_thetamax, &thetaMax, RtDetailType::k_constant );
-
-	return strings().k_Ri_Sphere;
+	static RiPredefinedStrings g_strings = [] {
+		auto resolver = (RixSymbolResolver *)RixGetContextViaRMANTREE()->GetRixInterface( k_RixSymbolResolver );
+		RiPredefinedStrings s;
+		resolver->ResolvePredefinedStrings( s );
+		return s;
+	}();
+	return g_strings;
 }
 
-GeometryAlgo::ConverterDescription<SpherePrimitive> g_sphereConverterDescription( convertStaticSphere );
-
-} // namespace

--- a/src/IECoreRenderMan/Strings.h
+++ b/src/IECoreRenderMan/Strings.h
@@ -34,42 +34,15 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "GeometryAlgo.h"
+#pragma once
 
-#include "Strings.h"
+#include "ri.hpp"
 
-#include "IECoreScene/SpherePrimitive.h"
-
-using namespace IECoreScene;
-using namespace IECoreRenderMan;
-
-namespace
+namespace IECoreRenderMan
 {
 
-RtUString convertStaticSphere( const IECoreScene::SpherePrimitive *sphere, RtPrimVarList &primVars, const std::string &messageContext )
-{
-	primVars.SetDetail(
-		sphere->variableSize( PrimitiveVariable::Uniform ),
-		sphere->variableSize( PrimitiveVariable::Vertex ),
-		sphere->variableSize( PrimitiveVariable::Varying ),
-		sphere->variableSize( PrimitiveVariable::FaceVarying )
-	);
+/// Accessor for RenderMan's predefined RtUString constants. This takes
+/// care of loading them from `libprman`.
+const RiPredefinedStrings &strings();
 
-	GeometryAlgo::convertPrimitiveVariables( sphere, primVars );
-
-	const float radius = sphere->radius();
-	const float zMin = sphere->zMin();
-	const float zMax = sphere->zMax();
-	const float thetaMax = sphere->thetaMax();
-
-	primVars.SetFloatDetail( strings().k_Ri_radius, &radius, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_zmin, &zMin, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_zmax, &zMax, RtDetailType::k_constant );
-	primVars.SetFloatDetail( strings().k_Ri_thetamax, &thetaMax, RtDetailType::k_constant );
-
-	return strings().k_Ri_Sphere;
-}
-
-GeometryAlgo::ConverterDescription<SpherePrimitive> g_sphereConverterDescription( convertStaticSphere );
-
-} // namespace
+} // namespace IECoreRenderMan

--- a/src/IECoreRenderMan/VolumeAlgo.cpp
+++ b/src/IECoreRenderMan/VolumeAlgo.cpp
@@ -36,10 +36,9 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "GeometryAlgo.h"
+#include "Strings.h"
 
 #include "IECoreVDB/VDBObject.h"
-
-#include "RixPredefinedStrings.hpp"
 
 #include "fmt/format.h"
 
@@ -65,13 +64,13 @@ RtUString convertVDBObject( const IECoreVDB::VDBObject *vdbObject, RtPrimVarList
 		return RtUString();
 	}
 
-	primVars.SetString( Rix::k_Ri_type, g_implOpenVDB );
+	primVars.SetString( strings().k_Ri_type, g_implOpenVDB );
 	// Dimensions is a required parameter so we have to set it.
 	// I think it is only useful if you want to provide the volume
 	// data as a dense grid via primvars. We're providing the data via
 	// VDB so can set it all to zeroes.
 	const int dimensions[] = { 0, 0, 0 };
-	primVars.SetIntegerArray( Rix::k_Ri_dimensions, dimensions, 3 );
+	primVars.SetIntegerArray( strings().k_Ri_dimensions, dimensions, 3 );
 	// Because dimensions is 0, all primvar details are size 0 too,
 	// except for constant.
 	primVars.SetDetail( 1, 0, 0, 0 );
@@ -134,9 +133,9 @@ RtUString convertVDBObject( const IECoreVDB::VDBObject *vdbObject, RtPrimVarList
 		/// Where would we get those from? Attributes perhaps?
 		RtUString( "{}" )
 	};
-	primVars.SetStringArray( Rix::k_blobbydso_stringargs, stringArgs.data(), stringArgs.size() );
+	primVars.SetStringArray( strings().k_blobbydso_stringargs, stringArgs.data(), stringArgs.size() );
 
-	return Rix::k_Ri_Volume;
+	return strings().k_Ri_Volume;
 }
 
 GeometryAlgo::ConverterDescription<VDBObject> g_meshConverterDescription( convertVDBObject );


### PR DESCRIPTION
This seems to be necessary to avoid crashes when rendering with XPU. Let's not merge this before 1.6.1.0 gets released though - it might benefit from a bit of bedding in time.