### PR TITLE
EditScopeUI : Fix crash changing `childNodesAreReadOnly` metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.5.16.x (relative to 1.5.16.4)
 ========
 
+Fixes
+-----
 
+- EditScopeUI : Fixed crash if `childNodesAreReadOnly` metadata was edited while no EditScope was selected.
 
 1.5.16.4 (relative to 1.5.16.3)
 ========

--- a/python/GafferUI/EditScopeUI.py
+++ b/python/GafferUI/EditScopeUI.py
@@ -282,6 +282,9 @@ class EditScopePlugValueWidget( GafferUI.PlugValueWidget ) :
 	def __nodeMetadataChanged( self, nodeTypeId, key, node ) :
 
 		editScope = self.__editScope()
+		if editScope is None :
+			return
+
 		if (
 			Gaffer.MetadataAlgo.readOnlyAffectedByChange( editScope, nodeTypeId, key, node ) or
 			node == editScope and key == "nodeGadget:color"


### PR DESCRIPTION
If we didn't have a current edit scope, then we were passing `nullptr` to `readOnlyAffectedByChange()`, triggering a crash in MetadataAlgo. We should also fix the binding for `readOnlyAffectedByChange()` so that it's not possible to pass `None`, but that will still require the same fix in EditScopeUI (this time to avoid an exception rather than a crash). For now I'm just making the most minimal fix, since I have other fish to fry.
