### PR TITLE
Metadata ordering

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@ API
 
 - Metadata : The `registerNode()` function now accepts dictionaries containing plug metadata. This should be preferred to the previous list-based values.
 - SceneInspector : Added `deregisterInspectors()` method.
+- KindAlgo : Added GafferUSD namespace with utility functions for dealing with kinds.
 
 1.6.2.1 (relative to 1.6.2.0)
 =======

--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - SceneInspector : The Globals tab no longer shows the A/B columns when only locations are being compared.
 - BoolWidget : Fixed label text styling when disabled.
 - Scene Editors : Fixed cell background colour when a property is deleted by the current EditScope. It is now blue to indicate the edit, whereas before it had the default colour.
+- USDAttributes : Fixed unstable ordering of `kind` presets. These are now sorted to match the kind hierarchy.
 
 API
 ---

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Fixes
 - BoolWidget : Fixed label text styling when disabled.
 - Scene Editors : Fixed cell background colour when a property is deleted by the current EditScope. It is now blue to indicate the edit, whereas before it had the default colour.
 - USDAttributes : Fixed unstable ordering of `kind` presets. These are now sorted to match the kind hierarchy.
+- CyclesShader : Fixed unstable ordering of parameter presets. These are now sorted alphabetically.
 
 API
 ---

--- a/python/GafferCyclesUI/CyclesShaderUI.py
+++ b/python/GafferCyclesUI/CyclesShaderUI.py
@@ -62,9 +62,9 @@ def __translateParamMetadata( nodeTypeName, socketName, value ) :
 	if socketType == "enum" :
 		presetNames = IECore.StringVectorData()
 		presetValues = IECore.StringVectorData()
-		for enumName, enumValues in value["enum_values"].items() :
+		for enumName in sorted( value["enum_values"].keys() ):
 			presetNames.append(enumName)
-			presetValues.append( enumValues.value )
+			presetValues.append( value["enum_values"][enumName].value )
 		__metadata[paramPath]["presetNames"] = presetNames
 		__metadata[paramPath]["presetValues"] = presetValues
 		__metadata[paramPath]["plugValueWidget:type"] = "GafferUI.PresetsPlugValueWidget"

--- a/python/GafferSceneUI/SelectionToolUI.py
+++ b/python/GafferSceneUI/SelectionToolUI.py
@@ -125,7 +125,7 @@ class SelectModePlugValueWidget( GafferUI.PlugValueWidget ) :
 			assert( len( values ) == 1 )
 
 			if values[0] in modes :
-				self.__menuButton.setText( values[0].partition( "/" )[-1] )
+				self.__menuButton.setText( values[0].partition( "/" )[-1].lstrip() )
 			else :
 				self.__menuButton.setText( "Invalid" )
 

--- a/python/GafferUSDTest/KindAlgoTest.py
+++ b/python/GafferUSDTest/KindAlgoTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2022, Cinesite VFX Ltd. All rights reserved.
+#  Copyright (c) 2025, Cinesite VFX Ltd. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -15,7 +15,7 @@
 #        disclaimer in the documentation and/or other materials provided with
 #        the distribution.
 #
-#      * Neither the name of John Haddon nor the names of
+#      * Neither the name of Image Engine Design Inc nor the names of
 #        any other contributors to this software may be used to endorse or
 #        promote products derived from this software without specific prior
 #        written permission.
@@ -34,12 +34,24 @@
 #
 ##########################################################################
 
-from . import KindAlgo
+import unittest
 
-__import__( "GafferScene" )
+import GafferUSD
+import GafferSceneTest
 
-from ._GafferUSD import *
-from ._PointInstancerAdaptor import _PointInstancerAdaptor
-from .PromotePointInstances import PromotePointInstances
+class KindAlgoTest( GafferSceneTest.SceneTestCase ) :
 
-__import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "GafferUSD" )
+	def testPath( self ) :
+
+		self.assertEqual( GafferUSD.KindAlgo.path( "assembly" ), [ "model", "group", "assembly" ] )
+		self.assertEqual( GafferUSD.KindAlgo.path( "model" ), [ "model" ] )
+
+	def testTopologicallySorted( self ) :
+
+		kinds = GafferUSD.KindAlgo.topologicallySorted()
+		self.assertLess( kinds.index( "model" ), kinds.index( "group" ) )
+		self.assertLess( kinds.index( "model" ), kinds.index( "component" ) )
+		self.assertLess( kinds.index( "group" ), kinds.index( "assembly" ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/python/GafferUSDTest/__init__.py
+++ b/python/GafferUSDTest/__init__.py
@@ -41,6 +41,7 @@ from .USDShaderTest import USDShaderTest
 from .USDLightTest import USDLightTest
 from ._PointInstancerAdaptorTest import _PointInstancerAdaptorTest
 from .PromotePointInstancesTest import PromotePointInstancesTest
+from .KindAlgoTest import KindAlgoTest
 
 if __name__ == "__main__":
 	import unittest

--- a/startup/GafferScene/usdAttributes.py
+++ b/startup/GafferScene/usdAttributes.py
@@ -34,11 +34,12 @@
 #
 ##########################################################################
 
+import collections
+
 import IECore
 
 import Gaffer
-
-import pxr.Kind
+import GafferUSD
 
 Gaffer.Metadata.registerValues( {
 
@@ -83,8 +84,8 @@ Gaffer.Metadata.registerValues( {
 		""",
 		"label", "Kind",
 		"plugValueWidget:type", "GafferUI.PresetsPlugValueWidget",
-		"presetNames", IECore.StringVectorData( [ IECore.CamelCase.toSpaced( k ) for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ] ),
-		"presetValues", IECore.StringVectorData( k for k in pxr.Kind.Registry().GetAllKinds() if k != "model" ),
+		"presetNames", IECore.StringVectorData( [ IECore.CamelCase.toSpaced( k ) for k in GafferUSD.KindAlgo.topologicallySorted() ] ),
+		"presetValues", IECore.StringVectorData( GafferUSD.KindAlgo.topologicallySorted() ),
 
 	],
 

--- a/startup/gui/selectionTool.py
+++ b/startup/gui/selectionTool.py
@@ -64,7 +64,10 @@ def __kindSelectionModifier( targetKind, scene, pathString ) :
 
 for kind in GafferUSD.KindAlgo.topologicallySorted() :
 	GafferSceneUI.SelectionTool.registerSelectMode(
-		"USD Kind/" + IECore.CamelCase.toSpaced( kind ),
+		"USD Kind/{indent}{label}".format(
+			indent = "  " * ( len( GafferUSD.KindAlgo.path( kind ) ) - 1 ),
+			label = IECore.CamelCase.toSpaced( kind )
+		),
 		functools.partial( __kindSelectionModifier, kind ),
 	)
 

--- a/startup/gui/selectionTool.py
+++ b/startup/gui/selectionTool.py
@@ -41,6 +41,7 @@ from pxr import Kind
 
 import IECore
 
+import GafferUSD
 import GafferSceneUI
 
 ##########################################################################
@@ -61,30 +62,7 @@ def __kindSelectionModifier( targetKind, scene, pathString ) :
 
 	return path
 
-
-usdKinds = Kind.Registry.GetAllKinds()
-
-# Build a simplified hierarchy for sorting
-kindPaths = []
-for kind in usdKinds :
-	kindPath = kind
-	kindParent = Kind.Registry.GetBaseKind( kind )
-	while kindParent != "" :
-		kindPath = kindParent + "/" + kindPath
-		kindParent = Kind.Registry.GetBaseKind( kindParent )
-	kindPaths.append( kindPath )
-
-kindPaths.sort( reverse = True)
-
-# We prefer to have "subcomponent" at the end.
-try :
-	kindPaths.remove( "subcomponent" )
-	kindPaths.append( "subcomponent" )
-except :
-	pass
-
-for kindPath in kindPaths :
-	kind = kindPath.split( "/" )[-1]
+for kind in GafferUSD.KindAlgo.topologicallySorted() :
 	GafferSceneUI.SelectionTool.registerSelectMode(
 		"USD Kind/" + IECore.CamelCase.toSpaced( kind ),
 		functools.partial( __kindSelectionModifier, kind ),

--- a/startup/gui/selectionTool.py
+++ b/startup/gui/selectionTool.py
@@ -105,13 +105,13 @@ def __shaderSource( attributeKeyword, scene, pathString ) :
 				k != "surface:full" and
 				k != "surface:preview" and
 				k != "displacement:full" and
-				k != "displacement:preview" and 
+				k != "displacement:preview" and
 				isinstance( v, IECoreScene.ShaderNetwork )
 			) :
 				return path
-		
+
 		path.pop()
-	
+
 	return []
 
 GafferSceneUI.SelectionTool.registerSelectMode( "Shader Assignment/Surface", functools.partial( __shaderSource, "surface" ) )


### PR DESCRIPTION
To validate the ongoing [Great Metadata Reformatting of 2025](https://github.com/GafferHQ/gaffer/pull/6615), I've been comparing before/after metadata by querying it from the API. This PR fixes a couple of cases of nondeterministic presets ordering unearthed by that comparison.

The changes to the SelectionTool config isn't actually necessary, but it seemed odd to have two different ways of sorting USD kinds, and I think maybe the new presentation is an improvement over the old. I could drop that if folks are attached to the old ordering though...