### PR TITLE
Timeline : Fix handling of current frame when outside playback range

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,11 +1,17 @@
 1.6.x.x (relative to 1.6.6.1)
 =======
 
+Improvements
+------------
+
+- Timeline : Added scrubbing outside the playback range, enabled by holding <kbd>Shift</kbd>.
+
 Fixes
 -----
 
 - RenderPassEditor, Spreadsheet : Conformed menu buttons to match the rest of Gaffer by showing menu on button press, not release.
 - NodeEditor : Added missing widget for Color4fVectorDataPlug.
+- Timeline : Fixed bug that meant the wrong frame number was drawn when the current frame was outside the playback range.
 
 API
 ---


### PR DESCRIPTION
The Timeline was acting as if it was the sole arbiter of the current frame, assuming that because _it_ clamped the current frame inside the playback range, that would always be so. But of course that wasn't true - anyone can call `context.setFrame()` at any time, and the value needn't be inside the playback range.

This caused problems for a "shot switcher" UI which changed frame ranges, which can be reproduced by running the script below in the PythonEditor :

```
def changeRange( script, start, end ) :

	script["frameRange"]["start"].setValue( start )
	script["frameRange"]["end"].setValue( end )
	script["frame"].setValue( start )

	GafferUI.Playback.acquire( script.context() ).setFrameRange( start, end )

changeRange( root, 1001, 1180 )
changeRange( root, 99, 156 )
```

After this, the indicator in the frame slider would be at 156, instead of the true value of 99. This is because the change of frame occurred before the change of playback range, with the slider value being clamped to the old range before being re-clamped to the new one.

This is fixed by adding a full-range hard min and hard max to the slider, so that it never clamps the value. We also update the drawing to indicate out-of-playback-range values with a triangle, just as we indicate out of range values in regular sliders. As a side effect, this lets the user do a Shift+Drag on the slider to take the current frame outside of the playback range, which seems potentially useful, and explicit enough to not cause accidental problems.

I also removed the clamping of values entered via the numeric field for the current frame. It would be possible to reintroduce this while still allowing the slider to go out of range if we feel that it is too easy to get wrong. One justification for the new behaviour is that it lets you enter subframe positions beyond the end frame, which is useful for debugging motion blur. And hopefully the slider indicators make it reasonably obvious if you accidentally go out of range.
