### PR TITLE
Dispatcher compatibility : Remove unnecessary `dispatch()` restrictions

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Improvements
 - ImageToTensor : Added `tensorElementType` plug to choose between `Float`, `Float16` and `BFloat16`.
 - TensorToImage : Added conversion from `Float16` and `BFloat16` tensor elements in addition to the existing `Float` support.
 - RenderManOptions : Added XPU device configuration options.
+- `gaffer dispatch` : Removed restrictions that prevented nodes such as Switch and ContextVariables from being dispatched.
 
 Fixes
 -----

--- a/apps/dispatch/dispatch-1.py
+++ b/apps/dispatch/dispatch-1.py
@@ -100,6 +100,9 @@ class dispatch( Gaffer.Application ) :
 					defaultValue = False,
 				),
 
+				## \todo This should take the names of TaskPlugs to dispatch, with some
+				# backwards-compatibility/convenience behaviour of taking the first output
+				# if a Node is named instead.
 				IECore.StringVectorParameter(
 					name = "tasks",
 					description = "The names of the task nodes to dispatch. Note if a script is supplied, the tasks must "

--- a/python/GafferDispatchTest/DispatchApplicationTest.py
+++ b/python/GafferDispatchTest/DispatchApplicationTest.py
@@ -330,5 +330,23 @@ class DispatchApplicationTest( GafferTest.TestCase ) :
 		with open( self.__outputTextFile.with_suffix( ".2" ), "r", encoding = "utf-8" ) as f :
 			self.assertEqual( f.readlines(), [ "its a 2nd test" ] )
 
+	def testSwitch( self ) :
+
+		script = Gaffer.ScriptNode()
+
+		script["textWriter"] = GafferDispatchTest.TextWriter( "test" )
+		script["textWriter"]["text"].setValue( "dispatched via switch" )
+		script["textWriter"]["fileName"].setValue( self.__outputTextFile )
+
+		script["switch"] = Gaffer.NameSwitch()
+		script["switch"].setup( script["textWriter"]["task"] )
+		script["switch"]["in"][0]["value"].setInput( script["textWriter"]["task"] )
+
+		script["fileName"].setValue( self.__scriptFileName )
+		script.save()
+
+		self.waitForCommand( f"gaffer dispatch -script {self.__scriptFileName} -tasks switch" )
+		self.assertTrue( self.__outputTextFile.exists() )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/python/GafferDispatchUI/DispatchDialogue.py
+++ b/python/GafferDispatchUI/DispatchDialogue.py
@@ -61,6 +61,7 @@ class DispatchDialogue( GafferUI.Dialogue ) :
 
 	__dispatchDialogueMenuDefinition = None
 
+	## \todo `tasks` should be a list of TaskPlugs instead of a list of nodes.
 	def __init__( self, tasks, dispatchers, nodesToShow, postDispatchBehaviour=PostDispatchBehaviour.Confirm, title="Dispatch Tasks", sizeMode=GafferUI.Window.SizeMode.Manual, **kw ) :
 
 		GafferUI.Dialogue.__init__( self, title, sizeMode=sizeMode, **kw )

--- a/startup/GafferDispatch/dispatcherCompatibility.py
+++ b/startup/GafferDispatch/dispatcherCompatibility.py
@@ -54,12 +54,13 @@ def __dispatch( self, nodes ) :
 	for node in nodes :
 		if isinstance( node, GafferDispatch.TaskNode ) :
 			self["tasks"].next().setInput( node["task"] )
-		elif isinstance( node, Gaffer.SubGraph ) :
-			for plug in GafferDispatch.TaskNode.TaskPlug.RecursiveOutputRange( node ) :
-				if isinstance( plug.source().node(), GafferDispatch.TaskNode ) :
-					self["tasks"].next().setInput( plug )
 		else :
-			raise IECore.Exception( "Dispatched nodes must be TaskNodes or SubGraphs containing TaskNodes" )
+			foundPlug = False
+			for plug in GafferDispatch.TaskNode.TaskPlug.RecursiveOutputRange( node ) :
+				self["tasks"].next().setInput( plug )
+				foundPlug = True
+			if not foundPlug :
+				raise IECore.Exception( "Dispatched nodes must have at least one TaskPlug output." )
 
 	self["task"].execute()
 


### PR DESCRIPTION
These were emulating restrictions from the original `Dispatcher::dispatch()` method that the config provides compatibility for. But they prevented more modern dispatch idioms such as using Switch or ContextVariables set up with TaskPlugs.

It's a little strange to be improving a compatibility config to add new features, but it's the best way of improving the `dispatch` app and DispatcherDialogue without introducing a breaking change. Added todos documenting how we should deal with this when we get the chance to make a break.
