### PR TITLE
ReferenceUI : Fix order of operations for "Duplicate as Box"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Fixes
   - Fixed invalid results from evaluating `"name" in variables`.
   - Fixed handling of CompoundObjectPlugs, ObjectPlugs and ObjectVectorPlugs in `variables` plug.
 - Dispatcher : Fixed omission that prevented values from CompoundObjectPlugs, ObjectPlugs and ObjectVectorPlugs with inputs from being saved in a dispatch with `isolated` enabled.
+- Reference : Fixed "Duplicate as Box" order of operations, so the new Box is fully initialised before being parented and selected.
 
 1.6.6.0 (relative to 1.6.5.1)
 =======


### PR DESCRIPTION
Previously we were parenting and selecting the Box before loading its contents.
This meant that the parent's `childAddedSignal()` and the selection's `memberAddedSignal()`
were emitted when the node was in an intermediate state. We don't want to emit signals in
such a state, as we want client code to always see a final and consistent state. So now
we prepare the box in a temporary script and move it over once it is finalised.