### PR TITLE
Inspector : Delay signal connection until `dirtiedSignal()` called

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,9 @@ Fixes
 -----
 
 - Arnold : Fixed `options.frame` value, which was previously always `0`. This fixes the `arnold/frame` EXR metadata.
-- SceneInspector : The Globals tab no longer shows the A/B columns when only locations are being compared.
+- SceneInspector :
+  - Fixed potential crashes caused by a thread-safety bug. These were more likely in layouts with multiple SceneInspectors.
+  - The Globals tab no longer shows the A/B columns when only locations are being compared.
 - BoolWidget : Fixed label text styling when disabled.
 - Scene Editors : Fixed cell background colour when a property is deleted by the current EditScope. It is now blue to indicate the edit, whereas before it had the default colour.
 - GraphEditor : Fixed duplicate annotations that occurred when default annotation metadata was registered for a particular node type.

--- a/include/GafferSceneUI/Private/AttributeInspector.h
+++ b/include/GafferSceneUI/Private/AttributeInspector.h
@@ -73,10 +73,6 @@ class GAFFERSCENEUI_API AttributeInspector : public Inspector
 
 	private :
 
-		void plugDirtied( Gaffer::Plug *plug );
-		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
-		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
-
 		const GafferScene::ScenePlugPtr m_scene;
 		const IECore::InternedString m_attribute;
 

--- a/include/GafferSceneUI/Private/BasicInspector.h
+++ b/include/GafferSceneUI/Private/BasicInspector.h
@@ -78,7 +78,6 @@ class GAFFERSCENEUI_API BasicInspector : public Inspector
 		// Logically part of constructor, but in a separate function to avoid
 		// bloating the template.
 		void init();
-		void plugDirtied( Gaffer::Plug *plug );
 
 		const Gaffer::ValuePlugPtr m_plug;
 		using ValueFunction = std::function<IECore::ConstObjectPtr( const Gaffer::Plug * )>;

--- a/include/GafferSceneUI/Private/BasicInspector.inl
+++ b/include/GafferSceneUI/Private/BasicInspector.inl
@@ -45,7 +45,7 @@ BasicInspector::BasicInspector(
 	const ValueFunctionType &&valueFunction,
 	const std::string &type, const std::string &name
 )
-	: 	Inspector( plug, type, name, editScope ), m_plug( plug )
+	: 	Inspector( { plug }, type, name, editScope ), m_plug( plug )
 {
 	// Wrapper downcasts the plug to the correct type, removing the
 	// need to do that manually in the supplied lambda.

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -139,7 +139,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 		/// Protected constructor for use by derived classes. The `name` argument
 		/// will be returned verbatim by the `name()` method.
-		Inspector( const Gaffer::ConstPlugPtr &target, const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
+		Inspector( const std::vector<Gaffer::PlugPtr> &targets, const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
 
 		Gaffer::EditScope *targetEditScope() const;
 
@@ -213,6 +213,9 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 	private :
 
 		void inspectHistoryWalk( const GafferScene::SceneAlgo::History *history, Result *result ) const;
+		void plugDirtied( Gaffer::Plug *plug );
+		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
+		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
 		void editScopeInputChanged( const Gaffer::Plug *plug );
 
 		/// Utility class representing the history of the property in a
@@ -266,7 +269,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 
 		};
 
-		const Gaffer::ConstPlugPtr m_target;
+		const std::vector<Gaffer::PlugPtr> m_targets;
 		const std::string m_type;
 		const std::string m_name;
 		const Gaffer::PlugPtr m_editScope;

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -141,6 +141,8 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 		/// will be returned verbatim by the `name()` method.
 		Inspector( const Gaffer::ConstPlugPtr &target, const std::string &type, const std::string &name, const Gaffer::PlugPtr &editScope );
 
+		Gaffer::EditScope *targetEditScope() const;
+
 		/// Methods to be implemented in derived classes
 		/// ============================================
 		///
@@ -207,8 +209,6 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 		/// edit `plug` to set `value`. Called with `history->context` as the
 		/// current context.
 		virtual EditFunction editFunction( const GafferScene::SceneAlgo::History *history ) const;
-
-		Gaffer::EditScope *targetEditScope() const;
 
 	private :
 

--- a/include/GafferSceneUI/Private/Inspector.h
+++ b/include/GafferSceneUI/Private/Inspector.h
@@ -273,7 +273,7 @@ class GAFFERSCENEUI_API Inspector : public IECore::RunTimeTyped, public Gaffer::
 		const std::string m_type;
 		const std::string m_name;
 		const Gaffer::PlugPtr m_editScope;
-		InspectorSignal m_dirtiedSignal;
+		std::optional<InspectorSignal> m_dirtiedSignal;
 
 		// So we can access HistoryPath.
 		friend void GafferSceneUIModule::bindInspector();

--- a/include/GafferSceneUI/Private/OptionInspector.h
+++ b/include/GafferSceneUI/Private/OptionInspector.h
@@ -69,10 +69,6 @@ class GAFFERSCENEUI_API OptionInspector : public Inspector
 
 	private :
 
-		void plugDirtied( Gaffer::Plug *plug );
-		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
-		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
-
 		const GafferScene::ScenePlugPtr m_scene;
 		const IECore::InternedString m_option;
 

--- a/include/GafferSceneUI/Private/SetMembershipInspector.h
+++ b/include/GafferSceneUI/Private/SetMembershipInspector.h
@@ -79,10 +79,6 @@ class GAFFERSCENEUI_API SetMembershipInspector : public Inspector
 
 	private :
 
-		void plugDirtied( Gaffer::Plug *plug );
-		void plugMetadataChanged( IECore::InternedString key, const Gaffer::Plug *plug );
-		void nodeMetadataChanged( IECore::InternedString key, const Gaffer::Node *node );
-
 		const GafferScene::ScenePlugPtr m_scene;
 		const IECore::InternedString m_setName;
 };

--- a/python/GafferSceneUITest/AttributeInspectorTest.py
+++ b/python/GafferSceneUITest/AttributeInspectorTest.py
@@ -600,9 +600,14 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		light = GafferSceneTest.TestLight()
 		light["visualiserAttributes"]["scale"]["enabled"].setValue( True )
 
+		globalAttributes = GafferScene.Attributes()
+		globalAttributes["in"].setInput( light["out"] )
+		globalAttributes["global"].setValue( True )
+		globalAttributes["attributes"].addChild( Gaffer.NameValuePlug( "gl:visualiser:scale", 1.0 ) )
+
 		editScope1 = Gaffer.EditScope()
 		editScope1.setup( light["out"] )
-		editScope1["in"].setInput( light["out"] )
+		editScope1["in"].setInput( globalAttributes["out"] )
 
 		editScope2 = Gaffer.EditScope()
 		editScope2.setup( editScope1["out"] )
@@ -632,6 +637,10 @@ class AttributeInspectorTest( GafferUITest.TestCase ) :
 		self.assertEqual( len( cs ), 3 )
 		settings["editScope"].setInput( None )
 		self.assertEqual( len( cs ), 4 )
+
+		# As should changing a global attribute.
+		globalAttributes["attributes"][0]["value"].setValue( 20 )
+		self.assertEqual( len( cs ), 5 )
 
 	def testNonExistentLocation( self ) :
 

--- a/src/GafferSceneUI/BasicInspector.cpp
+++ b/src/GafferSceneUI/BasicInspector.cpp
@@ -131,10 +131,6 @@ void BasicInspector::init()
 	{
 		throw IECore::Exception( fmt::format( "Plug \"{}\" is not a child of a ScenePlug", m_plug->fullName() ) );
 	}
-
-	m_plug->node()->plugDirtiedSignal().connect(
-		boost::bind( &BasicInspector::plugDirtied, this, ::_1 )
-	);
 }
 
 GafferScene::SceneAlgo::History::ConstPtr BasicInspector::history() const
@@ -157,12 +153,4 @@ IECore::ConstObjectPtr BasicInspector::value( const GafferScene::SceneAlgo::Hist
 	/// appropriate canceller for us before calling `value()`?
 	Context::Scope scope( history->context.get() );
 	return m_valueFunction( history->scene->getChild<ValuePlug>( m_plug->getName() ) );
-}
-
-void BasicInspector::plugDirtied( Gaffer::Plug *plug )
-{
-	if( plug == m_plug )
-	{
-		dirtiedSignal()( this );
-	}
 }


### PR DESCRIPTION
This fixes crashes caused by non-thread-safe signal accesses in the SceneInspector. The easiest way to reproduce these was to make a couple of SceneInspectors and scrub around on the timeline.