### PR TITLE
PythonEditor : Fix reference Cycle in "Execute" menu item

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,7 @@ Fixes
 - RenderManDisplayFilter, RenderManSampleFilter :
   - Fixed handling of dedicated XPU filters implemented in OSL.
   - Fixed missing `NPRnormals` AOV required by PxrStylizedLines.
+- PythonEditor : Fixed reference cycle in "Execute" menu item.
 
 API
 ---

--- a/python/GafferUI/PythonEditor.py
+++ b/python/GafferUI/PythonEditor.py
@@ -246,7 +246,7 @@ class PythonEditor( GafferUI.Editor ) :
 			definition.append(
 				"/Execute Selection" if widget.selectedText() else "/Execute",
 				{
-					"command" : self.execute,
+					"command" : Gaffer.WeakMethod( self.execute ),
 					"shortCut" : "Enter",
 				}
 			)


### PR DESCRIPTION
This is the first fruit born from 2115c97b18b25dccb65d4730091b5220e20fdb42.
