### PR TITLE
Fmt : v10 support

### DIFF
--- a/include/GafferML/Tensor.h
+++ b/include/GafferML/Tensor.h
@@ -85,6 +85,8 @@ class GAFFERML_API Tensor : public IECore::Object
 		IECore::DataPtr asData();
 		IECore::ConstDataPtr asData() const;
 
+		static const char *elementDataTypeToString( ONNXTensorElementDataType elementDataType );
+
 	private :
 
 		struct State : public IECore::RefCounted

--- a/src/Gaffer/TweakPlug.cpp
+++ b/src/Gaffer/TweakPlug.cpp
@@ -139,7 +139,7 @@ T applyNumericTweak(
 					)
 				);
 			default:
-				throw IECore::Exception( fmt::format( "Not a valid tweak mode: {}.", mode ) );
+				throw IECore::Exception( fmt::format( "Not a valid tweak mode: {}.", TweakPlug::modeToString( mode ) ) );
 		}
 	}
 	else

--- a/src/GafferArnold/ParameterHandler.cpp
+++ b/src/GafferArnold/ParameterHandler.cpp
@@ -416,7 +416,7 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 				"GafferArnold::ParameterHandler::setupPlug",
 				fmt::format(
 					"Unsupported plug type \"{}\" for parameter \"{}\"",
-					plugTypeOverride,
+					plugTypeOverride.c_str(),
 					name.c_str()
 				)
 			);
@@ -581,7 +581,7 @@ Gaffer::Plug *ParameterHandler::setupPlug( const AtNodeEntry *node, const AtPara
 			"GafferArnold::ParameterHandler::setupPlug",
 			fmt::format(
 				"Unsupported parameter \"{}\" of type \"{}\" on node \"{}\" of type \"{}\"",
-				AiParamGetName( parameter ),
+				AiParamGetName( parameter ).c_str(),
 				AiParamGetTypeName( AiParamGetType( parameter ) ),
 				nodeName( plugParent ),
 				AiNodeEntryGetName( node )

--- a/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/IECoreCycles.cpp
@@ -474,7 +474,7 @@ bool init()
 	auto kernelFile = std::filesystem::path( cyclesRootValue ) / "source" / "kernel" / "types.h";
 	if( !std::filesystem::is_regular_file( kernelFile ) )
 	{
-		IECore::msg( IECore::Msg::Error, "IECoreCycles::init", fmt::format( "File \"{}\" not found", kernelFile ) );
+		IECore::msg( IECore::Msg::Error, "IECoreCycles::init", fmt::format( "File \"{}\" not found", kernelFile.string() ) );
 		return false;
 	}
 

--- a/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
+++ b/src/GafferCycles/IECoreCyclesPreview/OIIOOutputDriver.cpp
@@ -233,7 +233,7 @@ void OIIOOutputDriver::write_render_tile( const Tile &tile )
 				for( int i = 0; i < layer.numChannels; ++i )
 				{
 					spec.channelnames.push_back(
-						fmt::format( "{}{}{}", layerName, layerName.size() ? "." : "", g_channels[i] )
+						fmt::format( "{}{}{}", layerName, layerName.size() ? "." : "", g_channels[i].string() )
 					);
 				}
 			}

--- a/src/GafferImage/Merge.cpp
+++ b/src/GafferImage/Merge.cpp
@@ -181,6 +181,42 @@ struct OpMax
 	static const SingleInputMode onlyB = Operate;
 };
 
+const char *mergeOpToString( Merge::Operation op )
+{
+	switch( op )
+	{
+		case Merge::Add:
+			return "Add";
+		case Merge::Atop:
+			return "Atop";
+		case Merge::Divide:
+			return "Divide";
+		case Merge::In:
+			return "In";
+		case Merge::Out:
+			return "Out";
+		case Merge::Mask:
+			return "Mask";
+		case Merge::Matte:
+			return "Matte";
+		case Merge::Multiply:
+			return "Multiply";
+		case Merge::Over:
+			return "Over";
+		case Merge::Subtract:
+			return "Subtract";
+		case Merge::Difference:
+			return "Difference";
+		case Merge::Under:
+			return "Under";
+		case Merge::Min:
+			return "Min";
+		case Merge::Max:
+			return "Max";
+	}
+	return  "Invalid";
+}
+
 template< class Functor, typename... Args >
 typename Functor::ReturnType dispatchOperation( Merge::Operation op, Functor &&functor, Args&&... args )
 {
@@ -201,7 +237,7 @@ typename Functor::ReturnType dispatchOperation( Merge::Operation op, Functor &&f
 		case Merge::Min : return functor.template operator()<OpMin>( std::forward<Args>( args )... );
 		case Merge::Max : return functor.template operator()<OpMax>( std::forward<Args>( args )... );
 		default:
-			throw InvalidArgumentException( fmt::format( "Invalid Merge Operation : {}", op ) );
+			throw InvalidArgumentException( fmt::format( "Invalid Merge Operation : {}", mergeOpToString( op ) ) );
 	}
 }
 

--- a/src/GafferML/Tensor.cpp
+++ b/src/GafferML/Tensor.cpp
@@ -137,7 +137,7 @@ void dispatchTensorData( const Ort::Value &value, F &&functor )
 			// > implies that we shouldn't know that, let alone depend on it.
 			[[fallthrough]];
 		default :
-			throw IECore::Exception( fmt::format( "Unsupported element type {}", elementType ) );
+			throw IECore::Exception( fmt::format( "Unsupported element type {}", Tensor::elementDataTypeToString( elementType ) ) );
 	}
 }
 
@@ -477,4 +477,58 @@ IECore::ConstDataPtr Tensor::asData() const
 		return m_state->data;
 	}
 	return dataFromValue( m_state->value );
+}
+
+const char *Tensor::elementDataTypeToString( ONNXTensorElementDataType elementDataType )
+{
+	switch( elementDataType )
+	{
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED :
+			return "Undefined";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT :
+			return "Float";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT8 :
+			return "Uint8";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT8 :
+			return "Int8";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT16 :
+			return "Uint16";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT16 :
+			return "Int16";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32 :
+			return "Int32";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64 :
+			return "int64";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING :
+			return "String";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL :
+			return "Bool";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16 :
+			return "Float16";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_DOUBLE :
+			return "Double";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT32 :
+			return "Uint32";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64 :
+			return "Uint64";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX64 :
+			return "Complex64";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX128 :
+			return "Complex128";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16 :
+			return "BFloat16";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FN :
+			return "Float8E4M3FN";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E4M3FNUZ :
+			return "Float8E4M3FNUZ";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2 :
+			return "Float8E5M2";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT8E5M2FNUZ :
+			return "Float8E5M2FNUZ";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT4 :
+			return "Uint4";
+		case ONNX_TENSOR_ELEMENT_DATA_TYPE_INT4 :
+			return "Int4";
+	}
+	return "Invalid";
 }

--- a/src/GafferML/TensorToImage.cpp
+++ b/src/GafferML/TensorToImage.cpp
@@ -295,7 +295,7 @@ IECore::ConstFloatVectorDataPtr TensorToImage::computeChannelData( const std::st
 	if( elementType != ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT )
 	{
 		/// \todo Support other types by converting to float.
-		throw IECore::Exception( fmt::format( "Unsupported tensor data type \"{}\"", elementType ) );
+		throw IECore::Exception( fmt::format( "Unsupported tensor data type \"{}\"", Tensor::elementDataTypeToString( elementType ) ) );
 	}
 
 	FloatVectorDataPtr outData = new FloatVectorData;

--- a/src/GafferMLModule/GafferMLModule.cpp
+++ b/src/GafferMLModule/GafferMLModule.cpp
@@ -112,7 +112,7 @@ std::string tensorRepr( const Tensor &tensor )
 	{
 		// We don't have a good `repr()` for this - just return a default one
 		// and the ValuePlugSerialiser will attempt a base 64 encoding instead.
-		return fmt::format( "<GafferML._GafferML.Tensor object at {}>", (void *)&tensor );
+		return fmt::format( "<GafferML._GafferML.Tensor object at {}>", reinterpret_cast<uintptr_t>( (void *)&tensor ) );
 	}
 }
 
@@ -152,7 +152,7 @@ object tensorGetItem( const Tensor &tensor, const std::vector<int64_t> &location
 		case ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING :
 			return object( tensor.value().GetStringTensorElement( toLinearIndex( tensor.shape(), location ) ) );
 		default :
-			throw IECore::Exception( fmt::format( "Unsupported element type {}", elementType ) );
+			throw IECore::Exception( fmt::format( "Unsupported element type {}", Tensor::elementDataTypeToString( elementType ) ) );
 	}
 }
 

--- a/src/GafferScene/IECoreScenePreview/PrimitiveAlgo.cpp
+++ b/src/GafferScene/IECoreScenePreview/PrimitiveAlgo.cpp
@@ -1448,7 +1448,7 @@ IECoreScene::PrimitivePtr PrimitiveAlgo::mergePrimitives(
 	else
 	{
 		throw IECore::Exception( fmt::format(
-			"Unsupported Primitive type for merging: {}", primitives[0].first->typeId()
+			"Unsupported Primitive type for merging: {}", IECore::RunTimeTyped::typeNameFromTypeId( primitives[0].first->typeId() )
 		) );
 	}
 }

--- a/src/GafferScene/RenderController.cpp
+++ b/src/GafferScene/RenderController.cpp
@@ -1759,7 +1759,7 @@ void RenderController::updateInternal( const ProgressCallback &callback, const I
 					IECore::Msg::Warning, "RenderController",
 					fmt::format(
 						"{} attribute edit{} required geometry to be regenerated",
-						m_failedAttributeEdits, m_failedAttributeEdits > 1 ? "s" : ""
+						m_failedAttributeEdits.load(), m_failedAttributeEdits > 1 ? "s" : ""
 					)
 				);
 				m_failedAttributeEdits = 0;

--- a/src/IECoreArnold/ParameterAlgo.cpp
+++ b/src/IECoreArnold/ParameterAlgo.cpp
@@ -75,12 +75,12 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 		AtArray *a = ParameterAlgo::dataToArray( value, parameterType );
 		if( !a )
 		{
-			msg( Msg::Warning, messageContext, fmt::format( "Unable to create array from data of type \"{}\" for parameter \"{}\"", value->typeName(), name ) );
+			msg( Msg::Warning, messageContext, fmt::format( "Unable to create array from data of type \"{}\" for parameter \"{}\"", value->typeName(), name.c_str() ) );
 			return;
 		}
 		if( AiArrayGetType( a ) != parameterType )
 		{
-			msg( Msg::Warning, messageContext, fmt::format( "Unable to create array of type {} from data of type \"{}\" for parameter \"{}\"", AiParamGetTypeName( parameterType ), value->typeName(), name ) );
+			msg( Msg::Warning, messageContext, fmt::format( "Unable to create array of type {} from data of type \"{}\" for parameter \"{}\"", AiParamGetTypeName( parameterType ), value->typeName(), name.c_str() ) );
 			return;
 		}
 		AiNodeSetArray( node, name, a );
@@ -99,7 +99,7 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 					}
 					else
 					{
-						msg( Msg::Warning, "setParameter", fmt::format( "Int64Data value {} is out of range for parameter \"{}\"", data->readable(), name ) );
+						msg( Msg::Warning, "setParameter", fmt::format( "Int64Data value {} is out of range for parameter \"{}\"", data->readable(), name.c_str() ) );
 					}
 				}
 				else if( const IntData *data = dataCast<IntData>( name, value, messageContext ) )
@@ -117,7 +117,7 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 					}
 					else
 					{
-						msg( Msg::Warning, "setParameter", fmt::format( "UInt64Data value {} is out of range for parameter \"{}\"", data->readable(), name ) );
+						msg( Msg::Warning, "setParameter", fmt::format( "UInt64Data value {} is out of range for parameter \"{}\"", data->readable(), name.c_str() ) );
 					}
 				}
 				else if( const IntData *data = runTimeCast<const IntData>( value ) )
@@ -251,7 +251,7 @@ void setParameterInternal( AtNode *node, AtString name, int parameterType, bool 
 					nodeStr = AiNodeEntryGetName( AiNodeGetNodeEntry( node ) );
 				}
 
-				msg( Msg::Warning, messageContext, fmt::format( "Arnold parameter \"{}\" on node \"{}\" has unsupported type \"{}\".", name, nodeStr, AiParamGetTypeName( parameterType ) ) );
+				msg( Msg::Warning, messageContext, fmt::format( "Arnold parameter \"{}\" on node \"{}\" has unsupported type \"{}\".", name.c_str(), nodeStr, AiParamGetTypeName( parameterType ) ) );
 			}
 		}
 	}
@@ -396,7 +396,7 @@ void setParameter( AtNode *node, AtString name, const IECore::Data *value, const
 			msg(
 				Msg::Warning,
 				messageContext,
-				fmt::format( "Unsupported data type \"{}\" for name \"{}\"", value->typeName(), name )
+				fmt::format( "Unsupported data type \"{}\" for name \"{}\"", value->typeName(), name.c_str() )
 			);
 		}
 	}

--- a/src/IECoreArnold/ShaderNetworkAlgo.cpp
+++ b/src/IECoreArnold/ShaderNetworkAlgo.cpp
@@ -432,7 +432,7 @@ void NodeParameter::updateParameter() const
 			AiNodeResetParameter( m_node, m_parameterName );
 			msg(
 				Msg::Warning, "NodeParameter",
-				fmt::format( "{}.{} : Node \"{}\" not found", AiNodeGetName( m_node ), m_parameterName, m_parameterValue )
+				fmt::format( "{}.{} : Node \"{}\" not found", AiNodeGetName( m_node ), m_parameterName.c_str(), m_parameterValue.c_str() )
 			);
 		}
 	}

--- a/src/IECoreArnold/ShapeAlgo.cpp
+++ b/src/IECoreArnold/ShapeAlgo.cpp
@@ -278,7 +278,7 @@ void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const Pr
 		msg(
 			Msg::Warning,
 			messageContext,
-			fmt::format( "Unable to create user parameter \"{}\" because primitive variable has unsupported interpolation", name )
+			fmt::format( "Unable to create user parameter \"{}\" because primitive variable has unsupported interpolation", name.c_str() )
 		);
 		return;
 	}
@@ -314,7 +314,7 @@ void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const Pr
 		msg(
 			Msg::Warning,
 			messageContext,
-			fmt::format( "Unable to create user parameter \"{}\" for primitive variable of type \"{}\"", name, primitiveVariable.data->typeName() )
+			fmt::format( "Unable to create user parameter \"{}\" for primitive variable of type \"{}\"", name.c_str(), primitiveVariable.data->typeName() )
 		);
 		return;
 	}
@@ -371,7 +371,7 @@ void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const Pr
 	msg(
 		Msg::Warning,
 		messageContext,
-		fmt::format( "Failed to create array for parameter \"{}\" from data of type \"{}\"", name, primitiveVariable.data->typeName() )
+		fmt::format( "Failed to create array for parameter \"{}\" from data of type \"{}\"", name.c_str(), primitiveVariable.data->typeName() )
 	);
 }
 


### PR DESCRIPTION
Fmt : When using Fmt 10.x it is more strict about types passed to fmt::format, ensure it is a std::string or c-string

Generally describe what this PR will do, and why it is needed

- When building against fmt 10 there were a few cases where the type sent to fmt::format needed a template specialisation, but in just about all cases they could be simply converted to a known type like std::string, c-string or int. Some cases needed a specific enumerator to string function conversion. In the case of ONNX I couldn't find a function which could reflect back a string form for element types so I just put them in myself...

### Related issues ###

- NA

### Dependencies ###

- Eventually there will be an update to fmt so this would help here, but it'll work still with fmt 9.x (well, lets see how the CI goes...)

### Breaking changes ###

- Shouldn't have any

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Gaffer project's prevailing coding style and conventions.
