### PR TITLE
SceneInspector : Fix use of invalid context when isolating differences

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
   - Fixed unnecessary updates when editing a plug value.
   - Fixed bug adding rows to VectorData plugs - the newly added rows were being deselected immediately after they appeared.
 - SceneWriter : Fixed identifiers used when writing RenderMan shaders.
+- SceneInspector : Fixed `Context has no variable named "scene:path"` error when "Isolate Differences" is on.
 - VectorDataWidget : Fixed errors showing popup colour choosers.
 - Startup : Fixed UnicodeDecodeError when running in non-UTF8 locales.
 

--- a/python/GafferSceneUITest/SceneInspectorTest.py
+++ b/python/GafferSceneUITest/SceneInspectorTest.py
@@ -510,5 +510,21 @@ class SceneInspectorTest( GafferUITest.TestCase ) :
 			for task in tasks :
 				task.wait()
 
+	def testIsolateDifferencesWithMissingPath( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		contextA = Gaffer.Context()
+		contextA["scene:path"] = GafferScene.ScenePlug.stringToPath( "/sphere" )
+		contextB = Gaffer.Context()
+
+		tree = _GafferSceneUI._SceneInspector.InspectorTree( sphere["out"], [ contextA, contextB ], None )
+		tree.setIsolateDifferences( True )
+
+		path = _GafferSceneUI._SceneInspector.InspectorPath( tree, "/" )
+		# If we're not careful with the implementation, this will throw an error about
+		# `scene:path` being missing from the context.
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/Location" ] )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This could be triggered by comparing locations, but not entering a location for the B column.