### PR TITLE
Arnold Renderer : Set `options.frame` Arnold parameter

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.2.1)
 =======
 
+Fixes
+-----
+
+- Arnold : Fixed `options.frame` value, which was previously always `0`. This fixes the `arnold/frame` EXR metadata.
+
 API
 ---
 

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -3094,6 +3094,11 @@ class RendererTest( GafferTest.TestCase ) :
 						seed or frame or 1
 					)
 
+					self.assertEqual(
+						arnold.AiNodeGetFlt( options, "frame" ),
+						frame or 1
+					)
+
 	def testLogDirectoryCreation( self ) :
 
 		# Directory for log file should be made automatically if

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -300,6 +300,7 @@ const AtString g_driverEXRArnoldString( "driver_exr" );
 const AtString g_enableProgressiveRenderString( "enable_progressive_render" );
 const AtString g_fileNameArnoldString( "filename" );
 const AtString g_filtersArnoldString( "filters" );
+const AtString g_frameArnoldString( "frame" );
 const AtString g_funcPtrArnoldString( "funcptr" );
 const AtString g_ginstanceArnoldString( "ginstance" );
 const AtString g_ignoreMotionBlurArnoldString( "ignore_motion_blur" );
@@ -4025,6 +4026,11 @@ class ArnoldGlobals
 			updateDrivers();
 
 			AtNode *options = AiUniverseGetOptions( m_universeBlock->universe() );
+
+			AiNodeSetFlt(
+				options, g_frameArnoldString,
+				m_frame.value_or( 1 )
+			);
 
 			AiNodeSetInt(
 				options, g_aaSeedArnoldString,


### PR DESCRIPTION
This is needed to get the right value for the `arnold/frame` EXR metadata written by `driver_exr`, and also for the frame number in `imager_overlay`. The Arnold devs assure me that it is only used for this sort of informational purpose, and that it will have no effect on images themselves (it's not related to motion blur in the same way that `reference_time` is).

The motivating factor here is that `noice` doesn't work properly with the EXR metadata, as reported on [gaffer-dev](https://groups.google.com/g/gaffer-dev/c/nAnRyHTLCUI/m/tyd5GBTuAQAJ).
