### PR TITLE
Shader : Implement `correspondingInput()` via metadata lookups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,8 +4,14 @@
 Improvements
 ------------
 
+- RenderManShader : Defined pass-through behaviour for LamaAdd, LamaLayer and LamaMix. When disabled, these now pass through the `material1` input (`materialBase` for LamaLayer). Note that this will change the rendered look of shading networks where such shaders were previously disabled.
 - SceneInspector : Added inspection of shader networks in options and global attributes. Examples include RenderMan display filters and Arnold background shaders.
 - Menu : Added checks for reference cycles, emitting warnings if any are found.
+
+API
+---
+
+- Shader : Pass-throughs may now be defined by registering `correspondingInput` metadata against a `{shaderType}:{shaderName}:{outputName}` target.
 
 1.6.11.1 (relative to 1.6.11.0)
 ========

--- a/include/GafferScene/Shader.h
+++ b/include/GafferScene/Shader.h
@@ -90,15 +90,17 @@ class GAFFERSCENE_API Shader : public Gaffer::ComputeNode
 		Gaffer::Plug *parametersPlug();
 		const Gaffer::Plug *parametersPlug() const;
 
-		/// Shaders can be enabled and disabled. A disabled shader
-		/// returns an empty object from the state() method, causing
-		/// any downstream ShaderAssignments to act as if they've been
-		/// disabled. If a shader in the middle of a network is disabled
-		/// then by default its output connections are ignored on any
-		/// downstream nodes. Derived classes may implement correspondingInput( outPlug() )
-		/// to allow disabled shaders to act as a pass-through instead.
+		/// Shaders can be enabled and disabled. By default, disabled shaders
+		/// and all their upstream inputs are omitted from the generated
+		/// network. But pass-through behaviours can be defined using metadata,
+		/// as documented on `correspondingInput()`.
 		Gaffer::BoolPlug *enabledPlug() override;
 		const Gaffer::BoolPlug *enabledPlug() const override;
+		/// Implemented to look up `correspondingInput` metadata on a
+		/// `{shaderType}:{shaderName}:{outputName}` target. The value should
+		/// be the name of an input parameter.
+		Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) override;
+		const Gaffer::Plug *correspondingInput( const Gaffer::Plug *output ) const override;
 
 		/// Plug which defines the shader's output - this should
 		/// be connected to a ShaderAssignment::shaderPlug() or

--- a/python/GafferRenderManTest/RenderManShaderTest.py
+++ b/python/GafferRenderManTest/RenderManShaderTest.py
@@ -442,5 +442,17 @@ class RenderManShaderTest( GafferSceneTest.SceneTestCase ) :
 		self.assertNotIn( "baselayer_diffuseGain", shader["parameters"] )
 		self.assertEqual( shader["out"].keys(), [ "pxrMaterialOut" ] )
 
+	def testCorrespondingInput( self ) :
+
+		shader = GafferRenderMan.RenderManShader()
+		shader.loadShader( "LamaAdd" )
+		self.assertTrue( shader.correspondingInput( shader["out"]["bxdf_out"] ).isSame( shader["parameters"]["material1"] ) )
+
+		shader.loadShader( "LamaMix" )
+		self.assertTrue( shader.correspondingInput( shader["out"]["bxdf_out"] ).isSame( shader["parameters"]["material1"] ) )
+
+		shader.loadShader( "LamaLayer" )
+		self.assertTrue( shader.correspondingInput( shader["out"]["bxdf_out"] ).isSame( shader["parameters"]["materialBase"] ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/startup/GafferRenderMan/shaderMetadata.py
+++ b/startup/GafferRenderMan/shaderMetadata.py
@@ -1,0 +1,50 @@
+##########################################################################
+#
+#  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import Gaffer
+
+# Defines metadata overrides for pass-through behaviours during network
+# generation. See `startup/GafferRenderManUI/shaderMetadata.py` for
+# metadata that only affects the operation of the UI.
+
+for target, correspondingInput in [
+
+	( "ri:surface:LamaAdd:bxdf_out", "material1" ),
+	( "ri:surface:LamaLayer:bxdf_out", "materialBase" ),
+	( "ri:surface:LamaMix:bxdf_out", "material1" ),
+
+] :
+	Gaffer.Metadata.registerValue( target, "correspondingInput", correspondingInput )


### PR DESCRIPTION
This allows us to define pass-throughs for RenderMan's LamaAdd, LamaLayer and LamaMix shaders.

It should be noted that this is not 100% backwards compatible, on two counts :

- We have overridden a virtual function on `Shader`. In practice this should be fine. The vtable offsets haven't changed. Compilers may in theory have "devirtualised" calls that they could determine statically at compile-time, but such static analysis won't have been possible for NetworkBuilder.
- We have changed the rendered look of shader networks where one of the Lama nodes was disabled. But in a way which makes way more sense in terms of the user's intention.

Despite this, I think making these improvements in 1.6.x is preferable to holding them back for 1.7. I'm confident that folks will take advantage of them immediately, and confident enough that this will outweigh any hypothetical downsides. If the change of look does cause anyone a problem, they can always deregister the metadata anyway.