### PR TITLE
SceneGadget : Improve destruction/creation sequence in `setRenderer()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - NodeEditor, Viewer : Fixed bug that could cause unnecessary widget updates. In particular, this fixes flickering in the Viewer toolbar widgets when viewing the output of an InteractiveRender.
+- Viewer : Improved error handling when unable to create the requested renderer.
 
 1.6.4.0 (relative to 1.6.3.0)
 =======

--- a/include/GafferSceneUI/SceneGadget.h
+++ b/include/GafferSceneUI/SceneGadget.h
@@ -225,6 +225,7 @@ class GAFFERSCENEUI_API SceneGadget : public GafferUI::Gadget
 		void bufferChanged();
 		void visibilityChanged();
 		void cancelUpdateAndPauseRenderer();
+		void clearRenderer();
 
 		Gaffer::Signals::Connection m_viewportChangedConnection;
 		Gaffer::Signals::Connection m_viewportCameraChangedConnection;


### PR DESCRIPTION
Previously, we created the new renderer before destroying the old one. This was problematic for RenderMan, which has RIS/XPU variants we might want to switch between, and can't have more than one renderer active per process. So we now destroy the previous renderer before creating the new one.

In this changed sequence, we need to be extra careful that `m_renderer` doesn't end up null. Previously, if the creation of the new renderer failed (threw an exception) our state wasn't changed at all. But now we have destroyed the old renderer already and we can't remain in that state. So now if we can't create the new renderer, we fall back to using an OpenGL renderer to draw visualisations (but not objects) so that it is clear from the viewport that something is wrong. We also emit an explanatory warning. This is an improvement over the previous behaviour which had a more confusing warning, and would continue to render with the old renderer even though the dropdown menu in the viewer would list the new one.
