### PR TITLE
Inspector : Remove `SourceType.Fallback`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.2.0)
 =======
 
+Fixes
+-----
 
+- LightEditor, AttributeEditor, HierarchyView, RenderPassEditor : Fixed cell background colour when a property is deleted by the current EditScope. It is now blue to indicate the edit, whereas before it had the default colour.
 
 1.6.2.0 (relative to 1.6.1.0)
 =======

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -291,15 +291,23 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		/// =======
 
 		/// The inspected value that should be displayed by the UI.
-		const IECore::Object *value() const;
+		/// If the inspected value is null, then `useFallbacks` allows
+		/// a fallback value to be returned instead - for example a
+		/// known default value or an inherited attribute value.
+		const IECore::Object *value( bool useFallbacks = true ) const;
 		/// The inspected value cast to its native type. If the inspected
 		/// value is not of the requested type, the given default value
 		/// will be returned.
 		template<typename T>
-		const T typedValue( const T &defaultValue ) const;
+		const T typedValue( const T &defaultValue, bool useFallbacks = true ) const;
 
 		/// The plug that was used to author the current value, or null if
 		/// it cannot be determined.
+		///
+		/// > Note : Does not consider fallback values. When a fallback is in
+		/// > effect because the main value is null, `source()` will either
+		/// > return `nullptr` or the edit which was responsible for removing
+		/// > the value.
 		Gaffer::ValuePlug *source() const;
 		/// The target EditScope.
 		Gaffer::EditScope *editScope() const;
@@ -316,15 +324,14 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 			Downstream,
 			/// No EditScope was specified, or the EditScope was not found in
 			/// the value's history.
-			Other,
-			/// The value was provided from a fallback value from the Inspector.
-			Fallback
+			Other
 		};
 
 		/// The relationship between `source()` and `editScope()`.
 		SourceType sourceType() const;
-		/// Returns a user-facing description of the source of the
-		/// fallback value when `SourceType` is `Fallback`.
+		/// If a fallback value is in effect due to the primary value
+		/// being null, returns a user-facing description of the fallback
+		/// value. Otherwise returns an empty string.
 		const std::string &fallbackDescription() const;
 
 		/// Editing
@@ -371,6 +378,7 @@ class GAFFERSCENEUI_API Inspector::Result : public IECore::RefCounted
 		friend class Inspector;
 
 		const IECore::ConstObjectPtr m_value;
+		IECore::ConstObjectPtr m_fallbackValue;
 		Gaffer::ValuePlugPtr m_source;
 		SourceType m_sourceType;
 		std::string m_fallbackDescription;

--- a/include/GafferSceneUI/Private/Inspector.inl
+++ b/include/GafferSceneUI/Private/Inspector.inl
@@ -46,9 +46,9 @@ namespace Private
 {
 
 template<typename T>
-const T Inspector::Result::typedValue( const T &defaultValue ) const
+const T Inspector::Result::typedValue( const T &defaultValue, bool useFallbacks ) const
 {
-	if( auto valueData = IECore::runTimeCast<const IECore::TypedData<T>>( value() ) )
+	if( auto valueData = IECore::runTimeCast<const IECore::TypedData<T>>( value( useFallbacks ) ) )
 	{
 		return valueData->readable();
 	}

--- a/include/GafferSceneUI/Private/InspectorColumn.h
+++ b/include/GafferSceneUI/Private/InspectorColumn.h
@@ -76,6 +76,13 @@ class GAFFERSCENEUI_API InspectorColumn : public GafferUI::PathColumn
 		/// be reused by `_HistoryWindow`.
 		static CellData cellDataFromValue( const IECore::Object *value );
 
+	protected :
+
+		/// The internal implementation of `cellData()`. Available as a separate
+		/// function so that derived classes can override `cellData()` without
+		/// having to make their own separate call to `inspect()`.
+		CellData cellDataFromInspection( const GafferSceneUI::Private::Inspector::Result *inspection ) const;
+
 	private :
 
 		void inspectorDirtied();

--- a/python/GafferSceneUITest/OptionInspectorTest.py
+++ b/python/GafferSceneUITest/OptionInspectorTest.py
@@ -855,7 +855,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		self.addCleanup( Gaffer.Metadata.deregisterValue, "option:test:enabled", "defaultValue" )
 		inspection = self.__inspect( editScope["out"], "test:enabled", editScope )
 		self.assertEqual( inspection.value(), IECore.BoolData( 1 ) )
-		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Fallback )
+		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Other )
 		self.assertEqual( inspection.fallbackDescription(), "Default value" )
 
 		# If the option does exist, then its value is returned as normal
@@ -872,7 +872,7 @@ class OptionInspectorTest( GafferUITest.TestCase ) :
 		optionPlug["enabled"].setValue( False )
 		inspection = self.__inspect( editScope["out"], "test:enabled", editScope )
 		self.assertEqual( inspection.value(), IECore.BoolData( 1 ) )
-		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Fallback )
+		self.assertEqual( inspection.sourceType(), GafferSceneUI.Private.Inspector.Result.SourceType.Other )
 		self.assertEqual( inspection.fallbackDescription(), "Default value" )
 
 		# Updates to "defaultValue" are reflected in new inspections

--- a/python/GafferSceneUITest/ParameterInspectorTest.py
+++ b/python/GafferSceneUITest/ParameterInspectorTest.py
@@ -73,10 +73,11 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 			context["scene:path"] = IECore.InternedStringVectorData( path.split( "/" )[1:] )
 			return inspector.inspect()
 
-	def __assertExpectedResult( self, result, source, sourceType, editable, nonEditableReason = "", edit = None, editWarning = "" ) :
+	def __assertExpectedResult( self, result, source, sourceType, editable, nonEditableReason = "", edit = None, editWarning = "", fallbackDescription = "" ) :
 
 		self.assertEqual( result.source(), source )
 		self.assertEqual( result.sourceType(), sourceType )
+		self.assertEqual( result.fallbackDescription(), fallbackDescription )
 		self.assertEqual( result.editable(), editable )
 
 		if editable :
@@ -1306,11 +1307,11 @@ class ParameterInspectorTest( GafferUITest.TestCase ) :
 		self.__assertExpectedResult(
 			inspection,
 			source = None,
-			sourceType = SourceType.Fallback,
+			sourceType = SourceType.Other,
+			fallbackDescription = "Inherited from /group",
 			editable = False,
 			nonEditableReason = "No editable source found in history."
 		)
-		self.assertEqual( inspection.fallbackDescription(), "Inherited from /group" )
 
 		planeShader = GafferSceneTest.TestShader()
 		planeShader["type"].setValue( "test:surface" )

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -59,7 +59,6 @@ const boost::container::flat_map<int, ConstColor4fDataPtr> g_sourceTypeColors = 
 { (int)Inspector::Result::SourceType::EditScope, new Color4fData( Imath::Color4f( 48, 100, 153, 150 ) / 255.0f ) },
 { (int)Inspector::Result::SourceType::Downstream, new Color4fData( Imath::Color4f( 239, 198, 24, 104 ) / 255.0f ) },
 { (int)Inspector::Result::SourceType::Other, nullptr },
-{ (int)Inspector::Result::SourceType::Fallback, nullptr },
 };
 const Color4fDataPtr g_fallbackValueForegroundColor = new Color4fData( Imath::Color4f( 163, 163, 163, 255 ) / 255.0f );
 const ConstStringDataPtr g_missingOutputShader = new StringData( "Missing output shader" );
@@ -241,7 +240,7 @@ PathColumn::CellData InspectorColumn::cellDataFromInspection( const GafferSceneU
 
 	result.background = g_sourceTypeColors.at( (int)inspection->sourceType() );
 	std::string toolTip;
-	if( inspection->sourceType() == Inspector::Result::SourceType::Fallback )
+	if( inspection->fallbackDescription().size() )
 	{
 		toolTip = "Source : " + inspection->fallbackDescription();
 		result.foreground = g_fallbackValueForegroundColor;

--- a/src/GafferSceneUI/InspectorColumn.cpp
+++ b/src/GafferSceneUI/InspectorColumn.cpp
@@ -158,47 +158,8 @@ Gaffer::ConstContextPtr InspectorColumn::inspectorContext( const Gaffer::Path &p
 
 PathColumn::CellData InspectorColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
 {
-	CellData result;
 	Inspector::ConstResultPtr inspectorResult = inspect( path, canceller );
-	if( !inspectorResult )
-	{
-		return result;
-	}
-
-	result = cellDataFromValue( inspectorResult->value() );
-
-	result.background = g_sourceTypeColors.at( (int)inspectorResult->sourceType() );
-	std::string toolTip;
-	if( inspectorResult->sourceType() == Inspector::Result::SourceType::Fallback )
-	{
-		toolTip = "Source : " + inspectorResult->fallbackDescription();
-		result.foreground = g_fallbackValueForegroundColor;
-	}
-	else if( const auto source = inspectorResult->source() )
-	{
-		toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
-	}
-
-	/// \todo Should we have the ability to create read-only columns?
-	if( inspectorResult->editable() )
-	{
-		toolTip += !toolTip.empty() ? "\n\n" : "";
-		if( runTimeCast<const IECore::BoolData>( result.value ) )
-		{
-			toolTip += "Double-click to toggle";
-		}
-		else
-		{
-			toolTip += "Double-click to edit";
-		}
-	}
-
-	if( !toolTip.empty() )
-	{
-		result.toolTip = new StringData( toolTip );
-	}
-
-	return result;
+	return cellDataFromInspection( inspectorResult.get() );
 }
 
 PathColumn::CellData InspectorColumn::headerData( const IECore::Canceller *canceller ) const
@@ -266,4 +227,48 @@ PathColumn::CellData InspectorColumn::cellDataFromValue( const IECore::Object *v
 	}
 
 	return CellData();
+}
+
+PathColumn::CellData InspectorColumn::cellDataFromInspection( const GafferSceneUI::Private::Inspector::Result *inspection ) const
+{
+	CellData result;
+	if( !inspection )
+	{
+		return result;
+	}
+
+	result = cellDataFromValue( inspection->value() );
+
+	result.background = g_sourceTypeColors.at( (int)inspection->sourceType() );
+	std::string toolTip;
+	if( inspection->sourceType() == Inspector::Result::SourceType::Fallback )
+	{
+		toolTip = "Source : " + inspection->fallbackDescription();
+		result.foreground = g_fallbackValueForegroundColor;
+	}
+	else if( const auto source = inspection->source() )
+	{
+		toolTip = "Source : " + source->relativeName( source->ancestor<ScriptNode>() );
+	}
+
+	/// \todo Should we have the ability to create read-only columns?
+	if( inspection->editable() )
+	{
+		toolTip += !toolTip.empty() ? "\n\n" : "";
+		if( runTimeCast<const IECore::BoolData>( result.value ) )
+		{
+			toolTip += "Double-click to toggle";
+		}
+		else
+		{
+			toolTip += "Double-click to edit";
+		}
+	}
+
+	if( !toolTip.empty() )
+	{
+		result.toolTip = new StringData( toolTip );
+	}
+
+	return result;
 }

--- a/src/GafferSceneUI/VisibilityColumn.cpp
+++ b/src/GafferSceneUI/VisibilityColumn.cpp
@@ -91,7 +91,7 @@ InspectorColumn::CellData VisibilityColumn::cellData( const Gaffer::Path &path, 
 	const auto visibilityValue = runTimeCast<const BoolData>( inspectorResult->value() );
 
 	std::string toolTip;
-	if( inspectorResult->sourceType() == Inspector::Result::SourceType::Fallback )
+	if( !inspectorResult->value( /* useFallbacks = */ false ) )
 	{
 		result.icon = visible ? g_locationVisibleTransparentIcon : g_locationInvisibleTransparentIcon;
 		toolTip = visible ? "Location visible by inheritance." : "Location invisible by inheritance. It will not be rendered, and neither will its descendants.";

--- a/src/GafferSceneUI/VisibilityColumn.cpp
+++ b/src/GafferSceneUI/VisibilityColumn.cpp
@@ -73,9 +73,8 @@ VisibilityColumn::VisibilityColumn( const GafferScene::ScenePlugPtr &scene, cons
 
 InspectorColumn::CellData VisibilityColumn::cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const
 {
-	CellData result = InspectorColumn::cellData( path, canceller );
-
 	Inspector::ConstResultPtr inspectorResult = inspect( path, canceller );
+	CellData result = cellDataFromInspection( inspectorResult.get() );
 	if( !inspectorResult )
 	{
 		return result;

--- a/src/GafferSceneUIModule/InspectorBinding.cpp
+++ b/src/GafferSceneUIModule/InspectorBinding.cpp
@@ -68,9 +68,10 @@ GafferSceneUI::Private::Inspector::ResultPtr inspectWrapper( const GafferSceneUI
 	return inspector.inspect();
 }
 
-IECore::ObjectPtr valueWrapper( const GafferSceneUI::Private::Inspector::Result &result )
+IECore::ObjectPtr valueWrapper( const GafferSceneUI::Private::Inspector::Result &result, bool useFallbacks )
 {
-	return result.value() ? result.value()->copy() : nullptr;
+	const IECore::Object *v = result.value( useFallbacks );
+	return v ? v->copy() : nullptr;
 }
 
 Gaffer::ValuePlugPtr acquireEditWrapper( GafferSceneUI::Private::Inspector::Result &result, bool createIfNecessary )
@@ -167,7 +168,7 @@ void GafferSceneUIModule::bindInspector()
 		PathClass<Inspector::HistoryPath>();
 
 		scope resultScope = RefCountedClass<Inspector::Result, IECore::RefCounted>( "Result" )
-			.def( "value", &valueWrapper )
+			.def( "value", &valueWrapper, ( arg( "useFallbacks" ) = true ) )
 			.def( "source", &Inspector::Result::source, return_value_policy<CastToIntrusivePtr>() )
 			.def( "editScope", &Inspector::Result::editScope, return_value_policy<CastToIntrusivePtr>() )
 			.def( "sourceType", &Inspector::Result::sourceType )
@@ -188,7 +189,6 @@ void GafferSceneUIModule::bindInspector()
 			.value( "EditScope", Inspector::Result::SourceType::EditScope )
 			.value( "Downstream", Inspector::Result::SourceType::Downstream )
 			.value( "Other", Inspector::Result::SourceType::Other )
-			.value( "Fallback", Inspector::Result::SourceType::Fallback )
 		;
 	}
 

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -194,7 +194,7 @@ class MuteColumn : public InspectorColumn
 
 			if( auto value = runTimeCast<const BoolData>( inspection->value() ) )
 			{
-				if( inspection->sourceType() != Inspector::Result::SourceType::Fallback )
+				if( inspection->fallbackDescription().empty() )
 				{
 					result.icon = value->readable() ? m_muteIconData : m_unMuteIconData;
 				}
@@ -294,7 +294,7 @@ class SetMembershipColumn : public InspectorColumn
 
 			if( inspection->typedValue<bool>( false ) )
 			{
-				if( inspection->sourceType() != Inspector::Result::SourceType::Fallback )
+				if( inspection->fallbackDescription().empty() )
 				{
 					result.icon = m_setMemberIconData;
 				}

--- a/src/GafferSceneUIModule/LightEditorBinding.cpp
+++ b/src/GafferSceneUIModule/LightEditorBinding.cpp
@@ -187,12 +187,6 @@ class MuteColumn : public InspectorColumn
 		{
 			CellData result = InspectorColumn::cellData( path, canceller );
 
-			auto scenePath = runTimeCast<const ScenePath>( &path );
-			if( !scenePath )
-			{
-				return result;
-			}
-
 			if( auto value = runTimeCast<const BoolData>( result.value ) )
 			{
 				Inspector::ConstResultPtr inspectorResult = inspect( path, canceller );
@@ -283,12 +277,6 @@ class SetMembershipColumn : public InspectorColumn
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
 		{
 			CellData result = InspectorColumn::cellData( path, canceller );
-
-			auto scenePath = runTimeCast<const ScenePath>( &path );
-			if( !scenePath )
-			{
-				return result;
-			}
 
 			if( auto value = runTimeCast<const BoolData>( result.value ) )
 			{

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -1525,11 +1525,11 @@ class InspectorDiffColumn : public GafferSceneUI::Private::InspectorColumn
 
 		CellData cellData( const Gaffer::Path &path, const IECore::Canceller *canceller ) const override
 		{
-			CellData result = InspectorColumn::cellData( path, canceller );
-
-			/// \todo Rejig InspectorColumn so we can share the inspection it already did.
 			GafferSceneUI::Private::Inspector::ResultPtr inspectionA = inspect( path, canceller );
 			GafferSceneUI::Private::Inspector::ResultPtr inspectionB = m_otherColumn->inspect( path, canceller );
+
+			CellData result = InspectorColumn::cellDataFromInspection( inspectionA.get() );
+
 			const Object *valueA = inspectionA ? inspectionA->value() : nullptr;
 			const Object *valueB = inspectionB ? inspectionB->value() : nullptr;
 


### PR DESCRIPTION
This was obscuring the source of edits which deleted a property, meaning we failed to indicate the edit with the blue cell background in our various scene editors. I've also included a couple of other commits which make small improvements to the Inspector framework, since they were in the vicinity of the code touched by the main commit.