### PR TITLE
**Fix:** Only set render ID if it doesn't exist

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 1.5.x.x (relative to 1.5.16.2)
 =======
 
+Fixes
+-----
+- RendererAlgo : Prevent renderID overwrite if an existing renderID exists (for merge drivers writing to the same catalogue).
 
 
 1.5.16.2 (relative to 1.5.16.1)

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -1660,8 +1660,13 @@ ConstOutputPtr addGafferOutputParameters( const Output *output, const ScenePlug 
 
 	// Add parameters that provide unique identifiers for the render and the
 	// output. This is used by the Catalogue to know when to start a new image
-	// and when to just update an existing one.
-	param->writable()["gaffer:renderID"] = new StringData( fmt::format( "{}:{}", getpid(), reinterpret_cast<uintptr_t>( renderer ) ) );
+	// and when to just update an existing one. We only create a new renderID
+	// if one doesn't already exist, allowing it to be propagated from a parent
+	// context.
+	if ( !param->member<StringData>( "gaffer:renderID" ) )
+	{
+		param->writable()["gaffer:renderID"] = new StringData( fmt::format( "{}:{}", getpid(), reinterpret_cast<uintptr_t>( renderer ) ) );
+	}
 	param->writable()["gaffer:outputID"] = new StringData( outputID );
 
 	const Node *node = scene->node();


### PR DESCRIPTION
The existing code unconditionally overwrote the `gaffer:renderID` parameter. This change introduces a check to ensure the parameter is only set if it does not already exist, allowing it to be propagated from a parent context.

This change is required to prevent new catalogue images from being created for separate AOVs when they originate from the same merge driver. When merge drivers are created from Cortex and sent to Gaffer, each might be assigned a different `renderID`. This is problematic because all AOVs from a single merge driver must be grouped within the same Catalogue image. This fix ensures that the `renderID` remains consistent across all AOVs from the same source, making functionalities like net rendering more robust.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
