### PR TITLE
RenderMan Camera : Fix handling of `ri:` prefixed parameters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 1.6.x.x (relative to 1.6.10.0)
 =======
 
-
+- RenderMan : Fixed handling of custom camera parameters prefixed with `ri:` (#6775).
 
 1.6.10.0 (relative to 1.6.9.1)
 ========

--- a/src/IECoreRenderMan/Camera.cpp
+++ b/src/IECoreRenderMan/Camera.cpp
@@ -129,9 +129,32 @@ Camera::Camera( const std::string &name, const IECoreScene::Camera *camera, Sess
 
 	for( const auto &[parameterName, parameterValue] : camera->parameters() )
 	{
-		if( boost::starts_with( name.c_str(), "ri:" ) )
+		if( boost::starts_with( parameterName.c_str(), "ri:" ) )
 		{
-			ParamListAlgo::convertParameter( RtUString( parameterName.c_str() + 3 ), parameterValue.get(), projectionParamList );
+			const RtUString parameterNameU( parameterName.c_str() + 3 );
+			if(
+				parameterNameU == Loader::strings().k_apertureAngle ||
+				parameterNameU == Loader::strings().k_apertureDensity ||
+				parameterNameU == Loader::strings().k_apertureNSides ||
+				parameterNameU == Loader::strings().k_apertureRoundness ||
+				parameterNameU == Loader::strings().k_dofaspect ||
+				parameterNameU == Loader::strings().k_shutterCloseTime ||
+				parameterNameU == Loader::strings().k_shutterOpenTime ||
+				parameterNameU == Loader::strings().k_shutteropening ||
+				parameterNameU == Loader::strings().k_stereoplanedepths ||
+				parameterNameU == Loader::strings().k_stereoplaneoffsets
+			)
+			{
+				// Presumably for the usual historical reasons, some parameters
+				// are considered to be features of the camera. We derived this
+				// list from `$RMANTREE/lib/defaults/PRManCamera.args`.
+				ParamListAlgo::convertParameter( RtUString( parameterName.c_str() + 3 ), parameterValue.get(), cameraParamList );
+			}
+			else
+			{
+				// And some are considered to be features of the projection plugin.
+				ParamListAlgo::convertParameter( RtUString( parameterName.c_str() + 3 ), parameterValue.get(), projectionParamList );
+			}
 		}
 	}
 


### PR DESCRIPTION
There were two problems here :

- We were checking for the prefix on `name` rather than `parameterName`.
- We were sending all parameters to the projection, rather than categorising them according to whether they originated before or after RenderMan added plugin projections.

Fixes #6775
