### PR TITLE
GafferImage : Avoid `OIIO_NAMESPACE_USING`

### DIFF
--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -82,10 +82,9 @@
 #endif
 #include <zlib.h>
 
-OIIO_NAMESPACE_USING
-
 using namespace std;
 using namespace Imath;
+using namespace OIIO;
 using namespace IECore;
 using namespace Gaffer;
 using namespace GafferDispatch;

--- a/src/GafferImage/OpenImageIOReader.cpp
+++ b/src/GafferImage/OpenImageIOReader.cpp
@@ -66,12 +66,11 @@
 
 #include <memory>
 
-OIIO_NAMESPACE_USING
-
 using namespace std;
 using namespace boost::placeholders;
 using namespace tbb;
 using namespace Imath;
+using namespace OIIO;
 using namespace IECore;
 using namespace GafferImage;
 using namespace Gaffer;


### PR DESCRIPTION
It got removed in OIIO 3.1, and although I think in the past it did do something cleverer to support custom namespaces, it is currently equivalent to `using namespace OIIO`, with OIIO always being aliased to the custom namespace anyway.
