### PR TITLE
SceneViewUI : Move purposes and add presets

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,9 @@ Improvements
 - OSLShader :
  - Improved loading of spline parameters with additional duplicate endpoints.
  - Added support for loading splines from RenderMan shaders.
+- Viewer :
+  - Moved purpose menu items from the Drawing Mode menu to the Expansion menu, and renamed the Expansion menu to `Visibility`.
+  - Added purpose presets for Render (Default + Render purposes), Preview (Default + Proxy) and Preview with Guides (Default + Proxy + Guide).
 
 Fixes
 -----

--- a/startup/GafferSceneUI/usdPointInstancerAdaptor.py
+++ b/startup/GafferSceneUI/usdPointInstancerAdaptor.py
@@ -59,13 +59,13 @@ def __expandUSDPointInstancersMenu( menuDefinition, plugValueWidget ) :
 			modifiedList = currentList + [ renderer ]
 		renderAdaptor["enabledRenderers"].setValue( IECore.StringVectorData( modifiedList ) )
 
-	menuDefinition.append( "/AttributesDivider", { "divider" : True } )
-	menuDefinition.append(
+	menuDefinition.insertAfter(
 		"/Expand USD Instancers",
 		{
 			"command" : callBackFunc,
 			"checkBox" : current
-		}
+		},
+		"/Expand All"
 	)
 
 GafferSceneUI.SceneViewUI._ExpansionPlugValueWidget.menuSignal().connect( __expandUSDPointInstancersMenu )


### PR DESCRIPTION
This moves the purposes menu to the Expansion menu and adds a few commonly used presets. The full range or purpose options are still available under the `Values` sub-menu.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
