### PR TITLE
SetEditor : Register `Settings` node

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,8 @@ Fixes
 - RenderPassEditor, Spreadsheet : Conformed menu buttons to match the rest of Gaffer by showing menu on button press, not release.
 - NodeEditor : Added missing widget for Color4fVectorDataPlug.
 - Timeline : Fixed bug that meant the wrong frame number was drawn when the current frame was outside the playback range.
+- SetEditor : Fixed RunTimeTyped registration of `SetEditor.Settings`.
+- HierarchyView, AttributeEditor : Fixed search filter tooltip.
 
 API
 ---

--- a/python/GafferSceneUI/SetEditor.py
+++ b/python/GafferSceneUI/SetEditor.py
@@ -58,6 +58,8 @@ class SetEditor( GafferSceneUI.SceneEditor ) :
 			self["hideEmptySets"] = Gaffer.BoolPlug()
 			self["hideEmptySelection"] = Gaffer.BoolPlug()
 
+	IECore.registerRunTimeTyped( Settings, typeName = "GafferSceneUI::SetEditor::Settings" )
+
 	def __init__( self, scriptNode, **kw ) :
 
 		mainColumn = GafferUI.ListContainer( GafferUI.ListContainer.Orientation.Vertical, borderWidth = 4, spacing = 4 )


### PR DESCRIPTION
Without this registration, `SetEditor.Settings` shared the TypeId of `SceneEditor.Settings`, causing metadata registrations to collide on common plugs. Which meant the `SetEditor.Settings.filter` description metadata registration was overriding the `filter` description of other editors deriving from `SceneEditor`, such as the Hierarchy View and Attribute Editor.