### PR TITLE
Menu : Check for reference cycles in definition

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@ Improvements
 ------------
 
 - SceneInspector : Added inspection of shader networks in options and global attributes. Examples include RenderMan display filters and Arnold background shaders.
+- Menu : Added checks for reference cycles, emitting warnings if any are found.
 
 1.6.11.1 (relative to 1.6.11.0)
 ========


### PR DESCRIPTION
As demonstrated by c2a7fd7bfbe3d251cb62fd688b0cab5688141bde, it's too easy to fall into the trap of creating these, and they can have dire consequences. We have reasonable cycle-checking test coverage for most of the UI via `GafferUITest.TestCase.tearDown`, but that doesn't cover menus unless the unit tests explicitly pop them up. Since that doesn't happen in general, we resort to testing at runtime instead. Measuring NodeMenu popup time, this appears to have negligible overhead.
