### PR TITLE
Revert "Menu : Support enter/leave callback for menu items"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@ Breaking Changes
 - ValuePlug : Disconnection no longer emits `plugSetSignal()`.
 - ArnoldShader : The `standard_volume` shader is now assigned via an `ai:volume` attribute instead of `ai:surface`.
 - RenderUI : Removed deprecated `rendererPresetNames()` function.
+- Menu : Removed support for `enter` and `leave` properties on menu items.
 
 1.6.x.x (relative to 1.6.6.0)
 =======


### PR DESCRIPTION
We no longer use this functionality, and Menu is far more complex than we'd like, so it makes sense to remove it.

This reverts commit bf78e84f1bc92bf75c67adf0cd653d2733f95826.

