### PR TITLE
SceneInspector : Show `GeometricData::Interpretation` for primvars

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.5.0)
 =======
 
+Improvements
+------------
 
+- SceneInspector : Added Interpretation row for primitive variables, with values of "Point", "Vector", "Normal" or "UV".
 
 1.6.5.0 (relative to 1.6.4.0)
 =======


### PR DESCRIPTION
The GeometricInterpretation of a primitive variable (point, vector, normal etc) affects how it is transformed, so it can be handy to use the SceneInspector to check that the interpretation has been set correctly.