### PR TITLE
PlugAlgo : Support ramp data in `createPlugFromData()`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@ Improvements
 - Application :
   - Applications now run using a dedicated `gaffer` executable instead of `python`. This means the root process is now called `gaffer` on all platforms. The `bin/gaffer` (Linux) and `bin/gaffer.cmd` (Windows) launch scripts should still be used as before (#6654).
   - Matched TBB worker thread stack limit to the limit for the main thread. On Linux, this can be configured with `ulimit -s`.
+- ShaderTweaks : Added support for tweaking ramp parameters.
 
 Fixes
 -----
@@ -19,6 +20,7 @@ API
 ---
 
 - Metadata : `ValueFunctions` now receive a `target` parameter. This is particularly useful when registering a function against a wildcard pattern.
+- PlugAlgo : Added `RampffData` and `RampfColor3fData` support to `createPlugFromData()`.
 
 Breaking Changes
 ----------------

--- a/src/Gaffer/PlugAlgo.cpp
+++ b/src/Gaffer/PlugAlgo.cpp
@@ -495,6 +495,14 @@ ValuePlugPtr createPlugFromData( const std::string &name, Plug::Direction direct
 			);
 			return valuePlug;
 		}
+		case RampffDataTypeId :
+		{
+			return new RampffPlug( name, direction, static_cast<const RampffData *>( value )->readable(), flags );
+		}
+		case RampfColor3fDataTypeId :
+		{
+			return new RampfColor3fPlug( name, direction, static_cast<const RampfColor3fData *>( value )->readable(), flags );
+		}
 		default :
 			throw IECore::Exception(
 				fmt::format( "Data for \"{}\" has unsupported value data type \"{}\"", name, value->typeName() )


### PR DESCRIPTION
Among other things, this allows us to create ramp ShaderTweaks by dragging and dropping from the SceneInspector.
