### PR TITLE
IECoreRenderMan : Support overscan

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@ Improvements
 - LightEditor : Added column for Arnold 7.4.4.0's new `sampling_mode` parameter.
 - ArnoldShader : Moved Arnold 7.4.4.0's new `standard_hair.scattering_mode` parameter to the "Specular" section of the UI.
 - ArnoldImager : Added activators for Arnold 7.4.4.0's new `lens_effects` imager parameters.
+- RenderMan : Added overscan support.
 
 1.6.7.0 (relative to 1.6.6.1)
 =======


### PR DESCRIPTION
Pretty straightforward, with just one weird floating point rounding thing, which has been documented and probably tested enough that there aren't any problems ( at least not with images smaller than 16 million pixels across ).