### PR TITLE
SceneInspector : Fix cancellation handling

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 Fixes
 -----
 
+- SceneInspector : Fixed sporadic incomplete updates, particularly when an interactive render was running.
 - Render, InteractiveRender, StandardOptions : Fixed bugs allowing Cycles and 3Delight to appear as available renderers even when hidden from the UI or not configured.
 - ImageWriter : Fixed file corruption or crashes caused by `openexr:lineOrder` being set in image metadata.
 

--- a/python/GafferSceneUITest/SceneInspectorTest.py
+++ b/python/GafferSceneUITest/SceneInspectorTest.py
@@ -526,5 +526,26 @@ class SceneInspectorTest( GafferUITest.TestCase ) :
 		# `scene:path` being missing from the context.
 		self.assertEqual( [ str( c ) for c in path.children() ], [ "/Location" ] )
 
+	def testCancellationRecovery( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		context = Gaffer.Context()
+		context["scene:path"] = GafferScene.ScenePlug.stringToPath( "/sphere" )
+
+		tree = _GafferSceneUI._SceneInspector.InspectorTree( sphere["out"], [ context, context ], None )
+		path = _GafferSceneUI._SceneInspector.InspectorPath( tree, "/" )
+
+		# Do an evaluation which is cancelled immediately.
+
+		canceller = IECore.Canceller()
+		canceller.cancel()
+		with self.assertRaises( IECore.Cancelled ) :
+			path.children( canceller )
+
+		# That shouldn't prevent a subsequent evaluation from working.
+
+		self.assertEqual( [ str( c ) for c in path.children() ], [ "/Location" ] )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferSceneUIModule/SceneInspectorBinding.cpp
+++ b/src/GafferSceneUIModule/SceneInspectorBinding.cpp
@@ -487,7 +487,7 @@ class InspectorTree : public IECore::RefCounted
 			// Note : This is not as bad as it sounds, because the more
 			// expensive calls to `TreeItem::inspector` _are_ deferred.
 
-			m_rootItem = std::make_shared<TreeItem>();
+			auto newRootItem = std::make_shared<TreeItem>();
 			const IECore::StringAlgo::MatchPatternPath filterPath = IECore::StringAlgo::matchPatternPath( m_filter );
 
 			for( const auto &context : m_contexts )
@@ -527,7 +527,7 @@ class InspectorTree : public IECore::RefCounted
 							continue;
 						}
 
-						TreeItem *inspectorItem = m_rootItem->insertDescendant( fullPath );
+						TreeItem *inspectorItem = newRootItem->insertDescendant( fullPath );
 						inspectorItem->inspector = inspector;
 					}
 				}
@@ -535,9 +535,10 @@ class InspectorTree : public IECore::RefCounted
 
 			if( m_isolateDifferences )
 			{
-				isolateDifferencesWalk( m_rootItem.get(), Path::Names(), canceller );
+				isolateDifferencesWalk( newRootItem.get(), Path::Names(), canceller );
 			}
 
+			m_rootItem = newRootItem;
 			return m_rootItem;
 		}
 


### PR DESCRIPTION
Don't assign `m_rootItem` until we have built the tree completely, otherwise if an `IECore::Cancelled` exception occurs before `rootItem()` completes, we end up using a partial result until we are next dirtied.
