### PR TITLE
SConstruct : Add `-Wl,--as-needed` to GCC link flags

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -518,6 +518,10 @@ if env["PLATFORM"] != "win32" :
 			SHLINKFLAGS = [ "-pthread", "-Wl,--no-undefined" ],
 		)
 
+		# Make the linker behave more like Windows, omitting shared libraries that it didn't resolve
+		# any symbols from.
+		env.Append( LINKFLAGS = "-Wl,--as-needed" )
+
 	# Shared config
 
 	env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )

--- a/python/Gaffer/__init__.py
+++ b/python/Gaffer/__init__.py
@@ -79,4 +79,16 @@ def executablePath( absolute = True ) :
 
 	return executable
 
+def __loadSharedLibrary( name ) :
+
+	import platform
+	import ctypes
+
+	prefix, suffix = {
+		"Darwin" : ( "lib", ".dylib" ),
+		"Windows" : ( "", ".dll" ),
+	}.get( platform.system(), ( "lib", ".so" ) )
+
+	return ctypes.CDLL( f"{prefix}{name}{suffix}" )
+
 __import__( "IECore" ).loadConfig( "GAFFER_STARTUP_PATHS", subdirectory = "Gaffer" )

--- a/python/GafferOSLUI/__init__.py
+++ b/python/GafferOSLUI/__init__.py
@@ -36,15 +36,10 @@
 
 from ._GafferOSLUI import *
 
-import os
-import ctypes
-if os.name == "nt" :
-	# Because `_GafferOSLUI.pyd` currently doesn't require any symbols
-	# from `GafferOSLUI.dll`, the Windows linker omits the latter. Load
-	# it explicitly, because it contains custom gadget registrations
-	# that we need.
-	ctypes.CDLL( "GafferOSLUI.dll" )
-del os, ctypes
+# Because the `_GafferOSLUI` Python module currently doesn't require any symbols
+# from the `GafferOSLUI` library, we need to load it explicitly to get its
+# custom gadget registrations.
+__import__( "Gaffer" ).__loadSharedLibrary( "GafferOSLUI" )
 
 from . import OSLShaderUI
 from . import OSLImageUI

--- a/python/GafferRenderManUI/__init__.py
+++ b/python/GafferRenderManUI/__init__.py
@@ -34,21 +34,8 @@
 #
 ##########################################################################
 
-import ctypes
-import platform
-
-# There is no `GafferRenderManUI` Python module, so we load the root module
-# manually in order to register the light filter visualisers.
-
-prefix, suffix = {
-	"Darwin" : ( "lib", ".dylib" ),
-	"Windows" : ( "", ".dll" ),
-}.get( platform.system(), ( "lib", ".so" ) )
-
-ctypes.CDLL( f"{prefix}GafferRenderManUI{suffix}" )
-
-del ctypes, platform
-
+# Registers the light filter visualisers.
+__import__( "Gaffer" ).__loadSharedLibrary( "GafferRenderManUI" )
 __import__( "GafferSceneUI" )
 
 from . import RenderManAttributesUI

--- a/python/GafferUI/DocumentationAlgo.py
+++ b/python/GafferUI/DocumentationAlgo.py
@@ -326,21 +326,9 @@ def __cmark() :
 	if __cmarkDLL != "" :
 		return __cmarkDLL
 
-	sys = platform.system()
-
-	if sys == "Darwin" :
-		prefix = "lib"
-		suffix = ".dylib"
-	elif sys == "Windows" :
-		prefix = ""
-		suffix = ".dll"
-	else :
-		prefix = "lib"
-		suffix = ".so"
-
 	try :
-		__cmarkDLL = ctypes.CDLL( f"{prefix}cmark-gfm{suffix}" )
-		__cmarkExtensionsDLL = ctypes.CDLL( f"{prefix}cmark-gfm-extensions{suffix}" )
+		__cmarkDLL = Gaffer.__loadSharedLibrary( "cmark-gfm" )
+		__cmarkExtensionsDLL = Gaffer.__loadSharedLibrary( "cmark-gfm-extensions" )
 	except :
 		__cmarkDLL = None
 		return __cmarkDLL

--- a/python/GafferVDBUI/__init__.py
+++ b/python/GafferVDBUI/__init__.py
@@ -36,15 +36,10 @@
 
 from ._GafferVDBUI import *
 
-import os
-import ctypes
-if os.name == "nt" :
-	# Because `_GafferVDBUI.pyd` currently doesn't require any symbols
-	# from `GafferVDBUI.dll`, the Windows linker omits the latter. Load
-	# it explicitly, because it contains a custom visualiser registration
-	# that we need.
-	ctypes.CDLL( "GafferVDBUI.dll" )
-del os, ctypes
+# Because the `_GafferVDBUI` Python module currently doesn't require
+# any symbols from the `GafferVDBUI` library, we need to load it explicitly
+# to get our custom visualiser registered.
+__import__( "Gaffer" ).__loadSharedLibrary( "GafferVDBUI" )
 
 from . import LevelSetToMeshUI
 from . import MeshToLevelSetUI


### PR DESCRIPTION
This causes libraries to be omitted if they do not provide any symbols needed by the target. This is actually a pain for us, because we have several libraries which don't provide symbols publicly but which do register visualisers or other UI components during initialisation. But that pain is unavoidable on Windows, and it's better to have the same problem on all platforms so we discover it sooner during development, and can deal with it more uniformly.

What prompted this switch was that we discovered that apparently the linker defaults to this behaviour on Ubuntu, so what we thought was a problem isolated to Windows was actually hitting some folks building on Linux. @danieldresser-ie, would be good to verify that fixes your OSLObject problem.
