### PR TITLE
ImageWriter : Fix `openexr:lineOrder` causing corruption

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ Fixes
 -----
 
 - Render, InteractiveRender, StandardOptions : Fixed bugs allowing Cycles and 3Delight to appear as available renderers even when hidden from the UI or not configured.
+- ImageWriter : Fixed file corruption or crashes caused by `openexr:lineOrder` being set in image metadata.
 
 1.6.5.0 (relative to 1.6.4.0)
 =======

--- a/python/GafferImageTest/ImageWriterTest.py
+++ b/python/GafferImageTest/ImageWriterTest.py
@@ -1975,5 +1975,26 @@ class ImageWriterTest( GafferImageTest.ImageTestCase ) :
 		imageReader["fileName"].setValue( self.temporaryDirectory() / "test.exr" )
 		self.assertNotIn( "fileValid", imageReader["out"].metadata() )
 
+	def testNoLineOrderCorruption( self ) :
+
+		r = GafferImage.ImageReader()
+		r["fileName"].setValue( self.__largeFilePath )
+
+		im = GafferImage.ImageMetadata()
+		im["metadata"].addChild( Gaffer.NameValuePlug( "openexr:lineOrder", "decreasingY" ) )
+		im["in"].setInput( r["out"] )
+
+		testFile = self.__testFile( "badLineOrder", "RGBA", "exr" )
+
+		w = GafferImage.ImageWriter()
+		w['fileName'].setValue( testFile )
+		w['in'].setInput( im['out'] )
+		w["task"].execute()
+
+		reRead = GafferImage.ImageReader()
+		reRead["fileName"].setValue( testFile )
+
+		self.assertImagesEqual( r["out"], reRead["out"], ignoreMetadata = True )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferImage/ImageWriter.cpp
+++ b/src/GafferImage/ImageWriter.cpp
@@ -1280,6 +1280,11 @@ ImageSpec createImageSpec( const ImageWriter *node, const ImageOutput *out, cons
 	metadata->writable().erase( "fileValid" );
 	metadata->writable().erase( "dataType" );
 
+	// It's crucial to get rid of this particular metadata, because it affects OpenEXR during writing.
+	// If it's set to something that contradicts how we're writing the file, it can cause file corruption
+	// or crashes.
+	metadata->writable().erase( "openexr:lineOrder" );
+
 	// Also erase multiView metadata - if you want to create multi-view images, use CreateViews
 	// instead of just setting metadata.
 	metadata->writable().erase( "view" );


### PR DESCRIPTION
Pretty straightforward fix.

Only question that came up while I was implementing it was whether we should be blacklisting more metadata with an "openexr:" prefix ( either specifically targetting things, or openexr:* ). There is other metadata that definitely shouldn't be kept from the source file, like `openexr:chunkCount` and `openexr:dwaCompressionLevel`. It seems like OIIO is correctly handling overwriting those ( unlike lineOrder, which can actually screw up writing the file ) ... I wasn't sure whether it's more correct to let OIIO handle the ones where it works correctly, or if we should preemptively remove some of the other metadata that doesn't make sense.

For now, I've made the minimal change that fixes the issue we know about.