### PR TITLE
VectorDataWidget : Fix errors showing ColorChooser popups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.3.0)
 =======
 
+Fixes
+-----
 
+- VectorDataWidget : Fixed errors showing popup colour choosers.
 
 1.6.3.0 (relative to 1.6.2.1)
 =======

--- a/python/GafferUI/VectorDataWidget.py
+++ b/python/GafferUI/VectorDataWidget.py
@@ -1314,7 +1314,11 @@ class _Delegate( QtWidgets.QStyledItemDelegate ) :
 		# fall through to the base class which will provide a default
 		# editor.
 		if self.__editor is not None :
-			if not isinstance( self.__editor, GafferUI.Window ) :
+			if isinstance( self.__editor, GafferUI.PopupWindow ) :
+				self.__editor.popup( parent = GafferUI.Widget._owner( parent ) )
+			elif isinstance( self.__editor, GafferUI.Window ) :
+				self.__editor.setVisible( True )
+			else :
 				self.__editor._qtWidget().setParent( parent )
 			return self.__editor._qtWidget()
 		else :
@@ -1520,11 +1524,7 @@ class _ColorDelegate( _Delegate ) :
 			return GafferUI.NumericWidget( value )
 		else :
 			self.__colorChooser = GafferUI.ColorChooser( value )
-			self.__popup = GafferUI.PopupWindow( "", child = self.__colorChooser )
-
-			self.__popup.popup( parent = self )
-
-			return self.__popup
+			return GafferUI.PopupWindow( "", child = self.__colorChooser )
 
 	def setEditorData( self, editor, index ) :
 


### PR DESCRIPTION
When `_ColorDelegate` did `popup( parent = self )` it wasn't passing a widget as the parent - it was passing a QStyledItemDelegate. This caused later errors when the parent was retrieved and it was of an unexpected type.

It makes more sense to move the window parenting/popupping outside of `_createEditorInternal()` anyway, since the responsibility for setting the geometry for non-window editors is also outside of `_createEditorInternal()`. Now `_createEditorInternal()` and `editSignal()` are responsible only for what they are documented to be responsible for - creating the widget. Positioning and showing it are now handled automatically.

One way of demonstrating the previous bug is to create a RandomChoice node with Color3f type, and double click a swatch in the `Choices` widget to edit the colour.
