### PR TITLE
OSLShader : Fix missing PxrDisplace parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,10 @@
 1.6.x.x (relative to 1.6.9.0)
 =======
 
+Fixes
+-----
 
+- RenderMan : Fixed missing PxrDisplace shader `dispScale`, `dispVector`, and `modelDispVector` parameters. These parameters were omitted in 1.6.9.0.
 
 1.6.9.0 (relative to 1.6.8.0)
 =======

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -169,6 +169,14 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		shader.loadShader( "PxrDisplace" )
 		self.assertEqual( shader["type"].getValue(), "osl:displacement" )
 
+	def testPxrDisplaceOSLParameters( self ) :
+
+		shader = GafferOSL.OSLShader()
+		shader.loadShader( "PxrDisplace" )
+
+		for parameter in [ "dispAmount", "dispScalar", "dispVector" ] :
+			self.assertIn( parameter, shader["parameters"] )
+
 	def testPatternShaderType( self ) :
 
 		shader = GafferRenderMan.RenderManShader()

--- a/src/GafferOSL/OSLShader.cpp
+++ b/src/GafferOSL/OSLShader.cpp
@@ -1134,7 +1134,7 @@ Plug *loadStructParameter( const std::string &shaderName, const OSLQuery &query,
 Plug *loadShaderParameter( const std::string shaderName, const OSLQuery &query, const OSLQuery::Parameter *parameter, const InternedString &name, Gaffer::Plug *parent, const CompoundData *metadata )
 {
 	Plug *result = nullptr;
-	if( metadata && metadata->member( "vstructmember" ) )
+	if( metadata && metadata->member( "vstructmember" ) && shaderName != "PxrDisplace" )
 	{
 		// RenderMan "virtual struct" member. This isn't for authoring
 		// by users. Instead it will receive a connection or value in the


### PR DESCRIPTION
For some reason the `dispScalar`, `dispVector`, and `modelDispVector` parameters of the OSL PxrDisplace shader are marked as vstructmembers of `inputMaterial` so they would otherwise be omitted by this test.

Curiously, the args file for the C++ PxrDisplace shader doesn't mark the equivalent parameters as vstructmembers, but that shader is also missing the `inputMaterial` parameter...

@johnhaddon, I noticed this after releasing 1.6.9.0 so we'll likely want a 1.6.9.1 release with this fix (or equivalent) out tomorrow.