### PR TITLE
ShaderTweaksUI : Fix context used for "From Affected|Selected"

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,15 @@
 1.6.x.x (relative to 1.6.9.1)
 =======
 
+Fixes
+-----
 
+- ShaderTweaks : Fixed context handling in "From Affected" and "From Selected" menu items.
+
+API
+---
+
+- PlugCreationWidget : Added `context()` method.
 
 1.6.9.1 (relative to 1.6.9.0)
 =======

--- a/python/GafferSceneUI/ShaderTweaksUI.py
+++ b/python/GafferSceneUI/ShaderTweaksUI.py
@@ -217,12 +217,14 @@ def _shaderAttributes( plug, paths, affectedOnly ) :
 def __browseAffectedShaders( menu ) :
 
 	plugCreationWidget = menu.ancestor( GafferUI.PlugCreationWidget )
-	__browseShaders( plugCreationWidget, _pathsFromAffected( plugCreationWidget.plugParent() ), "Affected Shaders" )
+	with plugCreationWidget.context() :
+		__browseShaders( plugCreationWidget, _pathsFromAffected( plugCreationWidget.plugParent() ), "Affected Shaders" )
 
 def __browseSelectedShaders( menu ) :
 
 	plugCreationWidget = menu.ancestor( GafferUI.PlugCreationWidget )
-	__browseShaders( plugCreationWidget, _pathsFromSelection( plugCreationWidget.plugParent() ), "Selected Shaders" )
+	with plugCreationWidget.context() :
+		__browseShaders( plugCreationWidget, _pathsFromSelection( plugCreationWidget.plugParent() ), "Selected Shaders" )
 
 def __browseShaders( plugCreationWidget, paths, title ) :
 

--- a/python/GafferUI/PlugCreationWidget.py
+++ b/python/GafferUI/PlugCreationWidget.py
@@ -103,6 +103,11 @@ class PlugCreationWidget( GafferUI.Widget ) :
 
 		return self.__plugParent
 
+	## Returns the tracked context for `plugParent()`.
+	def context( self ) :
+
+		return self.__contextTracker.context( self.__plugParent )
+
 	__plugCreationMenuSignal = Gaffer.Signals.Signal2(
 		Gaffer.Signals.CatchingCombiner( "PlugCreationWidget.plugCreationMenuSignal" )
 	)


### PR DESCRIPTION
I broke this in 92a75d2a3ec744e10f7190faa36f562de50cecb0, because I confused `PlugCreationWidget.plugCreationMenuSignal()` being emitted in the right context with the menu items themselves being executed in the right context (which is not the case). It might be interesting to consider automatic propagation for that at some point, but for now we just make the straightforward fix.
