### PR TITLE
SceneInspector : Show rotations in degrees

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.1.0)
 =======
 
+Fixes
+-----
 
+- SceneInspector : Fixed units used to show transform rotation - it is now shown in degrees again (#6604).
 
 1.6.1.0 (relative to 1.6.0.0)
 =======

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -61,6 +61,8 @@
 #include "IECoreScene/ShaderNetwork.h"
 #include "IECoreScene/ShaderNetworkAlgo.h"
 
+#include "IECore/AngleConversion.h"
+
 #include "Imath/ImathMatrixAlgo.h"
 
 #include "boost/algorithm/string/predicate.hpp"
@@ -647,7 +649,7 @@ InspectorTree::Inspections transformInspectionProvider( ScenePlug *scene, const 
 						switch( component )
 						{
 							case 't' : return new V3fData( t );
-							case 'r' : return new V3fData( r );
+							case 'r' : return new V3fData( IECore::radiansToDegrees( r ) );
 							case 's' : return new V3fData( s );
 							default : return new V3fData( h );
 						}


### PR DESCRIPTION
It was shown in degrees in Gaffer 1.5, but that got lost in the rewrite for Gaffer 1.6.

Fixes #6604.
