### PR TITLE
_InspectorColumn : Remove reference to nonexistent enum value

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,9 @@ Fixes
 - VectorDataWidget : Fixed errors showing popup colour choosers.
 - Startup : Fixed UnicodeDecodeError when running in non-UTF8 locales.
 - Viewer : Fixed diagnostic shading modes for Arnold's diffuse and specular visibility attributes.
-- Scene Editors : Fixed undo after creating a new edit in an EditScope.
+- Scene Editors :
+  - Fixed undo after creating a new edit in an EditScope.
+  - Fixed "Inspect..." menu item when a property's source can not be determined.
 - RenderPasses : Fixed drawing of custom widgets registered by `registerRenderPassNameWidget()`.
 
 Build

--- a/python/GafferSceneUI/_InspectorColumn.py
+++ b/python/GafferSceneUI/_InspectorColumn.py
@@ -667,7 +667,9 @@ class __InspectionPopupWindow( GafferUI.PopupWindow ) :
 
 				GafferUI.Label( "<b>Source</b>", parenting = { "index" : ( 0, 0 ), "alignment" : (  GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top ) } )
 
-				if inspection.source() is not None :
+				if inspection.fallbackDescription() :
+					GafferUI.Label( inspection.fallbackDescription(), parenting = { "index" : ( 1, 0 ) } )
+				elif inspection.source() is not None :
 					node = inspection.source().node()
 					nameLabel = GafferUI.NameLabel(
 						node,
@@ -676,8 +678,6 @@ class __InspectionPopupWindow( GafferUI.PopupWindow ) :
 					)
 					nameLabel.setFormatter( lambda l : ".".join( x.getName() for x in l ) )
 					nameLabel.dragEndSignal().connectFront( Gaffer.WeakMethod( self.__nameLabelDragEnd ) )
-				elif inspection.sourceType() == inspection.SourceType.Fallback :
-					GafferUI.Label( inspection.fallbackDescription(), parenting = { "index" : ( 1, 0 ) } )
 
 				GafferUI.Label( "<b>Value</b>", parenting = { "index" : ( 0, 1 ), "alignment" : ( GafferUI.HorizontalAlignment.Right, GafferUI.VerticalAlignment.Top ) } )
 


### PR DESCRIPTION
This was removed in 91d305abfde482dc4231f9558c240565f602d461 (Gaffer 1.6.3.0). For the fix I've followed the presentation logic from `InspectorColumn::cellDataFromInspection()`, preferring a fallback description over a source plug. We might want to revisit at some point in the future though, as it's possible to have both (when the source was responsible for deleting the property).