### PR TITLE
Dispatcher : Support isolated Object related plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@ Fixes
 - PythonCommand :
   - Fixed invalid results from evaluating `"name" in variables`.
   - Fixed handling of CompoundObjectPlugs, ObjectPlugs and ObjectVectorPlugs in `variables` plug.
+- Dispatcher : Fixed omission that prevented values from CompoundObjectPlugs, ObjectPlugs and ObjectVectorPlugs with inputs from being saved in a dispatch with `isolated` enabled.
 
 1.6.6.0 (relative to 1.6.5.1)
 =======


### PR DESCRIPTION
This adds support for baking in plug values from `CompoundObjectPlug`, `ObjectPlug` and `ObjectVector` plug when using isolated dispatches.

This is based on #6707 where support was added for those plugs on `PythonCommand` nodes. Once we have that merged, I can rebase this which will drop commits from that PR and clear the way to have it merged.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/GafferHQ/gaffer/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Gaffer project's prevailing coding style and conventions.
