### PR TITLE
Metadata : Remove duplicate keys in `registeredValues()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,8 @@ Fixes
 - SceneInspector : The Globals tab no longer shows the A/B columns when only locations are being compared.
 - BoolWidget : Fixed label text styling when disabled.
 - Scene Editors : Fixed cell background colour when a property is deleted by the current EditScope. It is now blue to indicate the edit, whereas before it had the default colour.
+- GraphEditor : Fixed duplicate annotations that occurred when default annotation metadata was registered for a particular node type.
+- Metadata : Removed duplicate items returned by `registeredValues()`.
 
 API
 ---

--- a/python/GafferTest/MetadataAlgoTest.py
+++ b/python/GafferTest/MetadataAlgoTest.py
@@ -779,6 +779,17 @@ class MetadataAlgoTest( GafferTest.TestCase ) :
 			Gaffer.MetadataAlgo.Annotation( "hi" ),
 		)
 
+	def testAnnotationsDoesntReturnDuplicates( self ) :
+
+		Gaffer.Metadata.registerValue( Gaffer.Node, "annotation:user:text", "TypeId annotation" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, Gaffer.Node, "annotation:user:text" )
+
+		node = Gaffer.Node()
+		self.assertEqual( Gaffer.MetadataAlgo.annotations( node ), [ "user" ] )
+
+		Gaffer.MetadataAlgo.addAnnotation( node, "user", Gaffer.MetadataAlgo.Annotation( "Instance annotation", imath.Color3f( 1, 0, 0 ) ) )
+		self.assertEqual( Gaffer.MetadataAlgo.annotations( node ), [ "user" ] )
+
 	def testNonUserAnnotationTemplates( self ) :
 
 		defaultTemplates = Gaffer.MetadataAlgo.annotationTemplates()

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -468,6 +468,21 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertTrue( "ri" in Gaffer.Metadata.registeredValues( n ) )
 		self.assertTrue( "rpi" in Gaffer.Metadata.registeredValues( n["op1"] ) )
 
+	def testNoDuplicatesInRegisteredValues( self ) :
+
+		Gaffer.Metadata.registerValue( Gaffer.Node, "duplicatesTest", "Node registration" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, Gaffer.Node, "duplicatesTest" )
+		Gaffer.Metadata.registerValue( GafferTest.AddNode, "duplicatesTest", "AddNode registration" )
+		self.addCleanup( Gaffer.Metadata.deregisterValue, GafferTest.AddNode, "duplicatesTest" )
+
+		node = GafferTest.AddNode()
+		Gaffer.Metadata.registerValue( node, "duplicatesTest", "Instance registration" )
+
+		keys = Gaffer.Metadata.registeredValues( node )
+		self.assertEqual(
+			keys.count( "duplicatesTest" ), 1
+		)
+
 	def testInstanceDestruction( self ) :
 
 		for i in range( 0, 1000 ) :


### PR DESCRIPTION
Each of the maps we retrieve keys from preserved uniqueness internally, but there are no such guarantees when we combine keys from multiple maps. So when we detect that we have such a combination, we remove duplicates before returning the result. This fixes a bug whereby the GraphEditor would show multiple copies of an annotation if a default value for `annotation:<name>:text` was registered statically against a node type.

As mentioned in the comment, although this approach to deduplication is `O( N^2 )`, it works well in practice, beating a separate `unordered_set` for 100 keys, which I think is a plausible upper bound in practice. For 1000 keys, this approach is around 2x slower than `unordered_set`, which still isn't disastrous if we do encounter more keys than expected.

Even if number of keys becomes a concern then the algorithm might not be the first thing to reconsider anyway. Most clients of `registeredValues()` do a post-filtering of the keys using a match pattern - to find everything starting with `preset:` or `annotation:` for example. If the match pattern was instead passed to `registeredValues()` and the filtering done internally, the number of keys to deduplicate could be decreased dramatically.
