### PR TITLE
SceneInspector : Add "Isolate Differences" settings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.2.1)
 =======
 
+Improvements
+------------
+
+- SceneInspector : Removed redundant scene inspections when not in comparison mode.
+
 Fixes
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@ API
 ---
 
 - Metadata : The `registerNode()` function now accepts dictionaries containing plug metadata. This should be preferred to the previous list-based values.
+- SceneInspector : Added `deregisterInspectors()` method.
 
 1.6.2.1 (relative to 1.6.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Arnold : Fixed `options.frame` value, which was previously always `0`. This fixes the `arnold/frame` EXR metadata.
+- BoolWidget : Fixed label text styling when disabled.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@ Fixes
 -----
 
 - Arnold : Fixed `options.frame` value, which was previously always `0`. This fixes the `arnold/frame` EXR metadata.
+- SceneInspector : The Globals tab no longer shows the A/B columns when only locations are being compared.
 - BoolWidget : Fixed label text styling when disabled.
 
 API

--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- SceneInspector : Removed redundant scene inspections when not in comparison mode.
+- SceneInspector :
+  - Added "Isolate Differences" option for comparison modes. This filters out all properties which have the same value in the A and B columns.
+  - Removed redundant scene inspections when not in comparison mode.
 
 Fixes
 -----

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -224,6 +224,7 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 		if plug in (
 			self.settings()["location"],
 			self.settings()["compare"]["location"],
+			self.settings()["compare"]["scene"]["enabled"],
 			self.settings()["compare"]["renderPass"],
 		) :
 			self.__lazyUpdateFromContexts()
@@ -248,7 +249,8 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 		result = []
 		for inputIndex in range( 0, 2 ) :
 			context = Gaffer.Context( self.context() )
-			context["__sceneInspector:inputIndex"] = inputIndex
+			if self.settings()["compare"]["scene"]["enabled"].getValue() :
+				context["__sceneInspector:inputIndex"] = inputIndex
 			result.append( context )
 
 		if self.settings()["compare"]["renderPass"]["enabled"].getValue() :

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -233,10 +233,10 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 	def _updateFromSettings( self, plug ) :
 
 		if plug.getName() == "enabled" and self.settings()["compare"].isAncestorOf( plug ) :
-			comparing = any( p["enabled"].getValue() for p in self.settings()["compare"] )
-			columns = self.__diffColumns if comparing else self.__standardColumns
-			self.__locationPathListing.setColumns( columns )
-			self.__globalsPathListing.setColumns( columns )
+			comparingGlobals = any( self.settings()["compare"][n]["enabled"].getValue() for n in [ "scene", "renderPass" ] )
+			comparingLocations = comparingGlobals or self.settings()["compare"]["location"]["enabled"].getValue()
+			self.__locationPathListing.setColumns( self.__diffColumns if comparingLocations else self.__standardColumns )
+			self.__globalsPathListing.setColumns( self.__diffColumns if comparingGlobals else self.__standardColumns )
 
 		if plug in (
 			self.settings()["location"],

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -292,6 +292,7 @@ GafferUI.Editor.registerType( "SceneInspector", SceneInspector )
 # InspectorTree isn't public API. Expose the `registerInspectors()` function and the `Inspection` class
 # on SceneInspector itself to make them available to extension authors.
 SceneInspector.registerInspectors = _GafferSceneUI._SceneInspector.InspectorTree.registerInspectors
+SceneInspector.deregisterInspectors = _GafferSceneUI._SceneInspector.InspectorTree.deregisterInspectors
 SceneInspector.Inspection = _GafferSceneUI._SceneInspector.InspectorTree.Inspection
 
 ##########################################################################

--- a/python/GafferUI/_StyleSheet.py
+++ b/python/GafferUI/_StyleSheet.py
@@ -540,7 +540,7 @@ _styleSheet = string.Template(
 		background-color: none;
 	}
 
-	QPushButton:disabled, QComboBox:disabled, QLabel::disabled {
+	QPushButton:disabled, QComboBox:disabled, QLabel::disabled, QCheckBox::disabled {
 		color: $tintLighterStrong;
 	}
 

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -131,7 +131,7 @@ class InspectorTree : public IECore::RefCounted
 		using Contexts = std::array<Gaffer::ConstContextPtr, 2>;
 
 		InspectorTree( const ScenePlugPtr &scene, const Contexts &contexts, const Gaffer::PlugPtr &editScope )
-			:	m_scene( scene ), m_editScope( editScope ), m_filter( "*" )
+			:	m_scene( scene ), m_editScope( editScope ), m_filter( "*" ), m_isolateDifferences( false )
 		{
 			setContexts( contexts );
 			scene->node()->plugDirtiedSignal().connect( boost::bind( &InspectorTree::plugDirtied, this, ::_1 ) );
@@ -196,6 +196,24 @@ class InspectorTree : public IECore::RefCounted
 		const IECore::StringAlgo::MatchPattern &getFilter() const
 		{
 			return m_filter;
+		}
+
+		void setIsolateDifferences( bool isolateDifferences )
+		{
+			bool dirty = false;
+			{
+				std::scoped_lock lock( m_mutex );
+				if( isolateDifferences != m_isolateDifferences )
+				{
+					m_isolateDifferences = isolateDifferences;
+					dirty = true;
+					m_rootItem.reset();
+				}
+			}
+			if( dirty )
+			{
+				m_dirtiedSignal();
+			}
 		}
 
 		using DirtiedSignal = Gaffer::Signals::Signal<void ()>;
@@ -505,7 +523,60 @@ class InspectorTree : public IECore::RefCounted
 				}
 			}
 
+			if( m_isolateDifferences )
+			{
+				isolateDifferencesWalk( m_rootItem.get(), canceller );
+			}
+
 			return m_rootItem;
+		}
+
+		// Removes children from `tree` as necessary, and returns
+		// true if this item should be kept by its parent, false
+		// otherwise.
+		bool isolateDifferencesWalk( TreeItem *item, const IECore::Canceller *canceller ) const
+		{
+			for( auto it = item->children.begin(); it != item->children.end(); /* empty */ )
+			{
+				if( !isolateDifferencesWalk( it->second.get(), canceller ) )
+				{
+					it = item->children.erase( it );
+				}
+				else
+				{
+					++it;
+				}
+			}
+
+			if( !item->children.empty() )
+			{
+				return true;
+			}
+
+			if( !item->inspector )
+			{
+				return false;
+			}
+
+			std::array<ConstObjectPtr, 2> values;
+			for( size_t i = 0; i < m_contexts.size(); ++i )
+			{
+				Context::EditableScope scope( m_contexts[i].get() );
+				scope.setCanceller( canceller );
+				auto inspection = item->inspector->inspect();
+				values[i] = inspection ? inspection->value() : nullptr;
+			}
+
+			if( (bool)values[0] != (bool)values[1] )
+			{
+				return true;
+			}
+			else if( !values[0] )
+			{
+				return false;
+			}
+
+			return values[0]->isNotEqualTo( values[1].get() );
 		}
 
 		using InspectionProviders = vector<std::pair<vector<InternedString>, InspectionProvider>>;
@@ -528,6 +599,7 @@ class InspectorTree : public IECore::RefCounted
 		mutable std::shared_ptr<TreeItem> m_rootItem;
 		Contexts m_contexts;
 		IECore::StringAlgo::MatchPattern m_filter;
+		bool m_isolateDifferences;
 
 };
 
@@ -1613,6 +1685,12 @@ void inspectorTreeSetFilterWrapper( InspectorTree &tree, const IECore::StringAlg
 	tree.setFilter( filter );
 }
 
+void inspectorTreeSetIsolateDifferencesWrapper( InspectorTree &tree, bool isolateDifferences )
+{
+	IECorePython::ScopedGILRelease gilRelease;
+	tree.setIsolateDifferences( isolateDifferences );
+}
+
 void inspectorTreeRegisterInspectorsWrapper( const vector<InternedString> &path, object pythonInspectionProvider )
 {
 	InspectorTree::InspectionProvider inspectionProvider = [pythonInspectionProvider] ( ScenePlug *scene, const Gaffer::PlugPtr &editScope ) {
@@ -1659,6 +1737,7 @@ void GafferSceneUIModule::bindSceneInspector()
 			.def( "getContexts", &inspectorTreeGetContextsWrapper )
 			.def( "setFilter", &inspectorTreeSetFilterWrapper )
 			.def( "getFilter", &InspectorTree::getFilter, return_value_policy<copy_const_reference>() )
+			.def( "setIsolateDifferences", &inspectorTreeSetIsolateDifferencesWrapper )
 			.def( "dirtiedSignal", &InspectorTree::dirtiedSignal, return_internal_reference<1>() )
 			.def( "registerInspectors", &inspectorTreeRegisterInspectorsWrapper ).staticmethod( "registerInspectors" )
 			.def( "deregisterInspectors",  &InspectorTree::deregisterInspectors ).staticmethod( "deregisterInspectors" )

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -449,6 +449,12 @@ class InspectorTree : public IECore::RefCounted
 
 			for( const auto &context : m_contexts )
 			{
+				if( &context == &m_contexts[1] && *context == *m_contexts[0] )
+				{
+					// Second context is identical to the first, so skip it.
+					continue;
+				}
+
 				Context::EditableScope scope( context.get() );
 				if( canceller )
 				{

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -235,6 +235,21 @@ class InspectorTree : public IECore::RefCounted
 			inspectionProviders().push_back( { path, inspectionProvider } );
 		}
 
+		static void deregisterInspectors( const vector<InternedString> &path )
+		{
+			auto &providers = inspectionProviders();
+			providers.erase(
+				std::remove_if(
+					providers.begin(),
+					providers.end(),
+					[&] ( const auto &item ) {
+						return item.first == path;
+					}
+				),
+				providers.end()
+			);
+		}
+
 		// Convenience for making registrations using a static variable.
 		struct Registration : boost::noncopyable
 		{
@@ -1640,6 +1655,7 @@ void GafferSceneUIModule::bindSceneInspector()
 			.def( "getFilter", &InspectorTree::getFilter, return_value_policy<copy_const_reference>() )
 			.def( "dirtiedSignal", &InspectorTree::dirtiedSignal, return_internal_reference<1>() )
 			.def( "registerInspectors", &inspectorTreeRegisterInspectorsWrapper ).staticmethod( "registerInspectors" )
+			.def( "deregisterInspectors",  &InspectorTree::deregisterInspectors ).staticmethod( "deregisterInspectors" )
 		;
 
 		class_<InspectorTree::Inspection>( "Inspection" )


### PR DESCRIPTION
When in comparison mode, this lets you very quickly drill down to only the things that are different between the A and B columns. This simplifies common debugging scenarios.

The motivation for giving this a go was my lingering uncertainty about the "aggregate inspectors" I experimented with in the un-merged https://github.com/GafferHQ/gaffer/pull/6578. Although they would also allow you to drill down to the differences, there were a few things bothering me :

- The need to manually register an aggregate inspector for every location in the hierarchy, and therefore the extra faff involved for anyone registering their own inspectors. And the inconsistent user experience if aggregates were missing.
- The uncertainty surrounding the appropriate formatting of aggregate inspector values, and not-particularly-useful aggregates we'd need for transforms and bounds.
- Not being sure that people would "get" history tracebacks for the aggregate values. Or drag and drop from them.
- Not especially liking the appearance of the red/green diff backgrounds on empty-looking ancestor cells. I didn't feel like they particularly communicated "children have differences".

The "Isolate Differences" approach has none of these downsides, and is easier to use anyway. If this seems OK to folks, then I think I'm going to abandon the aggregate inspector idea...