### PR TITLE
CustomAttributes, CustomOptions : Disable sectioning in plug layout

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -26,6 +26,7 @@ Fixes
   - Fixed "Inspect..." menu item when a property's source can not be determined.
 - RenderPasses : Fixed drawing of custom widgets registered by `registerRenderPassNameWidget()`.
 - Environment : Gaffer's `LD_PRELOAD` overrides are no longer inherited by subprocesses launched from Gaffer.
+- CustomAttributes, CustomOptions : Fixed inconsistent layout sections.
 
 API
 ---

--- a/python/GafferSceneUI/CustomAttributesUI.py
+++ b/python/GafferSceneUI/CustomAttributesUI.py
@@ -67,6 +67,7 @@ Gaffer.Metadata.registerNode(
 		"attributes.*" : {
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug" : False,
+			"layout:section" : "",
 
 		},
 

--- a/python/GafferSceneUI/CustomOptionsUI.py
+++ b/python/GafferSceneUI/CustomOptionsUI.py
@@ -70,6 +70,7 @@ Gaffer.Metadata.registerNode(
 		"options.*" : {
 
 			"nameValuePlugPlugValueWidget:ignoreNamePlug" : False,
+			"layout:section" : "",
 
 		},
 


### PR DESCRIPTION
Otherwise we get inconsistent layouts when creating options or attributes which are registered with the metadata system (because they are part of StandardAttribute or CyclesOptions for example). In this case, the plug would appear in the main section when first created, but upon reopening the NodeEditor would move to a custom section as defined by the metadata.

Since the sections aren't useful in the context of the CustomOptions/CustomAttributes nodes, we simply remove them rather than try to make them work consistently.
