### PR TITLE
Inference : Reduce GPU device memory overhead

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@ Fixes
 
 - NodeEditor, Viewer : Fixed bug that could cause unnecessary widget updates. In particular, this fixes flickering in the Viewer toolbar widgets when viewing the output of an InteractiveRender.
 - Viewer : Improved error handling when unable to create the requested renderer.
+- Inference : GPU device memory is now freed where possible after each computation.
 
 1.6.4.0 (relative to 1.6.3.0)
 =======


### PR DESCRIPTION
As documented on `acquireSession()`, we want to share `Ort::Session` objects between nodes/computes, because they are slow to create. But unfortunately by default the session also hangs onto a lot of GPU memory after being run, so by reusing sessions we were wasting a lot of GPU memory. This is alleviated by encouraging ONNX to release memory where possible after each run. See "Memory arena shrinkage" on the following page for more details : https://onnxruntime.ai/docs/get-started/with-c.html.
