### PR TITLE
Crop : Add `AreaSource::Auto`

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 Improvements
 ------------
 
+- Crop : Added `Auto` mode for `areaSource`, automatically cropping to show only non-empty pixels.
 - GraphEditor : Improved responsiveness of select-drag, by deferring NodeEditor update until the drag ends.
 
 API

--- a/include/GafferImage/Crop.h
+++ b/include/GafferImage/Crop.h
@@ -60,7 +60,8 @@ class GAFFERIMAGE_API Crop : public ImageProcessor
 			Area = 0,
 			DataWindow = 1,
 			DisplayWindow = 2,
-			Format = 3
+			Format = 3,
+			Auto = 4
 		};
 
 		Gaffer::IntPlug *areaSourcePlug();
@@ -95,6 +96,9 @@ class GAFFERIMAGE_API Crop : public ImageProcessor
 		void hash( const Gaffer::ValuePlug *output, const Gaffer::Context *context, IECore::MurmurHash &h ) const override;
 		void compute( Gaffer::ValuePlug *output, const Gaffer::Context *context ) const override;
 
+		Gaffer::ValuePlug::CachePolicy computeCachePolicy( const Gaffer::ValuePlug *output ) const override;
+		Gaffer::ValuePlug::CachePolicy hashCachePolicy( const Gaffer::ValuePlug *output ) const override;
+
 	private :
 
 		Gaffer::AtomicBox2iPlug *cropWindowPlug();
@@ -105,6 +109,20 @@ class GAFFERIMAGE_API Crop : public ImageProcessor
 
 		Gaffer::V2iPlug *offsetPlug();
 		const Gaffer::V2iPlug *offsetPlug() const;
+
+		Gaffer::AtomicBox2iPlug *tileAutoAreaPlug();
+		const Gaffer::AtomicBox2iPlug *tileAutoAreaPlug() const;
+
+		Gaffer::AtomicBox2iPlug *autoAreaPlug();
+		const Gaffer::AtomicBox2iPlug *autoAreaPlug() const;
+
+		bool affectsTileAutoArea( const Gaffer::Plug *input ) const;
+		void hashTileAutoArea( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		Imath::Box2i computeTileAutoArea( const Gaffer::Context *context ) const;
+
+		bool affectsAutoArea( const Gaffer::Plug *input ) const;
+		void hashAutoArea( const Gaffer::Context *context, IECore::MurmurHash &h ) const;
+		Imath::Box2i computeAutoArea( const Gaffer::Context *context ) const;
 
 		static size_t g_firstPlugIndex;
 };

--- a/python/GafferImageUI/CropUI.py
+++ b/python/GafferImageUI/CropUI.py
@@ -74,17 +74,23 @@ Gaffer.Metadata.registerNode(
 
 			"description" :
 			"""
-			Where to source the actual area to use. If this is
-			set to DataWindow, it will use the input's Data Window,
-			if it is set to DisplayWindow, it will use the input's
-			Display Window, and if it is set to Area, it will use
-			the Area plug.
+			The source of the area to crop to.
+
+			- Area : A user-defined area specified by the `area` plug.
+			- Format : A user-defined area specified by the `format` plug.
+			- DataWindow : The data window of the input image.
+			- DisplayWindow : The display window of the input image.
+			- Auto : The minimal area that contains all the non-empty pixels
+			  of the input image. For flat images, this means pixels
+			  with a non-zero value in at least one channel, and for deep images
+			  it means pixels with at least one sample.
 			""",
 
 			"preset:Area" : GafferImage.Crop.AreaSource.Area,
 			"preset:Format" : GafferImage.Crop.AreaSource.Format,
 			"preset:DataWindow" : GafferImage.Crop.AreaSource.DataWindow,
 			"preset:DisplayWindow" : GafferImage.Crop.AreaSource.DisplayWindow,
+			"preset:Auto" : GafferImage.Crop.AreaSource.Auto,
 
 			"plugValueWidget:type" : "GafferUI.PresetsPlugValueWidget",
 

--- a/src/GafferImageModule/TransformBinding.cpp
+++ b/src/GafferImageModule/TransformBinding.cpp
@@ -88,6 +88,7 @@ void GafferImageModule::bindTransforms()
 			.value( "Format", Crop::Format )
 			.value( "DataWindow", Crop::DataWindow )
 			.value( "DisplayWindow", Crop::DisplayWindow )
+			.value( "Auto", Crop::Auto )
 		;
 	}
 


### PR DESCRIPTION
It was bugging me that I had to [tell Carlo](https://groups.google.com/g/gaffer-dev/c/bZ0kL22hKuM/m/vDLB7Uf5AAAJ?utm_medium=email&utm_source=footer) that we didn't have an auto-crop operation in Gaffer, so I've added one here, cropping to the bound of all pixels with non-empty values. For flat images we define non-empty to mean having a non-zero value in at least one channel. And for deep images we define non-empty to mean having at least one sample.

I did consider implementing the bounds computation on the ImageStats node instead, because it naturally has a similar tile gathering operation. But it wasn't a good fit because ImageStats works only on a subset of channels and for this we need to visit all of them. I can't think of any use cases outside of auto-cropping anyway, so it seems reasonable to bundle this into the Crop node itself.
