### PR TITLE
Multi-index containers : Prefer `boost::multi_index<key>`

### DIFF
--- a/include/Gaffer/Private/IECorePreview/LRUCache.inl
+++ b/include/Gaffer/Private/IECorePreview/LRUCache.inl
@@ -41,7 +41,7 @@
 #include "IECore/Exception.h"
 
 #include "boost/multi_index/hashed_index.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
 #include "boost/unordered_map.hpp"
@@ -119,7 +119,7 @@ class Serial
 				// First index is equivalent to std::unordered_map,
 				// using Item::key as the key.
 				boost::multi_index::hashed_unique<
-					boost::multi_index::member<Item, Key, &Item::key>
+					boost::multi_index::key<&Item::key>
 				>,
 				// Second index is equivalent to std::list.
 				boost::multi_index::sequenced<>
@@ -336,7 +336,7 @@ class Parallel
 				//   prehashed key prior to taking a Bin lock, although
 				//   this is not implemented here yet.
 				boost::multi_index::hashed_unique<
-					boost::multi_index::member<Item, Key, &Item::key>
+					boost::multi_index::key<&Item::key>
 				>
 			>
 		>;
@@ -682,7 +682,7 @@ class TaskParallel
 				//   prehashed key prior to taking a Bin lock, although
 				//   this is not implemented here yet.
 				boost::multi_index::hashed_unique<
-					boost::multi_index::member<Item, Key, &Item::key>
+					boost::multi_index::key<&Item::key>
 				>
 			>
 		>;

--- a/include/Gaffer/StandardSet.h
+++ b/include/Gaffer/StandardSet.h
@@ -39,7 +39,7 @@
 
 #include "Gaffer/Set.h"
 
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/random_access_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -162,7 +162,7 @@ class GAFFER_API StandardSet : public Gaffer::Set
 		using MemberContainer = boost::multi_index::multi_index_container<
 			SetMember,
 			boost::multi_index::indexed_by<
-				boost::multi_index::ordered_unique<boost::multi_index::member<SetMember, MemberPtr, &SetMember::member>>,
+				boost::multi_index::ordered_unique<boost::multi_index::key<&SetMember::member>>,
 				boost::multi_index::random_access<>
 			>
 		>;

--- a/include/GafferScene/Private/ChildNamesMap.h
+++ b/include/GafferScene/Private/ChildNamesMap.h
@@ -41,7 +41,7 @@
 #include "IECore/VectorTypedData.h"
 
 #include "boost/multi_index/hashed_index.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include <vector>
@@ -91,8 +91,8 @@ class ChildNamesMap : public IECore::Data
 		using Map = boost::multi_index::multi_index_container<
 			Child,
 			boost::multi_index::indexed_by<
-				boost::multi_index::hashed_unique<boost::multi_index::member<Child, const IECore::InternedString, &Child::output>>,
-				boost::multi_index::hashed_unique<boost::multi_index::member<Child, const Input, &Child::input>>
+				boost::multi_index::hashed_unique<boost::multi_index::key<&Child::output>>,
+				boost::multi_index::hashed_unique<boost::multi_index::key<&Child::input>>
 			>
 		>;
 

--- a/include/GafferScene/RenderManifest.h
+++ b/include/GafferScene/RenderManifest.h
@@ -40,7 +40,7 @@
 
 #include "GafferScene/ScenePlug.h"
 
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index_container.hpp"
 #include "boost/noncopyable.hpp"
@@ -107,10 +107,10 @@ class GAFFERSCENE_API RenderManifest : boost::noncopyable
 			PathAndID,
 			boost::multi_index::indexed_by<
 				boost::multi_index::ordered_unique<
-					boost::multi_index::member<PathAndID, ScenePlug::ScenePath, &PathAndID::first>
+					boost::multi_index::key<&PathAndID::first>
 				>,
 				boost::multi_index::ordered_unique<
-					boost::multi_index::member<PathAndID, uint32_t, &PathAndID::second>
+					boost::multi_index::key<&PathAndID::second>
 				>
 			>
 		>;

--- a/include/GafferUI/AuxiliaryConnectionsGadget.h
+++ b/include/GafferUI/AuxiliaryConnectionsGadget.h
@@ -38,8 +38,8 @@
 
 #include "GafferUI/Gadget.h"
 
-#include "boost/multi_index/member.hpp"
 #include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include <unordered_map>
@@ -151,21 +151,21 @@ class GAFFERUI_API AuxiliaryConnectionsGadget : public Gadget
 				// Primary key is the unique pair of endpoint
 				// gadgets the connection represents.
 				boost::multi_index::hashed_unique<
-					boost::multi_index::member<AuxiliaryConnection, std::pair<const Gadget *, const Gadget *>, &AuxiliaryConnection::endpoints>
+					boost::multi_index::key<&AuxiliaryConnection::endpoints>
 				>,
 				// Access to the range of connections originating
 				// at `srcNodeGadget`. This will include all source
 				// endpoints which are either `srcNodeGadget` itself
 				// or are a nodule belonging to it.
 				boost::multi_index::hashed_non_unique<
-					boost::multi_index::member<AuxiliaryConnection, const NodeGadget *, &AuxiliaryConnection::srcNodeGadget>
+					boost::multi_index::key<&AuxiliaryConnection::srcNodeGadget>
 				>,
 				// Access to the range of connections ending at
 				// `dstNodeGadget`. This will include all destination
 				// endpoints which are either `dstNodeGadget` itself or
 				// are a nodule belonging to it.
 				boost::multi_index::hashed_non_unique<
-					boost::multi_index::member<AuxiliaryConnection, const NodeGadget *, &AuxiliaryConnection::dstNodeGadget>
+					boost::multi_index::key<&AuxiliaryConnection::dstNodeGadget>
 				>
 			>
 		>;

--- a/src/Gaffer/BackgroundTask.cpp
+++ b/src/Gaffer/BackgroundTask.cpp
@@ -42,8 +42,8 @@
 
 #include "IECore/MessageHandler.h"
 
-#include "boost/multi_index/member.hpp"
 #include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include "tbb/task_arena.h"
@@ -136,10 +136,10 @@ using ActiveTasks = boost::multi_index::multi_index_container<
 	ActiveTask,
 	boost::multi_index::indexed_by<
 		boost::multi_index::hashed_unique<
-			boost::multi_index::member<ActiveTask, BackgroundTask *, &ActiveTask::task>
+			boost::multi_index::key<&ActiveTask::task>
 		>,
 		boost::multi_index::hashed_non_unique<
-			boost::multi_index::member<ActiveTask, ConstScriptNodePtr, &ActiveTask::subject>
+			boost::multi_index::key<&ActiveTask::subject>
 		>
 	>
 >;

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -45,7 +45,7 @@
 #include "IECore/StringAlgo.h"
 
 #include "boost/bind/bind.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -244,7 +244,7 @@ using Values = multi_index::multi_index_container<
 	NamedValue,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
-			multi_index::member<NamedValue, InternedString, &NamedValue::first>
+			multi_index::key<&NamedValue::first>
 		>,
 		multi_index::sequenced<>
 	>
@@ -256,7 +256,7 @@ using MetadataMap = multi_index::multi_index_container<
 	NamedValues,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
-			multi_index::member<NamedValues, InternedString, &NamedValues::first>
+			multi_index::key<&NamedValues::first>
 		>,
 		multi_index::sequenced<>
 	>
@@ -289,7 +289,7 @@ struct GraphComponentMetadata
 		NamedValue,
 		multi_index::indexed_by<
 			multi_index::ordered_unique<
-				multi_index::member<NamedValue, InternedString, &NamedValue::first>
+				multi_index::key<&NamedValue::first>
 			>,
 			multi_index::sequenced<>
 		>
@@ -299,7 +299,7 @@ struct GraphComponentMetadata
 		NamedPlugValue,
 		multi_index::indexed_by<
 			multi_index::ordered_unique<
-				multi_index::member<NamedPlugValue, InternedString, &NamedPlugValue::first>
+				multi_index::key<&NamedPlugValue::first>
 			>,
 			multi_index::sequenced<>
 		>
@@ -339,7 +339,7 @@ using InstanceValues = multi_index::multi_index_container<
 	NamedInstanceValue,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
-			multi_index::member<NamedInstanceValue, InternedString, &NamedInstanceValue::name>
+			multi_index::key<&NamedInstanceValue::name>
 		>,
 		multi_index::sequenced<>
 	>

--- a/src/Gaffer/Spreadsheet.cpp
+++ b/src/Gaffer/Spreadsheet.cpp
@@ -45,8 +45,8 @@
 #include "boost/bind/bind.hpp"
 #include "boost/container/small_vector.hpp"
 #include "boost/lexical_cast.hpp"
-#include "boost/multi_index/member.hpp"
 #include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include "fmt/format.h"
@@ -588,10 +588,10 @@ class Spreadsheet::RowsPlug::RowNameMap
 			Row,
 			multi_index::indexed_by<
 				multi_index::hashed_unique<
-					multi_index::member<Row, RowPlug *, &Row::plug>
+					multi_index::key<&Row::plug>
 				>,
 				multi_index::hashed_non_unique<
-					multi_index::member<Row, string, &Row::name>
+					multi_index::key<&Row::name>
 				>
 			>
 		>;

--- a/src/GafferScene/Outputs.cpp
+++ b/src/GafferScene/Outputs.cpp
@@ -40,7 +40,7 @@
 #include "Gaffer/CompoundDataPlug.h"
 #include "Gaffer/StringPlug.h"
 
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -64,7 +64,7 @@ using OutputMap = multi_index::multi_index_container<
 	NamedOutput,
 	multi_index::indexed_by<
 		multi_index::ordered_unique<
-			multi_index::member<NamedOutput, std::string, &NamedOutput::first>
+			multi_index::key<&NamedOutput::first>
 		>,
 		multi_index::sequenced<>
 	>

--- a/src/GafferScene/Rename.cpp
+++ b/src/GafferScene/Rename.cpp
@@ -43,7 +43,7 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/multi_index/hashed_index.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include "tbb/enumerable_thread_specific.h"
@@ -147,9 +147,9 @@ struct NameMapData : public IECore::Data
 		Names,
 		boost::multi_index::indexed_by<
 			// First index allows lookup using `inputName`.
-			boost::multi_index::hashed_unique<boost::multi_index::member<Names, IECore::InternedString, &Names::inputName>, InternedStringAddressHash>,
+			boost::multi_index::hashed_unique<boost::multi_index::key<&Names::inputName>, InternedStringAddressHash>,
 			// Second index allows lookup using `outputName`.
-			boost::multi_index::hashed_unique<boost::multi_index::member<Names, IECore::InternedString, &Names::outputName>, InternedStringAddressHash>
+			boost::multi_index::hashed_unique<boost::multi_index::key<&Names::outputName>, InternedStringAddressHash>
 		>
 	>;
 

--- a/src/GafferSceneUI/AttributeQueryUI.cpp
+++ b/src/GafferSceneUI/AttributeQueryUI.cpp
@@ -53,7 +53,7 @@
 
 #include <boost/bind/bind.hpp>
 #include <boost/multi_index_container.hpp>
-#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/key.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
 
@@ -134,7 +134,7 @@ using MenuItemContainer = boost::multi_index_container<
 	boost::multi_index::indexed_by<
 		boost::multi_index::random_access<>,
 		boost::multi_index::ordered_non_unique<
-			boost::multi_index::const_mem_fun<MenuItem, const std::string&, & MenuItem::getName>
+			boost::multi_index::key<&MenuItem::getName>
 		>
 	>
 >;

--- a/src/GafferSceneUI/SelectionTool.cpp
+++ b/src/GafferSceneUI/SelectionTool.cpp
@@ -45,7 +45,7 @@
 #include "GafferUI/Style.h"
 
 #include "boost/bind/bind.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -66,7 +66,7 @@ using SelectModeMap = boost::multi_index::multi_index_container<
 	NamedSelectMode,
 	boost::multi_index::indexed_by<
 		boost::multi_index::ordered_unique<
-			boost::multi_index::member<NamedSelectMode, std::string, &NamedSelectMode::first>
+			boost::multi_index::key<&NamedSelectMode::first>
 		>,
 		boost::multi_index::sequenced<>
 	>

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -66,7 +66,7 @@
 #include "Imath/ImathMatrixAlgo.h"
 
 #include "boost/algorithm/string/predicate.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -379,7 +379,7 @@ class InspectorTree : public IECore::RefCounted
 				NamedChild,
 				multi_index::indexed_by<
 					multi_index::ordered_unique<
-						multi_index::member<NamedChild, InternedString, &NamedChild::first>
+						multi_index::key<&NamedChild::first>
 					>,
 					multi_index::sequenced<>
 				>

--- a/src/GafferUI/ContextTracker.cpp
+++ b/src/GafferUI/ContextTracker.cpp
@@ -54,8 +54,8 @@
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"
 #include "boost/bind/placeholders.hpp"
-#include "boost/multi_index/member.hpp"
 #include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index_container.hpp"
 
 #include <unordered_set>
@@ -78,10 +78,10 @@ using SharedInstances = boost::multi_index::multi_index_container<
 	SharedInstance,
 	boost::multi_index::indexed_by<
 		boost::multi_index::hashed_unique<
-			boost::multi_index::member<SharedInstance, const Node *, &SharedInstance::first>
+			boost::multi_index::key<&SharedInstance::first>
 		>,
 		boost::multi_index::hashed_non_unique<
-			boost::multi_index::member<SharedInstance, ContextTracker *, &SharedInstance::second>
+			boost::multi_index::key<&SharedInstance::second>
 		>
 	>
 >;
@@ -97,10 +97,10 @@ using SharedFocusInstances = boost::multi_index::multi_index_container<
 	SharedFocusInstance,
 	boost::multi_index::indexed_by<
 		boost::multi_index::hashed_unique<
-			boost::multi_index::member<SharedFocusInstance, const ScriptNode *, &SharedFocusInstance::first>
+			boost::multi_index::key<&SharedFocusInstance::first>
 		>,
 		boost::multi_index::hashed_non_unique<
-			boost::multi_index::member<SharedFocusInstance, ContextTracker *, &SharedFocusInstance::second>
+			boost::multi_index::key<&SharedFocusInstance::second>
 		>
 	>
 >;

--- a/src/GafferUI/View.cpp
+++ b/src/GafferUI/View.cpp
@@ -49,7 +49,7 @@
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/bind/bind.hpp"
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/sequenced_index.hpp"
 #include "boost/multi_index_container.hpp"
@@ -364,7 +364,7 @@ using DisplayTransformCreatorMap = boost::multi_index::multi_index_container<
 	NamedTransform,
 	boost::multi_index::indexed_by<
 		boost::multi_index::ordered_unique<
-			boost::multi_index::member<NamedTransform, std::string, &NamedTransform::first>
+			boost::multi_index::key<&NamedTransform::first>
 		>,
 		boost::multi_index::sequenced<>
 	>

--- a/src/IECoreRenderMan/Session.h
+++ b/src/IECoreRenderMan/Session.h
@@ -41,7 +41,7 @@
 #include "Riley.h"
 #include "RixRiCtl.h"
 
-#include "boost/multi_index/member.hpp"
+#include "boost/multi_index/key.hpp"
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index_container.hpp"
 
@@ -145,10 +145,10 @@ struct Session
 			CameraInfo,
 			boost::multi_index::indexed_by<
 				boost::multi_index::ordered_unique<
-					boost::multi_index::member<CameraInfo, riley::CameraId, &CameraInfo::id>
+					boost::multi_index::key<&CameraInfo::id>
 				>,
 				boost::multi_index::ordered_unique<
-					boost::multi_index::member<CameraInfo, std::string, &CameraInfo::name>
+					boost::multi_index::key<&CameraInfo::name>
 				>
 			>
 		>;


### PR DESCRIPTION
This is a less verbose means of expressing keys that became available with C++ 17. It boils down to the original `member` or `mem_fn` through some template trickery behind the scenes. Since the verbosity of type definitions is perhaps the main downside of `multi_index_container`, this seems like a small but worthwhile improvement.
