### PR TITLE
CI : Pin setuptools on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Install toolchain (Windows)
       run: |
         python -m pip install scons
-        python -m pip install sphinx==4.3.1 sphinx_rtd_theme==1.0.0 myst-parser==0.15.2 docutils==0.17.1 sphinxcontrib-applehelp==1.0.2 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.0 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-serializinghtml==1.1.5 sphinxcontrib-qthelp==1.0.3
+        python -m pip install setuptools==81.0.0 sphinx==4.3.1 sphinx_rtd_theme==1.0.0 myst-parser==0.15.2 docutils==0.17.1 sphinxcontrib-applehelp==1.0.2 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.0 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-serializinghtml==1.1.5 sphinxcontrib-qthelp==1.0.3
         choco install inkscape --version 1.2.2 -y
       shell: pwsh
       if: runner.os == 'Windows'


### PR DESCRIPTION
The recent release of setuptools 82.0.0 removed `pkg_resources`, which is required by our current version of Sphinx. https://setuptools.pypa.io/en/latest/history.html#v82-0-0

```
 File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\sphinx\registry.py", line 24, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'
```