### PR TITLE
NodeMenu : Scope ScriptNode's context before calling `postCreator`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@ Fixes
 - Timeline : Fixed bug that meant the wrong frame number was drawn when the current frame was outside the playback range.
 - SetEditor : Fixed RunTimeTyped registration of `SetEditor.Settings`.
 - HierarchyView, AttributeEditor : Fixed search filter tooltip.
+- NodeMenu : The script's context is now scoped before calling a node's `postCreator`.
 
 API
 ---

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -45,11 +45,10 @@ import GafferImage
 # sets the area for the node to cover the entire format.
 def postCreate( node, menu ) :
 
-	with node.scriptNode().context() :
-		if node["in"].getInput() :
-			cropFormat = node["in"]["format"].getValue()
-		else:
-			cropFormat = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
+	if node["in"].getInput() :
+		cropFormat = node["in"]["format"].getValue()
+	else:
+		cropFormat = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
 
 	node['area'].setValue( cropFormat.getDisplayWindow() )
 

--- a/python/GafferImageUI/RectangleUI.py
+++ b/python/GafferImageUI/RectangleUI.py
@@ -45,11 +45,10 @@ import GafferImage
 # sets the rectangle area relative to the input format.
 def postCreate( node, menu ) :
 
-	with node.scriptNode().context() :
-		if node["in"].getInput() :
-			format = node["in"]["format"].getValue()
-		else:
-			format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
+	if node["in"].getInput() :
+		format = node["in"]["format"].getValue()
+	else:
+		format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
 
 	node["area"].setValue(
 		imath.Box2f(

--- a/python/GafferImageUI/TextUI.py
+++ b/python/GafferImageUI/TextUI.py
@@ -43,11 +43,10 @@ import GafferImage
 # sets the region of interest for the node to cover the entire format.
 def postCreate( node, menu ) :
 
-	with node.scriptNode().context() :
-		if node["in"].getInput() :
-			format = node["in"]["format"].getValue()
-		else:
-			format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
+	if node["in"].getInput() :
+		format = node["in"]["format"].getValue()
+	else:
+		format = GafferImage.FormatPlug.getDefaultFormat( node.scriptNode().context() )
 
 	node['area'].setValue( format.getDisplayWindow() )
 

--- a/python/GafferUI/NodeMenu.py
+++ b/python/GafferUI/NodeMenu.py
@@ -145,6 +145,7 @@ class NodeMenu( object ) :
 			graphEditor.frame( [ node ], extend = True )
 
 			if postCreator is not None :
-				postCreator( node, menu )
+				with script.context():
+					postCreator( node, menu )
 
 		return f


### PR DESCRIPTION
This means we can remove some manual scoping from our own `postCreators`, and extension authors have one less thing to worry about.
