### PR TITLE
RenderMan ShaderNetworkAlgo : Fix vstruct warnings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - ShaderTweaks : Fixed context handling in "From Affected" and "From Selected" menu items.
+- RenderMan : Fixed `R10043 {WARNING} inputMaterial, unknown or mismatched input parameter of PxrSurface`.
 
 API
 ---


### PR DESCRIPTION
The warnings occur when trying to give RenderMan a parameter value for a parameter which is merely a `vstruct`, which is declared in the `.args` file but does not actually exist in the shader. We were cleaning these up when there was a connection to the parameter, but not when there wasn't. Now we always clean them up. This fixes the following warnings :

```
R10043 {WARNING} inputMaterial, unknown or mismatched input parameter of PxrSurface
```

A similar warning remains for PxrDisplace however. The issue there is that there are two versions of the shader - C++ and OSL. Only the OSL shader has a vstruct input, but we end up loading the parameter info from the C++ `.args` file even when the user loaded the OSL shader in the UI. We can't use `Shader::getType()` to decide which info loader to use, because we don't round-trip the type through USD (we're trying to get rid of it in general). This will need dealing with separately somehow in future.
