### PR TITLE
Metadata : Add `target` argument to `ValueFunction`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,11 @@ Fixes
 
 - RenderController : Fixed bug where repeatedly setting the same VisibleSet could cause unnecessary updates.
 
+API
+---
+
+- Metadata : `ValueFunctions` now receive a `target` parameter. This is particularly useful when registering a function against a wildcard pattern.
+
 Breaking Changes
 ----------------
 
@@ -27,6 +32,7 @@ Breaking Changes
   - Renamed to Gaffer::RampPlug. Removed SplineDefinition ( use IECore::Ramp instead ).
 - OSL Shaders : Pattern/FloatSpline and Pattern/ColorSpline have been replaced by Pattern/FloatRamp and Pattern/ColorRamp. Old Gaffer scripts will automatically be updated on load, files exported from Gaffer will contain the new shaders. ( The .osl files for the old shaders are still included, so that old USD files can render ).
 - GafferUI : Renamed SplineWidget to RampWidget. Renamed SplinePlugValueWidget to RampPlugValueWidget. The old RampPlugValueWidget is no longer exposed, since it was only used internally.
+- Metadata : Added `target` argument to `ValueFunction` signature.
 
 1.6.x.x (relative to 1.6.8.0)
 =======

--- a/include/Gaffer/Metadata.h
+++ b/include/Gaffer/Metadata.h
@@ -61,7 +61,7 @@ class GAFFER_API Metadata
 
 	public :
 
-		using ValueFunction = std::function<IECore::ConstDataPtr ()>;
+		using ValueFunction = std::function<IECore::ConstDataPtr ( IECore::InternedString )>;
 		using GraphComponentValueFunction = std::function<IECore::ConstDataPtr ( const GraphComponent * )>;
 		using PlugValueFunction = std::function<IECore::ConstDataPtr ( const Plug * )>;
 

--- a/python/GafferRenderMan/ArgsFileAlgo.py
+++ b/python/GafferRenderMan/ArgsFileAlgo.py
@@ -136,9 +136,9 @@ def registerMetadata( argsFile, parametersToIgnore = set() ) :
 
 			# Using `partial()` to defer processing of description until it is queried,
 			# since it relatively expensive.
-			description = functools.partial( __cleanDescription, currentParameterTarget, element )
+			description = functools.partial( __cleanDescription, parameterTarget = currentParameterTarget, element = element )
 			if currentParameterTarget is not None :
-				Gaffer.Metadata.registerValue( currentParameterTarget or target, "description", description )
+				Gaffer.Metadata.registerValue( currentParameterTarget, "description", description )
 			else :
 				# We may not have the `target` yet, because a couple of files don't
 				# specify `shaderType` first. Store it and register at the end.
@@ -285,7 +285,7 @@ def __parseConditionalVisibility( source, parameterTarget ) :
 					if suffix in [ "Left", "Right" ] :
 						prefixes.append( value )
 
-def __cleanDescription( parameterTarget, element ) :
+def __cleanDescription( target, parameterTarget, element ) :
 
 	description = ElementTree.tostring( element, encoding = "unicode", method = "html" ).strip()
 	description = description.removeprefix( "<help>" )

--- a/python/GafferTest/MetadataTest.py
+++ b/python/GafferTest/MetadataTest.py
@@ -1061,8 +1061,8 @@ class MetadataTest( GafferTest.TestCase ) :
 		self.assertEqual( len( cs ), 2 )
 		self.assertEqual( cs[1], ( "testTarget", "testIntVectorData" ) )
 
-		Gaffer.Metadata.registerValue( "testTarget", "testDynamicValue", lambda : 20 )
-		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testDynamicValue" ), 20 )
+		Gaffer.Metadata.registerValue( "testTarget", "testDynamicValue", lambda target : f"{target}:foo" )
+		self.assertEqual( Gaffer.Metadata.value( "testTarget", "testDynamicValue" ), "testTarget:foo" )
 
 		self.assertEqual( len( cs ), 3 )
 		self.assertEqual( cs[2], ( "testTarget", "testDynamicValue" ) )

--- a/src/Gaffer/Metadata.cpp
+++ b/src/Gaffer/Metadata.cpp
@@ -527,7 +527,7 @@ unsigned registrationTypes( bool instanceOnly, bool persistentOnly = false )
 
 void Metadata::registerValue( IECore::InternedString target, IECore::InternedString key, IECore::ConstDataPtr value )
 {
-	registerValue( target, key, [value]{ return value; } );
+	registerValue( target, key, [value] ( InternedString key ) { return value; } );
 }
 
 void Metadata::registerValue( IECore::InternedString target, IECore::InternedString key, ValueFunction value )
@@ -637,7 +637,7 @@ IECore::ConstDataPtr Metadata::valueInternal( IECore::InternedString target, IEC
 		Values::const_iterator vIt = it->second.find( key );
 		if( vIt != it->second.end() )
 		{
-			return vIt->second();
+			return vIt->second( target );
 		}
 	}
 
@@ -651,7 +651,7 @@ IECore::ConstDataPtr Metadata::valueInternal( IECore::InternedString target, IEC
 		Values::const_iterator vIt = values.find( key );
 		if( vIt != values.end() )
 		{
-			return vIt->second();
+			return vIt->second( target );
 		}
 	}
 

--- a/src/GafferModule/MetadataBinding.cpp
+++ b/src/GafferModule/MetadataBinding.cpp
@@ -68,10 +68,10 @@ struct PythonValueFunction
 	{
 	}
 
-	ConstDataPtr operator()()
+	ConstDataPtr operator()( InternedString target )
 	{
 		IECorePython::ScopedGILLock gilLock;
-		ConstDataPtr result = extract<ConstDataPtr>( m_fn() );
+		ConstDataPtr result = extract<ConstDataPtr>( m_fn( target.c_str() ) );
 		return result;
 	}
 
@@ -146,7 +146,7 @@ Metadata::ValueFunction objectToValueFunction( InternedString name, object o )
 	if( dataExtractor.check() )
 	{
 		ConstDataPtr data = dedent( name, dataExtractor() );
-		return [data]{ return data; };
+		return [data] ( InternedString target ) { return data; };
 	}
 	else
 	{

--- a/startup/GafferScene/standardOptions.py
+++ b/startup/GafferScene/standardOptions.py
@@ -274,14 +274,14 @@ Gaffer.Metadata.registerValues( {
 		"layout:section" : "Renderer",
 
 		"plugValueWidget:type" : "GafferUI.PresetsPlugValueWidget",
-		"presetNames" : lambda : IECore.StringVectorData(
+		"presetNames" : lambda target : IECore.StringVectorData(
 			[ "None" ] + sorted(
 				Gaffer.Metadata.value( f"renderer:{t}", "label" ) or t
 				for t in GafferScene.Private.IECoreScenePreview.Renderer.types()
 				if Gaffer.Metadata.value( f"renderer:{t}", "ui:enabled" ) is not False
 			)
 		),
-		"presetValues" : lambda : IECore.StringVectorData(
+		"presetValues" : lambda target : IECore.StringVectorData(
 			[ "" ] + sorted(
 				t for t in GafferScene.Private.IECoreScenePreview.Renderer.types()
 				if Gaffer.Metadata.value( f"renderer:{t}", "ui:enabled" ) is not False


### PR DESCRIPTION
This is necessary to make ValueFunction useful for targets containing wildcards, as introduced in 2d92b876b8671522a2f2593db283e23761253697. Without the argument, there is no way for the function to know what concrete target matched the wildcard and is the current subject of the query.

This would have been useful to some work I'm currently doing for 1.6.x. I'd like to refactor the OSLShaderUI's metadata registrations to use string (rather than plug) targets, as we've done for RenderMan shaders. That would allow me to make overrides for specific parameters that don't have metadata we need, and for which I don't have access to the OSL source. Doing this via wildcard registrations would be ideal because it would defer actually loading shaders until the point they are queried. For now I'm hacking around the issue on the 1.6 branch, but merging this for 1.7 will allow a cleaner approach in the future.