### PR TITLE
EditScopeAlgo : Sanitise '.' in attribute names

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,6 +13,7 @@ Fixes
 -----
 
 - SceneInspector : Fixed cell background colour updates when changing EditScope.
+- AttributeEditor, SceneInspector : Fixed bug preventing edits from being created in an EditScope for attributes with `.` characters in their name.
 
 1.6.7.0 (relative to 1.6.6.1)
 =======

--- a/python/GafferSceneTest/EditScopeAlgoTest.py
+++ b/python/GafferSceneTest/EditScopeAlgoTest.py
@@ -1035,6 +1035,24 @@ class EditScopeAlgoTest( GafferSceneTest.SceneTestCase ) :
 		self.assertIsNotNone( GafferScene.EditScopeAlgo.acquireAttributeEdit( editScope, "/sphere", "test:bogus" ) )
 		self.assertNotEqual( editScope.keys(), emptyKeys )
 
+	def testAttributeEditNameSanitisation( self ) :
+
+		sphere = GafferScene.Sphere()
+
+		customAttributes = GafferScene.CustomAttributes()
+		customAttributes["in"].setInput( sphere["out"] )
+		customAttributes["attributes"].addMember( "test:fancy.attribute", 123 )
+
+		editScope = Gaffer.EditScope()
+		editScope.setup( customAttributes["out"] )
+		editScope["in"].setInput( customAttributes["out"] )
+
+		edit = GafferScene.EditScopeAlgo.acquireAttributeEdit( editScope, "/sphere", "test:fancy.attribute" )
+		self.assertIsInstance( edit, Gaffer.TweakPlug )
+		edit["enabled"].setValue( True )
+		edit["value"].setValue( 456 )
+		self.assertEqual( editScope["out"].attributes( "/sphere" )["test:fancy.attribute"].value, 456 )
+
 	def testProcessorNames( self ) :
 
 		plane = GafferScene.Plane()

--- a/src/GafferScene/EditScopeAlgo.cpp
+++ b/src/GafferScene/EditScopeAlgo.cpp
@@ -804,7 +804,8 @@ TweakPlug *GafferScene::EditScopeAlgo::acquireAttributeEdit( Gaffer::EditScope *
 
 	// Find cell for attribute
 
-	std::string columnName = boost::replace_all_copy( attribute, ":", "_" );
+	std::string columnName;
+	boost::replace_copy_if( attribute, std::back_inserter( columnName ), boost::is_any_of( ".:" ), '_' );
 	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
 	{
 		return cell->valuePlug<TweakPlug>();
@@ -867,7 +868,8 @@ const Gaffer::GraphComponent *GafferScene::EditScopeAlgo::attributeEditReadOnlyR
 		return reason;
 	}
 
-	std::string columnName = boost::replace_all_copy( attribute, ":", "_" );
+	std::string columnName;
+	boost::replace_copy_if( attribute, std::back_inserter( columnName ), boost::is_any_of( ".:" ), '_' );
 	if( auto *cell = row->cellsPlug()->getChild<Spreadsheet::CellPlug>( columnName ) )
 	{
 		if( MetadataAlgo::getReadOnly( cell ) )


### PR DESCRIPTION
Acquiring edits for attributes such as `dl:visibility.camera` would otherwise fail as we'd be trying to create a Spreadsheet column named `dl_visibility.camera`.