### PR TITLE
_InspectorColumn : Fix undo when creating a new edit 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - Viewer : Fixed diagnostic shading modes for Arnold's diffuse and specular visibility attributes.
+- SceneEditors : Fixed undo after creating a new edit in an EditScope.
 
 1.5.16.3 (relative to 1.5.16.2)
 ========

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -114,15 +114,16 @@ def __editSelectedCells( pathListing, quickBoolean = True, ensureEnabled = False
 
 		# Not toggleable, so show popup editor.
 
-		edits = [ i.acquireEdit() for i in inspections ]
-		warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
+		with Gaffer.UndoScope( pathListing.ancestor( GafferUI.Editor ).scriptNode() ) :
 
-		if ensureEnabled :
-			with Gaffer.UndoScope( pathListing.ancestor( GafferUI.Editor ).scriptNode() ) :
+			edits = [ i.acquireEdit() for i in inspections ]
+
+			if ensureEnabled :
 				for edit in edits :
 					if isinstance( edit, ( Gaffer.NameValuePlug, Gaffer.OptionalValuePlug, Gaffer.TweakPlug ) ) :
 						edit["enabled"].setValue( True )
 
+		warnings = "\n".join( [ i.editWarning() for i in inspections if i.editWarning() != "" ] )
 		__inspectorColumnPopup = GafferUI.PlugPopup( edits, warning = warnings )
 
 		if isinstance( __inspectorColumnPopup.plugValueWidget(), GafferUI.TweakPlugValueWidget ) :


### PR DESCRIPTION
The call to `acquireEdit()` can make graph modifications, so needs to be inside the UndoScope.