### PR TITLE
NodeEditor : Fix "Revert to Defaults" for ganged plugs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- NodeEditor : Fixed "Revert to Defaults" to handle ganged plugs, and other plugs where a subset of children have input connections. In this case, the subset without inputs now revert correctly to their default values.
 - ShaderTweaks : Fixed context handling in "From Affected" and "From Selected" menu items.
 - RenderMan : Fixed `R10043 {WARNING} inputMaterial, unknown or mismatched input parameter of PxrSurface`.
 

--- a/python/GafferUI/NodeEditor.py
+++ b/python/GafferUI/NodeEditor.py
@@ -225,7 +225,7 @@ class NodeEditor( GafferUI.NodeSetEditor ) :
 				if isinstance( plug, Gaffer.ValuePlug ) :
 					if plug.settable() :
 						plug.setToDefault()
-					return
+						return
 
 			for c in graphComponent.children( Gaffer.Plug ) :
 				applyDefaults( c )


### PR DESCRIPTION
We were terminating the recursion when we found a non-settable plug, but in the case of ganged plugs there will still be settable children, and we need to continue the recursion to find them.
