### PR TITLE
RenderMan shader metadata : Fix LamaDielectric normal metadata

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -14,6 +14,11 @@ API
 - Widget : Added `currentButtons()` static method. This returns the state of the mouse buttons during the last UI event to be processed.
 - LazyMethod : Added `deferUntilButtonRelease` option.
 
+Fixes
+-----
+
+- RenderManShader : Fixed default visibility of LamaDielectric's `dielectricNormal` parameter, which is now visible by default (and `normal` is now hidden).
+
 1.6.12.0 (relative to 1.6.11.1)
 ========
 

--- a/startup/GafferRenderManUI/shaderMetadata.py
+++ b/startup/GafferRenderManUI/shaderMetadata.py
@@ -91,7 +91,7 @@ shaderMetadata = {
 		"parameters" : {
 
 			k : { "noduleLayout:visible" : True }
-			for k in [ "reflectionTint", "transmissionTint", "roughness", "normal" ]
+			for k in [ "reflectionTint", "transmissionTint", "roughness", "dielectricNormal" ]
 
 		},
 


### PR DESCRIPTION
As requested by lookdev at Cinesite. The `dielectricNormal` parameter is the one that appears to actually do something, whereas we haven't figured out what `normal` does (and the docs are no help - both have the same tooltip).
