### PR TITLE
PathListingWidget : Add _FileSizeColumn

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,11 @@
 1.6.x.x (relative to 1.6.6.0)
 =======
 
+Improvements
+------------
+
+- File Browser : Added column displaying the size of files and sequences (#6698).
+
 Fixes
 -----
 


### PR DESCRIPTION
As requested in #6698, this adds a Size column to the file browsers displaying human-readable file sizes for files and sequences.

<img width="774" height="625" alt="image" src="https://github.com/user-attachments/assets/0a285b68-5400-4ffb-a8a2-64cd0bcba3dd" />
