### PR TITLE
FocalBlur : Minor UI fixes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ API
 
 - Metadata : The `registerNode()` function now accepts dictionaries containing plug metadata. This should be preferred to the previous list-based values.
 - SceneInspector : Added `deregisterInspectors()` method.
+- PathPlugValueWidget : Added support for placeholder text, via `pathPlugValueWidget:placeholderText` metadata.
 
 1.6.2.1 (relative to 1.6.2.0)
 =======

--- a/python/GafferOSL/FocalBlur.gfr
+++ b/python/GafferOSL/FocalBlur.gfr
@@ -839,7 +839,7 @@ __children["FocalBlur"]["Dot25"]["__uiPosition"].setValue( imath.V2f( 822.9505, 
 __children["FocalBlur"]["Dot26"]["in"].setInput( __children["FocalBlur"]["Dot25"]["out"] )
 __children["FocalBlur"]["Dot26"]["__uiPosition"].setValue( imath.V2f( 822.9505, 35.2791519 ) )
 Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'nodule:type', '' )
-Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'stringPlugValueWidget:placeholderText', 'Render Camera' )
+Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'pathPlugValueWidget:placeholderText', 'Render Camera' )
 Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'layout:section', 'Settings' )
 Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'layout:index', 7 )
 Gaffer.Metadata.registerValue( __children["FocalBlur"]["cameraPath"], 'layout:visibilityActivator', 'cameraScene' )

--- a/python/GafferUI/PathPlugValueWidget.py
+++ b/python/GafferUI/PathPlugValueWidget.py
@@ -51,6 +51,7 @@ import os
 # - "path:leaf"
 # - "path:valid"
 # - "path:bookmarks"
+# - "pathPlugValueWidget:placeholderText" : The text displayed when the string value is left empty
 class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 
 	## path should be an instance of Gaffer.Path, optionally with
@@ -154,6 +155,10 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 		self.pathWidget().setEditable( self._editable() )
 		self.__row[1].setEnabled( self._editable() ) # button
 
+	def _updateFromMetadata( self ) :
+
+		self.pathWidget().setPlaceholderText( self.__placeholderText() )
+
 	def _setPlugFromPath( self, path ) :
 
 		self.getPlug().setValue( str( self.__path ) )
@@ -188,3 +193,7 @@ class PathPlugValueWidget( GafferUI.PlugValueWidget ) :
 			v = Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:" + name )
 
 		return v
+
+	def __placeholderText( self ) :
+
+		return Gaffer.Metadata.value( self.getPlug(), "pathPlugValueWidget:placeholderText" )


### PR DESCRIPTION
Two little UI fixes we've discussed.

For the focalLengthWorldScale preset menu, I've just copy and pasted the metadata from the Camera. Usually I'd try to make it some sort of dynamic connection, but there isn't an obvious way to do that for a node that's maintained as a network.

For the placeholderText, definitely do review it - I've pretty blindly copied the implementation from StringPlugValueWidget, without paying a lot of attention to the context, but it's pretty simple, and appears to work fine.