### PR TITLE
RenderMan : Add trace sets support

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,14 @@
 1.6.x.x (relative to 1.6.10.0)
 =======
 
+Improvements
+------------
+
+- RenderManAttributes : Added trace set support via `grouping:membership` and `trace:*subset` attributes.
+
+Fixes
+-----
+
 - RenderMan : Fixed handling of custom camera parameters prefixed with `ri:` (#6775).
 
 1.6.10.0 (relative to 1.6.9.1)

--- a/startup/GafferScene/renderManAttributes.py
+++ b/startup/GafferScene/renderManAttributes.py
@@ -69,17 +69,9 @@ with IECore.IgnoredExceptions( ImportError ) :
 			# Things that we probably want to expose, but which will require
 			# additional plumbing before they will be useful.
 			"lightfilter:subset",
+			# Things used internally to implement light linking.
 			"lighting:excludesubset",
 			"lighting:subset",
-			"trace:reflectexcludesubset",
-			"trace:reflectsubset",
-			"trace:shadowexcludesubset",
-			"trace:shadowsubset",
-			"trace:transmitexcludesubset",
-			"trace:transmitsubset",
-			# Might it be better if we populate this automatically based on set
-			# memberships and/or light links? Don't expose it until we know.
-			"grouping:membership",
 		}
 	)
 


### PR DESCRIPTION
This involves exposing some attributes via the RenderManAttributes node and updating the backend to merge the user-specified `grouping:membership` attribute with the groups generated automatically for shadow linking.

The other way of doing this would have been to do what we do for Arnold : mirror `render:*` set memberships into the `grouping:membership` attribute automatically. But being a Gaffer-specific mechanism that wouldn't translate naturally to USD when exporting lookdev, so we've chosen to expose the RenderMan functionality directly instead. This is more useable than it would have been back when we added the Arnold functionality, since we now have an AttributesTweak node with ListAppend and ListRemove modes.
