### PR TITLE
Dispatcher : Task Node Isolation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.2.1)
 =======
 
+Features
+--------
+
+- SystemCommand, PythonCommand : Added `isolated` plug. An isolated task is executed from a script containing only that node. This is a useful optimisation when the load time for the full script is high compared to the time taken to execute the task (#6541)
+
 Improvements
 ------------
 

--- a/Changes.md
+++ b/Changes.md
@@ -37,6 +37,7 @@ API
 - Metadata : The `registerNode()` function now accepts dictionaries containing plug metadata. This should be preferred to the previous list-based values.
 - SceneInspector : Added `deregisterInspectors()` method.
 - PathPlugValueWidget : Added support for placeholder text, via `pathPlugValueWidget:placeholderText` metadata.
+- TaskNode : Added "dispatcher:allowIsolation" metadata, which can be used to add the `isolated` plug to a `TaskNode`.
 
 1.6.2.1 (relative to 1.6.2.0)
 =======

--- a/include/GafferDispatch/Dispatcher.h
+++ b/include/GafferDispatch/Dispatcher.h
@@ -282,7 +282,8 @@ class GAFFERDISPATCH_API Dispatcher : public TaskNode
 		void createJobDirectory( const Gaffer::ScriptNode *script, Gaffer::Context *context ) const;
 		mutable std::filesystem::path m_jobDirectory;
 
-		void executeAndPruneImmediateBatches( TaskBatch *batch, bool immediate = false ) const;
+		void preprocessBatches( TaskBatch *batch, bool immediate = false ) const;
+		void isolateBatch( TaskBatch *batch ) const;
 
 		using CreatorMap = std::map<std::string, std::pair<Creator, SetupPlugsFn>>;
 		static CreatorMap &creators();

--- a/python/GafferArnold/ArnoldTextureBake.py
+++ b/python/GafferArnold/ArnoldTextureBake.py
@@ -317,9 +317,12 @@ class ArnoldTextureBake( GafferDispatch.TaskNode ) :
 			d.dispatch( [ self.parent()["__CleanUpSwitch"] ] )
 			"""
 		) )
-		# Connect through the dispatch settings to the render dispatcher
+		# Connect through the dispatch settings to the render dispatcher.
 		# ( The image dispatcher runs much quicker, and should be OK using default settings )
-		self["__RenderDispatcher"]["dispatcher"].setInput( self["dispatcher"] )
+		# We loop through the children ourselves to handle differences between the child plugs
+		# of `dispatcher` on `__RenderDispatcher` and `self`.
+		for c in [ i for i in self["__RenderDispatcher"]["dispatcher"].children() if i.getName() in self["dispatcher"] ] :
+			c.setInput( self["dispatcher"][c.getName()] )
 
 		# Set up variables so the dispatcher knows that the render and image dispatches depend on
 		# the file paths ( in case they are varying in a wedge )

--- a/python/GafferDispatch/PythonCommand.py
+++ b/python/GafferDispatch/PythonCommand.py
@@ -252,3 +252,5 @@ def __codeObjectCacheGetter( expression ) :
 _codeObjectCache = IECore.LRUCache( __codeObjectCacheGetter, 10000 )
 
 IECore.registerRunTimeTyped( PythonCommand, typeName = "GafferDispatch::PythonCommand" )
+
+Gaffer.Metadata.registerValue( PythonCommand, "dispatcher:allowIsolation", True )

--- a/python/GafferDispatch/SystemCommand.py
+++ b/python/GafferDispatch/SystemCommand.py
@@ -91,3 +91,5 @@ class SystemCommand( GafferDispatch.TaskNode ) :
 		subprocess.check_call( command, shell = useShell, env = env )
 
 IECore.registerRunTimeTyped( SystemCommand, typeName = "GafferDispatch::SystemCommand" )
+
+Gaffer.Metadata.registerValue( SystemCommand, "dispatcher:allowIsolation", True )

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -120,6 +120,8 @@ class DispatcherTest( GafferTest.TestCase ) :
 		GafferDispatch.Dispatcher.deregisterDispatcher( "testDispatcher" )
 		GafferDispatch.Dispatcher.deregisterDispatcher( "testDispatcherWithCustomPlugs" )
 
+		Gaffer.Metadata.deregisterValue( GafferDispatch.TaskList, "dispatcher:allowIsolation" )
+
 	def testBadJobDirectory( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -2345,6 +2347,18 @@ class DispatcherTest( GafferTest.TestCase ) :
 		pythonCommand = GafferDispatch.PythonCommand()
 		self.assertIs( SetupPlugsTestDispatcher.lastNode, pythonCommand )
 
+	def testIsolatedPlugExistence( self ) :
+
+		for nodeType, exists in [
+			( GafferDispatchTest.TextWriter, True ),
+			( GafferDispatch.PythonCommand, True ),
+			( GafferDispatch.SystemCommand, True ),
+			( GafferDispatch.TaskList, False ),
+			( GafferDispatch.FrameMask, False )
+		] :
+			n = nodeType()
+			self.assertEqual( "isolated" in n["dispatcher"], exists )
+
 	def testIsolatedScriptContext( self ) :
 
 		s = Gaffer.ScriptNode()
@@ -2628,6 +2642,7 @@ class DispatcherTest( GafferTest.TestCase ) :
 		s["n"]["dispatcher"]["isolated"].setValue( True )
 		s["n"]["text"].setValue( "nothing to see here" )
 
+		Gaffer.Metadata.registerValue( GafferDispatch.TaskList, "dispatcher:allowIsolation", True )
 		s["t"] = GafferDispatch.TaskList()
 		s["t"]["dispatcher"]["isolated"].setValue( True )
 		s["t"]["preTasks"][0].setInput( s["n"]["task"] )

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -93,6 +93,14 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 	IECore.registerRunTimeTyped( NullDispatcher )
 
+	def __soleSubdirectory( self, dir ) :
+		self.assertTrue( dir.is_dir() )
+
+		subDirectories = [ i for i in dir.iterdir() if i.is_dir() ]
+		self.assertEqual( len( subDirectories ), 1 )
+
+		return subDirectories[0]
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )
@@ -2336,6 +2344,369 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		pythonCommand = GafferDispatch.PythonCommand()
 		self.assertIs( SetupPlugsTestDispatcher.lastNode, pythonCommand )
+
+	def testIsolatedScriptContext( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["framesPerSecond"].setValue( 4 )
+		s["frameRange"]["start"].setValue( 8 )
+		s["frameRange"]["end"].setValue( 22 )
+		s["frame"].setValue( 11 )
+		s["variables"].addMember( "test", IECore.StringData( "value" ), "test" )
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["fileName"].setValue( "${script:name}" )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["n"]["task"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		newScript = Gaffer.ScriptNode()
+		newScript["fileName"].setValue( dispatchDir / "isolated" / "n" / self.__soleSubdirectory( dispatchDir / "isolated" / "n" ) / "1" / "untitled.gfr" )
+		newScript.load()
+
+		self.assertEqual( newScript["framesPerSecond"].getValue(), 4 )
+		self.assertEqual( newScript["frameRange"]["start"].getValue(), 8 )
+		self.assertEqual( newScript["frameRange"]["end"].getValue(), 22 )
+		self.assertEqual( newScript["frame"].getValue(), 11 )
+
+		testPlugs = [ p for p in newScript["variables"].children() if p["name"].getValue() == "test" ]
+		self.assertEqual( len( testPlugs ), 1 )
+		self.assertEqual( testPlugs[0]["value"].getValue(), "value" )
+
+	def testIsolated( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		def setupTestTask( p, n ) :
+			p[n] = GafferDispatchTest.TextWriter()
+			p[n]["dispatcher"]["isolated"].setValue( True )
+			p[n]["fileName"].setValue( "${script:name}" )
+			p[n]["mode"].setValue( "r" )
+
+			e = Gaffer.Expression()
+			p.addChild( e )
+			p.children()[-1].setExpression( 'parent["{}"]["text"] = str( 2 + 2 )'.format( n ) )
+
+			return p[n]
+
+		n = setupTestTask( s, "n" )
+		self.assertEqual( n["text"].getValue(), "4" )
+
+		n2 = setupTestTask( s, "n2" )
+
+		s["n3"] = GafferDispatchTest.TextWriter()
+
+		s["b"] = Gaffer.Box()
+		s["b"]["b2"] = Gaffer.Box()
+		s["b"]["b2"]["b3"] = Gaffer.Box()
+
+		n4 = setupTestTask( s["b"]["b2"]["b3"], "n4" )
+
+		n5 = setupTestTask( s["b"]["b2"]["b3"], "n5" )
+		promotedPlug = n5["task"]
+		for i in range( 0, 3 ) :
+			promotedPlug = Gaffer.PlugAlgo.promote( promotedPlug )
+		self.assertIn( "task", s["b"] )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( n["task"] )
+		s["d"]["tasks"][1].setInput( n2["task"] )
+		s["d"]["tasks"][2].setInput( s["n3"]["task"] )
+		s["d"]["tasks"][3].setInput( n4["task"] )
+		s["d"]["tasks"][4].setInput( s["b"]["task"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		newScript = Gaffer.ScriptNode()
+
+		for s in [ "n", "n2", "b.b2.b3.n4", "b.b2.b3.n5" ] :
+			with self.subTest( s = s ) :
+				self.assertTrue( ( dispatchDir / "isolated" / s / self.__soleSubdirectory( dispatchDir / "isolated" / s ) / "1" / "untitled.gfr" ).is_file() )
+				newScript["fileName"].setValue( dispatchDir / "isolated" / s / self.__soleSubdirectory( dispatchDir / "isolated" / s ) / "1" / "untitled.gfr" )
+				newScript.load()
+
+				nodeSequence = s.split( "." )
+
+				self.assertEqual( len( list( Gaffer.Node.RecursiveRange( newScript ) ) ), len( nodeSequence ) )
+
+				for i in range( 0, len( nodeSequence ) ) :
+					self.assertIsInstance( newScript.descendant( ".".join( nodeSequence[:(i + 1 )] ) ), Gaffer.Box if nodeSequence[i].startswith( "b" ) else GafferDispatchTest.TextWriter )
+
+				self.assertEqual( newScript.descendant( s )["fileName"].getValue(), "${script:name}" )
+				self.assertEqual( newScript.descendant( s )["mode"].getValue(), "r" )
+				self.assertEqual( newScript.descendant( s )["text"].getValue(), "4" )
+
+		self.assertFalse( ( dispatchDir / "isolated" / "n3" ).exists() )
+
+	def testIsolatedScriptNaming( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["fileName"].setValue( self.temporaryDirectory() / "testScript.gfr" )
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["text"].setValue( "#" )
+
+		s["n2"] = GafferDispatchTest.TextWriter()
+		s["n2"]["dispatcher"]["isolated"].setValue( True )
+		s["n2"]["dispatcher"]["batchSize"].setValue( 3 )
+		s["n2"]["text"].setValue( "#" )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d"]["frameRange"].setValue( "1-5" )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["n"]["task"] )
+		s["d"]["tasks"][1].setInput( s["n2"]["task"] )
+
+		s["n3"] = GafferDispatchTest.TextWriter()
+		s["n3"]["dispatcher"]["isolated"].setValue( True )
+		s["n3"]["dispatcher"]["batchSize"].setValue( 3 )
+		s["n3"]["text"].setValue( "#" )
+
+		s["d2"] = self.NullDispatcher()
+		s["d2"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d2"]["frameRange"].setValue( "1-5x2" )
+		s["d2"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d2"]["tasks"][0].setInput( s["n3"]["task"] )
+
+		s["d3"] = self.NullDispatcher()
+		s["d3"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d3"]["frameRange"].setValue( "1, 4, 5" )
+		s["d3"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d3"]["tasks"][0].setInput( s["n3"]["task"] )
+
+		s["d"]["task"].execute()
+		s["d2"]["task"].execute()
+		s["d3"]["task"].execute()
+
+		dispatchDirs = sorted( [ p for p in self.temporaryDirectory().iterdir() if p.is_dir() ] )
+		self.assertEqual( len( dispatchDirs ), 3 )
+
+		self.assertEqual(
+			sorted( list( self.temporaryDirectory().rglob( "*" ) ) ),
+			sorted(
+				[
+					dispatchDirs[0],
+					dispatchDirs[0] / "testScript.gfr",
+					dispatchDirs[0] / "isolated",
+					dispatchDirs[0] / "isolated" / "n",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ),
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "1",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "2",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "3",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "4",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "5",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "1" / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "2" / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "3" / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "4" / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n" ) / "5" / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n2",
+					dispatchDirs[0] / "isolated" / "n2" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n2" ),
+					dispatchDirs[0] / "isolated" / "n2" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n2" ) / str( IECore.frameListFromList( [ 1, 2, 3 ] ) ),
+					dispatchDirs[0] / "isolated" / "n2" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n2" ) / str( IECore.frameListFromList( [ 1, 2, 3 ] ) ) / "testScript.gfr",
+					dispatchDirs[0] / "isolated" / "n2" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n2" ) / str( IECore.frameListFromList( [ 4, 5 ] ) ),
+					dispatchDirs[0] / "isolated" / "n2" / self.__soleSubdirectory( dispatchDirs[0] / "isolated" / "n2" ) / str( IECore.frameListFromList( [ 4, 5 ] ) ) / "testScript.gfr",
+
+					dispatchDirs[1],
+					dispatchDirs[1] / "testScript.gfr",
+					dispatchDirs[1] / "isolated",
+					dispatchDirs[1] / "isolated" / "n3",
+					dispatchDirs[1] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[1] / "isolated" / "n3" ),
+					dispatchDirs[1] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[1] / "isolated" / "n3" ) / str( IECore.frameListFromList( [ 1, 3, 5 ] ) ),
+					dispatchDirs[1] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[1] / "isolated" / "n3" ) /  str( IECore.frameListFromList( [ 1, 3, 5 ] ) ) / "testScript.gfr",
+
+					dispatchDirs[2],
+					dispatchDirs[2] / "testScript.gfr",
+					dispatchDirs[2] / "isolated",
+					dispatchDirs[2] / "isolated" / "n3",
+					dispatchDirs[1] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[2] / "isolated" / "n3" ),
+					dispatchDirs[2] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[2] / "isolated" / "n3" ) / str( IECore.frameListFromList( [ 1, 4, 5 ] ) ),
+					dispatchDirs[2] / "isolated" / "n3" / self.__soleSubdirectory( dispatchDirs[2] / "isolated" / "n3" ) / str( IECore.frameListFromList( [ 1, 4, 5 ] ) ) / "testScript.gfr",
+				]
+			)
+		)
+
+	def testIsolatedContextVariation( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["q"] = Gaffer.ContextQuery()
+		s["q"].addQuery( Gaffer.StringPlug(), "textQuery" )
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["text"].setInput( s["q"]["out"][0]["value"] )
+
+		s["c1"] = Gaffer.ContextVariables()
+		s["c1"].setup( s["n"]["task"] )
+		s["c1"]["in"].setInput( s["n"]["task"] )
+		s["c1"]["variables"].addChild( Gaffer.NameValuePlug( "textQuery", IECore.StringData( "A" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s["c2"] = Gaffer.ContextVariables()
+		s["c2"].setup( s["n"]["task"] )
+		s["c2"]["in"].setInput( s["n"]["task"] )
+		s["c1"]["variables"].addChild( Gaffer.NameValuePlug( "textQuery", IECore.StringData( "B" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["c1"]["out"] )
+		s["d"]["tasks"][1].setInput( s["c2"]["out"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		contextDirs = list( p for p in ( dispatchDir / "isolated" / "n" ).iterdir() if p.is_dir() )
+		self.assertEqual( len( contextDirs ), 2 )
+
+		self.assertEqual(
+			sorted( list( dispatchDir.rglob( "*" ) ) ),
+			sorted(
+				[
+					dispatchDir / "untitled.gfr",
+					dispatchDir / "isolated",
+					dispatchDir / "isolated" / "n",
+					dispatchDir / "isolated" / "n" / contextDirs[0],
+					dispatchDir / "isolated" / "n" / contextDirs[0] / "1",
+					dispatchDir / "isolated" / "n" / contextDirs[0] / "1" / "untitled.gfr",
+					dispatchDir / "isolated" / "n" / contextDirs[1],
+					dispatchDir / "isolated" / "n" / contextDirs[1] / "1",
+					dispatchDir / "isolated" / "n" / contextDirs[1] / "1" / "untitled.gfr",
+				]
+			)
+		)
+
+	def testIsolatedBakePlugContext( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'parent["n"]["text"] = context["a"]' )
+
+		s["v"] = Gaffer.ContextVariables()
+		s["v"].setup( s["n"]["task"] )
+		s["v"]["in"].setInput( s["n"]["task"] )
+		s["v"]["variables"].addChild( Gaffer.NameValuePlug( "a", IECore.StringData( "A" ), flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic ) )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["v"]["out"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+		newScript = Gaffer.ScriptNode()
+		newScript["fileName"].setValue( dispatchDir / "isolated" / "n" / self.__soleSubdirectory( dispatchDir / "isolated" / "n" ) / "1" / "untitled.gfr" )
+		newScript.load()
+
+		self.assertIsNone( newScript["n"]["text"].getInput() )
+		self.assertEqual( newScript["n"]["text"].getValue(), "A" )
+
+	def testIsolatedNoOp( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["text"].setValue( "nothing to see here" )
+
+		s["t"] = GafferDispatch.TaskList()
+		s["t"]["dispatcher"]["isolated"].setValue( True )
+		s["t"]["preTasks"][0].setInput( s["n"]["task"] )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CurrentFrame )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["t"]["task"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+		self.assertEqual(
+			list( ( dispatchDir / "isolated" ).iterdir() ),
+			[ dispatchDir / "isolated" / "n" ]
+		)
+
+	def testIsolatedDontSetChildrenOfPlugWithInput( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["dispatcher"]["batchSize"].setValue( 10 )
+		p = Gaffer.Color3fPlug( "colorPlug", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"].addChild( p )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'import imath;parent["n"]["user"]["colorPlug"] = imath.Color3f( context.getFrame() + 2 )' )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d"]["frameRange"].setValue( "1-10" )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["n"]["task"] )
+
+		s["d"]["task"].execute()
+
+		self.assertTrue( s["n"]["user"]["colorPlug"].getInput() is not None )
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+		self.assertEqual(
+			list( ( dispatchDir / "isolated" ).iterdir() ),
+			[ dispatchDir / "isolated" / "n" ]
+		)
+
+	class TextWriterWithChildNode( GafferDispatchTest.TextWriter ) :
+		def __init__( self, name = "TextWriterWithChildNode" ) :
+			GafferDispatchTest.TextWriter.__init__( self, name )
+
+			self["e"] = Gaffer.Expression()
+			self["e"].setExpression( 'parent["text"] = "test"' )
+
+	def testIsolatedInputFromChildNode( self ) :
+
+		s = Gaffer.ScriptNode()
+
+		s["n"] = DispatcherTest.TextWriterWithChildNode()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+
+		s["n"]["e"] = Gaffer.Expression()
+		s["n"]["e"].setExpression( 'parent["text"] = "test"' )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d"]["frameRange"].setValue( "1-10" )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["n"]["task"] )
+
+		s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		newScript = Gaffer.ScriptNode()
+		newScript["fileName"].setValue( dispatchDir / "isolated" / "n" / self.__soleSubdirectory( dispatchDir / "isolated" / "n" ) / "1" / "untitled.gfr" )
+		newScript.load()
+
+		self.assertEqual( newScript["n"]["text"].getValue(), "test" )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/DispatcherTest.py
+++ b/python/GafferDispatchTest/DispatcherTest.py
@@ -2707,6 +2707,130 @@ class DispatcherTest( GafferTest.TestCase ) :
 
 		self.assertEqual( newScript["n"]["text"].getValue(), "test" )
 
+	def testIsolatedAnimation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["framesPerSecond"].setValue( 1.0 )
+
+		s["n"] = GafferDispatchTest.TextWriter()
+		s["n"]["dispatcher"]["isolated"].setValue( True )
+		s["n"]["dispatcher"]["batchSize"].setValue( 5 )
+		s["n"]["fileName"].setValue( "${script:name}" )
+		s["n"]["text"].setValue( "####" )
+
+		p = Gaffer.FloatPlug( "floatPlug1", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"].addChild( p )
+		curve = Gaffer.Animation.acquire( p )
+		curve.addKey( Gaffer.Animation.Key( time = 2, value = 2 ) )
+		curve.addKey( Gaffer.Animation.Key( time = 3, value = 3 ) )
+
+		s["q"] = Gaffer.ContextQuery()
+		s["q"].addQuery( Gaffer.FloatPlug(), "frame" )
+
+		# Make the hash of frames 4 and 5 the same as 1 by using a time warp
+		s["w"] = Gaffer.TimeWarp()
+		s["w"].setup( s["q"]["out"][0]["value"] )
+		s["w"]["in"].setInput( s["q"]["out"][0]["value"] )
+
+		s["we"] = Gaffer.Expression()
+		s["we"].setExpression( 'parent["w"]["offset"] = {1: 0, 2: -1, 3: 0, 4: -3, 5: -4}[context.getFrame()]')
+
+		s["n"]["user"]["floatPlug2"] = Gaffer.FloatPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["n"]["user"]["floatPlug2"].setInput( s["w"]["out"] )
+
+		s["n"]["user"]["stringPlug"] = Gaffer.StringPlug( flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+
+		s["e"] = Gaffer.Expression()
+		s["e"].setExpression( 'parent["n"]["mode"] = "x"' )
+
+		s["e2"] = Gaffer.Expression()
+		s["e2"].setExpression( 'parent["n"]["user"]["stringPlug"] = { 1.0 : "one", 2.0 : "two" }.get( context.getFrame(), "buckleMyShoe" )')
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d"]["frameRange"].setValue( "1-5" )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( s["n"]["task"] )
+
+		with s.context() :
+			s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		newScript = Gaffer.ScriptNode()
+		newScript["fileName"].setValue( dispatchDir / "isolated" / "n" / self.__soleSubdirectory( dispatchDir / "isolated" / "n" ) / "1-5" / "untitled.gfr" )
+		newScript.load()
+
+		self.assertEqual( len( list( Gaffer.Node.RecursiveRange( newScript ) ) ), 2 )
+
+		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
+
+		self.assertEqual( len( newScript["isolatedAnimation"]["rows"] ), 6 )  # default + frame count
+		self.assertEqual( len( newScript["isolatedAnimation"]["rows"].defaultRow()["cells"] ), 3 )
+
+		self.assertIsNone( newScript["n"]["fileName"].getInput() )
+		self.assertIsNone( newScript["n"]["text"].getInput() )
+		self.assertIsNone( newScript["n"]["mode"].getInput() )
+		self.assertEqual( newScript["n"]["user"]["floatPlug1"].getInput(), newScript["isolatedAnimation"]["out"]["user_floatPlug1"] )
+		self.assertEqual( newScript["n"]["user"]["floatPlug2"].getInput(), newScript["isolatedAnimation"]["out"]["user_floatPlug2"] )
+		self.assertEqual( newScript["n"]["user"]["stringPlug"].getInput(), newScript["isolatedAnimation"]["out"]["user_stringPlug"] )
+
+		with newScript.context() as c :
+			for f in range( 1, 6 ) :
+				with self.subTest( f = f ) :
+					c.setFrame( f )
+					self.assertEqual( newScript["n"]["fileName"].getValue(), "${script:name}" )
+					self.assertEqual( newScript["n"]["text"].getValue(), "####" )
+					self.assertEqual( newScript["n"]["mode"].getValue(), "x" )
+					self.assertEqual( newScript["n"]["user"]["floatPlug1"].getValue(), [ 2, 2, 3, 3, 3 ][f - 1] )
+					self.assertEqual( newScript["n"]["user"]["floatPlug2"].getValue(), [ 1, 1, 3, 1, 1 ][f - 1] )
+					self.assertEqual( newScript["n"]["user"]["stringPlug"].getValue(), ["one", "two", "buckleMyShoe", "buckleMyShoe", "buckleMyShoe"][f - 1] )
+
+	def testIsolatedAnimationNodeLocation( self ) :
+
+		s = Gaffer.ScriptNode()
+		s["framesPerSecond"].setValue( 1.0 )
+
+		s["b"] = Gaffer.Box()
+
+		s["b"]["n"] = GafferDispatchTest.TextWriter()
+		s["b"]["n"]["dispatcher"]["isolated"].setValue( True )
+		s["b"]["n"]["dispatcher"]["batchSize"].setValue( 2 )
+		p = Gaffer.FloatPlug( "floatPlug", flags = Gaffer.Plug.Flags.Default | Gaffer.Plug.Flags.Dynamic )
+		s["b"]["n"]["user"].addChild( p )
+		promotedPlug = Gaffer.PlugAlgo.promote( p )
+		promotedTask = Gaffer.PlugAlgo.promote( s["b"]["n"]["task"] )
+
+		curve = Gaffer.Animation.acquire( promotedPlug )
+		curve.addKey( Gaffer.Animation.Key( time = 1, value = 1 ) )
+		curve.addKey( Gaffer.Animation.Key( time = 2, value = 2 ) )
+
+		s["d"] = self.NullDispatcher()
+		s["d"]["framesMode"].setValue( GafferDispatch.Dispatcher.FramesMode.CustomRange )
+		s["d"]["frameRange"].setValue( "1-2" )
+		s["d"]["jobsDirectory"].setValue( self.temporaryDirectory() )
+		s["d"]["tasks"][0].setInput( promotedTask )
+
+		with s.context() :
+			s["d"]["task"].execute()
+
+		dispatchDir = next( p for p in self.temporaryDirectory().iterdir() if p.is_dir() )
+
+		newScript = Gaffer.ScriptNode()
+		newScript["fileName"].setValue( dispatchDir / "isolated" / "b.n" / self.__soleSubdirectory( dispatchDir / "isolated" / "b.n" ) / "1-2" / "untitled.gfr" )
+		newScript.load()
+
+		self.assertEqual( len( list( Gaffer.Node.RecursiveRange( newScript["b"] ) ) ), 2 )
+
+		self.assertEqual( set( [ type( n ) for n in Gaffer.Node.RecursiveRange( newScript["b"] ) ] ), set( [ GafferDispatchTest.TextWriter, Gaffer.Spreadsheet ] ) )
+
+		self.assertEqual( newScript["b"]["n"]["user"]["floatPlug"].getInput(), newScript["b"]["isolatedAnimation"]["out"]["user_floatPlug"] )
+
+		with s.context() as c :
+			for f in range( 1, 3 ) :
+				c.setFrame( f )
+				self.assertEqual( newScript["b"]["n"]["user"]["floatPlug"].getValue(), [ 1, 2 ][f - 1] )
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchTest/TextWriter.py
+++ b/python/GafferDispatchTest/TextWriter.py
@@ -114,3 +114,5 @@ class TextWriter( GafferDispatch.TaskNode ) :
 		return text
 
 IECore.registerRunTimeTyped( TextWriter, typeName = "GafferDispatchTest::TextWriter" )
+
+Gaffer.Metadata.registerValue( TextWriter, "dispatcher:allowIsolation", True )

--- a/python/GafferDispatchUI/DispatcherUI.py
+++ b/python/GafferDispatchUI/DispatcherUI.py
@@ -224,6 +224,7 @@ Gaffer.Metadata.registerNode(
 		"dispatcher" : (
 
 			"layout:activator:doesNotRequireSequenceExecution", lambda plug : not plug.node()["task"].requiresSequenceExecution(),
+			"layout:activator:immediateIsOff", lambda plug : not plug["immediate"].getValue(),
 
 		),
 
@@ -253,7 +254,20 @@ Gaffer.Metadata.registerNode(
 			considered to be immediate too, regardless of their settings.
 			"""
 
-		)
+		),
+
+		"dispatcher.isolated" : (
+
+			"description",
+			"""
+			Causes this node to be executed from a script containing *only* this node.
+			This is a useful optimisation when the load time for the full script is
+			high compared to the time taken to execute the task.
+			""",
+
+			"layout:activator", "immediateIsOff",
+
+		),
 
 	}
 

--- a/python/GafferTractor/TractorDispatcher.py
+++ b/python/GafferTractor/TractorDispatcher.py
@@ -98,7 +98,6 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 		# might just be member data for a subclass of one of those.
 		dispatchData = {}
 		dispatchData["scriptNode"] = rootBatch.preTasks()[0].node().scriptNode()
-		dispatchData["scriptFile"] = Gaffer.Context.current()["dispatcher:scriptFileName"]
 		dispatchData["batchesToTasks"] = {}
 		dispatchData["taskData"] = {}
 
@@ -180,7 +179,7 @@ class TractorDispatcher( GafferDispatch.Dispatcher ) :
 
 			args = [
 				"gaffer", "execute",
-				"-script", dispatchData["scriptFile"],
+				"-script", batch.context()["dispatcher:scriptFileName"],
 				"-nodes", nodeName,
 				"-frames", frames,
 			]

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -52,6 +52,7 @@
 #include "IECore/MessageHandler.h"
 
 #include "boost/algorithm/string/predicate.hpp"
+#include "boost/algorithm/string/replace.hpp"
 
 #include "fmt/format.h"
 
@@ -120,18 +121,92 @@ struct BatchContextPool
 
 };
 
-void bakePlugValue( ValuePlug *destinationPlug, const ValuePlug *sourcePlug )
+ValuePlug *acquireCellValuePlug( Spreadsheet *spreadsheet, const InternedString columnName, const float frame )
+{
+	const std::string rowName = fmt::format( "{}", frame );
+	if( auto row = spreadsheet->rowsPlug()->row( rowName ) )
+	{
+		assert( row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) );
+		return row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName )->valuePlug();
+	}
+
+	Spreadsheet::RowPlug *newRow = spreadsheet->rowsPlug()->addRow();
+	newRow->namePlug()->setValue( rowName );
+	newRow->enabledPlug()->setValue( true );
+
+	assert( newRow->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) );
+	return newRow->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName )->valuePlug();
+}
+
+void bakePlugValue( ValuePlug *destinationPlug, const ValuePlug *sourcePlug, const std::vector<float> &frames )
 {
 	if( !PlugAlgo::canSetValueFromData( destinationPlug ) )
 	{
 		return;
 	}
 
-	const DataPtr value = PlugAlgo::getValueAsData( sourcePlug );
-	PlugAlgo::setValueFromData( destinationPlug, value.get() );
+	ScriptNode *destinationScript = destinationPlug->node()->scriptNode();
+	Spreadsheet *animationSpreadsheet = destinationScript->getChild<Spreadsheet>( g_isolatedAnimationNodeName );
+
+	Context::EditableScope frameContext( Context::current() );
+	frameContext.setFrame( frames.front() );
+
+	const DataPtr originalValue = PlugAlgo::getValueAsData( sourcePlug );
+	PlugAlgo::setValueFromData( destinationPlug, originalValue.get() );
+
+	const MurmurHash originalHash = sourcePlug->hash();
+
+	InternedString columnName( "" );
+	bool animating = false;
+
+	for( std::vector<float>::const_iterator it = frames.begin() + 1, eIt = frames.end(); it != eIt; ++it )
+	{
+		frameContext.setFrame( *it );
+
+		const MurmurHash frameValueHash = sourcePlug->hash();
+
+		if( !animating && frameValueHash != originalHash )
+		{
+			animating = true;
+			if( !animationSpreadsheet )
+			{
+				Node *parentNode = destinationPlug->node()->parent<Node>();
+				parentNode->addChild( new Spreadsheet( g_isolatedAnimationNodeName ) );
+				animationSpreadsheet = parentNode->getChild<Spreadsheet>( parentNode->children().size() - 1 );
+				animationSpreadsheet->selectorPlug()->setValue( "${frame}" );
+			}
+
+			if( columnName.string().empty() )
+			{
+				columnName = boost::replace_all_copy( destinationPlug->relativeName( destinationPlug->node() ), ".", "_" );
+				animationSpreadsheet->rowsPlug()->addColumn( destinationPlug, columnName );
+
+				destinationPlug->setInput( animationSpreadsheet->outPlug()->getChild<Plug>( columnName ) );
+
+				// We set the plug values for all frames if any are animated. Go back and set
+				// the previous frame cell values.
+				for( std::vector<float>::const_iterator pIt = frames.begin(); pIt != it; ++pIt )
+				{
+					frameContext.setFrame( *pIt );
+					const DataPtr previousValue = PlugAlgo::getValueAsData( sourcePlug );
+					ValuePlug *cellValuePlug = acquireCellValuePlug( animationSpreadsheet, columnName, *pIt );
+					PlugAlgo::setValueFromData( cellValuePlug, previousValue.get() );
+				}
+
+				frameContext.setFrame( *it );
+			}
+		}
+
+		if( animating )
+		{
+			ValuePlug *cellValuePlug = acquireCellValuePlug( animationSpreadsheet, columnName, *it );
+			const DataPtr frameValue = PlugAlgo::getValueAsData( sourcePlug );
+			PlugAlgo::setValueFromData( cellValuePlug, frameValue.get() );
+		}
+	}
 }
 
-void isolateScriptPlugs( ScriptNode *destinationScript, const ScriptNode *sourceScript )
+void isolateScriptPlugs( ScriptNode *destinationScript, const ScriptNode *sourceScript, const std::vector<float> &frames )
 {
 	StandardSetPtr plugsToSerialise = new StandardSet();
 
@@ -148,7 +223,7 @@ void isolateScriptPlugs( ScriptNode *destinationScript, const ScriptNode *source
 		auto destinationPlug = destinationScript->descendant<ValuePlug>( sourcePlug->relativeName( sourceScript ) );
 		assert( destinationPlug );
 
-		bakePlugValue( destinationPlug, sourcePlug.get() );
+		bakePlugValue( destinationPlug, sourcePlug.get(), frames );
 	}
 }
 
@@ -1035,7 +1110,7 @@ void Dispatcher::isolateBatch( TaskBatch *batch ) const
 
 	Context::Scope batchScope( batch->context() );
 
-	isolateScriptPlugs( destinationScript.get(), sourceScript );
+	isolateScriptPlugs( destinationScript.get(), sourceScript, batch->frames() );
 
 	NodePtr topBox = nullptr;
 	Node *lowestContainer = destinationScript.get();
@@ -1087,7 +1162,7 @@ void Dispatcher::isolateBatch( TaskBatch *batch ) const
 
 		if( (*it)->getInput() )
 		{
-			bakePlugValue( destinationPlug, (*it).get() );
+			bakePlugValue( destinationPlug, (*it).get(), batch->frames() );
 			it.prune();
 		}
 	}

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -36,15 +36,18 @@
 
 #include "GafferDispatch/Dispatcher.h"
 
+#include "Gaffer/Box.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextProcessor.h"
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
+#include "Gaffer/StandardSet.h"
 #include "Gaffer/StringPlug.h"
 #include "Gaffer/SubGraph.h"
 #include "Gaffer/Switch.h"
 
+#include "IECore/FileSequenceFunctions.h"
 #include "IECore/FrameRange.h"
 #include "IECore/MessageHandler.h"
 
@@ -67,6 +70,9 @@ namespace
 {
 
 const InternedString g_frame( "frame" );
+const InternedString g_isolatedBlindDataKey( "isolated" );
+const InternedString g_isolatedAnimationNodeName( "isolatedAnimation" );
+const BoolDataPtr g_trueData = new BoolData( true );
 
 // TaskBatch contexts are identical to the contexts of their corresponding
 // Tasks, except that they omit the `frame` variable. We need to construct a
@@ -114,6 +120,38 @@ struct BatchContextPool
 
 };
 
+void bakePlugValue( ValuePlug *destinationPlug, const ValuePlug *sourcePlug )
+{
+	if( !PlugAlgo::canSetValueFromData( destinationPlug ) )
+	{
+		return;
+	}
+
+	const DataPtr value = PlugAlgo::getValueAsData( sourcePlug );
+	PlugAlgo::setValueFromData( destinationPlug, value.get() );
+}
+
+void isolateScriptPlugs( ScriptNode *destinationScript, const ScriptNode *sourceScript )
+{
+	StandardSetPtr plugsToSerialise = new StandardSet();
+
+	for( const auto &sourcePlug : Gaffer::ValuePlug::RecursiveInputRange( *sourceScript ) )
+	{
+		plugsToSerialise->add( const_cast<ValuePlug *>( sourcePlug.get() ) );
+	}
+
+	const std::string scriptVariablesSerialisation = sourceScript->serialise( sourceScript, plugsToSerialise.get() );
+	destinationScript->execute( scriptVariablesSerialisation );
+
+	for( const auto &sourcePlug : Gaffer::ValuePlug::RecursiveInputRange( *sourceScript ) )
+	{
+		auto destinationPlug = destinationScript->descendant<ValuePlug>( sourcePlug->relativeName( sourceScript ) );
+		assert( destinationPlug );
+
+		bakePlugValue( destinationPlug, sourcePlug.get() );
+	}
+}
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -124,6 +162,7 @@ namespace
 {
 
 const InternedString g_batchSize( "batchSize" );
+const InternedString g_isolatedPlugName( "isolated" );
 const InternedString g_immediatePlugName( "immediate" );
 const InternedString g_jobDirectoryContextEntry( "dispatcher:jobDirectory" );
 const InternedString g_scriptFileNameContextEntry( "dispatcher:scriptFileName" );
@@ -308,6 +347,7 @@ void Dispatcher::setupPlugs( Plug *parentPlug )
 {
 	parentPlug->addChild( new IntPlug( g_batchSize, Plug::In, 1 ) );
 	parentPlug->addChild( new BoolPlug( g_immediatePlugName, Plug::In, false ) );
+	parentPlug->addChild( new BoolPlug( g_isolatedPlugName, Plug::In, false ) );
 
 	const CreatorMap &m = creators();
 	for( const auto &[name, creator] : m )
@@ -625,6 +665,12 @@ class Dispatcher::Batcher
 				batch->m_immediate = true;
 			}
 
+			const BoolPlug *isolatePlug = dispatcherPlug( task )->getChild<const BoolPlug>( g_isolatedPlugName );
+			if( isolatePlug && isolatePlug->getValue() )
+			{
+				batch->blindData()->writable()[g_isolatedBlindDataKey] = g_trueData;
+			}
+
 			// Remember which batch we stored this task in, for
 			// the next time someone asks for it.
 			batchForTask = batch;
@@ -891,7 +937,7 @@ void Dispatcher::execute() const
 		}
 	}
 
-	executeAndPruneImmediateBatches( batcher.rootBatch() );
+	preprocessBatches( batcher.rootBatch() );
 
 	// Save the script. If we're in a nested dispatch, this may have been done already by
 	// the outer dispatch, hence the call to `exists()`. Performing the saving here is
@@ -924,7 +970,7 @@ void Dispatcher::execute() const
 	}
 }
 
-void Dispatcher::executeAndPruneImmediateBatches( TaskBatch *batch, bool immediate ) const
+void Dispatcher::preprocessBatches( TaskBatch *batch, bool immediate ) const
 {
 	if( batch->m_visited )
 	{
@@ -936,7 +982,7 @@ void Dispatcher::executeAndPruneImmediateBatches( TaskBatch *batch, bool immedia
 	TaskBatches &preTasks = batch->m_preTasks;
 	for( TaskBatches::iterator it = preTasks.begin(); it != preTasks.end(); )
 	{
-		executeAndPruneImmediateBatches( it->get(), immediate );
+		preprocessBatches( it->get(), immediate );
 		if( (*it)->m_executed )
 		{
 			batch->m_preTasksSet.erase( it->get() );
@@ -953,8 +999,103 @@ void Dispatcher::executeAndPruneImmediateBatches( TaskBatch *batch, bool immedia
 		batch->execute();
 		batch->m_executed = true;
 	}
+	else if( batch->blindData()->member( g_isolatedBlindDataKey ) && !batch->frames().empty() )
+	{
+		isolateBatch( batch );
+	}
 
 	batch->m_visited = true;
+
+}
+
+void Dispatcher::isolateBatch( TaskBatch *batch ) const
+{
+	auto sourceNode = runTimeCast<const TaskNode>( batch->plug()->node() );
+	const ScriptNode *sourceScript = sourceNode->scriptNode();  // `execute()` has already checked that this will be valid
+
+	std::filesystem::path scriptPath( batch->context()->get<std::string>( g_scriptFileNameContextEntry ) );
+	const std::string sourceNodeRelativeName = sourceNode->relativeName( sourceScript );
+	const std::vector<FrameList::Frame> intFrames( batch->frames().begin(), batch->frames().end() );
+	FrameListPtr batchFrames = frameListFromList( intFrames );
+
+	std::filesystem::path isolatedPath =
+		scriptPath.parent_path() /
+		"isolated" /
+		sourceNodeRelativeName /
+		batch->context()->hash().toString() /
+		batchFrames->asString() /
+		( scriptPath.stem().string() + ".gfr" )
+	;
+
+	ContextPtr isolatedContext = new Context( *batch->context() );
+	isolatedContext->set( g_scriptFileNameContextEntry, isolatedPath.generic_string() );
+	batch->m_context = isolatedContext;
+
+	ScriptNodePtr destinationScript = new ScriptNode();
+
+	Context::Scope batchScope( batch->context() );
+
+	isolateScriptPlugs( destinationScript.get(), sourceScript );
+
+	NodePtr topBox = nullptr;
+	Node *lowestContainer = destinationScript.get();
+	const GraphComponent *node = sourceNode->parent();
+	while( node != sourceScript )
+	{
+		BoxPtr newChild = new Box( node->getName() );
+		if( topBox )
+		{
+			newChild->addChild( topBox );
+		}
+		else
+		{
+			// The `TaskNode` will be in a `Box`, rather than a child of the script,
+			// and this is the first iteration of this loop. This will be the `Box`
+			// to add the `TaskNode` to.
+			lowestContainer = newChild.get();
+		}
+		topBox = newChild;
+		node = node->parent();
+	}
+
+	if( topBox )
+	{
+		destinationScript->addChild( topBox );
+	}
+
+	auto parentNode = sourceNode->parent<Node>();
+	StandardSetPtr sourceSet = new StandardSet();
+	sourceSet->add( const_cast<TaskNode*>( sourceNode ) );
+	const std::string serialisation = sourceScript->serialise( parentNode, sourceSet.get() );
+	destinationScript->execute( serialisation, lowestContainer );
+
+	TaskNode *destinationNode = lowestContainer->getChild<TaskNode>( sourceNode->getName() );
+	assert( destinationNode );
+
+	for( ValuePlug::RecursiveInputIterator it( sourceNode ); !it.done(); ++it )
+	{
+		auto destinationPlug = destinationNode->descendant<ValuePlug>( (*it)->relativeName( sourceNode ) );
+		assert( destinationPlug != nullptr );
+
+		if( destinationPlug->getInput() )
+		{
+			// Since the destination node is isolated, this must be an internal connection
+			// forming part of the node's implementation. Leave it alone.
+			it.prune();
+			continue;
+		}
+
+		if( (*it)->getInput() )
+		{
+			bakePlugValue( destinationPlug, (*it).get() );
+			it.prune();
+		}
+	}
+
+	destinationScript->fileNamePlug()->setValue( isolatedPath.generic_string() );
+	std::filesystem::create_directories( isolatedPath.parent_path() );
+	destinationScript->serialiseToFile( isolatedPath );
+
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/GafferDispatch/Dispatcher.cpp
+++ b/src/GafferDispatch/Dispatcher.cpp
@@ -39,6 +39,7 @@
 #include "Gaffer/Box.h"
 #include "Gaffer/Context.h"
 #include "Gaffer/ContextProcessor.h"
+#include "Gaffer/Metadata.h"
 #include "Gaffer/PlugAlgo.h"
 #include "Gaffer/Process.h"
 #include "Gaffer/ScriptNode.h"
@@ -238,6 +239,7 @@ namespace
 
 const InternedString g_batchSize( "batchSize" );
 const InternedString g_isolatedPlugName( "isolated" );
+const InternedString g_allowIsolationName( "dispatcher:allowIsolation" );
 const InternedString g_immediatePlugName( "immediate" );
 const InternedString g_jobDirectoryContextEntry( "dispatcher:jobDirectory" );
 const InternedString g_scriptFileNameContextEntry( "dispatcher:scriptFileName" );
@@ -422,7 +424,13 @@ void Dispatcher::setupPlugs( Plug *parentPlug )
 {
 	parentPlug->addChild( new IntPlug( g_batchSize, Plug::In, 1 ) );
 	parentPlug->addChild( new BoolPlug( g_immediatePlugName, Plug::In, false ) );
-	parentPlug->addChild( new BoolPlug( g_isolatedPlugName, Plug::In, false ) );
+	if( auto allowIsolation = Metadata::value<BoolData>( parentPlug->node(), g_allowIsolationName ) )
+	{
+		if( allowIsolation->readable() )
+		{
+			parentPlug->addChild( new BoolPlug( g_isolatedPlugName, Plug::In, false ) );
+		}
+	}
 
 	const CreatorMap &m = creators();
 	for( const auto &[name, creator] : m )


### PR DESCRIPTION
This adds an option to Task nodes that, when enabled, will save a dispatch script with that node alone. Inputs to plugs on the node are computed at the time of dispatch in order to maintain their values (since the inputs to the plugs will be gone) and animated inputs are supported.

This allows for saving very lightweight scripts for tasks that don't need the full script node graph to execute, such as some `SystemCommand` and `PythonCommand`. Executing isolated tasks can therefore be much faster since only a single task (and maybe a spreadsheet) needs to be loaded, and plug inputs have been precomputed.

Fixes #6541.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
