### PR TITLE
SetMembershipInspector : Don't hardcode context variable name

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.2.0)
 =======
 
+Fixes
+-----
 
+- LightEditor : Fixed bug that could cause filter evaluation in an invalid context.
 
 1.6.2.0 (relative to 1.6.1.0)
 =======


### PR DESCRIPTION
`setMembership:set` is just the name that happens to be used by EditScopeAlgo's SetMembershipEdits processor. It's highly unlikely to be used anywhere else, and we shouldn't even be aware of its existence. By getting the variable name from the `setVariable` plug we maintain compatibility with the SetMembershipEdits processors but gain compatibility with everything else.
