### PR TITLE
Forward compatibility for Gaffer 1.7 RampPlugs / shaders

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@ Improvements
     - Parameters dragged from non-terminal shaders create tweaks that include the shader name to correctly identify the parameter.
   - Added array parameter types to the tweak creation menu.
 - PlugCreationWidget : User defaults are now applied to newly created `TweakPlug.mode` plugs.
+- OSLShader : Added forward compatibility for spline parameters saved from Gaffer 1.7.
 
 Fixes
 -----

--- a/startup/Gaffer/rampPlugCompatibility.py
+++ b/startup/Gaffer/rampPlugCompatibility.py
@@ -1,0 +1,48 @@
+##########################################################################
+#
+#  Copyright (c) 2025, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+import IECore
+
+IECore.RampInterpolation = Gaffer.SplineDefinitionInterpolation
+
+IECore.Rampff = Gaffer.SplineDefinitionff
+IECore.RampfColor3f = Gaffer.SplineDefinitionfColor3f
+IECore.RampfColor4f = Gaffer.SplineDefinitionfColor4f
+
+Gaffer.RampffPlug = Gaffer.SplineffPlug
+Gaffer.RampfColor3fPlug = Gaffer.SplinefColor3fPlug
+Gaffer.RampfColor4fPlug = Gaffer.SplinefColor4fPlug


### PR DESCRIPTION
Copying the spline compatibility stuff from Gaffer 1.7, but running all of it backwards, to load Gaffer 1.7 ramps in Gaffer 1.6

If Murray is doing some practical testing of #6717, might make sense for him to have this available as well.