### PR TITLE
Arnold Renderer : Fix nondeterministic EXR part order

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -27,6 +27,7 @@ Fixes
 - RenderPasses : Fixed drawing of custom widgets registered by `registerRenderPassNameWidget()`.
 - Environment : Gaffer's `LD_PRELOAD` overrides are no longer inherited by subprocesses launched from Gaffer.
 - CustomAttributes, CustomOptions : Fixed inconsistent layout sections.
+- Arnold : Fixed inconsistent part ordering in multipart EXR outputs.
 
 API
 ---

--- a/python/IECoreArnoldTest/RendererTest.py
+++ b/python/IECoreArnoldTest/RendererTest.py
@@ -38,6 +38,7 @@ import ctypes
 import json
 import os
 import pathlib
+import random
 import struct
 import subprocess
 import sys
@@ -4451,6 +4452,76 @@ class RendererTest( GafferTest.TestCase ) :
 			set( beautyImage.spec().channelnames ),
 			{ "beauty_{}.{}".format( g, c ) for g in lightGroups for c in "RGBA" }
 		)
+
+	@staticmethod
+	def _renderCombinedEXR( fileName ) :
+
+		r = GafferScene.Private.IECoreScenePreview.Renderer.create(
+			"Arnold",
+			GafferScene.Private.IECoreScenePreview.Renderer.RenderType.Batch,
+		)
+
+		if random.choice( [ True, False ] ) :
+			# The bug that motivated this test was that output order was
+			# non-deterministic, being based on InternedString ordering (which
+			# is based on memory location). Randomising the order the strings
+			# are created in increases the probability of that bug being
+			# triggered.
+			IECore.InternedString( "diffuseLPE" )
+
+		r.output(
+			"whatABeauty", IECoreScene.Output(
+				fileName, "exr", "rgba",
+				{
+					"multipart" : True,
+				}
+			)
+		)
+
+		r.output(
+			"diffuseLPE", IECoreScene.Output(
+				fileName, "exr", "lpe C<RD>.*",
+				{
+					"layerName" : "diffuse",
+					"multipart" : True,
+				}
+			)
+		)
+
+		r.output(
+			"albedo", IECoreScene.Output(
+				fileName, "exr", "color albedo",
+				{
+					"multipart" : True,
+				}
+			)
+		)
+
+		r.render()
+
+	def testOutputOrderIsStable( self ) :
+
+		env = os.environ.copy()
+		if sys.platform == "linux" :
+			# See `bin/_gaffer.py`
+			env["LD_PRELOAD"] = "libstdc++.so.6"
+
+		for i in range( 0, 10 ) :
+
+			fileName = ( self.temporaryDirectory() / f"test{i}.exr" ).as_posix()
+			subprocess.check_call(
+				[ "python", "-c", f"import IECoreArnoldTest; IECoreArnoldTest.RendererTest._renderCombinedEXR( '{fileName}' )" ],
+				env = env
+			)
+
+			# We want the RGBA channels first, because some apps will show the
+			# first part of a multipart file by default. After that, we sort
+			# alphabetically.
+			image = OpenImageIO.ImageInput.open( fileName )
+			self.assertEqual(
+				image.spec().channelnames + image.spec( 1 ).channelnames + image.spec( 2 ).channelnames,
+				( "R", "G", "B", "A", "albedo.R", "albedo.G", "albedo.B", "diffuse.R", "diffuse.G", "diffuse.B" )
+			)
 
 	def testNamedOutputParameter( self ) :
 

--- a/src/IECoreArnold/Renderer.cpp
+++ b/src/IECoreArnold/Renderer.cpp
@@ -935,6 +935,26 @@ class ArnoldOutput : public IECore::RefCounted
 			return m_driverParameters.get();
 		}
 
+		// Defines an ordering suitable for use in multipart EXR files, with
+		// RGBA data coming first, and everything ordered alphabetically after
+		// that.
+		bool operator<( const ArnoldOutput &other ) const
+		{
+			bool isRGB = m_data == "RGB" || m_data == "RGBA";
+			bool otherIsRGB = other.m_data == "RGB" || other.m_data == "RGBA";
+			if( isRGB != otherIsRGB )
+			{
+				return isRGB > otherIsRGB;
+			}
+
+			if( m_layerName != other.m_layerName )
+			{
+				return m_layerName < other.m_layerName;
+			}
+
+			return m_data < other.m_data;
+		}
+
 	private :
 
 		IECore::InternedString m_driverName;
@@ -4249,27 +4269,35 @@ class ArnoldGlobals
 		{
 			AtNode *options = AiUniverseGetOptions( m_universeBlock->universe() );
 
-			// Set the global output list in the options to all outputs matching the current camera
+			// Set the global output list in the options to all outputs matching the current camera.
+
+			vector<const ArnoldOutput *> activeOutputs;
+			for( const auto &[name, output] : m_outputs )
+			{
+				const std::string &outputCamera = output->cameraOverride().size() ? output->cameraOverride() : m_cameraName;
+				if( outputCamera == cameraName )
+				{
+					activeOutputs.push_back( output.get() );
+				}
+			}
+			std::sort(
+				activeOutputs.begin(), activeOutputs.end(),
+				[] ( const ArnoldOutput *a, const ArnoldOutput *b ) {
+					return *a < *b;
+				}
+			);
+
 			IECore::StringVectorDataPtr outputs = new IECore::StringVectorData;
 			IECore::StringVectorDataPtr lpes = new IECore::StringVectorData;
 			vector<int> interactiveIndices;
-			for( auto & it : m_outputs )
+			for( auto output : activeOutputs )
 			{
-				std::string outputCamera = it.second->cameraOverride();
-				if( outputCamera == "" )
+				// We're relying on updateDrivers being called before updateCamera
+				if( output->updateInteractively() )
 				{
-					outputCamera = m_cameraName;
+					interactiveIndices.push_back( outputs->writable().size() );
 				}
-
-				if( outputCamera == cameraName )
-				{
-					// We're relying on updateDrivers being called before updateCamera
-					if( it.second->updateInteractively() )
-					{
-						interactiveIndices.push_back( outputs->writable().size() );
-					}
-					it.second->append( outputs->writable(), lpes->writable(), m_drivers );
-				}
+				output->append( outputs->writable(), lpes->writable(), m_drivers );
 			}
 
 			AiRenderRemoveAllInteractiveOutputs( m_renderSession.get() );
@@ -4281,6 +4309,8 @@ class ArnoldGlobals
 			{
 				AiRenderAddInteractiveOutput( m_renderSession.get(), i );
 			}
+
+			// Set the camera up.
 
 			const IECoreScene::Camera *cortexCamera;
 			AtNode *arnoldCamera = AiNodeLookUpByName( m_universeBlock->universe(), AtString( cameraName.c_str() ) );


### PR DESCRIPTION
It was previously defined by the ordering of InternedStrings, which is not consistent from process to process. We now sort outputs so that RGBA comes first, and everything else comes alphabetically sorted after it.

Although Gaffer (and Nuke from the sounds of it) don't really care about part order, some apps (RV seems to be one) show the first part by default, causing confusion if that part keeps changing.

I also did a little bit of tidying/simplification of ArnoldOutput in some preceding commits, originally with the intention of storing ArnoldOutputs in a `multi_index_container` with an index sorted in the way we want for part order. I decided against the container change, but I think the simplifications are still worth having.

Seems worth seeing if we can get this merged in time for today's release.