### PR TITLE
FileSystemPath binding : Implement `os.PathLike` interface

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,7 @@ API
 
 - MenuButton : Added `set/getImmediate()` methods. These allow the button to execute a menu item immediately instead of showing the menu, if the menu has only a single item.
 - Signals : Added CatchingCombiner Python class, equivalent to the C++ template class.
+- FileSystemPath : Implemented Python's `os.PathLike` interface, to allow FileSystemPath objects to be passed directly to Python's standard filesystem functions.
 
 1.6.6.1 (relative to 1.6.6.0)
 =======

--- a/python/GafferTest/FileSystemPathTest.py
+++ b/python/GafferTest/FileSystemPathTest.py
@@ -545,6 +545,16 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 
 		self.assertEqual( Gaffer.FileSystemPath( pathlib.Path( __file__ ) ).standardPath(), pathlib.Path( __file__ ) )
 
+	def testPathLike( self ) :
+
+		self.assertEqual( pathlib.Path( Gaffer.FileSystemPath( __file__ ) ), pathlib.Path( __file__ ) )
+
+		path = Gaffer.FileSystemPath( self.temporaryDirectory() / "test.txt" )
+		with open( path, "w" ) as file :
+			file.write( "test" )
+
+		self.assertEqual( pathlib.Path( path ).read_text(), "test" )
+
 	def setUp( self ) :
 
 		GafferTest.TestCase.setUp( self )
@@ -574,7 +584,6 @@ class FileSystemPathTest( GafferTest.TestCase ) :
 			securityDescriptor = GafferTest._WindowsUtils.getFileSecurity( filePath )
 			group, domain = securityDescriptor.group()
 			return group
-
 
 if __name__ == "__main__":
 	unittest.main()

--- a/src/GafferModule/PathBinding.cpp
+++ b/src/GafferModule/PathBinding.cpp
@@ -632,6 +632,7 @@ void GafferModule::bindPath()
 		.def( "nativeString", &FileSystemPath::nativeString )
 		.def( "standardPath", &FileSystemPath::standardPath )
 		.staticmethod( "createStandardFilter" )
+		.def( "__fspath__", &FileSystemPath::nativeString )
 	;
 
 	StdPathFromPathlibPath();


### PR DESCRIPTION
This allows `pathlib.Path` to be constructed directly from `Gaffer.FileSystemPath`, and `FileSystemPath` to be passed directly to Python functions like `open()` and `os.mkdir()`.
