### PR TITLE
Wrapper : Don't pass LD_PRELOAD modifications to child processes

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ Fixes
   - Fixed undo after creating a new edit in an EditScope.
   - Fixed "Inspect..." menu item when a property's source can not be determined.
 - RenderPasses : Fixed drawing of custom widgets registered by `registerRenderPassNameWidget()`.
+- Environment : Gaffer's `LD_PRELOAD` overrides are no longer inherited by subprocesses launched from Gaffer.
 
 Build
 -----

--- a/bin/__gaffer.py
+++ b/bin/__gaffer.py
@@ -50,6 +50,18 @@ signal.signal( signal.SIGINT, signal.SIG_DFL )
 # to catch all the naughty deprecated things we do.
 warnings.simplefilter( "default", DeprecationWarning )
 
+# Revert environment modifications that the `_gaffer.py` wrapper made, where they're not suitable
+# for passing to child processes.
+
+restorePrefix = "__GAFFER_RESTORE_"
+for name, value in list( os.environ.items() ) :
+	if name.startswith( restorePrefix ) :
+		if value != "__NONE__" :
+			os.environ[name[len(restorePrefix):]] = value
+		else :
+			del os.environ[name[len(restorePrefix):]]
+		del os.environ[name]
+
 import Gaffer
 Gaffer._Gaffer._nameProcess()
 

--- a/bin/_gaffer.py
+++ b/bin/_gaffer.py
@@ -76,6 +76,16 @@ def prependToPath( pathToPrepend, envVar ) :
 
 gafferRoot = pathlib.Path( __file__ ).resolve().parents[1]
 
+# Clean environment setup
+# =======================
+
+# Not every environment variable we set for Gaffer itself is something
+# we want to be inherited by subprocesses that Gaffer launches. Store
+# clean copies that can be restored by `__gaffer.py`.
+
+if sys.platform == "linux" :
+	os.environ["__GAFFER_RESTORE_LD_PRELOAD"] = os.environ.get( "LD_PRELOAD", "__NONE__" )
+
 # Cortex Setup
 # ============
 


### PR DESCRIPTION
Back in https://github.com/GafferHQ/gaffer/pull/6563, we added `libstdc++` to `LD_PRELOAD` to work around problems caused by Arnold's `libai.so` exposing its own global `operator new` and `operator delete`. But because subprocesses launched by Gaffer inherit this environment, we were preloading `libstdc++` in those too, which may not be desirable. So we now restore `LD_PRELOAD` to its previous value after Gaffer launch, so any subprocess will inherit the original value unchanged.

This also means that `libjemalloc` will no longer be preloaded by child subprocesses. Although preloading it hasn't caused any problems that we know of, it still seems preferable to omit it to for child processes.
