### PR TITLE
RenderPassEditor : Deduplicate section names when updating tabs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,11 @@ Improvements
 
 - Outputs : Custom `gaffer:renderID` parameters are now preserved, allowing custom "netrender" style workflows to be implemented.
 
+Fixes
+-----
+
+- RenderPassEditor : Fixed bug that could cause duplicate tabs to appear when registering custom columns to an existing section via a different group key.
+
 1.5.16.2 (relative to 1.5.16.1)
 ========
 

--- a/python/GafferSceneUI/RenderPassEditor.py
+++ b/python/GafferSceneUI/RenderPassEditor.py
@@ -832,10 +832,14 @@ class _SectionPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 			tabGroup = self.getPlug().node()["tabGroup"].getValue()
 
+			tabNames = []
 			for groupKey, sections in RenderPassEditor._RenderPassEditor__columnRegistry.items() :
 				if IECore.StringAlgo.match( tabGroup, groupKey ) :
-					for section in sections.keys() :
-						self._qtWidget().addTab( section )
+					tabNames.extend( sections.keys() )
+			# Deduplicate sections while preserving order in case the same
+			# section has been registered to multiple matching groupKeys.
+			for name in list( dict.fromkeys( tabNames ) ) :
+				self._qtWidget().addTab( name )
 		finally :
 			self.__ignoreCurrentChanged = False
 


### PR DESCRIPTION
Otherwise registrations of `GafferSceneUI.RenderPassEditor.registerOption( "*", "user:customOption1", "Custom" )` and `GafferSceneUI.RenderPassEditor.registerOption( "Arnold", "user:customOption2", "Custom" )` would result in two "Custom" tabs appearing when `tabGroup` is set to "Arnold" as we'd create a tab per section in each matching group.

The LightEditor and AttributeEditor would be exposed to the same bug, though would be far less likely to have wildcard registrations. Is it worth fixing them the same way just in case?