### PR TITLE
Arnold Renderer : Support M44f `header:*` output metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Improvements
 - SceneInspector :
   - Added "Isolate Differences" option for comparison modes. This filters out all properties which have the same value in the A and B columns.
   - Removed redundant scene inspections when not in comparison mode.
+- Arnold : Added support for M44f `header:*` output metadata.
 
 Fixes
 -----

--- a/python/GafferDelightTest/DelightRenderTest.py
+++ b/python/GafferDelightTest/DelightRenderTest.py
@@ -36,12 +36,16 @@
 
 import unittest
 
+import IECore
+
 import GafferSceneTest
 
 class DelightRenderTest( GafferSceneTest.RenderTest ) :
 
 	renderer = "3Delight"
 	sceneDescriptionSuffix = ".nsi"
+	# Apparent bug in 3Delight's EXR driver writes M44f as Box2f.
+	unsupportedOutputMetadataTypes = [ IECore.M44fData ]
 
 	@unittest.skip( "No light linking support just yet" )
 	def testLightLinking( self ) :

--- a/python/GafferSceneTest/RenderTest.py
+++ b/python/GafferSceneTest/RenderTest.py
@@ -60,6 +60,9 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 	# And set this to the file extension used for scene description, if
 	# scene description is supported.
 	sceneDescriptionSuffix = None
+	# May be filled with types that aren't supported as `header:*` output
+	# metadata parameters.
+	unsupportedOutputMetadataTypes = []
 
 	@classmethod
 	def setUpClass( cls ) :
@@ -538,6 +541,7 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 			"test:int" : IECore.IntData( 1 ),
 			"test:float" : IECore.FloatData( 2.5 ),
 			"test:string" : IECore.StringData( "foo" ),
+			"test:matrix" : IECore.M44fData( imath.M44f( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ) ),
 		}
 
 		fileName = self.temporaryDirectory() / "test.exr"
@@ -564,6 +568,8 @@ class RenderTest( GafferSceneTest.SceneTestCase ) :
 		imageReader["fileName"].setValue( fileName )
 
 		for k, v in metadata.items() :
+			if type( v ) in self.unsupportedOutputMetadataTypes :
+				continue
 			self.assertIn( k, imageReader["out"].metadata() )
 			self.assertEqual( imageReader["out"].metadata()[k], v )
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -63,6 +63,7 @@
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/join.hpp"
 #include "boost/algorithm/string/predicate.hpp"
+#include "boost/core/span.hpp"
 #include "boost/container/flat_map.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "boost/lexical_cast.hpp"
@@ -82,6 +83,7 @@
 #include "tbb/spin_mutex.h"
 
 #include "fmt/format.h"
+#include "fmt/ranges.h"
 
 #include <condition_variable>
 #include <filesystem>
@@ -202,6 +204,10 @@ std::string formatHeaderParameter( const std::string name, const IECore::Data *d
 	else if( const IECore::Color4fData *c4fData = IECore::runTimeCast<const IECore::Color4fData>( data ) )
 	{
 		return fmt::format( "string '{}' ({} {} {} {})", name, c4fData->readable().r, c4fData->readable().g, c4fData->readable().b, c4fData->readable().a );
+	}
+	else if( const IECore::M44fData *m44fData = IECore::runTimeCast<const IECore::M44fData>( data ) )
+	{
+		return fmt::format( "matrix '{}' {}", name, fmt::join( boost::span( m44fData->readable().getValue(), 16 ), " " ) );
 	}
 	else
 	{


### PR DESCRIPTION
And test the existing support in all other renderers. 3Delight spoils the party here by writing matrices as boxes, so we skip that test for 3Delight only.
