### PR TITLE
RenderMan shader metadata : Register more nodule layout metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,9 @@
 Improvements
 ------------
 
-- RenderManShader : Defined pass-through behaviour for LamaAdd, LamaLayer and LamaMix. When disabled, these now pass through the `material1` input (`materialBase` for LamaLayer). Note that this will change the rendered look of shading networks where such shaders were previously disabled.
+- RenderManShader :
+  - Defined pass-through behaviour for LamaAdd, LamaLayer and LamaMix. When disabled, these now pass through the `material1` input (`materialBase` for LamaLayer). Note that this will change the rendered look of shading networks where such shaders were previously disabled.
+  - Improved default visibility of shader parameters in the Graph Editor, showing only the most commonly used parameters for the most common shaders.
 - SceneInspector : Added inspection of shader networks in options and global attributes. Examples include RenderMan display filters and Arnold background shaders.
 - Menu : Added checks for reference cycles, emitting warnings if any are found.
 

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -161,6 +161,70 @@ shaderMetadata = {
 
 	},
 
+	"osl:shader:PxrArithmetic" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "input1", "input2", "resultRGB", "resultR", "resultG", "resultB" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrBumpManifold2D" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "result" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrColorCorrect" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "inputRGB", "resultRGB", "resultR", "resultG", "resultB" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrColorGrade" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "inputColor", "resultRGB" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrHexTileManifold" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			"resultMulti" : { "noduleLayout:visible" : True },
+
+		},
+
+	},
+
 	"osl:shader:PxrLayer" : {
 
 		"noduleLayout:defaultVisibility" : False,
@@ -224,6 +288,71 @@ shaderMetadata = {
 
 	},
 
+	"osl:shader:PxrManifold2D" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "result" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrManifold3D" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "result" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrMultiTexture" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "manifoldMulti", "resultRGB", "resultR", "resultG", "resultB", "resultA" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrRandomTextureManifold" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "resultMulti", "resultMask" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrRemap" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "inputRGB", "resultRGB", "resultR", "resultG", "resultB", "resultA" ]
+
+		},
+
+	},
+
 	"ri:surface:PxrSurface" : {
 
 		"noduleLayout:defaultVisibility" : False,
@@ -246,6 +375,45 @@ shaderMetadata = {
 				"layout:section" : "Globals",
 
 			},
+
+		},
+
+	},
+
+	"osl:shader:PxrTexture" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "manifold", "resultRGB", "resultR", "resultG", "resultB", "resultA" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrTileManifold" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "resultMulti", "resultMask" ]
+
+		},
+
+	},
+
+	"osl:shader:PxrVary" : {
+
+		"noduleLayout:defaultVisibility" : False,
+
+		"parameters" : {
+
+			k : { "noduleLayout:visible" : True }
+			for k in [ "inputRGB", "resultRGB", "resultR", "resultG", "resultB" ]
 
 		},
 


### PR DESCRIPTION
This improves the presentation of some common shaders, as requested by the lookdev department at Cinesite. General principles :

- Reduce clutter.
- Only show commonly used parameters by default, so it's easier to find them.
- Do still show the separate R, G and B outputs from nodes, because RenderMan and USD don't like real component connections, and we don't want folks to make them accidentally.

We'll need to do a pass over all the remaining shaders at some point, but I'm hoping some other folks can chip in there.

<img width="1275" height="810" alt="image" src="https://github.com/user-attachments/assets/7b152b28-da13-4f36-adb5-27b39650e9c7" />
