### PR TITLE
Arnold Renderer : Fix nondeterministic EXR part order 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - RenderPasses : Fixed drawing of custom widgets registered by `registerRenderPassNameWidget()`.
 - Environment : Gaffer's `LD_PRELOAD` overrides are no longer inherited by subprocesses launched from Gaffer.
 - CustomAttributes, CustomOptions : Fixed inconsistent layout sections.
+- Arnold : Fixed inconsistent part ordering in multipart EXR outputs.
 
 API
 ---


### PR DESCRIPTION
It was previously defined by the ordering of InternedStrings, which is not consistent from process to process. We now sort outputs so that RGBA comes first, and everything else comes alphabetically sorted after it.

Although Gaffer (and Nuke from the sounds of it) don't really care about part order, some apps (RV seems to be one) show the first part by default, causing confusion if that part keeps changing.

I also did a little bit of tidying/simplification of ArnoldOutput in some preceding commits, originally with the intention of storing ArnoldOutputs in a `multi_index_container` with an index sorted in the way we want for part order. I decided against the container change, but I think the simplifications are still worth having.

Seems worth seeing if we can get this merged in time for today's release.