### PR TITLE
SceneEditor : Remove `numInputs` argument to `Settings` constructor

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@ Breaking Changes
 - ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`.
 - RenderUI : Removed deprecated `rendererPresetNames()` function.
 - Menu : Removed support for `enter` and `leave` properties on menu items.
+- SceneEditor : Removed `numInputs` argument to `Settings` constructor.
 
 1.6.x.x (relative to 1.6.6.1)
 =======


### PR DESCRIPTION
This used to be necessary for the SceneInspector, which used two inputs to provide A/B scenes for comparison. But the SceneInspector now uses a combination of context-sensitive switches and a `compare.scene` plug to provide the comparison scene, so we can simplify the `Settings` constructor.
