### PR TITLE
RendererAlgo::objectSamples : Output single samples for static objects

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - OSLShader :
  - Improved loading of spline parameters with additional duplicate endpoints.
  - Added support for loading splines from RenderMan shaders.
+- Rendering : Improved detection of static objects. This fixes messages from Arnold like "discarded X duplicate deformation keys", and may improve performance in some cases.
 
 Fixes
 -----

--- a/src/GafferScene/RendererAlgo.cpp
+++ b/src/GafferScene/RendererAlgo.cpp
@@ -556,6 +556,9 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 		const Context *frameContext = Context::current();
 		Context::EditableScope timeContext( frameContext );
 
+		bool actualMovement = false;
+		IECore::MurmurHash actualHash;
+
 		samples.reserve( sampleTimes.size() );
 		for( size_t i = 0; i < sampleTimes.size(); i++ )
 		{
@@ -568,6 +571,15 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 				runTimeCast<const Camera>( object.get() )
 			)
 			{
+				if( i == 0 )
+				{
+					actualHash = object->hash();
+				}
+				else if( !actualMovement )
+				{
+					actualMovement = object->hash() != actualHash;
+				}
+
 				samples.push_back( object.get() );
 			}
 			else if(
@@ -607,6 +619,11 @@ bool objectSamples( const ObjectPlug *objectPlug, const std::vector<float> &samp
 				// don't take any samples at all.
 				break;
 			}
+		}
+
+		if( !actualMovement && samples.size() > 1 )
+		{
+			samples.resize( 1 );
 		}
 	}
 


### PR DESCRIPTION
I've got a task on the task board with a fairly vague description: "Detect static motion in InstancerCapsule.". While doing some initial investigation on this, I was assuming this related the fact that it is possible to trigger Arnold warnings "discarded X duplicate deformation keys". During some quick initial testing, I was unable to find anything specific to InstancerCapsule, but what I did notice is that if I set up an object that does not change with time, but has a hash that does change, then I get that warning ( whether or not is rendered as an InstancerCapsule ).

It seemed like this stuff might be easiest to discuss with some code to look at. I've added two more tests to RendererAlgoTest, one which documents existing behaviour ( outputting a single sample for the range of times if all samples have the same Gaffer hash ), and one that fails with the existing code ( rendering samples which don't have the same Gaffer hash, but are actually identical ).

I've also included a simple possible fix: after checking the Gaffer hashes, also check the Cortex hashes of the objects to see if they're identical - since the Cortex hashes should actually include all data in the object, unlike the Gaffer hashes which just include the parameters contributing to the object's creation.

Possible concerns with this approach:
* evaluating the Cortex hashes is somewhat expensive ( possibly more expensive than just doing an actual compare of the full data for an object? ). I had thought that we were storing hashes for objects that are expensive to hash, so that we wouldn't be needing to repeat this work if the hash is also required by something like IECoreArnold::Renderer::InstanceCache, but maybe I recalled wrong.
* we should probably consider whether we are masking legitimate problems with this approach. If the upstream network is producing different hashes, and requiring us to fully evaluate the geo before we can figure out that it isn't changing, then that is definitely hurting performance. Should we output our own warning in this case? That would kind of conflict with the goal of getting rid of the warning that's been showing up in Arnold.

Anyway, this does appear to fix the issue of getting "duplicate deformation keys" messages from Arnold. Switching to returning a single sample from this method feels a bit dangerous ... except that we're already doing this when the input hashes the same, so any clients of this method must already be able to deal with receiving single samples even if multiple were requested.