### PR TITLE
SceneInspector : Improve filtering

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,10 @@ Improvements
 
 - SceneInspector :
   - Added "Isolate Differences" option for comparison modes. This filters out all properties which have the same value in the A and B columns.
+  - Improved filtering :
+    - By default, filters now match any part of the hierarchy, allowing primitive variables to be matched.
+    - Filters may optionally specify a full path, such as `/Object/Primitive Variables/velocity` to avoid matches elsewhere in the hierarchy.
+    - The new behaviour matches the filters in the HierarchyView and AttributeEditor.
   - Removed redundant scene inspections when not in comparison mode.
 
 Fixes

--- a/python/GafferSceneUI/SceneInspector.py
+++ b/python/GafferSceneUI/SceneInspector.py
@@ -310,12 +310,16 @@ class SceneInspector( GafferSceneUI.SceneEditor ) :
 	def __updateFilter( self, tree, plug ) :
 
 		pattern = plug.getValue()
-		if not pattern :
-			pattern = "*"
-		elif not IECore.StringAlgo.hasWildcards( pattern ) :
-				pattern = f"*{pattern}*"
+		if "/" in pattern :
+			# Initial "/*" needed to match the "/Location"
+			# or "/Global" root that the user doesn't see.
+			pathPattern = f"/*/{pattern}/..."
+		elif IECore.StringAlgo.hasWildcards( pattern ) :
+			pathPattern = f"/.../{pattern}/..."
+		else :
+			pathPattern = f"/.../*{pattern}*/..."
 
-		tree.setFilter( pattern )
+		tree.setFilter( pathPattern )
 
 GafferUI.Editor.registerType( "SceneInspector", SceneInspector )
 
@@ -393,7 +397,19 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Filters the displayed properties. Accepts standard wildcards such as `*` and `?`.
+			Filters the displayed properties. The filter may contain any of Gaffer's
+			standard wildcards, and may either be used to match individual property
+			names or entire paths.
+
+			Examples
+			--------
+
+			- `velocity` : Shows all properties which have `velocity` anywhere
+			  in their name, be they attributes, primitive variables or anything else.
+			- `/Object/Primitive Variables` : Shows primitive variables.
+			- `/Attributes/Standard` : Shows standard attributes.
+			- `/Attributes/*/*surface/*/*color*` : Shows surface shader parameters whose
+			  name contains `color`.
 			""",
 
 			"plugValueWidget:type", "GafferUI.TogglePlugValueWidget",
@@ -427,7 +443,17 @@ Gaffer.Metadata.registerNode(
 
 			"description",
 			"""
-			Filters the displayed properties. Accepts standard wildcards such as `*` and `?`.
+			Filters the displayed properties. The filter may contain any of Gaffer's
+			standard wildcards, and may either be used to match individual property
+			names or entire paths.
+
+			Examples
+			--------
+
+			- `samples` : Shows all properties which have `samples` anywhere
+			  in their name, be they options, outputs or anything else.
+			- `/Options/Standard` : Shows standard options.
+			- `/Outputs/.../Data` : Shows the Data field for all outputs.
 			""",
 
 			"plugValueWidget:type", "GafferUI.TogglePlugValueWidget",


### PR DESCRIPTION
Previously we only matched the filter against locations where there was actually an inspector, meaning that it was impossible to match against primitive variable names (which are at intermediate levels in the hierarchy). We now use a hierarchical path filter as in the HierarchyView and AttributeEditor, allowing any part of the hierarchy to be matched.

I also experimented with a more complex approach whereby individual inspectors could be tagged as filterable or not. This had a few potential benefits :

- Searching for `P` wouldn't match the whole `Primitive Variables` section (which starts with "P"), because that would be tagged as non-filterable.
- Searching for `Interpolation` wouldn't match underneath every primitive variable, on the assumption that users wouldn't want to filter those.

This would have been combined with a "power" mode where including "/" in the filter string would perform full patch matching against everything instead. But having implemented it, I felt that it was confusing, due to it being really unclear why certain locations were matchable but not others, and the behaviour being different to our other editors. It put us in a position where we have to read the user's mind as to what they might be looking for.

So I went for this simpler and more predictable version instead.
